### PR TITLE
P1.7-b: comprehensive llama.cpp safe wrapper + E2E smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,46 @@ jobs:
 
       - name: just ci
         run: just ci
+
+  smoke-test-with-model:
+    name: smoke-test-with-model (kx-llamacpp E2E inference)
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - name: Checkout (with submodules for kx-llamacpp-sys/llama.cpp)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: |
+          rustup show active-toolchain
+          rustc --version
+          cargo --version
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Install bindgen + CMake build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev clang cmake build-essential
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-smoke-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', '.gitmodules') }}
+          restore-keys: |
+            cargo-smoke-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Configure RUSTFLAGS for path-stripping
+        run: |
+          echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}= -Cmetadata=kortecx-v0" >> $GITHUB_ENV
+
+      - name: just smoke-test-with-model
+        run: just smoke-test-with-model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +125,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -210,11 +225,51 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -236,7 +291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -276,6 +331,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +361,27 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -370,10 +455,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -451,10 +639,12 @@ name = "kx-llamacpp"
 version = "0.0.1"
 dependencies = [
  "kx-llamacpp-sys",
+ "sha2",
  "tempfile",
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]
@@ -539,6 +729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +797,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -620,6 +816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +832,15 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -811,6 +1022,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +1095,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -941,6 +1201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1248,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1268,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -997,7 +1291,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1027,6 +1321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1106,6 +1410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,10 +1434,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1171,6 +1520,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1270,10 +1625,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1283,6 +1665,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1379,6 +1825,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1867,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,11 @@ kx-mote            = { path = "kx-mote" }
 kx-content         = { path = "kx-content" }
 kx-journal         = { path = "kx-journal" }
 kx-llamacpp-sys    = { path = "kx-llamacpp-sys" }
+kx-llamacpp        = { path = "kx-llamacpp" }
 bindgen            = "0.70"
 cmake              = "0.1"
+ureq               = { version = "2", default-features = false, features = ["tls"] }
+sha2               = "0.10"
 
 [profile.release]
 strip         = "symbols"

--- a/justfile
+++ b/justfile
@@ -54,6 +54,13 @@ check-reproducible:
     diff /tmp/kortecx-build-1.norm /tmp/kortecx-build-2.norm
     echo "I1.c byte-determinism: PASS"
 
+# Run the kx-llamacpp model-smoke-test feature: downloads a ~1.2 MB GGUF and
+# runs the full safe-wrapper inference pipeline (load → tokenize → decode →
+# sample → detokenize). Gated separately so the default `just ci` doesn't
+# need network access.
+smoke-test-with-model:
+    cargo test -p kx-llamacpp --features model-smoke-test -- --nocapture
+
 # Wipe all build artifacts.
 clean:
     cargo clean

--- a/kx-llamacpp-sys/build.rs
+++ b/kx-llamacpp-sys/build.rs
@@ -45,6 +45,10 @@ fn main() {
         // scope per D28. Cloud-side serving uses vLLM / SGLang (P5.1 / P5.1.5)
         // which handle their own batching + threading.
         .define("GGML_OPENMP", "OFF")
+        // Embed Metal shader library directly into the static archive on
+        // Apple targets so downstream binaries don't need to ship a separate
+        // `default.metallib` next to the executable. No effect on non-Apple.
+        .define("GGML_METAL_EMBED_LIBRARY", "ON")
         // Position-independent code for downstream static linking.
         .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
         // Use Release optimization for the C++ build to keep runtime perf.
@@ -69,6 +73,8 @@ fn main() {
     // expects on Apple Silicon. On Linux, link libstdc++.
     let target = env::var("TARGET").unwrap_or_default();
     if target.contains("apple") {
+        // Metal backend (only built on Apple targets by cmake).
+        println!("cargo:rustc-link-lib=static=ggml-metal");
         println!("cargo:rustc-link-lib=framework=Foundation");
         println!("cargo:rustc-link-lib=framework=Accelerate");
         println!("cargo:rustc-link-lib=framework=Metal");

--- a/kx-llamacpp/Cargo.toml
+++ b/kx-llamacpp/Cargo.toml
@@ -7,14 +7,30 @@ license      = { workspace = true }
 authors      = { workspace = true }
 repository   = { workspace = true }
 description  = "Safe Rust wrapper over kx-llamacpp-sys. Contains all unsafe behind a safe public API."
+build        = "build.rs"
 
 [lib]
 path = "src/lib.rs"
+
+[features]
+# Default: no model is downloaded; only API-shape unit tests run.
+default = []
+
+# Enable to make `build.rs` download the stories260K GGUF and the
+# `tests/smoke.rs` integration test exercise the full inference pipeline
+# (load → tokenize → decode → sample → detokenize). Used in CI's
+# `smoke-test-with-model` job. Local devs can opt in with
+# `cargo test -p kx-llamacpp --features model-smoke-test`.
+model-smoke-test = []
 
 [dependencies]
 kx-llamacpp-sys = { workspace = true }
 thiserror       = { workspace = true }
 tracing         = { workspace = true }
+
+[build-dependencies]
+ureq = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile           = { workspace = true }

--- a/kx-llamacpp/build.rs
+++ b/kx-llamacpp/build.rs
@@ -1,0 +1,146 @@
+//! `kx-llamacpp/build.rs` — optional GGUF download for the model smoke test.
+//!
+//! When the `model-smoke-test` feature is **disabled** (the default), this
+//! script does nothing. The crate compiles without network access.
+//!
+//! When the feature is **enabled**, this script downloads a tiny GGUF
+//! (stories260K, ~1.2 MB) into `OUT_DIR`, verifies its SHA-256, and emits
+//! `cargo:rustc-env=KX_LLAMACPP_SMOKE_TEST_MODEL=<path>` so the integration
+//! test in `tests/smoke.rs` can `include_str!` / `env!` the path.
+//!
+//! The file is cached in `OUT_DIR` across builds; subsequent invocations
+//! reuse the on-disk copy as long as the SHA matches.
+
+use std::env;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+/// The model URL — a 1.18 MB tinystories model in GGUF v3 format.
+///
+/// Hosted by ggml-org/models. This is the canonical tiny-GGUF location and
+/// has been stable since the GGUF v3 transition.
+const MODEL_URL: &str =
+    "https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf";
+
+/// SHA-256 of the model file. Computed locally + committed.
+/// If the upstream file changes, the download will fail loudly.
+const MODEL_SHA256: &str = "270cba1bd5109f42d03350f60406024560464db173c0e387d91f0426d3bd256d";
+
+/// The output filename inside `OUT_DIR`.
+const MODEL_FILENAME: &str = "stories260K.gguf";
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MODEL_SMOKE_TEST");
+
+    if env::var("CARGO_FEATURE_MODEL_SMOKE_TEST").is_err() {
+        // Feature disabled — nothing to do.
+        return;
+    }
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo"));
+    let model_path = out_dir.join(MODEL_FILENAME);
+
+    if model_path.exists() {
+        // Verify the cached copy matches the expected SHA. If it does, reuse.
+        // If it doesn't, re-download (cache poisoning / partial-write recovery).
+        if verify_sha(&model_path, MODEL_SHA256).is_ok() {
+            println!(
+                "cargo:rustc-env=KX_LLAMACPP_SMOKE_TEST_MODEL={}",
+                model_path.display()
+            );
+            return;
+        }
+        let _ = fs::remove_file(&model_path);
+    }
+
+    download_and_verify(MODEL_URL, &model_path, MODEL_SHA256);
+
+    println!(
+        "cargo:rustc-env=KX_LLAMACPP_SMOKE_TEST_MODEL={}",
+        model_path.display()
+    );
+}
+
+fn download_and_verify(url: &str, dest: &PathBuf, expected_sha: &str) {
+    eprintln!(
+        "kx-llamacpp build.rs: downloading {url} → {}",
+        dest.display()
+    );
+
+    // ureq with default TLS handles the redirects HF serves.
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(300))
+        .build();
+
+    let resp = agent
+        .get(url)
+        .call()
+        .unwrap_or_else(|e| panic!("HTTP GET failed for {url}: {e}"));
+
+    let mut reader = resp.into_reader();
+    let mut bytes = Vec::with_capacity(2 * 1024 * 1024);
+    reader
+        .read_to_end(&mut bytes)
+        .unwrap_or_else(|e| panic!("failed to read GGUF body from {url}: {e}"));
+
+    eprintln!(
+        "kx-llamacpp build.rs: downloaded {} bytes, verifying SHA-256",
+        bytes.len()
+    );
+
+    // Verify SHA-256 BEFORE writing — never trust a download.
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&bytes);
+    let actual = hex_encode(&hasher.finalize());
+    assert_eq!(
+        actual, expected_sha,
+        "SHA-256 mismatch for {url}: expected {expected_sha}, got {actual}. \
+         If the upstream file was updated, recompute the SHA and update build.rs."
+    );
+
+    // Write to a temporary path then rename — POSIX atomic-on-completion.
+    let tmp = dest.with_extension("partial");
+    {
+        let mut f = fs::File::create(&tmp)
+            .unwrap_or_else(|e| panic!("failed to create {}: {e}", tmp.display()));
+        f.write_all(&bytes)
+            .unwrap_or_else(|e| panic!("failed to write {}: {e}", tmp.display()));
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, dest).unwrap_or_else(|e| {
+        panic!(
+            "failed to rename {} → {}: {e}",
+            tmp.display(),
+            dest.display()
+        )
+    });
+}
+
+fn verify_sha(path: &PathBuf, expected: &str) -> Result<(), String> {
+    let mut f = fs::File::open(path).map_err(|e| e.to_string())?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf).map_err(|e| e.to_string())?;
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&buf);
+    let got = hex_encode(&hasher.finalize());
+    if got == expected {
+        Ok(())
+    } else {
+        Err(format!("expected {expected}, got {got}"))
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}

--- a/kx-llamacpp/src/backend.rs
+++ b/kx-llamacpp/src/backend.rs
@@ -1,0 +1,59 @@
+//! `LlamaBackend` — RAII for llama.cpp's global init / free.
+//!
+//! Per llama.cpp's documented thread-safety: backend init/free is not thread-safe.
+//! We serialize via an internal mutex + ref-count so [`LlamaBackend::new`] is safe
+//! to call from any thread, and the backend is only freed when the last handle
+//! is dropped.
+
+use std::sync::Mutex;
+
+use kx_llamacpp_sys as sys;
+
+use crate::error::LlamaError;
+
+/// RAII initialization of llama.cpp's global backend state.
+///
+/// Calls `llama_backend_init` on construction and `llama_backend_free` on the
+/// final Drop. **Must outlive every [`crate::Model`], [`crate::Context`], and
+/// [`crate::Sampler`]** — llama.cpp's backend state is shared global state
+/// required by all subsequent calls.
+pub struct LlamaBackend {
+    _marker: std::marker::PhantomData<*const ()>,
+}
+
+// Backend is a global resource but the Rust type is a witness, not a holder.
+// The backend itself is initialized once globally; multiple `LlamaBackend`
+// instances share state via a process-global ref-count.
+static BACKEND_INIT_LOCK: Mutex<usize> = Mutex::new(0);
+
+impl LlamaBackend {
+    /// Initialize llama.cpp's backend. Returns a RAII handle; the backend is
+    /// freed when the last `LlamaBackend` is dropped.
+    ///
+    /// # Errors
+    /// Currently infallible — llama.cpp's `llama_backend_init` does not return
+    /// an error code in the version pinned at [`sys::PINNED_LLAMACPP_TAG`].
+    pub fn new() -> Result<Self, LlamaError> {
+        let mut guard = BACKEND_INIT_LOCK.lock().expect("poisoned backend lock");
+        if *guard == 0 {
+            // SAFETY: llama_backend_init is documented as safe to call once; the
+            // mutex above serializes any racing init calls.
+            unsafe { sys::llama_backend_init() };
+        }
+        *guard += 1;
+        Ok(Self {
+            _marker: std::marker::PhantomData,
+        })
+    }
+}
+
+impl Drop for LlamaBackend {
+    fn drop(&mut self) {
+        let mut guard = BACKEND_INIT_LOCK.lock().expect("poisoned backend lock");
+        *guard = guard.saturating_sub(1);
+        if *guard == 0 {
+            // SAFETY: ref-counted; freed only when the last handle is dropped.
+            unsafe { sys::llama_backend_free() };
+        }
+    }
+}

