### PR TITLE
P1.7.6: kx-warrant — Warrant + Role + monotonic narrowing (D30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-warrant"
+version = "0.0.1"
+dependencies = [
+ "bincode",
+ "blake3",
+ "kx-content",
+ "kx-mote",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator"]
+members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator", "kx-warrant"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -29,6 +29,7 @@ kx-journal         = { path = "kx-journal" }
 kx-llamacpp-sys    = { path = "kx-llamacpp-sys" }
 kx-llamacpp        = { path = "kx-llamacpp" }
 kx-model-validator = { path = "kx-model-validator" }
+kx-warrant         = { path = "kx-warrant" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/kx-warrant/Cargo.toml
+++ b/kx-warrant/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name         = "kx-warrant"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx capability layer (D30) — Warrant + Role + monotonic narrowing. Pure intersection function refuses widening on any axis. WarrantSpec is content-addressed."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-mote    = { workspace = true }
+kx-content = { workspace = true }
+bincode    = { workspace = true }
+blake3     = { workspace = true }
+serde      = { workspace = true }
+smallvec   = { workspace = true }
+thiserror  = { workspace = true }
+tracing    = { workspace = true }
+
+[dev-dependencies]
+proptest           = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-warrant/src/lib.rs
+++ b/kx-warrant/src/lib.rs
@@ -1,0 +1,1231 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-warrant` — the runtime-enforced capability layer (D30).
+//!
+//! A **Warrant** is the scoped capability boundary a Mote executes under: a
+//! runtime-ENFORCED FACT, typed and structured (never prose), re-derivable
+//! bit-for-bit on recovery. A **Role** is a named, versioned, content-addressed
+//! `WarrantSpec` template — the RBAC surface.
+//!
+//! The load-bearing invariant of this crate is **monotonic narrowing**:
+//!
+//! ```text
+//! child.warrant = intersect(parent.warrant, child.role)
+//! ```
+//!
+//! - The **runtime ENFORCES** the intersection; the **model PROPOSES** which
+//!   role to assume and may narrow within it.
+//! - The model **never authorizes a widen** on any axis. Widening is a typed
+//!   error (`NarrowingError::AttemptedWiden`).
+//! - The intersection function is **PURE**: same inputs → byte-identical
+//!   output. No I/O, no clock, no journal access. Recovery re-derives warrants
+//!   bit-for-bit (machine-independent).
+//!
+//! # Six narrowable axes (qualitative — widening rejected as typed error)
+//!
+//! | Axis                  | Semantics                                              |
+//! |-----------------------|--------------------------------------------------------|
+//! | `fs_scope`            | path-set intersection; per-path mode min-bound         |
+//! | `net_scope`           | egress allowlist subset; `None` blocks all egress      |
+//! | `syscall_profile_ref` | opaque content-ref; subset check deferred to compiler  |
+//! | `tool_grants`         | set subset on `(ToolName, ToolVersion)`                |
+//! | `executor_class`      | set by child's role; not narrowed from parent          |
+//! | `environment_ref`     | set by child's role; not narrowed from parent          |
+//!
+//! # Quantitative axes (narrowed silently via `min()`)
+//!
+//! - `resource_ceiling.*` — cpu_milli, mem_bytes, wall_clock_ms, fd_count, disk_bytes.
+//! - `model_route.max_input_tokens` / `max_output_tokens` / `max_calls`.
+//!
+//! # `mote_class` and `nd_class` are set by child's role (NOT inherited).
+//!
+//! A child may be `Pure` under a `WorldMutating` parent (workers may choose to
+//! be tighter). The intersection function leaves these fields as the child's
+//! declared value without narrowing.
+//!
+//! # Content-addressed identity
+//!
+//! ```text
+//! warrant_ref = blake3(canonical_bincode(WarrantSpec))
+//! ```
+//!
+//! Two semantically-identical warrants produce byte-identical refs;
+//! identity-bearing. See [`warrant_ref_of`].
+//!
+//! # Reading further
+//!
+//! - `docs/design/warrant.md` (private corpus) — the locked spec for D30.
+//! - `docs/design/decisions.md` D30, D32, D33, D35, D36 — interlocking decisions.
+//! - `05-progress-tracker.md` SN-8 — *model proposes, runtime enforces*.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use,
+    clippy::needless_pass_by_value
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_mote::{canonical_config, ModelId, NdClass, ToolName, ToolVersion};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Small enums (stable u8 discriminants — wire-stable)
+// ---------------------------------------------------------------------------
+
+/// The non-determinism class a Mote attempts under. Mirrors [`NdClass`] from
+/// `kx-mote`; restated here so the warrant layer carries its own semantically
+/// equivalent enum without coupling to the journal-side discriminant.
+///
+/// Set by the child's role; **NOT inherited** from the parent warrant. A child
+/// may be `Pure` under a `WorldMutating` parent (workers may be tighter than
+/// their parent on this axis).
+///
+/// # Example
+///
+/// ```
+/// use kx_warrant::MoteClass;
+/// assert_eq!(MoteClass::Pure as u8, 0);
+/// assert_eq!(MoteClass::ReadOnlyNondet as u8, 1);
+/// assert_eq!(MoteClass::WorldMutating as u8, 2);
+/// ```
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum MoteClass {
+    /// Pure: bit-stable function of inputs. No side effects. Safe to re-run.
+    Pure = 0,
+    /// Reads from a non-deterministic source (model inference, RNG) but causes
+    /// no external state change. NEVER re-run once Committed.
+    ReadOnlyNondet = 1,
+    /// Performs an external effect (filesystem write, network call, etc.).
+    /// Validate-then-commit per D20; effect-once via the broker.
+    WorldMutating = 2,
+}
+
+impl MoteClass {
+    /// Convert from kx-mote's `NdClass` to keep wire-format parity.
+    #[inline]
+    #[must_use]
+    pub fn from_nd_class(nd: NdClass) -> Self {
+        match nd {
+            NdClass::Pure => Self::Pure,
+            NdClass::ReadOnlyNondet => Self::ReadOnlyNondet,
+            NdClass::WorldMutating => Self::WorldMutating,
+        }
+    }
+
+    /// Convert to kx-mote's `NdClass`.
+    #[inline]
+    #[must_use]
+    pub fn to_nd_class(self) -> NdClass {
+        match self {
+            Self::Pure => NdClass::Pure,
+            Self::ReadOnlyNondet => NdClass::ReadOnlyNondet,
+            Self::WorldMutating => NdClass::WorldMutating,
+        }
+    }
+}
+
+/// Which executor backend is responsible for running the Mote. Set by the
+/// child's role; orthogonal to narrowing.
+///
+/// `Bwrap` is the OSS default on Linux; `OciDaemon` is a warrant-declared
+/// opt-in for narrow cases (GPU passthrough or live-service environments);
+/// `CloudMicroVm` is cloud-side per D28.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum ExecutorClass {
+    /// Bubblewrap over an extracted, content-addressed OCI rootfs. Daemonless;
+    /// ms-spawn; least-privilege. The OSS default.
+    Bwrap = 0,
+    /// Container runtime (Podman/runc preferred over Docker). Warrant-declared
+    /// opt-in for narrow cases.
+    OciDaemon = 1,
+    /// Cloud-side microVM (firecracker / kata). Stub in OSS; impl in
+    /// `kx-cloud-executor-microvm` per D28.
+    CloudMicroVm = 2,
+}
+
+/// Filesystem access mode for a mount in [`FsScope`].
+///
+/// Modes form a total order under "permits at most": `ReadOnly < ReadWrite`
+/// for write access; `ExecOnly` is orthogonal (permits `exec` but not
+/// read/write). The intersection per path is set-intersection on the
+/// permitted operations.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum FsMode {
+    /// Read access only.
+    ReadOnly = 0,
+    /// Read + write access.
+    ReadWrite = 1,
+    /// Execute access only (no read/write).
+    ExecOnly = 2,
+}
+
+impl FsMode {
+    /// `true` iff `self` is no wider than `parent` on every operation.
+    #[inline]
+    #[must_use]
+    pub fn is_subset_of(self, parent: FsMode) -> bool {
+        matches!(
+            (self, parent),
+            (Self::ReadOnly, Self::ReadOnly | Self::ReadWrite)
+                | (Self::ReadWrite, Self::ReadWrite)
+                | (Self::ExecOnly, Self::ExecOnly)
+        )
+    }
+}
+
+/// Identifier for a [`WarrantField`]; used by [`NarrowingError`] to report
+/// which axis a child role tried to widen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum WarrantField {
+    /// Filesystem scope.
+    FsScope,
+    /// Network egress scope.
+    NetScope,
+    /// Seccomp-bpf syscall profile.
+    SyscallProfile,
+    /// Tool grants.
+    ToolGrants,
+    /// Model route.
+    ModelRoute,
+    /// Resource ceilings.
+    ResourceCeiling,
+    /// Executor class.
+    ExecutorClass,
+    /// Environment rootfs.
+    EnvironmentRef,
+}
+
+// ---------------------------------------------------------------------------
+// Composite axes
+// ---------------------------------------------------------------------------
+
+/// A host:port pair in the egress allowlist of [`NetScope::EgressAllowlist`].
+///
+/// Stored as an opaque string so the warrant layer doesn't reimplement URL
+/// parsing; validation happens at workflow-author time (SDK / CLI front door).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Host(pub String);
+
+/// Filesystem scope: a mapping from mount points to access modes.
+///
+/// Intersection is **set-intersection** on the path keys, with per-path mode
+/// intersection on the values (see [`FsMode::is_subset_of`]). A child may
+/// reference only paths the parent also references; a child's mode at any
+/// path must be `is_subset_of` the parent's mode.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct FsScope {
+    /// Mount points and their access modes. `BTreeMap` for canonical
+    /// iteration order (bincode-canonical encoding depends on this).
+    pub mounts: BTreeMap<PathBuf, FsMode>,
+}
+
+impl FsScope {
+    /// Construct an empty `FsScope` (no mounts; no filesystem access).
+    #[inline]
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            mounts: BTreeMap::new(),
+        }
+    }
+
+    /// `true` iff `self` is no wider than `parent`: every path of `self` is a
+    /// path of `parent`, AND `self`'s mode at that path is a subset of
+    /// `parent`'s mode there.
+    #[must_use]
+    pub fn is_subset_of(&self, parent: &Self) -> bool {
+        self.mounts.iter().all(|(path, mode)| {
+            parent
+                .mounts
+                .get(path)
+                .is_some_and(|p_mode| mode.is_subset_of(*p_mode))
+        })
+    }
+}
+
+/// Network egress scope.
+///
+/// `None` blocks all egress. `EgressAllowlist({h1, h2})` permits egress to
+/// exactly the listed hosts. Intersection respects monotonic narrowing:
+/// `None ∩ anything = None`; `EgressAllowlist(C) ∩ EgressAllowlist(P) = C`
+/// only when `C ⊆ P` (else widening, refused).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetScope {
+    /// No egress permitted.
+    None,
+    /// Egress permitted to exactly the listed hosts.
+    EgressAllowlist(BTreeSet<Host>),
+}
+
+impl NetScope {
+    /// `true` iff `self` permits no more egress than `parent`.
+    #[must_use]
+    pub fn is_subset_of(&self, parent: &Self) -> bool {
+        match (self, parent) {
+            (Self::None, _) => true,
+            (Self::EgressAllowlist(_), Self::None) => false,
+            (Self::EgressAllowlist(child), Self::EgressAllowlist(parent)) => {
+                child.is_subset(parent)
+            }
+        }
+    }
+}
+
+/// A reference to a tool in the shared registry (per D32).
+///
+/// Carries `(ToolName, ToolVersion)` — a reference, NOT an embedded copy of
+/// the tool's specification. The registry (P1.7.7) holds the spec; this is
+/// only a handle.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ToolGrant {
+    /// The tool's name in the registry.
+    pub tool_id: ToolName,
+    /// The pinned version of the tool.
+    pub tool_version: ToolVersion,
+}
+
+/// The model that this Mote attempts under, with quantitative ceilings.
+///
+/// In OSS v0.1, `model_id` is **named by the user** (per D35 — no auto
+/// selection). The dispatcher routes to this exact model; switching models
+/// busts the cache (the model id participates in the idempotency key).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ModelRoute {
+    /// Named model identifier.
+    pub model_id: ModelId,
+    /// Maximum input tokens per call.
+    pub max_input_tokens: u32,
+    /// Maximum output tokens per call.
+    pub max_output_tokens: u32,
+    /// Maximum inference calls under this warrant.
+    pub max_calls: u32,
+}
+
+impl ModelRoute {
+    /// `true` iff every quantitative axis of `self` is no greater than the
+    /// matching axis of `parent`. Different `model_id`s are allowed (the
+    /// child's role may name a different model — see D30 §4.2).
+    #[must_use]
+    pub fn is_within(&self, parent: &Self) -> bool {
+        self.max_input_tokens <= parent.max_input_tokens
+            && self.max_output_tokens <= parent.max_output_tokens
+            && self.max_calls <= parent.max_calls
+    }
+
+    /// Narrow `self` to the per-axis min against `parent`, returning the
+    /// resulting `ModelRoute`. `model_id` is taken from `self` (child's choice).
+    #[must_use]
+    pub fn narrow_quantitative(&self, parent: &Self) -> Self {
+        Self {
+            model_id: self.model_id.clone(),
+            max_input_tokens: self.max_input_tokens.min(parent.max_input_tokens),
+            max_output_tokens: self.max_output_tokens.min(parent.max_output_tokens),
+            max_calls: self.max_calls.min(parent.max_calls),
+        }
+    }
+}
+
+/// Quantitative resource ceilings for the Mote attempt.
+///
+/// Narrowed silently per axis via `min()`. Negative narrowing is never an
+/// error: child asking for less than parent is the EXPECTED case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ResourceCeiling {
+    /// CPU allocation in milli-cores.
+    pub cpu_milli: u32,
+    /// Memory cap in bytes.
+    pub mem_bytes: u64,
+    /// Wall-clock timeout in milliseconds (also the inference-call timeout per D35).
+    pub wall_clock_ms: u64,
+    /// Open file descriptor cap.
+    pub fd_count: u32,
+    /// Disk byte cap.
+    pub disk_bytes: u64,
+}
+
+impl ResourceCeiling {
+    /// Per-axis `min` narrowing.
+    #[inline]
+    #[must_use]
+    pub fn narrow(&self, parent: &Self) -> Self {
+        Self {
+            cpu_milli: self.cpu_milli.min(parent.cpu_milli),
+            mem_bytes: self.mem_bytes.min(parent.mem_bytes),
+            wall_clock_ms: self.wall_clock_ms.min(parent.wall_clock_ms),
+            fd_count: self.fd_count.min(parent.fd_count),
+            disk_bytes: self.disk_bytes.min(parent.disk_bytes),
+        }
+    }
+}
+
+/// The complete capability envelope a Mote attempts under.
+///
+/// Computed via [`intersect`] of the parent's warrant and the child's role.
+/// Content-addressed via [`warrant_ref_of`]; recovery re-derives bit-for-bit.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WarrantSpec {
+    /// Non-determinism class. Set by child's role; NOT inherited.
+    pub mote_class: MoteClass,
+    /// Mirror of [`mote_class`](Self::mote_class) for journal-side parity.
+    pub nd_class: MoteClass,
+    /// Filesystem scope. Narrowable; widening → `AttemptedWiden`.
+    pub fs_scope: FsScope,
+    /// Network egress scope. Narrowable; widening → `AttemptedWiden`.
+    pub net_scope: NetScope,
+    /// Content-addressed seccomp-bpf profile. Treated opaquely; subset check
+    /// happens at the seccomp compiler (out of scope for this crate).
+    pub syscall_profile_ref: ContentRef,
+    /// Set of granted tool refs. Narrowable via set subset.
+    pub tool_grants: BTreeSet<ToolGrant>,
+    /// Model route. Quantitative axes narrow via `min()`; `model_id` is set
+    /// by the child's role.
+    pub model_route: ModelRoute,
+    /// Resource ceilings. Narrow silently via `min()` per axis.
+    pub resource_ceiling: ResourceCeiling,
+    /// Optional reference to an extracted OCI rootfs. Set by child's role;
+    /// not narrowed from parent.
+    pub environment_ref: Option<ContentRef>,
+    /// Executor backend selection. Set by child's role.
+    pub executor_class: ExecutorClass,
+}
+
+/// A `(name, version, spec, description)` tuple identifying a named, versioned
+/// capability template — the RBAC surface authored ahead of time.
+///
+/// Roles are content-addressed via [`role_id_of`]: two byte-identical roles
+/// have the same `RoleId`; any byte-level change produces a new `RoleId`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Role {
+    /// Human-readable handle (e.g., `"read-only-research"`).
+    pub name: String,
+    /// Monotonic version number.
+    pub version: u32,
+    /// The capability template.
+    pub spec: WarrantSpec,
+    /// Free-form human description. NEVER parsed for enforcement.
+    pub description: String,
+}
+
+/// Capability requirements a tool declares at registration time (per D32).
+/// Checked by [`check_tool_requirement`] at resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ToolRequirement {
+    /// Required egress (must be ⊆ warrant.net_scope).
+    pub net_scope_required: NetScope,
+    /// Required filesystem access (must be ⊆ warrant.fs_scope).
+    pub fs_scope_required: FsScope,
+    /// Required seccomp profile (treated opaquely; compiler enforces subset).
+    pub syscall_profile_ref: ContentRef,
+    /// Minimum resource ceiling required (each axis ≤ warrant ceiling).
+    pub min_resource_ceiling: ResourceCeiling,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Typed error returned by [`intersect`] when the child's role attempts to
+/// widen on a qualitative axis. Quantitative axes never produce this error;
+/// they narrow silently via `min()`.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum NarrowingError {
+    /// Child's role proposed a value wider than the parent's on a qualitative
+    /// axis. Always refused; the model NEVER authorizes a widen.
+    #[error("child role attempted to widen warrant on field {field:?}: parent={parent} proposed={proposed}")]
+    AttemptedWiden {
+        /// The axis that was widened.
+        field: WarrantField,
+        /// Debug rendering of parent's value.
+        parent: String,
+        /// Debug rendering of child's proposed value.
+        proposed: String,
+    },
+    /// Intersection on this axis is empty after narrowing.
+    #[error("intersection on field {field:?} is empty")]
+    EmptyIntersect {
+        /// The axis with the empty intersection.
+        field: WarrantField,
+    },
+    /// Syscall profile is not a subset of the parent's profile (per the
+    /// seccomp compiler; treated opaquely here).
+    #[error("syscall profile {profile_ref:?} is not a subset of parent")]
+    SyscallProfileNotASubset {
+        /// The non-subset profile reference.
+        profile_ref: ContentRef,
+    },
+    /// Model route is structurally invalid (e.g., zero token ceiling).
+    #[error("invalid model route: {reason}")]
+    InvalidModelRoute {
+        /// Description of why the route is invalid.
+        reason: String,
+    },
+}
+
+/// Typed error returned by [`check_tool_requirement`] when the tool's
+/// `ToolRequirement` exceeds the Mote's warrant on a specific axis.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[error("tool requirement exceeds warrant on field {field:?}")]
+pub struct ToolDenied {
+    /// The axis that was exceeded.
+    pub field: WarrantField,
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions: intersect, narrow, check_tool_requirement
+// ---------------------------------------------------------------------------
+
+/// Compute the child Mote's effective warrant via monotonic narrowing.
+///
+/// The child proposes its role; the runtime enforces:
+/// `child.warrant = intersect(parent.warrant, child.role.spec)`.
+///
+/// # Returns
+///
+/// `Ok(child_warrant)` — the narrowed warrant, with every axis no wider than
+/// the parent's. Quantitative axes (`resource_ceiling.*`,
+/// `model_route.max_*`) are silently narrowed via `min()`. Qualitative axes
+/// that the child proposed wider produce typed errors.
+///
+/// # Errors
+///
+/// Returns [`NarrowingError::AttemptedWiden`] if the child proposed wider on
+/// any of: `fs_scope`, `net_scope`, `tool_grants`. Returns
+/// [`NarrowingError::SyscallProfileNotASubset`] if the child's syscall
+/// profile differs from the parent's (the seccomp compiler's subset check is
+/// stubbed here as profile-ref equality; the real check lives in the seccomp
+/// compiler, out of scope).
+///
+/// # Purity
+///
+/// This function is **pure**: same inputs → byte-identical output. No clock,
+/// no I/O, no journal access. Recovery may call it freely.
+///
+/// # Example
+///
+/// ```
+/// use kx_warrant::{intersect, ExecutorClass, FsScope, MoteClass, NetScope,
+///     ModelRoute, ResourceCeiling, Role, WarrantSpec};
+/// use kx_content::ContentRef;
+/// use kx_mote::ModelId;
+/// use std::collections::BTreeSet;
+///
+/// // Build a permissive parent warrant.
+/// let parent = WarrantSpec {
+///     mote_class: MoteClass::Pure,
+///     nd_class: MoteClass::Pure,
+///     fs_scope: FsScope::empty(),
+///     net_scope: NetScope::None,
+///     syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+///     tool_grants: BTreeSet::new(),
+///     model_route: ModelRoute {
+///         model_id: ModelId("gpt-4".into()),
+///         max_input_tokens: 8000,
+///         max_output_tokens: 2000,
+///         max_calls: 10,
+///     },
+///     resource_ceiling: ResourceCeiling {
+///         cpu_milli: 1000, mem_bytes: 1 << 30, wall_clock_ms: 60_000,
+///         fd_count: 256, disk_bytes: 1 << 30,
+///     },
+///     environment_ref: None,
+///     executor_class: ExecutorClass::Bwrap,
+/// };
+///
+/// // A child role that strictly tightens (max_calls 10 → 5).
+/// let mut child_spec = parent.clone();
+/// child_spec.model_route.max_calls = 5;
+/// let role = Role {
+///     name: "tighter-child".into(),
+///     version: 1,
+///     spec: child_spec,
+///     description: String::new(),
+/// };
+///
+/// // Intersection returns Ok with the tighter ceiling.
+/// let child_warrant = intersect(&parent, &role).expect("tightening is allowed");
+/// assert_eq!(child_warrant.model_route.max_calls, 5);
+/// ```
+#[tracing::instrument(level = "debug", skip_all, fields(role_name = %role.name, role_version = role.version))]
+pub fn intersect(parent: &WarrantSpec, role: &Role) -> Result<WarrantSpec, NarrowingError> {
+    let proposed = &role.spec;
+
+    // fs_scope: child must reference only paths the parent references, with
+    // mode ⊆ parent's mode on each.
+    if !proposed.fs_scope.is_subset_of(&parent.fs_scope) {
+        return Err(NarrowingError::AttemptedWiden {
+            field: WarrantField::FsScope,
+            parent: format!("{:?}", parent.fs_scope),
+            proposed: format!("{:?}", proposed.fs_scope),
+        });
+    }
+
+    // net_scope: None blocks all; allowlist must be subset of parent's.
+    if !proposed.net_scope.is_subset_of(&parent.net_scope) {
+        return Err(NarrowingError::AttemptedWiden {
+            field: WarrantField::NetScope,
+            parent: format!("{:?}", parent.net_scope),
+            proposed: format!("{:?}", proposed.net_scope),
+        });
+    }
+
+    // syscall_profile_ref: treated opaquely. v0.1 subset check is equality
+    // (the seccomp compiler will enforce the real subset relation).
+    if proposed.syscall_profile_ref != parent.syscall_profile_ref {
+        return Err(NarrowingError::SyscallProfileNotASubset {
+            profile_ref: proposed.syscall_profile_ref,
+        });
+    }
+
+    // tool_grants: child grants must be subset of parent grants.
+    if !proposed.tool_grants.is_subset(&parent.tool_grants) {
+        return Err(NarrowingError::AttemptedWiden {
+            field: WarrantField::ToolGrants,
+            parent: format!("{:?}", parent.tool_grants),
+            proposed: format!("{:?}", proposed.tool_grants),
+        });
+    }
+
+    // model_route: child names its own model; quantitative ceilings narrow.
+    // Reject zero ceilings as structurally invalid (a route with zero tokens
+    // is useless; surface loudly).
+    if proposed.model_route.max_input_tokens == 0
+        || proposed.model_route.max_output_tokens == 0
+        || proposed.model_route.max_calls == 0
+    {
+        return Err(NarrowingError::InvalidModelRoute {
+            reason: "max_input_tokens, max_output_tokens, and max_calls must all be > 0".into(),
+        });
+    }
+    let model_route = proposed
+        .model_route
+        .narrow_quantitative(&parent.model_route);
+
+    // resource_ceiling: per-axis min.
+    let resource_ceiling = proposed.resource_ceiling.narrow(&parent.resource_ceiling);
+
+    // mote_class / nd_class: set by child's role (NOT inherited).
+    // executor_class: set by child's role (orthogonal to narrowing).
+    // environment_ref: set by child's role (orthogonal to narrowing).
+
+    Ok(WarrantSpec {
+        mote_class: proposed.mote_class,
+        nd_class: proposed.nd_class,
+        fs_scope: proposed.fs_scope.clone(),
+        net_scope: proposed.net_scope.clone(),
+        syscall_profile_ref: proposed.syscall_profile_ref,
+        tool_grants: proposed.tool_grants.clone(),
+        model_route,
+        resource_ceiling,
+        environment_ref: proposed.environment_ref,
+        executor_class: proposed.executor_class,
+    })
+}
+
+/// Typed wrapper over [`intersect`]; aliases for call-site readability.
+///
+/// `narrow(parent, child_role)` ≡ `intersect(parent, child_role)`. Use
+/// whichever reads better in context.
+#[inline]
+pub fn narrow(parent: &WarrantSpec, child_role: &Role) -> Result<WarrantSpec, NarrowingError> {
+    intersect(parent, child_role)
+}
+
+/// Check that a tool's [`ToolRequirement`] is satisfied by the Mote's warrant.
+///
+/// Called by the tool registry at resolution time (per D32 — refuses dispatch
+/// if the tool's required capability exceeds the warrant on any axis). The
+/// broker (P1.8.5) NEVER sees a tool whose capability exceeds the warrant.
+///
+/// # Returns
+///
+/// `Ok(())` iff every axis of `req` is ⊆ the matching axis of `warrant`.
+///
+/// # Errors
+///
+/// Returns [`ToolDenied`] with the offending axis when the requirement exceeds
+/// the warrant.
+///
+/// # Example
+///
+/// ```
+/// use kx_warrant::{check_tool_requirement, ExecutorClass, FsScope, MoteClass,
+///     ModelRoute, NetScope, ResourceCeiling, ToolRequirement, WarrantSpec};
+/// use kx_content::ContentRef;
+/// use kx_mote::ModelId;
+/// use std::collections::BTreeSet;
+///
+/// let warrant = WarrantSpec {
+///     mote_class: MoteClass::Pure, nd_class: MoteClass::Pure,
+///     fs_scope: FsScope::empty(), net_scope: NetScope::None,
+///     syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+///     tool_grants: BTreeSet::new(),
+///     model_route: ModelRoute {
+///         model_id: ModelId("m".into()), max_input_tokens: 100,
+///         max_output_tokens: 100, max_calls: 1,
+///     },
+///     resource_ceiling: ResourceCeiling {
+///         cpu_milli: 500, mem_bytes: 1 << 28, wall_clock_ms: 5_000,
+///         fd_count: 64, disk_bytes: 1 << 28,
+///     },
+///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+/// };
+///
+/// // A tool requiring more memory than the warrant permits → ToolDenied.
+/// let req = ToolRequirement {
+///     net_scope_required: NetScope::None,
+///     fs_scope_required: FsScope::empty(),
+///     syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+///     min_resource_ceiling: ResourceCeiling {
+///         cpu_milli: 100, mem_bytes: 1 << 40, wall_clock_ms: 1_000,
+///         fd_count: 16, disk_bytes: 1 << 20,
+///     },
+/// };
+/// assert!(check_tool_requirement(&req, &warrant).is_err());
+/// ```
+#[tracing::instrument(level = "debug", skip_all)]
+pub fn check_tool_requirement(
+    req: &ToolRequirement,
+    warrant: &WarrantSpec,
+) -> Result<(), ToolDenied> {
+    if !req.fs_scope_required.is_subset_of(&warrant.fs_scope) {
+        return Err(ToolDenied {
+            field: WarrantField::FsScope,
+        });
+    }
+    if !req.net_scope_required.is_subset_of(&warrant.net_scope) {
+        return Err(ToolDenied {
+            field: WarrantField::NetScope,
+        });
+    }
+    if req.syscall_profile_ref != warrant.syscall_profile_ref {
+        return Err(ToolDenied {
+            field: WarrantField::SyscallProfile,
+        });
+    }
+    let need = req.min_resource_ceiling;
+    let have = warrant.resource_ceiling;
+    if need.cpu_milli > have.cpu_milli
+        || need.mem_bytes > have.mem_bytes
+        || need.wall_clock_ms > have.wall_clock_ms
+        || need.fd_count > have.fd_count
+        || need.disk_bytes > have.disk_bytes
+    {
+        return Err(ToolDenied {
+            field: WarrantField::ResourceCeiling,
+        });
+    }
+    Ok(())
+}
+
+/// Compute the content-addressed [`ContentRef`] for a [`WarrantSpec`].
+///
+/// `warrant_ref = blake3(canonical_bincode(WarrantSpec))`.
+///
+/// The bincode configuration is the workspace canonical
+/// ([`kx_mote::canonical_config`]): standard + little-endian + fixed-int.
+/// Two semantically-identical warrants produce byte-identical refs.
+///
+/// # Panics
+///
+/// Panics if the bincode encoder fails — which cannot happen for the
+/// `WarrantSpec` shape (all fields are deterministically encodable). The
+/// panic surfaces loudly rather than corrupting identity.
+///
+/// # Example
+///
+/// ```
+/// use kx_warrant::{warrant_ref_of, ExecutorClass, FsScope, MoteClass,
+///     ModelRoute, NetScope, ResourceCeiling, WarrantSpec};
+/// use kx_content::ContentRef;
+/// use kx_mote::ModelId;
+/// use std::collections::BTreeSet;
+///
+/// let spec = WarrantSpec {
+///     mote_class: MoteClass::Pure, nd_class: MoteClass::Pure,
+///     fs_scope: FsScope::empty(), net_scope: NetScope::None,
+///     syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+///     tool_grants: BTreeSet::new(),
+///     model_route: ModelRoute {
+///         model_id: ModelId("m".into()), max_input_tokens: 10,
+///         max_output_tokens: 10, max_calls: 1,
+///     },
+///     resource_ceiling: ResourceCeiling {
+///         cpu_milli: 0, mem_bytes: 0, wall_clock_ms: 0,
+///         fd_count: 0, disk_bytes: 0,
+///     },
+///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+/// };
+/// // Same spec → same ref (idempotent).
+/// assert_eq!(warrant_ref_of(&spec), warrant_ref_of(&spec));
+/// ```
+#[tracing::instrument(level = "trace", skip_all)]
+#[must_use]
+pub fn warrant_ref_of(spec: &WarrantSpec) -> ContentRef {
+    let bytes = bincode::serde::encode_to_vec(spec, canonical_config())
+        .expect("canonical bincode encoding of WarrantSpec cannot fail");
+    ContentRef::of(&bytes)
+}
+
+/// Compute the content-addressed [`ContentRef`] for a [`Role`].
+///
+/// `role_id = blake3(canonical_bincode(Role))`. Two byte-identical roles
+/// produce identical IDs; one byte changed → new ID.
+///
+/// # Panics
+///
+/// Panics if bincode encoding fails (impossible for the `Role` shape).
+#[must_use]
+pub fn role_id_of(role: &Role) -> ContentRef {
+    let bytes = bincode::serde::encode_to_vec(role, canonical_config())
+        .expect("canonical bincode encoding of Role cannot fail");
+    ContentRef::of(&bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (per-axis truth tables + edge cases)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn permissive_warrant() -> WarrantSpec {
+        WarrantSpec {
+            mote_class: MoteClass::Pure,
+            nd_class: MoteClass::Pure,
+            fs_scope: FsScope {
+                mounts: BTreeMap::from([
+                    (PathBuf::from("/input"), FsMode::ReadOnly),
+                    (PathBuf::from("/output"), FsMode::ReadWrite),
+                ]),
+            },
+            net_scope: NetScope::EgressAllowlist(BTreeSet::from([
+                Host("api.example.com:443".into()),
+                Host("registry.example.com:443".into()),
+            ])),
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            tool_grants: BTreeSet::from([
+                ToolGrant {
+                    tool_id: ToolName("fs-read".into()),
+                    tool_version: ToolVersion("1".into()),
+                },
+                ToolGrant {
+                    tool_id: ToolName("http-get".into()),
+                    tool_version: ToolVersion("2".into()),
+                },
+            ]),
+            model_route: ModelRoute {
+                model_id: ModelId("gpt-4".into()),
+                max_input_tokens: 8000,
+                max_output_tokens: 2000,
+                max_calls: 10,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 2000,
+                mem_bytes: 4 << 30,
+                wall_clock_ms: 60_000,
+                fd_count: 256,
+                disk_bytes: 4 << 30,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::Bwrap,
+        }
+    }
+
+    fn role_with(spec: WarrantSpec) -> Role {
+        Role {
+            name: "child".into(),
+            version: 1,
+            spec,
+            description: String::new(),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Identity: intersect with self == self (modulo silent-narrow noop)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn intersect_with_self_is_identity() {
+        let parent = permissive_warrant();
+        let role = role_with(parent.clone());
+        let result = intersect(&parent, &role).expect("self-intersect is always Ok");
+        assert_eq!(result, parent);
+    }
+
+    // -----------------------------------------------------------------
+    // fs_scope: per-axis truth table
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn fs_scope_subset_path_subset_mode_ok() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.fs_scope = FsScope {
+            mounts: BTreeMap::from([(PathBuf::from("/input"), FsMode::ReadOnly)]),
+        };
+        let result = intersect(&parent, &role_with(child_spec.clone())).unwrap();
+        assert_eq!(result.fs_scope, child_spec.fs_scope);
+    }
+
+    #[test]
+    fn fs_scope_unknown_path_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.fs_scope = FsScope {
+            mounts: BTreeMap::from([(PathBuf::from("/etc"), FsMode::ReadOnly)]),
+        };
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::AttemptedWiden {
+                field: WarrantField::FsScope,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn fs_scope_mode_widen_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.fs_scope = FsScope {
+            mounts: BTreeMap::from([(PathBuf::from("/input"), FsMode::ReadWrite)]),
+        };
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::AttemptedWiden {
+                field: WarrantField::FsScope,
+                ..
+            }
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // net_scope: per-axis truth table
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn net_scope_none_under_none_ok() {
+        let mut parent = permissive_warrant();
+        parent.net_scope = NetScope::None;
+        let mut child_spec = parent.clone();
+        child_spec.net_scope = NetScope::None;
+        assert!(intersect(&parent, &role_with(child_spec)).is_ok());
+    }
+
+    #[test]
+    fn net_scope_allowlist_under_none_rejected() {
+        let mut parent = permissive_warrant();
+        parent.net_scope = NetScope::None;
+        let mut child_spec = parent.clone();
+        child_spec.net_scope = NetScope::EgressAllowlist(BTreeSet::from([Host("h:1".into())]));
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::AttemptedWiden {
+                field: WarrantField::NetScope,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn net_scope_allowlist_subset_ok() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.net_scope =
+            NetScope::EgressAllowlist(BTreeSet::from([Host("api.example.com:443".into())]));
+        assert!(intersect(&parent, &role_with(child_spec)).is_ok());
+    }
+
+    #[test]
+    fn net_scope_allowlist_extra_host_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.net_scope = NetScope::EgressAllowlist(BTreeSet::from([
+            Host("api.example.com:443".into()),
+            Host("evil.example.com:443".into()),
+        ]));
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::AttemptedWiden {
+                field: WarrantField::NetScope,
+                ..
+            }
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // tool_grants: set subset
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn tool_grants_subset_ok() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.tool_grants = BTreeSet::from([ToolGrant {
+            tool_id: ToolName("fs-read".into()),
+            tool_version: ToolVersion("1".into()),
+        }]);
+        assert!(intersect(&parent, &role_with(child_spec)).is_ok());
+    }
+
+    #[test]
+    fn tool_grants_unknown_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.tool_grants = BTreeSet::from([ToolGrant {
+            tool_id: ToolName("evil-tool".into()),
+            tool_version: ToolVersion("1".into()),
+        }]);
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::AttemptedWiden {
+                field: WarrantField::ToolGrants,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn tool_grants_wrong_version_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        // Same name, different version is a DIFFERENT ToolGrant (ToolVersion
+        // is part of the tuple identity). Must be in the parent's set.
+        child_spec.tool_grants = BTreeSet::from([ToolGrant {
+            tool_id: ToolName("fs-read".into()),
+            tool_version: ToolVersion("999".into()),
+        }]);
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::AttemptedWiden {
+                field: WarrantField::ToolGrants,
+                ..
+            }
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // syscall_profile_ref: opaque equality (v0.1)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn syscall_profile_mismatch_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.syscall_profile_ref = ContentRef::from_bytes([1; 32]);
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(
+            err,
+            NarrowingError::SyscallProfileNotASubset { .. }
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // model_route: zero ceilings rejected; quantitative axes narrow silently
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn model_route_zero_max_calls_rejected() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.model_route.max_calls = 0;
+        let err = intersect(&parent, &role_with(child_spec)).unwrap_err();
+        assert!(matches!(err, NarrowingError::InvalidModelRoute { .. }));
+    }
+
+    #[test]
+    fn model_route_silently_narrows_quantitative_axes() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.model_route.max_input_tokens = 99_999_999; // wider than parent (8000)
+        let result = intersect(&parent, &role_with(child_spec)).unwrap();
+        // Silently narrowed to parent's ceiling (8000), no error.
+        assert_eq!(result.model_route.max_input_tokens, 8000);
+    }
+
+    #[test]
+    fn model_route_child_can_name_different_model() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.model_route.model_id = ModelId("claude-3.7".into());
+        let result = intersect(&parent, &role_with(child_spec)).unwrap();
+        assert_eq!(result.model_route.model_id.0, "claude-3.7");
+    }
+
+    // -----------------------------------------------------------------
+    // resource_ceiling: silent min() narrowing
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn resource_ceiling_narrows_to_min() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.resource_ceiling.cpu_milli = 99_999; // wider than parent (2000)
+        child_spec.resource_ceiling.mem_bytes = 1 << 20; // tighter than parent
+        let result = intersect(&parent, &role_with(child_spec)).unwrap();
+        assert_eq!(result.resource_ceiling.cpu_milli, 2000); // min(99_999, 2000)
+        assert_eq!(result.resource_ceiling.mem_bytes, 1 << 20); // min(1<<20, 4<<30)
+    }
+
+    // -----------------------------------------------------------------
+    // mote_class / nd_class set by child, NOT inherited
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn mote_class_set_by_child_not_inherited() {
+        let mut parent = permissive_warrant();
+        parent.mote_class = MoteClass::WorldMutating;
+        parent.nd_class = MoteClass::WorldMutating;
+        let mut child_spec = parent.clone();
+        child_spec.mote_class = MoteClass::Pure;
+        child_spec.nd_class = MoteClass::Pure;
+        let result = intersect(&parent, &role_with(child_spec)).unwrap();
+        assert_eq!(result.mote_class, MoteClass::Pure);
+        assert_eq!(result.nd_class, MoteClass::Pure);
+    }
+
+    // -----------------------------------------------------------------
+    // executor_class / environment_ref set by child
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn executor_class_set_by_child() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.executor_class = ExecutorClass::OciDaemon;
+        let result = intersect(&parent, &role_with(child_spec)).unwrap();
+        assert_eq!(result.executor_class, ExecutorClass::OciDaemon);
+    }
+
+    #[test]
+    fn environment_ref_set_by_child() {
+        let parent = permissive_warrant();
+        let mut child_spec = parent.clone();
+        child_spec.environment_ref = Some(ContentRef::from_bytes([42; 32]));
+        let result = intersect(&parent, &role_with(child_spec)).unwrap();
+        assert_eq!(
+            result.environment_ref,
+            Some(ContentRef::from_bytes([42; 32]))
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // check_tool_requirement: per-axis truth table
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn tool_req_within_warrant_ok() {
+        let warrant = permissive_warrant();
+        let req = ToolRequirement {
+            net_scope_required: NetScope::EgressAllowlist(BTreeSet::from([Host(
+                "api.example.com:443".into(),
+            )])),
+            fs_scope_required: FsScope {
+                mounts: BTreeMap::from([(PathBuf::from("/input"), FsMode::ReadOnly)]),
+            },
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 100,
+                mem_bytes: 1 << 20,
+                wall_clock_ms: 1_000,
+                fd_count: 16,
+                disk_bytes: 1 << 20,
+            },
+        };
+        assert!(check_tool_requirement(&req, &warrant).is_ok());
+    }
+
+    #[test]
+    fn tool_req_too_much_memory_rejected() {
+        let warrant = permissive_warrant();
+        let req = ToolRequirement {
+            net_scope_required: NetScope::None,
+            fs_scope_required: FsScope::empty(),
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 1 << 50,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+        };
+        assert!(matches!(
+            check_tool_requirement(&req, &warrant),
+            Err(ToolDenied {
+                field: WarrantField::ResourceCeiling
+            })
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // warrant_ref_of / role_id_of: byte-determinism
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn warrant_ref_of_is_deterministic() {
+        let spec = permissive_warrant();
+        let a = warrant_ref_of(&spec);
+        let b = warrant_ref_of(&spec);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn warrant_ref_of_changes_with_byte_change() {
+        let spec_a = permissive_warrant();
+        let mut spec_b = spec_a.clone();
+        spec_b.model_route.max_calls += 1;
+        assert_ne!(warrant_ref_of(&spec_a), warrant_ref_of(&spec_b));
+    }
+
+    #[test]
+    fn role_id_of_is_deterministic() {
+        let role = role_with(permissive_warrant());
+        assert_eq!(role_id_of(&role), role_id_of(&role));
+    }
+
+    // -----------------------------------------------------------------
+    // narrow == intersect alias
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn narrow_is_alias_for_intersect() {
+        let parent = permissive_warrant();
+        let role = role_with(parent.clone());
+        assert_eq!(intersect(&parent, &role), narrow(&parent, &role));
+    }
+
+    // -----------------------------------------------------------------
+    // MoteClass conversion round-trip
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn mote_class_nd_class_roundtrip() {
+        for mc in [
+            MoteClass::Pure,
+            MoteClass::ReadOnlyNondet,
+            MoteClass::WorldMutating,
+        ] {
+            assert_eq!(MoteClass::from_nd_class(mc.to_nd_class()), mc);
+        }
+    }
+}

--- a/kx-warrant/tests/concurrency.rs
+++ b/kx-warrant/tests/concurrency.rs
@@ -1,0 +1,167 @@
+//! Concurrency tests for `kx-warrant` (SN-4 v2 #7 — concurrency mandate; D30).
+//!
+//! - Compile-time `Send + Sync` assertions over the full public-type set.
+//! - 4-thread thread-independence of `intersect` (Arc<>'d inputs, identical
+//!   outcomes).
+//! - 4-thread byte-identity of `warrant_ref_of` (no clock, no thread-local).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+use kx_content::ContentRef;
+use kx_mote::{ModelId, ToolName, ToolVersion};
+use kx_warrant::{
+    intersect, warrant_ref_of, ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass,
+    NarrowingError, NetScope, ResourceCeiling, Role, ToolDenied, ToolGrant, ToolRequirement,
+    WarrantField, WarrantSpec,
+};
+
+// ---------------------------------------------------------------------------
+// Compile-time Send + Sync assertions
+// ---------------------------------------------------------------------------
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn public_types_are_send_and_sync() {
+    // Small enums
+    assert_send_sync::<MoteClass>();
+    assert_send_sync::<ExecutorClass>();
+    assert_send_sync::<FsMode>();
+    assert_send_sync::<WarrantField>();
+
+    // Composite axes
+    assert_send_sync::<Host>();
+    assert_send_sync::<FsScope>();
+    assert_send_sync::<NetScope>();
+    assert_send_sync::<ToolGrant>();
+    assert_send_sync::<ModelRoute>();
+    assert_send_sync::<ResourceCeiling>();
+    assert_send_sync::<WarrantSpec>();
+    assert_send_sync::<Role>();
+    assert_send_sync::<ToolRequirement>();
+
+    // Errors
+    assert_send_sync::<NarrowingError>();
+    assert_send_sync::<ToolDenied>();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn permissive_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::from([
+                (PathBuf::from("/input"), FsMode::ReadOnly),
+                (PathBuf::from("/output"), FsMode::ReadWrite),
+            ]),
+        },
+        net_scope: NetScope::EgressAllowlist(BTreeSet::from([Host("api.example.com:443".into())])),
+        syscall_profile_ref: ContentRef::from_bytes([7; 32]),
+        tool_grants: BTreeSet::from([
+            ToolGrant {
+                tool_id: ToolName("fs-read".into()),
+                tool_version: ToolVersion("1".into()),
+            },
+            ToolGrant {
+                tool_id: ToolName("http-get".into()),
+                tool_version: ToolVersion("2".into()),
+            },
+        ]),
+        model_route: ModelRoute {
+            model_id: ModelId("gpt-4".into()),
+            max_input_tokens: 8000,
+            max_output_tokens: 2000,
+            max_calls: 10,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 2000,
+            mem_bytes: 4 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 256,
+            disk_bytes: 4 << 30,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn tightening_role() -> Role {
+    let mut spec = permissive_warrant();
+    spec.resource_ceiling.cpu_milli = 500;
+    spec.model_route.max_calls = 3;
+    Role {
+        name: "tighten".into(),
+        version: 1,
+        spec,
+        description: String::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4-thread thread-independence of `intersect`
+// ---------------------------------------------------------------------------
+
+/// 4 threads each compute `intersect(parent, role)` against identical inputs
+/// (via `Arc<>`). The result must be byte-identical across threads — pins the
+/// "no thread-local seed in BLAKE3/bincode" contract that machine-independent
+/// replay depends on.
+#[test]
+fn intersect_is_thread_independent_under_real_move() {
+    let parent = Arc::new(permissive_warrant());
+    let role = Arc::new(tightening_role());
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let p = Arc::clone(&parent);
+            let r = Arc::clone(&role);
+            thread::spawn(move || intersect(&p, &r).expect("ok"))
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(4);
+    for h in handles {
+        results.push(h.join().expect("worker did not panic"));
+    }
+
+    // All four threads produced byte-identical warrants.
+    let first = &results[0];
+    for r in &results[1..] {
+        assert_eq!(first, r, "intersect must be thread-independent");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4-thread byte-identity of `warrant_ref_of`
+// ---------------------------------------------------------------------------
+
+/// 4 threads each compute `warrant_ref_of(spec)` against an Arc<>'d spec. The
+/// resulting `ContentRef`s must be byte-identical — pins the deterministic
+/// content-addressing contract that journal recovery depends on.
+#[test]
+fn warrant_ref_of_is_thread_independent() {
+    let spec = Arc::new(permissive_warrant());
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let s = Arc::clone(&spec);
+            thread::spawn(move || warrant_ref_of(&s))
+        })
+        .collect();
+
+    let mut refs = Vec::with_capacity(4);
+    for h in handles {
+        refs.push(h.join().expect("worker did not panic"));
+    }
+
+    let first = refs[0];
+    for r in &refs[1..] {
+        assert_eq!(&first, r, "warrant_ref_of must be thread-independent");
+    }
+}

--- a/kx-warrant/tests/proptest_warrant.rs
+++ b/kx-warrant/tests/proptest_warrant.rs
@@ -1,0 +1,467 @@
+//! Property tests for `intersect`, `narrow`, `check_tool_requirement`, and
+//! `warrant_ref_of` (SN-4 v2 #6 — pinned per D30).
+//!
+//! Properties:
+//!
+//! 1. `intersect(p, r)` is TOTAL — never panics on any arbitrary input pair.
+//! 2. `intersect(p, r)` is DETERMINISTIC — same inputs → same outcome.
+//! 3. `intersect(p, p_as_role)` is IDENTITY — intersecting a parent with a role
+//!    whose spec equals the parent's returns Ok(parent).
+//! 4. `warrant_ref_of(s)` is DETERMINISTIC and PURE — same spec → same ref.
+//! 5. Quantitative-axis narrowing is correct: `result.resource_ceiling.X ==
+//!    min(parent.X, child.X)` for every axis.
+//! 6. Widening on a qualitative axis is REFUSED: if the child role proposes
+//!    `tool_grants` not ⊆ parent's, intersect returns `AttemptedWiden`.
+//! 7. The narrowing is MONOTONIC: if `child2.role` is itself a narrowing of
+//!    `child1.warrant`, then `intersect(child1.warrant, child2_role)` produces
+//!    a warrant whose quantitative axes are ≤ `child1.warrant`'s.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_mote::{ModelId, ToolName, ToolVersion};
+use kx_warrant::{
+    check_tool_requirement, intersect, narrow, warrant_ref_of, ExecutorClass, FsMode, FsScope,
+    Host, ModelRoute, MoteClass, NarrowingError, NetScope, ResourceCeiling, Role, ToolGrant,
+    ToolRequirement, WarrantField, WarrantSpec,
+};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_mote_class() -> impl Strategy<Value = MoteClass> {
+    prop_oneof![
+        Just(MoteClass::Pure),
+        Just(MoteClass::ReadOnlyNondet),
+        Just(MoteClass::WorldMutating),
+    ]
+}
+
+fn arb_executor_class() -> impl Strategy<Value = ExecutorClass> {
+    prop_oneof![
+        Just(ExecutorClass::Bwrap),
+        Just(ExecutorClass::OciDaemon),
+        Just(ExecutorClass::CloudMicroVm),
+    ]
+}
+
+fn arb_fs_mode() -> impl Strategy<Value = FsMode> {
+    prop_oneof![
+        Just(FsMode::ReadOnly),
+        Just(FsMode::ReadWrite),
+        Just(FsMode::ExecOnly)
+    ]
+}
+
+fn arb_path() -> impl Strategy<Value = PathBuf> {
+    prop_oneof![
+        Just(PathBuf::from("/input")),
+        Just(PathBuf::from("/output")),
+        Just(PathBuf::from("/tmp")),
+        Just(PathBuf::from("/etc")),
+        Just(PathBuf::from("/var/run")),
+    ]
+}
+
+fn arb_fs_scope() -> impl Strategy<Value = FsScope> {
+    proptest::collection::btree_map(arb_path(), arb_fs_mode(), 0..=4)
+        .prop_map(|mounts| FsScope { mounts })
+}
+
+fn arb_host() -> impl Strategy<Value = Host> {
+    prop_oneof![
+        Just(Host("api.example.com:443".into())),
+        Just(Host("registry.example.com:443".into())),
+        Just(Host("storage.example.com:443".into())),
+        Just(Host("evil.example.com:443".into())),
+    ]
+}
+
+fn arb_net_scope() -> impl Strategy<Value = NetScope> {
+    prop_oneof![
+        Just(NetScope::None),
+        proptest::collection::btree_set(arb_host(), 0..=3).prop_map(NetScope::EgressAllowlist),
+    ]
+}
+
+fn arb_content_ref() -> impl Strategy<Value = ContentRef> {
+    prop_oneof![
+        Just(ContentRef::from_bytes([0; 32])),
+        Just(ContentRef::from_bytes([1; 32])),
+        Just(ContentRef::from_bytes([42; 32])),
+    ]
+}
+
+fn arb_tool_grant() -> impl Strategy<Value = ToolGrant> {
+    (
+        prop_oneof![
+            Just(ToolName("fs-read".into())),
+            Just(ToolName("fs-write".into())),
+            Just(ToolName("http-get".into())),
+            Just(ToolName("text-summarize".into())),
+        ],
+        prop_oneof![
+            Just(ToolVersion("1".into())),
+            Just(ToolVersion("2".into())),
+            Just(ToolVersion("3".into())),
+        ],
+    )
+        .prop_map(|(tool_id, tool_version)| ToolGrant {
+            tool_id,
+            tool_version,
+        })
+}
+
+fn arb_tool_grants() -> impl Strategy<Value = BTreeSet<ToolGrant>> {
+    proptest::collection::btree_set(arb_tool_grant(), 0..=4)
+}
+
+fn arb_model_route() -> impl Strategy<Value = ModelRoute> {
+    (
+        prop_oneof![
+            Just(ModelId("gpt-4".into())),
+            Just(ModelId("claude-3.7".into())),
+            Just(ModelId("llama-3-8b".into())),
+        ],
+        1u32..=128_000,
+        1u32..=128_000,
+        1u32..=1000,
+    )
+        .prop_map(
+            |(model_id, max_input_tokens, max_output_tokens, max_calls)| ModelRoute {
+                model_id,
+                max_input_tokens,
+                max_output_tokens,
+                max_calls,
+            },
+        )
+}
+
+fn arb_resource_ceiling() -> impl Strategy<Value = ResourceCeiling> {
+    (
+        0u32..=100_000,
+        0u64..=(64u64 << 30),
+        0u64..=600_000,
+        0u32..=4096,
+        0u64..=(64u64 << 30),
+    )
+        .prop_map(
+            |(cpu_milli, mem_bytes, wall_clock_ms, fd_count, disk_bytes)| ResourceCeiling {
+                cpu_milli,
+                mem_bytes,
+                wall_clock_ms,
+                fd_count,
+                disk_bytes,
+            },
+        )
+}
+
+fn arb_warrant_spec() -> impl Strategy<Value = WarrantSpec> {
+    (
+        arb_mote_class(),
+        arb_fs_scope(),
+        arb_net_scope(),
+        arb_content_ref(),
+        arb_tool_grants(),
+        arb_model_route(),
+        arb_resource_ceiling(),
+        proptest::option::of(arb_content_ref()),
+        arb_executor_class(),
+    )
+        .prop_map(
+            |(
+                cls,
+                fs_scope,
+                net_scope,
+                syscall_profile_ref,
+                tool_grants,
+                model_route,
+                resource_ceiling,
+                environment_ref,
+                executor_class,
+            )| WarrantSpec {
+                mote_class: cls,
+                nd_class: cls,
+                fs_scope,
+                net_scope,
+                syscall_profile_ref,
+                tool_grants,
+                model_route,
+                resource_ceiling,
+                environment_ref,
+                executor_class,
+            },
+        )
+}
+
+fn arb_role(spec_strategy: impl Strategy<Value = WarrantSpec>) -> impl Strategy<Value = Role> {
+    (prop_oneof!["[a-z]{3,8}"], 1u32..=100, spec_strategy).prop_map(|(name, version, spec)| Role {
+        name,
+        version,
+        spec,
+        description: String::new(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 1: `intersect` is TOTAL — never panics on any input pair.
+    #[test]
+    fn prop_intersect_is_total(
+        parent in arb_warrant_spec(),
+        role in arb_role(arb_warrant_spec()),
+    ) {
+        let _ = intersect(&parent, &role); // Reaching this line proves no panic.
+    }
+
+    /// Property 2: `intersect` is DETERMINISTIC — same inputs → same outcome.
+    #[test]
+    fn prop_intersect_is_deterministic(
+        parent in arb_warrant_spec(),
+        role in arb_role(arb_warrant_spec()),
+    ) {
+        let a = intersect(&parent, &role);
+        let b = intersect(&parent, &role);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Property 3: `intersect(p, p_as_role) == Ok(p)` — identity property.
+    /// A role whose spec equals the parent's must produce the parent back
+    /// (modulo silent no-op narrowing which produces byte-identical fields).
+    #[test]
+    fn prop_intersect_self_is_identity(parent in arb_warrant_spec()) {
+        let role = Role {
+            name: "self".into(),
+            version: 1,
+            spec: parent.clone(),
+            description: String::new(),
+        };
+        // Self-intersect succeeds AND produces byte-identical parent.
+        let result = intersect(&parent, &role).expect("self-intersect always Ok");
+        prop_assert_eq!(result, parent);
+    }
+
+    /// Property 4: `warrant_ref_of` is DETERMINISTIC — same spec → same ref.
+    #[test]
+    fn prop_warrant_ref_of_is_deterministic(spec in arb_warrant_spec()) {
+        let a = warrant_ref_of(&spec);
+        let b = warrant_ref_of(&spec);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Property 5: Quantitative-axis narrowing — `result.resource_ceiling.X ==
+    /// min(parent.X, child.X)` for every axis.
+    #[test]
+    fn prop_resource_ceiling_narrows_to_min(
+        parent in arb_warrant_spec(),
+        child_ceiling in arb_resource_ceiling(),
+    ) {
+        // Build a child role that matches parent except resource_ceiling.
+        let mut child_spec = parent.clone();
+        child_spec.resource_ceiling = child_ceiling;
+        // Also match the syscall_profile_ref so we don't trip that check.
+        child_spec.syscall_profile_ref = parent.syscall_profile_ref;
+        // Ensure model_route ceilings are valid (>0) to avoid InvalidModelRoute.
+        // Already true by arb_model_route's 1.. bounds — preserved here.
+        let role = Role {
+            name: "rc-test".into(),
+            version: 1,
+            spec: child_spec.clone(),
+            description: String::new(),
+        };
+
+        // Other axes (fs_scope, net_scope, tool_grants) inherited from parent
+        // (identical to parent's), so widening rejection doesn't trip.
+        let role = Role {
+            spec: WarrantSpec {
+                fs_scope: parent.fs_scope.clone(),
+                net_scope: parent.net_scope.clone(),
+                tool_grants: parent.tool_grants.clone(),
+                ..role.spec
+            },
+            ..role
+        };
+
+        let result = intersect(&parent, &role);
+        if let Ok(r) = result {
+            prop_assert_eq!(
+                r.resource_ceiling.cpu_milli,
+                parent.resource_ceiling.cpu_milli.min(child_ceiling.cpu_milli)
+            );
+            prop_assert_eq!(
+                r.resource_ceiling.mem_bytes,
+                parent.resource_ceiling.mem_bytes.min(child_ceiling.mem_bytes)
+            );
+            prop_assert_eq!(
+                r.resource_ceiling.wall_clock_ms,
+                parent.resource_ceiling.wall_clock_ms.min(child_ceiling.wall_clock_ms)
+            );
+            prop_assert_eq!(
+                r.resource_ceiling.fd_count,
+                parent.resource_ceiling.fd_count.min(child_ceiling.fd_count)
+            );
+            prop_assert_eq!(
+                r.resource_ceiling.disk_bytes,
+                parent.resource_ceiling.disk_bytes.min(child_ceiling.disk_bytes)
+            );
+        }
+    }
+
+    /// Property 6: Widening tool_grants is REFUSED.
+    /// If the child role's tool_grants is NOT a subset of parent's, intersect
+    /// returns `AttemptedWiden { field: WarrantField::ToolGrants, .. }`.
+    #[test]
+    fn prop_tool_grants_widening_is_refused(
+        parent in arb_warrant_spec(),
+        extra_grant in arb_tool_grant(),
+    ) {
+        // Skip degenerate case where extra_grant is already in parent's set.
+        if parent.tool_grants.contains(&extra_grant) {
+            return Ok(());
+        }
+        let mut child_spec = parent.clone();
+        let mut grants = parent.tool_grants.clone();
+        grants.insert(extra_grant);
+        child_spec.tool_grants = grants;
+        let role = Role {
+            name: "widening".into(),
+            version: 1,
+            spec: child_spec,
+            description: String::new(),
+        };
+
+        match intersect(&parent, &role) {
+            Err(NarrowingError::AttemptedWiden { field: WarrantField::ToolGrants, .. }) => {}
+            other => prop_assert!(
+                false,
+                "expected ToolGrants AttemptedWiden, got {:?}", other
+            ),
+        }
+    }
+
+    /// Property 7: Two-level narrowing chains MONOTONICALLY.
+    /// If `intersect(parent, role1) = Ok(child1)` and `intersect(child1, role2)
+    /// = Ok(child2)`, then `child2.resource_ceiling.X ≤ child1.resource_ceiling.X`
+    /// on every axis. (Monotonic narrowing across the chain.)
+    #[test]
+    fn prop_two_level_narrowing_is_monotonic(
+        parent in arb_warrant_spec(),
+        rc1 in arb_resource_ceiling(),
+        rc2 in arb_resource_ceiling(),
+    ) {
+        // Build role1 that inherits everything except resource_ceiling.
+        let mut spec1 = parent.clone();
+        spec1.resource_ceiling = rc1;
+        let role1 = Role { name: "l1".into(), version: 1, spec: spec1, description: String::new() };
+
+        let child1 = match intersect(&parent, &role1) {
+            Ok(c) => c,
+            Err(_) => return Ok(()), // skip cases where role1 is rejected
+        };
+
+        // Build role2 inheriting from child1's qualitative shape with rc2.
+        let mut spec2 = child1.clone();
+        spec2.resource_ceiling = rc2;
+        let role2 = Role { name: "l2".into(), version: 1, spec: spec2, description: String::new() };
+
+        let child2 = match intersect(&child1, &role2) {
+            Ok(c) => c,
+            Err(_) => return Ok(()),
+        };
+
+        prop_assert!(child2.resource_ceiling.cpu_milli <= child1.resource_ceiling.cpu_milli);
+        prop_assert!(child2.resource_ceiling.mem_bytes <= child1.resource_ceiling.mem_bytes);
+        prop_assert!(child2.resource_ceiling.wall_clock_ms <= child1.resource_ceiling.wall_clock_ms);
+        prop_assert!(child2.resource_ceiling.fd_count <= child1.resource_ceiling.fd_count);
+        prop_assert!(child2.resource_ceiling.disk_bytes <= child1.resource_ceiling.disk_bytes);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Spot-check: narrow == intersect alias
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
+
+    /// `narrow` is exactly `intersect`.
+    #[test]
+    fn narrow_is_alias_for_intersect(
+        parent in arb_warrant_spec(),
+        role in arb_role(arb_warrant_spec()),
+    ) {
+        prop_assert_eq!(intersect(&parent, &role), narrow(&parent, &role));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Spot-check: check_tool_requirement under permissive vs none warrants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_tool_requirement_smoke() {
+    let warrant = WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::from([(PathBuf::from("/input"), FsMode::ReadOnly)]),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 100,
+            max_output_tokens: 100,
+            max_calls: 1,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 500,
+            mem_bytes: 1 << 28,
+            wall_clock_ms: 5_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    };
+
+    // Permissive req: ok.
+    let ok_req = ToolRequirement {
+        net_scope_required: NetScope::None,
+        fs_scope_required: FsScope::empty(),
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        min_resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+    };
+    assert!(check_tool_requirement(&ok_req, &warrant).is_ok());
+
+    // Excessive memory req: rejected.
+    let bad_req = ToolRequirement {
+        min_resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 1 << 50,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        ..ok_req
+    };
+    assert!(check_tool_requirement(&bad_req, &warrant).is_err());
+}


### PR DESCRIPTION
## Summary

Implements **D30** in full — the runtime-enforced capability layer every Mote runs under. Pure `intersect(parent_warrant, child_role)` function with typed `NarrowingError` per axis; content-addressed identity via `warrant_ref_of`; monotonic narrowing across recursive chains.

**Second crate born SN-4 v2 + SN-7 compliant** (after P1.7.5 kx-model-validator).

## What ships

- `kx-warrant/Cargo.toml` — new crate at `0.0.1`. Deps: `kx-mote` + `kx-content` + `bincode` + `blake3` + `serde` + `smallvec` + `thiserror` + `tracing`. Dev: `proptest` + `tracing-subscriber`.
- `kx-warrant/src/lib.rs` (~1,230 LOC) — `WarrantSpec`, `Role`, `MoteClass`, `ExecutorClass`, `FsMode`, `FsScope`, `NetScope`, `Host`, `ToolGrant`, `ModelRoute`, `ResourceCeiling`, `ToolRequirement`, `WarrantField`, `NarrowingError`, `ToolDenied`. Pure functions: `intersect`, `narrow`, `check_tool_requirement`, `warrant_ref_of`, `role_id_of`.
- `kx-warrant/tests/proptest_warrant.rs` (~470 LOC) — 8 proptest properties + check_tool_requirement smoke test.
- `kx-warrant/tests/concurrency.rs` — Send+Sync compile-time + 4-thread thread-independence + warrant_ref byte-identity.
- `Cargo.toml` — workspace member + workspace dep.

## Invariants

- **Monotonic narrowing**: `child.warrant = intersect(parent.warrant, child.role)`. The model NEVER authorizes a widen. Widening on a qualitative axis (`fs_scope`, `net_scope`, `syscall_profile_ref`, `tool_grants`) is `NarrowingError::AttemptedWiden`. Quantitative axes (`resource_ceiling.*`, `model_route.max_*`) narrow silently via `min()`.
- `mote_class` / `nd_class` / `executor_class` / `environment_ref` are **set by child's role** — NOT inherited from parent. A child may be `Pure` under a `WorldMutating` parent.
- `intersect` is **pure**: no clock, no I/O, no journal access. Same inputs → byte-identical output. Recovery re-derives warrants bit-for-bit.
- `warrant_ref = blake3(canonical_bincode(WarrantSpec))` — content-addressed identity using the same workspace canonical bincode config as `kx-mote`.

## Tests (Apple Silicon local, all green)

| Category | Count |
|---|---|
| Unit | 26 |
| Proptest | 8 properties × 64 cases each + alias property × 16 |
| Concurrency | 3 |
| Doctest | 4 |
| **Crate total** | **42** |
| **Workspace total** | **266 / 266** |

## Gates (Apple Silicon local)

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (clippy::pedantic enabled with standard allow-list)
- `cargo test --workspace` ✓ (266/266, 0 failures)
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✓

## SN-2 pre-merge audit

- Path sentinel scan: ✅ no private paths in diff
- Content sentinel scan: ✅ no private tokens
- Files touched: `Cargo.toml`, `Cargo.lock`, `kx-warrant/{Cargo.toml,src/lib.rs,tests/{proptest_warrant,concurrency}.rs}` — OSS-only

## SN-7 evidence

Apple Silicon local (Darwin 25.5.0, M-series, rustc 1.94.0):
- kx-warrant: 42/42 passed
- workspace: 266/266 passed, 0 failures
- All gates green

Linux CI link added as PR comment after `just ci` reports green.

## Compliance checklist

- [x] SN-1: D30 already locked in `docs/design/decisions.md` (private corpus, design freeze commit `cbd3b98`).
- [x] SN-2: pre-merge audit clean (no private content).
- [x] SN-4 v2: property tests + concurrency tests + doctests + architectural review (this crate is pure data + pure functions; review confirmed no I/O, no clock, no global state).
- [x] SN-5: plan already archived (`docs/plans/2026-05-24-warrant-tool-registry-context-memoization.md`).
- [x] SN-6: predecessor crates (kx-mote, kx-content) both at SN-4 v2 ✅ + SN-7 ✅.
- [x] SN-7: Apple Silicon local + Linux Actions (link to follow in comment after CI).
- [x] SN-8: model proposes, runtime enforces — the entire crate's design IS this principle; widening is a typed error, never an "override" or a "force" path.

## Deviation from the locked plan

The plan said "kx-mote only" for deps, but the spec at `docs/design/warrant.md` uses `ContentRef` (from `kx-content`) for `syscall_profile_ref`, `environment_ref`, and `warrant_ref_of`'s return type. Adding `kx-content` is semantically correct and aligns the warrant layer with the workspace's content-addressing primitive. Noted in the commit message; no impact on other crates.

## What this does NOT do

- Seccomp-bpf compilation (warrant treats `syscall_profile_ref` opaquely; the real subset check lives in the seccomp compiler, out of scope).
- Executor wiring (P1.9).
- Cloud-side `WarrantSpec` extensions (`kx-cloud-*` crates plug in behind the same types per D28).
- v2 verified-capability probe paths (deferred future P-step).

## Next

P1.7.7 `kx-tool-registry` (D32) — the two-file tool layer with refs-not-copies + MCP-as-egress + self-generated-tools INERT until human review. Will depend on `kx-warrant` (just shipped) + `kx-mote` + `kx-content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)