### PR TITLE
P1.7.9: kx-memoizer — pure lookup over projection state (D33 + validate-then-commit.md §10.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-memoizer"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-journal",
+ "kx-mote",
+ "kx-projection",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-model-validator"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator", "kx-warrant", "kx-tool-registry", "kx-context-assembler"]
+members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator", "kx-warrant", "kx-tool-registry", "kx-context-assembler", "kx-memoizer"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -33,6 +33,7 @@ kx-model-validator = { path = "kx-model-validator" }
 kx-warrant         = { path = "kx-warrant" }
 kx-tool-registry   = { path = "kx-tool-registry" }
 kx-context-assembler = { path = "kx-context-assembler" }
+kx-memoizer        = { path = "kx-memoizer" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/kx-memoizer/Cargo.toml
+++ b/kx-memoizer/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name         = "kx-memoizer"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx memoizer — pure lookup over projection state. EXACT cryptographic equality only; no similarity operator (SN-8). Returns CacheHit variants honoring the per-NdClass effect-once vs inference-once separation (validate-then-commit.md §10.5)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-content    = { workspace = true }
+kx-mote       = { workspace = true }
+kx-projection = { workspace = true }
+serde         = { workspace = true }
+thiserror     = { workspace = true }
+tracing       = { workspace = true }
+
+[dev-dependencies]
+kx-journal         = { workspace = true }
+proptest           = { workspace = true }
+smallvec           = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-memoizer/src/lib.rs
+++ b/kx-memoizer/src/lib.rs
@@ -1,0 +1,351 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+
+//! # kx-memoizer — pure lookup over projection state
+//!
+//! The memoizer answers a single question, with cryptographic precision:
+//!
+//! > "Have we already committed for this exact `MoteId`, and is the
+//! > commitment safe to serve as a cache hit?"
+//!
+//! [`lookup`] is a **pure, total, deterministic** function over a candidate
+//! [`Mote`] and a read-only [`Snapshot`]. It performs **EXACT cryptographic
+//! equality only** — there is no similarity operator anywhere on the identity
+//! path, by SN-8 mandate. Two Motes match iff their derived `MoteId`s match
+//! bit-for-bit (which implies their `MoteDef`, `input_data_id`, and
+//! `graph_position` all match by BLAKE3 collision resistance).
+//!
+//! ## What the memoizer does (and doesn't)
+//!
+//! - **Does**: cross-reference the candidate Mote against the projection
+//!   snapshot. If the projection reports the Mote as `Committed` AND no
+//!   Data-edge parent is `Repudiated` AND a `result_ref` is present, returns
+//!   a [`CacheHit`] variant whose discriminant mirrors the candidate's
+//!   declared [`NdClass`].
+//! - **Doesn't**: dispatch effects, re-dispatch effects, run inference, or
+//!   mutate state. The executor (P1.9) is what acts on the hit.
+//!
+//! ## Effect-once vs inference-once (per `validate-then-commit.md` §10.5)
+//!
+//! These are SEPARATE primitives. The memoizer is the inference-once
+//! primitive: it caches the model's decision. The broker (P1.8.5) is the
+//! effect-once primitive: it deduplicates side effects against the
+//! warrant-scoped world.
+//!
+//! On a [`CacheHit::WorldMutating`], the executor MUST re-dispatch the
+//! broker effect against the cached `result_ref` — the cache supplies the
+//! decision, but the effect goes through the broker per attempt. The
+//! `redispatch_effect: true` field exists to make this constraint loud at
+//! every match site.
+//!
+//! ## Repudiation cascade
+//!
+//! A `Repudiated` Data-edge parent poisons the cache: the upstream lineage
+//! is invalid, so any cached result downstream is stale. Control-edge
+//! parents are sync-only and do **not** taint cache eligibility (they carry
+//! no data semantics — they sequence, they do not feed).
+//!
+//! ## NO similarity, NO fuzzy match — by design
+//!
+//! If two Motes "look similar" but have different `MoteId`s, they are
+//! distinct facts. The runtime serves cache hits only on exact match. The
+//! [`kx_mote::derive_mote_id`] function is the single source of identity
+//! truth; the memoizer trusts it by construction. The escape hatch for
+//! fuzzy-similar-but-not-identical inputs is the normalizer (P1.7.10):
+//! deterministic canonicalization BEFORE fingerprinting. Fuzzy residue lives
+//! behind a model-as-Mote seam whose canonical output is committed as a
+//! durable fact.
+//!
+//! ## What lives here
+//!
+//! - [`CacheHit`] — the three-variant enum mirroring [`NdClass`].
+//! - [`lookup`] — the pure cross-reference function.
+//!
+//! ## What does NOT live here
+//!
+//! - The executor's dispatch decision tree (P1.9).
+//! - The broker's effect-once primitive (P1.8.5 / capability-broker).
+//! - The journal-write side of memoization (memoization is a READ-side
+//!   primitive; writes go through the executor's commit protocol).
+
+use kx_content::ContentRef;
+use kx_mote::{EdgeKind, Mote, NdClass};
+use kx_projection::{MoteState, Snapshot};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// CacheHit
+// ---------------------------------------------------------------------------
+
+/// A cache hit returned by [`lookup`].
+///
+/// The variant corresponds to the candidate [`Mote`]'s [`NdClass`]:
+///
+/// - [`CacheHit::Pure`] — deterministic result; safe to serve directly.
+/// - [`CacheHit::ReadOnlyNondet`] — durable observation already committed;
+///   safe to serve directly. The non-determinism was resolved on the prior
+///   attempt and the observation is now a fact.
+/// - [`CacheHit::WorldMutating`] — the model's decision is reusable, but
+///   the executor MUST re-dispatch the broker effect against `result_ref`.
+///   The `redispatch_effect: true` field exists to make this constraint
+///   loud at every match site.
+///
+/// All variants carry the cached `result_ref`. Use [`CacheHit::result_ref`]
+/// to read it variant-agnostically.
+///
+/// # Examples
+///
+/// ```
+/// use kx_content::ContentRef;
+/// use kx_memoizer::CacheHit;
+///
+/// let r = ContentRef::of(b"cached payload");
+/// let hit = CacheHit::Pure { result_ref: r };
+/// assert_eq!(hit.result_ref(), &r);
+///
+/// // Variants are distinct under PartialEq.
+/// assert_ne!(
+///     CacheHit::Pure { result_ref: r },
+///     CacheHit::ReadOnlyNondet { result_ref: r },
+/// );
+///
+/// // WorldMutating signals re-dispatch is required.
+/// let wm = CacheHit::WorldMutating { result_ref: r, redispatch_effect: true };
+/// assert!(matches!(
+///     wm,
+///     CacheHit::WorldMutating { redispatch_effect: true, .. },
+/// ));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CacheHit {
+    /// PURE Mote cache hit. Result is deterministic; downstream consumers
+    /// read `result_ref` directly. No effect to re-dispatch.
+    Pure {
+        /// The cached payload's content ref.
+        result_ref: ContentRef,
+    },
+
+    /// READ-ONLY-NONDET cache hit. The cached observation was committed on
+    /// a prior attempt; the downstream reads `result_ref` to obtain the
+    /// durable fact. No effect to re-dispatch (the observation IS the fact).
+    ReadOnlyNondet {
+        /// The cached observation's content ref.
+        result_ref: ContentRef,
+    },
+
+    /// WORLD-MUTATING cache hit. The cached decision is reusable, but the
+    /// broker effect MUST be re-dispatched per attempt against `result_ref`.
+    /// `redispatch_effect` is always `true` for this variant; it exists to
+    /// make the constraint loud in match arms.
+    WorldMutating {
+        /// The cached decision's content ref. The broker re-dispatches the
+        /// effect against this ref per attempt.
+        result_ref: ContentRef,
+        /// Always `true` for this variant. Loud-by-design — the constraint
+        /// is named at every match site rather than buried in prose.
+        redispatch_effect: bool,
+    },
+}
+
+impl CacheHit {
+    /// Borrow the cached `result_ref` variant-agnostically.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kx_content::ContentRef;
+    /// use kx_memoizer::CacheHit;
+    ///
+    /// let r = ContentRef::of(b"x");
+    /// let hits = [
+    ///     CacheHit::Pure { result_ref: r },
+    ///     CacheHit::ReadOnlyNondet { result_ref: r },
+    ///     CacheHit::WorldMutating { result_ref: r, redispatch_effect: true },
+    /// ];
+    /// for h in &hits {
+    ///     assert_eq!(h.result_ref(), &r);
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn result_ref(&self) -> &ContentRef {
+        match self {
+            Self::Pure { result_ref }
+            | Self::ReadOnlyNondet { result_ref }
+            | Self::WorldMutating { result_ref, .. } => result_ref,
+        }
+    }
+
+    /// `true` iff the caller must re-dispatch a broker effect against
+    /// `result_ref`. Always `true` for [`CacheHit::WorldMutating`], always
+    /// `false` for the other variants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kx_content::ContentRef;
+    /// use kx_memoizer::CacheHit;
+    ///
+    /// let r = ContentRef::of(b"x");
+    /// assert!(!CacheHit::Pure { result_ref: r }.requires_redispatch());
+    /// assert!(!CacheHit::ReadOnlyNondet { result_ref: r }.requires_redispatch());
+    /// assert!(
+    ///     CacheHit::WorldMutating { result_ref: r, redispatch_effect: true }
+    ///         .requires_redispatch()
+    /// );
+    /// ```
+    #[must_use]
+    pub const fn requires_redispatch(&self) -> bool {
+        matches!(
+            self,
+            Self::WorldMutating {
+                redispatch_effect: true,
+                ..
+            }
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// lookup
+// ---------------------------------------------------------------------------
+
+/// Look up a cache hit for `mote` against `snapshot`.
+///
+/// Returns `Some(CacheHit)` iff ALL of:
+///
+/// 1. The projection reports `snapshot.state_of(&mote.id) == MoteState::Committed`.
+/// 2. No `Data`-edge parent of `mote` is `MoteState::Repudiated`. Control-edge
+///    parents are sync-only and do NOT taint cache eligibility.
+/// 3. `snapshot.result_ref_of(&mote.id)` returns `Some(ref)`.
+///
+/// Returns `None` otherwise — the caller must dispatch the Mote.
+///
+/// The returned [`CacheHit`] variant mirrors the candidate Mote's declared
+/// [`NdClass`]. By BLAKE3 collision resistance over [`kx_mote::derive_mote_id`]'s
+/// inputs (which include `mote_def_hash`, and `mote_def_hash` includes
+/// `nd_class`), a `MoteId` match implies the prior commit's `nd_class`
+/// matches the candidate's — the memoizer can trust the candidate's
+/// declared class without re-querying the committed entry.
+///
+/// **No similarity operator.** This is EXACT cryptographic equality only.
+///
+/// # Examples
+///
+/// Cache miss when no Committed entry exists for the Mote:
+///
+/// ```
+/// use kx_journal::InMemoryJournal;
+/// use kx_memoizer::lookup;
+/// use kx_projection::Projection;
+/// // Build an empty projection (no commits).
+/// let journal = InMemoryJournal::new();
+/// let snapshot = Projection::from_journal(&journal).unwrap().snapshot();
+/// // A Mote that isn't in the projection cannot have a cache hit.
+/// // (See kx-memoizer/tests/proptest_memoizer.rs for the full fixture.)
+/// // ...
+/// ```
+#[tracing::instrument(level = "debug", skip_all, fields(mote_id = ?mote.id))]
+#[must_use]
+pub fn lookup(mote: &Mote, snapshot: &Snapshot) -> Option<CacheHit> {
+    // 1. Snapshot must report the Mote as Committed.
+    if !matches!(snapshot.state_of(&mote.id), MoteState::Committed) {
+        return None;
+    }
+
+    // 2. Data-edge parents that are Repudiated poison the cache hit.
+    //    Control edges do NOT taint (they're synchronization-only).
+    for parent in &mote.parents {
+        if parent.edge.kind != EdgeKind::Data {
+            continue;
+        }
+        if matches!(snapshot.state_of(&parent.parent_id), MoteState::Repudiated) {
+            return None;
+        }
+    }
+
+    // 3. The cached result_ref must be present (Committed without a
+    //    result_ref would be a projection-side anomaly; absence here is a
+    //    cache miss, not an error).
+    let result_ref = snapshot.result_ref_of(&mote.id)?;
+
+    // 4. Construct the CacheHit variant per the candidate's NdClass.
+    //    BLAKE3 collision resistance over derive_mote_id's inputs means
+    //    the candidate's nd_class matches the committed entry's
+    //    nondeterminism when their MoteIds match.
+    Some(match mote.def.nd_class {
+        NdClass::Pure => CacheHit::Pure { result_ref },
+        NdClass::ReadOnlyNondet => CacheHit::ReadOnlyNondet { result_ref },
+        NdClass::WorldMutating => CacheHit::WorldMutating {
+            result_ref,
+            redispatch_effect: true,
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Inline tests — fixture-heavy unit tests live in tests/proptest_memoizer.rs
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hit_result_ref_accessor_is_variant_agnostic() {
+        let r = ContentRef::of(b"x");
+        assert_eq!(CacheHit::Pure { result_ref: r }.result_ref(), &r);
+        assert_eq!(CacheHit::ReadOnlyNondet { result_ref: r }.result_ref(), &r);
+        assert_eq!(
+            CacheHit::WorldMutating {
+                result_ref: r,
+                redispatch_effect: true
+            }
+            .result_ref(),
+            &r
+        );
+    }
+
+    #[test]
+    fn variants_are_distinct_under_partial_eq() {
+        let r = ContentRef::of(b"x");
+        assert_ne!(
+            CacheHit::Pure { result_ref: r },
+            CacheHit::ReadOnlyNondet { result_ref: r },
+        );
+        assert_ne!(
+            CacheHit::Pure { result_ref: r },
+            CacheHit::WorldMutating {
+                result_ref: r,
+                redispatch_effect: true
+            },
+        );
+        assert_ne!(
+            CacheHit::ReadOnlyNondet { result_ref: r },
+            CacheHit::WorldMutating {
+                result_ref: r,
+                redispatch_effect: true
+            },
+        );
+    }
+
+    #[test]
+    fn requires_redispatch_only_true_for_world_mutating() {
+        let r = ContentRef::of(b"x");
+        assert!(!CacheHit::Pure { result_ref: r }.requires_redispatch());
+        assert!(!CacheHit::ReadOnlyNondet { result_ref: r }.requires_redispatch());
+        assert!(CacheHit::WorldMutating {
+            result_ref: r,
+            redispatch_effect: true
+        }
+        .requires_redispatch());
+    }
+}

--- a/kx-memoizer/tests/concurrency.rs
+++ b/kx-memoizer/tests/concurrency.rs
@@ -1,0 +1,132 @@
+//! Concurrency tests for `kx-memoizer` (SN-4 v2 #7).
+//!
+//! - Compile-time `Send + Sync` over the full public-type set.
+//! - 4-thread thread-independence of `lookup` (Arc<Snapshot> + Arc<Mote>;
+//!   identical outcomes across threads — pins the "no thread-local state"
+//!   contract that machine-independent replay requires).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::thread;
+
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_memoizer::{lookup, CacheHit};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    MoteId, NdClass, PromptTemplateHash,
+};
+use kx_projection::Projection;
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Compile-time Send + Sync
+// ---------------------------------------------------------------------------
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn public_types_are_send_and_sync() {
+    assert_send_sync::<CacheHit>();
+}
+
+// ---------------------------------------------------------------------------
+// 4-thread thread-independence of `lookup`
+// ---------------------------------------------------------------------------
+
+fn make_pure_mote(mote_id: MoteId) -> Mote {
+    Mote {
+        id: mote_id,
+        def: MoteDef {
+            logic_ref: LogicRef([0; 32]),
+            model_id: ModelId("m".into()),
+            prompt_template_hash: PromptTemplateHash([0; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::Pure,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            schema_version: kx_mote::MOTE_DEF_SCHEMA_VERSION,
+        },
+        input_data_id: InputDataId([0; 32]),
+        graph_position: GraphPosition(vec![0]),
+        parents: SmallVec::new(),
+    }
+}
+
+fn build_committed(mote_id: MoteId, result_ref: ContentRef) -> JournalEntry {
+    JournalEntry::Committed {
+        mote_id,
+        idempotency_key: mote_id.0,
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref,
+        parents: SmallVec::new(),
+        mote_def_hash: MoteDefHash([0; 32]),
+    }
+}
+
+#[test]
+fn lookup_is_thread_independent_under_real_move() {
+    let store = InMemoryContentStore::new();
+    let rr = store.put(b"pure-payload").unwrap();
+    let mid = MoteId([42; 32]);
+    let journal = InMemoryJournal::new();
+    let _ = journal.append(build_committed(mid, rr)).unwrap();
+    let snapshot = Projection::from_journal(&journal).unwrap().snapshot();
+
+    let mote = make_pure_mote(mid);
+
+    let snapshot = Arc::new(snapshot);
+    let mote = Arc::new(mote);
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let s = Arc::clone(&snapshot);
+            let m = Arc::clone(&mote);
+            thread::spawn(move || lookup(&m, &s))
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(4);
+    for h in handles {
+        results.push(h.join().expect("worker did not panic"));
+    }
+    let first = &results[0];
+    for r in &results[1..] {
+        assert_eq!(first, r, "lookup must be thread-independent");
+    }
+    assert_eq!(*first, Some(CacheHit::Pure { result_ref: rr }));
+}
+
+#[test]
+fn lookup_miss_is_thread_independent_under_real_move() {
+    // Same shape as above, but with an empty projection — every thread
+    // should observe a cache miss. Pins that misses are also
+    // thread-independent (not just hits).
+    let journal = InMemoryJournal::new();
+    let snapshot = Projection::from_journal(&journal).unwrap().snapshot();
+    let mote = make_pure_mote(MoteId([99; 32]));
+
+    let snapshot = Arc::new(snapshot);
+    let mote = Arc::new(mote);
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let s = Arc::clone(&snapshot);
+            let m = Arc::clone(&mote);
+            thread::spawn(move || lookup(&m, &s))
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(4);
+    for h in handles {
+        results.push(h.join().expect("worker did not panic"));
+    }
+    let first = &results[0];
+    for r in &results[1..] {
+        assert_eq!(first, r, "lookup miss must be thread-independent");
+    }
+    assert_eq!(*first, None);
+}

--- a/kx-memoizer/tests/proptest_memoizer.rs
+++ b/kx-memoizer/tests/proptest_memoizer.rs
@@ -1,0 +1,437 @@
+//! Property tests for `kx-memoizer` (SN-4 v2 #6 — pinned per D33 + `validate-then-commit.md` §10.5).
+//!
+//! Properties:
+//!
+//! 1. `lookup` is DETERMINISTIC — same `(mote, snapshot)` → same result.
+//! 2. `lookup` is TOTAL — never panics on any input shape.
+//! 3. Cache hit on a Committed Mote returns the **right variant** per
+//!    the candidate's [`NdClass`] AND carries the snapshot's `result_ref`.
+//! 4. Non-Committed Motes ALWAYS miss (Pending, Scheduled, Failed,
+//!    Repudiated → `None`).
+//! 5. Data-edge Repudiated parents POISON the cache (return `None`) even
+//!    when the candidate itself is Committed.
+//! 6. Control-edge Repudiated parents do NOT taint (they're sync-only;
+//!    Control edges contribute no data semantics).
+//! 7. WorldMutating cache hits ALWAYS carry `redispatch_effect: true` —
+//!    the constraint is enforced by construction, not by convention.
+
+use std::collections::BTreeMap;
+
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry, RepudiationReason};
+use kx_memoizer::{lookup, CacheHit};
+use kx_mote::{
+    EdgeMeta, EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef,
+    MoteDefHash, MoteId, NdClass, ParentRef, PromptTemplateHash,
+};
+use kx_projection::{Projection, Snapshot};
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn make_mote_with_nd(mote_id: MoteId, parents: SmallVec<[ParentRef; 4]>, nd: NdClass) -> Mote {
+    Mote {
+        id: mote_id,
+        def: MoteDef {
+            logic_ref: LogicRef([0; 32]),
+            model_id: ModelId("m".into()),
+            prompt_template_hash: PromptTemplateHash([0; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: nd,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            schema_version: kx_mote::MOTE_DEF_SCHEMA_VERSION,
+        },
+        input_data_id: InputDataId([0; 32]),
+        graph_position: GraphPosition(vec![0]),
+        parents,
+    }
+}
+
+fn build_committed(mote_id: MoteId, result_ref: ContentRef, nd: NdClass) -> JournalEntry {
+    JournalEntry::Committed {
+        mote_id,
+        idempotency_key: mote_id.0,
+        seq: 0,
+        nondeterminism: nd,
+        result_ref,
+        parents: SmallVec::new(),
+        mote_def_hash: MoteDefHash([0; 32]),
+    }
+}
+
+fn build_repudiation(target_mote_id: MoteId, target_committed_seq: u64) -> JournalEntry {
+    JournalEntry::Repudiated {
+        target_mote_id,
+        idempotency_key: kx_journal::repudiation_idempotency_key(
+            &target_mote_id,
+            target_committed_seq,
+        ),
+        seq: 0,
+        target_committed_seq,
+        reason_class: RepudiationReason::CriticInvalidated,
+        repudiator_id: 0,
+    }
+}
+
+/// Build a `Snapshot` with `(mote_id, result_ref, nd_class)` triples
+/// committed. Optionally repudiate the first one (to test the cascade).
+///
+/// `InMemoryJournal::append` assigns monotonic `seq` per insertion,
+/// overriding whatever the caller put in. To repudiate correctly we must
+/// capture the seq the journal assigned to the Committed entry and use
+/// it as the Repudiated entry's `target_committed_seq`.
+fn fixture_snapshot(commits: &[(MoteId, ContentRef, NdClass)], repudiate_first: bool) -> Snapshot {
+    let store = InMemoryContentStore::new();
+    let journal = InMemoryJournal::new();
+    let mut first_committed_seq: Option<u64> = None;
+    let mut first_mid: Option<MoteId> = None;
+    for (i, (mid, rr, nd)) in commits.iter().enumerate() {
+        let _ = store.put(rr.as_bytes()).ok();
+        let returned = journal.append(build_committed(*mid, *rr, *nd)).unwrap();
+        if i == 0 {
+            first_committed_seq = Some(returned.seq());
+            first_mid = Some(*mid);
+        }
+    }
+    if repudiate_first {
+        if let (Some(mid), Some(seq)) = (first_mid, first_committed_seq) {
+            let _ = journal.append(build_repudiation(mid, seq)).unwrap();
+        }
+    }
+    Projection::from_journal(&journal).unwrap().snapshot()
+}
+
+fn arb_seed() -> impl Strategy<Value = u8> {
+    1u8..=200
+}
+
+fn arb_payload() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 0..=128)
+}
+
+fn arb_nd_class() -> impl Strategy<Value = NdClass> {
+    // MUST be updated when a NdClass variant is added — this strategy is the
+    // test surface's gate against silent variant addition (mirrors the
+    // STEP 6.2 canonical-classifier-cannot-drift contract from PR 4.5).
+    prop_oneof![
+        Just(NdClass::Pure),
+        Just(NdClass::ReadOnlyNondet),
+        Just(NdClass::WorldMutating),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Hand-written unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lookup_on_empty_projection_misses() {
+    let journal = InMemoryJournal::new();
+    let snapshot = Projection::from_journal(&journal).unwrap().snapshot();
+    let mote = make_mote_with_nd(MoteId([1; 32]), SmallVec::new(), NdClass::Pure);
+    assert_eq!(lookup(&mote, &snapshot), None);
+}
+
+#[test]
+fn lookup_pure_committed_returns_pure_hit_with_committed_result_ref() {
+    let mid = MoteId([5; 32]);
+    let rr = ContentRef::of(b"pure-result");
+    let snapshot = fixture_snapshot(&[(mid, rr, NdClass::Pure)], false);
+    let mote = make_mote_with_nd(mid, SmallVec::new(), NdClass::Pure);
+    assert_eq!(
+        lookup(&mote, &snapshot),
+        Some(CacheHit::Pure { result_ref: rr })
+    );
+}
+
+#[test]
+fn lookup_read_only_nondet_committed_returns_ron_hit() {
+    let mid = MoteId([6; 32]);
+    let rr = ContentRef::of(b"ron-observation");
+    let snapshot = fixture_snapshot(&[(mid, rr, NdClass::ReadOnlyNondet)], false);
+    let mote = make_mote_with_nd(mid, SmallVec::new(), NdClass::ReadOnlyNondet);
+    assert_eq!(
+        lookup(&mote, &snapshot),
+        Some(CacheHit::ReadOnlyNondet { result_ref: rr })
+    );
+}
+
+#[test]
+fn lookup_world_mutating_committed_returns_wm_hit_with_redispatch_true() {
+    let mid = MoteId([7; 32]);
+    let rr = ContentRef::of(b"wm-decision");
+    let snapshot = fixture_snapshot(&[(mid, rr, NdClass::WorldMutating)], false);
+    let mote = make_mote_with_nd(mid, SmallVec::new(), NdClass::WorldMutating);
+    let hit = lookup(&mote, &snapshot).expect("WM committed should be a cache hit");
+    match hit {
+        CacheHit::WorldMutating {
+            result_ref,
+            redispatch_effect,
+        } => {
+            assert_eq!(result_ref, rr);
+            assert!(
+                redispatch_effect,
+                "WM hits MUST have redispatch_effect=true"
+            );
+        }
+        other => panic!("expected WorldMutating, got {other:?}"),
+    }
+    assert!(hit.requires_redispatch());
+}
+
+#[test]
+fn lookup_repudiated_mote_misses() {
+    let mid = MoteId([8; 32]);
+    let rr = ContentRef::of(b"repudiated-payload");
+    // Commit then repudiate the same Mote.
+    let snapshot = fixture_snapshot(&[(mid, rr, NdClass::Pure)], true);
+    let mote = make_mote_with_nd(mid, SmallVec::new(), NdClass::Pure);
+    // The Mote itself is Repudiated → cache miss.
+    assert_eq!(lookup(&mote, &snapshot), None);
+}
+
+#[test]
+fn lookup_with_repudiated_data_edge_parent_misses() {
+    // Commit a parent + child, then repudiate the parent. Child's cache
+    // hit should be poisoned by the cascade.
+    let parent_id = MoteId([10; 32]);
+    let child_id = MoteId([11; 32]);
+    let parent_rr = ContentRef::of(b"parent-result");
+    let child_rr = ContentRef::of(b"child-result");
+
+    let store = InMemoryContentStore::new();
+    let _ = store.put(parent_rr.as_bytes()).ok();
+    let _ = store.put(child_rr.as_bytes()).ok();
+    let journal = InMemoryJournal::new();
+    let parent_committed = journal
+        .append(build_committed(parent_id, parent_rr, NdClass::Pure))
+        .unwrap();
+    let _ = journal
+        .append(build_committed(child_id, child_rr, NdClass::Pure))
+        .unwrap();
+    let _ = journal
+        .append(build_repudiation(parent_id, parent_committed.seq()))
+        .unwrap();
+    let snapshot = Projection::from_journal(&journal).unwrap().snapshot();
+
+    let parents: SmallVec<[ParentRef; 4]> = SmallVec::from_vec(vec![ParentRef {
+        parent_id,
+        edge: EdgeMeta::data(),
+    }]);
+    let child = make_mote_with_nd(child_id, parents, NdClass::Pure);
+    assert_eq!(
+        lookup(&child, &snapshot),
+        None,
+        "Repudiated Data-edge parent MUST poison the cache"
+    );
+}
+
+#[test]
+fn lookup_with_repudiated_control_edge_parent_still_hits() {
+    // Control edges are sync-only; a Repudiated Control parent does NOT
+    // taint the cache (Control carries no data semantics).
+    let parent_id = MoteId([12; 32]);
+    let child_id = MoteId([13; 32]);
+    let parent_rr = ContentRef::of(b"control-parent-result");
+    let child_rr = ContentRef::of(b"child-result-ctrl");
+
+    let journal = InMemoryJournal::new();
+    let parent_committed = journal
+        .append(build_committed(parent_id, parent_rr, NdClass::Pure))
+        .unwrap();
+    let _ = journal
+        .append(build_committed(child_id, child_rr, NdClass::Pure))
+        .unwrap();
+    let _ = journal
+        .append(build_repudiation(parent_id, parent_committed.seq()))
+        .unwrap();
+    let snapshot = Projection::from_journal(&journal).unwrap().snapshot();
+
+    let parents: SmallVec<[ParentRef; 4]> = SmallVec::from_vec(vec![ParentRef {
+        parent_id,
+        edge: EdgeMeta::control(),
+    }]);
+    let child = make_mote_with_nd(child_id, parents, NdClass::Pure);
+    assert_eq!(
+        lookup(&child, &snapshot),
+        Some(CacheHit::Pure {
+            result_ref: child_rr
+        }),
+        "Repudiated Control-edge parent MUST NOT poison the cache (Control = sync only)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 1: `lookup` is DETERMINISTIC — same inputs → same result.
+    #[test]
+    fn prop_lookup_is_deterministic(
+        seed in arb_seed(),
+        payload in arb_payload(),
+        nd in arb_nd_class(),
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let snapshot = fixture_snapshot(&[(mid, rr, nd)], false);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), nd);
+        let a = lookup(&mote, &snapshot);
+        let b = lookup(&mote, &snapshot);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Property 2: `lookup` is TOTAL — never panics regardless of inputs.
+    /// Sweeps NdClass × Repudiated × empty/committed snapshot.
+    #[test]
+    fn prop_lookup_is_total(
+        seed in arb_seed(),
+        payload in arb_payload(),
+        nd in arb_nd_class(),
+        is_committed in any::<bool>(),
+        is_repudiated in any::<bool>(),
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let commits: Vec<(MoteId, ContentRef, NdClass)> = if is_committed {
+            vec![(mid, rr, nd)]
+        } else {
+            vec![]
+        };
+        let snapshot = fixture_snapshot(&commits, is_repudiated);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), nd);
+        // Reaching this assertion proves no panic.
+        let _ = lookup(&mote, &snapshot);
+    }
+
+    /// Property 3: a Committed Mote (not Repudiated) with no Repudiated
+    /// parents ALWAYS yields a CacheHit whose variant mirrors the
+    /// candidate's NdClass AND whose result_ref matches the snapshot's.
+    #[test]
+    fn prop_committed_yields_correct_variant_and_ref(
+        seed in arb_seed(),
+        payload in arb_payload(),
+        nd in arb_nd_class(),
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let snapshot = fixture_snapshot(&[(mid, rr, nd)], false);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), nd);
+        let hit = lookup(&mote, &snapshot).expect("Committed non-Repudiated MUST hit");
+        prop_assert_eq!(*hit.result_ref(), rr);
+        match (nd, &hit) {
+            (NdClass::Pure, CacheHit::Pure { .. })
+            | (NdClass::ReadOnlyNondet, CacheHit::ReadOnlyNondet { .. })
+            | (NdClass::WorldMutating, CacheHit::WorldMutating { redispatch_effect: true, .. })
+                => {}
+            _ => prop_assert!(false,
+                "variant mismatch: candidate nd={nd:?}, hit={hit:?}"),
+        }
+    }
+
+    /// Property 4: a non-Committed Mote ALWAYS misses.
+    /// (Pending → not in journal; Repudiated covered separately.)
+    #[test]
+    fn prop_non_committed_always_misses(
+        seed in arb_seed(),
+        nd in arb_nd_class(),
+    ) {
+        // Empty journal → no commit for this mote_id → not Committed.
+        let snapshot = fixture_snapshot(&[], false);
+        let mote = make_mote_with_nd(MoteId([seed; 32]), SmallVec::new(), nd);
+        prop_assert_eq!(lookup(&mote, &snapshot), None);
+    }
+
+    /// Property 5: a Repudiated Mote ALWAYS misses regardless of NdClass.
+    #[test]
+    fn prop_repudiated_self_always_misses(
+        seed in arb_seed(),
+        payload in arb_payload(),
+        nd in arb_nd_class(),
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let snapshot = fixture_snapshot(&[(mid, rr, nd)], true);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), nd);
+        prop_assert_eq!(lookup(&mote, &snapshot), None);
+    }
+
+    /// Property 6: WorldMutating hits ALWAYS have redispatch_effect == true.
+    /// Construction-enforced (the variant only has one shape), but pin it
+    /// with a property to guard against a future API change relaxing this.
+    #[test]
+    fn prop_world_mutating_hits_always_require_redispatch(
+        seed in arb_seed(),
+        payload in arb_payload(),
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let snapshot = fixture_snapshot(&[(mid, rr, NdClass::WorldMutating)], false);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), NdClass::WorldMutating);
+        let hit = lookup(&mote, &snapshot).expect("WM Committed MUST hit");
+        prop_assert!(hit.requires_redispatch());
+        if let CacheHit::WorldMutating { redispatch_effect, .. } = hit {
+            prop_assert!(redispatch_effect);
+        } else {
+            prop_assert!(false, "expected WorldMutating, got {:?}", hit);
+        }
+    }
+
+    /// Property 7: lookup is PURE — read-only over snapshot, no observable
+    /// side effects. We approximate "no side effects" by asserting the
+    /// snapshot's state is unchanged across N back-to-back lookups.
+    /// (Snapshot is immutable by type; this property guards against a
+    /// future API change introducing interior mutability.)
+    #[test]
+    fn prop_lookup_is_pure_over_snapshot(
+        seed in arb_seed(),
+        payload in arb_payload(),
+        nd in arb_nd_class(),
+        n in 1usize..=8,
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let snapshot = fixture_snapshot(&[(mid, rr, nd)], false);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), nd);
+        let baseline = snapshot.committed_count();
+        let first = lookup(&mote, &snapshot);
+        for _ in 0..n {
+            let r = lookup(&mote, &snapshot);
+            prop_assert_eq!(&first, &r, "lookup must be idempotent");
+        }
+        prop_assert_eq!(snapshot.committed_count(), baseline,
+            "lookup must NOT mutate the snapshot");
+    }
+
+    /// Property 8 (class-covering sweep — mirrors PR 4.5 STEP 6.2): for
+    /// every NdClass variant generated by `arb_nd_class`, a Committed
+    /// non-Repudiated Mote MUST hit. If a future variant is added but the
+    /// strategy isn't updated, this proptest's coverage shrinks but
+    /// existing variants still pass — the comment on `arb_nd_class` is
+    /// the canonical update site.
+    #[test]
+    fn prop_every_nd_class_can_hit(
+        seed in arb_seed(),
+        payload in arb_payload(),
+        nd in arb_nd_class(),
+    ) {
+        let mid = MoteId([seed; 32]);
+        let rr = ContentRef::of(&payload);
+        let snapshot = fixture_snapshot(&[(mid, rr, nd)], false);
+        let mote = make_mote_with_nd(mid, SmallVec::new(), nd);
+        prop_assert!(lookup(&mote, &snapshot).is_some(),
+            "NdClass {nd:?} MUST be cacheable when Committed and not Repudiated");
+    }
+}


