### PR TITLE
P1.5: kx-projection — the log's read-side fold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-projection"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-journal",
+ "kx-mote",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote", "kx-content", "kx-journal"]
+members = ["kx-mote", "kx-content", "kx-journal", "kx-projection"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -25,6 +25,7 @@ rkyv               = "0.8"
 rusqlite           = { version = "0.32", features = ["bundled"] }
 kx-mote            = { path = "kx-mote" }
 kx-content         = { path = "kx-content" }
+kx-journal         = { path = "kx-journal" }
 
 [profile.release]
 strip         = "symbols"

--- a/kx-projection/Cargo.toml
+++ b/kx-projection/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name         = "kx-projection"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx projection — the read-side fold of the journal log; serves ready_set, parents/children, transitive_consumers, promotion_state."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-content = { workspace = true }
+kx-journal = { workspace = true }
+kx-mote    = { workspace = true }
+smallvec   = { workspace = true }
+thiserror  = { workspace = true }
+tracing    = { workspace = true }
+
+[dev-dependencies]
+tempfile           = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-projection/src/lib.rs
+++ b/kx-projection/src/lib.rs
@@ -1,0 +1,861 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+//! # kx-projection — the log's read-side fold
+//!
+//! The journal (`kx_journal`) is the durable truth; **the projection is its in-memory
+//! read view**. Folding `JournalEntry` records in `seq` order produces the per-Mote
+//! state (Pending → Scheduled → Committed | Failed → Repudiated), the dependency graph,
+//! the `ready_set` the scheduler consumes, and the `transitive_consumers` set the
+//! poison-cascade (D22) walks.
+//!
+//! ## Hard rules (from `projection.md`)
+//!
+//! - **Pure function of the log.** Two folds of the same log prefix produce
+//!   bit-equivalent state. The projection is never durably stored as a mutable graph;
+//!   on restart it is re-folded from the log.
+//! - **Read-only against the journal.** `kx-projection` never calls
+//!   `Journal::append`. Single-writer-per-run (D13) is preserved by construction —
+//!   `kx-projection` does not depend on `Journal` as a *mut* surface.
+//! - **Snapshot isolation** (D16). Each `snapshot()` returns a stable point-in-time
+//!   view. Subsequent log appends are not visible mid-read.
+//! - **Cycle tolerant.** Cycles in the dependency graph do not crash, hang, or
+//!   corrupt the fold. Traversals (`transitive_consumers`) use visited-sets.
+//!
+//! ## Topology-shaper materialization is deferred to P1.11
+//!
+//! `projection.md` §5 specifies that the projection materializes shaper-declared
+//! children when a `Committed` entry's Mote has `is_topology_shaper == true`. This
+//! requires decoding a `TopologyDecision` payload from the content store. P1.5 lays
+//! the framework (the `MoteInfo` carries metadata about each Mote; new children can be
+//! added to the graph mid-fold); P1.11 wires the content-store-side decoder and the
+//! child-edge materialization algorithm.
+//!
+//! ## 3c promotion state — P1 default
+//!
+//! Per D18, `promotion_state` defaults to `NotApplicable` for non-WORLD-MUTATING and
+//! for WORLD-MUTATING-without-observable-critic-relationship. Until the executor
+//! (P1.9) wires a `MoteDef` lookup into the projection so the projection can read
+//! each Committed Mote's `critic_for`, the projection treats all WORLD-MUTATING Motes
+//! as `NotApplicable` — matching D18's "3a/3b workflows run normally in P1; 3c
+//! workflows are expressible but unsafe until P0.8 binds the critic." The
+//! `promotion_state` method is exposed today; full 3c behavior activates when the
+//! executor populates the `MoteDef` registry the projection consults.
+//!
+//! ## What lives here
+//!
+//! - [`MoteState`] — the per-identity state machine (§4 of `projection.md`).
+//! - [`PromotionState`] — Promoted / Unpromoted / NotApplicable.
+//! - [`RegisterMote`] — workflow-author declaration of a Mote's parents + properties
+//!   before any journal entry exists for it.
+//! - [`Projection`] — the in-memory fold state; mutate via `register_mote` + `fold`.
+//! - [`Snapshot`] — an immutable point-in-time view of the projection.
+//! - The 7-method read API surface (`state_of`, `parents_of`, `children_of`,
+//!   `transitive_consumers`, `result_ref_of`, `ready_set`, `promotion_state`).
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use kx_content::ContentRef;
+use kx_journal::{Journal, JournalEntry, ParentEntry};
+use kx_mote::{EdgeKind, EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Public state / outcome types
+// ---------------------------------------------------------------------------
+
+/// Per-Mote state, derived from the log via the precedence rules in `projection.md`
+/// §4. A Mote registered but with no journal entry yet is [`MoteState::Pending`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MoteState {
+    /// Workflow-declared but no journal entry yet.
+    Pending,
+    /// At least one `Proposed` entry exists; no `Committed`, no later `Failed`.
+    Scheduled,
+    /// A `Committed` entry exists and has not been Repudiated.
+    Committed,
+    /// At least one `Failed` entry exists; no later `Proposed`, no `Committed`.
+    Failed,
+    /// A `Committed` entry exists AND a `Repudiated` entry targeting it has landed.
+    Repudiated,
+}
+
+/// 3c (validate-then-commit) promotion state, per D18 + D20.
+///
+/// - `NotApplicable`: PURE / READ-ONLY-NONDET, OR WORLD-MUTATING with no
+///   observable critic relationship in the projection (3a / 3b — effective on commit).
+/// - `Unpromoted`: WORLD-MUTATING with an observed critic relationship that has not
+///   yet committed `Valid` (the critic hasn't committed at all, or committed `Invalid`).
+/// - `Promoted`: WORLD-MUTATING with an observed critic that committed `Valid`.
+///
+/// **P1 default behavior.** The projection observes no critic-of-producer
+/// relationships until the executor (P1.9) wires a `MoteDef` lookup. Until then, all
+/// Motes return `NotApplicable` regardless of nd_class — matching the D18 P1 default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PromotionState {
+    /// Effective on commit — no critic gate applies.
+    NotApplicable,
+    /// 3c WORLD-MUTATING with an unsatisfied critic gate (P1: unreachable).
+    Unpromoted,
+    /// 3c WORLD-MUTATING with a satisfied critic gate (P1: unreachable).
+    Promoted,
+}
+
+/// Workflow-author declaration of a Mote before any journal entry exists for it.
+///
+/// Submitted at workflow-compile time by the executor (P1.9) or directly by tests.
+/// Adds the Mote to the projection's "expected" set so it appears as
+/// [`MoteState::Pending`] in `state_of` and is eligible for `ready_set` once its
+/// parents commit.
+#[derive(Debug, Clone)]
+pub struct RegisterMote {
+    /// The Mote's identity.
+    pub mote_id: MoteId,
+    /// The Mote's non-determinism tag (drives recovery semantics, scheduling priority).
+    pub nd_class: NdClass,
+    /// Which effect pattern this Mote uses (D20). Determines whether `ready_set`
+    /// gates downstream consumers on a critic verdict (3c only).
+    pub effect_pattern: EffectPattern,
+    /// If this Mote is a critic of another Mote, the producer's identity.
+    pub critic_for: Option<MoteId>,
+    /// If this Mote is a topology shaper, set to `true` (P1.11 will use this).
+    pub is_topology_shaper: bool,
+    /// The Mote's declared parents with edge metadata. Up to 4 inline; spill heap.
+    pub parents: SmallVec<[ParentRef; 4]>,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors raised by [`Projection`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionError {
+    /// The fold detected two `Committed` entries for the same `MoteId` — this is
+    /// a journal-layer bug (the dedupe-by-key path failed). Surfaced loudly per
+    /// `projection.md` §4 ("if it does, that is a journal-impl bug, not a precedence
+    /// question — surface it loudly").
+    #[error("two Committed entries for MoteId {0} (journal dedupe-by-key bug)")]
+    DuplicateCommitted(MoteId),
+
+    /// Wraps an underlying [`kx_journal::JournalError`] surfaced while folding from
+    /// a `Journal` instance.
+    #[error(transparent)]
+    Journal(#[from] kx_journal::JournalError),
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct CommittedInfo {
+    seq: u64,
+    result_ref: ContentRef,
+    nondeterminism: NdClass,
+    parents_in_entry: SmallVec<[ParentEntry; 4]>,
+    /// Retained for the D22 `list_committed_by_mote_def_hash`-driven cascade
+    /// (operator-level definition repudiation surfaces the def_hash; consumers
+    /// reach for it here when constructing cascade sets). Not yet read in P1.5;
+    /// will be consumed by the executor-side flow that initiates definition-
+    /// level cascades.
+    #[allow(dead_code)]
+    mote_def_hash: MoteDefHash,
+    repudiated: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct MoteInfo {
+    /// Workflow-author-declared properties (when registered).
+    declared: Option<DeclaredInfo>,
+    /// Committed-entry info (when a `Committed` entry has been folded).
+    committed: Option<CommittedInfo>,
+    /// `true` if at least one `Proposed` entry has been folded for this MoteId.
+    has_proposed: bool,
+    /// `true` if at least one `Failed` entry has been folded with no later `Proposed`.
+    /// We track this directly because `Failed → Proposed` is a valid sequence
+    /// (`mote.md` §7 + `journal-entry.md` §7.5).
+    failed_pending_reattempt: bool,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+// `nd_class`, `effect_pattern`, `critic_for`, `is_topology_shaper` are stored at
+// registration but unread in P1.5. P1.9 (the executor) consumes them via a MoteDef
+// registry lookup to compute the full 3c promotion behavior + the topology-shaper
+// materialization at P1.11.
+struct DeclaredInfo {
+    nd_class: NdClass,
+    effect_pattern: EffectPattern,
+    critic_for: Option<MoteId>,
+    is_topology_shaper: bool,
+    parents: SmallVec<[ParentRef; 4]>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct State {
+    /// Per-MoteId info — declared, committed, and any in-flight state.
+    motes: BTreeMap<MoteId, MoteInfo>,
+    /// child → parents adjacency (derived from `MoteInfo.declared.parents` or
+    /// `committed.parents_in_entry`). Computed by `parents_of`.
+    /// We also maintain a reverse index for fast `children_of`.
+    children: BTreeMap<MoteId, Vec<(MoteId, EdgeMeta)>>,
+    /// The largest `seq` value applied so far.
+    last_seq: u64,
+}
+
+impl State {
+    fn moteinfo_mut(&mut self, id: &MoteId) -> &mut MoteInfo {
+        self.motes.entry(*id).or_default()
+    }
+
+    /// Compute the per-identity state per `projection.md` §4.
+    fn state_of_id(&self, id: &MoteId) -> MoteState {
+        match self.motes.get(id) {
+            None => MoteState::Pending,
+            Some(info) => {
+                if let Some(c) = &info.committed {
+                    if c.repudiated {
+                        MoteState::Repudiated
+                    } else {
+                        MoteState::Committed
+                    }
+                } else if info.failed_pending_reattempt {
+                    MoteState::Failed
+                } else if info.has_proposed {
+                    MoteState::Scheduled
+                } else {
+                    MoteState::Pending
+                }
+            }
+        }
+    }
+
+    /// Return the declared-or-committed parent list for `id`. Declared takes
+    /// precedence if both exist (they SHOULD be identical — the executor passes the
+    /// same `parents` list to register_mote and to the journal entry).
+    fn parents_of_id(&self, id: &MoteId) -> SmallVec<[(MoteId, EdgeMeta); 4]> {
+        let Some(info) = self.motes.get(id) else {
+            return SmallVec::new();
+        };
+        if let Some(d) = &info.declared {
+            return d.parents.iter().map(|p| (p.parent_id, p.edge)).collect();
+        }
+        if let Some(c) = &info.committed {
+            return c
+                .parents_in_entry
+                .iter()
+                .filter_map(|p| p.to_parent_ref().map(|pr| (pr.parent_id, pr.edge)))
+                .collect();
+        }
+        SmallVec::new()
+    }
+
+    /// Rebuild the child→parent reverse index from the declared-or-committed
+    /// adjacency. Cheap given typical workflow sizes; recomputed on graph mutation.
+    fn rebuild_children_index(&mut self) {
+        let mut idx: BTreeMap<MoteId, Vec<(MoteId, EdgeMeta)>> = BTreeMap::new();
+        let ids: Vec<MoteId> = self.motes.keys().copied().collect();
+        for id in ids {
+            for (parent_id, edge) in self.parents_of_id(&id) {
+                idx.entry(parent_id).or_default().push((id, edge));
+            }
+        }
+        // Stable ordering: sort each adjacency list by child id for determinism.
+        for v in idx.values_mut() {
+            v.sort_by(|a, b| a.0.cmp(&b.0));
+        }
+        self.children = idx;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The Projection — the live in-memory state
+// ---------------------------------------------------------------------------
+
+/// The journal's read-side projection.
+///
+/// Apply [`Projection::register_mote`] for workflow-declared Motes, then
+/// [`Projection::fold`] each journal entry in `seq` order; query via the 7-method
+/// read API. [`Projection::snapshot`] returns an immutable point-in-time view that
+/// implements the same read API with stable snapshot semantics.
+#[derive(Debug, Default)]
+pub struct Projection {
+    state: State,
+}
+
+impl Projection {
+    /// Construct an empty projection.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a projection by reading every entry from `journal` in `seq` order.
+    ///
+    /// Convenience for tests and for cold-start replay. Production callers
+    /// typically construct an empty projection, [`Projection::register_mote`] for
+    /// each workflow-declared Mote, and [`Projection::fold`] incrementally as new
+    /// journal entries land.
+    pub fn from_journal<J: Journal>(journal: &J) -> Result<Self, ProjectionError> {
+        let mut p = Self::new();
+        let max_seq = journal.current_seq()?;
+        // current_seq returns 0 for empty; use saturating range.
+        let entries = journal.read_entries_by_seq(0..(max_seq + 1))?;
+        for entry in entries {
+            p.fold(&entry)?;
+        }
+        Ok(p)
+    }
+
+    /// Register a workflow-declared Mote.
+    ///
+    /// Adds the Mote to the projection's expected set; its state becomes
+    /// [`MoteState::Pending`] until the first journal entry lands. Re-registration
+    /// of the same `MoteId` is permitted and overwrites the declared info (the
+    /// workflow author may update parents before submission; the journal-side
+    /// dedupe-by-key path is the authoritative arbiter for identity equality).
+    pub fn register_mote(&mut self, reg: RegisterMote) {
+        let info = self.state.moteinfo_mut(&reg.mote_id);
+        info.declared = Some(DeclaredInfo {
+            nd_class: reg.nd_class,
+            effect_pattern: reg.effect_pattern,
+            critic_for: reg.critic_for,
+            is_topology_shaper: reg.is_topology_shaper,
+            parents: reg.parents,
+        });
+        self.state.rebuild_children_index();
+    }
+
+    /// Apply one journal entry. **Caller must invoke in `seq` order**; the fold is
+    /// `seq`-order-dependent for correctness (per `projection.md` §3 — the
+    /// determinism contract assumes log-order folding).
+    ///
+    /// Returns the previous `last_seq` for diagnostics; callers may ignore the
+    /// return value. A duplicate `Committed` for the same `MoteId` surfaces
+    /// [`ProjectionError::DuplicateCommitted`] — that is a journal-impl bug per
+    /// `projection.md` §4.
+    pub fn fold(&mut self, entry: &JournalEntry) -> Result<u64, ProjectionError> {
+        let prev = self.state.last_seq;
+        match entry {
+            JournalEntry::Proposed { mote_id, seq, .. } => {
+                let info = self.state.moteinfo_mut(mote_id);
+                info.has_proposed = true;
+                // A new Proposed clears any prior pending-failure marker (failed→proposed
+                // is a valid sequence per mote.md §7).
+                info.failed_pending_reattempt = false;
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
+            JournalEntry::Committed {
+                mote_id,
+                seq,
+                nondeterminism,
+                result_ref,
+                parents,
+                mote_def_hash,
+                ..
+            } => {
+                let info = self.state.moteinfo_mut(mote_id);
+                if info.committed.is_some() {
+                    return Err(ProjectionError::DuplicateCommitted(*mote_id));
+                }
+                info.committed = Some(CommittedInfo {
+                    seq: *seq,
+                    result_ref: *result_ref,
+                    nondeterminism: *nondeterminism,
+                    parents_in_entry: parents.clone(),
+                    mote_def_hash: *mote_def_hash,
+                    repudiated: false,
+                });
+                self.state.last_seq = self.state.last_seq.max(*seq);
+                // Rebuild children index since this Committed entry may introduce
+                // parent→child edges not previously visible (e.g., entry written
+                // for a Mote that wasn't pre-registered).
+                self.state.rebuild_children_index();
+            }
+            JournalEntry::Failed { mote_id, seq, .. } => {
+                let info = self.state.moteinfo_mut(mote_id);
+                if info.committed.is_none() {
+                    info.failed_pending_reattempt = true;
+                }
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
+            JournalEntry::Repudiated {
+                target_mote_id,
+                seq,
+                target_committed_seq,
+                ..
+            } => {
+                let info = self.state.moteinfo_mut(target_mote_id);
+                // Only flip the repudiated flag if the target Committed entry is
+                // actually present in the projection AND its seq matches. Per
+                // `projection.md` §5, a Repudiated naming a non-existent target is
+                // recorded as a fact (the cascade walker can list repudiation
+                // entries from the journal directly) but does NOT create a phantom
+                // marker in `state_of` — keeps `state_of` semantics clean.
+                if let Some(c) = info.committed.as_mut() {
+                    if c.seq == *target_committed_seq {
+                        c.repudiated = true;
+                    }
+                }
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
+        }
+        Ok(prev)
+    }
+
+    /// The largest `seq` applied so far. `0` for an empty projection.
+    #[inline]
+    #[must_use]
+    pub fn current_seq(&self) -> u64 {
+        self.state.last_seq
+    }
+
+    /// Number of Motes the projection knows about (registered + entry-introduced).
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.state.motes.len()
+    }
+
+    /// `true` when the projection has no registered or entry-introduced Motes.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.state.motes.is_empty()
+    }
+
+    /// Capture an immutable point-in-time view. Subsequent folds against the
+    /// `Projection` do not affect the returned `Snapshot` — this is the
+    /// snapshot-isolation contract per D16 / `projection.md` §6.
+    #[must_use]
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            state: self.state.clone(),
+        }
+    }
+
+    // ----- Read API (delegates to State; same surface as Snapshot) -----
+
+    /// The per-identity state per `projection.md` §4.
+    #[must_use]
+    pub fn state_of(&self, mote_id: &MoteId) -> MoteState {
+        self.state.state_of_id(mote_id)
+    }
+
+    /// Direct parents with edge metadata.
+    #[must_use]
+    pub fn parents_of(&self, mote_id: &MoteId) -> SmallVec<[(MoteId, EdgeMeta); 4]> {
+        self.state.parents_of_id(mote_id)
+    }
+
+    /// Direct children with edge metadata.
+    #[must_use]
+    pub fn children_of(&self, mote_id: &MoteId) -> Vec<(MoteId, EdgeMeta)> {
+        self.state
+            .children
+            .get(mote_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// The transitive closure of downstream consumers reachable via data edges
+    /// (always) and non-opted-out control edges (per `control-edge-cascade-default.md`).
+    /// BFS with visited-set termination — cycle-safe.
+    #[must_use]
+    pub fn transitive_consumers(&self, mote_id: &MoteId) -> Vec<MoteId> {
+        transitive_consumers_impl(&self.state, mote_id)
+    }
+
+    /// The Mote's committed `result_ref`, if any.
+    #[must_use]
+    pub fn result_ref_of(&self, mote_id: &MoteId) -> Option<ContentRef> {
+        self.state
+            .motes
+            .get(mote_id)
+            .and_then(|i| i.committed.as_ref().map(|c| c.result_ref))
+    }
+
+    /// Motes whose parents are all `Committed-and-not-Repudiated` AND whose
+    /// WORLD-MUTATING parents have promotion_state ∈ {NotApplicable, Promoted} AND
+    /// that are themselves in `Pending` state.
+    ///
+    /// The WORLD-MUTATING promotion filter is in the contract here, not in the
+    /// caller — per `projection.md` §7. (In P1 the filter is a no-op because
+    /// promotion_state always returns NotApplicable; the filter activates once
+    /// P1.9 wires the MoteDef registry.)
+    #[must_use]
+    pub fn ready_set(&self) -> Vec<MoteId> {
+        ready_set_impl(&self.state)
+    }
+
+    /// 3c promotion state for the producer.
+    ///
+    /// **P1 default**: returns `NotApplicable` for every Mote (per D18). Full 3c
+    /// semantics activate when the executor (P1.9) wires a `MoteDef` lookup that
+    /// lets the projection observe critic-of-producer relationships.
+    #[must_use]
+    pub fn promotion_state(&self, mote_id: &MoteId) -> PromotionState {
+        promotion_state_impl(&self.state, mote_id)
+    }
+
+    /// `true` when a Repudiated entry targeting this Mote's committed entry has
+    /// been folded.
+    #[must_use]
+    pub fn is_repudiated(&self, mote_id: &MoteId) -> bool {
+        matches!(self.state_of(mote_id), MoteState::Repudiated)
+    }
+
+    /// The `seq` of the Mote's `Committed` entry, if present. Useful for callers
+    /// constructing a `Repudiated` entry that needs to reference the target.
+    #[must_use]
+    pub fn committed_seq_of(&self, mote_id: &MoteId) -> Option<u64> {
+        self.state
+            .motes
+            .get(mote_id)
+            .and_then(|i| i.committed.as_ref().map(|c| c.seq))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot — immutable point-in-time view
+// ---------------------------------------------------------------------------
+
+/// An immutable point-in-time view of a [`Projection`].
+///
+/// Returned by [`Projection::snapshot`]. Subsequent folds against the source
+/// projection do not affect this snapshot — the snapshot-isolation contract from
+/// D16 / `projection.md` §6 is provided by cloning the underlying state.
+#[derive(Debug, Clone)]
+pub struct Snapshot {
+    state: State,
+}
+
+impl Snapshot {
+    /// The `seq` at which this snapshot was captured.
+    #[inline]
+    #[must_use]
+    pub fn seq(&self) -> u64 {
+        self.state.last_seq
+    }
+
+    /// Number of Motes in this snapshot.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.state.motes.len()
+    }
+
+    /// `true` when the snapshot is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.state.motes.is_empty()
+    }
+
+    /// Per-identity state. See [`Projection::state_of`].
+    #[must_use]
+    pub fn state_of(&self, mote_id: &MoteId) -> MoteState {
+        self.state.state_of_id(mote_id)
+    }
+
+    /// Direct parents. See [`Projection::parents_of`].
+    #[must_use]
+    pub fn parents_of(&self, mote_id: &MoteId) -> SmallVec<[(MoteId, EdgeMeta); 4]> {
+        self.state.parents_of_id(mote_id)
+    }
+
+    /// Direct children. See [`Projection::children_of`].
+    #[must_use]
+    pub fn children_of(&self, mote_id: &MoteId) -> Vec<(MoteId, EdgeMeta)> {
+        self.state
+            .children
+            .get(mote_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Transitive consumers via data + non-opted-out control edges.
+    #[must_use]
+    pub fn transitive_consumers(&self, mote_id: &MoteId) -> Vec<MoteId> {
+        transitive_consumers_impl(&self.state, mote_id)
+    }
+
+    /// Committed result_ref. See [`Projection::result_ref_of`].
+    #[must_use]
+    pub fn result_ref_of(&self, mote_id: &MoteId) -> Option<ContentRef> {
+        self.state
+            .motes
+            .get(mote_id)
+            .and_then(|i| i.committed.as_ref().map(|c| c.result_ref))
+    }
+
+    /// The ready set at the snapshot's `seq`.
+    #[must_use]
+    pub fn ready_set(&self) -> Vec<MoteId> {
+        ready_set_impl(&self.state)
+    }
+
+    /// Promotion state (P1 default: `NotApplicable`).
+    #[must_use]
+    pub fn promotion_state(&self, mote_id: &MoteId) -> PromotionState {
+        promotion_state_impl(&self.state, mote_id)
+    }
+
+    /// `true` when the Mote's committed entry has been Repudiated by `seq`.
+    #[must_use]
+    pub fn is_repudiated(&self, mote_id: &MoteId) -> bool {
+        matches!(self.state_of(mote_id), MoteState::Repudiated)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared read-side implementations (used by both Projection and Snapshot)
+// ---------------------------------------------------------------------------
+
+fn transitive_consumers_impl(state: &State, root: &MoteId) -> Vec<MoteId> {
+    let mut visited: BTreeSet<MoteId> = BTreeSet::new();
+    let mut order: Vec<MoteId> = Vec::new();
+    let mut queue: VecDeque<MoteId> = VecDeque::new();
+    queue.push_back(*root);
+
+    while let Some(current) = queue.pop_front() {
+        // children_of for the current node
+        let children = state.children.get(&current).cloned().unwrap_or_default();
+        for (child, edge) in children {
+            // Cascade rule: data edges always cascade; control edges cascade unless
+            // explicitly non_cascade.
+            let should_walk = match edge.kind {
+                EdgeKind::Data => true,
+                EdgeKind::Control => !edge.non_cascade,
+            };
+            if !should_walk {
+                continue;
+            }
+            if visited.insert(child) {
+                order.push(child);
+                queue.push_back(child);
+            }
+        }
+    }
+    order
+}
+
+fn ready_set_impl(state: &State) -> Vec<MoteId> {
+    let mut out: Vec<MoteId> = Vec::new();
+    for (id, info) in &state.motes {
+        if state.state_of_id(id) != MoteState::Pending {
+            continue;
+        }
+        // Parents must all be Committed-and-not-Repudiated.
+        let Some(d) = info.declared.as_ref() else {
+            // Pending implies declared (registered).
+            continue;
+        };
+        let mut all_parents_committed = true;
+        let mut all_wm_parents_promoted = true;
+        for p in &d.parents {
+            let pstate = state.state_of_id(&p.parent_id);
+            if pstate != MoteState::Committed {
+                all_parents_committed = false;
+                break;
+            }
+            // WORLD-MUTATING promotion gate (per projection.md §7). In P1 default,
+            // promotion_state always returns NotApplicable, so the gate passes
+            // trivially. The check is in the contract so it activates when the
+            // executor (P1.9) wires the MoteDef registry.
+            if let Some(pinfo) = state.motes.get(&p.parent_id) {
+                if let Some(committed) = &pinfo.committed {
+                    if committed.nondeterminism == NdClass::WorldMutating {
+                        match promotion_state_impl(state, &p.parent_id) {
+                            PromotionState::Promoted | PromotionState::NotApplicable => {}
+                            PromotionState::Unpromoted => {
+                                all_wm_parents_promoted = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if all_parents_committed && all_wm_parents_promoted {
+            out.push(*id);
+        }
+    }
+    out
+}
+
+fn promotion_state_impl(_state: &State, _mote_id: &MoteId) -> PromotionState {
+    // P1 default per D18: no observable critic-of-producer relationships until
+    // P1.9's MoteDef registry wires the lookup. All Motes return NotApplicable.
+    PromotionState::NotApplicable
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_journal::{FailureReason, RepudiationReason};
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    fn cref(b: u8) -> ContentRef {
+        ContentRef::from_bytes([b; 32])
+    }
+
+    fn dh(b: u8) -> MoteDefHash {
+        MoteDefHash::from_bytes([b; 32])
+    }
+
+    fn proposed_entry(mote_byte: u8, seq: u64) -> JournalEntry {
+        JournalEntry::Proposed {
+            mote_id: mid(mote_byte),
+            idempotency_key: [mote_byte; 32],
+            seq,
+            nondeterminism: NdClass::Pure,
+            placement_hint: 0,
+        }
+    }
+
+    fn committed_entry(mote_byte: u8, seq: u64, nd: NdClass) -> JournalEntry {
+        JournalEntry::Committed {
+            mote_id: mid(mote_byte),
+            idempotency_key: [mote_byte; 32],
+            seq,
+            nondeterminism: nd,
+            result_ref: cref(mote_byte),
+            parents: SmallVec::new(),
+            mote_def_hash: dh(mote_byte),
+        }
+    }
+
+    fn failed_entry(mote_byte: u8, seq: u64) -> JournalEntry {
+        JournalEntry::Failed {
+            mote_id: mid(mote_byte),
+            idempotency_key: [mote_byte; 32],
+            seq,
+            reason_class: FailureReason::TimedOut,
+            reporter_id: 0,
+        }
+    }
+
+    fn repudiated_entry(target_byte: u8, target_seq: u64, seq: u64) -> JournalEntry {
+        JournalEntry::Repudiated {
+            target_mote_id: mid(target_byte),
+            idempotency_key: [0u8; 32], // would be derived; for in-memory fold the byte content doesn't matter
+            seq,
+            target_committed_seq: target_seq,
+            reason_class: RepudiationReason::OperatorAction,
+            repudiator_id: 0,
+        }
+    }
+
+    #[test]
+    fn empty_projection_is_pending_for_unknown_motes() {
+        let p = Projection::new();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Pending);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn proposed_then_committed_collapses_to_committed() {
+        let mut p = Projection::new();
+        p.fold(&proposed_entry(1, 1)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Scheduled);
+        p.fold(&committed_entry(1, 2, NdClass::Pure)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Committed);
+    }
+
+    #[test]
+    fn failed_then_proposed_resets_to_scheduled() {
+        let mut p = Projection::new();
+        p.fold(&proposed_entry(1, 1)).unwrap();
+        p.fold(&failed_entry(1, 2)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Failed);
+        p.fold(&proposed_entry(1, 3)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Scheduled);
+    }
+
+    #[test]
+    fn repudiated_only_applies_when_target_committed_seq_matches() {
+        let mut p = Projection::new();
+        p.fold(&committed_entry(1, 5, NdClass::Pure)).unwrap();
+        // Wrong target_committed_seq — projection ignores
+        p.fold(&repudiated_entry(1, 99, 6)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Committed);
+        // Correct target_committed_seq
+        p.fold(&repudiated_entry(1, 5, 7)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Repudiated);
+    }
+
+    #[test]
+    fn duplicate_committed_for_same_mote_id_surfaces_loudly() {
+        let mut p = Projection::new();
+        p.fold(&committed_entry(1, 1, NdClass::Pure)).unwrap();
+        let result = p.fold(&committed_entry(1, 2, NdClass::Pure));
+        assert!(matches!(
+            result,
+            Err(ProjectionError::DuplicateCommitted(_))
+        ));
+    }
+
+    #[test]
+    fn last_seq_advances_monotonically() {
+        let mut p = Projection::new();
+        p.fold(&proposed_entry(1, 1)).unwrap();
+        p.fold(&proposed_entry(2, 2)).unwrap();
+        p.fold(&committed_entry(1, 3, NdClass::Pure)).unwrap();
+        assert_eq!(p.current_seq(), 3);
+    }
+
+    #[test]
+    fn register_mote_makes_it_pending() {
+        let mut p = Projection::new();
+        p.register_mote(RegisterMote {
+            mote_id: mid(1),
+            nd_class: NdClass::Pure,
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            parents: SmallVec::new(),
+        });
+        assert_eq!(p.state_of(&mid(1)), MoteState::Pending);
+    }
+
+    #[test]
+    fn snapshot_is_immutable_under_subsequent_folds() {
+        let mut p = Projection::new();
+        p.fold(&committed_entry(1, 1, NdClass::Pure)).unwrap();
+        let snap = p.snapshot();
+        assert_eq!(snap.state_of(&mid(1)), MoteState::Committed);
+        // Mutate the projection — snapshot must NOT change
+        p.fold(&repudiated_entry(1, 1, 2)).unwrap();
+        assert_eq!(snap.state_of(&mid(1)), MoteState::Committed); // unchanged
+        assert_eq!(p.state_of(&mid(1)), MoteState::Repudiated); // updated
+    }
+
+    #[test]
+    fn promotion_state_is_not_applicable_in_p1() {
+        let mut p = Projection::new();
+        p.fold(&committed_entry(1, 1, NdClass::WorldMutating))
+            .unwrap();
+        // Per D18 P1 default — even WM motes are NotApplicable until the
+        // executor (P1.9) wires the MoteDef registry.
+        assert_eq!(p.promotion_state(&mid(1)), PromotionState::NotApplicable);
+    }
+
+    #[test]
+    fn state_of_for_non_existent_target_of_repudiation_remains_pending() {
+        let mut p = Projection::new();
+        // Repudiate a MoteId that was never committed — projection records nothing
+        // observable via state_of (per projection.md §5).
+        p.fold(&repudiated_entry(1, 99, 1)).unwrap();
+        assert_eq!(p.state_of(&mid(1)), MoteState::Pending);
+    }
+}

--- a/kx-projection/tests/dod.rs
+++ b/kx-projection/tests/dod.rs
@@ -1,0 +1,552 @@
+//! P1.5 Definition-of-Done tests covering `projection.md` §13 obligations.
+//!
+//! Each test is annotated with the obligation it satisfies. Integration tests at the
+//! bottom exercise the trait-seam by folding through both `SqliteJournal` and
+//! `InMemoryJournal`.
+
+use kx_content::ContentRef;
+use kx_journal::{
+    FailureReason, InMemoryJournal, Journal, JournalEntry, RepudiationReason, SqliteJournal,
+};
+use kx_mote::{EdgeKind, EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use kx_projection::{MoteState, Projection, PromotionState, RegisterMote};
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn mid(b: u8) -> MoteId {
+    MoteId::from_bytes([b; 32])
+}
+
+fn cref(b: u8) -> ContentRef {
+    ContentRef::from_bytes([b; 32])
+}
+
+fn dh(b: u8) -> MoteDefHash {
+    MoteDefHash::from_bytes([b; 32])
+}
+
+fn register(p: &mut Projection, mote_byte: u8, nd: NdClass, parents: &[(u8, EdgeMeta)]) {
+    let parents: SmallVec<[ParentRef; 4]> = parents
+        .iter()
+        .map(|(pb, edge)| ParentRef {
+            parent_id: mid(*pb),
+            edge: *edge,
+        })
+        .collect();
+    p.register_mote(RegisterMote {
+        mote_id: mid(mote_byte),
+        nd_class: nd,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        parents,
+    });
+}
+
+fn commit(p: &mut Projection, mote_byte: u8, seq: u64, nd: NdClass) {
+    p.fold(&JournalEntry::Committed {
+        mote_id: mid(mote_byte),
+        idempotency_key: [mote_byte; 32],
+        seq,
+        nondeterminism: nd,
+        result_ref: cref(mote_byte),
+        parents: SmallVec::new(),
+        mote_def_hash: dh(mote_byte),
+    })
+    .unwrap();
+}
+
+fn propose(p: &mut Projection, mote_byte: u8, seq: u64) {
+    p.fold(&JournalEntry::Proposed {
+        mote_id: mid(mote_byte),
+        idempotency_key: [mote_byte; 32],
+        seq,
+        nondeterminism: NdClass::Pure,
+        placement_hint: 0,
+    })
+    .unwrap();
+}
+
+fn fail(p: &mut Projection, mote_byte: u8, seq: u64) {
+    p.fold(&JournalEntry::Failed {
+        mote_id: mid(mote_byte),
+        idempotency_key: [mote_byte; 32],
+        seq,
+        reason_class: FailureReason::TimedOut,
+        reporter_id: 0,
+    })
+    .unwrap();
+}
+
+fn repudiate(p: &mut Projection, target_byte: u8, target_seq: u64, seq: u64) {
+    p.fold(&JournalEntry::Repudiated {
+        target_mote_id: mid(target_byte),
+        idempotency_key: [0u8; 32],
+        seq,
+        target_committed_seq: target_seq,
+        reason_class: RepudiationReason::OperatorAction,
+        repudiator_id: 0,
+    })
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 1 — hand-built log → expected graph state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_1_handbuilt_log_produces_expected_states() {
+    // 3-Mote DAG: A → B, A → C
+    // A commits; B proposed; C still pending.
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    register(&mut p, b'c', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+
+    commit(&mut p, b'a', 1, NdClass::Pure);
+    propose(&mut p, b'b', 2);
+
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Committed);
+    assert_eq!(p.state_of(&mid(b'b')), MoteState::Scheduled);
+    assert_eq!(p.state_of(&mid(b'c')), MoteState::Pending);
+
+    // Adjacency: a's children are b and c.
+    let children: Vec<MoteId> = p
+        .children_of(&mid(b'a'))
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect();
+    assert_eq!(children.len(), 2);
+    assert!(children.contains(&mid(b'b')));
+    assert!(children.contains(&mid(b'c')));
+
+    // b's parents include a.
+    let parents: Vec<MoteId> = p
+        .parents_of(&mid(b'b'))
+        .into_iter()
+        .map(|(pi, _)| pi)
+        .collect();
+    assert_eq!(parents, vec![mid(b'a')]);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 2 — re-fold determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_2_refold_yields_bit_equivalent_state() {
+    // Build a fresh projection by folding the same log twice; assert the read API
+    // returns identical results for every MoteId.
+    let log = sample_log();
+
+    let mut p1 = Projection::new();
+    register_sample_motes(&mut p1);
+    for e in &log {
+        p1.fold(e).unwrap();
+    }
+
+    let mut p2 = Projection::new();
+    register_sample_motes(&mut p2);
+    for e in &log {
+        p2.fold(e).unwrap();
+    }
+
+    for b in [b'a', b'b', b'c', b'd'] {
+        assert_eq!(p1.state_of(&mid(b)), p2.state_of(&mid(b)));
+        assert_eq!(p1.parents_of(&mid(b)), p2.parents_of(&mid(b)));
+        assert_eq!(p1.children_of(&mid(b)), p2.children_of(&mid(b)));
+        assert_eq!(p1.result_ref_of(&mid(b)), p2.result_ref_of(&mid(b)));
+    }
+    assert_eq!(p1.current_seq(), p2.current_seq());
+    assert_eq!(p1.ready_set(), p2.ready_set());
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 3 — seq-order independence of queries
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_3_queries_return_consistent_results_at_a_fixed_state() {
+    // The fold itself is seq-order-dependent (covered elsewhere); but once folded,
+    // querying the same projection multiple times must return identical results.
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    commit(&mut p, b'a', 1, NdClass::Pure);
+
+    let a = p.state_of(&mid(b'a'));
+    let a2 = p.state_of(&mid(b'a'));
+    let a3 = p.state_of(&mid(b'a'));
+    assert_eq!(a, a2);
+    assert_eq!(a2, a3);
+
+    let p_a = p.parents_of(&mid(b'a'));
+    let p_a2 = p.parents_of(&mid(b'a'));
+    assert_eq!(p_a, p_a2);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 4 — repudiation reflects + cascade is reachable via transitive_consumers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_4_repudiation_marker_and_cascade_reachable() {
+    // DAG: a → b → c (all data edges). Commit all three; repudiate a; verify b
+    // and c are reachable via transitive_consumers(a).
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    register(&mut p, b'c', NdClass::Pure, &[(b'b', EdgeMeta::data())]);
+
+    commit(&mut p, b'a', 1, NdClass::Pure);
+    commit(&mut p, b'b', 2, NdClass::Pure);
+    commit(&mut p, b'c', 3, NdClass::Pure);
+    repudiate(&mut p, b'a', 1, 4);
+
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Repudiated);
+    assert!(p.is_repudiated(&mid(b'a')));
+    assert_eq!(p.state_of(&mid(b'b')), MoteState::Committed); // not transitively flipped
+    assert_eq!(p.state_of(&mid(b'c')), MoteState::Committed);
+
+    // Cascade walker collects downstream consumers.
+    let cascade = p.transitive_consumers(&mid(b'a'));
+    assert!(cascade.contains(&mid(b'b')));
+    assert!(cascade.contains(&mid(b'c')));
+    assert_eq!(cascade.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 5 — read-only against the journal (structural)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_5_projection_does_not_depend_on_journal_mut_surface() {
+    // Structural check: the Projection API has no method that takes &mut Journal
+    // or calls Journal::append. We verify this by exercising the API and confirming
+    // the projection works WITHOUT borrowing a journal mutably.
+    let mut p = Projection::new();
+    commit(&mut p, b'a', 1, NdClass::Pure);
+    // Building a fresh projection only reads from the journal — Projection::from_journal
+    // takes &J, never &mut J.
+    let j = InMemoryJournal::new();
+    let _ = j.append(JournalEntry::Committed {
+        mote_id: mid(b'a'),
+        idempotency_key: [b'a'; 32],
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref: cref(b'a'),
+        parents: SmallVec::new(),
+        mote_def_hash: dh(b'a'),
+    });
+    let _ = Projection::from_journal(&j).unwrap();
+    // Compile-time test: this signature only accepts &J, not &mut J.
+    fn requires_immutable_journal<J: Journal>(_j: &J) {}
+    requires_immutable_journal(&j);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 6 — snapshot consistency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_6_snapshot_is_stable_under_subsequent_folds() {
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    commit(&mut p, b'a', 1, NdClass::Pure);
+
+    let snap_before = p.snapshot();
+    assert_eq!(snap_before.seq(), 1);
+    assert_eq!(snap_before.state_of(&mid(b'a')), MoteState::Committed);
+    assert_eq!(snap_before.state_of(&mid(b'b')), MoteState::Pending);
+
+    // Fold a Commit + Repudiation against the projection; snapshot must remain stable.
+    commit(&mut p, b'b', 2, NdClass::Pure);
+    repudiate(&mut p, b'a', 1, 3);
+
+    assert_eq!(snap_before.seq(), 1);
+    assert_eq!(snap_before.state_of(&mid(b'a')), MoteState::Committed); // snapshot unchanged
+    assert_eq!(snap_before.state_of(&mid(b'b')), MoteState::Pending);
+
+    // The live projection reflects the new state.
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Repudiated);
+    assert_eq!(p.state_of(&mid(b'b')), MoteState::Committed);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 7 — ready_set correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_7_ready_set_returns_pending_with_all_parents_committed() {
+    // DAG: a (root) → b → c
+    // After a commits, b is ready (parent committed). c is not (parent b is pending).
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    register(&mut p, b'c', NdClass::Pure, &[(b'b', EdgeMeta::data())]);
+
+    // Nothing committed: only a is ready (no parents).
+    let ready: Vec<MoteId> = p.ready_set();
+    assert_eq!(ready, vec![mid(b'a')]);
+
+    commit(&mut p, b'a', 1, NdClass::Pure);
+    let ready: Vec<MoteId> = p.ready_set();
+    assert_eq!(ready, vec![mid(b'b')]);
+
+    commit(&mut p, b'b', 2, NdClass::Pure);
+    let ready: Vec<MoteId> = p.ready_set();
+    assert_eq!(ready, vec![mid(b'c')]);
+
+    commit(&mut p, b'c', 3, NdClass::Pure);
+    let ready: Vec<MoteId> = p.ready_set();
+    assert!(ready.is_empty(), "no Pending Motes remain");
+}
+
+#[test]
+fn obligation_7b_ready_set_excludes_children_of_repudiated_parents() {
+    // Repudiating a parent excludes its children from ready_set (they no longer
+    // have a Committed-and-not-Repudiated parent).
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+
+    commit(&mut p, b'a', 1, NdClass::Pure);
+    assert_eq!(p.ready_set(), vec![mid(b'b')]);
+
+    repudiate(&mut p, b'a', 1, 2);
+    let ready = p.ready_set();
+    assert!(
+        !ready.contains(&mid(b'b')),
+        "b's parent a is Repudiated; b must not be in ready_set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 8 — transitive_consumers with control-edge opt-out
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_8_transitive_consumers_respects_non_cascade_control_edges() {
+    // DAG: a → b (data), a → c (control with non_cascade=true), a → d (control normal)
+    // transitive_consumers(a) should reach b and d but NOT c.
+    let mut p = Projection::new();
+    register(&mut p, b'a', NdClass::Pure, &[]);
+    register(&mut p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    register(
+        &mut p,
+        b'c',
+        NdClass::Pure,
+        &[(b'a', EdgeMeta::control_non_cascading())],
+    );
+    register(&mut p, b'd', NdClass::Pure, &[(b'a', EdgeMeta::control())]);
+
+    let cascade: Vec<MoteId> = p.transitive_consumers(&mid(b'a'));
+    assert!(cascade.contains(&mid(b'b')), "data child reachable");
+    assert!(
+        cascade.contains(&mid(b'd')),
+        "non-opted-out control child reachable"
+    );
+    assert!(
+        !cascade.contains(&mid(b'c')),
+        "opted-out control child NOT reachable"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 9 — cycle tolerance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_9_cycle_in_control_edges_does_not_loop() {
+    // Force a cycle via Committed entries (parents come from committed bodies).
+    // a → b → a (mutual control-edge cycle).
+    let mut p = Projection::new();
+
+    // Commit a with no parents (yet).
+    p.fold(&JournalEntry::Committed {
+        mote_id: mid(b'a'),
+        idempotency_key: [b'a'; 32],
+        seq: 1,
+        nondeterminism: NdClass::Pure,
+        result_ref: cref(b'a'),
+        parents: SmallVec::new(),
+        mote_def_hash: dh(b'a'),
+    })
+    .unwrap();
+
+    // Commit b with parent a (control edge).
+    let mut b_parents: SmallVec<[kx_journal::ParentEntry; 4]> = SmallVec::new();
+    b_parents.push(kx_journal::ParentEntry {
+        parent_id: mid(b'a'),
+        edge_kind: 1,
+        non_cascade: 0,
+    });
+    p.fold(&JournalEntry::Committed {
+        mote_id: mid(b'b'),
+        idempotency_key: [b'b'; 32],
+        seq: 2,
+        nondeterminism: NdClass::Pure,
+        result_ref: cref(b'b'),
+        parents: b_parents,
+        mote_def_hash: dh(b'b'),
+    })
+    .unwrap();
+
+    // Register a as having a back-edge to b (control). This creates a → b → a cycle.
+    register(&mut p, b'a', NdClass::Pure, &[(b'b', EdgeMeta::control())]);
+    // (registration overwrites declared info — the parent now appears in
+    // children_of(b), but a is already Committed; the cycle is in the graph.)
+
+    // BFS terminates and does not loop.
+    let cascade_a: Vec<MoteId> = p.transitive_consumers(&mid(b'a'));
+    let cascade_b: Vec<MoteId> = p.transitive_consumers(&mid(b'b'));
+
+    // Both walks should terminate; the visited-set bounds them.
+    assert!(cascade_a.len() <= 2);
+    assert!(cascade_b.len() <= 2);
+}
+
+// ---------------------------------------------------------------------------
+// Obligation 10 — promotion-state default
+// ---------------------------------------------------------------------------
+
+#[test]
+fn obligation_10_promotion_state_default_is_not_applicable() {
+    // Per D18 / projection.md §8: until P0.8 wires the MoteDef registry, every
+    // Mote's promotion_state is NotApplicable, regardless of nd_class.
+    let mut p = Projection::new();
+
+    commit(&mut p, b'a', 1, NdClass::Pure);
+    commit(&mut p, b'b', 2, NdClass::ReadOnlyNondet);
+    commit(&mut p, b'c', 3, NdClass::WorldMutating);
+
+    assert_eq!(p.promotion_state(&mid(b'a')), PromotionState::NotApplicable);
+    assert_eq!(p.promotion_state(&mid(b'b')), PromotionState::NotApplicable);
+    assert_eq!(p.promotion_state(&mid(b'c')), PromotionState::NotApplicable);
+
+    // Even an unknown MoteId returns NotApplicable (the default for absent Motes).
+    assert_eq!(p.promotion_state(&mid(b'z')), PromotionState::NotApplicable);
+}
+
+// ---------------------------------------------------------------------------
+// Trait-seam: from_journal works for both backends (Journal trait surface only)
+// ---------------------------------------------------------------------------
+
+fn exercise_from_journal<J: Journal>(j: &J) {
+    let _ = j.append(JournalEntry::Committed {
+        mote_id: mid(b'a'),
+        idempotency_key: [b'a'; 32],
+        seq: 0, // ignored
+        nondeterminism: NdClass::Pure,
+        result_ref: cref(b'a'),
+        parents: SmallVec::new(),
+        mote_def_hash: dh(b'a'),
+    });
+    let p = Projection::from_journal(j).unwrap();
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Committed);
+    assert_eq!(p.result_ref_of(&mid(b'a')), Some(cref(b'a')));
+}
+
+#[test]
+fn from_journal_works_via_sqlite_backend() {
+    let j = SqliteJournal::open_in_memory().unwrap();
+    exercise_from_journal(&j);
+}
+
+#[test]
+fn from_journal_works_via_in_memory_backend() {
+    let j = InMemoryJournal::new();
+    exercise_from_journal(&j);
+}
+
+// ---------------------------------------------------------------------------
+// Extra: failed → proposed → committed lifecycle through the projection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn failed_then_proposed_then_committed_resolves_to_committed() {
+    let mut p = Projection::new();
+    propose(&mut p, b'a', 1);
+    fail(&mut p, b'a', 2);
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Failed);
+    propose(&mut p, b'a', 3);
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Scheduled);
+    commit(&mut p, b'a', 4, NdClass::Pure);
+    assert_eq!(p.state_of(&mid(b'a')), MoteState::Committed);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers used by obligation 2's re-fold determinism test
+// ---------------------------------------------------------------------------
+
+fn register_sample_motes(p: &mut Projection) {
+    register(p, b'a', NdClass::Pure, &[]);
+    register(p, b'b', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    register(p, b'c', NdClass::Pure, &[(b'a', EdgeMeta::data())]);
+    register(
+        p,
+        b'd',
+        NdClass::Pure,
+        &[(b'b', EdgeMeta::data()), (b'c', EdgeMeta::data())],
+    );
+}
+
+fn sample_log() -> Vec<JournalEntry> {
+    vec![
+        JournalEntry::Proposed {
+            mote_id: mid(b'a'),
+            idempotency_key: [b'a'; 32],
+            seq: 1,
+            nondeterminism: NdClass::Pure,
+            placement_hint: 0,
+        },
+        JournalEntry::Committed {
+            mote_id: mid(b'a'),
+            idempotency_key: [b'a'; 32],
+            seq: 2,
+            nondeterminism: NdClass::Pure,
+            result_ref: cref(b'a'),
+            parents: SmallVec::new(),
+            mote_def_hash: dh(b'a'),
+        },
+        JournalEntry::Proposed {
+            mote_id: mid(b'b'),
+            idempotency_key: [b'b'; 32],
+            seq: 3,
+            nondeterminism: NdClass::Pure,
+            placement_hint: 0,
+        },
+        JournalEntry::Committed {
+            mote_id: mid(b'b'),
+            idempotency_key: [b'b'; 32],
+            seq: 4,
+            nondeterminism: NdClass::Pure,
+            result_ref: cref(b'b'),
+            parents: parent_entries(&[(b'a', EdgeKind::Data, false)]),
+            mote_def_hash: dh(b'b'),
+        },
+        JournalEntry::Committed {
+            mote_id: mid(b'c'),
+            idempotency_key: [b'c'; 32],
+            seq: 5,
+            nondeterminism: NdClass::Pure,
+            result_ref: cref(b'c'),
+            parents: parent_entries(&[(b'a', EdgeKind::Data, false)]),
+            mote_def_hash: dh(b'c'),
+        },
+    ]
+}
+
+fn parent_entries(spec: &[(u8, EdgeKind, bool)]) -> SmallVec<[kx_journal::ParentEntry; 4]> {
+    spec.iter()
+        .map(|(b, kind, nc)| kx_journal::ParentEntry {
+            parent_id: mid(*b),
+            edge_kind: kind.as_u8(),
+            non_cascade: u8::from(*nc),
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary

Implements **P1.5 — the projection that folds the append-only journal into the live graph view**. Per-Mote state, dependency adjacency, `ready_set`, `transitive_consumers` (the BFS cascade walker D22 builds on), snapshot isolation, cycle tolerance, and the P1 default for 3c promotion.

- `MoteState` (Pending / Scheduled / Committed / Failed / Repudiated) + `PromotionState` (Promoted / Unpromoted / NotApplicable).
- `RegisterMote` — workflow-author declaration so Pending Motes appear in `ready_set` before any journal entry lands.
- `Projection` + `Snapshot` (deep-cloned point-in-time view for snapshot-isolation contract per D16).
- 7-method read API on both: `state_of`, `parents_of`, `children_of`, `transitive_consumers`, `result_ref_of`, `ready_set`, `promotion_state`.
- `from_journal<J: Journal>` — cold-start replay through any backend.

## DoD coverage — all 10 obligations + extras

| # | Obligation | Test |
|---|---|---|
| 1 | Hand-built log → expected graph | `obligation_1_handbuilt_log_produces_expected_states` |
| 2 | Re-fold determinism | `obligation_2_refold_yields_bit_equivalent_state` |
| 3 | Query stability | `obligation_3_queries_return_consistent_results_at_a_fixed_state` |
| 4 | Repudiation reflects + cascade reachable | `obligation_4_repudiation_marker_and_cascade_reachable` |
| 5 | Read-only against the journal (structural) | `obligation_5_projection_does_not_depend_on_journal_mut_surface` |
| 6 | Snapshot consistency | `obligation_6_snapshot_is_stable_under_subsequent_folds` |
| 7 | `ready_set` correctness (+ repudiated-parent exclusion) | `obligation_7*` |
| 8 | `transitive_consumers` respects non-cascade control edges | `obligation_8_transitive_consumers_respects_non_cascade_control_edges` |
| 9 | Cycle tolerance | `obligation_9_cycle_in_control_edges_does_not_loop` |
| 10 | Promotion-state default = `NotApplicable` in P1 | `obligation_10_promotion_state_default_is_not_applicable` |
| extra | failed→proposed→committed lifecycle | `failed_then_proposed_then_committed_resolves_to_committed` |
| extra | `from_journal` via SqliteJournal + InMemoryJournal | trait-seam coverage |

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — **115/115 pass** (24 new + 91 unchanged; zero regression)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` — clean
- [x] **I1.c byte-determinism**: `libkx_projection.rlib` SHA-256 `096214af6aab33a10666482a416789b1a189f03983ec48da5d9ce7bceeb12301` reproducible across two release builds.
- [x] **SN-2 pre-commit diff audit**: 3 paths touched (`Cargo.lock`, `Cargo.toml`, `kx-projection/`); all OSS-allowlist.
- [ ] CI green on this PR.

## What's deliberately deferred (per the corpus)

- **Topology-shaper materialization** (P1.11). The projection lays the framework — `MoteInfo` carries metadata; the fold could add children mid-stream — but the content-store-side `TopologyDecision` decoder and child-edge materialization algorithm land at P1.11.
- **Full 3c promotion behavior** (P1.9). Per D18, `promotion_state` returns `NotApplicable` for every Mote in P1; the executor (P1.9) wires the `MoteDef` registry the projection consults for critic-of-producer lookups. 3a / 3b workflows run normally in P1; 3c is expressible but unsafe until P1.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)