--- a/kx-llamacpp/src/batch.rs
+++ b/kx-llamacpp/src/batch.rs
@@ -1,0 +1,109 @@
+//! `Batch` — RAII wrapper over `llama_batch`.
+//!
+//! A batch is a heap-allocated bundle of tokens (or embedding vectors) plus
+//! per-token position, sequence membership, and logits-output flags. It is
+//! populated by the caller, then submitted to [`crate::Context::decode`] for a
+//! forward pass.
+//!
+//! Lifetime: the batch owns its internal buffers via `llama_batch_init` /
+//! `llama_batch_free`. The capacity (`n_tokens`, `embd`, `n_seq_max`) is fixed
+//! at construction time; populating beyond it is a programming error.
+
+use kx_llamacpp_sys as sys;
+
+use crate::vocab::Token;
+
+/// RAII wrapper over `llama_batch`.
+///
+/// Construct via [`Self::with_capacity`] or [`Self::with_embeddings`]; populate
+/// via [`Self::add`]; submit to `Context::decode`.
+pub struct Batch {
+    inner: sys::llama_batch,
+    capacity: i32,
+}
+
+impl Batch {
+    /// Allocate a batch that holds up to `n_tokens` tokens, with up to
+    /// `n_seq_max` distinct sequence ids per token. Token mode (no embeddings).
+    pub fn with_capacity(n_tokens: i32, n_seq_max: i32) -> Self {
+        // SAFETY: llama_batch_init allocates internal buffers; we free them in Drop.
+        let inner = unsafe { sys::llama_batch_init(n_tokens, 0, n_seq_max) };
+        Self {
+            inner,
+            capacity: n_tokens,
+        }
+    }
+
+    /// Allocate a batch that holds up to `n_tokens` embedding vectors of
+    /// dimension `embd`. Embedding mode (no token ids).
+    pub fn with_embeddings(n_tokens: i32, embd: i32, n_seq_max: i32) -> Self {
+        let inner = unsafe { sys::llama_batch_init(n_tokens, embd, n_seq_max) };
+        Self {
+            inner,
+            capacity: n_tokens,
+        }
+    }
+
+    /// Current number of populated tokens in the batch.
+    pub fn n_tokens(&self) -> i32 {
+        self.inner.n_tokens
+    }
+
+    /// The allocated capacity (the `n_tokens` passed at construction).
+    pub fn capacity(&self) -> i32 {
+        self.capacity
+    }
+
+    /// Reset the batch's logical size to zero. Does not reallocate; the
+    /// internal buffers are reused.
+    pub fn clear(&mut self) {
+        self.inner.n_tokens = 0;
+    }
+
+    /// Append a token at `pos` (position in its sequence), belonging to
+    /// `seq_ids`, with `compute_logits` controlling whether the output for
+    /// this position is materialized after `decode`.
+    ///
+    /// # Panics
+    /// Panics if the batch is full (caller should size it for the workload).
+    pub fn add(&mut self, token: Token, pos: i32, seq_ids: &[i32], compute_logits: bool) {
+        assert!(
+            self.inner.n_tokens < self.capacity,
+            "Batch is full (capacity = {}); resize or use multiple batches",
+            self.capacity
+        );
+        let i = self.inner.n_tokens as usize;
+        // SAFETY: All four arrays are sized to at least `capacity`; we just
+        // checked the bound. seq_id is an array-of-arrays; the j-th inner array
+        // is sized to n_seq_max (asserted via the construction-time guarantee).
+        unsafe {
+            *self.inner.token.add(i) = token;
+            *self.inner.pos.add(i) = pos;
+            *self.inner.n_seq_id.add(i) = seq_ids.len() as i32;
+            let seq_ptr = *self.inner.seq_id.add(i);
+            for (j, &s) in seq_ids.iter().enumerate() {
+                *seq_ptr.add(j) = s;
+            }
+            *self.inner.logits.add(i) = i8::from(compute_logits);
+        }
+        self.inner.n_tokens += 1;
+    }
+
+    /// Borrow the raw `llama_batch` value for submission to `llama_decode`.
+    ///
+    /// # Safety
+    /// The returned struct's pointers remain valid only for the lifetime of
+    /// `self`. Do not store the returned struct beyond a single decode call.
+    pub(crate) fn as_raw(&self) -> sys::llama_batch {
+        self.inner
+    }
+}
+
+impl Drop for Batch {
+    fn drop(&mut self) {
+        // SAFETY: inner was produced by llama_batch_init in the constructor.
+        unsafe { sys::llama_batch_free(self.inner) }
+    }
+}
+
+unsafe impl Send for Batch {}

