### PR TITLE
P1.7-a: kx-llamacpp safe wrapper + build infra (smoke test deferred to P1.7-b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
     name: just ci
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (with submodules for kx-llamacpp-sys/llama.cpp)
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       # rust-toolchain.toml in the workspace root pins the exact version.
       # rustup auto-detects and installs it on first cargo invocation.
@@ -29,6 +31,13 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
+      # bindgen needs libclang; the kx-llamacpp-sys CMake build needs cmake + a
+      # C++ toolchain (already present on ubuntu-latest via build-essential).
+      - name: Install bindgen + CMake build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev clang cmake build-essential
+
       - name: Cache Cargo registry + target
         uses: actions/cache@v4
         with:
@@ -36,7 +45,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', '.gitmodules') }}
           restore-keys: |
             cargo-${{ runner.os }}-
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "kx-llamacpp-sys/llama.cpp"]
+	path = kx-llamacpp-sys/llama.cpp
+	url = https://github.com/ggerganov/llama.cpp.git
+	branch = master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,10 +168,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -167,6 +216,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -270,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +388,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,8 +447,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-llamacpp"
+version = "0.0.1"
+dependencies = [
+ "kx-llamacpp-sys",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-llamacpp-sys"
 version = "0.0.1"
+dependencies = [
+ "bindgen",
+ "cmake",
+]
 
 [[package]]
 name = "kx-mote"
@@ -427,6 +512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +560,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +583,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -662,6 +773,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +853,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys"]
+members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -26,6 +26,9 @@ rusqlite           = { version = "0.32", features = ["bundled"] }
 kx-mote            = { path = "kx-mote" }
 kx-content         = { path = "kx-content" }
 kx-journal         = { path = "kx-journal" }
+kx-llamacpp-sys    = { path = "kx-llamacpp-sys" }
+bindgen            = "0.70"
+cmake              = "0.1"
 
 [profile.release]
 strip         = "symbols"

--- a/kx-llamacpp-sys/Cargo.toml
+++ b/kx-llamacpp-sys/Cargo.toml
@@ -7,18 +7,18 @@ license      = { workspace = true }
 authors      = { workspace = true }
 repository   = { workspace = true }
 description  = "Raw FFI bindings to llama.cpp's C API. The single unsafe-heavy crate. Nothing but kx-llamacpp may import this."
-
-# Tells Cargo a downstream C library (llama) will be linked at the kx-llamacpp
-# crate level (P1.7). Today (P1.6, bindings-only) we ship forward declarations
-# only — no linking is performed and no -sys library is produced by this crate
-# directly. The `links` key is reserved for the P1.7 wiring; commented out so
-# `cargo build` stays happy in P1.6's bindings-only scope.
-# links = "llama"
+# `links = "llama"` declares that this crate, when built, produces a native library
+# named `llama` (via the build script's CMake invocation). Tells Cargo this crate
+# can be linked at most once per build graph — prevents duplicate-symbol surprises.
+links        = "llama"
+build        = "build.rs"
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
-# Intentionally none. This crate is forward declarations only and must not
-# carry any Rust dependencies beyond what `extern "C"` requires (i.e., nothing).
-# The FFI boundary stays narrow.
+# Intentionally none. Pure FFI: only what `extern "C"` needs (nothing).
+
+[build-dependencies]
+bindgen = { workspace = true }
+cmake   = { workspace = true }

--- a/kx-llamacpp-sys/build.rs
+++ b/kx-llamacpp-sys/build.rs
@@ -39,6 +39,12 @@ fn main() {
         .define("GGML_CUDA", "OFF")
         // BLAS optional; disable to keep the build dep-light.
         .define("GGML_BLAS", "OFF")
+        // OpenMP off: avoids the libgomp link-time requirement on Linux
+        // (rust-lld doesn't auto-link it). ggml-cpu falls back to its own
+        // thread-pool. Slight CPU perf cost; acceptable for OSS single-compute
+        // scope per D28. Cloud-side serving uses vLLM / SGLang (P5.1 / P5.1.5)
+        // which handle their own batching + threading.
+        .define("GGML_OPENMP", "OFF")
         // Position-independent code for downstream static linking.
         .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
         // Use Release optimization for the C++ build to keep runtime perf.

--- a/kx-llamacpp-sys/build.rs
+++ b/kx-llamacpp-sys/build.rs
@@ -1,0 +1,110 @@
+//! `kx-llamacpp-sys/build.rs` — builds llama.cpp and generates Rust bindings.
+//!
+//! Per `03-ffi-and-inference.md` §1 + D28:
+//! - llama.cpp is the OSS in-process inference backend.
+//! - CUDA is disabled (GPU-batched serving is cloud-side per D28).
+//! - llama.cpp's native platform defaults handle Metal on Apple Silicon, CPU elsewhere.
+//! - Static linking so downstream binaries are self-contained.
+//!
+//! What this script does:
+//! 1. Builds llama.cpp's static libraries via CMake (the `cmake` crate drives it).
+//! 2. Generates Rust bindings via `bindgen` against llama.h, with an allowlist
+//!    that limits the surface to `llama_*` symbols.
+//! 3. Emits the cargo directives so the downstream rlib links the produced library.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let llama_cpp_dir = manifest_dir.join("llama.cpp");
+
+    // Invalidate the build if the submodule contents change. The submodule pointer
+    // is the load-bearing pin; rebuilds happen when llama.cpp is updated.
+    println!("cargo:rerun-if-changed=llama.cpp/include/llama.h");
+    println!("cargo:rerun-if-changed=llama.cpp/CMakeLists.txt");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // ------------------------------------------------------------------
+    // 1. Build llama.cpp via CMake.
+    // ------------------------------------------------------------------
+    let dst = cmake::Config::new(&llama_cpp_dir)
+        // Static libraries — no .so/.dylib runtime dependencies.
+        .define("BUILD_SHARED_LIBS", "OFF")
+        // No tests, no examples, no server (they bloat the build and pull deps).
+        .define("LLAMA_BUILD_TESTS", "OFF")
+        .define("LLAMA_BUILD_EXAMPLES", "OFF")
+        .define("LLAMA_BUILD_SERVER", "OFF")
+        // CUDA is cloud-side per D28. Disable for OSS portability.
+        .define("GGML_CUDA", "OFF")
+        // BLAS optional; disable to keep the build dep-light.
+        .define("GGML_BLAS", "OFF")
+        // Position-independent code for downstream static linking.
+        .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
+        // Use Release optimization for the C++ build to keep runtime perf.
+        .profile("Release")
+        .build();
+
+    // ------------------------------------------------------------------
+    // 2. Tell cargo about the build output + libraries.
+    // ------------------------------------------------------------------
+    let lib_dir = dst.join("lib");
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+
+    // llama.cpp's static archives produced by `BUILD_SHARED_LIBS=OFF`.
+    // Linking order matters for static libs — dependencies after dependents.
+    println!("cargo:rustc-link-lib=static=llama");
+    println!("cargo:rustc-link-lib=static=ggml");
+    println!("cargo:rustc-link-lib=static=ggml-base");
+    println!("cargo:rustc-link-lib=static=ggml-cpu");
+
+    // Platform-conditional libs: link the C++ standard library; on macOS link the
+    // Foundation / Accelerate / Metal frameworks that llama.cpp's default build
+    // expects on Apple Silicon. On Linux, link libstdc++.
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("apple") {
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=Accelerate");
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=MetalKit");
+        println!("cargo:rustc-link-lib=framework=MetalPerformanceShaders");
+        println!("cargo:rustc-link-lib=c++");
+    } else {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Generate Rust bindings via bindgen.
+    // ------------------------------------------------------------------
+    let llama_h = llama_cpp_dir.join("include").join("llama.h");
+    let include_dir = llama_cpp_dir.join("include");
+    let ggml_include = llama_cpp_dir.join("ggml").join("include");
+
+    let bindings = bindgen::Builder::default()
+        .header(llama_h.to_string_lossy())
+        .clang_arg(format!("-I{}", include_dir.display()))
+        .clang_arg(format!("-I{}", ggml_include.display()))
+        // Allowlist: only llama_* (and the closely-related ggml types llama_h
+        // transitively references). Keeps the binding surface manageable.
+        .allowlist_function("llama_.*")
+        .allowlist_type("llama_.*")
+        .allowlist_var("LLAMA_.*")
+        // Use core types so the bindings work in no_std contexts too.
+        .use_core()
+        .ctypes_prefix("::core::ffi")
+        // Generate Rust enums for known C enums; rustified for usability.
+        .rustified_enum("llama_.*")
+        // Block clang from looking at system headers it doesn't need.
+        .layout_tests(false)
+        .derive_default(true)
+        .derive_debug(true)
+        // Cargo invalidation hook for header changes.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .expect("Failed to generate llama.cpp bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Failed to write bindings.rs to OUT_DIR");
+}

--- a/kx-llamacpp-sys/src/lib.rs
+++ b/kx-llamacpp-sys/src/lib.rs
@@ -1,218 +1,31 @@
-// Notice: this crate intentionally does NOT have `#![forbid(unsafe_code)]`.
-// Per `03-ffi-and-inference.md` §1, `kx-llamacpp-sys` is the **single unsafe boundary**
-// of the runtime — the only crate that defines `extern "C"` FFI declarations. The
-// `kx-llamacpp` safe wrapper (P1.7) is the only crate that imports this one;
-// downstream callers see only the safe API.
+// Per `03-ffi-and-inference.md` §1, this is the **single unsafe boundary** of the
+// runtime. `#![forbid(unsafe_code)]` is intentionally OMITTED here.
 
-#![warn(missing_docs)]
-// llama.cpp's C API uses snake_case + leading-underscore identifiers that don't fit
-// Rust's idiomatic naming. We deliberately preserve the upstream names so callers
-// (only `kx-llamacpp`, by rule) can recognize the C API one-to-one.
+#![allow(missing_docs)]
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+#![allow(clippy::all)]
 
 //! # kx-llamacpp-sys — raw FFI to llama.cpp's C API
 //!
-//! **The single unsafe-heavy crate in the runtime.** Per the FFI boundary rule from
-//! `03-ffi-and-inference.md` §1:
+//! The single unsafe-heavy crate. Bindings are generated at build time by `bindgen`
+//! against the vendored llama.cpp submodule (pinned to a specific upstream tag via
+//! `git submodule`).
 //!
-//! > **Rust owns *what / where / when / on-failure*. C++ owns *how to run a forward
-//! > pass*.**
+//! **Nothing but `kx-llamacpp` (P1.7) may import this crate.** The rule is enforced
+//! by convention; future workspace lints will catch violations.
 //!
-//! This crate carries the raw FFI declarations of llama.cpp's C API. **Nothing but
-//! `kx-llamacpp` (P1.7) may import this crate** — the rule is enforced by review and
-//! by a future compile-time lint at the workspace level. Downstream callers
-//! (`kx-inference`, `kx-executor`, etc.) see only the safe wrapper.
+//! ## Pinned upstream version
 //!
-//! ## P1.6 scope — bindings-only, linking deferred to P1.7
-//!
-//! This step ships **forward declarations only**: opaque types (`llama_model`,
-//! `llama_context`, `llama_vocab`) + a minimal set of `extern "C"` function
-//! signatures that operate on pointers. No `bindgen`, no `build.rs`, no
-//! `cc`/`cmake` invocation of llama.cpp's source, no linking. The DoD checks
-//! at this step are:
-//!
-//! 1. The crate compiles cleanly.
-//! 2. The binding shape is recognizable as llama.cpp's C API (one-to-one names).
-//! 3. The pinned upstream version is recorded (see [`PINNED_LLAMACPP_VERSION`]).
-//!
-//! The full set of bindings (including by-value params structs like
-//! `llama_model_params` and `llama_context_params`, the `llama_batch` interface, the
-//! tokenization + sampling API surface) lands at P1.7 alongside:
-//!
-//! - The `bindgen` integration (vendored llama.cpp headers + `build.rs`).
-//! - The C++ source compilation + linking (via the `cc` or `cmake` crate).
-//! - The safe wrapper (`kx-llamacpp`) over this raw surface.
-//! - The smoke test that loads a tiny GGUF and runs one forward pass through the
-//!   raw API. The GGUF will live under Git LFS per the established convention.
-//!
-//! ## Safety
-//!
-//! Every function in this crate is `unsafe` to call. Callers are responsible for
-//! upholding llama.cpp's documented preconditions (init order, lifetime/ownership
-//! of pointers, threading rules). The safe wrapper (`kx-llamacpp`) absorbs these
-//! preconditions behind a Rust-friendly API.
-//!
-//! ## The pinned version
-//!
-//! See [`PINNED_LLAMACPP_VERSION`]. When P1.7 lands the actual linking, the build
-//! script will pin to this same upstream version via either a git submodule or a
-//! vendored source drop.
+//! [`PINNED_LLAMACPP_TAG`] records the git tag the submodule is pinned to. The
+//! build script invokes CMake against that source tree.
 
-/// The upstream llama.cpp version this binding shape was authored against.
+/// The upstream llama.cpp git tag this crate's build script compiles against.
 ///
-/// Updates to this value MUST be paired with regeneration of the bindings + a CI
-/// integration test against the new version. As of P1.6 (bindings-only), this is a
-/// documentation pin; P1.7 will hold the binding ABI to the same version via the
-/// build script.
-pub const PINNED_LLAMACPP_VERSION: &str = "b4000 (placeholder — P1.7 pins via submodule/vendor)";
+/// Updates: bump the submodule (`git -C kx-llamacpp-sys/llama.cpp checkout <new_tag>;
+/// git add kx-llamacpp-sys/llama.cpp`) and update this string in lock-step.
+pub const PINNED_LLAMACPP_TAG: &str = "b9000";
 
-// ===========================================================================
-// Primitive type aliases (matching llama.h on 64-bit Linux/macOS as of 2026)
-// ===========================================================================
-
-/// `int32_t` token identifier in the model's vocabulary.
-pub type llama_token = i32;
-
-/// `int32_t` token position within a sequence (KV-cache slot index).
-pub type llama_pos = i32;
-
-/// `int32_t` per-batch sequence identifier.
-pub type llama_seq_id = i32;
-
-// ===========================================================================
-// Opaque types
-// ===========================================================================
-//
-// These follow the Rust FFI idiom for opaque C types: zero-sized struct with a
-// private field, so a `*mut llama_model` is unforgeable from safe Rust and any
-// dereference requires `unsafe`. The actual size/layout lives in llama.cpp; we
-// never construct these types in Rust — we only hold pointers to them.
-
-/// Opaque handle to a loaded model (the weights + tokenizer + metadata).
-///
-/// Lifetime: created by `llama_model_load_from_file` (P1.7 signature); freed by
-/// [`llama_model_free`]. **NOT thread-safe** — synchronize access in Rust.
-#[repr(C)]
-pub struct llama_model {
-    _private: [u8; 0],
-}
-
-/// Opaque handle to an inference context (KV-cache + per-context state).
-///
-/// One context per concurrent inference stream. Created from a `*llama_model` by
-/// `llama_new_context_with_model` (P1.7 signature); freed by [`llama_free`].
-#[repr(C)]
-pub struct llama_context {
-    _private: [u8; 0],
-}
-
-/// Opaque handle to the model's vocabulary (tokenizer state).
-///
-/// Borrowed view obtained via [`llama_model_get_vocab`]; lifetime tied to the
-/// owning model.
-#[repr(C)]
-pub struct llama_vocab {
-    _private: [u8; 0],
-}
-
-// ===========================================================================
-// Functions — the minimal pointer-only surface for P1.6
-// ===========================================================================
-//
-// By-value-struct functions (`llama_model_load_from_file` taking
-// `llama_model_params`, `llama_new_context_with_model` taking
-// `llama_context_params`, the entire tokenize / decode / sample surface) are
-// deferred to P1.7 because they require knowing the upstream struct layouts.
-// P1.7 introduces bindgen, which generates the layouts from the actual headers.
-
-extern "C" {
-    /// Initialize the llama.cpp backend. Must be called once before any other
-    /// llama_* function. Idempotent: calling twice is a no-op in upstream.
-    pub fn llama_backend_init();
-
-    /// Tear down the llama.cpp backend. Must be called after all
-    /// models/contexts have been freed.
-    pub fn llama_backend_free();
-
-    /// Free a previously-loaded model. After this returns, `model` is dangling.
-    ///
-    /// # Safety
-    /// `model` must have been produced by a llama_model_load_* function and
-    /// must not have been previously freed.
-    pub fn llama_model_free(model: *mut llama_model);
-
-    /// Free an inference context. After this returns, `ctx` is dangling.
-    ///
-    /// # Safety
-    /// `ctx` must have been produced by `llama_new_context_with_model` (or
-    /// equivalent) and must not have been previously freed. The model the
-    /// context was created from must outlive this call.
-    pub fn llama_free(ctx: *mut llama_context);
-
-    /// The context window size of an inference context (number of tokens it can
-    /// hold). Pure read.
-    ///
-    /// # Safety
-    /// `ctx` must be a valid, non-dangling context pointer.
-    pub fn llama_n_ctx(ctx: *const llama_context) -> u32;
-
-    /// The embedding dimensionality of a model. Pure read.
-    ///
-    /// # Safety
-    /// `model` must be a valid, non-dangling model pointer.
-    pub fn llama_n_embd(model: *const llama_model) -> i32;
-
-    /// The vocabulary size of a vocab. Pure read.
-    ///
-    /// # Safety
-    /// `vocab` must be a valid, non-dangling vocab pointer.
-    pub fn llama_n_vocab(vocab: *const llama_vocab) -> i32;
-
-    /// Borrow the vocabulary owned by `model`. The returned pointer is valid
-    /// for the lifetime of `model`.
-    ///
-    /// # Safety
-    /// `model` must be a valid, non-dangling model pointer.
-    pub fn llama_model_get_vocab(model: *const llama_model) -> *const llama_vocab;
-}
-
-// ===========================================================================
-// Compile-only shape check
-// ===========================================================================
-//
-// A binding-shape check that runs at *compile* time (zero runtime cost): if any
-// of the declared signatures is malformed, the const expressions below fail to
-// type-check. P1.6's "the crate compiles cleanly" DoD is captured here.
-
-const _ASSERT_TOKEN_IS_I32: usize = 0 - !(core::mem::size_of::<llama_token>() == 4) as usize;
-const _ASSERT_POS_IS_I32: usize = 0 - !(core::mem::size_of::<llama_pos>() == 4) as usize;
-const _ASSERT_SEQ_ID_IS_I32: usize = 0 - !(core::mem::size_of::<llama_seq_id>() == 4) as usize;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn opaque_types_are_zero_sized_to_prevent_construction_in_rust() {
-        // `llama_model`, `llama_context`, `llama_vocab` are zero-sized
-        // forward declarations. Their actual layout lives in C; Rust must only
-        // hold pointers. The ZST discipline prevents accidental
-        // safe-Rust-side construction.
-        assert_eq!(core::mem::size_of::<llama_model>(), 0);
-        assert_eq!(core::mem::size_of::<llama_context>(), 0);
-        assert_eq!(core::mem::size_of::<llama_vocab>(), 0);
-    }
-
-    #[test]
-    fn primitive_token_aliases_match_int32() {
-        assert_eq!(core::mem::size_of::<llama_token>(), 4);
-        assert_eq!(core::mem::size_of::<llama_pos>(), 4);
-        assert_eq!(core::mem::size_of::<llama_seq_id>(), 4);
-    }
-
-    #[test]
-    fn pinned_version_constant_is_non_empty() {
-        // Documentation pin; P1.7's build script will assert against this.
-        assert!(!PINNED_LLAMACPP_VERSION.is_empty());
-    }
-}
+// The generated bindings live at OUT_DIR/bindings.rs. They're verbose (1000s of
+// lines for the full llama.h surface) so they're not pre-committed — they're
+// regenerated on every build by `build.rs`.
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/kx-llamacpp-sys/src/lib.rs
+++ b/kx-llamacpp-sys/src/lib.rs
@@ -4,6 +4,10 @@
 #![allow(missing_docs)]
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 #![allow(clippy::all)]
+// The bindgen-generated bindings include doc comments lifted from llama.h that
+// contain bare URLs (linking to upstream PRs / issues). Suppress rustdoc lints
+// on the generated file rather than post-processing every release.
+#![allow(rustdoc::all)]
 
 //! # kx-llamacpp-sys — raw FFI to llama.cpp's C API
 //!

--- a/kx-llamacpp/Cargo.toml
+++ b/kx-llamacpp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name         = "kx-llamacpp"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "Safe Rust wrapper over kx-llamacpp-sys. Contains all unsafe behind a safe public API."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-llamacpp-sys = { workspace = true }
+thiserror       = { workspace = true }
+tracing         = { workspace = true }
+
+[dev-dependencies]
+tempfile           = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-llamacpp/src/lib.rs
+++ b/kx-llamacpp/src/lib.rs
@@ -1,0 +1,323 @@
+#![warn(missing_docs)]
+
+//! # kx-llamacpp — safe wrapper over llama.cpp's C API
+//!
+//! Per `03-ffi-and-inference.md` §1, **all unsafe is contained in this crate** (and the
+//! `-sys` crate it sits atop). Public surface is `unsafe`-free: callers see RAII Rust
+//! types, idiomatic `Result` returns, and lifetimes that enforce llama.cpp's ownership
+//! rules.
+//!
+//! ## Layering
+//!
+//! ```text
+//! caller (kx-inference, downstream)
+//!    │   safe Rust API only
+//!    ▼
+//! kx-llamacpp (this crate)        ← safe public API; unsafe blocks contained
+//!    │   `extern "C"` calls
+//!    ▼
+//! kx-llamacpp-sys (FFI)           ← bindgen-generated; no Rust above
+//!    │   ABI boundary
+//!    ▼
+//! llama.cpp (C++; vendored submodule, pinned tag)
+//! ```
+//!
+//! Nothing outside this crate imports `kx-llamacpp-sys` directly.
+//!
+//! ## P1.7-a scope
+//!
+//! This step ships the **safe wrapper API shape** + the build infrastructure that
+//! compiles + links llama.cpp. The smoke test that loads a real model is at P1.7-b
+//! (with a tiny GGUF downloaded in CI via a build script + SHA-256 verification).
+//!
+//! At P1.7-a:
+//! - [`LlamaBackend`] — RAII initialization of llama.cpp's backend.
+//! - [`Model`] — RAII handle to a loaded model.
+//! - [`Context`] — RAII handle to an inference context.
+//! - [`LlamaError`] — error type.
+//! - Tests that exercise the safe wrapper invariants WITHOUT loading a model
+//!   (LlamaBackend init/Drop sequence; Model::load on a non-existent path
+//!   returns the right error).
+
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr::NonNull;
+use std::sync::Mutex;
+
+use kx_llamacpp_sys as sys;
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors raised by the safe wrapper.
+#[derive(Debug, Error)]
+pub enum LlamaError {
+    /// The model file could not be loaded — bad path, malformed GGUF, or
+    /// llama.cpp internally rejected the model.
+    #[error("failed to load model from {path:?}")]
+    LoadFailed {
+        /// The path that was attempted.
+        path: std::path::PathBuf,
+    },
+
+    /// Failed to create an inference context from a model.
+    #[error("failed to create inference context")]
+    ContextCreationFailed,
+
+    /// The supplied path could not be converted to a C string (interior nul byte
+    /// or non-UTF-8 on platforms where C strings must be UTF-8).
+    #[error("path is not representable as a C string: {0:?}")]
+    PathInvalid(std::path::PathBuf),
+
+    /// An underlying I/O error while reading metadata before passing to llama.cpp.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+// ---------------------------------------------------------------------------
+// LlamaBackend — RAII for llama.cpp's global init/free
+// ---------------------------------------------------------------------------
+
+/// RAII initialization of llama.cpp's global backend state.
+///
+/// Calls `llama_backend_init` on construction and `llama_backend_free` on Drop.
+/// **Must outlive every [`Model`] and [`Context`]** — llama.cpp's backend state
+/// is shared global state required by all subsequent calls.
+///
+/// Per llama.cpp's documented thread-safety: backend init/free is not thread-safe.
+/// We serialize via an internal mutex so `LlamaBackend::new()` is safe to call
+/// from any thread; concurrent calls block briefly.
+pub struct LlamaBackend {
+    // The mutex is here to record that we hold the global backend slot. The
+    // unit field is sufficient — llama.cpp manages the actual state internally.
+    _marker: std::marker::PhantomData<*const ()>,
+}
+
+// Backend is a global resource but the Rust type is a witness, not a holder.
+// The backend itself is initialized once globally; multiple `LlamaBackend`
+// instances are NOT supported (the backend is conceptually a singleton).
+// We track init state via a process-global counter.
+
+static BACKEND_INIT_LOCK: Mutex<usize> = Mutex::new(0);
+
+impl LlamaBackend {
+    /// Initialize llama.cpp's backend. Returns a RAII handle; the backend is
+    /// freed when the last `LlamaBackend` is dropped.
+    ///
+    /// # Errors
+    /// Currently infallible — llama.cpp's `llama_backend_init` does not return
+    /// an error code in the version pinned at [`sys::PINNED_LLAMACPP_TAG`].
+    pub fn new() -> Result<Self, LlamaError> {
+        let mut guard = BACKEND_INIT_LOCK.lock().expect("poisoned backend lock");
+        if *guard == 0 {
+            // SAFETY: llama_backend_init is documented as safe to call once; the
+            // mutex above serializes any racing init calls.
+            unsafe { sys::llama_backend_init() };
+        }
+        *guard += 1;
+        Ok(Self {
+            _marker: std::marker::PhantomData,
+        })
+    }
+}
+
+impl Drop for LlamaBackend {
+    fn drop(&mut self) {
+        let mut guard = BACKEND_INIT_LOCK.lock().expect("poisoned backend lock");
+        *guard = guard.saturating_sub(1);
+        if *guard == 0 {
+            // SAFETY: ref-counted; freed only when the last handle is dropped.
+            unsafe { sys::llama_backend_free() };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model — RAII handle to a loaded model
+// ---------------------------------------------------------------------------
+
+/// RAII handle to a loaded llama.cpp model.
+///
+/// Construction performs the model load; Drop calls `llama_model_free`. The
+/// `Model` borrows from the `LlamaBackend` (lifetime-tied) so the backend
+/// outlives the model.
+pub struct Model<'b> {
+    // NonNull so the type is `!ZST` and impossible to construct without going
+    // through `Model::load`.
+    ptr: NonNull<sys::llama_model>,
+    _backend: std::marker::PhantomData<&'b LlamaBackend>,
+}
+
+impl<'b> Model<'b> {
+    /// Load a model from a GGUF file. Uses llama.cpp's default model parameters.
+    ///
+    /// # Errors
+    /// - [`LlamaError::PathInvalid`] if `path` cannot be converted to a C string.
+    /// - [`LlamaError::LoadFailed`] if llama.cpp returns a null pointer (file
+    ///   missing, malformed GGUF, model rejected internally).
+    pub fn load(_backend: &'b LlamaBackend, path: impl AsRef<Path>) -> Result<Self, LlamaError> {
+        let path_ref = path.as_ref();
+        let c_path = CString::new(path_ref.as_os_str().to_string_lossy().as_bytes())
+            .map_err(|_| LlamaError::PathInvalid(path_ref.to_owned()))?;
+
+        // SAFETY: llama_model_default_params is pure (returns a value struct);
+        // llama_model_load_from_file is unsafe because it reads from disk and
+        // returns a raw pointer (null on failure).
+        let model_ptr = unsafe {
+            let params = sys::llama_model_default_params();
+            sys::llama_model_load_from_file(c_path.as_ptr(), params)
+        };
+
+        let ptr = NonNull::new(model_ptr).ok_or_else(|| LlamaError::LoadFailed {
+            path: path_ref.to_owned(),
+        })?;
+
+        Ok(Self {
+            ptr,
+            _backend: std::marker::PhantomData,
+        })
+    }
+
+    /// The model's embedding dimensionality.
+    pub fn n_embd(&self) -> i32 {
+        // SAFETY: ptr is non-null and points to a live model owned by this Model.
+        unsafe { sys::llama_model_n_embd(self.ptr.as_ptr()) }
+    }
+}
+
+impl<'b> Drop for Model<'b> {
+    fn drop(&mut self) {
+        // SAFETY: ptr is non-null and was produced by llama_model_load_from_file;
+        // Drop runs exactly once.
+        unsafe { sys::llama_model_free(self.ptr.as_ptr()) }
+    }
+}
+
+// Model is Send if the underlying pointer is opaque + llama.cpp is documented as
+// per-model-thread-safe-for-non-mutating-reads. We don't claim Sync; callers wrap
+// in Mutex if cross-thread mutation is needed.
+unsafe impl<'b> Send for Model<'b> {}
+
+// ---------------------------------------------------------------------------
+// Context — RAII handle to an inference context
+// ---------------------------------------------------------------------------
+
+/// RAII handle to an inference context for a model.
+///
+/// Construction creates a fresh KV-cache context tied to the model; Drop calls
+/// `llama_free` to release the context. The `Context` borrows from the `Model`
+/// so the model outlives the context.
+pub struct Context<'m, 'b: 'm> {
+    ptr: NonNull<sys::llama_context>,
+    _model: std::marker::PhantomData<&'m Model<'b>>,
+}
+
+impl<'m, 'b: 'm> Context<'m, 'b> {
+    /// Create a new inference context for `model`. Uses llama.cpp's default
+    /// context parameters.
+    ///
+    /// # Errors
+    /// [`LlamaError::ContextCreationFailed`] if llama.cpp returns null.
+    pub fn new(model: &'m Model<'b>) -> Result<Self, LlamaError> {
+        // SAFETY: llama_context_default_params is pure; llama_new_context_with_model
+        // returns a raw pointer (null on failure).
+        let ctx_ptr = unsafe {
+            let params = sys::llama_context_default_params();
+            sys::llama_init_from_model(model.ptr.as_ptr(), params)
+        };
+
+        let ptr = NonNull::new(ctx_ptr).ok_or(LlamaError::ContextCreationFailed)?;
+
+        Ok(Self {
+            ptr,
+            _model: std::marker::PhantomData,
+        })
+    }
+
+    /// The context window size (number of tokens this context can hold).
+    pub fn n_ctx(&self) -> u32 {
+        // SAFETY: ptr is non-null and points to a live context owned by this Context.
+        unsafe { sys::llama_n_ctx(self.ptr.as_ptr()) }
+    }
+}
+
+impl<'m, 'b: 'm> Drop for Context<'m, 'b> {
+    fn drop(&mut self) {
+        // SAFETY: ptr is non-null and was produced by llama_init_from_model;
+        // Drop runs exactly once.
+        unsafe { sys::llama_free(self.ptr.as_ptr()) }
+    }
+}
+
+unsafe impl<'m, 'b: 'm> Send for Context<'m, 'b> {}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exercises the backend init/free cycle through real FFI. Verifies that the
+    /// link chain works end-to-end (kx-llamacpp → -sys → llama.cpp library).
+    #[test]
+    fn backend_init_and_drop() {
+        let backend = LlamaBackend::new().expect("backend init must succeed");
+        // Drop happens at end of scope. No model, no context — just init/free.
+        drop(backend);
+    }
+
+    /// Two backends in sequence: the ref-counted init mechanism handles repeated
+    /// construction safely.
+    #[test]
+    fn two_backends_in_sequence_work() {
+        let b1 = LlamaBackend::new().unwrap();
+        drop(b1);
+        let b2 = LlamaBackend::new().unwrap();
+        drop(b2);
+    }
+
+    /// Two concurrent backends share the same global state via ref-counting. The
+    /// backend is only freed when both are dropped.
+    #[test]
+    fn two_concurrent_backends_share_state() {
+        let b1 = LlamaBackend::new().unwrap();
+        let b2 = LlamaBackend::new().unwrap();
+        drop(b1);
+        // Backend should still be alive (b2 holds it).
+        drop(b2);
+        // Now backend is freed.
+    }
+
+    /// Loading a non-existent file produces `LlamaError::LoadFailed`.
+    #[test]
+    fn load_nonexistent_model_returns_load_failed() {
+        let backend = LlamaBackend::new().unwrap();
+        let result = Model::load(&backend, "/nonexistent/path/to.gguf");
+        match result {
+            Err(LlamaError::LoadFailed { path }) => {
+                assert_eq!(path, std::path::PathBuf::from("/nonexistent/path/to.gguf"));
+            }
+            other => panic!("expected LoadFailed, got: {other:?}"),
+        }
+    }
+
+    /// A path with a NUL byte fails with `PathInvalid`.
+    #[test]
+    fn path_with_nul_byte_returns_path_invalid() {
+        let backend = LlamaBackend::new().unwrap();
+        let bad_path = std::ffi::OsString::from("bad\0path.gguf");
+        let result = Model::load(&backend, std::path::PathBuf::from(bad_path));
+        assert!(matches!(result, Err(LlamaError::PathInvalid(_))));
+    }
+
+    /// The pinned tag constant is non-empty and matches what we expect to be
+    /// using. Forces a tracker update when the submodule version moves.
+    #[test]
+    fn pinned_tag_is_b9000() {
+        assert_eq!(sys::PINNED_LLAMACPP_TAG, "b9000");
+    }
+}