### PR DESCRIPTION
## Summary

NEW CRATE. Born SN-4 v2 + SN-7 compliant — fifth crate in the foundation-pattern chain (P1.7.5 → P1.7.6 → P1.7.7 → P1.7.8 → **P1.7.9**).

The memoizer answers one question with cryptographic precision:

> "Have we already committed for this exact `MoteId`, and is the commitment safe to serve as a cache hit?"

`lookup(mote, snapshot) → Option<CacheHit>` is **pure, total, deterministic**. EXACT cryptographic equality only — **NO similarity operator** anywhere on the identity path (SN-8 mandate). Two Motes match iff their derived `MoteId`s match bit-for-bit.

## Public API (entirely additive)

- `CacheHit` enum (3 variants mirroring `NdClass`):
  - `Pure { result_ref }` — deterministic; serve directly.
  - `ReadOnlyNondet { result_ref }` — durable observation; serve directly.
  - `WorldMutating { result_ref, redispatch_effect: true }` — decision is reusable, but the executor MUST re-dispatch the broker effect. `redispatch_effect` is **loud-by-design** — the constraint is named at every match site rather than buried in prose.
- `CacheHit::result_ref(&self) -> &ContentRef` — variant-agnostic accessor.
- `CacheHit::requires_redispatch(&self) -> bool` — true iff `WorldMutating`.
- `lookup(mote: &Mote, snapshot: &Snapshot) -> Option<CacheHit>` — the pure cross-reference.

