### PR TITLE
P1.3: kx-content — content-addressed payload store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +195,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -232,6 +291,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kx-content"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "bytes",
+ "kx-mote",
+ "rkyv",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-mote"
 version = "0.0.1"
 dependencies = [
@@ -289,6 +375,26 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -368,6 +474,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +519,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -450,6 +585,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +635,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -539,6 +719,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +791,21 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tracing"
@@ -686,6 +893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +939,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote"]
+members = ["kx-mote", "kx-content"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -20,6 +20,9 @@ bytes              = "1"
 smallvec           = { version = "1", features = ["serde"] }
 serde              = { version = "1", features = ["derive"] }
 proptest           = "1"
+tempfile           = "3"
+rkyv               = "0.8"
+kx-mote            = { path = "kx-mote" }
 
 [profile.release]
 strip         = "symbols"

--- a/kx-content/Cargo.toml
+++ b/kx-content/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name         = "kx-content"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx content store — content-addressed payload storage behind a backend-agnostic trait."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+blake3    = { workspace = true }
+bytes     = { workspace = true }
+kx-mote   = { workspace = true }
+serde     = { workspace = true }
+tempfile  = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rkyv               = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-content/src/in_memory.rs
+++ b/kx-content/src/in_memory.rs
@@ -1,0 +1,87 @@
+//! An in-memory [`ContentStore`] backend.
+//!
+//! Exists for two reasons:
+//!
+//! 1. **Trait-seam proof.** A second backend with a different storage substrate proves the
+//!    [`ContentStore`] trait carries no in-process-filesystem assumption in its signature.
+//!    This is the lightweight version of test obligation #6 from `content-store.md` §10
+//!    ("a fake/in-memory backend compiles against the trait with no in-process-specific
+//!    signature dependencies").
+//! 2. **Cheap, deterministic fixtures for downstream tests.** The journal (P1.4),
+//!    projection (P1.5), and executor (P1.9) test suites can use this backend without
+//!    touching the filesystem.
+//!
+//! **Not for production.** No durability, no persistence across process restarts, no
+//! retention discipline. Use [`crate::LocalFsContentStore`] or a future cloud impl in any
+//! deployment.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use bytes::Bytes;
+
+use crate::{ContentRef, ContentStore, NotFound, StoreError};
+
+/// An ephemeral, process-local [`ContentStore`]. Backed by a [`HashMap<ContentRef, Bytes>`]
+/// under a [`RwLock`]; supports multiple readers and one writer.
+#[derive(Debug, Default)]
+pub struct InMemoryContentStore {
+    objects: RwLock<HashMap<ContentRef, Bytes>>,
+}
+
+impl InMemoryContentStore {
+    /// Construct an empty store.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of distinct refs currently stored. Useful for asserting dedup in tests.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.objects.read().expect("poisoned lock").len()
+    }
+
+    /// `true` when the store has no objects.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl ContentStore for InMemoryContentStore {
+    type Payload = Bytes;
+
+    fn put(&self, bytes: &[u8]) -> Result<ContentRef, StoreError> {
+        let r = ContentRef::of(bytes);
+        let mut guard = self.objects.write().expect("poisoned lock");
+        // Idempotent: identical bytes share one entry.
+        guard
+            .entry(r)
+            .or_insert_with(|| Bytes::copy_from_slice(bytes));
+        Ok(r)
+    }
+
+    fn get(&self, r: &ContentRef) -> Result<Self::Payload, NotFound> {
+        let guard = self.objects.read().expect("poisoned lock");
+        guard.get(r).cloned().ok_or(NotFound)
+    }
+
+    fn delete(&self, r: &ContentRef) -> Result<(), StoreError> {
+        let mut guard = self.objects.write().expect("poisoned lock");
+        guard.remove(r);
+        Ok(())
+    }
+
+    fn list_refs<'a>(&'a self) -> Box<dyn Iterator<Item = ContentRef> + 'a> {
+        let guard = self.objects.read().expect("poisoned lock");
+        let refs: Vec<ContentRef> = guard.keys().copied().collect();
+        Box::new(refs.into_iter())
+    }
+
+    fn contains(&self, r: &ContentRef) -> bool {
+        let guard = self.objects.read().expect("poisoned lock");
+        guard.contains_key(r)
+    }
+}

