### PR TITLE
P1.7.5: kx-model-validator — static bind-time fitness type check (D29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-model-validator"
+version = "0.0.1"
+dependencies = [
+ "kx-mote",
+ "proptest",
+ "serde",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-mote"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp"]
+members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -28,6 +28,7 @@ kx-content         = { path = "kx-content" }
 kx-journal         = { path = "kx-journal" }
 kx-llamacpp-sys    = { path = "kx-llamacpp-sys" }
 kx-llamacpp        = { path = "kx-llamacpp" }
+kx-model-validator = { path = "kx-model-validator" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/kx-model-validator/Cargo.toml
+++ b/kx-model-validator/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name         = "kx-model-validator"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx model-validator (D29) — static bind-time type check on capability sets. Refuses model–task mismatches before the first token."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-mote   = { workspace = true }
+serde     = { workspace = true }
+thiserror = { workspace = true }
+tracing   = { workspace = true }
+
+[dev-dependencies]
+proptest           = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-model-validator/src/lib.rs
+++ b/kx-model-validator/src/lib.rs
@@ -1,0 +1,1184 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless,
+    clippy::match_same_arms
+)]
+
+//! # kx-model-validator — static bind-time fitness type check
+//!
+//! Model fitness as a **type check over capability sets**.
+//!
+//! - A task declares a [`RequiredCapabilities`] — the type signature it expects.
+//! - A model exposes a [`ProvidedCapabilities`] — its actual type.
+//! - [`check`] performs structural subtyping: the model is a valid binding iff
+//!   its provided capabilities satisfy (are a superset of) the task's required
+//!   ones.
+//!
+//! Runs at **bind time** — when a model is loaded, or before a Mote needing
+//! that model is scheduled. It is a **static** check, never a mid-execution
+//! discovery. The whole value: find the wrong model at load time, not three
+//! Motes into a workflow.
+//!
+//! ## Three outcomes ([`ValidatorOutcome`])
+//!
+//! - [`ValidatorOutcome::TypeOk`] — `provided ⊇ required` — clean bind.
+//! - [`ValidatorOutcome::DegradedSubtype`] — binds, but an optional/soft
+//!   capability is missing or emulated (e.g. tool-calling done via prompting
+//!   instead of native). Records the degraded mode for downstream callers
+//!   (the formatter adapter compensates).
+//! - [`ValidatorOutcome::TypeError`] — a REQUIRED capability is missing —
+//!   refuses to bind, names the missing member and why.
+//!
+//! ## Hard boundary: interface, NOT quality
+//!
+//! The validator type-checks the model's **interface (signature)**, never its
+//! output **quality (behavior)**. Capability is statically checkable; quality
+//! is not — that's the workflow / eval / critic layer's job (orchestration vs
+//! semantic correctness).
+//!
+//! The validator's smaller, honest claim ("I prove your model HAS the required
+//! capabilities; I do not claim it'll be GOOD at them") is the source of its
+//! credibility. Do not let it drift into a quality oracle.
+//!
+//! ## Soundness boundary: v1 → v2
+//!
+//! - **v1 (this crate)** — the validator type-checks against the model's
+//!   **declared** [`ProvidedCapabilities`]. Declarations can lie. v1's guarantee
+//!   is *"the model CLAIMS to satisfy the signature."* All v1 language uses
+//!   "declared." `TypeOk` is more precisely "TypeOk-as-declared."
+//! - **v2 (deferred)** — a capability probe will verify each declaration via a
+//!   one-time deterministic test, result cached. v2 language will use "verified"
+//!   and "guaranteed."
+//! - In v1, the capability broker (P1.8.5) remains the runtime backstop that
+//!   catches false declarations at execution.
+//!
+//! ## House model competes on equal merit
+//!
+//! The validator does **not** know which model is the house model. There is
+//! no field, no flag, no boost. The type-theoretic framing makes the
+//! no-favoritism property structural rather than aspirational. See
+//! [`Recommender`] for the ranking discipline.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+pub use kx_mote::ModelId;
+
+// ===========================================================================
+// Capability primitives (small enums; stable u8/string discriminants for
+// future on-disk encoding when capabilities land in a model registry).
+// ===========================================================================
+
+/// Input/output modalities a model supports.
+///
+/// Closed enum; new modalities require a coordinated update to the registry
+/// schema. The discriminants are stable for forward-compat metadata storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Modality {
+    /// Text (always present; the baseline modality).
+    Text = 0,
+    /// Vision input (images, frames).
+    Vision = 1,
+    /// Audio input (speech, music).
+    Audio = 2,
+    /// Generic embedding output (the model emits a fixed-dim vector rather
+    /// than tokens).
+    Embedding = 3,
+}
+
+/// Quantization format the model is loaded in.
+///
+/// Closed enum for the formats kortecx's OSS inference path (llama.cpp via
+/// `kx-llamacpp`) actually loads. Cloud backends with different format
+/// support (e.g., vLLM with safetensors) plug their own [`Quantization`]
+/// extensions in via the registry's free-form metadata, not here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Quantization {
+    /// Full 32-bit floats (no quantization).
+    F32 = 0,
+    /// Half-precision floats.
+    F16 = 1,
+    /// BFloat16.
+    Bf16 = 2,
+    /// 8-bit integer (gguf `Q8_0`, common for accuracy-sensitive deployments).
+    Q8_0 = 10,
+    /// 5-bit, K-quant medium.
+    Q5KM = 20,
+    /// 4-bit, K-quant medium (the sweet-spot default for many local
+    /// deployments).
+    Q4KM = 30,
+    /// 4-bit, `Q4_0` (gguf legacy/portable).
+    Q4_0 = 31,
+    /// 2-bit, K-quant (memory-constrained deployments; large quality loss).
+    Q2K = 40,
+}
+
+/// License under which a model is distributed.
+///
+/// Tagged as either an SPDX identifier (`SpdxId("Apache-2.0")`) or one of the
+/// common open-but-restrictive license patterns. Workflow authors declare
+/// constraints via [`LicenseConstraint`]; the check is an exact-match or
+/// inclusion lookup, NOT a free-form SPDX expression parser.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum License {
+    /// An SPDX identifier (e.g., `"Apache-2.0"`, `"MIT"`).
+    SpdxId(String),
+    /// Llama-style community license (commercial use permitted with
+    /// per-account caps; common for Meta models).
+    LlamaCommunity,
+    /// Open-weights-non-commercial (research use only; e.g., some early
+    /// Llama variants).
+    OpenWeightsNonCommercial,
+    /// Proprietary / closed (e.g., GPT-class API access; the runtime can
+    /// call but not redistribute weights).
+    Proprietary,
+    /// License is unknown to the registry. Treated as restrictive by default
+    /// (matches no constraint that requires a specific license).
+    Unknown,
+}
+
+/// Workflow-author constraint on the model's license.
+///
+/// Constraints compose by intersection: declaring `RequireCommercialOk` AND
+/// `RequireRedistributable` requires a license satisfying both.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum LicenseConstraint {
+    /// No license restriction (any model permitted).
+    NoRestriction,
+    /// The license must explicitly allow commercial use.
+    RequireCommercialOk,
+    /// The license must allow weight redistribution (e.g., shipping the
+    /// model file in a container image).
+    RequireRedistributable,
+    /// The model's license must be one of an explicit set (e.g.,
+    /// `{"Apache-2.0", "MIT"}`).
+    OneOf(BTreeSet<License>),
+}
+
+impl LicenseConstraint {
+    /// `true` when `license` satisfies the constraint.
+    #[must_use]
+    pub fn is_satisfied_by(&self, license: &License) -> bool {
+        match self {
+            Self::NoRestriction => true,
+            Self::RequireCommercialOk => commercial_use_permitted(license),
+            Self::RequireRedistributable => redistribution_permitted(license),
+            Self::OneOf(allowed) => allowed.contains(license),
+        }
+    }
+}
+
+/// Heuristic: does this license permit commercial use?
+///
+/// Conservative — only returns `true` for licenses we KNOW permit commercial
+/// use. Unknown licenses are treated as restrictive.
+fn commercial_use_permitted(license: &License) -> bool {
+    match license {
+        License::SpdxId(id) => matches!(
+            id.as_str(),
+            "Apache-2.0" | "MIT" | "BSD-2-Clause" | "BSD-3-Clause" | "ISC"
+        ),
+        License::LlamaCommunity => true, // commercial use permitted with caveats
+        License::Proprietary => true,    // commercial API access IS commercial use
+        License::OpenWeightsNonCommercial | License::Unknown => false,
+    }
+}
+
+/// Heuristic: does this license permit redistribution of the model weights?
+fn redistribution_permitted(license: &License) -> bool {
+    match license {
+        License::SpdxId(id) => matches!(
+            id.as_str(),
+            "Apache-2.0" | "MIT" | "BSD-2-Clause" | "BSD-3-Clause" | "ISC"
+        ),
+        License::LlamaCommunity => true, // permits redistribution under the community license
+        License::Proprietary | License::OpenWeightsNonCommercial | License::Unknown => false,
+    }
+}
+
+// ===========================================================================
+// Capability sets
+// ===========================================================================
+
+/// What a task requires from any model it will be bound to.
+///
+/// Workflow-author-supplied at workflow-compile time. The runtime never
+/// invents one.
+///
+/// Per D29's "no MoteDef field for v1" decision, this lives on the SDK side
+/// as a separate input to [`check`], NOT on the Mote's identity hash. Adding
+/// it to `MoteDef` would force a `schema_version` bump (v3 → v4); the v1
+/// validator delivers its value without that disturbance. Re-evaluate at P4.
+///
+/// # Examples
+///
+/// ```
+/// use kx_model_validator::{LicenseConstraint, Modality, Quantization, RequiredCapabilities};
+/// use std::collections::BTreeSet;
+///
+/// // A reasonable default for a long-context tool-calling chat workflow.
+/// let req = RequiredCapabilities {
+///     min_context_window_tokens: 8_192,
+///     requires_native_tool_calling: true,
+///     prefers_native_tool_calling: true,
+///     required_modalities: BTreeSet::from([Modality::Text]),
+///     allowed_quantizations: BTreeSet::from([
+///         Quantization::F16,
+///         Quantization::Bf16,
+///         Quantization::Q8_0,
+///         Quantization::Q4KM,
+///     ]),
+///     requires_chat_template: true,
+///     license_constraint: LicenseConstraint::RequireCommercialOk,
+/// };
+/// assert_eq!(req.min_context_window_tokens, 8_192);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RequiredCapabilities {
+    /// Minimum context window the task needs (in tokens). Model's
+    /// `context_window_tokens` must be ≥ this.
+    pub min_context_window_tokens: u32,
+
+    /// `true` if the workflow REQUIRES native tool-calling — TypeError if the
+    /// model lacks it.
+    pub requires_native_tool_calling: bool,
+
+    /// `true` if the workflow PREFERS native tool-calling but can tolerate a
+    /// degraded mode (the formatter adapter compensates). If both
+    /// `requires_native_tool_calling` and `prefers_native_tool_calling` are
+    /// `false`, native tool calling is not consulted.
+    pub prefers_native_tool_calling: bool,
+
+    /// Modalities the task needs. The model's `modalities` must be a superset.
+    /// Empty set ≡ Text-only (the implicit baseline).
+    pub required_modalities: BTreeSet<Modality>,
+
+    /// Allowed quantization formats. The model's `quantization` must be in
+    /// this set. Empty set ≡ any quantization permitted.
+    pub allowed_quantizations: BTreeSet<Quantization>,
+
+    /// `true` if the task needs a chat template present on the model (multi-
+    /// turn / role-formatted prompting).
+    pub requires_chat_template: bool,
+
+    /// License constraint the model must satisfy.
+    pub license_constraint: LicenseConstraint,
+}
+
+impl RequiredCapabilities {
+    /// A constraint set that admits any model that exists (no requirements).
+    ///
+    /// Useful for tests, debugging, and workflows that don't care about
+    /// fitness (the runtime will still refuse non-existent models — this just
+    /// means the validator is permissive for any-existing model).
+    #[must_use]
+    pub fn permissive() -> Self {
+        Self {
+            min_context_window_tokens: 0,
+            requires_native_tool_calling: false,
+            prefers_native_tool_calling: false,
+            required_modalities: BTreeSet::new(),
+            allowed_quantizations: BTreeSet::new(),
+            requires_chat_template: false,
+            license_constraint: LicenseConstraint::NoRestriction,
+        }
+    }
+}
+
+/// What a model exposes — populated by the model registry from declared
+/// metadata.
+///
+/// Per D29: v1 trusts these declarations. The capability broker (P1.8.5) is
+/// the runtime backstop that catches false declarations at execution. v2
+/// (deferred) will add a capability probe to verify each declaration at
+/// model-load time and cache the result.
+///
+/// # Examples
+///
+/// ```
+/// use kx_model_validator::{License, Modality, ProvidedCapabilities, Quantization};
+/// use std::collections::BTreeSet;
+///
+/// // What a Llama-3-8B-Instruct GGUF might expose.
+/// let provided = ProvidedCapabilities::declared()
+///     .with_context_window_tokens(8_192)
+///     .with_native_tool_calling(true)
+///     .with_modalities(BTreeSet::from([Modality::Text]))
+///     .with_quantization(Quantization::Q4KM)
+///     .with_chat_template(Some("llama-3-instruct".into()))
+///     .with_license(License::LlamaCommunity);
+/// assert_eq!(provided.context_window_tokens, 8_192);
+/// assert!(provided.native_tool_calling);
+/// ```
+// `Eq` / `Hash` deliberately NOT derived: `eval_scores` contains `f32`
+// values which only implement `PartialEq` / `PartialOrd`. The validator
+// compares structurally via `check`; capability sets are never used as
+// HashMap keys.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProvidedCapabilities {
+    /// Context window in tokens (the loaded model's `n_ctx_train` or
+    /// configured value).
+    pub context_window_tokens: u32,
+
+    /// `true` if the model has native tool/function-calling (vs. prompted
+    /// emulation).
+    pub native_tool_calling: bool,
+
+    /// Input/output modalities the model supports.
+    pub modalities: BTreeSet<Modality>,
+
+    /// The loaded quantization format (single value — the model is loaded in
+    /// exactly one format).
+    pub quantization: Quantization,
+
+    /// The model's chat-template name if present (e.g., `"llama-3-instruct"`,
+    /// `"chatml"`), `None` if absent (raw completion only).
+    pub chat_template: Option<String>,
+
+    /// The model's distribution license.
+    pub license: License,
+
+    /// Soundness tag: v1 records `Declared`; v2 will record `Verified` after
+    /// a capability probe. Recommender ranking can prefer verified providers
+    /// (future).
+    pub soundness: Soundness,
+
+    /// Opt-in published eval scores keyed by eval name (e.g.,
+    /// `"mmlu" → 0.823`). The workflow author names which eval to rank by;
+    /// the recommender never picks one on its own (prevents flattering the
+    /// house model).
+    pub eval_scores: BTreeMap<String, f32>,
+}
+
+/// Soundness tag for [`ProvidedCapabilities`] (D29 v1 → v2 boundary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Soundness {
+    /// The capabilities come from a model-supplied declaration (manifest,
+    /// metadata file). v1's default — trust assumed.
+    Declared = 0,
+    /// The capabilities were verified at model-load time by a deterministic
+    /// probe (v2 — deferred). The result is cached.
+    Verified = 1,
+}
+
+impl ProvidedCapabilities {
+    /// Start a `ProvidedCapabilities` builder in `Declared` soundness mode
+    /// (v1 default).
+    ///
+    /// Returns a sensible baseline (text-only, F32, no tool calling, no chat
+    /// template, Unknown license) that the caller refines via `with_*`
+    /// chaining. Avoids forcing every call site to specify every field.
+    #[must_use]
+    pub fn declared() -> Self {
+        let mut modalities = BTreeSet::new();
+        modalities.insert(Modality::Text);
+        Self {
+            context_window_tokens: 0,
+            native_tool_calling: false,
+            modalities,
+            quantization: Quantization::F32,
+            chat_template: None,
+            license: License::Unknown,
+            soundness: Soundness::Declared,
+            eval_scores: BTreeMap::new(),
+        }
+    }
+
+    /// Same as [`Self::declared`] but stamped `Verified` (for v2 / probe-
+    /// validated callers when that path exists).
+    #[must_use]
+    pub fn verified() -> Self {
+        let mut p = Self::declared();
+        p.soundness = Soundness::Verified;
+        p
+    }
+
+    // ---- Builder methods (composable; chainable) -------------------------
+
+    /// Set the context window in tokens.
+    pub fn with_context_window_tokens(mut self, n: u32) -> Self {
+        self.context_window_tokens = n;
+        self
+    }
+
+    /// Set the native-tool-calling flag.
+    pub fn with_native_tool_calling(mut self, on: bool) -> Self {
+        self.native_tool_calling = on;
+        self
+    }
+
+    /// Replace the modalities set.
+    pub fn with_modalities(mut self, m: BTreeSet<Modality>) -> Self {
+        self.modalities = m;
+        self
+    }
+
+    /// Set the quantization format.
+    pub fn with_quantization(mut self, q: Quantization) -> Self {
+        self.quantization = q;
+        self
+    }
+
+    /// Set the chat template name (or `None` for absent).
+    pub fn with_chat_template(mut self, t: Option<String>) -> Self {
+        self.chat_template = t;
+        self
+    }
+
+    /// Set the license.
+    pub fn with_license(mut self, l: License) -> Self {
+        self.license = l;
+        self
+    }
+
+    /// Add or replace one eval score.
+    pub fn with_eval_score(mut self, name: impl Into<String>, score: f32) -> Self {
+        self.eval_scores.insert(name.into(), score);
+        self
+    }
+}
+
+// ===========================================================================
+// ValidatorOutcome — the type-check result
+// ===========================================================================
+
+/// Why a capability binds in degraded mode.
+///
+/// Distinct from [`MissingCapability`] (which causes TypeError refusal). A
+/// `DegradationReason` is information for the downstream caller — the
+/// formatter adapter, the SDK author, the observability layer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DegradationReason {
+    /// `prefers_native_tool_calling` was set but `provided.native_tool_calling`
+    /// is false. Tool calls will need prompted emulation; downstream code
+    /// (the formatter adapter) should compensate.
+    NativeToolCallingMissing,
+}
+
+/// What's missing when the check returns TypeError.
+///
+/// Named explicitly so the executor can surface a typed reason at refusal
+/// time (Mote enters Failed with a specific cause).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MissingCapability {
+    /// `provided.context_window_tokens < required.min_context_window_tokens`.
+    ContextWindowTooSmall {
+        /// What the model provides.
+        provided: u32,
+        /// What the task needs.
+        required: u32,
+    },
+    /// `required.requires_native_tool_calling` set but
+    /// `provided.native_tool_calling = false`.
+    NativeToolCallingRequired,
+    /// One or more required modalities are not in the model's modality set.
+    ModalityMissing {
+        /// The modality the task requires but the model lacks.
+        missing: Modality,
+    },
+    /// The model's `quantization` is not in the task's `allowed_quantizations`.
+    QuantizationNotAllowed {
+        /// The model's quantization.
+        provided: Quantization,
+    },
+    /// `requires_chat_template` set but `provided.chat_template` is `None`.
+    ChatTemplateRequired,
+    /// The model's license does not satisfy the task's constraint.
+    LicenseUnsatisfied {
+        /// The model's license.
+        provided: License,
+    },
+}
+
+/// Outcome of a [`check`] call.
+///
+/// Three variants:
+/// - [`Self::TypeOk`] — `provided ⊇ required`. Clean bind.
+/// - [`Self::DegradedSubtype`] — required ⊆ provided AND at least one
+///   *preferred* (soft) capability is missing or emulated.
+/// - [`Self::TypeError`] — at least one *required* capability is absent.
+///   Refuse the bind.
+///
+/// # Examples
+///
+/// ```
+/// use kx_model_validator::{check, ProvidedCapabilities, Quantization, RequiredCapabilities, ValidatorOutcome};
+///
+/// // Permissive task + any model = TypeOk.
+/// let req = RequiredCapabilities::permissive();
+/// let provided = ProvidedCapabilities::declared()
+///     .with_context_window_tokens(4096)
+///     .with_quantization(Quantization::Q4KM);
+/// assert_eq!(check(&provided, &req), ValidatorOutcome::TypeOk);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ValidatorOutcome {
+    /// Provided capabilities satisfy required + all preferences. Clean bind.
+    TypeOk,
+    /// Provided capabilities satisfy required, but a preferred (soft)
+    /// capability is missing. The bind proceeds; the caller records the
+    /// degraded mode (e.g., the formatter adapter compensates).
+    DegradedSubtype {
+        /// The reasons the bind is degraded (non-empty).
+        reasons: Vec<DegradationReason>,
+    },
+    /// One or more required capabilities are missing. The bind is refused.
+    /// The executor surfaces a typed error naming the missing members.
+    TypeError {
+        /// The capabilities that were required but absent (non-empty).
+        missing: Vec<MissingCapability>,
+    },
+}
+
+impl ValidatorOutcome {
+    /// `true` if the bind would proceed (TypeOk or DegradedSubtype).
+    #[must_use]
+    pub fn is_acceptable(&self) -> bool {
+        matches!(self, Self::TypeOk | Self::DegradedSubtype { .. })
+    }
+
+    /// `true` if the bind is refused.
+    #[must_use]
+    pub fn is_type_error(&self) -> bool {
+        matches!(self, Self::TypeError { .. })
+    }
+}
+
+// ===========================================================================
+// The check function — pure, total, deterministic
+// ===========================================================================
+
+/// Perform the bind-time fitness type check.
+///
+/// **Pure**: no I/O, no model invocation, no journal access.
+/// **Total**: every `(provided, required)` pair returns a `ValidatorOutcome`.
+/// **Deterministic**: identical inputs yield identical outputs across calls
+/// and threads.
+///
+/// Returns:
+/// - [`ValidatorOutcome::TypeError`] if any REQUIRED capability is missing
+///   (the missing list is non-empty in PR order: context window → tool
+///   calling → modality → quantization → chat template → license).
+/// - [`ValidatorOutcome::DegradedSubtype`] if no required capability is
+///   missing but a PREFERRED capability is missing (e.g.,
+///   `prefers_native_tool_calling` set and provider lacks native tool
+///   calling).
+/// - [`ValidatorOutcome::TypeOk`] otherwise.
+#[tracing::instrument(level = "debug", skip(provided, required))]
+#[must_use]
+pub fn check(provided: &ProvidedCapabilities, required: &RequiredCapabilities) -> ValidatorOutcome {
+    let mut missing: Vec<MissingCapability> = Vec::new();
+
+    // 1. Context window.
+    if provided.context_window_tokens < required.min_context_window_tokens {
+        missing.push(MissingCapability::ContextWindowTooSmall {
+            provided: provided.context_window_tokens,
+            required: required.min_context_window_tokens,
+        });
+    }
+
+    // 2. Native tool calling (required form).
+    if required.requires_native_tool_calling && !provided.native_tool_calling {
+        missing.push(MissingCapability::NativeToolCallingRequired);
+    }
+
+    // 3. Modalities.
+    for m in &required.required_modalities {
+        if !provided.modalities.contains(m) {
+            missing.push(MissingCapability::ModalityMissing { missing: *m });
+        }
+    }
+
+    // 4. Quantization.
+    if !required.allowed_quantizations.is_empty()
+        && !required
+            .allowed_quantizations
+            .contains(&provided.quantization)
+    {
+        missing.push(MissingCapability::QuantizationNotAllowed {
+            provided: provided.quantization,
+        });
+    }
+
+    // 5. Chat template.
+    if required.requires_chat_template && provided.chat_template.is_none() {
+        missing.push(MissingCapability::ChatTemplateRequired);
+    }
+
+    // 6. License.
+    if !required
+        .license_constraint
+        .is_satisfied_by(&provided.license)
+    {
+        missing.push(MissingCapability::LicenseUnsatisfied {
+            provided: provided.license.clone(),
+        });
+    }
+
+    if !missing.is_empty() {
+        return ValidatorOutcome::TypeError { missing };
+    }
+
+    // No required missing — check preferences for degraded mode.
+    let mut reasons: Vec<DegradationReason> = Vec::new();
+    if required.prefers_native_tool_calling
+        && !required.requires_native_tool_calling
+        && !provided.native_tool_calling
+    {
+        reasons.push(DegradationReason::NativeToolCallingMissing);
+    }
+
+    if reasons.is_empty() {
+        ValidatorOutcome::TypeOk
+    } else {
+        ValidatorOutcome::DegradedSubtype { reasons }
+    }
+}
+
+// ===========================================================================
+// ModelRegistry trait + in-memory impl
+// ===========================================================================
+
+/// A lookup over models the runtime knows about, keyed by [`ModelId`].
+///
+/// OSS ships [`InMemoryModelRegistry`]; cloud impls (hosted registry, S3-
+/// backed manifests) plug in behind the same trait per D28 (cloud-first
+/// scale principle).
+pub trait ModelRegistry: Send + Sync {
+    /// Look up a model's declared (or verified) provided capabilities.
+    fn lookup(&self, model_id: &ModelId) -> Option<ProvidedCapabilities>;
+
+    /// Iterate every model in the registry. Used by [`Recommender::candidates`]
+    /// to find substitutes when the requested model fails its check.
+    fn entries(&self) -> Vec<(ModelId, ProvidedCapabilities)>;
+}
+
+/// In-memory `ModelRegistry`. The OSS default; cloud impls bring their own.
+///
+/// # Examples
+///
+/// ```
+/// use kx_model_validator::{InMemoryModelRegistry, ModelRegistry, ProvidedCapabilities};
+/// use kx_mote::ModelId;
+///
+/// let mut reg = InMemoryModelRegistry::new();
+/// reg.insert(
+///     ModelId("llama-3-8b-instruct".into()),
+///     ProvidedCapabilities::declared().with_context_window_tokens(8_192),
+/// );
+/// assert!(reg.lookup(&ModelId("llama-3-8b-instruct".into())).is_some());
+/// assert!(reg.lookup(&ModelId("unknown".into())).is_none());
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryModelRegistry {
+    by_id: BTreeMap<ModelId, ProvidedCapabilities>,
+}
+
+impl InMemoryModelRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert (or replace) a model entry.
+    pub fn insert(&mut self, id: ModelId, capabilities: ProvidedCapabilities) {
+        self.by_id.insert(id, capabilities);
+    }
+
+    /// Remove an entry; returns whether it was present.
+    pub fn remove(&mut self, id: &ModelId) -> bool {
+        self.by_id.remove(id).is_some()
+    }
+
+    /// Number of entries in the registry.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// `true` when the registry has no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+impl ModelRegistry for InMemoryModelRegistry {
+    fn lookup(&self, model_id: &ModelId) -> Option<ProvidedCapabilities> {
+        self.by_id.get(model_id).cloned()
+    }
+
+    fn entries(&self) -> Vec<(ModelId, ProvidedCapabilities)> {
+        self.by_id
+            .iter()
+            .map(|(id, cap)| (id.clone(), cap.clone()))
+            .collect()
+    }
+}
+
+// ===========================================================================
+// Recommender — type inference as a thin layer over `check`
+// ===========================================================================
+
+/// Ranking authority used by [`Recommender::candidates`].
+///
+/// Strict precedence (D29):
+/// 1. **Deterministic capability match** (always). Models that fail the
+///    check are filtered out; among the remaining, TypeOk outranks
+///    DegradedSubtype, and within each tier, models with more soft
+///    preferences satisfied outrank fewer.
+/// 2. **Workflow-named eval score** (optional). If the caller names an eval,
+///    higher scores rank higher within tier 1.
+/// 3. **In-runtime Mote-measured performance** (deferred to P1.13+). v1
+///    returns a stable order within the tier; v2 will plug a journal-derived
+///    score in here.
+///
+/// **The recommender does NOT know which model is the house model.** No
+/// flag, no boost, no field. Type framing makes no-favoritism structural.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RankingPolicy {
+    /// If `Some(name)`, the recommender ranks acceptable candidates by
+    /// `provided.eval_scores[name]` descending. Caller-chosen, never picked
+    /// by the recommender.
+    pub eval_metric: Option<String>,
+}
+
+/// One candidate result from the recommender.
+///
+/// Sorted within a `Vec<Candidate>` by the [`RankingPolicy`] precedence.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    /// The candidate's identity.
+    pub model_id: ModelId,
+    /// The check outcome against the workflow's `required` capabilities.
+    pub outcome: ValidatorOutcome,
+    /// The candidate's declared capabilities (carried for the caller's
+    /// inspection — e.g., showing why one ranked above another).
+    pub provided: ProvidedCapabilities,
+    /// The eval score under the workflow's `RankingPolicy.eval_metric`, if
+    /// present and applicable.
+    pub eval_score: Option<f32>,
+}
+
+/// Thin layer over [`check`] + a [`ModelRegistry`]. Suggests, never
+/// substitutes.
+///
+/// Same principle as the broker (P1.8.5) never silently rewriting a tool
+/// call: the recommender returns ranked candidates; the caller (SDK or
+/// runtime router) decides whether to act on the suggestion.
+///
+/// # Examples
+///
+/// ```
+/// use kx_model_validator::{
+///     check, InMemoryModelRegistry, ProvidedCapabilities, Quantization,
+///     RankingPolicy, Recommender, RequiredCapabilities, ValidatorOutcome,
+/// };
+/// use kx_mote::ModelId;
+/// use std::collections::BTreeSet;
+///
+/// let mut reg = InMemoryModelRegistry::new();
+/// reg.insert(
+///     ModelId("small-text".into()),
+///     ProvidedCapabilities::declared().with_context_window_tokens(2_048),
+/// );
+/// reg.insert(
+///     ModelId("big-text".into()),
+///     ProvidedCapabilities::declared().with_context_window_tokens(32_768),
+/// );
+///
+/// let req = RequiredCapabilities {
+///     min_context_window_tokens: 16_000,
+///     ..RequiredCapabilities::permissive()
+/// };
+///
+/// let recommender = Recommender::new(&reg, RankingPolicy::default());
+/// let candidates = recommender.candidates(&req);
+///
+/// // Only big-text satisfies the 16k context requirement.
+/// assert_eq!(candidates.len(), 1);
+/// assert_eq!(candidates[0].model_id, ModelId("big-text".into()));
+/// assert_eq!(candidates[0].outcome, ValidatorOutcome::TypeOk);
+/// ```
+pub struct Recommender<'a, R: ModelRegistry + ?Sized> {
+    registry: &'a R,
+    policy: RankingPolicy,
+}
+
+impl<'a, R: ModelRegistry + ?Sized> Recommender<'a, R> {
+    /// Construct a recommender over `registry` with the given ranking
+    /// `policy`.
+    pub fn new(registry: &'a R, policy: RankingPolicy) -> Self {
+        Self { registry, policy }
+    }
+
+    /// Check one specific model against the requirements.
+    pub fn check_model(
+        &self,
+        model_id: &ModelId,
+        required: &RequiredCapabilities,
+    ) -> Option<Candidate> {
+        let provided = self.registry.lookup(model_id)?;
+        let outcome = check(&provided, required);
+        let eval_score = self.eval_score_of(&provided);
+        Some(Candidate {
+            model_id: model_id.clone(),
+            outcome,
+            provided,
+            eval_score,
+        })
+    }
+
+    /// Return every model in the registry whose check is `TypeOk` or
+    /// `DegradedSubtype`, ranked by the configured `RankingPolicy`.
+    ///
+    /// TypeError candidates are NOT returned — the caller asked for
+    /// "candidates that could bind."
+    pub fn candidates(&self, required: &RequiredCapabilities) -> Vec<Candidate> {
+        let mut out: Vec<Candidate> = self
+            .registry
+            .entries()
+            .into_iter()
+            .filter_map(|(id, provided)| {
+                let outcome = check(&provided, required);
+                if outcome.is_acceptable() {
+                    let eval_score = self.eval_score_of(&provided);
+                    Some(Candidate {
+                        model_id: id,
+                        outcome,
+                        provided,
+                        eval_score,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Stable sort: TypeOk before DegradedSubtype; within each, higher
+        // eval score first (if eval_metric is set); otherwise ModelId
+        // ascending (deterministic, no implicit preference).
+        out.sort_by(|a, b| {
+            let a_rank = outcome_rank(&a.outcome);
+            let b_rank = outcome_rank(&b.outcome);
+            a_rank.cmp(&b_rank).then_with(|| {
+                // Higher eval score first → compare b vs a.
+                match (a.eval_score, b.eval_score) {
+                    (Some(av), Some(bv)) => {
+                        bv.partial_cmp(&av).unwrap_or(std::cmp::Ordering::Equal)
+                    }
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => a.model_id.cmp(&b.model_id),
+                }
+            })
+        });
+
+        out
+    }
+
+    fn eval_score_of(&self, provided: &ProvidedCapabilities) -> Option<f32> {
+        self.policy
+            .eval_metric
+            .as_deref()
+            .and_then(|name| provided.eval_scores.get(name).copied())
+    }
+}
+
+/// Numeric rank for outcome sorting: lower = better.
+fn outcome_rank(o: &ValidatorOutcome) -> u8 {
+    match o {
+        ValidatorOutcome::TypeOk => 0,
+        ValidatorOutcome::DegradedSubtype { .. } => 1,
+        ValidatorOutcome::TypeError { .. } => 2,
+    }
+}
+
+// ===========================================================================
+// Unit tests (in-module; integration + proptest live in tests/)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn permissive_provided() -> ProvidedCapabilities {
+        ProvidedCapabilities::declared()
+            .with_context_window_tokens(8_192)
+            .with_native_tool_calling(true)
+            .with_quantization(Quantization::Q4KM)
+            .with_chat_template(Some("chatml".into()))
+            .with_license(License::SpdxId("Apache-2.0".into()))
+    }
+
+    #[test]
+    fn permissive_required_with_capable_provided_is_type_ok() {
+        let outcome = check(&permissive_provided(), &RequiredCapabilities::permissive());
+        assert_eq!(outcome, ValidatorOutcome::TypeOk);
+    }
+
+    #[test]
+    fn context_window_too_small_is_type_error() {
+        let provided = ProvidedCapabilities::declared().with_context_window_tokens(2_048);
+        let required = RequiredCapabilities {
+            min_context_window_tokens: 8_192,
+            ..RequiredCapabilities::permissive()
+        };
+        match check(&provided, &required) {
+            ValidatorOutcome::TypeError { missing } => {
+                assert!(missing
+                    .iter()
+                    .any(|m| matches!(m, MissingCapability::ContextWindowTooSmall { .. })));
+            }
+            other => panic!("expected TypeError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn required_tool_calling_missing_is_type_error() {
+        let provided = permissive_provided().with_native_tool_calling(false);
+        let required = RequiredCapabilities {
+            requires_native_tool_calling: true,
+            ..RequiredCapabilities::permissive()
+        };
+        let outcome = check(&provided, &required);
+        assert!(outcome.is_type_error());
+    }
+
+    #[test]
+    fn preferred_tool_calling_missing_is_degraded_not_error() {
+        let provided = permissive_provided().with_native_tool_calling(false);
+        let required = RequiredCapabilities {
+            requires_native_tool_calling: false,
+            prefers_native_tool_calling: true,
+            ..RequiredCapabilities::permissive()
+        };
+        match check(&provided, &required) {
+            ValidatorOutcome::DegradedSubtype { reasons } => {
+                assert!(reasons.contains(&DegradationReason::NativeToolCallingMissing));
+            }
+            other => panic!("expected DegradedSubtype, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn required_modality_missing_is_type_error() {
+        let provided = permissive_provided(); // only Text
+        let required = RequiredCapabilities {
+            required_modalities: BTreeSet::from([Modality::Vision]),
+            ..RequiredCapabilities::permissive()
+        };
+        assert!(check(&provided, &required).is_type_error());
+    }
+
+    #[test]
+    fn quantization_not_in_allowed_set_is_type_error() {
+        let provided = permissive_provided().with_quantization(Quantization::Q2K);
+        let required = RequiredCapabilities {
+            allowed_quantizations: BTreeSet::from([
+                Quantization::F16,
+                Quantization::Q8_0,
+                Quantization::Q4KM,
+            ]),
+            ..RequiredCapabilities::permissive()
+        };
+        assert!(check(&provided, &required).is_type_error());
+    }
+
+    #[test]
+    fn empty_allowed_quantizations_admits_any() {
+        let provided = permissive_provided().with_quantization(Quantization::Q2K);
+        let required = RequiredCapabilities {
+            allowed_quantizations: BTreeSet::new(),
+            ..RequiredCapabilities::permissive()
+        };
+        assert_eq!(check(&provided, &required), ValidatorOutcome::TypeOk);
+    }
+
+    #[test]
+    fn missing_chat_template_required_is_type_error() {
+        let provided = permissive_provided().with_chat_template(None);
+        let required = RequiredCapabilities {
+            requires_chat_template: true,
+            ..RequiredCapabilities::permissive()
+        };
+        assert!(check(&provided, &required).is_type_error());
+    }
+
+    #[test]
+    fn license_constraint_no_restriction_admits_any() {
+        let provided = permissive_provided().with_license(License::Unknown);
+        let required = RequiredCapabilities::permissive();
+        assert_eq!(check(&provided, &required), ValidatorOutcome::TypeOk);
+    }
+
+    #[test]
+    fn license_constraint_commercial_ok_rejects_unknown() {
+        let provided = permissive_provided().with_license(License::Unknown);
+        let required = RequiredCapabilities {
+            license_constraint: LicenseConstraint::RequireCommercialOk,
+            ..RequiredCapabilities::permissive()
+        };
+        assert!(check(&provided, &required).is_type_error());
+    }
+
+    #[test]
+    fn license_constraint_commercial_ok_admits_apache() {
+        let provided = permissive_provided().with_license(License::SpdxId("Apache-2.0".into()));
+        let required = RequiredCapabilities {
+            license_constraint: LicenseConstraint::RequireCommercialOk,
+            ..RequiredCapabilities::permissive()
+        };
+        assert_eq!(check(&provided, &required), ValidatorOutcome::TypeOk);
+    }
+
+    #[test]
+    fn license_constraint_one_of_works() {
+        let provided = permissive_provided().with_license(License::SpdxId("MIT".into()));
+        let allowed: BTreeSet<License> = BTreeSet::from([
+            License::SpdxId("MIT".into()),
+            License::SpdxId("Apache-2.0".into()),
+        ]);
+        let required = RequiredCapabilities {
+            license_constraint: LicenseConstraint::OneOf(allowed),
+            ..RequiredCapabilities::permissive()
+        };
+        assert_eq!(check(&provided, &required), ValidatorOutcome::TypeOk);
+    }
+
+    #[test]
+    fn multiple_missing_capabilities_all_reported() {
+        let provided = ProvidedCapabilities::declared(); // minimal: 0 ctx, no tools, F32, no template, Unknown license
+        let required = RequiredCapabilities {
+            min_context_window_tokens: 4096,
+            requires_native_tool_calling: true,
+            requires_chat_template: true,
+            license_constraint: LicenseConstraint::RequireCommercialOk,
+            ..RequiredCapabilities::permissive()
+        };
+        match check(&provided, &required) {
+            ValidatorOutcome::TypeError { missing } => {
+                assert_eq!(missing.len(), 4, "expected 4 missing, got: {missing:?}");
+            }
+            other => panic!("expected TypeError, got {other:?}"),
+        }
+    }
+
+    // ---- Recommender ----------------------------------------------------
+
+    #[test]
+    fn recommender_filters_out_type_errors() {
+        let mut reg = InMemoryModelRegistry::new();
+        reg.insert(
+            ModelId("small".into()),
+            ProvidedCapabilities::declared().with_context_window_tokens(2_048),
+        );
+        reg.insert(
+            ModelId("big".into()),
+            ProvidedCapabilities::declared().with_context_window_tokens(32_768),
+        );
+        let r = Recommender::new(&reg, RankingPolicy::default());
+        let required = RequiredCapabilities {
+            min_context_window_tokens: 16_000,
+            ..RequiredCapabilities::permissive()
+        };
+        let cands = r.candidates(&required);
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].model_id, ModelId("big".into()));
+    }
+
+    #[test]
+    fn recommender_ranks_type_ok_before_degraded() {
+        let mut reg = InMemoryModelRegistry::new();
+        // model_a: has native tool calling → TypeOk
+        reg.insert(
+            ModelId("a-native".into()),
+            ProvidedCapabilities::declared()
+                .with_context_window_tokens(8_192)
+                .with_native_tool_calling(true),
+        );
+        // model_b: lacks native tool calling but it's only preferred → Degraded
+        reg.insert(
+            ModelId("b-emulated".into()),
+            ProvidedCapabilities::declared()
+                .with_context_window_tokens(8_192)
+                .with_native_tool_calling(false),
+        );
+        let r = Recommender::new(&reg, RankingPolicy::default());
+        let required = RequiredCapabilities {
+            prefers_native_tool_calling: true,
+            ..RequiredCapabilities::permissive()
+        };
+        let cands = r.candidates(&required);
+        assert_eq!(cands.len(), 2);
+        // TypeOk first
+        assert_eq!(cands[0].model_id, ModelId("a-native".into()));
+        assert_eq!(cands[0].outcome, ValidatorOutcome::TypeOk);
+        // Degraded second
+        assert_eq!(cands[1].model_id, ModelId("b-emulated".into()));
+        assert!(matches!(
+            cands[1].outcome,
+            ValidatorOutcome::DegradedSubtype { .. }
+        ));
+    }
+
+    #[test]
+    fn recommender_uses_named_eval_when_set() {
+        let mut reg = InMemoryModelRegistry::new();
+        reg.insert(
+            ModelId("alpha".into()),
+            ProvidedCapabilities::declared()
+                .with_context_window_tokens(8_192)
+                .with_eval_score("mmlu", 0.65),
+        );
+        reg.insert(
+            ModelId("beta".into()),
+            ProvidedCapabilities::declared()
+                .with_context_window_tokens(8_192)
+                .with_eval_score("mmlu", 0.82),
+        );
+        let policy = RankingPolicy {
+            eval_metric: Some("mmlu".into()),
+        };
+        let r = Recommender::new(&reg, policy);
+        let cands = r.candidates(&RequiredCapabilities::permissive());
+        assert_eq!(cands[0].model_id, ModelId("beta".into())); // higher mmlu first
+        assert_eq!(cands[1].model_id, ModelId("alpha".into()));
+    }
+
+    #[test]
+    fn check_model_returns_none_for_unknown() {
+        let reg = InMemoryModelRegistry::new();
+        let r = Recommender::new(&reg, RankingPolicy::default());
+        assert!(r
+            .check_model(
+                &ModelId("ghost".into()),
+                &RequiredCapabilities::permissive(),
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn outcome_is_acceptable_helpers() {
+        assert!(ValidatorOutcome::TypeOk.is_acceptable());
+        assert!(ValidatorOutcome::DegradedSubtype { reasons: vec![] }.is_acceptable());
+        assert!(!ValidatorOutcome::TypeError { missing: vec![] }.is_acceptable());
+        assert!(!ValidatorOutcome::TypeOk.is_type_error());
+    }
+}

--- a/kx-model-validator/tests/proptest_check.rs
+++ b/kx-model-validator/tests/proptest_check.rs
@@ -24,8 +24,8 @@
 
 use kx_model_validator::{
     check, DegradationReason, InMemoryModelRegistry, License, LicenseConstraint, MissingCapability,
-    Modality, ProvidedCapabilities, Quantization, RankingPolicy, Recommender,
-    RequiredCapabilities, ValidatorOutcome,
+    Modality, ProvidedCapabilities, Quantization, RankingPolicy, Recommender, RequiredCapabilities,
+    ValidatorOutcome,
 };
 use kx_mote::ModelId;
 use proptest::prelude::*;

--- a/kx-model-validator/tests/proptest_check.rs
+++ b/kx-model-validator/tests/proptest_check.rs
@@ -1,0 +1,452 @@
+//! Property tests for `check` and the `Recommender` (SN-4 v2 #6).
+//!
+//! The validator's correctness contract from D29 is:
+//! - **Pure**: identical inputs yield identical outputs.
+//! - **Total**: every input pair returns a `ValidatorOutcome`.
+//! - **Deterministic**: across threads, across calls, across rebuilds.
+//!
+//! These properties pin those across the arbitrary-input space.
+//!
+//! Properties:
+//!
+//! 1. `check(p, r)` is total — never panics.
+//! 2. `check(p, r)` is deterministic — same inputs → same outcome.
+//! 3. The `TypeError.missing` list is non-empty iff outcome is `TypeError`.
+//! 4. `permissive` requirements + any provider → `TypeOk` or
+//!    `DegradedSubtype` (never `TypeError` — permissive has no requirements).
+//! 5. `Recommender::candidates` returns only acceptable candidates (no
+//!    `TypeError` ever leaks through).
+//! 6. `Recommender::candidates` is rank-stable: TypeOk before
+//!    DegradedSubtype.
+//! 7. Reflexivity: if `provided` satisfies `required` per the documented
+//!    rules, `check` returns an acceptable outcome (or a `TypeError` whose
+//!    `missing` list is consistent with the input).
+
+use kx_model_validator::{
+    check, DegradationReason, InMemoryModelRegistry, License, LicenseConstraint, MissingCapability,
+    Modality, ProvidedCapabilities, Quantization, RankingPolicy, Recommender,
+    RequiredCapabilities, ValidatorOutcome,
+};
+use kx_mote::ModelId;
+use proptest::prelude::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_modality() -> impl Strategy<Value = Modality> {
+    prop_oneof![
+        Just(Modality::Text),
+        Just(Modality::Vision),
+        Just(Modality::Audio),
+        Just(Modality::Embedding),
+    ]
+}
+
+fn arb_quantization() -> impl Strategy<Value = Quantization> {
+    prop_oneof![
+        Just(Quantization::F32),
+        Just(Quantization::F16),
+        Just(Quantization::Bf16),
+        Just(Quantization::Q8_0),
+        Just(Quantization::Q5KM),
+        Just(Quantization::Q4KM),
+        Just(Quantization::Q4_0),
+        Just(Quantization::Q2K),
+    ]
+}
+
+fn arb_license() -> impl Strategy<Value = License> {
+    prop_oneof![
+        Just(License::SpdxId("Apache-2.0".into())),
+        Just(License::SpdxId("MIT".into())),
+        Just(License::SpdxId("GPL-3.0".into())),
+        Just(License::LlamaCommunity),
+        Just(License::OpenWeightsNonCommercial),
+        Just(License::Proprietary),
+        Just(License::Unknown),
+    ]
+}
+
+fn arb_license_constraint() -> impl Strategy<Value = LicenseConstraint> {
+    prop_oneof![
+        Just(LicenseConstraint::NoRestriction),
+        Just(LicenseConstraint::RequireCommercialOk),
+        Just(LicenseConstraint::RequireRedistributable),
+        proptest::collection::btree_set(arb_license(), 1..=3).prop_map(LicenseConstraint::OneOf),
+    ]
+}
+
+fn arb_modality_set() -> impl Strategy<Value = BTreeSet<Modality>> {
+    proptest::collection::btree_set(arb_modality(), 0..=4)
+}
+
+fn arb_quantization_set() -> impl Strategy<Value = BTreeSet<Quantization>> {
+    proptest::collection::btree_set(arb_quantization(), 0..=8)
+}
+
+fn arb_chat_template() -> impl Strategy<Value = Option<String>> {
+    prop_oneof![
+        Just(None),
+        Just(Some("chatml".into())),
+        Just(Some("llama-3-instruct".into())),
+        Just(Some("mistral-instruct".into())),
+    ]
+}
+
+prop_compose! {
+    fn arb_provided()(
+        ctx in 0u32..=128_000,
+        ntc in any::<bool>(),
+        mods in arb_modality_set(),
+        q in arb_quantization(),
+        tmpl in arb_chat_template(),
+        lic in arb_license(),
+        m1_name in "[a-z]{2,6}",
+        m1_score in 0.0f32..=1.0,
+    ) -> ProvidedCapabilities {
+        let mut p = ProvidedCapabilities::declared()
+            .with_context_window_tokens(ctx)
+            .with_native_tool_calling(ntc)
+            .with_modalities(mods)
+            .with_quantization(q)
+            .with_chat_template(tmpl)
+            .with_license(lic);
+        let mut evals = BTreeMap::new();
+        evals.insert(m1_name, m1_score);
+        p.eval_scores = evals;
+        p
+    }
+}
+
+prop_compose! {
+    fn arb_required()(
+        ctx in 0u32..=128_000,
+        ntc_req in any::<bool>(),
+        ntc_pref in any::<bool>(),
+        mods in arb_modality_set(),
+        q_set in arb_quantization_set(),
+        templ in any::<bool>(),
+        lic_c in arb_license_constraint(),
+    ) -> RequiredCapabilities {
+        RequiredCapabilities {
+            min_context_window_tokens: ctx,
+            requires_native_tool_calling: ntc_req,
+            prefers_native_tool_calling: ntc_pref,
+            required_modalities: mods,
+            allowed_quantizations: q_set,
+            requires_chat_template: templ,
+            license_constraint: lic_c,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 1: `check` is total — never panics on any input pair.
+    #[test]
+    fn prop_check_is_total(p in arb_provided(), r in arb_required()) {
+        let _ = check(&p, &r); // Reaching this line proves no panic.
+    }
+
+    /// Property 2: `check` is deterministic — same inputs → same outcome.
+    #[test]
+    fn prop_check_is_deterministic(p in arb_provided(), r in arb_required()) {
+        let a = check(&p, &r);
+        let b = check(&p, &r);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Property 3: `TypeError.missing` is non-empty iff outcome is `TypeError`.
+    #[test]
+    fn prop_type_error_missing_is_non_empty(p in arb_provided(), r in arb_required()) {
+        match check(&p, &r) {
+            ValidatorOutcome::TypeError { missing } => {
+                prop_assert!(
+                    !missing.is_empty(),
+                    "TypeError must carry at least one MissingCapability"
+                );
+            }
+            ValidatorOutcome::DegradedSubtype { reasons } => {
+                prop_assert!(
+                    !reasons.is_empty(),
+                    "DegradedSubtype must carry at least one DegradationReason"
+                );
+            }
+            ValidatorOutcome::TypeOk => {} // no inner data to check
+        }
+    }
+
+    /// Property 4: permissive requirements + any provider → acceptable.
+    /// Permissive has zero requirements, so no `TypeError` can be produced.
+    /// At worst the outcome is `DegradedSubtype` (which permissive doesn't
+    /// trigger either — preferences are zero) — so always `TypeOk`.
+    #[test]
+    fn prop_permissive_requirements_always_type_ok(p in arb_provided()) {
+        let outcome = check(&p, &RequiredCapabilities::permissive());
+        prop_assert_eq!(outcome, ValidatorOutcome::TypeOk);
+    }
+
+    /// Property 5: `Recommender::candidates` filters out `TypeError`.
+    #[test]
+    fn prop_recommender_filters_type_errors(
+        providers in proptest::collection::vec(arb_provided(), 0..=8),
+        r in arb_required(),
+    ) {
+        let mut reg = InMemoryModelRegistry::new();
+        for (i, p) in providers.iter().enumerate() {
+            reg.insert(ModelId(format!("model-{i}")), p.clone());
+        }
+        let rec = Recommender::new(&reg, RankingPolicy::default());
+        let cands = rec.candidates(&r);
+        for c in &cands {
+            prop_assert!(
+                c.outcome.is_acceptable(),
+                "candidate {:?} has non-acceptable outcome {:?}",
+                c.model_id,
+                c.outcome
+            );
+        }
+    }
+
+    /// Property 6: TypeOk candidates come before DegradedSubtype in the
+    /// ranked list.
+    #[test]
+    fn prop_recommender_ranks_type_ok_first(
+        providers in proptest::collection::vec(arb_provided(), 0..=8),
+        r in arb_required(),
+    ) {
+        let mut reg = InMemoryModelRegistry::new();
+        for (i, p) in providers.iter().enumerate() {
+            reg.insert(ModelId(format!("model-{i}")), p.clone());
+        }
+        let rec = Recommender::new(&reg, RankingPolicy::default());
+        let cands = rec.candidates(&r);
+        // Verify no Degraded appears before a TypeOk in the list.
+        let mut seen_degraded = false;
+        for c in &cands {
+            match c.outcome {
+                ValidatorOutcome::TypeOk => {
+                    prop_assert!(
+                        !seen_degraded,
+                        "TypeOk candidate appeared after DegradedSubtype"
+                    );
+                }
+                ValidatorOutcome::DegradedSubtype { .. } => {
+                    seen_degraded = true;
+                }
+                ValidatorOutcome::TypeError { .. } => {
+                    prop_assert!(false, "TypeError leaked into candidates");
+                }
+            }
+        }
+    }
+
+    /// Property 7: reflexivity — when the missing list cites a capability,
+    /// `provided` actually lacks it (decoder/encoder symmetry on the
+    /// MissingCapability tags).
+    #[test]
+    fn prop_missing_list_is_consistent_with_provided(
+        p in arb_provided(),
+        r in arb_required(),
+    ) {
+        if let ValidatorOutcome::TypeError { missing } = check(&p, &r) {
+            for m in &missing {
+                match m {
+                    MissingCapability::ContextWindowTooSmall { provided, required } => {
+                        prop_assert_eq!(*provided, p.context_window_tokens);
+                        prop_assert_eq!(*required, r.min_context_window_tokens);
+                        prop_assert!(*provided < *required);
+                    }
+                    MissingCapability::NativeToolCallingRequired => {
+                        prop_assert!(r.requires_native_tool_calling);
+                        prop_assert!(!p.native_tool_calling);
+                    }
+                    MissingCapability::ModalityMissing { missing } => {
+                        prop_assert!(r.required_modalities.contains(missing));
+                        prop_assert!(!p.modalities.contains(missing));
+                    }
+                    MissingCapability::QuantizationNotAllowed { provided } => {
+                        prop_assert_eq!(*provided, p.quantization);
+                        prop_assert!(!r.allowed_quantizations.is_empty());
+                        prop_assert!(!r.allowed_quantizations.contains(provided));
+                    }
+                    MissingCapability::ChatTemplateRequired => {
+                        prop_assert!(r.requires_chat_template);
+                        prop_assert!(p.chat_template.is_none());
+                    }
+                    MissingCapability::LicenseUnsatisfied { provided } => {
+                        prop_assert_eq!(provided, &p.license);
+                        prop_assert!(!r.license_constraint.is_satisfied_by(&p.license));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Property 8: only-preferred (not required) capability missing →
+    /// outcome is `DegradedSubtype`, never `TypeError`. Pin the
+    /// preferred-vs-required boundary.
+    #[test]
+    fn prop_only_preferred_missing_yields_degraded(p in arb_provided()) {
+        // Build requirements where everything is satisfied EXCEPT
+        // native_tool_calling is preferred (not required) and the provider
+        // lacks it.
+        let mut p_no_tool = p.clone();
+        p_no_tool.native_tool_calling = false;
+
+        let r = RequiredCapabilities {
+            min_context_window_tokens: 0, // satisfied
+            requires_native_tool_calling: false, // not required
+            prefers_native_tool_calling: true,   // preferred
+            required_modalities: BTreeSet::new(),
+            allowed_quantizations: BTreeSet::new(),
+            requires_chat_template: false,
+            license_constraint: LicenseConstraint::NoRestriction,
+        };
+
+        let outcome = check(&p_no_tool, &r);
+        match outcome {
+            ValidatorOutcome::DegradedSubtype { reasons } => {
+                prop_assert!(reasons.contains(&DegradationReason::NativeToolCallingMissing));
+            }
+            other => prop_assert!(false, "expected DegradedSubtype, got {other:?}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency: pure-function determinism across threads (SN-4 v2 #7)
+// ---------------------------------------------------------------------------
+
+/// Compile-time `Send + Sync` assertions for the public types. The crate is
+/// pure data; every type must be cross-thread shareable.
+#[test]
+fn public_types_are_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    assert_send_sync::<Modality>();
+    assert_send_sync::<Quantization>();
+    assert_send_sync::<License>();
+    assert_send_sync::<LicenseConstraint>();
+    assert_send_sync::<RequiredCapabilities>();
+    assert_send_sync::<ProvidedCapabilities>();
+    assert_send_sync::<ValidatorOutcome>();
+    assert_send_sync::<DegradationReason>();
+    assert_send_sync::<MissingCapability>();
+    assert_send_sync::<InMemoryModelRegistry>();
+    assert_send_sync::<RankingPolicy>();
+}
+
+/// `check` is a pure function — calling it concurrently from 4 threads with
+/// the same inputs must produce identical results. Catches any hypothetical
+/// thread-local in the validator path.
+#[test]
+fn check_is_thread_independent() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let provided = Arc::new(
+        ProvidedCapabilities::declared()
+            .with_context_window_tokens(8192)
+            .with_native_tool_calling(true)
+            .with_quantization(Quantization::Q4KM)
+            .with_chat_template(Some("chatml".into()))
+            .with_license(License::SpdxId("Apache-2.0".into())),
+    );
+    let required = Arc::new(RequiredCapabilities {
+        min_context_window_tokens: 4096,
+        requires_native_tool_calling: true,
+        prefers_native_tool_calling: true,
+        required_modalities: BTreeSet::from([Modality::Text]),
+        allowed_quantizations: BTreeSet::from([Quantization::Q4KM]),
+        requires_chat_template: true,
+        license_constraint: LicenseConstraint::RequireCommercialOk,
+    });
+
+    let mut handles = Vec::with_capacity(4);
+    for _ in 0..4 {
+        let p = Arc::clone(&provided);
+        let r = Arc::clone(&required);
+        handles.push(thread::spawn(move || check(&p, &r)));
+    }
+    let results: Vec<ValidatorOutcome> = handles
+        .into_iter()
+        .map(|h| h.join().expect("worker panic"))
+        .collect();
+
+    let first = &results[0];
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(
+            r, first,
+            "thread {i} produced a different outcome than thread 0"
+        );
+    }
+    assert_eq!(*first, ValidatorOutcome::TypeOk);
+}
+
+/// `Recommender::candidates` is pure over its inputs (the registry is
+/// shared `Arc`-style). Calling it concurrently must produce identical
+/// ranked lists.
+#[test]
+fn recommender_is_thread_independent() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let mut reg = InMemoryModelRegistry::new();
+    for (name, ctx) in [
+        ("alpha", 2048),
+        ("beta", 8192),
+        ("gamma", 32_768),
+        ("delta", 128_000),
+    ] {
+        reg.insert(
+            ModelId(name.into()),
+            ProvidedCapabilities::declared().with_context_window_tokens(ctx),
+        );
+    }
+    let reg: Arc<InMemoryModelRegistry> = Arc::new(reg);
+
+    let required = Arc::new(RequiredCapabilities {
+        min_context_window_tokens: 4096,
+        ..RequiredCapabilities::permissive()
+    });
+
+    let mut handles = Vec::with_capacity(4);
+    for _ in 0..4 {
+        let reg = Arc::clone(&reg);
+        let r = Arc::clone(&required);
+        handles.push(thread::spawn(move || {
+            let rec = Recommender::new(&*reg, RankingPolicy::default());
+            rec.candidates(&r)
+                .into_iter()
+                .map(|c| c.model_id)
+                .collect::<Vec<_>>()
+        }));
+    }
+
+    let results: Vec<Vec<ModelId>> = handles
+        .into_iter()
+        .map(|h| h.join().expect("worker panic"))
+        .collect();
+
+    let first = &results[0];
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(
+            r, first,
+            "thread {i} produced a different ranked list than thread 0"
+        );
+    }
+    // beta, gamma, delta satisfy 4096-token requirement; alpha does not.
+    assert_eq!(first.len(), 3);
+    assert!(!first.contains(&ModelId("alpha".into())));
+}


### PR DESCRIPTION
## Summary

New crate per the approved plan. Model fitness as a **type check over capability sets**: a task declares \`RequiredCapabilities\`, a model exposes \`ProvidedCapabilities\`, and \`check(provided, required) → ValidatorOutcome\` performs structural subtyping. Runs at **bind time** — find the wrong model at load time, not three Motes into a workflow.

Locks **D29 — Model-validator seam**. First new crate **born SN-4 v2 + SN-7 compliant**.

## SN-7 Cross-Platform Verification

| Platform | Result |
|---|---|
| **(A) Linux x86_64** GitHub Actions CI | _pending — will update once green_ |
| **(B) Apple Silicon (aarch64-apple-darwin)** local cargo test | **PASS** — 34/34 in kx-model-validator; 0 failed workspace-wide on Darwin arm64, rustc 1.94.0 |

## Three outcomes

| Outcome | Meaning |
|---|---|
| \`TypeOk\` | provided ⊇ required — clean bind |
| \`DegradedSubtype { reasons }\` | required ⊆ provided AND a preferred (soft) capability is missing — bind proceeds with degraded mode recorded |
| \`TypeError { missing }\` | at least one REQUIRED capability is missing — refuse the bind, name the missing members |

## Six checkable capabilities (all decidable before generating a token)

1. **Context window** — \`provided.context_window_tokens >= required.min_context_window_tokens\`
2. **Native tool calling** — required vs preferred (soft) distinction
3. **Modalities** — Text / Vision / Audio / Embedding (closed enum)
4. **Quantization** — F32 / F16 / Bf16 / Q8_0 / Q5KM / Q4KM / Q4_0 / Q2K
5. **Chat template** — present (with name) vs absent
6. **License** — SPDX + LlamaCommunity + OpenWeightsNonCommercial + Proprietary + Unknown; constraints: NoRestriction / RequireCommercialOk / RequireRedistributable / OneOf

## D29 invariants honored in code

- **Hard interface-vs-quality boundary** — \`check\` does NOT consult \`eval_scores\`. Quality assessment lives in the workflow/eval/critic layer, NOT here. Documented in the crate-level docs.
- **House model competes on equal merit** — no flag, no boost, no special path. The recommender doesn't know which model is the house model.
- **Soundness boundary v1 → v2** — v1 trusts the model's *declared* capabilities. \`Soundness::Declared\` is the default; \`Soundness::Verified\` path reserved for v2's probe. v1 language uses "declared"; v2 will use "verified."
- **Recommender suggests, never substitutes** — same principle as the broker (P1.8.5). Ranking strict order: (1) deterministic capability match (TypeOk before DegradedSubtype), (2) workflow-named eval score, (3) Mote-measured perf (deferred to P1.13+).

## API surface

- \`Modality\`, \`Quantization\`, \`License\`, \`LicenseConstraint\` — closed enums with serde derives
- \`RequiredCapabilities\` (+ \`::permissive()\`) — workflow-author input
- \`ProvidedCapabilities\` (+ builder methods, \`::declared()\` / \`::verified()\`) — model metadata input
- \`Soundness\` — v1 → v2 boundary tag
- \`ValidatorOutcome\` — \`is_acceptable()\` / \`is_type_error()\` helpers
- \`DegradationReason\` / \`MissingCapability\` — typed surface
- \`ModelRegistry\` trait (Send + Sync) + \`InMemoryModelRegistry\`
- \`Recommender\` + \`RankingPolicy\` + \`Candidate\`

## Tests — born SN-4 v2 + SN-7

| Tier | Count |
|---|---|
| Unit (in \`lib.rs\` tests mod) | 18 |
| Property (\`tests/proptest_check.rs\`) | 8 properties × 64 cases + Send+Sync compile-time + 2 concurrent-thread tests = 11 |
| Doctest | 5 |
| **Total** | **34** |

**Property highlights:**
- \`check\` is total (never panics over arbitrary input)
- \`check\` is deterministic (same input → same outcome)
- \`TypeError.missing\` is non-empty iff outcome is \`TypeError\`
- Permissive requirements + any provider → always \`TypeOk\`
- Recommender filters \`TypeError\` (never leaks through)
- Recommender ranks \`TypeOk\` before \`DegradedSubtype\`
- Missing list is reflexively consistent with provided input
- Preferred-not-required missing → \`Degraded\` not \`TypeError\`

**Concurrency:**
- Send+Sync compile-time assertions on every public type
- \`check\` is thread-independent (4 threads, same input, same outcome)
- \`Recommender::candidates\` is thread-independent (4 threads, same registry, same ranked list)

## Test count + workspace status

| Crate | SN-4 v2 + SN-7 |
|---|---|
| kx-mote | ✅ |
| kx-content | ✅ |
| kx-journal | ✅ |
| kx-projection | ✅ |
| kx-llamacpp | ✅ |
| **kx-model-validator** | **✅ (this PR)** |

**Workspace total: ~251 tests across 6 crates on Apple Silicon (was 217). P1.8 (kx-inference router) is now buildable atop a fully SN-4 v2 + SN-7 certified foundation.**

## Corpus updates (queued for post-merge private sync)

Per the approved plan, on merge the private corpus gets:
- \`docs/design/decisions.md\` — append **D29** (full text in the plan)
- \`01-build-sequence.md\` — insert P1.7.5 row
- \`02-crate-specs.md\` — new spec + 3 tiny edits to P1.8 / P1.8.5 / P1.9
- \`03-ffi-and-inference.md\` — one-paragraph note in §3 (router routing policy)
- \`docs/design/capability-broker.md\` — composition note (broker = runtime backstop; validator = pre-bind)
- \`06-language-and-sdk-strategy.md\` — one sentence on fine-tuning artifact handoff
- \`05-progress-tracker.md\` — P1.7.5 row → validated + deviation log entry

\`mote.md\` is **NOT** updated — D29's Option D preserves MoteDef (no schema_version bump).

## Next per locked sequence

P1.7.5 → **P1.8** (\`kx-inference\` — the InferenceBackend trait + llama.cpp backend + router skeleton). The router consults the validator at bind time, refuses on TypeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)