--- a/kx-llamacpp/src/context.rs
+++ b/kx-llamacpp/src/context.rs
@@ -1,0 +1,399 @@
+//! `Context` + `ContextParams` — RAII inference context, decode, KV-cache
+//! management, logits + embeddings readout, and performance counters.
+
+use std::ptr::NonNull;
+
+use kx_llamacpp_sys as sys;
+
+use crate::batch::Batch;
+use crate::error::LlamaError;
+use crate::model::Model;
+
+/// Pooling strategy for embedding extraction.
+///
+/// Mirrors `llama_pooling_type`. For text-only generation, leave at
+/// [`Self::Unspecified`] (llama.cpp picks per-model).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum PoolingType {
+    /// Let llama.cpp pick the per-model default.
+    Unspecified = -1,
+    /// No pooling — per-token embeddings.
+    None = 0,
+    /// Mean over all tokens in the sequence.
+    Mean = 1,
+    /// Use the embedding at the CLS position.
+    Cls = 2,
+    /// Use the embedding at the last position.
+    Last = 3,
+    /// Rerank pooling (cls-head for reranker models).
+    Rank = 4,
+}
+
+/// Builder for inference-context parameters.
+///
+/// Wraps llama.cpp's default `llama_context_params` and exposes the knobs
+/// kortecx cares about. Defaults are inherited from llama.cpp.
+pub struct ContextParams {
+    inner: sys::llama_context_params,
+}
+
+impl Default for ContextParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContextParams {
+    /// Construct with llama.cpp's defaults.
+    pub fn new() -> Self {
+        // SAFETY: pure C function returning a value struct.
+        Self {
+            inner: unsafe { sys::llama_context_default_params() },
+        }
+    }
+
+    /// Text context size in tokens. 0 = take from model.
+    pub fn with_n_ctx(mut self, n: u32) -> Self {
+        self.inner.n_ctx = n;
+        self
+    }
+
+    /// Logical maximum batch size submitted to `llama_decode`.
+    pub fn with_n_batch(mut self, n: u32) -> Self {
+        self.inner.n_batch = n;
+        self
+    }
+
+    /// Physical maximum batch size.
+    pub fn with_n_ubatch(mut self, n: u32) -> Self {
+        self.inner.n_ubatch = n;
+        self
+    }
+
+    /// Maximum number of sequences this context can hold.
+    pub fn with_n_seq_max(mut self, n: u32) -> Self {
+        self.inner.n_seq_max = n;
+        self
+    }
+
+    /// Number of threads for generation. 0 = auto (llama.cpp picks).
+    pub fn with_n_threads(mut self, n: i32) -> Self {
+        self.inner.n_threads = n;
+        self
+    }
+
+    /// Number of threads for batch processing.
+    pub fn with_n_threads_batch(mut self, n: i32) -> Self {
+        self.inner.n_threads_batch = n;
+        self
+    }
+
+    /// Extract embeddings alongside logits during decode.
+    pub fn with_embeddings(mut self, on: bool) -> Self {
+        self.inner.embeddings = on;
+        self
+    }
+
+    /// Embedding pooling strategy.
+    pub fn with_pooling_type(mut self, pt: PoolingType) -> Self {
+        // The bindgen-generated enum's discriminants match the C enum values.
+        // SAFETY: transmute is between two `#[repr(i32)]` enums with matching
+        // values; both sides are POD i32.
+        self.inner.pooling_type =
+            unsafe { core::mem::transmute::<i32, sys::llama_pooling_type>(pt as i32) };
+        self
+    }
+
+    /// Offload the KQV matmul and KV cache to GPU when available.
+    pub fn with_offload_kqv(mut self, on: bool) -> Self {
+        self.inner.offload_kqv = on;
+        self
+    }
+
+    /// Disable per-call performance timing collection (default: enabled).
+    pub fn with_no_perf(mut self, on: bool) -> Self {
+        self.inner.no_perf = on;
+        self
+    }
+}
+
+/// Performance counters snapshot.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerfData {
+    /// Absolute start time in milliseconds.
+    pub t_start_ms: f64,
+    /// Time spent loading the model in milliseconds.
+    pub t_load_ms: f64,
+    /// Time spent processing prompt tokens in milliseconds.
+    pub t_p_eval_ms: f64,
+    /// Time spent generating tokens in milliseconds.
+    pub t_eval_ms: f64,
+    /// Number of prompt tokens processed.
+    pub n_p_eval: i32,
+    /// Number of generated tokens.
+    pub n_eval: i32,
+    /// Number of reused compute graphs (cache hits).
+    pub n_reused: i32,
+}
+
+/// RAII handle to an inference context for a model.
+pub struct Context<'m, 'b: 'm> {
+    pub(crate) ptr: NonNull<sys::llama_context>,
+    n_vocab: i32,
+    n_embd: i32,
+    _model: std::marker::PhantomData<&'m Model<'b>>,
+}
+
+impl<'m, 'b: 'm> Context<'m, 'b> {
+    /// Create a context with llama.cpp defaults.
+    ///
+    /// # Errors
+    /// [`LlamaError::ContextCreationFailed`] if llama.cpp returns null.
+    pub fn new(model: &'m Model<'b>) -> Result<Self, LlamaError> {
+        Self::new_with_params(model, &ContextParams::new())
+    }
+
+    /// Create a context with custom parameters.
+    ///
+    /// # Errors
+    /// [`LlamaError::ContextCreationFailed`] if llama.cpp returns null.
+    pub fn new_with_params(
+        model: &'m Model<'b>,
+        params: &ContextParams,
+    ) -> Result<Self, LlamaError> {
+        // Cache n_vocab + n_embd so logits/embeddings slices are properly bounded.
+        let vocab = model.vocab();
+        let n_vocab = vocab.n_tokens();
+        let n_embd = model.n_embd();
+
+        // SAFETY: llama_init_from_model returns a raw pointer (null on failure).
+        let ctx_ptr = unsafe { sys::llama_init_from_model(model.ptr.as_ptr(), params.inner) };
+
+        let ptr = NonNull::new(ctx_ptr).ok_or(LlamaError::ContextCreationFailed)?;
+
+        Ok(Self {
+            ptr,
+            n_vocab,
+            n_embd,
+            _model: std::marker::PhantomData,
+        })
+    }
+
+    /// The context window size (number of tokens this context can hold).
+    pub fn n_ctx(&self) -> u32 {
+        // SAFETY: ptr is non-null and points to a live context.
+        unsafe { sys::llama_n_ctx(self.ptr.as_ptr()) }
+    }
+
+    /// The logical batch size this context was created with.
+    pub fn n_batch(&self) -> u32 {
+        unsafe { sys::llama_n_batch(self.ptr.as_ptr()) }
+    }
+
+    /// The maximum number of sequences this context supports.
+    pub fn n_seq_max(&self) -> u32 {
+        unsafe { sys::llama_n_seq_max(self.ptr.as_ptr()) }
+    }
+
+    /// Run a forward pass over `batch`. Tokens with `compute_logits=true`
+    /// will have their logits available via [`Self::logits_ith`].
+    ///
+    /// # Errors
+    /// [`LlamaError::DecodeFailed`] for any non-zero return code.
+    pub fn decode(&mut self, batch: &Batch) -> Result<(), LlamaError> {
+        // SAFETY: ctx is live; batch.as_raw exposes valid arrays for the
+        // duration of this call.
+        let rc = unsafe { sys::llama_decode(self.ptr.as_ptr(), batch.as_raw()) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(LlamaError::DecodeFailed(rc))
+        }
+    }
+
+    /// Run the encoder pass (for encoder-decoder models). Most decoder-only
+    /// models won't need this.
+    ///
+    /// # Errors
+    /// [`LlamaError::EncodeFailed`] for any non-zero return code.
+    pub fn encode(&mut self, batch: &Batch) -> Result<(), LlamaError> {
+        let rc = unsafe { sys::llama_encode(self.ptr.as_ptr(), batch.as_raw()) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(LlamaError::EncodeFailed(rc))
+        }
+    }
+
+    /// Logits for the i-th output position in the last decoded batch.
+    ///
+    /// Returns `None` if `i` references a position whose `compute_logits` was
+    /// false at decode time, or if no batch has been decoded yet.
+    pub fn logits_ith(&self, i: i32) -> Option<&[f32]> {
+        // SAFETY: returned pointer is valid until the next decode call; the
+        // slice is bounded by the cached n_vocab (= vocab.n_tokens()).
+        let ptr = unsafe { sys::llama_get_logits_ith(self.ptr.as_ptr(), i) };
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: llama.cpp guarantees the returned pointer addresses
+            // `n_vocab` contiguous floats.
+            Some(unsafe { core::slice::from_raw_parts(ptr, self.n_vocab as usize) })
+        }
+    }
+
+    /// Logits for the last output position (convenience).
+    pub fn logits_last(&self) -> Option<&[f32]> {
+        self.logits_ith(-1)
+    }
+
+    /// Per-token embeddings for the i-th output position. Requires the context
+    /// was created with `with_embeddings(true)`.
+    pub fn embeddings_ith(&self, i: i32) -> Option<&[f32]> {
+        let ptr = unsafe { sys::llama_get_embeddings_ith(self.ptr.as_ptr(), i) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { core::slice::from_raw_parts(ptr, self.n_embd as usize) })
+        }
+    }
+
+    /// Pooled embedding for a sequence. Requires the context was created with
+    /// `with_embeddings(true)` and a non-`None` pooling type.
+    ///
+    /// # Errors
+    /// [`LlamaError::EmbeddingsUnavailable`] if pooling is not configured
+    /// (the returned pointer would be null).
+    pub fn embeddings_seq(&self, seq_id: i32) -> Result<&[f32], LlamaError> {
+        let ptr = unsafe { sys::llama_get_embeddings_seq(self.ptr.as_ptr(), seq_id) };
+        if ptr.is_null() {
+            Err(LlamaError::EmbeddingsUnavailable(
+                "no pooled vector for seq_id (pooling disabled or seq absent)",
+            ))
+        } else {
+            // SAFETY: pooled vector is `n_embd` floats.
+            Ok(unsafe { core::slice::from_raw_parts(ptr, self.n_embd as usize) })
+        }
+    }
+
+    // -- KV-cache management ------------------------------------------------
+
+    /// Clear the KV cache. If `data` is true, also zero the underlying buffer
+    /// (useful for benchmarking determinism).
+    pub fn kv_cache_clear(&mut self, data: bool) {
+        // SAFETY: ctx is live; the memory handle is owned by ctx.
+        unsafe {
+            let mem = sys::llama_get_memory(self.ptr.as_ptr());
+            sys::llama_memory_clear(mem, data);
+        }
+    }
+
+    /// Remove the tokens in `[p0, p1)` from sequence `seq_id`. `p1 < 0` means
+    /// "through the end". Returns false if the underlying memory backend
+    /// doesn't support the operation.
+    pub fn kv_cache_seq_rm(&mut self, seq_id: i32, p0: i32, p1: i32) -> bool {
+        unsafe {
+            let mem = sys::llama_get_memory(self.ptr.as_ptr());
+            sys::llama_memory_seq_rm(mem, seq_id, p0, p1)
+        }
+    }
+
+    /// Copy positions `[p0, p1)` from `src` to `dst` (creates a parallel
+    /// sequence sharing prefix state).
+    pub fn kv_cache_seq_cp(&mut self, src: i32, dst: i32, p0: i32, p1: i32) {
+        unsafe {
+            let mem = sys::llama_get_memory(self.ptr.as_ptr());
+            sys::llama_memory_seq_cp(mem, src, dst, p0, p1);
+        }
+    }
+
+    /// Drop all sequences except `seq_id` from the KV cache.
+    pub fn kv_cache_seq_keep(&mut self, seq_id: i32) {
+        unsafe {
+            let mem = sys::llama_get_memory(self.ptr.as_ptr());
+            sys::llama_memory_seq_keep(mem, seq_id);
+        }
+    }
+
+    /// Maximum position currently held for `seq_id`, or -1 if none.
+    pub fn kv_cache_seq_pos_max(&self, seq_id: i32) -> i32 {
+        unsafe {
+            let mem = sys::llama_get_memory(self.ptr.as_ptr());
+            sys::llama_memory_seq_pos_max(mem, seq_id)
+        }
+    }
+
+    // -- Performance counters ----------------------------------------------
+
+    /// Snapshot of performance counters (load time, prompt eval time,
+    /// generation time, token counts).
+    pub fn perf(&self) -> PerfData {
+        // SAFETY: pure read from ctx.
+        let raw = unsafe { sys::llama_perf_context(self.ptr.as_ptr()) };
+        PerfData {
+            t_start_ms: raw.t_start_ms,
+            t_load_ms: raw.t_load_ms,
+            t_p_eval_ms: raw.t_p_eval_ms,
+            t_eval_ms: raw.t_eval_ms,
+            n_p_eval: raw.n_p_eval,
+            n_eval: raw.n_eval,
+            n_reused: raw.n_reused,
+        }
+    }
+
+    /// Reset performance counters to zero.
+    pub fn perf_reset(&mut self) {
+        unsafe { sys::llama_perf_context_reset(self.ptr.as_ptr()) }
+    }
+
+    /// Underlying context pointer for the sampler — used by [`crate::Sampler`]
+    /// and not exposed publicly. This intentionally lives inside the crate.
+    pub(crate) fn raw_mut(&mut self) -> *mut sys::llama_context {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<'m, 'b: 'm> Drop for Context<'m, 'b> {
+    fn drop(&mut self) {
+        // SAFETY: ptr is non-null and was produced by llama_init_from_model;
+        // Drop runs exactly once.
+        unsafe { sys::llama_free(self.ptr.as_ptr()) }
+    }
+}
+
+unsafe impl<'m, 'b: 'm> Send for Context<'m, 'b> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pooling_type_repr_matches_c_enum() {
+        // Sanity-check that our #[repr(i32)] discriminants match what bindgen
+        // expects. Failing this means the model has been updated and the enum
+        // variant numbers have shifted.
+        assert_eq!(PoolingType::Unspecified as i32, -1);
+        assert_eq!(PoolingType::None as i32, 0);
+        assert_eq!(PoolingType::Mean as i32, 1);
+        assert_eq!(PoolingType::Cls as i32, 2);
+        assert_eq!(PoolingType::Last as i32, 3);
+        assert_eq!(PoolingType::Rank as i32, 4);
+    }
+
+    #[test]
+    fn context_params_builder_compiles() {
+        // Just exercise the builder surface — no llama state is touched.
+        let _p = ContextParams::new()
+            .with_n_ctx(512)
+            .with_n_batch(64)
+            .with_n_ubatch(64)
+            .with_n_seq_max(1)
+            .with_n_threads(2)
+            .with_n_threads_batch(2)
+            .with_embeddings(false)
+            .with_pooling_type(PoolingType::Unspecified)
+            .with_offload_kqv(true)
+            .with_no_perf(false);
+    }
+}