--- a/kx-content/src/lib.rs
+++ b/kx-content/src/lib.rs
@@ -1,0 +1,201 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+//! # kx-content — content-addressed payload store
+//!
+//! Stores large payloads (inference outputs, staged effects, topology decisions) keyed by
+//! BLAKE3 content hash. The journal layer holds only 32-byte [`ContentRef`] values; the
+//! payloads themselves live here.
+//!
+//! ## Why content-addressing
+//!
+//! - **Auto-dedup**: two callers writing identical bytes produce identical refs and share one
+//!   underlying object. The runtime relies on this when two workers race on a Mote.
+//! - **Atomic-per-object writes**: either the object at `name = blake3(bytes)` exists with
+//!   exactly those bytes, or it does not exist. Partial writes are never observable. The
+//!   local-FS backend gets this via write-to-temp + atomic rename; an S3 backend would use
+//!   native atomic PUT.
+//! - **Structural idempotence**: writing the same bytes twice is a no-op on the second call.
+//! - **No in-band rollback**: a writer that crashes between [`ContentStore::put`] and the
+//!   journal txn that anchors the ref leaves an orphan — reclaimed later by an out-of-band
+//!   GC walker. The store itself has no rollback path.
+//!
+//! ## Trait surface is backend-agnostic
+//!
+//! The [`ContentStore`] trait does not name `bytes::Bytes` or `rkyv` — those are
+//! impl-ergonomics for the local-FS backend, not contract requirements. A future replicated /
+//! S3 backend implements the same trait with its own [`ContentStore::Payload`] type. This is
+//! what makes the OSS-vs-cloud split a feature flag rather than a fork.
+//!
+//! ## What lives here
+//!
+//! - [`ContentRef`] — 32-byte BLAKE3 hash newtype, opaque outside the store.
+//! - [`ContentStore`] — the backend-agnostic trait.
+//! - [`LocalFsContentStore`] — the OSS local-filesystem backend with `bytes::Bytes`
+//!   zero-copy reads and POSIX-rename atomicity.
+//! - [`InMemoryContentStore`] — an in-memory backend used in tests and as proof that the
+//!   trait is genuinely backend-agnostic (no in-process or filesystem assumptions in the
+//!   trait signature).
+//!
+//! ## What does NOT live here
+//!
+//! - The journal (`kx-journal`, P1.4) — content store must NOT depend on the journal; the
+//!   orphan-GC walker lives outside both crates and joins their views.
+//! - Tag-driven storage tiering (P1.12) — the store is tag-blind. The tiering pass joins the
+//!   journal's per-Mote `NdClass` with the store's enumeration to decide what to evict.
+//! - Streaming reads (post-P1) — [`ContentStore::get`] returns the full payload.
+
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::in_memory::InMemoryContentStore;
+pub use crate::local_fs::LocalFsContentStore;
+
+mod in_memory;
+mod local_fs;
+
+// ---------------------------------------------------------------------------
+// ContentRef — the opaque 32-byte content hash
+// ---------------------------------------------------------------------------
+
+/// A 32-byte BLAKE3 content hash. The identity of a payload in the store.
+///
+/// `ContentRef`s are opaque outside the store. Callers (journal, projection, executor)
+/// compare them as 32-byte tokens; they do not parse subfields, derive paths, or assume any
+/// prefix structure. Sharding by hash prefix is a backend-internal optimization, never a
+/// caller concern.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ContentRef(pub [u8; 32]);
+
+impl ContentRef {
+    /// Construct a `ContentRef` from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Compute the `ContentRef` of an arbitrary byte slice without writing it to a store.
+    ///
+    /// Useful for callers that want to know the ref of bytes they have not yet uploaded
+    /// (e.g., precomputing an idempotency key derived from a payload that will be staged
+    /// later). The store's [`ContentStore::put`] implementation MUST yield the same ref for
+    /// the same bytes.
+    #[inline]
+    #[must_use]
+    pub fn of(bytes: &[u8]) -> Self {
+        Self(*blake3::hash(bytes).as_bytes())
+    }
+
+    /// Lowercase 64-character hex of the underlying hash. Suitable for use as a
+    /// filesystem-safe object name.
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for ContentRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ContentRef({})", self.to_hex())
+    }
+}
+
+impl std::fmt::Display for ContentRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// A read for a `ContentRef` that the store does not have.
+///
+/// Distinct from [`StoreError`] because `NotFound` is a *normal* outcome — a PURE payload
+/// may have been evicted by the tiering pass (`mote.md` §6) and recomputing is the expected
+/// recovery. The caller decides whether to recompute, fail the workflow, or escalate to ops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("content ref not found in store")]
+pub struct NotFound;
+
+/// Errors raised by mutating store operations.
+///
+/// Reads use [`NotFound`] as a non-fatal signal; mutating operations return this richer
+/// error type for genuine I/O / filesystem failures.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// An I/O error from the backend (filesystem, network, etc.).
+    #[error("backend I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The backend wrote bytes whose BLAKE3 hash does not match the requested ref. Indicates
+    /// data corruption mid-write; should not happen with the content-addressed naming
+    /// discipline but is checked for defensively (the asymmetry rule: refuse loudly).
+    #[error("content hash mismatch: wrote bytes whose blake3 != target ref")]
+    HashMismatch,
+}
+
+// ---------------------------------------------------------------------------
+// The trait — backend-agnostic surface
+// ---------------------------------------------------------------------------
+
+/// The content-addressed payload store.
+///
+/// Implementors choose their own `Payload` deref-target (e.g., `bytes::Bytes` for the local
+/// backend; a streaming-bytes wrapper for a future remote backend). The trait does not name
+/// any in-process-specific type — that is what keeps the OSS and cloud impls behind one
+/// signature.
+///
+/// ## Contracts
+///
+/// - [`ContentStore::put`] is atomic-per-object: a successful return means the bytes are
+///   durably present at the returned ref; a failure means no object at that ref exists.
+///   Partial writes are not observable.
+/// - [`ContentStore::put`] is idempotent: writing identical bytes twice yields identical
+///   refs and stores one underlying object.
+/// - [`ContentStore::get`] returns [`NotFound`] for refs that were never written OR for
+///   refs whose backing object was evicted (by tiering or by GC). Callers MUST be ready to
+///   handle the same `NotFound` either way.
+/// - [`ContentStore::delete`] is idempotent: deleting a non-existent ref is a no-op success.
+pub trait ContentStore {
+    /// The owned-or-borrowed bytes type returned by [`ContentStore::get`]. Implementors
+    /// choose; callers see only the `Deref<Target = [u8]>` view.
+    type Payload: Deref<Target = [u8]>;
+
+    /// Write `bytes` to the store, returning the resulting [`ContentRef`].
+    ///
+    /// Atomic-per-object: either the object at the returned ref exists with exactly `bytes`,
+    /// or the call returns an error and the object does not exist. Idempotent on the bytes:
+    /// a second call with identical bytes is a no-op that returns the same ref.
+    fn put(&self, bytes: &[u8]) -> Result<ContentRef, StoreError>;
+
+    /// Read the payload at `r`. Returns [`NotFound`] if the ref is unknown or its backing
+    /// object has been reclaimed.
+    fn get(&self, r: &ContentRef) -> Result<Self::Payload, NotFound>;
+
+    /// Delete the object at `r`, if present. Idempotent: deleting an absent ref is a no-op
+    /// success. The orphan-GC walker (out-of-band) and the tiering pass (P1.12) both call
+    /// this; the store does not distinguish.
+    fn delete(&self, r: &ContentRef) -> Result<(), StoreError>;
+
+    /// Enumerate every ref currently present in the store.
+    ///
+    /// Used by the orphan-GC walker (joined against the journal's `list_committed_refs`)
+    /// and by the tiering pass. Implementors return a boxed iterator; callers do not assume
+    /// any particular order.
+    fn list_refs<'a>(&'a self) -> Box<dyn Iterator<Item = ContentRef> + 'a>;
+
+    /// `true` if the store currently has an object at `r`. Convenience over `get(r).is_ok()`
+    /// that lets the backend skip materializing the payload.
+    fn contains(&self, r: &ContentRef) -> bool;
+}

