### PR TITLE
ci: bump actions to Node 24 majors (clears 2026-06-02 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (with submodules for kx-llamacpp-sys/llama.cpp)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -29,7 +29,7 @@ jobs:
           cargo --version
 
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v4
 
       # bindgen needs libclang; the kx-llamacpp-sys CMake build needs cmake + a
       # C++ toolchain (already present on ubuntu-latest via build-essential).
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install -y libclang-dev clang cmake build-essential
 
       - name: Cache Cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -64,7 +64,7 @@ jobs:
     needs: ci
     steps:
       - name: Checkout (with submodules for kx-llamacpp-sys/llama.cpp)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -75,7 +75,7 @@ jobs:
           cargo --version
 
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v4
 
       - name: Install bindgen + CMake build dependencies
         run: |
@@ -83,7 +83,7 @@ jobs:
           sudo apt-get install -y libclang-dev clang cmake build-essential
 
       - name: Cache Cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary

GitHub Actions deprecated Node.js 20 effective 2026-06-02; existing v4/v2 of the three JavaScript actions in our workflow will be force-migrated to Node 24 then, and Node 20 is removed from runners on 2026-09-16. This PR proactively bumps each to its latest major that runs on Node 24, clearing the deprecation warnings.

## Bumps

| Action | Before | After | Runtime |
|---|---|---|---|
| Checkout | `actions/checkout@v4` | `actions/checkout@v6` | node24 |
| Cache | `actions/cache@v4` | `actions/cache@v5` | node24 |
| Setup just | `extractions/setup-just@v2` | `extractions/setup-just@v4` | composite → `setup-crate@v2` (node24) |

## Validation

- All three are stable releases verified to use Node 24 runtimes (checked `action.yml` / `action.yaml` on each tag).
- `extractions/setup-just@v4` is a composite action; its dependency `extractions/setup-crate@v2` is what runs JavaScript, and it uses `node24`.
- No env-var workaround (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`) needed.
- Inputs unchanged across the bumps (per release notes of each), so behavior should be identical.

## Test plan

- [x] CI on this PR must pass green on both jobs (`just ci` + `smoke-test-with-model`); a green CI proves the bumps don't break the workflow.

## Reference

GitHub deprecation announcement: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)