--- a/kx-llamacpp/src/error.rs
+++ b/kx-llamacpp/src/error.rs
@@ -1,0 +1,65 @@
+//! Error type for the safe wrapper.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors raised by the safe wrapper.
+#[derive(Debug, Error)]
+pub enum LlamaError {
+    /// The model file could not be loaded — bad path, malformed GGUF, or
+    /// llama.cpp internally rejected the model.
+    #[error("failed to load model from {path:?}")]
+    LoadFailed {
+        /// The path that was attempted.
+        path: PathBuf,
+    },
+
+    /// Failed to create an inference context from a model.
+    #[error("failed to create inference context")]
+    ContextCreationFailed,
+
+    /// The supplied path could not be converted to a C string (interior nul byte
+    /// or non-UTF-8 on platforms where C strings must be UTF-8).
+    #[error("path is not representable as a C string: {0:?}")]
+    PathInvalid(PathBuf),
+
+    /// Failed to tokenize the input text — typically because the supplied
+    /// scratch buffer was too small AND llama.cpp rejected the resize loop.
+    #[error("tokenization failed (rc = {0})")]
+    TokenizeFailed(i32),
+
+    /// Failed to detokenize (write the piece for a token to a buffer).
+    #[error("detokenization failed for token {token} (rc = {rc})")]
+    DetokenizeFailed {
+        /// The token that failed to be detokenized.
+        token: i32,
+        /// The return code from `llama_token_to_piece`.
+        rc: i32,
+    },
+
+    /// `llama_decode` returned a non-zero status. 1 = no kv slots, 2 = compute error.
+    #[error("llama_decode returned non-zero status {0}")]
+    DecodeFailed(i32),
+
+    /// `llama_encode` returned a non-zero status (encoder-decoder models only).
+    #[error("llama_encode returned non-zero status {0}")]
+    EncodeFailed(i32),
+
+    /// Sampler chain construction failed (e.g. llama_sampler_chain_init returned NULL,
+    /// which would only happen under OOM).
+    #[error("failed to construct sampler chain")]
+    SamplerChainFailed,
+
+    /// A constructor for a particular sampler returned NULL.
+    #[error("failed to construct sampler: {0}")]
+    SamplerInitFailed(&'static str),
+
+    /// Embedding readout requested but the context was not configured with
+    /// `with_embeddings(true)` — or the requested seq_id has no pooled vector.
+    #[error("embeddings unavailable: {0}")]
+    EmbeddingsUnavailable(&'static str),
+
+    /// An underlying I/O error while reading metadata before passing to llama.cpp.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/kx-llamacpp/src/lib.rs
+++ b/kx-llamacpp/src/lib.rs
@@ -2,10 +2,10 @@
 
 //! # kx-llamacpp — safe wrapper over llama.cpp's C API
 //!
-//! Per `03-ffi-and-inference.md` §1, **all unsafe is contained in this crate** (and the
-//! `-sys` crate it sits atop). Public surface is `unsafe`-free: callers see RAII Rust
-//! types, idiomatic `Result` returns, and lifetimes that enforce llama.cpp's ownership
-//! rules.
+//! Per `03-ffi-and-inference.md` §1, **all unsafe is contained in this crate**
+//! (and the [`kx_llamacpp_sys`] crate it sits atop). Public surface is
+//! `unsafe`-free: callers see RAII Rust types, idiomatic `Result` returns, and
+//! lifetimes that enforce llama.cpp's ownership rules.
 //!
 //! ## Layering
 //!
@@ -24,254 +24,70 @@
 //!
 //! Nothing outside this crate imports `kx-llamacpp-sys` directly.
 //!
-//! ## P1.7-a scope
+//! ## API surface (P1.7-b)
 //!
-//! This step ships the **safe wrapper API shape** + the build infrastructure that
-//! compiles + links llama.cpp. The smoke test that loads a real model is at P1.7-b
-//! (with a tiny GGUF downloaded in CI via a build script + SHA-256 verification).
+//! | Type | Purpose |
+//! |---|---|
+//! | [`LlamaBackend`] | RAII initialization of llama.cpp's global backend. |
+//! | [`Model`] / [`ModelParams`] | Load a GGUF; query metadata (n_embd, n_layer, n_params, desc, size, …). |
+//! | [`Vocab`] | Borrowed from [`Model`]: tokenize, detokenize, BOS/EOS/NL queries. |
+//! | [`Batch`] | RAII over `llama_batch`: token + position + seq-id + logits-flag bundles. |
+//! | [`Context`] / [`ContextParams`] | RAII inference context: decode, encode, logits/embedding readout, KV-cache management, perf counters. |
+//! | [`Sampler`] / [`SamplerChainBuilder`] | Sampler chains: greedy, dist, temp, top_k, top_p, min_p, temp_ext. |
+//! | [`PoolingType`] | Embedding pooling strategy. |
+//! | [`PerfData`] | Snapshot of llama.cpp's internal performance counters. |
+//! | [`LlamaError`] | Error type. |
 //!
-//! At P1.7-a:
-//! - [`LlamaBackend`] — RAII initialization of llama.cpp's backend.
-//! - [`Model`] — RAII handle to a loaded model.
-//! - [`Context`] — RAII handle to an inference context.
-//! - [`LlamaError`] — error type.
-//! - Tests that exercise the safe wrapper invariants WITHOUT loading a model
-//!   (LlamaBackend init/Drop sequence; Model::load on a non-existent path
-//!   returns the right error).
+//! ## Lifetimes
+//!
+//! ```text
+//! LlamaBackend  ──┐ borrowed by ──┐
+//!                 │               ▼
+//!                 │           Sampler<'b>
+//!                 │
+//!                 └─ borrowed by ─► Model<'b>
+//!                                       │
+//!                                       └─ borrowed by ─► Vocab<'m,'b>
+//!                                                          Context<'m,'b>
+//!                                                          │
+//!                                                          └─ &mut by ─► decode(&Batch)
+//! ```
+//!
+//! `Batch` and `LlamaBackend` have no inbound lifetime: they're free-standing.
+//! Every other type encodes its dependency through a generic lifetime so the
+//! borrow checker rejects use-after-free at compile time.
 
-use std::ffi::CString;
-use std::path::Path;
-use std::ptr::NonNull;
-use std::sync::Mutex;
+pub mod backend;
+pub mod batch;
+pub mod context;
+pub mod error;
+pub mod model;
+pub mod sampler;
+pub mod vocab;
 
-use kx_llamacpp_sys as sys;
-use thiserror::Error;
-
-// ---------------------------------------------------------------------------
-// Error type
-// ---------------------------------------------------------------------------
-
-/// Errors raised by the safe wrapper.
-#[derive(Debug, Error)]
-pub enum LlamaError {
-    /// The model file could not be loaded — bad path, malformed GGUF, or
-    /// llama.cpp internally rejected the model.
-    #[error("failed to load model from {path:?}")]
-    LoadFailed {
-        /// The path that was attempted.
-        path: std::path::PathBuf,
-    },
-
-    /// Failed to create an inference context from a model.
-    #[error("failed to create inference context")]
-    ContextCreationFailed,
-
-    /// The supplied path could not be converted to a C string (interior nul byte
-    /// or non-UTF-8 on platforms where C strings must be UTF-8).
-    #[error("path is not representable as a C string: {0:?}")]
-    PathInvalid(std::path::PathBuf),
-
-    /// An underlying I/O error while reading metadata before passing to llama.cpp.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-}
+pub use backend::LlamaBackend;
+pub use batch::Batch;
+pub use context::{Context, ContextParams, PerfData, PoolingType};
+pub use error::LlamaError;
+pub use model::{Model, ModelParams};
+pub use sampler::{Sampler, SamplerChainBuilder};
+pub use vocab::{Token, Vocab};
 
 // ---------------------------------------------------------------------------
-// LlamaBackend — RAII for llama.cpp's global init/free
-// ---------------------------------------------------------------------------
-
-/// RAII initialization of llama.cpp's global backend state.
-///
-/// Calls `llama_backend_init` on construction and `llama_backend_free` on Drop.
-/// **Must outlive every [`Model`] and [`Context`]** — llama.cpp's backend state
-/// is shared global state required by all subsequent calls.
-///
-/// Per llama.cpp's documented thread-safety: backend init/free is not thread-safe.
-/// We serialize via an internal mutex so `LlamaBackend::new()` is safe to call
-/// from any thread; concurrent calls block briefly.
-pub struct LlamaBackend {
-    // The mutex is here to record that we hold the global backend slot. The
-    // unit field is sufficient — llama.cpp manages the actual state internally.
-    _marker: std::marker::PhantomData<*const ()>,
-}
-
-// Backend is a global resource but the Rust type is a witness, not a holder.
-// The backend itself is initialized once globally; multiple `LlamaBackend`
-// instances are NOT supported (the backend is conceptually a singleton).
-// We track init state via a process-global counter.
-
-static BACKEND_INIT_LOCK: Mutex<usize> = Mutex::new(0);
-
-impl LlamaBackend {
-    /// Initialize llama.cpp's backend. Returns a RAII handle; the backend is
-    /// freed when the last `LlamaBackend` is dropped.
-    ///
-    /// # Errors
-    /// Currently infallible — llama.cpp's `llama_backend_init` does not return
-    /// an error code in the version pinned at [`sys::PINNED_LLAMACPP_TAG`].
-    pub fn new() -> Result<Self, LlamaError> {
-        let mut guard = BACKEND_INIT_LOCK.lock().expect("poisoned backend lock");
-        if *guard == 0 {
-            // SAFETY: llama_backend_init is documented as safe to call once; the
-            // mutex above serializes any racing init calls.
-            unsafe { sys::llama_backend_init() };
-        }
-        *guard += 1;
-        Ok(Self {
-            _marker: std::marker::PhantomData,
-        })
-    }
-}
-
-impl Drop for LlamaBackend {
-    fn drop(&mut self) {
-        let mut guard = BACKEND_INIT_LOCK.lock().expect("poisoned backend lock");
-        *guard = guard.saturating_sub(1);
-        if *guard == 0 {
-            // SAFETY: ref-counted; freed only when the last handle is dropped.
-            unsafe { sys::llama_backend_free() };
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Model — RAII handle to a loaded model
-// ---------------------------------------------------------------------------
-
-/// RAII handle to a loaded llama.cpp model.
-///
-/// Construction performs the model load; Drop calls `llama_model_free`. The
-/// `Model` borrows from the `LlamaBackend` (lifetime-tied) so the backend
-/// outlives the model.
-pub struct Model<'b> {
-    // NonNull so the type is `!ZST` and impossible to construct without going
-    // through `Model::load`.
-    ptr: NonNull<sys::llama_model>,
-    _backend: std::marker::PhantomData<&'b LlamaBackend>,
-}
-
-impl<'b> Model<'b> {
-    /// Load a model from a GGUF file. Uses llama.cpp's default model parameters.
-    ///
-    /// # Errors
-    /// - [`LlamaError::PathInvalid`] if `path` cannot be converted to a C string.
-    /// - [`LlamaError::LoadFailed`] if llama.cpp returns a null pointer (file
-    ///   missing, malformed GGUF, model rejected internally).
-    pub fn load(_backend: &'b LlamaBackend, path: impl AsRef<Path>) -> Result<Self, LlamaError> {
-        let path_ref = path.as_ref();
-        let c_path = CString::new(path_ref.as_os_str().to_string_lossy().as_bytes())
-            .map_err(|_| LlamaError::PathInvalid(path_ref.to_owned()))?;
-
-        // SAFETY: llama_model_default_params is pure (returns a value struct);
-        // llama_model_load_from_file is unsafe because it reads from disk and
-        // returns a raw pointer (null on failure).
-        let model_ptr = unsafe {
-            let params = sys::llama_model_default_params();
-            sys::llama_model_load_from_file(c_path.as_ptr(), params)
-        };
-
-        let ptr = NonNull::new(model_ptr).ok_or_else(|| LlamaError::LoadFailed {
-            path: path_ref.to_owned(),
-        })?;
-
-        Ok(Self {
-            ptr,
-            _backend: std::marker::PhantomData,
-        })
-    }
-
-    /// The model's embedding dimensionality.
-    pub fn n_embd(&self) -> i32 {
-        // SAFETY: ptr is non-null and points to a live model owned by this Model.
-        unsafe { sys::llama_model_n_embd(self.ptr.as_ptr()) }
-    }
-}
-
-impl<'b> Drop for Model<'b> {
-    fn drop(&mut self) {
-        // SAFETY: ptr is non-null and was produced by llama_model_load_from_file;
-        // Drop runs exactly once.
-        unsafe { sys::llama_model_free(self.ptr.as_ptr()) }
-    }
-}
-
-// Model is Send if the underlying pointer is opaque + llama.cpp is documented as
-// per-model-thread-safe-for-non-mutating-reads. We don't claim Sync; callers wrap
-// in Mutex if cross-thread mutation is needed.
-unsafe impl<'b> Send for Model<'b> {}
-
-// ---------------------------------------------------------------------------
-// Context — RAII handle to an inference context
-// ---------------------------------------------------------------------------
-
-/// RAII handle to an inference context for a model.
-///
-/// Construction creates a fresh KV-cache context tied to the model; Drop calls
-/// `llama_free` to release the context. The `Context` borrows from the `Model`
-/// so the model outlives the context.
-pub struct Context<'m, 'b: 'm> {
-    ptr: NonNull<sys::llama_context>,
-    _model: std::marker::PhantomData<&'m Model<'b>>,
-}
-
-impl<'m, 'b: 'm> Context<'m, 'b> {
-    /// Create a new inference context for `model`. Uses llama.cpp's default
-    /// context parameters.
-    ///
-    /// # Errors
-    /// [`LlamaError::ContextCreationFailed`] if llama.cpp returns null.
-    pub fn new(model: &'m Model<'b>) -> Result<Self, LlamaError> {
-        // SAFETY: llama_context_default_params is pure; llama_new_context_with_model
-        // returns a raw pointer (null on failure).
-        let ctx_ptr = unsafe {
-            let params = sys::llama_context_default_params();
-            sys::llama_init_from_model(model.ptr.as_ptr(), params)
-        };
-
-        let ptr = NonNull::new(ctx_ptr).ok_or(LlamaError::ContextCreationFailed)?;
-
-        Ok(Self {
-            ptr,
-            _model: std::marker::PhantomData,
-        })
-    }
-
-    /// The context window size (number of tokens this context can hold).
-    pub fn n_ctx(&self) -> u32 {
-        // SAFETY: ptr is non-null and points to a live context owned by this Context.
-        unsafe { sys::llama_n_ctx(self.ptr.as_ptr()) }
-    }
-}
-
-impl<'m, 'b: 'm> Drop for Context<'m, 'b> {
-    fn drop(&mut self) {
-        // SAFETY: ptr is non-null and was produced by llama_init_from_model;
-        // Drop runs exactly once.
-        unsafe { sys::llama_free(self.ptr.as_ptr()) }
-    }
-}
-
-unsafe impl<'m, 'b: 'm> Send for Context<'m, 'b> {}
-
-// ---------------------------------------------------------------------------
-// Tests
+// Wrapper-invariant tests that don't need a GGUF model
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kx_llamacpp_sys as sys;
 
-    /// Exercises the backend init/free cycle through real FFI. Verifies that the
-    /// link chain works end-to-end (kx-llamacpp → -sys → llama.cpp library).
     #[test]
     fn backend_init_and_drop() {
         let backend = LlamaBackend::new().expect("backend init must succeed");
-        // Drop happens at end of scope. No model, no context — just init/free.
         drop(backend);
     }
 
-    /// Two backends in sequence: the ref-counted init mechanism handles repeated
-    /// construction safely.
     #[test]
     fn two_backends_in_sequence_work() {
         let b1 = LlamaBackend::new().unwrap();
@@ -280,25 +96,18 @@ mod tests {
         drop(b2);
     }
 
-    /// Two concurrent backends share the same global state via ref-counting. The
-    /// backend is only freed when both are dropped.
     #[test]
     fn two_concurrent_backends_share_state() {
         let b1 = LlamaBackend::new().unwrap();
         let b2 = LlamaBackend::new().unwrap();
         drop(b1);
-        // Backend should still be alive (b2 holds it).
         drop(b2);
-        // Now backend is freed.
     }
 
-    /// Loading a non-existent file produces `LlamaError::LoadFailed`.
     #[test]
     fn load_nonexistent_model_returns_load_failed() {
         let backend = LlamaBackend::new().unwrap();
         let result = Model::load(&backend, "/nonexistent/path/to.gguf");
-        // `Model` wraps a raw pointer and does not derive `Debug`; match the Err
-        // variant directly rather than relying on Debug formatting.
         match result {
             Err(LlamaError::LoadFailed { path }) => {
                 assert_eq!(path, std::path::PathBuf::from("/nonexistent/path/to.gguf"));
@@ -308,7 +117,6 @@ mod tests {
         }
     }
 
-    /// A path with a NUL byte fails with `PathInvalid`.
     #[test]
     fn path_with_nul_byte_returns_path_invalid() {
         let backend = LlamaBackend::new().unwrap();
@@ -317,10 +125,78 @@ mod tests {
         assert!(matches!(result, Err(LlamaError::PathInvalid(_))));
     }
 
-    /// The pinned tag constant is non-empty and matches what we expect to be
-    /// using. Forces a tracker update when the submodule version moves.
     #[test]
     fn pinned_tag_is_b9000() {
         assert_eq!(sys::PINNED_LLAMACPP_TAG, "b9000");
+    }
+
+    #[test]
+    fn sampler_chain_builder_constructs_without_model() {
+        // Exercise the builder API surface against real FFI but without
+        // sampling — only construction + Drop. This confirms the chain init
+        // and child-sampler add paths link correctly.
+        let backend = LlamaBackend::new().unwrap();
+        let sampler = Sampler::chain(&backend)
+            .add_top_k(40)
+            .unwrap()
+            .add_top_p(0.95, 1)
+            .unwrap()
+            .add_min_p(0.05, 1)
+            .unwrap()
+            .add_temp(0.8)
+            .unwrap()
+            .add_dist(42)
+            .unwrap()
+            .build()
+            .unwrap();
+        // Drop the chain (frees the chain + all stages).
+        drop(sampler);
+    }
+
+    #[test]
+    fn greedy_sampler_constructs() {
+        let backend = LlamaBackend::new().unwrap();
+        let _s = Sampler::greedy(&backend).unwrap();
+    }
+
+    #[test]
+    fn typical_sampler_constructs() {
+        let backend = LlamaBackend::new().unwrap();
+        let _s = Sampler::typical(&backend, 0.7, 40, 0.9, 1234).unwrap();
+    }
+
+    #[test]
+    fn batch_allocation_and_population() {
+        // Allocate a token-mode batch, populate, clear, drop. No llama state
+        // touched — pure batch buffer management.
+        let mut batch = Batch::with_capacity(8, 1);
+        assert_eq!(batch.n_tokens(), 0);
+        assert_eq!(batch.capacity(), 8);
+        batch.add(101, 0, &[0], true);
+        batch.add(202, 1, &[0], false);
+        assert_eq!(batch.n_tokens(), 2);
+        batch.clear();
+        assert_eq!(batch.n_tokens(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Batch is full")]
+    fn batch_overflow_panics() {
+        let mut batch = Batch::with_capacity(2, 1);
+        batch.add(1, 0, &[0], false);
+        batch.add(2, 1, &[0], false);
+        // This third add must panic.
+        batch.add(3, 2, &[0], false);
+    }
+
+    #[test]
+    fn model_params_builder_compiles() {
+        // Exercise the model-params surface (no llama state needed).
+        let _p = ModelParams::new()
+            .with_n_gpu_layers(0)
+            .with_vocab_only(false)
+            .with_use_mmap(true)
+            .with_use_mlock(false)
+            .with_check_tensors(false);
     }
 }

--- a/kx-llamacpp/src/model.rs
+++ b/kx-llamacpp/src/model.rs
@@ -1,0 +1,194 @@
+//! `Model` + `ModelParams` — RAII model handle plus the loader's builder.
+
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr::NonNull;
+
+use kx_llamacpp_sys as sys;
+
+use crate::backend::LlamaBackend;
+use crate::error::LlamaError;
+use crate::vocab::Vocab;
+
+/// Builder for the model-loader parameters.
+///
+/// Wraps llama.cpp's default `llama_model_params` and exposes the knobs
+/// kortecx cares about. Defaults are inherited from llama.cpp so every field
+/// you don't touch stays at the upstream-recommended value.
+pub struct ModelParams {
+    inner: sys::llama_model_params,
+}
+
+impl Default for ModelParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ModelParams {
+    /// Construct with llama.cpp's defaults.
+    pub fn new() -> Self {
+        // SAFETY: llama_model_default_params is a pure C function that returns
+        // a value struct populated with safe defaults.
+        Self {
+            inner: unsafe { sys::llama_model_default_params() },
+        }
+    }
+
+    /// Number of layers to offload to GPU. Negative = all. Per D28 CUDA is
+    /// disabled in OSS builds, so this only has effect when llama.cpp's
+    /// platform-default GPU backend is enabled (e.g. Metal on Apple Silicon).
+    pub fn with_n_gpu_layers(mut self, n: i32) -> Self {
+        self.inner.n_gpu_layers = n;
+        self
+    }
+
+    /// Load only the vocabulary, no weights. Useful for tokenizer-only access.
+    pub fn with_vocab_only(mut self, on: bool) -> Self {
+        self.inner.vocab_only = on;
+        self
+    }
+
+    /// Use mmap if the platform supports it (default true on most OSes).
+    pub fn with_use_mmap(mut self, on: bool) -> Self {
+        self.inner.use_mmap = on;
+        self
+    }
+
+    /// Lock model into RAM (prevents paging). Default false.
+    pub fn with_use_mlock(mut self, on: bool) -> Self {
+        self.inner.use_mlock = on;
+        self
+    }
+
+    /// Validate tensor data when loading (slower; default false).
+    pub fn with_check_tensors(mut self, on: bool) -> Self {
+        self.inner.check_tensors = on;
+        self
+    }
+}
+
+/// RAII handle to a loaded llama.cpp model.
+///
+/// Construction performs the model load; Drop calls `llama_model_free`. The
+/// `Model` borrows from the `LlamaBackend` so the backend outlives the model.
+pub struct Model<'b> {
+    pub(crate) ptr: NonNull<sys::llama_model>,
+    _backend: std::marker::PhantomData<&'b LlamaBackend>,
+}
+
+impl<'b> Model<'b> {
+    /// Load a model from a GGUF file using llama.cpp's default model parameters.
+    ///
+    /// # Errors
+    /// - [`LlamaError::PathInvalid`] if `path` cannot be converted to a C string.
+    /// - [`LlamaError::LoadFailed`] if llama.cpp returns a null pointer.
+    pub fn load(backend: &'b LlamaBackend, path: impl AsRef<Path>) -> Result<Self, LlamaError> {
+        Self::load_with_params(backend, path, &ModelParams::new())
+    }
+
+    /// Load a model from a GGUF file using the supplied parameters.
+    ///
+    /// # Errors
+    /// Same as [`Self::load`].
+    pub fn load_with_params(
+        _backend: &'b LlamaBackend,
+        path: impl AsRef<Path>,
+        params: &ModelParams,
+    ) -> Result<Self, LlamaError> {
+        let path_ref = path.as_ref();
+        let c_path = CString::new(path_ref.as_os_str().to_string_lossy().as_bytes())
+            .map_err(|_| LlamaError::PathInvalid(path_ref.to_owned()))?;
+
+        // SAFETY: llama_model_load_from_file is unsafe because it reads from
+        // disk and returns a raw pointer (null on failure). We pass a valid
+        // params struct (copy-by-value) and a NUL-terminated path.
+        let model_ptr = unsafe { sys::llama_model_load_from_file(c_path.as_ptr(), params.inner) };
+
+        let ptr = NonNull::new(model_ptr).ok_or_else(|| LlamaError::LoadFailed {
+            path: path_ref.to_owned(),
+        })?;
+
+        Ok(Self {
+            ptr,
+            _backend: std::marker::PhantomData,
+        })
+    }
+
+    /// Get the vocabulary owned by this model. The returned [`Vocab`] borrows
+    /// from `self` and is invalidated when the model is dropped.
+    pub fn vocab(&self) -> Vocab<'_, 'b> {
+        // SAFETY: llama_model_get_vocab returns a non-null pointer into the
+        // model's owned vocab; the lifetime of the returned reference is tied
+        // to `self` so the vocab cannot outlive the model.
+        let raw = unsafe { sys::llama_model_get_vocab(self.ptr.as_ptr()) };
+        // llama.cpp guarantees a non-null vocab for any successfully-loaded model.
+        let ptr = NonNull::new(raw.cast_mut()).expect("model_get_vocab returned NULL");
+        Vocab::from_raw(ptr)
+    }
+
+    /// Embedding dimensionality.
+    pub fn n_embd(&self) -> i32 {
+        // SAFETY: ptr is non-null and points to a live model owned by this Model.
+        unsafe { sys::llama_model_n_embd(self.ptr.as_ptr()) }
+    }
+
+    /// Training context size (max position embedding).
+    pub fn n_ctx_train(&self) -> i32 {
+        unsafe { sys::llama_model_n_ctx_train(self.ptr.as_ptr()) }
+    }
+
+    /// Number of transformer layers.
+    pub fn n_layer(&self) -> i32 {
+        unsafe { sys::llama_model_n_layer(self.ptr.as_ptr()) }
+    }
+
+    /// Number of attention heads.
+    pub fn n_head(&self) -> i32 {
+        unsafe { sys::llama_model_n_head(self.ptr.as_ptr()) }
+    }
+
+    /// Number of key/value attention heads (grouped-query attention).
+    pub fn n_head_kv(&self) -> i32 {
+        unsafe { sys::llama_model_n_head_kv(self.ptr.as_ptr()) }
+    }
+
+    /// Total parameter count.
+    pub fn n_params(&self) -> u64 {
+        unsafe { sys::llama_model_n_params(self.ptr.as_ptr()) }
+    }
+
+    /// On-disk model size in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { sys::llama_model_size(self.ptr.as_ptr()) }
+    }
+
+    /// Human-readable model description (e.g. "llama 7B Q4_0").
+    pub fn desc(&self) -> String {
+        let mut buf = [0u8; 256];
+        // SAFETY: buf is mut-borrowed; len is its capacity; llama writes at
+        // most `len` bytes and returns the length written.
+        let n = unsafe {
+            sys::llama_model_desc(
+                self.ptr.as_ptr(),
+                buf.as_mut_ptr().cast::<core::ffi::c_char>(),
+                buf.len(),
+            )
+        };
+        let n = n.max(0) as usize;
+        String::from_utf8_lossy(&buf[..n.min(buf.len())]).into_owned()
+    }
+}
+
+impl<'b> Drop for Model<'b> {
+    fn drop(&mut self) {
+        // SAFETY: ptr is non-null and was produced by llama_model_load_from_file;
+        // Drop runs exactly once.
+        unsafe { sys::llama_model_free(self.ptr.as_ptr()) }
+    }
+}
+
+// Model is Send if the underlying pointer is opaque + llama.cpp is documented
+// as per-model-thread-safe-for-non-mutating-reads. We don't claim Sync; callers
+// wrap in Mutex if cross-thread mutation is needed.
+unsafe impl<'b> Send for Model<'b> {}

--- a/kx-llamacpp/src/sampler.rs
+++ b/kx-llamacpp/src/sampler.rs
@@ -1,0 +1,180 @@
+//! `Sampler` — RAII wrapper over `llama_sampler` chains.
+//!
+//! A sampler is a stack of token-selection stages. The most common shape is:
+//!
+//! ```text
+//! [top_k | top_p | min_p | temp]  →  dist(seed)  →  token
+//! ```
+//!
+//! Greedy sampling collapses the whole stack to a single `argmax` stage.
+//!
+//! Lifetime: a [`Sampler`] borrows the [`crate::LlamaBackend`] so that the
+//! backend outlives every sampler chain.
+
+use std::ptr::NonNull;
+
+use kx_llamacpp_sys as sys;
+
+use crate::backend::LlamaBackend;
+use crate::context::Context;
+use crate::error::LlamaError;
+use crate::vocab::Token;
+
+/// RAII handle to a `llama_sampler` chain.
+pub struct Sampler<'b> {
+    ptr: NonNull<sys::llama_sampler>,
+    _backend: std::marker::PhantomData<&'b LlamaBackend>,
+}
+
+impl<'b> Sampler<'b> {
+    /// Construct an empty sampler chain ready for stages to be added.
+    pub fn chain(backend: &'b LlamaBackend) -> SamplerChainBuilder<'b> {
+        SamplerChainBuilder::new(backend)
+    }
+
+    /// Convenience: a greedy (argmax) sampler.
+    ///
+    /// # Errors
+    /// [`LlamaError::SamplerInitFailed`] under OOM.
+    pub fn greedy(backend: &'b LlamaBackend) -> Result<Self, LlamaError> {
+        Self::chain(backend).add_greedy()?.build()
+    }
+
+    /// Convenience: a temperature + top-k + top-p + dist chain.
+    ///
+    /// # Errors
+    /// [`LlamaError::SamplerInitFailed`] / [`LlamaError::SamplerChainFailed`].
+    pub fn typical(
+        backend: &'b LlamaBackend,
+        temperature: f32,
+        top_k: i32,
+        top_p: f32,
+        seed: u32,
+    ) -> Result<Self, LlamaError> {
+        Self::chain(backend)
+            .add_top_k(top_k)?
+            .add_top_p(top_p, 1)?
+            .add_temp(temperature)?
+            .add_dist(seed)?
+            .build()
+    }
+
+    /// Sample the next token using the i-th set of logits in the last decoded
+    /// batch. Use `-1` to sample from the last position.
+    pub fn sample(&mut self, ctx: &mut Context<'_, '_>, idx: i32) -> Token {
+        // SAFETY: sampler + ctx are live; the sampler reads logits via ctx.
+        unsafe { sys::llama_sampler_sample(self.ptr.as_ptr(), ctx.raw_mut(), idx) }
+    }
+
+    /// Inform the sampler that `token` was accepted (so stateful samplers like
+    /// repetition penalties / mirostat can update their history).
+    pub fn accept(&mut self, token: Token) {
+        unsafe { sys::llama_sampler_accept(self.ptr.as_ptr(), token) }
+    }
+
+    /// Reset internal sampler state (clears repetition history, mirostat
+    /// state, etc.). Does not change the chain composition.
+    pub fn reset(&mut self) {
+        unsafe { sys::llama_sampler_reset(self.ptr.as_ptr()) }
+    }
+}
+
+impl<'b> Drop for Sampler<'b> {
+    fn drop(&mut self) {
+        // SAFETY: ptr was produced by llama_sampler_chain_init; Drop runs once.
+        // llama.cpp frees the chain and all child samplers added via
+        // llama_sampler_chain_add.
+        unsafe { sys::llama_sampler_free(self.ptr.as_ptr()) }
+    }
+}
+
+unsafe impl<'b> Send for Sampler<'b> {}
+
+/// Builder for a sampler chain.
+///
+/// Each `add_*` returns `Result<Self, LlamaError>` so a NULL from llama.cpp
+/// (only realistic under OOM) is surfaced rather than ignored. Call
+/// [`Self::build`] to materialize a [`Sampler`].
+pub struct SamplerChainBuilder<'b> {
+    chain: NonNull<sys::llama_sampler>,
+    _backend: std::marker::PhantomData<&'b LlamaBackend>,
+}
+
+impl<'b> SamplerChainBuilder<'b> {
+    fn new(_backend: &'b LlamaBackend) -> Self {
+        // SAFETY: pure C function returning a value struct (chain params).
+        let params = unsafe { sys::llama_sampler_chain_default_params() };
+        // SAFETY: returns a fresh chain pointer; NULL only under OOM.
+        let chain_ptr = unsafe { sys::llama_sampler_chain_init(params) };
+        let chain = NonNull::new(chain_ptr).expect("sampler_chain_init returned NULL");
+        Self {
+            chain,
+            _backend: std::marker::PhantomData,
+        }
+    }
+
+    fn add(
+        self,
+        stage_ptr: *mut sys::llama_sampler,
+        name: &'static str,
+    ) -> Result<Self, LlamaError> {
+        if stage_ptr.is_null() {
+            return Err(LlamaError::SamplerInitFailed(name));
+        }
+        // SAFETY: chain owns the stage after this call (frees it on chain free).
+        unsafe { sys::llama_sampler_chain_add(self.chain.as_ptr(), stage_ptr) };
+        Ok(self)
+    }
+
+    /// Append a greedy (argmax) stage. Typically used as the last stage of a
+    /// chain that has already narrowed the candidate set.
+    pub fn add_greedy(self) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_greedy() };
+        self.add(ptr, "greedy")
+    }
+
+    /// Append a sampling-by-distribution stage seeded with `seed` (final
+    /// stochastic step of a typical chain).
+    pub fn add_dist(self, seed: u32) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_dist(seed) };
+        self.add(ptr, "dist")
+    }
+
+    /// Append a top-k truncation stage.
+    pub fn add_top_k(self, k: i32) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_top_k(k) };
+        self.add(ptr, "top_k")
+    }
+
+    /// Append a top-p (nucleus) truncation stage.
+    pub fn add_top_p(self, p: f32, min_keep: usize) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_top_p(p, min_keep) };
+        self.add(ptr, "top_p")
+    }
+
+    /// Append a min-p truncation stage.
+    pub fn add_min_p(self, p: f32, min_keep: usize) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_min_p(p, min_keep) };
+        self.add(ptr, "min_p")
+    }
+
+    /// Append a temperature scaling stage.
+    pub fn add_temp(self, t: f32) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_temp(t) };
+        self.add(ptr, "temp")
+    }
+
+    /// Append an extended temperature stage (dynamic temperature).
+    pub fn add_temp_ext(self, t: f32, delta: f32, exponent: f32) -> Result<Self, LlamaError> {
+        let ptr = unsafe { sys::llama_sampler_init_temp_ext(t, delta, exponent) };
+        self.add(ptr, "temp_ext")
+    }
+
+    /// Finalize the chain into a [`Sampler`].
+    pub fn build(self) -> Result<Sampler<'b>, LlamaError> {
+        Ok(Sampler {
+            ptr: self.chain,
+            _backend: std::marker::PhantomData,
+        })
+    }
+}