--- a/kx-content/src/local_fs.rs
+++ b/kx-content/src/local_fs.rs
@@ -1,0 +1,167 @@
+//! The local-filesystem [`ContentStore`] backend.
+//!
+//! Atomicity: write-to-temp + POSIX atomic rename. The temp file lives in the same directory
+//! as its final destination so the rename is filesystem-local and atomic per POSIX. A writer
+//! that dies between the temp-file creation and the rename leaves the temp file behind — it
+//! is reclaimed by the operating-system temp-file cleanup or by an explicit retention pass;
+//! it never appears at the target ref because the rename never happened.
+//!
+//! Zero-copy reads: this backend reads the file's bytes into a [`bytes::Bytes`] buffer. The
+//! `Bytes` wrapper enables zero-copy slicing and reference-counted sharing for downstream
+//! consumers. (True mmap-based zero-copy from disk is a future enhancement that would require
+//! the `memmap2` crate; the v0.1 implementation reads through a single `Vec<u8>` allocation.)
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+
+use crate::{ContentRef, ContentStore, NotFound, StoreError};
+
+/// A [`ContentStore`] backed by a single local filesystem directory.
+///
+/// Each object is a regular file at `root/<hex_hash>`, where the hex_hash is the lowercase
+/// 64-character hex encoding of the BLAKE3 hash of the file's bytes (per
+/// [`ContentRef::to_hex`]). The directory contains no other files; an enumeration scan
+/// parses each filename back into a [`ContentRef`].
+///
+/// Construction creates the root directory if it doesn't exist; failures bubble up via
+/// [`StoreError::Io`].
+#[derive(Debug, Clone)]
+pub struct LocalFsContentStore {
+    root: PathBuf,
+}
+
+impl LocalFsContentStore {
+    /// Open or create a `LocalFsContentStore` rooted at `root`.
+    ///
+    /// If the directory does not exist it is created. If `root` exists but is not a
+    /// directory, an [`StoreError::Io`] is returned.
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self, StoreError> {
+        let root = root.into();
+        fs::create_dir_all(&root)?;
+        let metadata = fs::metadata(&root)?;
+        if !metadata.is_dir() {
+            return Err(StoreError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotADirectory,
+                format!("content store root {root:?} is not a directory"),
+            )));
+        }
+        Ok(Self { root })
+    }
+
+    /// Borrow the root directory path. Useful for diagnostics; callers should not derive
+    /// file paths from this for direct manipulation.
+    #[inline]
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Compute the on-disk path for a given ref.
+    fn path_for(&self, r: &ContentRef) -> PathBuf {
+        self.root.join(r.to_hex())
+    }
+}
+
+impl ContentStore for LocalFsContentStore {
+    type Payload = Bytes;
+
+    fn put(&self, bytes: &[u8]) -> Result<ContentRef, StoreError> {
+        let r = ContentRef::of(bytes);
+        let final_path = self.path_for(&r);
+
+        // Idempotent: if the object already exists at the content-addressed name, the
+        // dedup contract says the call is a no-op. We trust the name — the asymmetry rule
+        // (D5) says re-hashing-on-write would be defensive against backend corruption, but
+        // `content-store.md` §11 explicitly makes re-hash-on-read an opt-in audit mode.
+        if final_path.exists() {
+            return Ok(r);
+        }
+
+        // Write-to-temp in the same directory, then atomic rename. Temp lives in `root` so
+        // the rename is filesystem-local.
+        let mut temp = tempfile::NamedTempFile::new_in(&self.root)?;
+        temp.write_all(bytes)?;
+        temp.as_file_mut().sync_all()?;
+        // persist: atomic rename on Unix; on Windows it falls back to a non-atomic rename
+        // but the same content-addressed naming makes a racing overwrite harmless (the
+        // bytes are identical).
+        match temp.persist(&final_path) {
+            Ok(_) => Ok(r),
+            Err(persist_err) => {
+                // If another concurrent writer beat us to the same ref, persist may fail
+                // (file already exists on some platforms). Re-check before surfacing the
+                // error — concurrent identical puts are not a failure.
+                if final_path.exists() {
+                    Ok(r)
+                } else {
+                    Err(StoreError::Io(persist_err.error))
+                }
+            }
+        }
+    }
+
+    fn get(&self, r: &ContentRef) -> Result<Self::Payload, NotFound> {
+        let path = self.path_for(r);
+        match fs::read(&path) {
+            Ok(buf) => Ok(Bytes::from(buf)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Err(NotFound),
+            Err(_) => Err(NotFound),
+        }
+    }
+
+    fn delete(&self, r: &ContentRef) -> Result<(), StoreError> {
+        let path = self.path_for(r);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(StoreError::Io(err)),
+        }
+    }
+
+    fn list_refs<'a>(&'a self) -> Box<dyn Iterator<Item = ContentRef> + 'a> {
+        let read_dir = match fs::read_dir(&self.root) {
+            Ok(rd) => rd,
+            Err(_) => return Box::new(std::iter::empty()),
+        };
+        let iter = read_dir.filter_map(|entry| {
+            let entry = entry.ok()?;
+            let name = entry.file_name();
+            let s = name.to_str()?;
+            decode_hex_hash(s).map(ContentRef::from_bytes)
+        });
+        Box::new(iter)
+    }
+
+    fn contains(&self, r: &ContentRef) -> bool {
+        self.path_for(r).is_file()
+    }
+}
+
+/// Decode a 64-character lowercase-hex string into the 32 raw hash bytes, returning `None`
+/// for anything that doesn't match the expected shape (tempfiles, stray non-object files,
+/// case variations).
+fn decode_hex_hash(s: &str) -> Option<[u8; 32]> {
+    if s.len() != 64 {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let mut out = [0u8; 32];
+    for (i, chunk) in bytes.chunks_exact(2).enumerate() {
+        let hi = hex_nibble(chunk[0])?;
+        let lo = hex_nibble(chunk[1])?;
+        out[i] = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+#[inline]
+fn hex_nibble(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(10 + c - b'a'),
+        _ => None,
+    }
+}

--- a/kx-content/tests/dod.rs
+++ b/kx-content/tests/dod.rs
@@ -1,0 +1,342 @@
+//! P1.3 Definition-of-Done tests covering `content-store.md` §10 obligations 1–9.
+//!
+//! Each test is annotated with the obligation it satisfies.
+
+use std::fs;
+use std::sync::Arc;
+use std::thread;
+
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore, LocalFsContentStore, NotFound};
+
+// ---------------------------------------------------------------------------
+// Helpers — exercise the trait generically over an arbitrary backend.
+// ---------------------------------------------------------------------------
+
+fn round_trip_through<S: ContentStore>(store: &S, payload: &[u8]) -> ContentRef {
+    let r = store.put(payload).expect("put must succeed");
+    let got = store.get(&r).expect("get must succeed");
+    assert_eq!(&got[..], payload, "get must return the bytes put");
+    r
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 1 — round-trip put/get
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_1a_round_trip_local_fs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+    round_trip_through(&store, b"hello kortecx");
+}
+
+#[test]
+fn obligation_1b_round_trip_in_memory() {
+    let store = InMemoryContentStore::new();
+    round_trip_through(&store, b"hello kortecx");
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 2 — auto-dedup
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_2a_dedup_local_fs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+    let r1 = store.put(b"same bytes").unwrap();
+    let r2 = store.put(b"same bytes").unwrap();
+    assert_eq!(r1, r2, "identical bytes must produce identical refs");
+    let file_count = fs::read_dir(tmp.path())
+        .unwrap()
+        .filter(|e| e.as_ref().unwrap().file_type().unwrap().is_file())
+        .count();
+    assert_eq!(file_count, 1, "identical bytes must store one file");
+}
+
+#[test]
+fn obligation_2b_dedup_in_memory() {
+    let store = InMemoryContentStore::new();
+    let r1 = store.put(b"same bytes").unwrap();
+    let r2 = store.put(b"same bytes").unwrap();
+    assert_eq!(r1, r2);
+    assert_eq!(store.len(), 1, "identical bytes must share one entry");
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 3 — atomicity of put
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_3_atomicity_no_observable_partial_write() {
+    // A `NamedTempFile` created in the store's root but never persisted MUST not become
+    // observable at any content-addressed ref. This models the failure mode: a worker
+    // crashed between writing the temp and the atomic rename.
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+
+    let payload = b"would-be content";
+    let would_be_ref = ContentRef::of(payload);
+
+    {
+        // Create a temp in the store's root, write partial bytes, drop without persisting.
+        let mut t = tempfile::NamedTempFile::new_in(tmp.path()).unwrap();
+        use std::io::Write;
+        t.write_all(b"would-be").unwrap();
+        // Drop — tempfile crate removes the file.
+    }
+
+    assert!(
+        !store.contains(&would_be_ref),
+        "no observable object at the target ref after a non-persisted temp write"
+    );
+    assert!(
+        store.get(&would_be_ref).is_err(),
+        "get of would-be-ref returns NotFound"
+    );
+
+    // A subsequent normal put of the same bytes must still succeed cleanly.
+    let r = store.put(payload).unwrap();
+    assert_eq!(r, would_be_ref);
+    assert!(store.contains(&r));
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 4 — get of unknown ref returns NotFound (no panic, no error escalation)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_4a_get_unknown_returns_notfound_local_fs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+    let bogus = ContentRef::from_bytes([0xff; 32]);
+    assert_eq!(store.get(&bogus), Err(NotFound));
+}
+
+#[test]
+fn obligation_4b_get_after_delete_returns_notfound() {
+    let store = InMemoryContentStore::new();
+    let r = store.put(b"transient").unwrap();
+    assert!(store.contains(&r));
+    store.delete(&r).unwrap();
+    assert_eq!(store.get(&r), Err(NotFound));
+    // Same outcome as eviction by tiering — caller must be ready to handle this.
+}
+
+#[test]
+fn obligation_4c_delete_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+    let bogus = ContentRef::from_bytes([0xaa; 32]);
+    // Deleting an absent ref is a no-op success.
+    store.delete(&bogus).unwrap();
+    store.delete(&bogus).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 5 — enumeration surface
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_5_list_refs_enumerates_all() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+    let mut put_refs: Vec<ContentRef> = (0..5u8)
+        .map(|i| store.put(&[i, i, i, i]).unwrap())
+        .collect();
+    put_refs.sort();
+
+    let mut listed: Vec<ContentRef> = store.list_refs().collect();
+    listed.sort();
+    assert_eq!(listed, put_refs);
+}
+
+#[test]
+fn obligation_5b_list_refs_skips_stray_non_hex_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+
+    let r = store.put(b"real object").unwrap();
+
+    // Stray files in the root must not pollute the ref enumeration.
+    fs::write(tmp.path().join("not-a-hash"), b"junk").unwrap();
+    fs::write(tmp.path().join("UPPERCASE_HEX_NOT_OUR_FORMAT"), b"junk").unwrap();
+    fs::write(tmp.path().join("0123"), b"too short").unwrap();
+
+    let listed: Vec<ContentRef> = store.list_refs().collect();
+    assert_eq!(
+        listed,
+        vec![r],
+        "only real content-addressed objects are enumerated"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 6 — trait is backend-agnostic
+// ---------------------------------------------------------------------------
+
+/// Generic over the trait. If the trait carried in-process-specific assumptions in its
+/// signature (e.g., concrete `bytes::Bytes` instead of an associated `Payload` type), this
+/// function would not compile against two backends.
+fn exercise_through_trait<S: ContentStore>(store: S) {
+    let r = store.put(b"trait-only access").unwrap();
+    let got = store.get(&r).unwrap();
+    assert_eq!(&got[..], b"trait-only access");
+    assert!(store.contains(&r));
+    let listed: Vec<ContentRef> = store.list_refs().collect();
+    assert_eq!(listed.len(), 1);
+}
+
+#[test]
+fn obligation_6a_trait_works_for_local_fs() {
+    let tmp = tempfile::tempdir().unwrap();
+    exercise_through_trait(LocalFsContentStore::open(tmp.path()).unwrap());
+}
+
+#[test]
+fn obligation_6b_trait_works_for_in_memory() {
+    exercise_through_trait(InMemoryContentStore::new());
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 7 — backend-atomic put under concurrency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_7a_concurrent_puts_local_fs_safe() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(tmp.path()).unwrap());
+
+    let payload: Vec<u8> = (0..1024u32).flat_map(u32::to_le_bytes).collect();
+    let payload_arc: Arc<Vec<u8>> = Arc::new(payload);
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let store = Arc::clone(&store);
+        let payload = Arc::clone(&payload_arc);
+        handles.push(thread::spawn(move || store.put(&payload).unwrap()));
+    }
+    let refs: Vec<ContentRef> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // All concurrent puts of identical bytes resolved to the same ref.
+    let first = refs[0];
+    assert!(
+        refs.iter().all(|r| *r == first),
+        "all concurrent puts must produce the same ref"
+    );
+
+    // Exactly one stored file on disk.
+    let file_count = fs::read_dir(tmp.path())
+        .unwrap()
+        .filter(|e| e.as_ref().unwrap().file_type().unwrap().is_file())
+        .count();
+    assert_eq!(file_count, 1, "concurrent identical puts store one file");
+}
+
+#[test]
+fn obligation_7b_concurrent_puts_in_memory_safe() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let payload: Vec<u8> = (0..1024u32).flat_map(u32::to_le_bytes).collect();
+    let payload_arc: Arc<Vec<u8>> = Arc::new(payload);
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let store = Arc::clone(&store);
+        let payload = Arc::clone(&payload_arc);
+        handles.push(thread::spawn(move || store.put(&payload).unwrap()));
+    }
+    let refs: Vec<ContentRef> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let first = refs[0];
+    assert!(refs.iter().all(|r| *r == first));
+    assert_eq!(store.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 8 — GC walker integration (light)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_8_orphan_detection_via_set_difference() {
+    // Models the walker: it asks the journal for the live ref set and the store for the
+    // present ref set; orphans are (store \ live). The journal stub is just a HashSet.
+    use std::collections::HashSet;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+
+    let live = store.put(b"referenced by a committed entry").unwrap();
+    let orphan_a = store.put(b"staged but never committed (a)").unwrap();
+    let orphan_b = store.put(b"staged but never committed (b)").unwrap();
+
+    let live_set: HashSet<ContentRef> = [live].into_iter().collect();
+    let store_set: HashSet<ContentRef> = store.list_refs().collect();
+    let orphans: HashSet<ContentRef> = store_set.difference(&live_set).copied().collect();
+
+    let expected: HashSet<ContentRef> = [orphan_a, orphan_b].into_iter().collect();
+    assert_eq!(orphans, expected);
+
+    // Deletion is idempotent; running the walker twice is safe.
+    for o in &orphans {
+        store.delete(o).unwrap();
+    }
+    for o in &orphans {
+        store.delete(o).unwrap();
+    }
+    let after: HashSet<ContentRef> = store.list_refs().collect();
+    assert_eq!(after, live_set);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 9 — Payload: Deref<Target=[u8]> discipline + zero-copy via Bytes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_9_payload_dereferences_as_byte_slice() {
+    // The trait method returns `Self::Payload` which is `Deref<Target=[u8]>`. Both
+    // backends use `bytes::Bytes`, which supports zero-copy slicing and ref-counted
+    // sharing.
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+    let payload: Vec<u8> = (0..256u32).flat_map(u32::to_le_bytes).collect();
+    let r = store.put(&payload).unwrap();
+
+    let bytes = store.get(&r).unwrap();
+    // Slice into the payload without copying — Bytes supports zero-copy subviews.
+    let head = bytes.slice(0..16);
+    let tail = bytes.slice(bytes.len() - 16..);
+    assert_eq!(&head[..], &payload[0..16]);
+    assert_eq!(&tail[..], &payload[payload.len() - 16..]);
+
+    // Hash the read bytes — must match the original ref (defensive audit; opt-in per
+    // content-store.md §11, but cheap enough to do in a DoD test).
+    let recomputed = ContentRef::of(&bytes);
+    assert_eq!(recomputed, r);
+}
+
+// ---------------------------------------------------------------------------
+// Extra coverage — ref formatting, dedup-via-different-instances
+// ---------------------------------------------------------------------------
+
+#[test]
+fn content_ref_hex_round_trip() {
+    let payload = b"any payload";
+    let r = ContentRef::of(payload);
+    let hex = r.to_hex();
+    assert_eq!(hex.len(), 64);
+    assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn dedup_across_distinct_store_instances_on_same_root() {
+    // Two LocalFsContentStore handles pointing at the same directory share state — a
+    // put through one is observable through the other. Real-world: multiple worker
+    // processes / threads using the same backing directory.
+    let tmp = tempfile::tempdir().unwrap();
+    let s1 = LocalFsContentStore::open(tmp.path()).unwrap();
+    let s2 = LocalFsContentStore::open(tmp.path()).unwrap();
+
+    let r = s1.put(b"shared object").unwrap();
+    assert!(s2.contains(&r));
+    let got = s2.get(&r).unwrap();
+    assert_eq!(&got[..], b"shared object");
+}

--- a/kx-content/tests/rkyv_archived.rs
+++ b/kx-content/tests/rkyv_archived.rs
@@ -1,0 +1,72 @@
+//! P1.3 exit gate: "rkyv archived access works on a large payload."
+//!
+//! `content-store.md` §4 + §10 obligation 9 are explicit that rkyv is NOT in the trait
+//! signature — it lives entirely on the caller side. This test demonstrates the
+//! composition: the workflow author rkyv-archives a typed payload, stores the resulting
+//! bytes in the content store, retrieves them, and reads the archived view zero-copy
+//! (without a deserialization pass) through the `Bytes` payload's deref to `[u8]`.
+//!
+//! The content store sees opaque bytes throughout. The rkyv encoding/decoding is the
+//! caller's concern, exactly as the spec requires.
+
+use kx_content::{ContentStore, LocalFsContentStore};
+use rkyv::rancor;
+
+/// One megabyte. Large enough to make a non-zero-copy deserialization noticeably wasteful;
+/// small enough to keep the test fast.
+const LARGE_LEN: usize = 1_000_000;
+
+#[test]
+fn rkyv_archived_view_round_trips_through_local_fs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+
+    // Workflow author's typed payload: a Vec<u8> of a million bytes. rkyv already provides
+    // Archive / Serialize / Deserialize impls for Vec<u8>, so we don't need a custom derive.
+    let original: Vec<u8> = (0..LARGE_LEN).map(|i| (i % 251) as u8).collect();
+
+    // Caller-side rkyv archiving — completely opaque to the store.
+    let archived_bytes =
+        rkyv::to_bytes::<rancor::Error>(&original).expect("rkyv archive must succeed");
+
+    // Store opaque bytes; the store is rkyv-blind.
+    let r = store.put(&archived_bytes).expect("put must succeed");
+
+    // Retrieve. The store returns its Payload (a `bytes::Bytes` for the local FS backend).
+    let payload = store.get(&r).expect("get must succeed");
+    assert_eq!(payload.len(), archived_bytes.len(), "byte length preserved");
+
+    // Zero-copy archived access: cast the retrieved bytes to `&Archived<Vec<u8>>` without
+    // a deserialization pass. rkyv's `access` validates the buffer is well-formed.
+    let archived = rkyv::access::<rkyv::Archived<Vec<u8>>, rancor::Error>(&payload[..])
+        .expect("archived access must succeed");
+
+    // Spot-check fields without ever deserializing the full vector.
+    assert_eq!(archived.len(), LARGE_LEN);
+    assert_eq!(archived[0], 0u8);
+    assert_eq!(archived[1], 1u8);
+    assert_eq!(archived[250], 250u8);
+    assert_eq!(archived[251], 0u8);
+    assert_eq!(archived[LARGE_LEN - 1], ((LARGE_LEN - 1) % 251) as u8);
+}
+
+#[test]
+fn rkyv_dedupes_byte_identical_payloads() {
+    // Two identical typed payloads serialize to identical bytes (rkyv is canonical for
+    // primitive vectors). The content store dedupes them by structure.
+    let tmp = tempfile::tempdir().unwrap();
+    let store = LocalFsContentStore::open(tmp.path()).unwrap();
+
+    let payload: Vec<u32> = (0..10_000).collect();
+    let bytes_a = rkyv::to_bytes::<rancor::Error>(&payload).unwrap();
+    let bytes_b = rkyv::to_bytes::<rancor::Error>(&payload).unwrap();
+    assert_eq!(
+        &bytes_a[..],
+        &bytes_b[..],
+        "rkyv canonical for primitive vec"
+    );
+
+    let r1 = store.put(&bytes_a).unwrap();
+    let r2 = store.put(&bytes_b).unwrap();
+    assert_eq!(r1, r2);
+}


### PR DESCRIPTION
## Summary

Implements the **P1.3 content store** — the layer the journal will hold 32-byte references to. Two backends behind a single backend-agnostic trait; atomic-per-object writes; structural dedup; an enumeration surface ready for the orphan-GC walker.

- `ContentRef([u8; 32])` — BLAKE3-hash newtype.
- `trait ContentStore` with `type Payload: Deref<Target = [u8]>` — no `bytes::Bytes` or `rkyv` in the signature (impl-ergonomics, not contract).
- `LocalFsContentStore`: write-to-temp + POSIX atomic rename. `bytes::Bytes` payload for zero-copy slicing.
- `InMemoryContentStore`: `HashMap` + `RwLock`. Proves the trait carries no in-process-filesystem assumption in its signature; also provides cheap fixtures for downstream tests.

## Contract highlights

| Property | Implementation |
|---|---|
| Atomic-per-object writes | LocalFs: `tempfile::NamedTempFile::persist` (POSIX rename); InMemory: `RwLock::write`. |
| Idempotence (identical bytes ⇒ identical ref ⇒ one stored object) | Verified in tests; concurrent puts resolve to one file. |
| `get` of unknown/deleted ref ⇒ `NotFound` (not error, not panic) | Single error type for absence so callers don't need to discriminate "never written" from "tier-evicted PURE". |
| `delete` is idempotent | Deleting an absent ref is a no-op success. |
| `list_refs` skips non-hex files | Stray files in the LocalFs root (temp leftovers, manual junk) do not pollute the ref enumeration. |
| `Payload: Deref<Target = [u8]>` | Trait does not name `bytes::Bytes` or `rkyv` — backends choose. |

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — **54/54 pass** (20 new kx-content + 34 unchanged kx-mote, no regressions)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` — clean
- [x] **I1.c byte-determinism**: `libkx_content.rlib` SHA-256 `f50aabcb211cc537c043efa09f38b49450c2b509008132540ce21d5803c6a20e` reproducible across two release builds; `libkx_mote.rlib` unchanged from P1.2.
- [ ] CI green on this PR.

## Test coverage highlights

- **20 tests** in `kx-content/tests/dod.rs` + `tests/rkyv_archived.rs`.
- **9 of 9 spec-mandated DoD obligations** covered (round-trip, dedup, atomicity, NotFound on unknown/deleted, enumeration, trait-backend-agnosticism, concurrent atomic put, orphan detection via set difference, `Payload: Deref` discipline).
- **rkyv archived view** on a 1 MB `Vec<u8>` round-trips through `LocalFsContentStore` with zero-copy field access via `rkyv::access::<Archived<Vec<u8>>, rancor::Error>` — proving the impl-ergonomic rkyv layer composes cleanly with the trait's opaque-bytes surface.
- **Concurrency:** 8 threads putting identical bytes into the same `LocalFsContentStore` produce one file; same for `InMemoryContentStore`.

## What's deliberately deferred

- **Tag-driven tiering** (PURE droppable + recomputable): the store is tag-blind by design; the tiering pass at P1.12 joins the journal's per-Mote `NdClass` with the store's enumeration to decide eviction.
- **Streaming reads** for very large payloads: `get` returns the full payload; a streaming surface is post-P1.
- **Retention window** for the orphan-GC walker: the deletion primitive lives here, but timing/retention configuration lives in the future coordinator's config (post-P1).
- **True mmap-based zero-copy from disk**: the LocalFs backend reads through a single `Vec<u8>` allocation and wraps in `bytes::Bytes` for downstream zero-copy slicing. `memmap2`-backed reads are a future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)