### PR TITLE
P1.2: kx-mote — the atomic execution unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 *.gcda
 *.gcno
 
+# proptest failure-persistence artifacts (auto-generated cache; not stable across runs)
+**/*.proptest-regressions
+
 # ---- Editor / OS ----
 .DS_Store
 *.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,235 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "kx-mote"
 version = "0.0.1"
 dependencies = [
+ "bincode",
+ "blake3",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -30,6 +250,24 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -62,6 +300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +321,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,12 +349,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -109,6 +450,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,10 +533,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "syn"
@@ -132,6 +556,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -205,16 +662,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -230,3 +772,123 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ repository   = "https://github.com/Kortecx/kortecx"
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 thiserror          = "1"
-bincode            = "2"
+bincode            = { version = "2", features = ["serde"] }
 blake3             = "1"
 bytes              = "1"
-smallvec           = "1"
+smallvec           = { version = "1", features = ["serde"] }
 serde              = { version = "1", features = ["derive"] }
+proptest           = "1"
 
 [profile.release]
 strip         = "symbols"

--- a/kx-mote/Cargo.toml
+++ b/kx-mote/Cargo.toml
@@ -6,15 +6,19 @@ rust-version = { workspace = true }
 license      = { workspace = true }
 authors      = { workspace = true }
 repository   = { workspace = true }
-description  = "kortecx Mote — the atomic execution unit (P1.2 will fill this in)."
+description  = "kortecx Mote — the atomic execution unit: types, lifecycle, idempotency identity."
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
-# Real dependencies (blake3, smallvec, serde, bincode, thiserror) land at P1.2
-# when the Mote type, lifecycle, idempotency identity, and ND-tag are implemented.
+bincode   = { workspace = true }
+blake3    = { workspace = true }
+serde     = { workspace = true }
+smallvec  = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
+proptest           = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/kx-mote/src/lib.rs
+++ b/kx-mote/src/lib.rs
@@ -3,14 +3,1061 @@
 
 //! # kx-mote — the atomic execution unit
 //!
-//! P1.1 ships an empty seed. P1.2 fills this crate with:
+//! This crate defines the *Mote*: the smallest indivisible thing the kortecx runtime
+//! schedules, recovers, and reasons about. Per the design corpus (private), a Mote is
+//! a durably-recorded record-of-an-attempt-to-effect-something — the deliberate
+//! inversion of Spark's recomputable RDD. A committed Mote is a fact in the journal
+//! and is never re-run; recovery is replay-from-journal.
 //!
-//! - The `Mote` type, `MoteId`, `MoteGraph`.
-//! - The lifecycle state machine (`Pending → Scheduled → Running → {Committed, Failed, Repudiated}`)
-//!   per `docs/design/mote.md` §7.
-//! - The idempotency-identity derivation per `docs/design/idempotency.md`.
-//! - The `NdClass` tag (`PURE` / `READ_ONLY_NONDET` / `WORLD_MUTATING`) per `mote.md` §6.
-//! - Typed dependency edges per `mote.md` §5.
+//! The crate is a *pure-types* crate. It has **no I/O, no async, and no runtime
+//! dependencies** — only `blake3`, `serde`, `bincode`, `smallvec`, and `thiserror`.
+//! Every downstream kortecx crate (journal, projection, executor, scheduler, runtime)
+//! imports types from here; it is the narrow waist.
 //!
-//! Per the design discipline, this crate has **zero runtime dependencies** (no I/O, no async,
-//! no runtime crates) — it is the narrow waist every other kortecx crate imports.
+//! ## What lives here
+//!
+//! - The [`MoteId`] 32-byte identity type and its derivation from `MoteDef`-hash +
+//!   `input_data_id` + `graph_position`.
+//! - The [`MoteDef`] struct and its canonical [`MoteDef::hash`] over a frozen bincode
+//!   configuration ([`canonical_config`]).
+//! - The [`Mote`] runtime-instance type that composes a `MoteDef` with per-instance
+//!   position data and parent edges.
+//! - The non-determinism tag [`NdClass`] (PURE / READ-ONLY-NONDET / WORLD-MUTATING).
+//! - The [`EffectPattern`] enum declaring which of the three effect/commit patterns
+//!   a Mote uses (idempotent-by-construction / stage-then-commit / validate-then-commit).
+//! - Typed dependency edges via [`EdgeKind`] and [`EdgeMeta`].
+//! - The per-attempt lifecycle state machine ([`AttemptState`], [`transition`]).
+//! - A minimal [`MoteGraph`] container for workflow-author-side composition.
+//!
+//! ## What does NOT live here
+//!
+//! - Journal types, content-store types, projection logic, executor logic, inference,
+//!   networking — those land in their respective `kx-*` crates.
+//! - Runtime behavior. This crate only defines the *shapes* the runtime moves around.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Hash newtypes
+// ---------------------------------------------------------------------------
+
+/// A 32-byte BLAKE3 hash. Common substrate for all hash newtypes in the crate.
+type Hash32 = [u8; 32];
+
+/// The stable 32-byte identity of a Mote (see crate-level docs).
+///
+/// Derived purely from the workflow definition, the committed inputs the Mote
+/// consumes, and its position in the DAG — never from clock, host, PID, or
+/// attempt number. Two workers attempting the same logical work derive the
+/// same `MoteId`; the journal dedupes them to one committed fact.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct MoteId(pub Hash32);
+
+impl MoteId {
+    /// Construct a `MoteId` from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for MoteId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MoteId({})", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+impl std::fmt::Display for MoteId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// The 32-byte canonical hash of a [`MoteDef`].
+///
+/// Computed by [`MoteDef::hash`]: serialize `MoteDef` with [`canonical_config`]
+/// (a frozen bincode configuration), then BLAKE3 the resulting bytes. Identifies
+/// a Mote's *kind of work* in the journal; the poison-cascade (definition-level
+/// repudiation) queries committed entries by this hash.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct MoteDefHash(pub Hash32);
+
+impl MoteDefHash {
+    /// Construct a `MoteDefHash` from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for MoteDefHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MoteDefHash({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+impl std::fmt::Display for MoteDefHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// The 32-byte identity of the actual upstream inputs a Mote consumes.
+///
+/// Derived from the `result_ref` content hashes of the Mote's committed parents
+/// (executor-owned derivation in P1.9). For zero-parent (entrypoint) Motes, it
+/// is the BLAKE3 of a per-run workflow-input seed; this crate stores the
+/// pre-computed bytes and never invents the derivation.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct InputDataId(pub Hash32);
+
+impl InputDataId {
+    /// Construct an `InputDataId` from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for InputDataId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InputDataId({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+/// The 32-byte hash of the compiled artifact backing a Mote's logic (its `logic_ref`).
+///
+/// The reproducible-build discipline (workspace-level, P1.1) ensures this hash is
+/// stable across machines and CI runs. Component of [`MoteDef::logic_ref`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct LogicRef(pub Hash32);
+
+impl LogicRef {
+    /// Construct a `LogicRef` from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for LogicRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LogicRef({})", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// The 32-byte hash of a Mote's system/prompt template.
+///
+/// A change in prompt template materially changes what the Mote commits; this
+/// hash is part of [`MoteDef`] so the change flows through `mote_def_hash`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PromptTemplateHash(pub Hash32);
+
+impl PromptTemplateHash {
+    /// Construct a `PromptTemplateHash` from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for PromptTemplateHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PromptTemplateHash({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Identifier newtypes (strings / bytes)
+// ---------------------------------------------------------------------------
+
+/// Pinned identity of an inference model, *inclusive of version and quantization*.
+///
+/// Workflow authors are responsible for packing version and quantization into
+/// this identifier — two models with the same name but different quantizations
+/// MUST produce different `ModelId`s, or behavior drifts silently across runs.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ModelId(pub String);
+
+/// The name of a tool a Mote may call. Paired with [`ToolVersion`] in
+/// [`MoteDef::tool_contract`].
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ToolName(pub String);
+
+/// The version of a tool a Mote may call. A version bump materially changes
+/// what a Mote commits and so changes its identity.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ToolVersion(pub String);
+
+/// A key in the curated `config_subset` allowlist of [`MoteDef`].
+///
+/// **Discipline (closes I2 from `02-improvement-areas.md`).** Only
+/// *behavior-affecting* keys belong here. Log-level, telemetry endpoints,
+/// worker thread count, and other operational knobs MUST be excluded —
+/// including them would re-fire the identity hash on operational tweaks
+/// without any change to what the Mote commits. Maintaining this allowlist
+/// is a deliberate, reviewed act; the workflow SDK (P4) will surface the
+/// review point.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ConfigKey(pub String);
+
+/// The byte-encoded value of a `config_subset` entry. Opaque to this crate;
+/// the workflow author decides the encoding (typically a serialized scalar
+/// or small struct). Bincode canonical-serializes the bytes verbatim.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ConfigVal(pub Vec<u8>);
+
+/// The stable position of a Mote in its DAG.
+///
+/// Assigned at DAG-compile time (workflow SDK) or derived from a topology
+/// shaper's `TopologyDecision` for shaper-spawned children (per `topology.md`
+/// §7 / D23: child positions extend the shaper's by appending the child's
+/// u32 index in `TopologyDecision.children`). Opaque bytes to this crate;
+/// participates in [`MoteId`] derivation alongside `mote_def_hash` and
+/// `input_data_id`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct GraphPosition(pub Vec<u8>);
+
+// ---------------------------------------------------------------------------
+// NdClass — the non-determinism tag (one knob, three jobs)
+// ---------------------------------------------------------------------------
+
+/// The non-determinism tag attached to every Mote.
+///
+/// One knob, three jobs (recovery, storage tiering, scheduling priority).
+/// See the private design corpus (`mote.md` §6 + D2) for the per-tag rules.
+/// Stable u8 representations are used in journal entry headers (PURE=0,
+/// READ-ONLY-NONDET=1, WORLD-MUTATING=2) — these MUST NOT change without
+/// a journal `schema_version` bump.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum NdClass {
+    /// Output is a mathematically-deterministic AND bit-stable function of inputs.
+    /// No side effects, no model sampling, no external calls. Safe to re-run.
+    /// Storage: droppable + recomputable under memory pressure.
+    Pure = 0,
+
+    /// Samples a non-deterministic source (model inference, RNG) but causes
+    /// **no external state change**. NEVER re-run once Committed; recovery
+    /// reads the committed result. Storage: always persisted.
+    ReadOnlyNondet = 1,
+
+    /// Causes external side effects (API call, write, message send) the runtime
+    /// cannot reverse or recompute. NEVER re-run once Committed; pre-commit
+    /// re-runs are safe only via [`EffectPattern::IdempotentByConstruction`] or
+    /// [`EffectPattern::ValidateThenCommit`]. Storage: always persisted.
+    /// Speculation forbidden by the executor.
+    WorldMutating = 2,
+}
+
+impl NdClass {
+    /// Convert to the canonical u8 representation for journal entry headers.
+    #[inline]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EffectPattern — which effect/commit pattern this Mote uses
+// ---------------------------------------------------------------------------
+
+/// Declares which of the three effect/commit patterns a Mote uses
+/// (`mote.md` §4, D20).
+///
+/// Read by the executor's submission-time refusal predicate
+/// (`validate-then-commit.md` §7) to enforce the safety contract: a
+/// WORLD-MUTATING Mote without an idempotency mechanism AND without a critic
+/// is refused at submission. The field is REQUIRED (not `Option`); workflow
+/// authors must declare a pattern explicitly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum EffectPattern {
+    /// The effect carries an idempotency mechanism the external system honors
+    /// (Stripe-style idempotency-key header, content-derived URL, deterministic
+    /// resource path, unique-constraint INSERT). Safe to retry.
+    IdempotentByConstruction,
+
+    /// The effect produces a payload; the executor stages the payload into the
+    /// content store and atomically commits the `result_ref`. Crashes before
+    /// the txn lands leave the staged payload orphaned (GC-able). Most natural
+    /// for pure-output WORLD-MUTATING work where the effect IS the payload.
+    StageThenCommit,
+
+    /// The effect proposes (writes to staging or makes a "draft" call); a
+    /// downstream critic Mote validates; only on a valid verdict does the
+    /// runtime promote to a committed effect. Full mechanics in
+    /// `validate-then-commit.md` (D20).
+    ValidateThenCommit,
+}
+
+// ---------------------------------------------------------------------------
+// Edges — typed dependencies between Motes
+// ---------------------------------------------------------------------------
+
+/// The type of a directed dependency edge between two Motes (`mote.md` §5, D6).
+///
+/// Stable u8 representations are used in journal `ParentEntry` encoding
+/// (Data=0, Control=1) — these MUST NOT change without a journal
+/// `schema_version` bump.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum EdgeKind {
+    /// A's `ContentRef` is in B's `input_data_id`. Repudiating A always cascades
+    /// to B (no opt-out — B read an invalidated input).
+    Data = 0,
+
+    /// A must be Committed before B runs, but A's output is not consumed by B.
+    /// Cascades by default (the asymmetry rule, D7); per-edge author-declared
+    /// causation-only opt-out via [`EdgeMeta::non_cascade`].
+    Control = 1,
+}
+
+impl EdgeKind {
+    /// Convert to the canonical u8 representation used by the journal.
+    #[inline]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Per-edge metadata attached to a dependency edge (`projection.md` §7;
+/// matches `journal-entry.md` §5 `ParentEntry`).
+///
+/// `non_cascade` is the per-edge author-declared causation-only opt-out, valid
+/// **only** when `kind == EdgeKind::Control`. The encoder for journal entries
+/// asserts `non_cascade == false` for Data edges (anti-pattern #6 in
+/// `journal-entry.md` §11) — this crate provides constructors that uphold the
+/// rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct EdgeMeta {
+    /// The kind of dependency this edge expresses.
+    pub kind: EdgeKind,
+    /// Whether this edge is exempt from the repudiation cascade. Only valid
+    /// when `kind == EdgeKind::Control`. Always `false` for Data edges.
+    pub non_cascade: bool,
+}
+
+impl EdgeMeta {
+    /// Construct a Data edge (always cascades).
+    #[inline]
+    #[must_use]
+    pub const fn data() -> Self {
+        Self {
+            kind: EdgeKind::Data,
+            non_cascade: false,
+        }
+    }
+
+    /// Construct a Control edge that cascades on repudiation (the default).
+    #[inline]
+    #[must_use]
+    pub const fn control() -> Self {
+        Self {
+            kind: EdgeKind::Control,
+            non_cascade: false,
+        }
+    }
+
+    /// Construct a Control edge with the per-edge non-cascade opt-out.
+    ///
+    /// Use this only when the workflow author has explicitly decided that
+    /// repudiating the parent should NOT invalidate the child — a real but
+    /// exceptional category (`mote.md` §5, D7). This is a reviewed act.
+    #[inline]
+    #[must_use]
+    pub const fn control_non_cascading() -> Self {
+        Self {
+            kind: EdgeKind::Control,
+            non_cascade: true,
+        }
+    }
+}
+
+/// A reference to a parent Mote within a [`Mote`]'s declared dependencies.
+///
+/// Mirrors the on-disk `ParentEntry` shape (`journal-entry.md` §5, D19) at
+/// the type level: a parent's `MoteId` plus its edge metadata. The journal
+/// entry's `parents` field is a `SmallVec<[ParentRef; 4]>` in code; the
+/// stack-inline storage covers the typical 0–4-parent case.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ParentRef {
+    /// The parent Mote's identity.
+    pub parent_id: MoteId,
+    /// The edge connecting this parent to the child.
+    pub edge: EdgeMeta,
+}
+
+// ---------------------------------------------------------------------------
+// MoteDef — the closed set of behavior-determining inputs
+// ---------------------------------------------------------------------------
+
+/// The current `MoteDef::schema_version`.
+///
+/// Bumped to **3** after the P0.6 addition of `is_topology_shaper`
+/// (and the prior P0.8 addition of `effect_pattern` + `critic_for` to v2).
+/// The schema version is the explicit forward-evolution mechanism: old-shape
+/// MoteDefs continue to hash and dedupe normally under their own
+/// schema_version; new-shape MoteDefs at v3 incorporate all fields.
+pub const MOTE_DEF_SCHEMA_VERSION: u16 = 3;
+
+/// The closed set of behavior-determining inputs that defines a Mote's *kind
+/// of work* (`idempotency.md` §"mote_def_hash", D4).
+///
+/// **The governing principle:** a Mote's definition changes when, and only
+/// when, any input that could change what it commits changes. Not source
+/// text (over-fires), not author-declared version (under-fires) — this
+/// closed set, hashed canonically.
+///
+/// **Canonical encoding.** Hashed via [`MoteDef::hash`], which serializes
+/// the struct with [`canonical_config`] (bincode v2 with little-endian,
+/// fixed-int encoding) and BLAKE3s the result. `BTreeMap` fields iterate in
+/// key order, giving canonical-by-construction stability across insertion
+/// order. The serialization configuration is shared with `JournalEntry`
+/// (`journal-entry.md` §2, D19) so a single primitive serves both surfaces.
+///
+/// **Deviation from `idempotency.md` literal text.** The spec types
+/// `tool_contract` as `Vec<(ToolName, ToolVersion)>`; this implementation
+/// uses `BTreeMap<ToolName, ToolVersion>` to make canonical iteration order
+/// a type-level guarantee. The semantic remains "the set of tools the Mote
+/// may call with their versions"; canonical hashing was always the intent.
+/// Recorded in the project deviation log.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MoteDef {
+    /// Hash of the compiled artifact backing this Mote's logic. The
+    /// reproducible-build discipline (P1.1) ensures stability across machines.
+    pub logic_ref: LogicRef,
+
+    /// Pinned model identity, inclusive of version and quantization.
+    pub model_id: ModelId,
+
+    /// Hash of the system/prompt template the Mote uses.
+    pub prompt_template_hash: PromptTemplateHash,
+
+    /// The closed set of tools the Mote may call, each at its pinned version.
+    /// Canonical order is guaranteed by `BTreeMap` iteration.
+    pub tool_contract: BTreeMap<ToolName, ToolVersion>,
+
+    /// The non-determinism tag — recovery semantics, storage tier, scheduling
+    /// priority all derive from this field.
+    pub nd_class: NdClass,
+
+    /// The curated allowlist of behavior-affecting configuration. ONLY keys
+    /// whose values change what the Mote commits. Operational keys (logging,
+    /// telemetry, thread count) MUST be excluded — see [`ConfigKey`] docs.
+    pub config_subset: BTreeMap<ConfigKey, ConfigVal>,
+
+    /// Which of the three effect/commit patterns this Mote uses. Required.
+    pub effect_pattern: EffectPattern,
+
+    /// If `Some(producer_mote_id)`, this Mote is a critic for that producer
+    /// (the `ValidateThenCommit` 3c pattern, D20). The projection's promotion
+    /// query reads this field via `is_critic_of`.
+    pub critic_for: Option<MoteId>,
+
+    /// If `true`, this Mote's `result_ref` payload IS a `TopologyDecision`
+    /// that the projection materializes children from on commit (D23).
+    /// Mutually exclusive with `critic_for == Some(_)` (executor refusal R-8).
+    pub is_topology_shaper: bool,
+
+    /// Schema version of the `MoteDef` itself. Bumped on any change to the
+    /// struct shape; see [`MOTE_DEF_SCHEMA_VERSION`].
+    pub schema_version: u16,
+}
+
+impl MoteDef {
+    /// Compute the canonical BLAKE3 hash of this `MoteDef`.
+    ///
+    /// Encoding pipeline (frozen):
+    /// 1. Serialize the struct with [`canonical_config`] (bincode v2,
+    ///    little-endian, fixed-int).
+    /// 2. BLAKE3-hash the resulting bytes → 32-byte [`MoteDefHash`].
+    ///
+    /// Two `MoteDef`s constructed with `BTreeMap` insertions in different
+    /// orders produce byte-identical encodings and so identical hashes.
+    /// Any change to a field that affects the encoding bytes (including
+    /// `schema_version`) re-derives the hash.
+    #[must_use]
+    pub fn hash(&self) -> MoteDefHash {
+        let bytes = bincode::serde::encode_to_vec(self, canonical_config())
+            .expect("MoteDef serialization is infallible (no floats, no non-encodable types)");
+        let digest = blake3::hash(&bytes);
+        MoteDefHash::from_bytes(*digest.as_bytes())
+    }
+}
+
+/// The canonical bincode configuration used to serialize types whose bytes
+/// participate in identity hashes or journal entries.
+///
+/// Frozen flags (per `journal-entry.md` §2, D19; matches `idempotency.md`
+/// §"Non-negotiable" #2):
+/// - Little-endian byte order.
+/// - Fixed-int encoding (no varint).
+/// - Length-prefixed strings (u64 prefix; follows from fixed-int).
+/// - No length limits at the encoder level (size caps enforced upstream).
+///
+/// Any change to these flags is a `schema_version` bump.
+#[must_use]
+pub fn canonical_config(
+) -> bincode::config::Configuration<bincode::config::LittleEndian, bincode::config::Fixint> {
+    bincode::config::standard()
+        .with_little_endian()
+        .with_fixed_int_encoding()
+}
+
+// ---------------------------------------------------------------------------
+// MoteId derivation
+// ---------------------------------------------------------------------------
+
+/// Derive a [`MoteId`] from its three identity components.
+///
+/// The formula (`idempotency.md` §"full key"):
+///
+/// ```text
+/// MoteId = blake3(mote_def_hash ‖ input_data_id ‖ graph_position)
+/// ```
+///
+/// `mote_def_hash` and `input_data_id` are fixed 32-byte values, so the
+/// concatenation boundary is unambiguous even with a variable-length
+/// `graph_position` suffix. The three components are kept separately
+/// queryable in the journal (D11) so the poison-cascade (D22) can answer
+/// queries like "every Mote sharing this `mote_def_hash` is now suspect"
+/// (`list_committed_by_mote_def_hash`, P1.4 R-E).
+#[must_use]
+pub fn derive_mote_id(
+    mote_def_hash: &MoteDefHash,
+    input_data_id: &InputDataId,
+    graph_position: &GraphPosition,
+) -> MoteId {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(mote_def_hash.as_bytes());
+    hasher.update(input_data_id.as_bytes());
+    hasher.update(&graph_position.0);
+    MoteId::from_bytes(*hasher.finalize().as_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Mote — the runtime-instance shape
+// ---------------------------------------------------------------------------
+
+/// A Mote instance: a `MoteDef` paired with the per-instance position data
+/// (`input_data_id`, `graph_position`) and declared parents, plus the
+/// computed [`MoteId`].
+///
+/// Construct via [`Mote::new`] to ensure `id` is derived correctly from the
+/// other fields. The `id` field is exposed for read access but not for
+/// independent mutation; any mutation of `def`, `input_data_id`, or
+/// `graph_position` invalidates `id` and must go through reconstruction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Mote {
+    /// The computed identity. Read-only after construction.
+    pub id: MoteId,
+    /// The behavior-determining inputs.
+    pub def: MoteDef,
+    /// The committed-input identity (executor-derived; opaque here).
+    pub input_data_id: InputDataId,
+    /// This Mote's stable position in the DAG.
+    pub graph_position: GraphPosition,
+    /// Declared parent edges. Up to 4 parents stack-inline; spillover heap-allocates.
+    pub parents: SmallVec<[ParentRef; 4]>,
+}
+
+impl Mote {
+    /// Build a `Mote`, computing the [`MoteId`] from its components.
+    ///
+    /// The constructor is the single entry point that guarantees `id`
+    /// matches the rest of the struct — direct struct literal construction
+    /// is supported by public fields, but callers are responsible for
+    /// maintaining the invariant if they go that route.
+    #[must_use]
+    pub fn new(
+        def: MoteDef,
+        input_data_id: InputDataId,
+        graph_position: GraphPosition,
+        parents: SmallVec<[ParentRef; 4]>,
+    ) -> Self {
+        let def_hash = def.hash();
+        let id = derive_mote_id(&def_hash, &input_data_id, &graph_position);
+        Self {
+            id,
+            def,
+            input_data_id,
+            graph_position,
+            parents,
+        }
+    }
+
+    /// The Mote's non-determinism tag (mirrors `def.nd_class` for fast access).
+    #[inline]
+    #[must_use]
+    pub const fn nd_class(&self) -> NdClass {
+        self.def.nd_class
+    }
+
+    /// The Mote's declared effect pattern.
+    #[inline]
+    #[must_use]
+    pub const fn effect_pattern(&self) -> EffectPattern {
+        self.def.effect_pattern
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle state machine (attempt-scoped, D3)
+// ---------------------------------------------------------------------------
+
+/// The per-attempt lifecycle state of a Mote (`mote.md` §7).
+///
+/// **Attempt-scoped, not Mote-scoped.** The Mote's *identity* (the [`MoteId`])
+/// may have many attempts in the journal — e.g., `Failed`, `Failed`,
+/// `Committed`. The journal records all attempts; the projection collapses
+/// them to a per-identity current state with the precedence rules in
+/// `projection.md` §4. This enum describes ONE attempt.
+///
+/// Stable u8 representations are not assigned here — `AttemptState` is an
+/// in-memory model only. The journal carries the *fact of an attempt's
+/// outcome* (`Proposed` / `Committed` / `Failed` / `Repudiated` entries),
+/// not the running state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum AttemptState {
+    /// The Mote exists in the DAG but the scheduler has not selected it.
+    Pending,
+    /// The scheduler has selected the Mote for placement; a `Proposed`
+    /// journal entry has been written.
+    Scheduled,
+    /// A worker has accepted the Mote and begun execution. **Not durable** —
+    /// "currently running" is an intent, tracked in worker memory only.
+    Running,
+    /// The atomic journal txn writing the `Committed` entry has landed.
+    Committed,
+    /// The attempt reached a terminal failure (typed error, retries
+    /// exhausted, validator rejection). A `Failed` journal entry has been
+    /// written. Future attempts under the same identity are independent.
+    Failed,
+    /// The committed result has been explicitly invalidated (operator action,
+    /// critic verdict, upstream cascade per D22). A `Repudiated` journal
+    /// entry referencing the original `Committed` has been written. Terminal
+    /// for this attempt; the log is append-only.
+    Repudiated,
+}
+
+/// An illegal-transition error from [`transition`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("illegal Mote attempt transition: {from:?} → {to:?}")]
+pub struct IllegalTransition {
+    /// The state the attempt was in.
+    pub from: AttemptState,
+    /// The state the caller attempted to move to.
+    pub to: AttemptState,
+}
+
+/// Validate a per-attempt lifecycle transition.
+///
+/// Returns `Ok(to)` if the transition is one of the five legal transitions
+/// (`Pending → Scheduled`, `Scheduled → Running`, `Running → Committed`,
+/// `Running → Failed`, `Committed → Repudiated`); otherwise returns
+/// [`IllegalTransition`]. Every other from→to pair in the 6×6 state matrix
+/// is illegal, including same-state self-loops, `Failed → *`, and
+/// `Repudiated → *` (both terminal).
+///
+/// This function is the single source of truth for the transition rules.
+/// `kx-executor` (P1.9) and `kx-coordinator` (P2.2) call it before writing
+/// any journal entry that would advance an attempt's state.
+pub fn transition(from: AttemptState, to: AttemptState) -> Result<AttemptState, IllegalTransition> {
+    use AttemptState::{Committed, Failed, Pending, Repudiated, Running, Scheduled};
+    let legal = matches!(
+        (from, to),
+        (Pending, Scheduled)
+            | (Scheduled, Running)
+            | (Running, Committed)
+            | (Running, Failed)
+            | (Committed, Repudiated)
+    );
+    if legal {
+        Ok(to)
+    } else {
+        Err(IllegalTransition { from, to })
+    }
+}
+
+/// All six [`AttemptState`] variants, for exhaustive iteration in tests and
+/// debug tools. Stable order; changes to this constant signal a schema-level
+/// adjustment.
+pub const ALL_ATTEMPT_STATES: [AttemptState; 6] = [
+    AttemptState::Pending,
+    AttemptState::Scheduled,
+    AttemptState::Running,
+    AttemptState::Committed,
+    AttemptState::Failed,
+    AttemptState::Repudiated,
+];
+
+/// Returns `true` for the five legal per-attempt transitions; `false`
+/// otherwise. Pure helper around [`transition`] for code paths that prefer a
+/// boolean check (e.g., precondition assertions in tests and debug panes).
+#[must_use]
+pub fn is_legal_transition(from: AttemptState, to: AttemptState) -> bool {
+    transition(from, to).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// MoteGraph — workflow-author-side container
+// ---------------------------------------------------------------------------
+
+/// A workflow-author-side container of Motes and their declared edges.
+///
+/// This is a *compile-time* shape — the structure a workflow author (or the
+/// P4 SDK) builds before any Mote runs. The runtime never reads this; at
+/// execution time the projection (P1.5) folds the journal log into the live
+/// graph view. This type exists so workflow code has a typed handle for
+/// composition and so unit tests have a convenient builder.
+///
+/// **Contains no traversal logic** — that lives in `kx-projection`. The
+/// shape is plain data: keyed nodes and adjacency lists.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MoteGraph {
+    /// All Motes in the graph, keyed by identity.
+    pub nodes: BTreeMap<MoteId, Mote>,
+    /// Adjacency: for each child, the list of declared parent edges.
+    /// Mirrors what lands in each Mote's `parents` field at commit time.
+    pub edges: BTreeMap<MoteId, SmallVec<[ParentRef; 4]>>,
+}
+
+impl MoteGraph {
+    /// Create an empty graph.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a Mote and its declared parents. Overwrites any existing entry
+    /// for the same `MoteId` (the caller is responsible for the uniqueness
+    /// guarantee at compose time; the journal enforces it at runtime via
+    /// dedupe-by-key).
+    pub fn insert(&mut self, mote: Mote) {
+        let id = mote.id;
+        self.edges.insert(id, mote.parents.clone());
+        self.nodes.insert(id, mote);
+    }
+
+    /// Number of Motes in the graph.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// `true` if the graph contains no Motes.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Borrow a Mote by identity.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, id: &MoteId) -> Option<&Mote> {
+        self.nodes.get(id)
+    }
+
+    /// Borrow the declared parent edges of a Mote.
+    #[inline]
+    #[must_use]
+    pub fn parents_of(&self, id: &MoteId) -> Option<&SmallVec<[ParentRef; 4]>> {
+        self.edges.get(id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_def() -> MoteDef {
+        MoteDef {
+            logic_ref: LogicRef::from_bytes([1u8; 32]),
+            model_id: ModelId("test-model:v1:q4".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([2u8; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::Pure,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        }
+    }
+
+    #[test]
+    fn nd_class_u8_repr_is_stable() {
+        assert_eq!(NdClass::Pure.as_u8(), 0);
+        assert_eq!(NdClass::ReadOnlyNondet.as_u8(), 1);
+        assert_eq!(NdClass::WorldMutating.as_u8(), 2);
+    }
+
+    #[test]
+    fn edge_kind_u8_repr_is_stable() {
+        assert_eq!(EdgeKind::Data.as_u8(), 0);
+        assert_eq!(EdgeKind::Control.as_u8(), 1);
+    }
+
+    #[test]
+    fn edge_meta_constructors_uphold_invariants() {
+        assert_eq!(
+            EdgeMeta::data(),
+            EdgeMeta {
+                kind: EdgeKind::Data,
+                non_cascade: false
+            }
+        );
+        assert_eq!(
+            EdgeMeta::control(),
+            EdgeMeta {
+                kind: EdgeKind::Control,
+                non_cascade: false
+            }
+        );
+        assert_eq!(
+            EdgeMeta::control_non_cascading(),
+            EdgeMeta {
+                kind: EdgeKind::Control,
+                non_cascade: true
+            }
+        );
+    }
+
+    #[test]
+    fn mote_def_hash_is_deterministic_across_calls() {
+        let def = sample_def();
+        let h1 = def.hash();
+        let h2 = def.hash();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn schema_version_is_v3() {
+        assert_eq!(MOTE_DEF_SCHEMA_VERSION, 3);
+        assert_eq!(sample_def().schema_version, 3);
+    }
+
+    #[test]
+    fn derive_mote_id_is_pure() {
+        let def_hash = MoteDefHash::from_bytes([7u8; 32]);
+        let input = InputDataId::from_bytes([8u8; 32]);
+        let pos = GraphPosition(vec![9, 9, 9]);
+        let a = derive_mote_id(&def_hash, &input, &pos);
+        let b = derive_mote_id(&def_hash, &input, &pos);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn derive_mote_id_differs_on_any_component_change() {
+        let def_hash = MoteDefHash::from_bytes([7u8; 32]);
+        let input = InputDataId::from_bytes([8u8; 32]);
+        let pos = GraphPosition(vec![9, 9, 9]);
+        let base = derive_mote_id(&def_hash, &input, &pos);
+
+        let diff_def = derive_mote_id(&MoteDefHash::from_bytes([6u8; 32]), &input, &pos);
+        let diff_input = derive_mote_id(&def_hash, &InputDataId::from_bytes([9u8; 32]), &pos);
+        let diff_pos = derive_mote_id(&def_hash, &input, &GraphPosition(vec![1]));
+
+        assert_ne!(base, diff_def);
+        assert_ne!(base, diff_input);
+        assert_ne!(base, diff_pos);
+        assert_ne!(diff_def, diff_input);
+    }
+
+    #[test]
+    fn mote_id_display_is_64_hex_chars() {
+        let id = MoteId::from_bytes([0xab; 32]);
+        let s = format!("{id}");
+        assert_eq!(s.len(), 64);
+        assert!(s.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn legal_transitions_are_accepted() {
+        use AttemptState::*;
+        assert!(transition(Pending, Scheduled).is_ok());
+        assert!(transition(Scheduled, Running).is_ok());
+        assert!(transition(Running, Committed).is_ok());
+        assert!(transition(Running, Failed).is_ok());
+        assert!(transition(Committed, Repudiated).is_ok());
+    }
+
+    #[test]
+    fn exhaustive_transition_matrix() {
+        use AttemptState::*;
+        let legal: std::collections::HashSet<(AttemptState, AttemptState)> = [
+            (Pending, Scheduled),
+            (Scheduled, Running),
+            (Running, Committed),
+            (Running, Failed),
+            (Committed, Repudiated),
+        ]
+        .into_iter()
+        .collect();
+
+        let mut legal_count = 0usize;
+        let mut illegal_count = 0usize;
+        for &from in &ALL_ATTEMPT_STATES {
+            for &to in &ALL_ATTEMPT_STATES {
+                let result = transition(from, to);
+                if legal.contains(&(from, to)) {
+                    assert!(
+                        result.is_ok(),
+                        "expected legal transition: {from:?} → {to:?}"
+                    );
+                    legal_count += 1;
+                } else {
+                    assert!(
+                        result.is_err(),
+                        "expected illegal transition: {from:?} → {to:?}"
+                    );
+                    illegal_count += 1;
+                }
+            }
+        }
+        assert_eq!(legal_count, 5);
+        assert_eq!(illegal_count, 36 - 5);
+    }
+
+    #[test]
+    fn failed_is_terminal() {
+        use AttemptState::*;
+        for &to in &ALL_ATTEMPT_STATES {
+            assert!(
+                transition(Failed, to).is_err(),
+                "Failed → {to:?} must be illegal (terminal)"
+            );
+        }
+    }
+
+    #[test]
+    fn repudiated_is_terminal() {
+        use AttemptState::*;
+        for &to in &ALL_ATTEMPT_STATES {
+            assert!(
+                transition(Repudiated, to).is_err(),
+                "Repudiated → {to:?} must be illegal (terminal)"
+            );
+        }
+    }
+
+    #[test]
+    fn self_loops_are_illegal() {
+        for &s in &ALL_ATTEMPT_STATES {
+            assert!(
+                transition(s, s).is_err(),
+                "{s:?} → {s:?} must be illegal (no self-loops)"
+            );
+        }
+    }
+
+    #[test]
+    fn committed_does_not_demote_to_failed() {
+        use AttemptState::*;
+        assert!(transition(Committed, Failed).is_err());
+    }
+
+    #[test]
+    fn mote_new_derives_id_correctly() {
+        let def = sample_def();
+        let input = InputDataId::from_bytes([5u8; 32]);
+        let pos = GraphPosition(vec![1, 2, 3]);
+        let mote = Mote::new(def.clone(), input, pos.clone(), SmallVec::new());
+        let expected = derive_mote_id(&def.hash(), &input, &pos);
+        assert_eq!(mote.id, expected);
+    }
+
+    #[test]
+    fn mote_graph_round_trips_a_single_mote() {
+        let def = sample_def();
+        let mote = Mote::new(
+            def,
+            InputDataId::from_bytes([0u8; 32]),
+            GraphPosition::default(),
+            SmallVec::new(),
+        );
+        let id = mote.id;
+        let mut g = MoteGraph::new();
+        g.insert(mote.clone());
+        assert_eq!(g.len(), 1);
+        assert!(!g.is_empty());
+        assert_eq!(g.get(&id), Some(&mote));
+        assert_eq!(g.parents_of(&id).map(|v| v.len()), Some(0));
+    }
+
+    #[test]
+    fn illegal_transition_error_carries_states() {
+        use AttemptState::*;
+        let err = transition(Pending, Committed).unwrap_err();
+        assert_eq!(err.from, Pending);
+        assert_eq!(err.to, Committed);
+        let s = format!("{err}");
+        assert!(s.contains("Pending"));
+        assert!(s.contains("Committed"));
+    }
+}

--- a/kx-mote/tests/identity.rs
+++ b/kx-mote/tests/identity.rs
@@ -1,0 +1,306 @@
+//! P1.2 identity-derivation tests.
+//!
+//! Two-pronged coverage per the `idempotency.md` test obligations:
+//!
+//! - **Insensitivity to non-behavioral change**: reordering `BTreeMap` insertions
+//!   (`config_subset`, `tool_contract`) must not change the canonical bytes or
+//!   the resulting `MoteDefHash` / `MoteId`.
+//! - **Sensitivity to behavioral change**: changing any field that affects what
+//!   the Mote commits must change the canonical bytes and so the hash.
+//!
+//! Determinism is property-tested via `proptest` so the guarantee holds across
+//! the entire input space, not just a few hand-picked cases.
+
+use std::collections::BTreeMap;
+
+use kx_mote::{
+    canonical_config, derive_mote_id, ConfigKey, ConfigVal, EffectPattern, GraphPosition,
+    InputDataId, LogicRef, ModelId, MoteDef, MoteDefHash, NdClass, PromptTemplateHash, ToolName,
+    ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn base_def() -> MoteDef {
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([0xaa; 32]),
+        model_id: ModelId("claude-opus-4-7:1m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([0xbb; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Insensitivity to non-behavioral change
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_subset_insertion_order_does_not_affect_hash() {
+    let mut a = base_def();
+    a.config_subset
+        .insert(ConfigKey("temperature".into()), ConfigVal(vec![0]));
+    a.config_subset
+        .insert(ConfigKey("max_tokens".into()), ConfigVal(vec![100]));
+    a.config_subset
+        .insert(ConfigKey("seed".into()), ConfigVal(vec![42]));
+
+    let mut b = base_def();
+    b.config_subset
+        .insert(ConfigKey("seed".into()), ConfigVal(vec![42]));
+    b.config_subset
+        .insert(ConfigKey("max_tokens".into()), ConfigVal(vec![100]));
+    b.config_subset
+        .insert(ConfigKey("temperature".into()), ConfigVal(vec![0]));
+
+    assert_eq!(a.hash(), b.hash());
+
+    let bytes_a = bincode::serde::encode_to_vec(&a, canonical_config()).unwrap();
+    let bytes_b = bincode::serde::encode_to_vec(&b, canonical_config()).unwrap();
+    assert_eq!(bytes_a, bytes_b);
+}
+
+#[test]
+fn tool_contract_insertion_order_does_not_affect_hash() {
+    let mut a = base_def();
+    a.tool_contract
+        .insert(ToolName("stripe".into()), ToolVersion("v2".into()));
+    a.tool_contract
+        .insert(ToolName("filesystem".into()), ToolVersion("v1".into()));
+    a.tool_contract
+        .insert(ToolName("github".into()), ToolVersion("v3".into()));
+
+    let mut b = base_def();
+    b.tool_contract
+        .insert(ToolName("github".into()), ToolVersion("v3".into()));
+    b.tool_contract
+        .insert(ToolName("stripe".into()), ToolVersion("v2".into()));
+    b.tool_contract
+        .insert(ToolName("filesystem".into()), ToolVersion("v1".into()));
+
+    assert_eq!(a.hash(), b.hash());
+}
+
+// ---------------------------------------------------------------------------
+// Sensitivity to behavioral change (per `idempotency.md` test obligations)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn changing_logic_ref_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.logic_ref = LogicRef::from_bytes([0xab; 32]);
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_model_id_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.model_id = ModelId("claude-sonnet-4-6".into());
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_prompt_template_hash_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.prompt_template_hash = PromptTemplateHash::from_bytes([0xbc; 32]);
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_a_tool_version_changes_hash() {
+    let mut a = base_def();
+    a.tool_contract
+        .insert(ToolName("stripe".into()), ToolVersion("v2".into()));
+    let mut b = base_def();
+    b.tool_contract
+        .insert(ToolName("stripe".into()), ToolVersion("v3".into()));
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_nd_class_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.nd_class = NdClass::WorldMutating;
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_an_included_config_key_changes_hash() {
+    let mut a = base_def();
+    a.config_subset
+        .insert(ConfigKey("temperature".into()), ConfigVal(vec![0]));
+    let mut b = base_def();
+    b.config_subset
+        .insert(ConfigKey("temperature".into()), ConfigVal(vec![1]));
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_effect_pattern_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.effect_pattern = EffectPattern::ValidateThenCommit;
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_critic_for_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.critic_for = Some(kx_mote::MoteId::from_bytes([1u8; 32]));
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_is_topology_shaper_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.is_topology_shaper = true;
+    assert_ne!(a.hash(), b.hash());
+}
+
+#[test]
+fn changing_schema_version_changes_hash() {
+    let a = base_def();
+    let mut b = base_def();
+    b.schema_version = MOTE_DEF_SCHEMA_VERSION.saturating_sub(1);
+    assert_ne!(a.hash(), b.hash());
+}
+
+// ---------------------------------------------------------------------------
+// MoteId composition: any component change → different id
+// ---------------------------------------------------------------------------
+
+#[test]
+fn entrypoint_motes_with_same_seed_collide_only_when_def_and_position_match() {
+    // Two entrypoint Motes in the same run with the SAME workflow-input seed,
+    // the SAME MoteDef, and the SAME graph_position derive the same MoteId.
+    // Distinct graph_positions diverge them, even though the seed matches.
+    let def_hash = MoteDefHash::from_bytes([0x55; 32]);
+    let seed = InputDataId::from_bytes([0x11; 32]);
+    let pos_a = GraphPosition(b"root/a".to_vec());
+    let pos_b = GraphPosition(b"root/b".to_vec());
+
+    let id_a = derive_mote_id(&def_hash, &seed, &pos_a);
+    let id_b = derive_mote_id(&def_hash, &seed, &pos_b);
+    let id_a2 = derive_mote_id(&def_hash, &seed, &pos_a);
+
+    assert_ne!(id_a, id_b, "different graph_position must diverge");
+    assert_eq!(
+        id_a, id_a2,
+        "identical components must produce identical id"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Canonical encoding: byte-determinism property tests
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Two `MoteDef`s identical in every behavioral field, regardless of how
+    /// their `config_subset` was inserted, serialize to byte-identical output.
+    /// This is the workhorse property: it covers an unbounded space of
+    /// insertion orderings against a single sorted canonical form.
+    ///
+    /// Input is generated as a `BTreeMap` so keys are unique-by-construction;
+    /// otherwise duplicate-key entries would produce different final maps in
+    /// forward vs reverse insertion order (the LAST insertion wins) — that is
+    /// a property of `BTreeMap::insert`, not a hash-stability issue.
+    #[test]
+    fn config_subset_canonical_bytes_invariant_under_permutation(
+        // 0–6 unique-key entries, ASCII to keep proptest output legible.
+        entries in prop::collection::btree_map(
+            r"[a-z_][a-z0-9_]{0,8}",
+            prop::collection::vec(any::<u8>(), 0..8),
+            0..6,
+        ),
+    ) {
+        // Insert the same unique-key entries in two opposite orders. With
+        // unique keys, forward and reverse produce the same final BTreeMap.
+        let pairs: Vec<_> = entries.into_iter().collect();
+        let mut forward = BTreeMap::new();
+        for (k, v) in pairs.iter() {
+            forward.insert(ConfigKey(k.clone()), ConfigVal(v.clone()));
+        }
+        let mut reverse = BTreeMap::new();
+        for (k, v) in pairs.iter().rev() {
+            reverse.insert(ConfigKey(k.clone()), ConfigVal(v.clone()));
+        }
+
+        let mut a = base_def();
+        a.config_subset = forward;
+        let mut b = base_def();
+        b.config_subset = reverse;
+
+        let bytes_a = bincode::serde::encode_to_vec(&a, canonical_config()).unwrap();
+        let bytes_b = bincode::serde::encode_to_vec(&b, canonical_config()).unwrap();
+        prop_assert_eq!(bytes_a, bytes_b);
+        prop_assert_eq!(a.hash(), b.hash());
+    }
+
+    /// Encoding is total (never panics, never errors) across arbitrary
+    /// MoteDef payloads — including empty maps, large hash bytes, and any
+    /// schema_version. The hash is a pure function of the bytes.
+    #[test]
+    fn mote_def_hash_is_total_and_pure(
+        logic in any::<[u8; 32]>(),
+        model in r"[a-z_][a-z0-9_:.-]{0,32}",
+        nd in 0u8..3,
+        eff in 0u8..3,
+        shaper in any::<bool>(),
+        version in any::<u16>(),
+    ) {
+        let mut d = base_def();
+        d.logic_ref = LogicRef::from_bytes(logic);
+        d.model_id = ModelId(model);
+        d.nd_class = match nd {
+            0 => NdClass::Pure,
+            1 => NdClass::ReadOnlyNondet,
+            _ => NdClass::WorldMutating,
+        };
+        d.effect_pattern = match eff {
+            0 => EffectPattern::IdempotentByConstruction,
+            1 => EffectPattern::StageThenCommit,
+            _ => EffectPattern::ValidateThenCommit,
+        };
+        d.is_topology_shaper = shaper;
+        d.schema_version = version;
+
+        let h1 = d.hash();
+        let h2 = d.hash();
+        prop_assert_eq!(h1, h2);
+
+        // The bytes that produced the hash must round-trip the same way.
+        let bytes_a = bincode::serde::encode_to_vec(&d, canonical_config()).unwrap();
+        let bytes_b = bincode::serde::encode_to_vec(&d, canonical_config()).unwrap();
+        prop_assert_eq!(bytes_a, bytes_b);
+    }
+
+    /// `derive_mote_id` is a deterministic pure function across its entire
+    /// 32+32+variable-length input space.
+    #[test]
+    fn derive_mote_id_is_deterministic(
+        def_hash in any::<[u8; 32]>(),
+        input in any::<[u8; 32]>(),
+        pos in prop::collection::vec(any::<u8>(), 0..32),
+    ) {
+        let dh = MoteDefHash::from_bytes(def_hash);
+        let id = InputDataId::from_bytes(input);
+        let gp = GraphPosition(pos);
+        let a = derive_mote_id(&dh, &id, &gp);
+        let b = derive_mote_id(&dh, &id, &gp);
+        prop_assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

Fill the `kx-mote` crate from a P1.1 seed into the runtime's *narrow waist* — the pure-types crate every downstream kortecx crate will import.

- **Identity:** `MoteId`, `MoteDef`, `derive_mote_id`, `canonical_config` (frozen bincode v2: little-endian + fixed-int). Shared encoding primitive for `MoteDef` hashing and the upcoming `JournalEntry` layer.
- **Types:** `NdClass` / `EffectPattern` / `EdgeKind` / `EdgeMeta` / `ParentRef`. Stable `#[repr(u8)]` representations where the journal will need them. `EdgeMeta` constructors uphold the "Data edges never non-cascade" rule by construction.
- **Lifecycle:** attempt-scoped `AttemptState` (6 variants) + `transition()` enforcing exactly the 5 legal transitions.
- **MoteGraph:** a workflow-author-side container with no traversal logic (that lives in the future `kx-projection` crate).

Pure-types crate. Zero I/O, zero async, zero runtime dependencies (only `blake3`, `bincode`, `serde`, `smallvec`, `thiserror`).

## What's new in this PR vs P1.1

- Workspace deps: enabled `serde` feature on `bincode` and `smallvec`; added `proptest` to workspace deps.
- `.gitignore`: exclude `**/*.proptest-regressions` (auto-generated proptest cache).
- `kx-mote/Cargo.toml`: real deps replacing the seed's empty list.
- `kx-mote/src/lib.rs`: ~1000 lines including unit tests.
- `kx-mote/tests/identity.rs`: ~270 lines of insensitivity + sensitivity + proptest property coverage.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 34/34 pass (17 unit + 16 identity-suite + 1 smoke)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` — clean
- [x] **I1.c byte-determinism:** two consecutive `cargo clean && cargo build --release` produce bit-identical `libkx_mote.rlib`. SHA-256 `db8e32eda43ddd037908f7a352571043325a0e0b230267e457104f602a673eb5`.
- [ ] CI green on this PR.

## Test coverage highlights

- **Exhaustive 6×6 transition matrix:** all 36 cells of the state machine verified (5 legal + 31 illegal).
- **Terminal states explicit:** `Failed → *` and `Repudiated → *` are all rejected; self-loops rejected; `Committed → Failed` rejected.
- **Per-field hash sensitivity:** changing any of the 10 `MoteDef` fields produces a different hash.
- **BTreeMap insertion-order insensitivity:** `config_subset` and `tool_contract` hash the same regardless of insertion order.
- **Property tests (proptest):** canonical bytes are invariant under permutation; `MoteDef::hash` is total/pure across the input space; `derive_mote_id` is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)