--- a/kx-llamacpp/src/vocab.rs
+++ b/kx-llamacpp/src/vocab.rs
@@ -1,0 +1,189 @@
+//! `Vocab` — borrowed handle to a model's vocabulary.
+//!
+//! The vocab is owned by [`crate::Model`]; this type is a lifetime-tied borrow
+//! that exposes tokenization, detokenization, and special-token queries.
+
+use std::ptr::NonNull;
+
+use kx_llamacpp_sys as sys;
+
+use crate::error::LlamaError;
+use crate::model::Model;
+
+/// A token id (int32). Bare type alias keeps the type ergonomic for indexing.
+pub type Token = i32;
+
+/// Borrowed handle to a model's vocabulary.
+pub struct Vocab<'m, 'b: 'm> {
+    ptr: NonNull<sys::llama_vocab>,
+    _model: std::marker::PhantomData<&'m Model<'b>>,
+}
+
+impl<'m, 'b: 'm> Vocab<'m, 'b> {
+    pub(crate) fn from_raw(ptr: NonNull<sys::llama_vocab>) -> Self {
+        Self {
+            ptr,
+            _model: std::marker::PhantomData,
+        }
+    }
+
+    /// Number of distinct tokens in the vocabulary.
+    pub fn n_tokens(&self) -> i32 {
+        // SAFETY: ptr borrowed from a live model.
+        unsafe { sys::llama_vocab_n_tokens(self.ptr.as_ptr()) }
+    }
+
+    /// Beginning-of-sentence token (or -1 / sentinel if the vocab has none).
+    pub fn bos(&self) -> Token {
+        unsafe { sys::llama_vocab_bos(self.ptr.as_ptr()) }
+    }
+
+    /// End-of-sentence token.
+    pub fn eos(&self) -> Token {
+        unsafe { sys::llama_vocab_eos(self.ptr.as_ptr()) }
+    }
+
+    /// Newline token.
+    pub fn nl(&self) -> Token {
+        unsafe { sys::llama_vocab_nl(self.ptr.as_ptr()) }
+    }
+
+    /// Is this token an end-of-generation marker? (EOS, EOT, EOM — varies by model.)
+    pub fn is_eog(&self, token: Token) -> bool {
+        unsafe { sys::llama_vocab_is_eog(self.ptr.as_ptr(), token) }
+    }
+
+    /// Tokenize `text` into a vector of token ids.
+    ///
+    /// * `add_special` — prepend the BOS token when the model conventions
+    ///   call for it.
+    /// * `parse_special` — interpret special-token markup (e.g. `<|im_start|>`).
+    ///
+    /// # Errors
+    /// [`LlamaError::TokenizeFailed`] if the underlying call returns an
+    /// unrecoverable error after the standard resize-and-retry path.
+    pub fn tokenize(
+        &self,
+        text: &str,
+        add_special: bool,
+        parse_special: bool,
+    ) -> Result<Vec<Token>, LlamaError> {
+        // First pass with a small buffer; if llama returns -n (would need n
+        // tokens), resize and retry once. That matches the upstream pattern.
+        let bytes = text.as_bytes();
+        let mut capacity = bytes.len().max(8) + 1;
+        let mut out = vec![0 as Token; capacity];
+
+        // SAFETY: vocab ptr is valid; text+len define a byte slice; out provides
+        // a writable buffer of `capacity` Token slots.
+        let rc = unsafe {
+            sys::llama_tokenize(
+                self.ptr.as_ptr(),
+                bytes.as_ptr().cast::<core::ffi::c_char>(),
+                bytes.len() as i32,
+                out.as_mut_ptr(),
+                capacity as i32,
+                add_special,
+                parse_special,
+            )
+        };
+
+        if rc < 0 {
+            // Need -rc tokens.
+            capacity = (-rc) as usize;
+            out = vec![0 as Token; capacity];
+            let rc2 = unsafe {
+                sys::llama_tokenize(
+                    self.ptr.as_ptr(),
+                    bytes.as_ptr().cast::<core::ffi::c_char>(),
+                    bytes.len() as i32,
+                    out.as_mut_ptr(),
+                    capacity as i32,
+                    add_special,
+                    parse_special,
+                )
+            };
+            if rc2 < 0 {
+                return Err(LlamaError::TokenizeFailed(rc2));
+            }
+            out.truncate(rc2 as usize);
+            Ok(out)
+        } else {
+            out.truncate(rc as usize);
+            Ok(out)
+        }
+    }
+
+    /// Convert a single token to its UTF-8 piece (bytes, since some tokens
+    /// are sub-character byte fragments).
+    ///
+    /// * `lstrip` — number of leading whitespace bytes to strip (passed
+    ///   directly to llama.cpp; typically 0).
+    /// * `special` — render special tokens visibly (`<|im_start|>` rather than
+    ///   the empty string).
+    ///
+    /// # Errors
+    /// [`LlamaError::DetokenizeFailed`] on a non-recoverable C-side failure.
+    pub fn token_to_piece(
+        &self,
+        token: Token,
+        lstrip: i32,
+        special: bool,
+    ) -> Result<Vec<u8>, LlamaError> {
+        // First pass with a small buffer; resize if llama signals more needed.
+        let mut buf = vec![0i8; 32];
+        let rc = unsafe {
+            sys::llama_token_to_piece(
+                self.ptr.as_ptr(),
+                token,
+                buf.as_mut_ptr().cast::<core::ffi::c_char>(),
+                buf.len() as i32,
+                lstrip,
+                special,
+            )
+        };
+
+        let written: i32 = if rc < 0 {
+            let need = (-rc) as usize;
+            buf.resize(need, 0);
+            let rc2 = unsafe {
+                sys::llama_token_to_piece(
+                    self.ptr.as_ptr(),
+                    token,
+                    buf.as_mut_ptr().cast::<core::ffi::c_char>(),
+                    buf.len() as i32,
+                    lstrip,
+                    special,
+                )
+            };
+            if rc2 < 0 {
+                return Err(LlamaError::DetokenizeFailed { token, rc: rc2 });
+            }
+            rc2
+        } else {
+            rc
+        };
+
+        buf.truncate(written.max(0) as usize);
+        // Convert the i8 buffer into a u8 buffer without copying — same layout.
+        let bytes: Vec<u8> = buf.into_iter().map(|c| c as u8).collect();
+        Ok(bytes)
+    }
+
+    /// Convenience: detokenize a slice of tokens into a UTF-8 String.
+    ///
+    /// Lossy conversion: invalid UTF-8 bytes are replaced with U+FFFD.
+    /// For raw byte access use [`Self::token_to_piece`] in a loop.
+    ///
+    /// # Errors
+    /// Propagates the first [`LlamaError::DetokenizeFailed`] from
+    /// [`Self::token_to_piece`].
+    pub fn detokenize(&self, tokens: &[Token], special: bool) -> Result<String, LlamaError> {
+        let mut out: Vec<u8> = Vec::with_capacity(tokens.len() * 4);
+        for &t in tokens {
+            let piece = self.token_to_piece(t, 0, special)?;
+            out.extend_from_slice(&piece);
+        }
+        Ok(String::from_utf8_lossy(&out).into_owned())
+    }
+}