## Algorithm

Returns `Some(CacheHit)` iff ALL of:
1. `snapshot.state_of(&mote.id) == MoteState::Committed`
2. No **Data**-edge parent is `MoteState::Repudiated` (cascade poison; **Control** edges are sync-only and do NOT taint)
3. `snapshot.result_ref_of(&mote.id)` returns `Some(ref)`

By BLAKE3 collision resistance over `derive_mote_id`'s inputs (which include `mote_def_hash`, and `mote_def_hash` includes `nd_class`), a `MoteId` match implies the prior commit's `nd_class` matches the candidate's — no need to re-query the committed entry's nondeterminism field.

## Effect-once vs inference-once separation (validate-then-commit.md §10.5)

These are **SEPARATE primitives**:
- **Memoizer** = inference-once: caches the model's decision.
- **Broker** (P1.8.5) = effect-once: deduplicates side effects against the warrant-scoped world.

On a `WorldMutating` cache hit, the executor still re-dispatches the broker effect against the cached `result_ref` — the cache supplies the decision, but the effect goes through the broker per attempt.

## NO similarity, NO fuzzy match — by design

Two "similar" Motes with different `MoteId`s are distinct facts. The escape hatch for fuzzy-similar-but-not-identical inputs is the **normalizer** (P1.7.10, the next PR): deterministic canonicalization BEFORE fingerprinting.

