### PR TITLE
P1.7.10: kx-normalizer — deterministic canonicalization BEFORE fingerprinting (D33 + context-assembly.md §4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-normalizer"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "kx-mote",
+ "proptest",
+ "serde",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-projection"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator", "kx-warrant", "kx-tool-registry", "kx-context-assembler", "kx-memoizer"]
+members = ["kx-mote", "kx-content", "kx-journal", "kx-projection", "kx-llamacpp-sys", "kx-llamacpp", "kx-model-validator", "kx-warrant", "kx-tool-registry", "kx-context-assembler", "kx-memoizer", "kx-normalizer"]
 exclude = ["kx-cloud"]
 
 [workspace.package]
@@ -34,6 +34,7 @@ kx-warrant         = { path = "kx-warrant" }
 kx-tool-registry   = { path = "kx-tool-registry" }
 kx-context-assembler = { path = "kx-context-assembler" }
 kx-memoizer        = { path = "kx-memoizer" }
+kx-normalizer      = { path = "kx-normalizer" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/kx-normalizer/Cargo.toml
+++ b/kx-normalizer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name         = "kx-normalizer"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx normalizer — deterministic canonicalization BEFORE fingerprinting (D33 + context-assembly.md §4). The fix is NOT fuzzy matching (forbidden by SN-8). Conservative: when unsure, keep distinct. v0.1 ships ONE rule set: CommandLineIntent v1."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+bytes     = { workspace = true }
+kx-mote   = { workspace = true }
+serde     = { workspace = true }
+thiserror = { workspace = true }
+tracing   = { workspace = true }
+
+[dev-dependencies]
+proptest           = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/kx-normalizer/src/lib.rs
+++ b/kx-normalizer/src/lib.rs
@@ -1,0 +1,382 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+
+//! # kx-normalizer — deterministic canonicalization BEFORE fingerprinting
+//!
+//! The normalizer is the controlled escape hatch for "two inputs that mean
+//! the same thing but aren't bit-identical" — exactly the situation where a
+//! lesser system would reach for fuzzy matching. **The fix is NOT fuzzy
+//! matching.** Per SN-8 ("model proposes, runtime enforces") and D33, the
+//! runtime serves cache hits only on EXACT cryptographic equality. Two
+//! Motes match iff their derived `MoteId`s match bit-for-bit. There is NO
+//! similarity operator anywhere on the identity path.
+//!
+//! The normalizer reconciles this with the workflow author's reasonable
+//! expectation that `"ls   -la"` and `"ls -la"` should refer to the same
+//! command. It does so by **canonicalizing inputs BEFORE they feed into
+//! `MoteId` derivation** — the two inputs become bit-identical after the
+//! rule applies, and the memoizer's exact-equality hit then fires for
+//! free. The fingerprint is computed over the canonical form.
+//!
+//! ## Two normalizer kinds (D33)
+//!
+//! - [`NormalizerKind::DeterministicRule`] — a versioned rule set, applied
+//!   purely. Bit-identical across machines + replays per `(rule_set,
+//!   version)`. **v0.1 ships ONE rule set**: [`RuleSet::CommandLineIntent`]
+//!   v1, which canonicalizes whitespace (trim + collapse internal
+//!   whitespace runs to a single ASCII space). Conservative — does NOT
+//!   reorder flags, does NOT resolve paths, does NOT canonicalize
+//!   quoting. **When the rule is unsure, it keeps inputs distinct.**
+//!
+//! - [`NormalizerKind::ModelAsMote`] — the model-as-Mote seam for fuzzy
+//!   residue. The normalizer IS itself a Mote whose canonical output is
+//!   content-addressed and replayed. This is the escape hatch when a
+//!   deterministic rule cannot encode the intent; the model's
+//!   canonicalization is frozen as a durable fact.
+//!
+//! ## Why "conservative" matters
+//!
+//! A normalizer that merges things it shouldn't is far worse than one that
+//! keeps too many things distinct. Merging silently routes cache hits to
+//! the wrong upstream — a correctness bug that surfaces only under
+//! workflow author surprise. Keeping things distinct surfaces as "the
+//! cache didn't fire" — diagnosable, addressable, never silently wrong.
+//!
+//! v0.1's `CommandLineIntent` v1 is intentionally tiny: trim + whitespace
+//! collapse only. No flag-reordering (would silently change `cp src dst`
+//! into `cp dst src` if applied naively). No path normalization (changes
+//! semantics under symlinks). No quoting normalization (requires shell
+//! parser). Each of these is a **deliberate future-rule slot** — when
+//! added, they bump the rule version, never silently change v1's
+//! behavior.
+//!
+//! ## Versioning
+//!
+//! `(rule_set, version)` is the dispatch key. Two callers with the same
+//! `(rule_set, version)` get bit-identical canonical bytes; replay
+//! reproduces verbatim. **Future rule additions MUST bump the version**
+//! — silently changing v1's canonical output would break replay for
+//! every MoteId derived from a v1-normalized input.
+//!
+//! ## What lives here
+//!
+//! - [`RuleSet`] — the versioned rule-set identifier enum.
+//! - [`NormalizerKind`] — the per-call dispatch discriminant.
+//! - [`NormalizerError`] — typed failures.
+//! - [`normalize_deterministic`] — apply a rule set + version to raw bytes.
+//!
+//! ## What does NOT live here
+//!
+//! - The fingerprint computation itself (that's `kx_mote::derive_mote_id`).
+//! - The journal-write side of "ModelAsMote" normalizers (the executor at
+//!   P1.9 commits the model's canonical output as a Mote).
+//! - Any similarity operator. **Forbidden by SN-8** anywhere on the
+//!   identity path.
+
+use bytes::Bytes;
+use kx_mote::MoteId;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// RuleSet — versioned identifier of a deterministic canonicalization rule
+// ---------------------------------------------------------------------------
+
+/// Identifier for a deterministic canonicalization rule set.
+///
+/// Two calls to [`normalize_deterministic`] with the same `(RuleSet,
+/// version)` produce bit-identical canonical bytes — across machines,
+/// across replays, across process restarts.
+///
+/// **v0.1 ships exactly one variant**: [`RuleSet::CommandLineIntent`].
+/// Future variants extend this enum; the canonical-classifier-cannot-drift
+/// pattern (STEP 6.2 from PR 4.5) governs the proptest strategy update.
+///
+/// # Examples
+///
+/// ```
+/// use kx_normalizer::RuleSet;
+///
+/// // RuleSet is small + Copy; cheap to pass by value.
+/// let rs = RuleSet::CommandLineIntent;
+/// assert_eq!(rs, RuleSet::CommandLineIntent);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum RuleSet {
+    /// Canonicalize command-line-intent text.
+    ///
+    /// **v1 ships exactly one rule**: trim leading/trailing whitespace
+    /// AND collapse internal whitespace runs (any Unicode whitespace) to
+    /// a single ASCII space. UTF-8 only.
+    ///
+    /// Deliberately conservative:
+    /// - Does NOT reorder flags (would silently break `cp src dst` if
+    ///   applied naively).
+    /// - Does NOT resolve `./` / `../` in paths (changes semantics under
+    ///   symlinks).
+    /// - Does NOT canonicalize quoting (requires a shell parser).
+    ///
+    /// Each of those is a deliberate future-rule slot. When added, they
+    /// bump the version — they NEVER silently change v1's behavior.
+    CommandLineIntent,
+}
+
+impl RuleSet {
+    /// The highest version this build supports for `self`. Increments when
+    /// a new rule lands on the same rule set.
+    #[must_use]
+    pub const fn current_version(self) -> u32 {
+        match self {
+            Self::CommandLineIntent => 1,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NormalizerKind — per-call dispatch discriminant
+// ---------------------------------------------------------------------------
+
+/// Per-call dispatch discriminant: which normalizer (if any) was applied
+/// to the raw input before `MoteId` derivation.
+///
+/// Stored in the workflow author's submission spec so replay knows how to
+/// reproduce the canonical form bit-for-bit.
+///
+/// # Examples
+///
+/// ```
+/// use kx_normalizer::{NormalizerKind, RuleSet};
+///
+/// // Deterministic rule: replay reproduces from (rule_set, version).
+/// let det = NormalizerKind::DeterministicRule {
+///     rule_set: RuleSet::CommandLineIntent,
+///     version: 1,
+/// };
+///
+/// // Model-as-Mote: replay reads the cached canonical output via mote_id.
+/// // (The MoteId here is illustrative.)
+/// let model = NormalizerKind::ModelAsMote {
+///     mote_id: kx_mote::MoteId::from_bytes([0; 32]),
+/// };
+///
+/// assert_ne!(det, model);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NormalizerKind {
+    /// A deterministic rule applied. Replay needs `(rule_set, version)`
+    /// to reproduce the canonical form bit-for-bit.
+    DeterministicRule {
+        /// The rule set identifier.
+        rule_set: RuleSet,
+        /// The rule set version (>= 1).
+        version: u32,
+    },
+
+    /// The normalizer IS a Mote — its canonical output is content-
+    /// addressed and replayed. Escape hatch for fuzzy residue per D33.
+    /// Replay reads the cached canonical output via `mote_id`; the
+    /// executor at P1.9 commits the model's canonical output as a Mote.
+    ModelAsMote {
+        /// The MoteId of the normalizer-Mote whose committed result_ref
+        /// is the canonical form.
+        mote_id: MoteId,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// NormalizerError — typed failures
+// ---------------------------------------------------------------------------
+
+/// Errors returned by [`normalize_deterministic`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NormalizerError {
+    /// The requested `(rule_set, version)` is not implemented in this
+    /// build. Most often hit when replay encounters a version newer
+    /// than the current binary supports.
+    #[error("rule set {rule_set:?} version {version} is not implemented (this build supports versions 1..={max_supported})")]
+    UnsupportedVersion {
+        /// The requested rule set.
+        rule_set: RuleSet,
+        /// The requested version.
+        version: u32,
+        /// The highest version this build supports for `rule_set`.
+        max_supported: u32,
+    },
+
+    /// The input bytes are not valid UTF-8. The current rule sets all
+    /// require UTF-8 text; this is a precondition violation.
+    #[error("input is not valid UTF-8 (rule set requires UTF-8 text)")]
+    InvalidUtf8,
+}
+
+// ---------------------------------------------------------------------------
+// normalize_deterministic — the dispatch entry point
+// ---------------------------------------------------------------------------
+
+/// Apply a deterministic rule set to raw `input` bytes, returning the
+/// canonical form.
+///
+/// Pure / total / deterministic per `(rule_set, version)`: two calls with
+/// identical inputs produce bit-identical outputs across machines + replays
+/// + process restarts.
+///
+/// # Versioning contract
+///
+/// `(rule_set, version)` is the dispatch key. Future rule additions MUST
+/// bump the version — silently changing an existing version's canonical
+/// output would break replay for every `MoteId` derived from a previously-
+/// normalized input. Replay encountering a version higher than the binary
+/// supports returns [`NormalizerError::UnsupportedVersion`].
+///
+/// # Errors
+///
+/// - [`NormalizerError::UnsupportedVersion`] — `(rule_set, version)` not
+///   implemented in this build.
+/// - [`NormalizerError::InvalidUtf8`] — input is not valid UTF-8 (current
+///   rule sets all require UTF-8 text).
+///
+/// # Examples
+///
+/// ```
+/// use kx_normalizer::{normalize_deterministic, RuleSet};
+///
+/// let raw = b"  ls   -la   ";
+/// let canon = normalize_deterministic(RuleSet::CommandLineIntent, 1, raw).unwrap();
+/// assert_eq!(&canon[..], b"ls -la");
+///
+/// // Same canonical form for any equivalent whitespace variant.
+/// let raw2 = b"\tls\n-la\t\t";
+/// let canon2 = normalize_deterministic(RuleSet::CommandLineIntent, 1, raw2).unwrap();
+/// assert_eq!(canon, canon2);
+/// ```
+#[tracing::instrument(level = "debug", skip(input), fields(rule_set = ?rule_set, version = version, input_len = input.len()))]
+pub fn normalize_deterministic(
+    rule_set: RuleSet,
+    version: u32,
+    input: &[u8],
+) -> Result<Bytes, NormalizerError> {
+    // Exhaustive match on RuleSet — adding a new variant is a compile
+    // error, NOT a silent wildcard match. This is the
+    // canonical-classifier-cannot-drift contract at the code level (mirror
+    // of STEP 6.2 + the `arb_rule_set` proptest strategy at the test
+    // level). Per-variant inner match dispatches on version.
+    match rule_set {
+        RuleSet::CommandLineIntent => match version {
+            1 => command_line_intent_v1(input),
+            _ => Err(NormalizerError::UnsupportedVersion {
+                rule_set,
+                version,
+                max_supported: rule_set.current_version(),
+            }),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CommandLineIntent v1 — the v0.1 rule
+// ---------------------------------------------------------------------------
+
+/// Trim + collapse-internal-whitespace canonicalization.
+///
+/// Algorithm:
+/// 1. Decode `input` as UTF-8 (error if invalid).
+/// 2. Trim leading/trailing whitespace (Unicode `White_Space` property).
+/// 3. Collapse internal runs of whitespace to a single ASCII space.
+/// 4. Encode back to UTF-8 bytes.
+///
+/// **What v1 does NOT do** (each is a deliberate future-rule slot):
+/// - Reorder flags (`ls -la` vs `ls -al` — sorting `-la` would silently
+///   break commands where argument order matters, e.g., `cp src dst`).
+/// - Resolve `./` / `../` in paths (changes semantics under symlinks).
+/// - Canonicalize quoting (`'foo'` vs `"foo"` — requires shell parser).
+/// - Normalize variable interpolation (`$HOME` vs `${HOME}` — env-dependent).
+///
+/// **Idempotence**: `f(f(x)) == f(x)` for all `x`. Verified by proptest.
+fn command_line_intent_v1(input: &[u8]) -> Result<Bytes, NormalizerError> {
+    let s = std::str::from_utf8(input).map_err(|_| NormalizerError::InvalidUtf8)?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Ok(Bytes::new());
+    }
+    // Walk the trimmed string char-by-char, emitting non-whitespace
+    // verbatim and collapsing runs of whitespace to a single ASCII space.
+    let mut out = String::with_capacity(trimmed.len());
+    let mut prev_was_ws = false;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            if !prev_was_ws {
+                out.push(' ');
+                prev_was_ws = true;
+            }
+        } else {
+            out.push(ch);
+            prev_was_ws = false;
+        }
+    }
+    Ok(Bytes::from(out.into_bytes()))
+}
+
+// ---------------------------------------------------------------------------
+// Inline tests — fixture-heavy tests live in tests/proptest_normalizer.rs
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_version_for_command_line_intent_is_one() {
+        assert_eq!(RuleSet::CommandLineIntent.current_version(), 1);
+    }
+
+    #[test]
+    fn unsupported_version_returns_typed_error() {
+        let err = normalize_deterministic(RuleSet::CommandLineIntent, 999, b"hi").unwrap_err();
+        match err {
+            NormalizerError::UnsupportedVersion {
+                rule_set,
+                version,
+                max_supported,
+            } => {
+                assert_eq!(rule_set, RuleSet::CommandLineIntent);
+                assert_eq!(version, 999);
+                assert_eq!(max_supported, 1);
+            }
+            NormalizerError::InvalidUtf8 => panic!("expected UnsupportedVersion, got InvalidUtf8"),
+        }
+    }
+
+    #[test]
+    fn version_zero_returns_unsupported() {
+        let err = normalize_deterministic(RuleSet::CommandLineIntent, 0, b"hi").unwrap_err();
+        assert!(matches!(err, NormalizerError::UnsupportedVersion { .. }));
+    }
+
+    #[test]
+    fn invalid_utf8_returns_typed_error() {
+        // 0xFF is invalid UTF-8.
+        let err =
+            normalize_deterministic(RuleSet::CommandLineIntent, 1, &[0xFF, 0xFE]).unwrap_err();
+        assert_eq!(err, NormalizerError::InvalidUtf8);
+    }
+
+    #[test]
+    fn normalizer_kind_variants_are_distinct() {
+        let det = NormalizerKind::DeterministicRule {
+            rule_set: RuleSet::CommandLineIntent,
+            version: 1,
+        };
+        let model = NormalizerKind::ModelAsMote {
+            mote_id: MoteId::from_bytes([0; 32]),
+        };
+        assert_ne!(det, model);
+    }
+}

--- a/kx-normalizer/tests/concurrency.rs
+++ b/kx-normalizer/tests/concurrency.rs
@@ -1,0 +1,82 @@
+//! Concurrency tests for `kx-normalizer` (SN-4 v2 #7).
+//!
+//! - Compile-time `Send + Sync` over the full public-type set.
+//! - 4-thread thread-independence of `normalize_deterministic`
+//!   (Arc<>'d input, byte-identical outputs across threads — pins the
+//!   "no thread-local state" contract that machine-independent replay
+//!   requires).
+
+use std::sync::Arc;
+use std::thread;
+
+use kx_normalizer::{normalize_deterministic, NormalizerError, NormalizerKind, RuleSet};
+
+// ---------------------------------------------------------------------------
+// Compile-time Send + Sync
+// ---------------------------------------------------------------------------
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn public_types_are_send_and_sync() {
+    assert_send_sync::<RuleSet>();
+    assert_send_sync::<NormalizerKind>();
+    assert_send_sync::<NormalizerError>();
+}
+
+// ---------------------------------------------------------------------------
+// 4-thread thread-independence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn normalize_is_thread_independent_under_real_move() {
+    let input = Arc::new(b"  ls   -la   foo\tbar  ".to_vec());
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let i = Arc::clone(&input);
+            thread::spawn(move || {
+                normalize_deterministic(RuleSet::CommandLineIntent, 1, &i).unwrap()
+            })
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(4);
+    for h in handles {
+        results.push(h.join().expect("worker did not panic"));
+    }
+    let first = &results[0];
+    for r in &results[1..] {
+        assert_eq!(
+            first, r,
+            "normalize_deterministic must be thread-independent (no thread-local state in the normalizer)"
+        );
+    }
+    assert_eq!(&first[..], b"ls -la foo bar");
+}
+
+#[test]
+fn unsupported_version_error_is_thread_independent() {
+    // Pins that even the error path is deterministic across threads.
+    let input = Arc::new(b"hi".to_vec());
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let i = Arc::clone(&input);
+            thread::spawn(move || normalize_deterministic(RuleSet::CommandLineIntent, 999, &i))
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(4);
+    for h in handles {
+        results.push(h.join().expect("worker did not panic"));
+    }
+    let first = &results[0];
+    for r in &results[1..] {
+        assert_eq!(first, r, "error path must be thread-independent");
+    }
+    assert!(matches!(
+        first,
+        Err(NormalizerError::UnsupportedVersion { .. })
+    ));
+}

--- a/kx-normalizer/tests/proptest_normalizer.rs
+++ b/kx-normalizer/tests/proptest_normalizer.rs
@@ -1,0 +1,315 @@
+//! Property tests for `kx-normalizer` (SN-4 v2 #6 — pinned per D33 + `context-assembly.md` §4).
+//!
+//! Properties:
+//!
+//! 1. `normalize_deterministic` is DETERMINISTIC — same `(rule_set,
+//!    version, input)` → bit-identical output.
+//! 2. `normalize_deterministic` is TOTAL — never panics on any input
+//!    shape (including invalid UTF-8 + huge whitespace runs +
+//!    pathological Unicode).
+//! 3. **IDEMPOTENT** — `f(f(x)) == f(x)`. The canonical form is a fixed
+//!    point of the rule; running the normalizer twice produces the same
+//!    bytes as running it once. This is what makes the normalizer safe
+//!    to re-apply on replay without drift.
+//! 4. **No INTERNAL whitespace runs in output** (CommandLineIntent v1
+//!    invariant) — every ASCII space in the output is a separator
+//!    between non-whitespace tokens; never two adjacent.
+//! 5. **No LEADING or TRAILING whitespace in output** (CommandLineIntent
+//!    v1 invariant) — output is trimmed.
+//! 6. **Conservative: when ambiguous, keep distinct.** Two inputs with
+//!    different non-whitespace token sequences MUST produce different
+//!    canonical outputs. Specifically: if a non-whitespace character
+//!    differs between inputs (or the count of non-whitespace tokens
+//!    differs), the canonical outputs differ. The normalizer does NOT
+//!    re-order or merge tokens.
+//! 7. **Class-covering sweep over `RuleSet`** (STEP 6.2 pattern from
+//!    PR 4.5): `arb_rule_set()` enumerates ALL variants with a "MUST
+//!    update on new variant" comment.
+
+use bytes::Bytes;
+use kx_normalizer::{normalize_deterministic, NormalizerError, NormalizerKind, RuleSet};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_rule_set() -> impl Strategy<Value = RuleSet> {
+    // MUST be updated when a RuleSet variant is added — this strategy is
+    // the test surface's gate against silent variant addition (mirrors the
+    // STEP 6.2 canonical-classifier-cannot-drift contract from PR 4.5).
+    prop_oneof![Just(RuleSet::CommandLineIntent),]
+}
+
+/// Strategy: an arbitrary string (any chars including Unicode whitespace).
+fn arb_text() -> impl Strategy<Value = String> {
+    proptest::collection::vec(any::<char>(), 0..=128).prop_map(|v| v.into_iter().collect())
+}
+
+/// Strategy: an arbitrary byte vector (may or may not be valid UTF-8).
+fn arb_bytes() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 0..=128)
+}
+
+// ---------------------------------------------------------------------------
+// Hand-written cell tests for CommandLineIntent v1
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_input_yields_empty_output() {
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"").unwrap();
+    assert_eq!(&out[..], b"");
+}
+
+#[test]
+fn pure_whitespace_yields_empty_output() {
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"   \t\n  ").unwrap();
+    assert_eq!(&out[..], b"");
+}
+
+#[test]
+fn single_word_unchanged() {
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"hello").unwrap();
+    assert_eq!(&out[..], b"hello");
+}
+
+#[test]
+fn collapses_internal_multi_space() {
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"ls   -la").unwrap();
+    assert_eq!(&out[..], b"ls -la");
+}
+
+#[test]
+fn trims_leading_and_trailing() {
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"  hello world  ").unwrap();
+    assert_eq!(&out[..], b"hello world");
+}
+
+#[test]
+fn normalizes_tabs_newlines_and_carriage_returns_to_single_space() {
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"ls\t-la\nfoo\rbar").unwrap();
+    assert_eq!(&out[..], b"ls -la foo bar");
+}
+
+#[test]
+fn unicode_whitespace_collapsed_to_ascii_space() {
+    // U+00A0 NO-BREAK SPACE + U+2003 EM SPACE + ASCII space.
+    let input = "ls\u{00A0}-la\u{2003}foo  bar".as_bytes();
+    let out = normalize_deterministic(RuleSet::CommandLineIntent, 1, input).unwrap();
+    assert_eq!(&out[..], b"ls -la foo bar");
+}
+
+#[test]
+fn flag_ordering_is_not_normalized_v1_conservative() {
+    // CommandLineIntent v1 deliberately does NOT reorder flags. `-la` and
+    // `-al` are DISTINCT inputs and produce DISTINCT canonical outputs.
+    // (A future v2 may add flag-sorting; that v2 will have its own
+    // version key and not silently change v1.)
+    let a = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"ls -la").unwrap();
+    let b = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"ls -al").unwrap();
+    assert_ne!(a, b, "v1 MUST NOT reorder flags (conservative)");
+}
+
+#[test]
+fn argument_ordering_is_not_normalized_v1_conservative() {
+    // `cp src dst` and `cp dst src` are distinct inputs. Sorting tokens
+    // would silently break command semantics — the normalizer refuses to
+    // do this.
+    let a = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"cp src dst").unwrap();
+    let b = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"cp dst src").unwrap();
+    assert_ne!(
+        a, b,
+        "v1 MUST NOT sort tokens (would silently break ordered-argument commands)"
+    );
+}
+
+#[test]
+fn case_is_preserved_v1_conservative() {
+    // Case-sensitivity matters in command-line semantics (especially
+    // flags). v1 preserves case.
+    let a = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"Hello World").unwrap();
+    let b = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"hello world").unwrap();
+    assert_ne!(a, b, "v1 MUST preserve case");
+}
+
+#[test]
+fn idempotent_smoke() {
+    let raw = b"  ls   -la  ";
+    let once = normalize_deterministic(RuleSet::CommandLineIntent, 1, raw).unwrap();
+    let twice = normalize_deterministic(RuleSet::CommandLineIntent, 1, &once).unwrap();
+    assert_eq!(once, twice, "normalize MUST be idempotent");
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 1: DETERMINISTIC — same inputs, same output.
+    #[test]
+    fn prop_normalize_is_deterministic(
+        rs in arb_rule_set(),
+        text in arb_text(),
+    ) {
+        let a = normalize_deterministic(rs, 1, text.as_bytes());
+        let b = normalize_deterministic(rs, 1, text.as_bytes());
+        prop_assert_eq!(a, b);
+    }
+
+    /// Property 2: TOTAL — never panics, even on arbitrary (possibly
+    /// invalid UTF-8) byte sequences. Returns either Ok or a typed Err.
+    #[test]
+    fn prop_normalize_is_total(
+        rs in arb_rule_set(),
+        bytes in arb_bytes(),
+        version in 0u32..=10,
+    ) {
+        // Reaching this assertion proves no panic.
+        let _ = normalize_deterministic(rs, version, &bytes);
+    }
+
+    /// Property 3: IDEMPOTENT — f(f(x)) == f(x).
+    /// **The canonical form is a fixed point**; replay safety depends on
+    /// this. If a future rule lands that's non-idempotent, this test
+    /// will fail loudly.
+    #[test]
+    fn prop_normalize_is_idempotent(
+        text in arb_text(),
+    ) {
+        let once = normalize_deterministic(RuleSet::CommandLineIntent, 1, text.as_bytes());
+        if let Ok(canon) = once {
+            let twice = normalize_deterministic(RuleSet::CommandLineIntent, 1, &canon)
+                .expect("canonical form is valid UTF-8 by construction");
+            prop_assert_eq!(canon, twice);
+        }
+        // If once was Err (e.g., invalid UTF-8), there's nothing to
+        // idempotently re-normalize. The error path is its own fixed
+        // point — total + deterministic — and Property 1 covers it.
+    }
+
+    /// Property 4: NO INTERNAL whitespace runs in CommandLineIntent v1
+    /// output. Every space in the output is between two non-whitespace
+    /// tokens; never two adjacent spaces.
+    #[test]
+    fn prop_no_internal_whitespace_runs(
+        text in arb_text(),
+    ) {
+        if let Ok(canon) = normalize_deterministic(RuleSet::CommandLineIntent, 1, text.as_bytes()) {
+            // The output is UTF-8 by construction.
+            let s = std::str::from_utf8(&canon).expect("output is UTF-8");
+            prop_assert!(
+                !s.contains("  "),
+                "output must not contain two adjacent ASCII spaces; got {:?}",
+                s
+            );
+            // No non-ASCII whitespace either (all whitespace was collapsed
+            // to ASCII space).
+            for ch in s.chars() {
+                if ch.is_whitespace() {
+                    prop_assert_eq!(ch, ' ', "all whitespace in output must be ASCII space");
+                }
+            }
+        }
+    }
+
+    /// Property 5: NO LEADING or TRAILING whitespace in CommandLineIntent
+    /// v1 output.
+    #[test]
+    fn prop_no_leading_or_trailing_whitespace(
+        text in arb_text(),
+    ) {
+        if let Ok(canon) = normalize_deterministic(RuleSet::CommandLineIntent, 1, text.as_bytes()) {
+            let s = std::str::from_utf8(&canon).expect("output is UTF-8");
+            if !s.is_empty() {
+                prop_assert!(!s.starts_with(char::is_whitespace), "output must not start with whitespace");
+                prop_assert!(!s.ends_with(char::is_whitespace), "output must not end with whitespace");
+            }
+        }
+    }
+
+    /// Property 6: CONSERVATIVE — different non-whitespace token
+    /// sequences produce different canonical outputs. The normalizer
+    /// does NOT re-order or merge tokens. We test this by comparing the
+    /// canonical form to a "ground truth" computed by collecting the
+    /// input's non-whitespace tokens in order and joining with single
+    /// spaces.
+    #[test]
+    fn prop_conservative_token_order_preserved(
+        text in arb_text(),
+    ) {
+        if let Ok(canon) = normalize_deterministic(RuleSet::CommandLineIntent, 1, text.as_bytes()) {
+            let canon_str = std::str::from_utf8(&canon).expect("output is UTF-8");
+            // Ground truth: split input on Unicode whitespace, keep
+            // non-empty tokens, join with single ASCII space.
+            let ground_truth: String = text
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            prop_assert_eq!(canon_str, &ground_truth,
+                "canonical form must equal whitespace-split-then-join (token-order preserving)");
+        }
+    }
+
+    /// Property 7: class-covering sweep over `RuleSet`. Every variant
+    /// generated by `arb_rule_set` must be implementable at its
+    /// `current_version()`. If a future variant is added but its
+    /// implementation isn't wired into `normalize_deterministic`, this
+    /// property fires.
+    #[test]
+    fn prop_every_rule_set_has_implementation_at_current_version(
+        rs in arb_rule_set(),
+        text in arb_text(),
+    ) {
+        let result = normalize_deterministic(rs, rs.current_version(), text.as_bytes());
+        // Must NOT return UnsupportedVersion at the current version.
+        match result {
+            Ok(_) => {}
+            Err(NormalizerError::UnsupportedVersion { .. }) => {
+                prop_assert!(false,
+                    "rule_set {:?} at current_version() {} returned UnsupportedVersion",
+                    rs, rs.current_version());
+            }
+            Err(NormalizerError::InvalidUtf8) => {
+                // Always OK — arb_text generates valid UTF-8 by
+                // construction, so this branch should be unreachable for
+                // CommandLineIntent. But if a future RuleSet accepts
+                // non-UTF-8 input, this branch is its own pass.
+            }
+        }
+    }
+
+    /// Property 8: NormalizerKind variants are distinct (PartialEq + Hash
+    /// behave). Pins that no Default impl was accidentally added.
+    #[test]
+    fn prop_normalizer_kind_variants_distinct(
+        version in 1u32..=10,
+        seed in any::<u8>(),
+    ) {
+        let det = NormalizerKind::DeterministicRule {
+            rule_set: RuleSet::CommandLineIntent,
+            version,
+        };
+        let model = NormalizerKind::ModelAsMote {
+            mote_id: kx_mote::MoteId::from_bytes([seed; 32]),
+        };
+        prop_assert_ne!(det, model);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bytes shape sanity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn output_bytes_type_is_bytes() {
+    // Compile-time check that the return type is bytes::Bytes (so
+    // downstream consumers can rely on zero-copy slicing + Arc-cheap
+    // cloning).
+    let out: Bytes = normalize_deterministic(RuleSet::CommandLineIntent, 1, b"hi").unwrap();
+    assert_eq!(&out[..], b"hi");
+}


### PR DESCRIPTION
## Summary

NEW CRATE. Sixth crate in the born-SN-4-v2 chain (P1.7.5 → P1.7.6 → P1.7.7 → P1.7.8 → P1.7.9 → **P1.7.10**).

The normalizer is the controlled escape hatch for "two inputs that mean the same thing but aren't bit-identical." Per SN-8, the runtime serves cache hits ONLY on EXACT cryptographic equality — there is NO similarity operator anywhere on the identity path. The normalizer reconciles this with the workflow author's reasonable expectation that `"ls   -la"` and `"ls -la"` should refer to the same command, by **canonicalizing inputs BEFORE they feed into `MoteId` derivation**. The two inputs become bit-identical after the rule applies, and the memoizer's exact-equality hit fires for free.

**The fix is NOT fuzzy matching.** The fix is deterministic canonicalization with conservative-when-unsure: keeping things distinct is diagnosable; silently merging things is a correctness bug.

## Public API (entirely additive)

- `RuleSet` enum — versioned rule-set identifier. **v0.1 ships ONE variant**: `CommandLineIntent`. `current_version()` reports the highest version this build supports.
- `NormalizerKind` enum — per-call dispatch discriminant:
  - `DeterministicRule { rule_set, version }` — replay needs `(rule_set, version)` to reproduce.
  - `ModelAsMote { mote_id }` — the model-as-Mote seam for fuzzy residue per D33. The executor at P1.9 commits the model's canonical output as a Mote.
- `NormalizerError` — `UnsupportedVersion` + `InvalidUtf8`.
- `normalize_deterministic(rule_set, version, &[u8]) -> Result<Bytes, NormalizerError>` — pure/total/deterministic dispatch.

## CommandLineIntent v1 (the v0.1 rule)

1. Decode input as UTF-8 (error if invalid).
2. Trim leading/trailing whitespace (Unicode `White_Space`).
3. Collapse internal runs of whitespace to a single ASCII space.
4. Encode back to UTF-8 bytes.

**What v1 deliberately does NOT do** (each is a future-rule slot; future additions MUST bump the version):
- Reorder flags (would silently break `cp src dst`).
- Resolve `./` / `../` in paths (changes semantics under symlinks).
- Canonicalize quoting (requires shell parser).
- Normalize variable interpolation (env-dependent).

## Canonical-classifier-cannot-drift (CODE + TEST level)

- **CODE**: `normalize_deterministic` matches `RuleSet` **exhaustively** (no wildcard). Adding a new variant is a compile error. Per-variant inner match dispatches on version.
- **TEST**: `arb_rule_set()` strategy enumerates ALL variants with a "MUST update on new variant" comment. Mirror of `arbitrary_failure_reason` (kx-projection) + `arb_idempotency_class` (kx-tool-registry) + `arb_nd_class` (kx-memoizer).
- `prop_every_rule_set_has_implementation_at_current_version` fires loudly if a variant lands without an impl.

## Tests: 31 (all green)

| Category | Count |
|---|---|
| Inline unit (src/lib.rs) | 5 (current_version, unsupported_version, version_zero, invalid_utf8, NormalizerKind variants distinct) |
| Integration unit (proptest_normalizer.rs) | 12 (empty, pure whitespace, single word, multi-space collapse, trim, tabs/CR/LF, Unicode whitespace, flag-ordering-NOT-normalized, argument-ordering-NOT-normalized, case-preserved, idempotent smoke, Bytes type pin) |
| Proptests × 64 cases | 8 (deterministic, total, idempotent, no-internal-whitespace-runs, no-leading-or-trailing-whitespace, conservative-token-order-preserved, every-rule-set-has-impl, NormalizerKind variants distinct) |
| Concurrency | 3 (Send+Sync over `RuleSet` + `NormalizerKind` + `NormalizerError`; 4-thread `normalize_deterministic` thread-independence under `Arc<input>`; 4-thread error-path thread-independence) |
| Doctests | 3 (RuleSet, NormalizerKind, normalize_deterministic + 2nd-form equivalence) |
| **Crate total** | **31** |
| **Workspace total** | **394 / 394** |

## Gates (Apple Silicon local)

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (only warning is the intentional pin echo from kx-llamacpp-sys)
- `cargo test --workspace` ✓ — 394/394
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✓

## SN-2 audit

- Path scan ✅ + content scan ✅ (0 matches across all 5 staged files)

## Deps (workspace-inherited only)

- Runtime: `kx-mote` + `bytes` + `serde` + `thiserror` + `tracing`
- Dev: `proptest` + `tracing-subscriber`
- Workspace `Cargo.toml`: added `kx-normalizer` member + workspace dep.

## Compliance

- [x] **SN-1**: D33 + context-assembly.md §4 locked in private corpus design freeze `cbd3b98`.
- [x] **SN-2**: pre-merge audit clean.
- [x] **SN-4 v2**: born compliant — `forbid(unsafe_code)` + `clippy::pedantic` + 8 proptests × 64 cases + Send+Sync compile-time set + 3 doctests + thread-independence under `Arc<>` + class-covering proptest strategy.
- [x] **SN-5**: master plan already archived in `cbd3b98`.
- [x] **SN-6**: prereqs all green (kx-mote ✅).
- [x] **SN-7**: Linux Actions comment follows after CI green.
- [x] **SN-8**: ENFORCED by API design — no similarity operator anywhere; exhaustive `RuleSet` match at code level + class-covering proptest at test level prevent silent variant addition.

## Integration with the rest of the foundation

```
raw input bytes
   │
   ▼
normalize_deterministic(rule_set, version, bytes)   ← THIS PR
   │
   ▼
canonical bytes (used as MoteDef input)
   │
   ▼
kx_mote::derive_mote_id(MoteDef, input_data_id, graph_position)
   │
   ▼
kx_memoizer::lookup(mote, snapshot) → Option<CacheHit>   ← shipped at P1.7.9
   │
   ├─ Some(Pure) / Some(ReadOnlyNondet) → skip inference
   ├─ Some(WorldMutating { redispatch_effect: true }) → skip inference + re-dispatch broker effect
   └─ None → dispatch (executor P1.9, unbuilt)
```

## Next

PR 7 — **THE KEYSTONE** — kx-journal v1→v2 + kx-projection fold update (9-cell recovery cross-product + `can_redispatch_world_effect` + `MoteState::Inconsistent` + prefix-monotonicity-of-refusal). With kx-normalizer merged, P1.8 (kx-inference dispatcher)'s pre-execution-helper deps (memoizer ✅ + context-assembler ✅ + normalizer ✅) are all green. The remaining keystone is PR 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)