--- a/kx-llamacpp/tests/smoke.rs
+++ b/kx-llamacpp/tests/smoke.rs
@@ -17,7 +17,9 @@
 
 #![cfg(feature = "model-smoke-test")]
 
-use kx_llamacpp::{Batch, Context, ContextParams, LlamaBackend, Model, ModelParams, Sampler};
+use kx_llamacpp::{
+    Batch, Context, ContextParams, LlamaBackend, Model, ModelParams, PoolingType, Sampler,
+};
 
 const MODEL_PATH: &str = env!(
     "KX_LLAMACPP_SMOKE_TEST_MODEL",
@@ -243,4 +245,207 @@ fn smoke_vocab_special_tokens() {
     assert!(eos >= 0 && eos < n, "eos {eos} out of range [0, {n})");
     assert!(vocab.is_eog(eos), "eos must be an end-of-generation marker");
     eprintln!("bos={bos} eos={eos} nl={} n_tokens={n}", vocab.nl());
+}
+
+// ---------------------------------------------------------------------------
+// Tightenings per the rigorous-testing mandate (SN-4): determinism assertions,
+// full-surface coverage, integration plumbing tests. The next three tests
+// move P1.7-b from "happy-path smoke" to "actually airtight at the wrapper
+// layer" by exercising guarantees that downstream code is going to rely on:
+// - greedy determinism (same prompt → same tokens, twice, end-to-end)
+// - embedding-mode plumbing (with_embeddings actually reaches llama.cpp)
+// - sampler-seed determinism (the seed actually plumbs through the chain)
+// ---------------------------------------------------------------------------
+
+/// Greedy pipeline must be deterministic end-to-end.
+///
+/// Two independent runs (separate backend, model, context, sampler) of the
+/// same prompt under greedy sampling must produce **byte-identical** token
+/// sequences. This is a wrapper-level guarantee: if a future llama.cpp bump
+/// changes determinism (e.g. introduces nondeterministic reduction order in
+/// a Metal/CPU kernel) this test catches it at the FFI boundary rather than
+/// surfacing it as flakiness in downstream replay.
+#[test]
+fn smoke_determinism_greedy_pipeline() {
+    fn run() -> Vec<i32> {
+        let backend = LlamaBackend::new().expect("backend init");
+        let model = Model::load(&backend, MODEL_PATH).expect("load");
+        let vocab = model.vocab();
+        let tokens = vocab
+            .tokenize("Once upon a time", true, false)
+            .expect("tokenize");
+
+        let mut ctx = Context::new_with_params(
+            &model,
+            &ContextParams::new().with_n_ctx(128).with_n_seq_max(1),
+        )
+        .expect("context");
+
+        let mut batch = Batch::with_capacity(tokens.len() as i32, 1);
+        for (i, &t) in tokens.iter().enumerate() {
+            let is_last = i + 1 == tokens.len();
+            batch.add(t, i as i32, &[0], is_last);
+        }
+        ctx.decode(&batch).expect("decode prompt");
+
+        let mut sampler = Sampler::greedy(&backend).expect("greedy");
+        let mut out = Vec::with_capacity(8);
+        let mut next = sampler.sample(&mut ctx, -1);
+        out.push(next);
+
+        for step in 0..6 {
+            if vocab.is_eog(next) {
+                break;
+            }
+            let mut step_batch = Batch::with_capacity(1, 1);
+            step_batch.add(next, (tokens.len() + step) as i32, &[0], true);
+            ctx.decode(&step_batch).expect("decode step");
+            next = sampler.sample(&mut ctx, -1);
+            out.push(next);
+        }
+        out
+    }
+
+    let a = run();
+    let b = run();
+    eprintln!("greedy run A: {a:?}");
+    eprintln!("greedy run B: {b:?}");
+    assert_eq!(
+        a, b,
+        "greedy + identical prompt + identical model must produce identical token sequences across runs"
+    );
+    assert!(a.len() >= 2, "expected at least 2 generated tokens");
+}
+
+/// Embedding-mode plumbing: `with_embeddings(true)` + decode + per-token
+/// embedding readout returns an `n_embd`-length vector containing at least
+/// one non-zero float.
+///
+/// This proves three things end-to-end:
+/// 1. The `embeddings` flag on `ContextParams` actually reaches the C side.
+/// 2. The cached `n_embd` on `Context` matches what the model produces.
+/// 3. `embeddings_ith` returns valid memory bounded correctly.
+///
+/// Per-token readout (`embeddings_ith`) rather than pooled (`embeddings_seq`)
+/// is used here because stories260K is a tiny generative model where pooling
+/// configuration depends on model metadata that may not be set. Per-token
+/// embeddings are universally available for any decoder-only model.
+#[test]
+fn smoke_embedding_mode() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let model = Model::load(&backend, MODEL_PATH).expect("load");
+    let vocab = model.vocab();
+
+    let tokens = vocab.tokenize("hello", true, false).expect("tokenize");
+    assert!(!tokens.is_empty());
+
+    // Embedding-mode context: pooling = None (per-token), embeddings = on.
+    let ctx_params = ContextParams::new()
+        .with_n_ctx(64)
+        .with_n_batch(16)
+        .with_n_ubatch(16)
+        .with_n_seq_max(1)
+        .with_embeddings(true)
+        .with_pooling_type(PoolingType::None);
+    let mut ctx = Context::new_with_params(&model, &ctx_params).expect("context");
+
+    // Need compute_logits = true on positions we want embeddings for.
+    let mut batch = Batch::with_capacity(tokens.len() as i32, 1);
+    for (i, &t) in tokens.iter().enumerate() {
+        batch.add(t, i as i32, &[0], true);
+    }
+    ctx.decode(&batch).expect("decode in embedding mode");
+
+    // Read embeddings for the last token. Returns Some(&[f32; n_embd]).
+    let last = (tokens.len() - 1) as i32;
+    let emb = ctx.embeddings_ith(last).expect(
+        "embeddings_ith returned None — with_embeddings(true) is not plumbing through to llama.cpp",
+    );
+    assert_eq!(
+        emb.len() as i32,
+        model.n_embd(),
+        "embedding slice must be exactly n_embd floats (cached bound mismatch)"
+    );
+    let any_nonzero = emb.iter().any(|x| x.abs() > 1e-9);
+    assert!(
+        any_nonzero,
+        "embedding vector is all zeros — model didn't produce hidden states"
+    );
+
+    let l2: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
+    eprintln!(
+        "embedding[{last}] L2 = {l2:.6}, len = {} (n_embd = {})",
+        emb.len(),
+        model.n_embd()
+    );
+    assert!(
+        l2.is_finite() && l2 > 0.0,
+        "embedding L2 norm must be finite and positive (got {l2})"
+    );
+}
+
+/// Sampler-chain plumbing: a `typical` sampler constructed with a fixed seed
+/// must produce identical token sequences across runs (proves the seed value
+/// actually reaches the `dist` stage at the end of the chain).
+///
+/// This complements `smoke_determinism_greedy_pipeline` by asserting the
+/// stochastic path. Without a seed-determinism assertion, a future change
+/// that drops `seed` on the way through `SamplerChainBuilder::add_dist`
+/// would silently still produce *some* output and the test would pass —
+/// this test catches that regression class.
+#[test]
+fn smoke_sampler_seed_determinism() {
+    fn run(seed: u32) -> Vec<i32> {
+        let backend = LlamaBackend::new().expect("backend init");
+        let model = Model::load(&backend, MODEL_PATH).expect("load");
+        let vocab = model.vocab();
+        let tokens = vocab
+            .tokenize("Once upon a time", true, false)
+            .expect("tokenize");
+
+        let mut ctx = Context::new_with_params(
+            &model,
+            &ContextParams::new().with_n_ctx(128).with_n_seq_max(1),
+        )
+        .expect("context");
+
+        let mut batch = Batch::with_capacity(tokens.len() as i32, 1);
+        for (i, &t) in tokens.iter().enumerate() {
+            let is_last = i + 1 == tokens.len();
+            batch.add(t, i as i32, &[0], is_last);
+        }
+        ctx.decode(&batch).expect("decode prompt");
+
+        // Stochastic chain. seed → dist → final token.
+        let mut sampler = Sampler::typical(
+            &backend, /* temp */ 0.8, /* top_k */ 40, /* top_p */ 0.95, seed,
+        )
+        .expect("typical sampler");
+
+        let mut out = Vec::with_capacity(6);
+        let mut next = sampler.sample(&mut ctx, -1);
+        out.push(next);
+        for step in 0..5 {
+            if vocab.is_eog(next) {
+                break;
+            }
+            let mut step_batch = Batch::with_capacity(1, 1);
+            step_batch.add(next, (tokens.len() + step) as i32, &[0], true);
+            ctx.decode(&step_batch).expect("decode step");
+            next = sampler.sample(&mut ctx, -1);
+            out.push(next);
+        }
+        out
+    }
+
+    let a = run(42);
+    let b = run(42);
+    eprintln!("typical seed=42 run A: {a:?}");
+    eprintln!("typical seed=42 run B: {b:?}");
+    assert_eq!(
+        a, b,
+        "typical(seed=42) must produce identical sequences across runs — \
+         the seed is not plumbing through to llama_sampler_init_dist"
+    );
+    assert!(a.len() >= 2, "expected at least 2 generated tokens");
 }