## Tests: 25 (all green)

| Category | Count |
|---|---|
| Inline unit (src/lib.rs) | 3 (variant accessors + distinctness + redispatch invariant) |
| Integration unit (proptest_memoizer.rs) | 7 (empty projection, Pure/RON/WM hits, self-Repudiated miss, Data-edge cascade poison, Control-edge non-taint) |
| Proptests × 64 cases | 8 (deterministic, total, variant-and-ref, non-committed-misses, repudiated-self-misses, WM-requires-redispatch, pure-over-snapshot, every-nd-class-can-hit) |
| Concurrency | 3 (Send+Sync over CacheHit; 4-thread hit + miss thread-independence under `Arc<Snapshot>`+`Arc<Mote>`) |
| Doctests | 4 (CacheHit module, result_ref accessor, requires_redispatch, lookup smoke) |
| **Crate total** | **25** |
| **Workspace total** | **363 / 363** |

## Canonical-classifier-cannot-drift (STEP 6.2 from PR 4.5)

`arb_nd_class()` proptest strategy enumerates ALL `NdClass` variants with a code comment marking it as the canonical update site for new variants. Mirror of the `arb_failure_reason` pattern PR 4.5 STEP 6.2 locked.

## Gates (Apple Silicon local)

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (363/363, up from 338)
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✓

