### PR TITLE
docs(README): badges + prominent kortecx.com + testing-discipline section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,15 @@
 > The distributed runtime for AI agents.
 > **Knowledge → Intelligence.**
 
-[![CI](https://github.com/Kortecx/kortecx/actions/workflows/ci.yml/badge.svg)](https://github.com/Kortecx/kortecx/actions/workflows/ci.yml)
+🌐 **[kortecx.com](https://kortecx.com)** &nbsp;·&nbsp; built in the open at [Kortecx/kortecx](https://github.com/Kortecx/kortecx)
+
+[![CI](https://github.com/Kortecx/kortecx/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Kortecx/kortecx/actions/workflows/ci.yml)
+[![Private-content leak check](https://github.com/Kortecx/kortecx/actions/workflows/leak-check.yml/badge.svg?branch=main)](https://github.com/Kortecx/kortecx/actions/workflows/leak-check.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![MSRV](https://img.shields.io/badge/MSRV-1.94.0-orange.svg)](rust-toolchain.toml)
+[![Rust Edition](https://img.shields.io/badge/Rust-2021-orange.svg)](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
+[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS-blue.svg)](#)
+[![Status](https://img.shields.io/badge/status-pre--alpha-yellow.svg)](#whats-in-this-repo-today)
 
 ---
 
@@ -36,18 +43,41 @@ a description of what runs today (see the next section for that).
 ## What's in this repo today
 
 kortecx is in early development. The public repo currently ships the **foundations**, not the
-runtime:
+full runtime:
 
-- The workspace, build system, and CI gates that the runtime crates land into.
-- `kx-mote`, the pure-types crate defining the atomic execution unit (Mote types, identity,
-  lifecycle state machine, three-way non-determinism tag).
-- Reproducible, byte-deterministic release builds (verified in CI on every push).
+- **`kx-mote`** — pure types for the atomic execution unit: Mote identity, lifecycle state
+  machine, three-way non-determinism tag.
+- **`kx-content`** — content-addressed payload storage (BLAKE3) with atomic-per-object writes;
+  local-FS and in-memory backends behind a single trait.
+- **`kx-journal`** — append-only journal (SQLite-backed, `BEGIN IMMEDIATE`, dedupe-by-key,
+  WAL + `synchronous=FULL`) plus an in-memory backend for fixtures.
+- **`kx-projection`** — pure read-side fold over the journal; cycle-tolerant BFS traversal;
+  snapshot isolation for the scheduler.
+- **`kx-llamacpp-sys`** + **`kx-llamacpp`** — the in-process llama.cpp safe wrapper (RAII,
+  lifetime-tied; no unsafe outside the FFI boundary). Generate, embed, chat: three calls.
+- Reproducible, byte-deterministic release builds, verified in CI on every push.
 - Structured tracing wired across the workspace.
+
+### Testing discipline
+
+Every foundation crate is gated by the same minimum bar before it can be built upon:
+
+- **Functionality + determinism** — every API has unit + integration tests; every operation
+  that promises determinism asserts it (run twice, identical output).
+- **Property tests** (`proptest`) — every function that accepts user-supplied input has at
+  least one property pinned across the input space, not just hand-picked cases.
+- **Concurrency tests** — every type that claims `Send` is exercised under ≥ 2 real threads.
+- **Doctests** — every non-trivial public method has a runnable doctest.
+- **Real-GGUF end-to-end smoke** — the inference wrapper's full pipeline (load → tokenize →
+  decode → sample → detokenize → KV-cache save/restore) is exercised against a real model in
+  CI on every push.
+- **Cross-platform** — Linux x86_64 in GitHub Actions CI; macOS Apple Silicon (Metal) verified
+  locally on every PR.
 
 The journal, executor, scheduler, capability broker, inference router, and runtime binary are
 **under active development** in the open. Until they land, `cargo build` produces foundational
-types — not yet a runnable agent runtime. The roadmap is to land them one crate at a time, each
-gated on the contract above.
+types — not yet a runnable agent runtime. The roadmap is to land them one crate at a time,
+each gated on the contract above.
 
 ## Installation
 
@@ -89,3 +119,5 @@ Licensed under the [Apache License, Version 2.0](LICENSE).
 
 - **Website:** [kortecx.com](https://kortecx.com)
 - **Issues:** [github.com/Kortecx/kortecx/issues](https://github.com/Kortecx/kortecx/issues)
+- **CI:** [Actions tab](https://github.com/Kortecx/kortecx/actions) — both `just ci` and the
+  real-GGUF smoke job must pass on every PR.


### PR DESCRIPTION
## Summary

Adds authentic legitimacy signals to the README without overclaiming. The runtime IS still pre-alpha; this PR just makes the underlying discipline visible.

## What's added

### Header / badges

- 🌐 Prominent **kortecx.com** link as a header line (was buried at the bottom)
- New badges next to the existing CI + License:
  - **MSRV** (1.94.0) — pinned via \`rust-toolchain.toml\`
  - **Rust Edition** (2021)
  - **Platform** (Linux | macOS)
  - **Status** (pre-alpha) — links to the "What's in this repo today" section
  - **Leak-check** — the new SN-2 automated workflow from PR #12

### Concrete crate enumeration

Replaces the previous one-line foundations summary with named per-crate descriptions:
- \`kx-mote\` — Mote types, identity, lifecycle
- \`kx-content\` — content-addressed storage (BLAKE3, atomic-per-object)
- \`kx-journal\` — SQLite-backed append-only log, WAL + dedupe-by-key
- \`kx-projection\` — pure read-side fold, snapshot isolation
- \`kx-llamacpp-sys\` + \`kx-llamacpp\` — in-process llama.cpp safe wrapper

### Testing-discipline subsection

New section under "What's in this repo today" naming the actual test categories every foundation crate clears before being built upon:

- Functionality + determinism
- Property tests (\`proptest\`)
- Concurrency tests (≥ 2 real threads against \`Send\` types)
- Doctests on every non-trivial public method
- Real-GGUF end-to-end smoke (load → tokenize → decode → sample → detokenize)
- Cross-platform (Linux CI + Apple Silicon local)

## Related (already applied, no PR needed)

- Repo "About" \`homepageUrl\` set to \`https://kortecx.com\` via \`gh repo edit\`.
- 16 custom labels created on the repo (area/*, type/*, compliance/*, phase/*) and applied to recent PRs.

## Test plan

- [x] Local SN-2 leak-check dry-run on the diff: clean
- [ ] CI must pass: \`just ci\` + \`smoke-test-with-model\` + \`private-content-leak-check\`
- [ ] Badge URLs resolve to real shields once merged

## SN-7

| Platform | Result |
|---|---|
| (A) Linux GitHub Actions CI | _pending_ |
| (B) Apple Silicon local | n/a — README-only change; no Rust touched |

🤖 Generated with [Claude Code](https://claude.com/claude-code)