--- a/kx-llamacpp/tests/smoke.rs
+++ b/kx-llamacpp/tests/smoke.rs
@@ -1,0 +1,246 @@
+//! End-to-end smoke test exercising the full llama.cpp inference pipeline
+//! through the safe wrapper:
+//!
+//! ```text
+//! LlamaBackend → Model::load → Vocab::tokenize → Batch + Context::decode
+//!              → Context::logits_ith → Sampler::sample → Vocab::detokenize
+//! ```
+//!
+//! Gated on the `model-smoke-test` feature so the default `cargo test` runs
+//! without a network dependency. With the feature, `build.rs` downloads the
+//! stories260K GGUF (~1.2 MB) and emits `KX_LLAMACPP_SMOKE_TEST_MODEL` as a
+//! compile-time env so this file `env!`s the path.
+//!
+//! The stories260K model is too small to produce coherent text, but it
+//! exercises every code path on a real GGUF: tensor load, tokenizer,
+//! KV-cache allocation, prompt decode, logits readout, sampling, detokenize.
+
+#![cfg(feature = "model-smoke-test")]
+
+use kx_llamacpp::{Batch, Context, ContextParams, LlamaBackend, Model, ModelParams, Sampler};
+
+const MODEL_PATH: &str = env!(
+    "KX_LLAMACPP_SMOKE_TEST_MODEL",
+    "build.rs should have set this when model-smoke-test feature is on"
+);
+
+/// Smallest possible end-to-end: load, tokenize, decode, sample once,
+/// detokenize. Verifies the full pipeline links and runs.
+#[test]
+fn smoke_end_to_end_inference() {
+    let backend = LlamaBackend::new().expect("backend init");
+
+    // Load with vocab-aware params (no GPU offload — single-compute OSS).
+    let params = ModelParams::new().with_n_gpu_layers(0);
+    let model = Model::load_with_params(&backend, MODEL_PATH, &params)
+        .expect("load stories260K from downloaded GGUF");
+
+    // Sanity: metadata is non-trivial.
+    assert!(model.n_embd() > 0, "model n_embd must be positive");
+    assert!(model.n_layer() > 0, "model n_layer must be positive");
+    assert!(model.n_params() > 0, "model n_params must be positive");
+    assert!(model.size() > 0, "model size must be positive");
+    let desc = model.desc();
+    assert!(!desc.is_empty(), "model description must be non-empty");
+    eprintln!(
+        "model: {desc} ({} params, {} bytes)",
+        model.n_params(),
+        model.size()
+    );
+
+    // Vocab + tokenize a short prompt.
+    let vocab = model.vocab();
+    assert!(vocab.n_tokens() > 0, "vocab must have tokens");
+
+    let prompt = "Once upon a time";
+    let tokens = vocab
+        .tokenize(
+            prompt, /* add_special */ true, /* parse_special */ false,
+        )
+        .expect("tokenize prompt");
+    assert!(
+        !tokens.is_empty(),
+        "tokenize must produce at least one token"
+    );
+    eprintln!(
+        "tokenized {} into {} tokens: {:?}",
+        prompt,
+        tokens.len(),
+        tokens
+    );
+
+    // Round-trip: detokenize the prompt tokens back. With BOS prepended the
+    // result starts with a BOS marker; we just check it includes the prompt
+    // substring (the model's BPE may insert leading-space tokens etc).
+    let round_trip = vocab
+        .detokenize(&tokens, /* special */ false)
+        .expect("detokenize");
+    eprintln!("round-trip: {round_trip:?}");
+
+    // Build a context sized for the smoke test (small, single seq).
+    let ctx_params = ContextParams::new()
+        .with_n_ctx(128)
+        .with_n_batch(32)
+        .with_n_ubatch(32)
+        .with_n_seq_max(1);
+    let mut ctx = Context::new_with_params(&model, &ctx_params).expect("context");
+    assert!(
+        ctx.n_ctx() >= 32,
+        "context must be at least the requested size"
+    );
+
+    // Build a batch with the prompt; only the last position needs logits.
+    let mut batch = Batch::with_capacity(tokens.len() as i32, 1);
+    for (i, &t) in tokens.iter().enumerate() {
+        let is_last = i + 1 == tokens.len();
+        batch.add(t, i as i32, &[0], is_last);
+    }
+    assert_eq!(batch.n_tokens() as usize, tokens.len());
+
+    // Decode the prompt.
+    ctx.decode(&batch).expect("decode prompt");
+
+    // KV-cache should now hold the prompt.
+    assert_eq!(
+        ctx.kv_cache_seq_pos_max(0) as usize,
+        tokens.len() - 1,
+        "after decode, seq 0 holds tokens[0..len-1]"
+    );
+
+    // Greedy-sample the next token from the last position's logits.
+    let mut sampler = Sampler::greedy(&backend).expect("greedy sampler");
+    let next = sampler.sample(&mut ctx, -1);
+    eprintln!("greedy-sampled next token: {next}");
+
+    // Detokenize that single token. Should yield some byte sequence (possibly
+    // not human-readable on such a tiny model — that's fine, we just need a
+    // round-trip without error).
+    let piece = vocab
+        .token_to_piece(next, 0, false)
+        .expect("token_to_piece for sampled token");
+    eprintln!("sampled piece bytes: {piece:?}");
+
+    // Continue for a few more tokens, exercising incremental decode.
+    let mut current = next;
+    let mut generated = vec![next];
+    for step in 0..5 {
+        // Submit just the new token; position continues from where prompt ended.
+        let mut step_batch = Batch::with_capacity(1, 1);
+        step_batch.add(current, (tokens.len() + step) as i32, &[0], true);
+        ctx.decode(&step_batch).expect("decode step");
+
+        current = sampler.sample(&mut ctx, -1);
+        generated.push(current);
+        if vocab.is_eog(current) {
+            eprintln!("hit EOG at step {step}");
+            break;
+        }
+    }
+    assert!(generated.len() >= 2, "should generate at least 2 tokens");
+
+    // Performance counters should be non-zero after a decode.
+    let perf = ctx.perf();
+    assert!(
+        perf.n_p_eval + perf.n_eval > 0,
+        "perf counters must reflect work"
+    );
+    eprintln!(
+        "perf: p_eval={} eval={} reused={}",
+        perf.n_p_eval, perf.n_eval, perf.n_reused
+    );
+}
+
+/// KV-cache management round-trip: decode → query positions → seq_keep →
+/// seq_rm → clear. Verifies the cache ops behave as documented.
+///
+/// Note: `seq_cp` is intentionally not exercised here. In llama.cpp b9000 the
+/// unified-KV-cache implementation only supports `seq_cp` when the source
+/// buffer page is "full" (an internal allocator constraint), which is not
+/// reproducible from a smoke test without intricate setup. The wrapper
+/// exposes the call; callers are expected to respect the upstream contract.
+#[test]
+fn smoke_kv_cache_management() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let model = Model::load(&backend, MODEL_PATH).expect("load model");
+    let mut ctx = Context::new_with_params(
+        &model,
+        &ContextParams::new().with_n_ctx(64).with_n_seq_max(1),
+    )
+    .expect("context");
+
+    let vocab = model.vocab();
+    let tokens = vocab
+        .tokenize("hello world", true, false)
+        .expect("tokenize");
+    assert!(!tokens.is_empty());
+
+    // Fill seq 0.
+    let mut batch = Batch::with_capacity(tokens.len() as i32, 1);
+    for (i, &t) in tokens.iter().enumerate() {
+        batch.add(t, i as i32, &[0], false);
+    }
+    ctx.decode(&batch).expect("decode");
+
+    let max_pos = ctx.kv_cache_seq_pos_max(0);
+    assert_eq!(max_pos as usize, tokens.len() - 1, "seq 0 should be full");
+
+    // seq_keep on the only sequence is a no-op (kept sequence stays).
+    ctx.kv_cache_seq_keep(0);
+    assert_eq!(
+        ctx.kv_cache_seq_pos_max(0),
+        max_pos,
+        "seq 0 should still be present after seq_keep(0)"
+    );
+
+    // Truncate seq 0: drop everything past position 1.
+    let _ = ctx.kv_cache_seq_rm(0, 1, -1);
+    let trimmed = ctx.kv_cache_seq_pos_max(0);
+    assert!(
+        trimmed < max_pos,
+        "after seq_rm(0, 1, -1) the max position must drop"
+    );
+
+    // Clear: cache should be empty.
+    ctx.kv_cache_clear(false);
+    assert_eq!(
+        ctx.kv_cache_seq_pos_max(0),
+        -1,
+        "after kv_cache_clear, seq 0 should be empty"
+    );
+}
+
+/// Tokenize → detokenize round-trip for several short strings.
+#[test]
+fn smoke_tokenize_detokenize_roundtrip() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let model = Model::load(&backend, MODEL_PATH).expect("load");
+    let vocab = model.vocab();
+
+    for s in ["hi", "the quick brown fox", "once upon a time, in a land"] {
+        let tokens = vocab.tokenize(s, false, false).expect("tokenize");
+        assert!(!tokens.is_empty(), "tokenize {s:?} produced empty");
+        let back = vocab.detokenize(&tokens, false).expect("detokenize");
+        // The model's tokenizer normalizes whitespace; just check non-empty
+        // and that obviously-present substrings survive.
+        assert!(!back.is_empty(), "detokenize {s:?} produced empty");
+        eprintln!("{s:?} -> {} tokens -> {back:?}", tokens.len());
+    }
+}
+
+/// Verifies BOS / EOS / NL token queries return sensible values for a LLaMA
+/// architecture model.
+#[test]
+fn smoke_vocab_special_tokens() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let model = Model::load(&backend, MODEL_PATH).expect("load");
+    let vocab = model.vocab();
+
+    // BOS / EOS should be valid tokens in [0, n_tokens).
+    let bos = vocab.bos();
+    let eos = vocab.eos();
+    let n = vocab.n_tokens();
+    assert!(bos >= 0 && bos < n, "bos {bos} out of range [0, {n})");
+    assert!(eos >= 0 && eos < n, "eos {eos} out of range [0, {n})");
+    assert!(vocab.is_eog(eos), "eos must be an end-of-generation marker");
+    eprintln!("bos={bos} eos={eos} nl={} n_tokens={n}", vocab.nl());
+}