## SN-2 audit

- Path scan ✅ + content scan ✅ (0 matches across all 4 staged files)

## Deps (workspace-inherited only)

- Runtime: `kx-content` + `kx-mote` + `kx-projection` + `serde` + `thiserror` + `tracing`
- Dev: `kx-journal` + `proptest` + `smallvec` + `tracing-subscriber`
- No new top-level workspace deps. Workspace `Cargo.toml`: added `kx-memoizer` member + workspace dep.

## What's NOT here

- The executor's dispatch decision tree (P1.9).
- The broker's effect-once primitive (P1.8.5).
- The journal-write side of memoization. **Memoizer is a READ-side primitive only.**
- Any "similar" or "fuzzy" matcher. The normalizer (P1.7.10, next PR) is the canonicalization seam.

## Compliance

- [x] **SN-1**: D33 + validate-then-commit.md §10.5 locked in private corpus (`cea0583`).
- [x] **SN-2**: pre-merge audit clean.
- [x] **SN-4 v2**: born compliant — `forbid(unsafe_code)` + `clippy::pedantic` + 8 proptests × 64 cases + Send+Sync compile-time set + 4 doctests + thread-independence under `Arc<>`.
- [x] **SN-5**: master plan already archived in `cbd3b98` (the D30–D36 design freeze; memoizer was part of that locked corpus).
- [x] **SN-6**: prereqs all green (kx-mote ✅ + kx-content ✅ + kx-projection ✅).
- [x] **SN-7**: Linux Actions comment follows after CI green.
- [x] **SN-8**: ENFORCED by API design — no similarity operator anywhere on the identity path; `lookup` performs cryptographic equality only.

## Next

PR 6 — kx-normalizer (P1.7.10) — the deterministic-canonicalization-before-fingerprinting primitive. With kx-memoizer merged, P1.7.10's prereqs are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)