--- a/kx-llamacpp/src/lib.rs
+++ b/kx-llamacpp/src/lib.rs
@@ -297,11 +297,14 @@ mod tests {
     fn load_nonexistent_model_returns_load_failed() {
         let backend = LlamaBackend::new().unwrap();
         let result = Model::load(&backend, "/nonexistent/path/to.gguf");
+        // `Model` wraps a raw pointer and does not derive `Debug`; match the Err
+        // variant directly rather than relying on Debug formatting.
         match result {
             Err(LlamaError::LoadFailed { path }) => {
                 assert_eq!(path, std::path::PathBuf::from("/nonexistent/path/to.gguf"));
             }
-            other => panic!("expected LoadFailed, got: {other:?}"),
+            Err(other) => panic!("expected LoadFailed, got error: {other}"),
+            Ok(_) => panic!("expected LoadFailed, got an unexpected Ok(Model)"),
         }
     }
 


### PR DESCRIPTION
## Summary

P1.7-a per the user-approved split: ships **build infra + safe wrapper** for llama.cpp. P1.7-b adds the tiny-GGUF download + actual smoke test.

### What's in this PR

**Build infrastructure:**
- llama.cpp added as a git submodule pinned to **tag `b9000`** under `kx-llamacpp-sys/llama.cpp/`.
- `kx-llamacpp-sys/build.rs` invokes CMake against the submodule with CPU-only flags (`GGML_CUDA=OFF` per D28, `BUILD_SHARED_LIBS=OFF`, `LLAMA_BUILD_{TESTS,EXAMPLES,SERVER}=OFF`) + runs `bindgen` against `llama.h` with an `llama_*` allowlist.
- Platform-conditional linking: Foundation / Accelerate / Metal / MetalKit / MetalPerformanceShaders frameworks on Apple Silicon; libstdc++ on Linux.

**Safe wrapper (`kx-llamacpp`):**
- `LlamaBackend` — RAII, ref-counted via process-global mutex so concurrent constructions/destructions are safe.
- `Model<'b>` — RAII handle to a loaded model; lifetime-tied to LlamaBackend.
- `Context<'m, 'b>` — RAII inference context; lifetime-tied to Model.
- `LlamaError` — error enum (LoadFailed, ContextCreationFailed, PathInvalid, Io).
- 6 unit tests exercising real FFI through the wrapper.

**CI updates:**
- `actions/checkout@v4 with submodules: recursive`.
- New step installs `libclang-dev clang cmake build-essential` on `ubuntu-latest`.
- Cache key includes `.gitmodules` so submodule bumps invalidate.

### What's deferred to P1.7-b

- Tiny GGUF download in CI via build script + SHA-256 checksum verification.
- Smoke test that loads the GGUF + runs one forward pass through the safe wrapper.

### Risk note

This PR pulls in a heavy CMake-driven C++ build (llama.cpp's full source). **CI build time will be significantly longer** than prior PRs (estimate 5-15 min cold; faster on cache hit). I expect CI may need iteration for platform-specific build flags or linking issues; will react to whatever the first CI run surfaces.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo metadata` resolves cleanly (Cargo.lock updated)
- [x] **SN-2 pre-commit diff audit**: 9 paths touched (`.github/workflows/ci.yml`, `.gitmodules`, `Cargo.lock`, `Cargo.toml`, `kx-llamacpp-sys/*`, `kx-llamacpp/*`); all OSS-allowlist.
- [ ] CI green on this PR. (Skipping local cargo build/test because the CMake build of llama.cpp is too slow to iterate against locally; CI is the verification path.)
- [ ] Verified: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy -D warnings`, `cargo doc -D warnings`, I1.c byte-determinism — all to be confirmed by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)