### PR DESCRIPTION
## Summary

Expands `kx-llamacpp` from the P1.7-a API stub into a complete safe wrapper covering the core llama.cpp capabilities a workflow needs: tokenization, decode, sampling chains, KV-cache management, embeddings, performance counters — exercised end-to-end against a real tiny GGUF.

## API surface (modules)

- `backend.rs` — `LlamaBackend` RAII (unchanged from P1.7-a)
- `error.rs` — `LlamaError` with new variants (Tokenize/Detokenize/Decode/Encode/SamplerChain/SamplerInit/EmbeddingsUnavailable)
- `model.rs` — `Model` + `ModelParams` builder; metadata: `n_embd`, `n_ctx_train`, `n_layer`, `n_head`, `n_head_kv`, `n_params`, `size`, `desc`
- `vocab.rs` — `Vocab` borrowed from `Model`: `tokenize` / `detokenize` round-trip, BOS/EOS/NL, `is_eog`, `token_to_piece`
- `batch.rs` — `Batch` RAII over `llama_batch` (init/free/add/clear)
- `context.rs` — `Context` + `ContextParams` builder (n_ctx/n_batch/n_ubatch/n_seq_max/threads/embeddings/pooling/offload_kqv/no_perf); `decode` + `encode`; `logits_ith` / `logits_last`; `embeddings_ith` / `embeddings_seq`; KV-cache management; `PerfData` snapshot + `perf_reset`
- `sampler.rs` — `Sampler` + `SamplerChainBuilder`: chains of top_k/top_p/min_p/temp/temp_ext/dist/greedy; `Sampler::greedy` + `Sampler::typical` convenience helpers

## Build infrastructure

- `kx-llamacpp/build.rs` downloads `stories260K.gguf` (~1.18 MB) into `OUT_DIR` with SHA-256 verification when the `model-smoke-test` feature is on. Cached across builds; corrupt cache auto-recovers.
- `kx-llamacpp-sys/build.rs` now links `libggml-metal.a` on Apple targets and enables `GGML_METAL_EMBED_LIBRARY` so Metal shaders ship inside the static archive.
- Workspace gets `ureq` + `sha2` deps for the build-time download.

## Tests

- 18 unit tests covering API shape, batch RAII + overflow, sampler-chain construction with real FFI, `PoolingType` discriminants — no model needed.
- 4 `#[cfg(feature = \"model-smoke-test\")]` integration tests in `tests/smoke.rs`:
  - `smoke_end_to_end_inference` — load → tokenize → decode prompt → greedy sample 5 tokens → detokenize, asserting perf counters reflect work
  - `smoke_kv_cache_management` — decode → seq_pos_max → seq_keep → seq_rm → clear
  - `smoke_tokenize_detokenize_roundtrip` — multiple strings round-trip
  - `smoke_vocab_special_tokens` — BOS/EOS in `[0, n_tokens)`, EOS is EOG

## CI

New `smoke-test-with-model` job that runs after the main `ci` job. Separate cache key so the ~1.2 MB download is amortized and a transient HF outage doesn't fail the main CI lane. Main ci job unchanged.

## Invariants preserved

- **Unsafe containment (`03-ffi-and-inference.md` §1)** — every public method is safe; unsafe blocks limited to FFI calls with `SAFETY:` comments. Lifetimes encode llama.cpp's ownership hierarchy (`LlamaBackend → Model → Context/Vocab`; `Sampler` borrows `LlamaBackend`) so use-after-free is rejected at compile time.
- **D28 cloud-first scale** — GPU-batched serving stays cloud-side. OSS llama.cpp picks the platform default backend (Metal on Apple Silicon, CPU on Linux); CUDA stays disabled. `n_gpu_layers` is exposed on `ModelParams` but only meaningful where a non-CUDA GPU backend is available.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `cargo test -p kx-llamacpp --features model-smoke-test` (locally with Metal; all 4 smoke tests pass against the downloaded GGUF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)