### PR TITLE
P1.7.11 (PR 7 — THE KEYSTONE): kx-journal v1→v2 + kx-projection 9-cell recovery fold

### DIFF
--- a/kx-context-assembler/src/lib.rs
+++ b/kx-context-assembler/src/lib.rs
@@ -487,6 +487,7 @@ mod tests {
             nondeterminism: NdClass::Pure,
             result_ref,
             parents,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: empty_def_hash(),
         }
     }

--- a/kx-context-assembler/tests/concurrency.rs
+++ b/kx-context-assembler/tests/concurrency.rs
@@ -99,6 +99,7 @@ fn build_committed(mote_id: MoteId, result_ref: ContentRef) -> JournalEntry {
         nondeterminism: NdClass::Pure,
         result_ref,
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash([0; 32]),
     }
 }

--- a/kx-context-assembler/tests/proptest_assembler.rs
+++ b/kx-context-assembler/tests/proptest_assembler.rs
@@ -108,6 +108,7 @@ fn build_committed_entry(mote_id: MoteId, result_ref: ContentRef) -> JournalEntr
         nondeterminism: NdClass::Pure,
         result_ref,
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash([0; 32]),
     }
 }

--- a/kx-journal/src/entry.rs
+++ b/kx-journal/src/entry.rs
@@ -47,23 +47,33 @@ use smallvec::SmallVec;
 
 /// Canonical journal-file schema version. Bumped per `journal-entry.md` §10 when the
 /// entry encoding changes. Readers refuse loudly on mismatch.
-pub const JOURNAL_SCHEMA_VERSION: u16 = 1;
+///
+/// **v2 (PR 7) changes** vs v1:
+/// - `warrant_ref: [u8; 32]` added to `Proposed` and `Committed` bodies (D36).
+/// - New `EffectStaged` entry kind (=4); dedup-by-key index expands to
+///   `{1, 2, 4}` (D38 §2b).
+/// - `MAX_ENTRY_LEN` raised 4460 → 4500 (40-byte headroom for `warrant_ref`).
+///
+/// v2 readers refuse v1 files loudly (no in-place evolution; no production v1
+/// journals exist per the corpus, acceptable).
+pub const JOURNAL_SCHEMA_VERSION: u16 = 2;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).
 pub const HEADER_LEN: usize = 74;
 
 /// Absolute per-entry size cap.
 ///
-/// **Arithmetic correction note:** `journal-entry.md` §8 quotes `4304` but the stated
-/// inputs (128 parents × 34 bytes + 32-byte result_ref + 2-byte u16 length prefix +
-/// 74-byte header) sum to `4460`. Two ways to reconcile: lower `MAX_PARENTS` to ~123
-/// to preserve the 4304 number, or update the cap to 4460 to preserve the
-/// "128 parents" promise (referenced in §5). The 128-parent promise is the
-/// load-bearing claim (it bounds the worst-case write path); the 4304 number was a
-/// stated arithmetic conclusion. We match the arithmetic. The spec correction lands
-/// in `journal-entry.md` on the next private-corpus sync — recorded as a deviation
-/// per SN-1.
-pub const MAX_ENTRY_LEN: usize = 4460;
+/// **Arithmetic correction note (v1):** `journal-entry.md` §8 originally quoted
+/// `4304` but the stated inputs (128 parents × 34 bytes + 32-byte result_ref +
+/// 2-byte u16 length prefix + 74-byte header) summed to `4460`. The
+/// 128-parent promise was load-bearing; we matched the arithmetic.
+///
+/// **v2 (PR 7) raises this to 4500** for 40-byte headroom — `warrant_ref` adds
+/// 32 bytes to Proposed and Committed bodies (D36). The corrected v2 inputs:
+/// 128 parents × 34 + 32 result_ref + 32 warrant_ref + 2 parents-count + 74
+/// header = 4492 bytes; the 8-byte buffer leaves room for a future per-body
+/// addition without another cap bump.
+pub const MAX_ENTRY_LEN: usize = 4500;
 
 /// Maximum number of parents per Committed entry (per the size cap).
 pub const MAX_PARENTS: usize = 128;
@@ -80,6 +90,16 @@ pub const KIND_COMMITTED: u8 = 1;
 pub const KIND_REPUDIATED: u8 = 2;
 /// `Failed` entry-kind byte.
 pub const KIND_FAILED: u8 = 3;
+/// `EffectStaged` entry-kind byte (NEW in v2; D38 §2b).
+///
+/// `EffectStaged` is the recovery hint that closes the WORLD-MUTATING
+/// double-effect window: an effect was staged (intent durably recorded) but
+/// not yet committed. On recovery, the projection's fold combines
+/// `EffectStaged` with subsequent entries to decide whether re-dispatch is
+/// safe (see the 9-cell cross-product in `journal-txn.md`). Body is
+/// **header-only** (no payload bytes); dedup-by-key participates per the
+/// expanded `{1, 2, 4}` index.
+pub const KIND_EFFECT_STAGED: u8 = 4;
 
 // ---------------------------------------------------------------------------
 // Closed reason enums (D19; `journal-entry.md` §6.2 + §7.2)
@@ -180,6 +200,52 @@ impl FailureReason {
     }
 }
 
+/// Canonical terminality classifier for `FailureReason`.
+///
+/// Returns `true` iff the failure represents a **pre-commit crash** — a
+/// liveness-driven death of the worker between attempt-start and commit.
+/// In the 9-cell recovery cross-product (`journal-txn.md` §"Recovery fold
+/// semantics"), pre-commit-crash failures paired with an `EffectStaged`
+/// entry **permit re-dispatch** (the executor's worker died, the broker's
+/// tool-boundary idempotency closes the window).
+///
+/// Returns `false` for **terminal** failures (deliberate refusals, critic
+/// rejections, cascade poisons, anti-pattern refusals). Terminal failures
+/// paired with an `EffectStaged` entry **forbid re-dispatch** — the
+/// executor declared a definite failure verdict; re-running a WM effect
+/// would be the double-effect the seam exists to prevent.
+///
+/// **Single source of class truth.** Both production code (kx-projection's
+/// fold; kx-executor's recovery predicate) AND tests (proptest sweeps via
+/// `arbitrary_failure_reason`) call this function. No hardcoded list
+/// anywhere. A new `FailureReason` variant must be classified here once,
+/// and every consumer picks up the new behavior automatically.
+///
+/// Per STEP 5.2 + STEP 6.2 of PR 4.5.
+///
+/// # Examples
+///
+/// ```
+/// use kx_journal::{is_pre_commit_crash, FailureReason};
+///
+/// // Pre-commit-crash class: liveness-driven, safe to re-dispatch.
+/// assert!(is_pre_commit_crash(FailureReason::TimedOut));
+/// assert!(is_pre_commit_crash(FailureReason::WorkerCrashed));
+///
+/// // Terminal class: deliberate, do NOT re-dispatch.
+/// assert!(!is_pre_commit_crash(FailureReason::ExecutorRefused));
+/// assert!(!is_pre_commit_crash(FailureReason::ValidatorRejected));
+/// assert!(!is_pre_commit_crash(FailureReason::UpstreamRepudiated));
+/// assert!(!is_pre_commit_crash(FailureReason::UnsafeWorldMutatingConstruction));
+/// ```
+#[must_use]
+pub const fn is_pre_commit_crash(reason: FailureReason) -> bool {
+    matches!(
+        reason,
+        FailureReason::TimedOut | FailureReason::WorkerCrashed
+    )
+}
+
 // ---------------------------------------------------------------------------
 // ParentEntry (the on-disk per-parent shape, D19 / journal-entry.md §5)
 // ---------------------------------------------------------------------------
@@ -269,6 +335,11 @@ pub enum JournalEntry {
         /// Opaque placement metadata (worker id, locality hint, etc.). Semantic
         /// interpretation is the coordinator's; the journal pins only the byte budget.
         placement_hint: u128,
+        /// The `warrant_ref` (`blake3(canonical_bincode(WarrantSpec))`) of the
+        /// warrant this attempt is being dispatched under. NEW in v2 (D36).
+        /// Replay re-derives the warrant bit-for-bit from this ref + the content
+        /// store; required for the executor's submission-time refusal predicates.
+        warrant_ref: ContentRef,
     },
 
     /// A Mote attempt landed durably. The runtime treats this entry as truth for all
@@ -287,6 +358,10 @@ pub enum JournalEntry {
         result_ref: ContentRef,
         /// Declared parents with edge metadata. SmallVec inline up to 4; heap for 5+.
         parents: SmallVec<[ParentEntry; 4]>,
+        /// The `warrant_ref` (`blake3(canonical_bincode(WarrantSpec))`) of the
+        /// warrant this commit was performed under. NEW in v2 (D36). The
+        /// durable fact carries the warrant identity; replay re-derives bit-for-bit.
+        warrant_ref: ContentRef,
         /// **Non-canonical metadata** (NOT in the on-disk body bytes per
         /// `journal-entry.md` §4.2). The Mote's `mote_def_hash` — used by the
         /// `list_committed_by_mote_def_hash` query (`repudiation.md` §6, D22). The
@@ -330,6 +405,40 @@ pub enum JournalEntry {
         /// UUID-shaped identifier of the worker / coordinator reporting the failure.
         reporter_id: u128,
     },
+
+    /// A WORLD-MUTATING effect was staged (intent durably recorded) but not yet
+    /// committed. NEW in v2 (D38 §2b). The recovery-hint kind that closes the
+    /// WM double-effect window.
+    ///
+    /// **Body is header-only** — no payload bytes. The MoteId, idempotency_key,
+    /// and seq in the header are the full carrying information; downstream
+    /// consumers (kx-projection's fold) read presence to set
+    /// `effect_staged_observed` on `MoteInfo`.
+    ///
+    /// **Dedup-by-key participates**: `(idempotency_key, kind = 4)` in the
+    /// expanded dedup index `{1, 2, 4}`. Second-write of the same staged-intent
+    /// is a no-op success.
+    ///
+    /// **Recovery-fold semantics**: see the 9-cell cross-product table in
+    /// `journal-txn.md`. The interesting cells:
+    /// - `EffectStaged` + `Committed` → done (cell 4); never re-dispatch.
+    /// - `EffectStaged` + `Failed`(`is_pre_commit_crash`) → re-dispatch permitted
+    ///   (cell 3); tool-boundary idempotency closes the window.
+    /// - `EffectStaged` + `Failed`(terminal) → **terminal failure** (cell 5); do
+    ///   NOT re-dispatch. The executor recorded a definite failure verdict;
+    ///   re-running a WM effect here is the double-effect the seam exists to
+    ///   prevent.
+    /// - `EffectStaged` + `Repudiated` (no `Committed`) → **anomaly** (cell 8);
+    ///   quarantine via `MoteState::Inconsistent`.
+    EffectStaged {
+        /// The Mote's identity.
+        mote_id: MoteId,
+        /// The Mote's identity key per `idempotency.md`. Participates in the
+        /// expanded dedup index `{1, 2, 4}`.
+        idempotency_key: [u8; 32],
+        /// Per-run monotonic sequence number assigned by the journal at append time.
+        seq: u64,
+    },
 }
 
 impl JournalEntry {
@@ -340,7 +449,8 @@ impl JournalEntry {
             Self::Proposed { seq, .. }
             | Self::Committed { seq, .. }
             | Self::Repudiated { seq, .. }
-            | Self::Failed { seq, .. } => *seq,
+            | Self::Failed { seq, .. }
+            | Self::EffectStaged { seq, .. } => *seq,
         }
     }
 
@@ -359,6 +469,9 @@ impl JournalEntry {
             }
             | Self::Failed {
                 idempotency_key, ..
+            }
+            | Self::EffectStaged {
+                idempotency_key, ..
             } => idempotency_key,
         }
     }
@@ -370,7 +483,8 @@ impl JournalEntry {
         match self {
             Self::Proposed { mote_id, .. }
             | Self::Committed { mote_id, .. }
-            | Self::Failed { mote_id, .. } => *mote_id,
+            | Self::Failed { mote_id, .. }
+            | Self::EffectStaged { mote_id, .. } => *mote_id,
             Self::Repudiated { target_mote_id, .. } => *target_mote_id,
         }
     }
@@ -383,6 +497,7 @@ impl JournalEntry {
             Self::Committed { .. } => KIND_COMMITTED,
             Self::Repudiated { .. } => KIND_REPUDIATED,
             Self::Failed { .. } => KIND_FAILED,
+            Self::EffectStaged { .. } => KIND_EFFECT_STAGED,
         }
     }
 }
@@ -516,6 +631,11 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             idempotency_key,
             seq,
             ..
+        }
+        | JournalEntry::EffectStaged {
+            mote_id,
+            idempotency_key,
+            seq,
         } => (*mote_id, *idempotency_key, *seq, 0),
     };
     out.extend_from_slice(mote_id_for_header.as_bytes());
@@ -526,18 +646,29 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
 
     // -------------------- BODY (per kind) --------------------
     match entry {
-        JournalEntry::Proposed { placement_hint, .. } => {
+        JournalEntry::Proposed {
+            placement_hint,
+            warrant_ref,
+            ..
+        } => {
+            // v2 (D36): Proposed body is 16 bytes (placement_hint u128) + 32
+            // bytes (warrant_ref ContentRef) = 48 bytes.
             out.extend_from_slice(&placement_hint.to_le_bytes());
+            out.extend_from_slice(warrant_ref.as_bytes());
         }
         JournalEntry::Committed {
             result_ref,
             parents,
+            warrant_ref,
             ..
         } => {
             if parents.len() > MAX_PARENTS {
                 return Err(EncodeError::TooManyParents { got: parents.len() });
             }
+            // v2 (D36): Committed body is 32 bytes (result_ref) + 32 bytes
+            // (warrant_ref) + 2 bytes (parents count u16) + N * 34 bytes.
             out.extend_from_slice(result_ref.as_bytes());
+            out.extend_from_slice(warrant_ref.as_bytes());
             let count = u16::try_from(parents.len()).expect("checked above");
             out.extend_from_slice(&count.to_le_bytes());
             for p in parents {
@@ -569,6 +700,12 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
         } => {
             out.push(reason_class.as_u8());
             out.extend_from_slice(&reporter_id.to_le_bytes());
+        }
+        JournalEntry::EffectStaged { .. } => {
+            // v2 (D38 §2b): EffectStaged body is HEADER-ONLY. No body bytes.
+            // The full carrying information (mote_id + idempotency_key + seq)
+            // is in the 74-byte header; the recovery fold reads presence to
+            // set `effect_staged_observed` on `MoteInfo`.
         }
     }
 
@@ -623,17 +760,21 @@ pub fn decode_entry_with_def_hash(
     // -------------------- Body, by kind --------------------
     match kind {
         KIND_PROPOSED => {
-            if body.len() < 16 {
+            // v2 (D36): Proposed body is 48 bytes (16 placement_hint + 32 warrant_ref).
+            if body.len() < 48 {
                 return Err(DecodeError::BodyTooShort {
                     kind,
                     got: body.len(),
-                    expected: 16,
+                    expected: 48,
                 });
             }
             let nondeterminism = nd_class_from_byte(nd_byte)?;
             let placement_hint = u128::from_le_bytes(body[..16].try_into().expect("16 bytes"));
-            if body.len() > 16 {
-                return Err(DecodeError::TrailingBytes(body.len() - 16));
+            let mut warrant_ref_bytes = [0u8; 32];
+            warrant_ref_bytes.copy_from_slice(&body[16..48]);
+            let warrant_ref = ContentRef::from_bytes(warrant_ref_bytes);
+            if body.len() > 48 {
+                return Err(DecodeError::TrailingBytes(body.len() - 48));
             }
             Ok(JournalEntry::Proposed {
                 mote_id,
@@ -641,22 +782,29 @@ pub fn decode_entry_with_def_hash(
                 seq,
                 nondeterminism,
                 placement_hint,
+                warrant_ref,
             })
         }
         KIND_COMMITTED => {
-            if body.len() < 34 {
+            // v2 (D36): Committed body is 32 (result_ref) + 32 (warrant_ref)
+            // + 2 (parents count) + N * 34 bytes. Fixed prefix is 66 bytes.
+            const COMMITTED_PREFIX_LEN: usize = 66;
+            if body.len() < COMMITTED_PREFIX_LEN {
                 return Err(DecodeError::BodyTooShort {
                     kind,
                     got: body.len(),
-                    expected: 34,
+                    expected: COMMITTED_PREFIX_LEN,
                 });
             }
             let nondeterminism = nd_class_from_byte(nd_byte)?;
             let mut result_ref_bytes = [0u8; 32];
             result_ref_bytes.copy_from_slice(&body[..32]);
             let result_ref = ContentRef::from_bytes(result_ref_bytes);
-            let n = u16::from_le_bytes(body[32..34].try_into().expect("2 bytes")) as usize;
-            let expected_parents_len = 34 + n * ParentEntry::ENCODED_LEN;
+            let mut warrant_ref_bytes = [0u8; 32];
+            warrant_ref_bytes.copy_from_slice(&body[32..64]);
+            let warrant_ref = ContentRef::from_bytes(warrant_ref_bytes);
+            let n = u16::from_le_bytes(body[64..66].try_into().expect("2 bytes")) as usize;
+            let expected_parents_len = COMMITTED_PREFIX_LEN + n * ParentEntry::ENCODED_LEN;
             if body.len() < expected_parents_len {
                 return Err(DecodeError::BodyTooShort {
                     kind,
@@ -671,7 +819,7 @@ pub fn decode_entry_with_def_hash(
             }
             let mut parents: SmallVec<[ParentEntry; 4]> = SmallVec::with_capacity(n);
             for i in 0..n {
-                let base = 34 + i * ParentEntry::ENCODED_LEN;
+                let base = COMMITTED_PREFIX_LEN + i * ParentEntry::ENCODED_LEN;
                 let mut pid = [0u8; 32];
                 pid.copy_from_slice(&body[base..base + 32]);
                 let edge_kind = body[base + 32];
@@ -698,6 +846,7 @@ pub fn decode_entry_with_def_hash(
                 nondeterminism,
                 result_ref,
                 parents,
+                warrant_ref,
                 mote_def_hash,
             })
         }
@@ -749,6 +898,18 @@ pub fn decode_entry_with_def_hash(
                 reporter_id,
             })
         }
+        KIND_EFFECT_STAGED => {
+            // v2 (D38 §2b): EffectStaged body is HEADER-ONLY. Any body bytes
+            // are a decoder-side error (trailing bytes per §2 no-trailing-data).
+            if !body.is_empty() {
+                return Err(DecodeError::TrailingBytes(body.len()));
+            }
+            Ok(JournalEntry::EffectStaged {
+                mote_id,
+                idempotency_key,
+                seq,
+            })
+        }
         other => Err(DecodeError::UnknownKind(other)),
     }
 }
@@ -797,6 +958,7 @@ mod tests {
             nondeterminism: NdClass::ReadOnlyNondet,
             result_ref: ContentRef::from_bytes([9u8; 32]),
             parents: SmallVec::new(),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: MoteDefHash::from_bytes([10u8; 32]),
         }
     }
@@ -810,6 +972,7 @@ mod tests {
                 seq: 0,
                 nondeterminism: NdClass::Pure,
                 placement_hint: 0,
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             },
             sample_committed(),
             JournalEntry::Repudiated {
@@ -827,6 +990,12 @@ mod tests {
                 reason_class: FailureReason::TimedOut,
                 reporter_id: 0,
             },
+            // v2 (D38 §2b): EffectStaged. Header-only; body is empty.
+            JournalEntry::EffectStaged {
+                mote_id: MoteId::from_bytes([1u8; 32]),
+                idempotency_key: [2u8; 32],
+                seq: 0,
+            },
         ];
         for e in &kinds {
             let bytes = encode_entry(e).unwrap();
@@ -837,25 +1006,30 @@ mod tests {
     }
 
     #[test]
-    fn proposed_total_length_is_90() {
+    fn proposed_total_length_is_122() {
+        // v2 (D36): 74 header + 16 placement_hint + 32 warrant_ref = 122 bytes.
         let e = JournalEntry::Proposed {
             mote_id: MoteId::from_bytes([1u8; 32]),
             idempotency_key: [2u8; 32],
             seq: 0,
             nondeterminism: NdClass::Pure,
             placement_hint: 0,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         };
-        assert_eq!(encode_entry(&e).unwrap().len(), 90);
+        assert_eq!(encode_entry(&e).unwrap().len(), 122);
     }
 
     #[test]
-    fn committed_zero_parents_is_108() {
+    fn committed_zero_parents_is_140() {
+        // v2 (D36): 74 header + 32 result_ref + 32 warrant_ref + 2 parents-count
+        // + 0 parents = 140 bytes.
         let bytes = encode_entry(&sample_committed()).unwrap();
-        assert_eq!(bytes.len(), 108);
+        assert_eq!(bytes.len(), 140);
     }
 
     #[test]
-    fn committed_four_parents_is_244() {
+    fn committed_four_parents_is_276() {
+        // v2 (D36): 140 (zero-parents baseline) + 4 * 34 = 276 bytes.
         let parents: SmallVec<[ParentEntry; 4]> = (0..4u8)
             .map(|i| ParentEntry {
                 parent_id: MoteId::from_bytes([i; 32]),
@@ -870,13 +1044,16 @@ mod tests {
             nondeterminism: NdClass::ReadOnlyNondet,
             result_ref: ContentRef::from_bytes([9u8; 32]),
             parents,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: MoteDefHash::from_bytes([10u8; 32]),
         };
-        assert_eq!(encode_entry(&e).unwrap().len(), 244);
+        assert_eq!(encode_entry(&e).unwrap().len(), 276);
     }
 
     #[test]
     fn repudiated_total_length_is_131() {
+        // Unchanged in v2 — Repudiated body has no warrant_ref (the Repudiated
+        // references a Committed which already carries its own warrant_ref).
         let e = JournalEntry::Repudiated {
             target_mote_id: MoteId::from_bytes([1u8; 32]),
             idempotency_key: [2u8; 32],
@@ -890,6 +1067,8 @@ mod tests {
 
     #[test]
     fn failed_total_length_is_91() {
+        // Unchanged in v2 — Failed body has no warrant_ref (the per-attempt
+        // failure references the prior Proposed which carries warrant_ref).
         let e = JournalEntry::Failed {
             mote_id: MoteId::from_bytes([1u8; 32]),
             idempotency_key: [2u8; 32],
@@ -901,8 +1080,22 @@ mod tests {
     }
 
     #[test]
-    fn absolute_cap_is_4304() {
-        // 128 parents at 34 bytes/parent + body fixed (34) + header (74) = 4304.
+    fn effect_staged_total_length_is_header_only_74() {
+        // v2 (D38 §2b): EffectStaged is header-only.
+        let e = JournalEntry::EffectStaged {
+            mote_id: MoteId::from_bytes([1u8; 32]),
+            idempotency_key: [2u8; 32],
+            seq: 0,
+        };
+        assert_eq!(encode_entry(&e).unwrap().len(), HEADER_LEN);
+        assert_eq!(encode_entry(&e).unwrap().len(), 74);
+    }
+
+    #[test]
+    fn absolute_cap_at_max_parents_is_4492() {
+        // v2 (D36): 74 header + 32 result_ref + 32 warrant_ref + 2 parents-count
+        // + 128 * 34 parent bytes = 4492 bytes. MAX_ENTRY_LEN is 4500, leaving
+        // 8 bytes of headroom for a future per-body addition.
         let parents: SmallVec<[ParentEntry; 4]> = (0..MAX_PARENTS as u32)
             .map(|i| ParentEntry {
                 parent_id: MoteId::from_bytes([(i & 0xff) as u8; 32]),
@@ -917,10 +1110,12 @@ mod tests {
             nondeterminism: NdClass::ReadOnlyNondet,
             result_ref: ContentRef::from_bytes([0u8; 32]),
             parents,
+            warrant_ref: ContentRef::from_bytes([0u8; 32]),
             mote_def_hash: MoteDefHash::from_bytes([0u8; 32]),
         };
         let bytes = encode_entry(&e).unwrap();
-        assert_eq!(bytes.len(), MAX_ENTRY_LEN);
+        assert_eq!(bytes.len(), 4492);
+        assert!(bytes.len() <= MAX_ENTRY_LEN);
     }
 
     #[test]
@@ -939,6 +1134,7 @@ mod tests {
             nondeterminism: NdClass::ReadOnlyNondet,
             result_ref: ContentRef::from_bytes([0u8; 32]),
             parents,
+            warrant_ref: ContentRef::from_bytes([0u8; 32]),
             mote_def_hash: MoteDefHash::from_bytes([0u8; 32]),
         };
         assert!(matches!(
@@ -961,6 +1157,7 @@ mod tests {
             nondeterminism: NdClass::ReadOnlyNondet,
             result_ref: ContentRef::from_bytes([0u8; 32]),
             parents,
+            warrant_ref: ContentRef::from_bytes([0u8; 32]),
             mote_def_hash: MoteDefHash::from_bytes([0u8; 32]),
         };
         assert_eq!(encode_entry(&e), Err(EncodeError::DataEdgeNonCascade));
@@ -986,6 +1183,7 @@ mod tests {
             seq: 7,
             nondeterminism: NdClass::WorldMutating,
             placement_hint: 0xDEAD_BEEF_CAFE_BABE,
+            warrant_ref: ContentRef::from_bytes([0xbb; 32]),
         };
         assert_eq!(decode_entry(&encode_entry(&p).unwrap()).unwrap(), p);
 
@@ -1009,6 +1207,28 @@ mod tests {
             reporter_id: 0xABCD,
         };
         assert_eq!(decode_entry(&encode_entry(&f).unwrap()).unwrap(), f);
+
+        // v2 (D38 §2b): EffectStaged
+        let es = JournalEntry::EffectStaged {
+            mote_id: MoteId::from_bytes([12u8; 32]),
+            idempotency_key: [13u8; 32],
+            seq: 200,
+        };
+        assert_eq!(decode_entry(&encode_entry(&es).unwrap()).unwrap(), es);
+    }
+
+    #[test]
+    fn is_pre_commit_crash_classifies_canonically() {
+        // Pre-commit-crash class (re-dispatch permitted under EffectStaged).
+        assert!(is_pre_commit_crash(FailureReason::TimedOut));
+        assert!(is_pre_commit_crash(FailureReason::WorkerCrashed));
+        // Terminal class (re-dispatch FORBIDDEN under EffectStaged — cell 5).
+        assert!(!is_pre_commit_crash(FailureReason::ExecutorRefused));
+        assert!(!is_pre_commit_crash(FailureReason::ValidatorRejected));
+        assert!(!is_pre_commit_crash(FailureReason::UpstreamRepudiated));
+        assert!(!is_pre_commit_crash(
+            FailureReason::UnsafeWorldMutatingConstruction
+        ));
     }
 
     #[test]

--- a/kx-journal/src/in_memory.rs
+++ b/kx-journal/src/in_memory.rs
@@ -16,7 +16,9 @@ use std::sync::RwLock;
 use kx_content::ContentRef;
 use kx_mote::{MoteDefHash, MoteId};
 
-use crate::entry::{repudiation_idempotency_key, JournalEntry, KIND_COMMITTED, KIND_REPUDIATED};
+use crate::entry::{
+    repudiation_idempotency_key, JournalEntry, KIND_COMMITTED, KIND_EFFECT_STAGED, KIND_REPUDIATED,
+};
 use crate::{Journal, JournalError};
 
 #[derive(Default)]
@@ -78,8 +80,11 @@ impl Journal for InMemoryJournal {
         let mut state = self.state.write().expect("poisoned lock");
         let kind = entry.kind();
 
-        // Dedupe-by-key for Committed + Repudiated only.
-        if kind == KIND_COMMITTED || kind == KIND_REPUDIATED {
+        // v2 (D38 §2b): dedupe-by-key index expands from {1, 2} to {1, 2, 4}.
+        // EffectStaged participates — second-write of the same staged-intent
+        // is a no-op success. Failed is INTENTIONALLY OUT (each retry is its
+        // own attempt-fact; collapsing would lose attempt history).
+        if kind == KIND_COMMITTED || kind == KIND_REPUDIATED || kind == KIND_EFFECT_STAGED {
             let key = *entry.idempotency_key();
             if let Some(existing) = state
                 .entries
@@ -173,6 +178,7 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         JournalEntry::Proposed { seq, .. }
         | JournalEntry::Committed { seq, .. }
         | JournalEntry::Repudiated { seq, .. }
-        | JournalEntry::Failed { seq, .. } => *seq = new_seq,
+        | JournalEntry::Failed { seq, .. }
+        | JournalEntry::EffectStaged { seq, .. } => *seq = new_seq,
     }
 }

--- a/kx-journal/src/lib.rs
+++ b/kx-journal/src/lib.rs
@@ -73,10 +73,10 @@
 //! - gRPC and the coordinator/worker split — P2.
 
 pub use crate::entry::{
-    decode_entry, decode_entry_with_def_hash, encode_entry, repudiation_idempotency_key,
-    DecodeError, EncodeError, FailureReason, JournalEntry, ParentEntry, RepudiationReason,
-    HEADER_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_FAILED, KIND_PROPOSED,
-    KIND_REPUDIATED, MAX_ENTRY_LEN, MAX_PARENTS,
+    decode_entry, decode_entry_with_def_hash, encode_entry, is_pre_commit_crash,
+    repudiation_idempotency_key, DecodeError, EncodeError, FailureReason, JournalEntry,
+    ParentEntry, RepudiationReason, HEADER_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED,
+    KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED, KIND_REPUDIATED, MAX_ENTRY_LEN, MAX_PARENTS,
 };
 pub use crate::in_memory::InMemoryJournal;
 pub use crate::sqlite::SqliteJournal;

--- a/kx-journal/src/sqlite.rs
+++ b/kx-journal/src/sqlite.rs
@@ -50,7 +50,7 @@ use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBeha
 
 use crate::entry::{
     decode_entry_with_def_hash, encode_entry, repudiation_idempotency_key, JournalEntry,
-    JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_REPUDIATED, MAX_ENTRY_LEN,
+    JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_EFFECT_STAGED, KIND_REPUDIATED, MAX_ENTRY_LEN,
 };
 use crate::{Journal, JournalError};
 
@@ -164,7 +164,7 @@ impl SqliteJournal {
              );
              CREATE INDEX IF NOT EXISTS idx_entries_mote_id ON entries (mote_id);
              CREATE UNIQUE INDEX IF NOT EXISTS idx_entries_dedupe
-                 ON entries (idempotency_key, kind) WHERE kind IN (1, 2);
+                 ON entries (idempotency_key, kind) WHERE kind IN (1, 2, 4);
              CREATE INDEX IF NOT EXISTS idx_entries_def_hash
                  ON entries (mote_def_hash) WHERE kind = 1;",
         )?;
@@ -218,9 +218,10 @@ impl Journal for SqliteJournal {
         let mut conn = self.conn.lock().expect("poisoned mutex");
         let txn = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
-        // Dedupe-by-key for Committed + Repudiated only.
+        // v2 (D38 §2b): dedupe-by-key index expands from {1, 2} to {1, 2, 4}.
+        // EffectStaged participates; Failed is intentionally out.
         let kind = entry.kind();
-        if kind == KIND_COMMITTED || kind == KIND_REPUDIATED {
+        if kind == KIND_COMMITTED || kind == KIND_REPUDIATED || kind == KIND_EFFECT_STAGED {
             let key = *entry.idempotency_key();
             let existing = txn
                 .query_row(
@@ -430,7 +431,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         JournalEntry::Proposed { seq, .. }
         | JournalEntry::Committed { seq, .. }
         | JournalEntry::Repudiated { seq, .. }
-        | JournalEntry::Failed { seq, .. } => *seq = new_seq,
+        | JournalEntry::Failed { seq, .. }
+        | JournalEntry::EffectStaged { seq, .. } => *seq = new_seq,
     }
 }
 

--- a/kx-journal/tests/dod.rs
+++ b/kx-journal/tests/dod.rs
@@ -28,6 +28,7 @@ fn proposed(mote_id_byte: u8, key_byte: u8) -> JournalEntry {
         seq: 0, // ignored on append
         nondeterminism: NdClass::Pure,
         placement_hint: 0,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
     }
 }
 
@@ -39,6 +40,7 @@ fn committed(mote_id_byte: u8, key_byte: u8, def_hash_byte: u8) -> JournalEntry 
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: ContentRef::from_bytes([mote_id_byte ^ 0xa5; 32]),
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash::from_bytes([def_hash_byte; 32]),
     }
 }
@@ -207,9 +209,12 @@ fn obligation_9_list_committed_refs() {
 fn obligation_10_no_inline_payload_bytes() {
     let entry = committed(0x11, 0x22, 0x33);
     let bytes = encode_entry(&entry).unwrap();
-    // For a committed entry with 0 parents: 74-byte header + 32 (result_ref) + 2 (count) = 108 bytes.
-    // The result_ref is a 32-byte hash, NOT the payload. Confirmed by size.
-    assert_eq!(bytes.len(), 108);
+    // **v2 (D36)**: For a committed entry with 0 parents — 74-byte header +
+    // 32 (result_ref) + 32 (warrant_ref) + 2 (parents count) = 140 bytes.
+    // The result_ref and warrant_ref are both 32-byte hashes, NOT inline
+    // payloads. Confirmed by size: even with both content-refs present, the
+    // entry is far below MAX_ENTRY_LEN (4500 in v2).
+    assert_eq!(bytes.len(), 140);
     assert!(bytes.len() < MAX_ENTRY_LEN);
 }
 
@@ -242,7 +247,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         JournalEntry::Proposed { seq, .. }
         | JournalEntry::Committed { seq, .. }
         | JournalEntry::Repudiated { seq, .. }
-        | JournalEntry::Failed { seq, .. } => *seq = new_seq,
+        | JournalEntry::Failed { seq, .. }
+        | JournalEntry::EffectStaged { seq, .. } => *seq = new_seq,
     }
 }
 
@@ -534,6 +540,7 @@ fn topology_decision_atomicity_committed_with_parents() {
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: ContentRef::from_bytes([0xCC; 32]),
         parents,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash::from_bytes([0xDD; 32]),
     };
 

--- a/kx-journal/tests/proptest_entry.rs
+++ b/kx-journal/tests/proptest_entry.rs
@@ -103,15 +103,17 @@ fn arb_proposed() -> impl Strategy<Value = JournalEntry> {
         any::<u64>(),
         arb_nd_class(),
         any::<u128>(),
+        arb_byte_array_32(),
     )
         .prop_map(
-            |(mote_id, idempotency_key, seq, nondeterminism, placement_hint)| {
+            |(mote_id, idempotency_key, seq, nondeterminism, placement_hint, warrant_ref_bytes)| {
                 JournalEntry::Proposed {
                     mote_id,
                     idempotency_key,
                     seq,
                     nondeterminism,
                     placement_hint,
+                    warrant_ref: ContentRef::from_bytes(warrant_ref_bytes),
                 }
             },
         )
@@ -126,9 +128,19 @@ fn arb_committed() -> impl Strategy<Value = JournalEntry> {
         arb_byte_array_32(),
         arb_parents(),
         arb_byte_array_32(),
+        arb_byte_array_32(),
     )
         .prop_map(
-            |(mote_id, idempotency_key, seq, nondeterminism, ref_bytes, parents, def_hash)| {
+            |(
+                mote_id,
+                idempotency_key,
+                seq,
+                nondeterminism,
+                ref_bytes,
+                parents,
+                warrant_ref_bytes,
+                def_hash,
+            )| {
                 JournalEntry::Committed {
                     mote_id,
                     idempotency_key,
@@ -136,10 +148,22 @@ fn arb_committed() -> impl Strategy<Value = JournalEntry> {
                     nondeterminism,
                     result_ref: ContentRef::from_bytes(ref_bytes),
                     parents,
+                    warrant_ref: ContentRef::from_bytes(warrant_ref_bytes),
                     mote_def_hash: MoteDefHash::from_bytes(def_hash),
                 }
             },
         )
+}
+
+/// **v2 (PR 7): EffectStaged strategy.** Header-only; no body fields.
+fn arb_effect_staged() -> impl Strategy<Value = JournalEntry> {
+    (arb_mote_id(), arb_byte_array_32(), any::<u64>()).prop_map(
+        |(mote_id, idempotency_key, seq)| JournalEntry::EffectStaged {
+            mote_id,
+            idempotency_key,
+            seq,
+        },
+    )
 }
 
 fn arb_repudiated() -> impl Strategy<Value = JournalEntry> {
@@ -223,6 +247,25 @@ proptest! {
         let bytes = encode_entry(&entry).expect("encode");
         let decoded = decode_entry(&bytes).expect("decode");
         prop_assert_eq!(decoded, entry);
+    }
+
+    // **v2 (PR 7)** — encode/decode round-trip for EffectStaged entries
+    // (header-only body per D38 §2b).
+    #[test]
+    fn prop_effect_staged_round_trip(entry in arb_effect_staged()) {
+        let bytes = encode_entry(&entry).expect("encode");
+        // EffectStaged is header-only — bytes.len() MUST equal HEADER_LEN.
+        prop_assert_eq!(bytes.len(), kx_journal::HEADER_LEN);
+        let decoded = decode_entry(&bytes).expect("decode");
+        prop_assert_eq!(decoded, entry);
+    }
+
+    // **v2 (PR 7)** — encoding determinism for EffectStaged.
+    #[test]
+    fn prop_encoding_is_deterministic_effect_staged(entry in arb_effect_staged()) {
+        let a = encode_entry(&entry).expect("encode a");
+        let b = encode_entry(&entry).expect("encode b");
+        prop_assert_eq!(a, b);
     }
 
     // Property 1 — encode/decode round-trip for Committed entries via

--- a/kx-memoizer/tests/concurrency.rs
+++ b/kx-memoizer/tests/concurrency.rs
@@ -63,6 +63,7 @@ fn build_committed(mote_id: MoteId, result_ref: ContentRef) -> JournalEntry {
         nondeterminism: NdClass::Pure,
         result_ref,
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash([0; 32]),
     }
 }

--- a/kx-memoizer/tests/proptest_memoizer.rs
+++ b/kx-memoizer/tests/proptest_memoizer.rs
@@ -61,6 +61,7 @@ fn build_committed(mote_id: MoteId, result_ref: ContentRef, nd: NdClass) -> Jour
         nondeterminism: nd,
         result_ref,
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash([0; 32]),
     }
 }

--- a/kx-projection/src/lib.rs
+++ b/kx-projection/src/lib.rs
@@ -81,6 +81,12 @@ use smallvec::SmallVec;
 
 /// Per-Mote state, derived from the log via the precedence rules in `projection.md`
 /// §4. A Mote registered but with no journal entry yet is [`MoteState::Pending`].
+///
+/// **v2 (PR 7) adds [`MoteState::Inconsistent`]** — the cell-8 anomaly state for
+/// `EffectStaged` + `Repudiated` without an intervening `Committed`. Per STEP 5.3
+/// of PR 4.5: the fold does NOT abort on this anomaly; it quarantines the affected
+/// Mote and surfaces it via [`Projection::anomaly_motes`] so an operator decides
+/// recovery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MoteState {
     /// Workflow-declared but no journal entry yet.
@@ -90,9 +96,35 @@ pub enum MoteState {
     /// A `Committed` entry exists and has not been Repudiated.
     Committed,
     /// At least one `Failed` entry exists; no later `Proposed`, no `Committed`.
+    /// In v2, this includes the **terminal failure** case (a `Failed` whose
+    /// `reason_class` is NOT pre-commit-crash, paired with an `EffectStaged` —
+    /// cell 5 of the 9-cell cross-product). Terminal failures forbid
+    /// re-dispatch; consult [`Projection::can_redispatch_world_effect`].
     Failed,
     /// A `Committed` entry exists AND a `Repudiated` entry targeting it has landed.
     Repudiated,
+    /// **v2 (PR 7): cell-8 anomaly.** An `EffectStaged` entry exists for the Mote
+    /// AND a `Repudiated` entry references it WITHOUT an intervening `Committed`.
+    /// Repudiated normally targets a Committed; an EffectStaged-then-Repudiated-
+    /// without-Committed sequence is a journal-consistency error per STEP 5.3.
+    /// Surfaced via [`Projection::anomaly_motes`]; never re-dispatched.
+    Inconsistent,
+}
+
+/// Categorical anomaly kind surfaced by [`Projection::anomaly_motes`].
+///
+/// **v2 (PR 7).** Extensible-by-additive-variants: when a new fold cell anomaly
+/// becomes possible (e.g., from a fifth journal kind), it extends this enum rather
+/// than adding another `MoteState` variant — keeps state semantically minimal
+/// while diagnostics remain expressive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AnomalyKind {
+    /// **Cell 8** of the 9-cell cross-product (`journal-txn.md` §"Recovery fold
+    /// semantics"): an `EffectStaged` entry was folded for this Mote, then a
+    /// `Repudiated` entry referencing it was folded, but no `Committed` was ever
+    /// folded in between. Repudiated targets a Committed that doesn't exist; the
+    /// fold quarantines the Mote (sets `info.inconsistent`) rather than aborting.
+    EffectStagedThenRepudiatedNoCommitted,
 }
 
 /// 3c (validate-then-commit) promotion state, per D18 + D20.
@@ -169,6 +201,13 @@ struct CommittedInfo {
     result_ref: ContentRef,
     nondeterminism: NdClass,
     parents_in_entry: SmallVec<[ParentEntry; 4]>,
+    /// The warrant under which this commit was performed. NEW in v2 (D36).
+    /// Stored so consumers (executor recovery, audit log walkers) can read
+    /// it via the projection's API without re-decoding the journal entry.
+    /// Not yet read in P1.5; will be consumed by P1.9's submission-time
+    /// refusal predicates.
+    #[allow(dead_code)]
+    warrant_ref: ContentRef,
     /// Retained for the D22 `list_committed_by_mote_def_hash`-driven cascade
     /// (operator-level definition repudiation surfaces the def_hash; consumers
     /// reach for it here when constructing cascade sets). Not yet read in P1.5;
@@ -179,6 +218,14 @@ struct CommittedInfo {
     repudiated: bool,
 }
 
+// MoteInfo has 5 bools because the 9-cell recovery cross-product needs each
+// flag's semantics distinct: `has_proposed` + `failed_pending_reattempt` are
+// non-monotonic per-attempt markers; `effect_staged_observed` +
+// `terminal_failure_observed` + `inconsistent` are prefix-monotonic-true
+// recovery-contract flags. Consolidating to a bitfield or enum would obscure
+// the per-flag invariants the fold + state_of_id depend on. Each flag's
+// reset/no-reset semantics is named at its field-level doc comment.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Default)]
 struct MoteInfo {
     /// Workflow-author-declared properties (when registered).
@@ -189,8 +236,26 @@ struct MoteInfo {
     has_proposed: bool,
     /// `true` if at least one `Failed` entry has been folded with no later `Proposed`.
     /// We track this directly because `Failed → Proposed` is a valid sequence
-    /// (`mote.md` §7 + `journal-entry.md` §7.5).
+    /// (`mote.md` §7 + `journal-entry.md` §7.5). **NOT prefix-monotonic** —
+    /// reset to `false` by a subsequent `Proposed`. Distinct from
+    /// `terminal_failure_observed` below.
     failed_pending_reattempt: bool,
+    /// **v2 (PR 7).** `true` if at least one `EffectStaged` entry has been
+    /// folded for this MoteId. **Prefix-monotonic-true** — never reset by any
+    /// fold branch. Set in the `EffectStaged` arm.
+    effect_staged_observed: bool,
+    /// **v2 (PR 7).** `true` if at least one `Failed` entry has been folded
+    /// with a terminal `reason_class` (i.e., NOT pre-commit-crash per
+    /// [`kx_journal::is_pre_commit_crash`]). **Prefix-monotonic-true** — never
+    /// reset. This is the LOAD-BEARING flag that closes the cell-5 WM
+    /// double-effect hazard per STEP 5.2 of PR 4.5.
+    terminal_failure_observed: bool,
+    /// **v2 (PR 7).** `true` if the cell-8 anomaly was observed: a
+    /// `Repudiated` entry referenced this Mote while an `EffectStaged` had
+    /// been folded but no `Committed` was ever folded in between.
+    /// **Prefix-monotonic-true** — never reset. Quarantines the Mote per
+    /// STEP 5.3.
+    inconsistent: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -224,17 +289,55 @@ impl State {
         self.motes.entry(*id).or_default()
     }
 
-    /// Compute the per-identity state per `projection.md` §4.
+    /// Compute the per-identity state per `projection.md` §4 (v2 derivation
+    /// per STEP 5.1 of PR 4.5).
+    ///
+    /// **Terminal-before-Staged ordering invariant (LOAD-BEARING).** Per STEP
+    /// 5.1: `terminal_failure_observed` MUST be checked BEFORE
+    /// `effect_staged_observed`. Swapping reopens the WM double-effect window
+    /// (cell 5 flips from "Failed-terminal — do NOT redispatch" to
+    /// "Pending-in-flight — OK to redispatch"). Reordering is a recovery-
+    /// correctness regression and is forbidden. Regression test:
+    /// `kx-projection/tests/cross_product.rs::
+    /// cell_5_terminal_failure_under_effect_staged_no_redispatch`.
+    ///
+    /// **v2 derivation order**:
+    /// 1. `info.inconsistent` → `Inconsistent` (highest priority; cell-8 anomaly)
+    /// 2. `committed.is_some() && repudiated` → `Repudiated`
+    /// 3. `committed.is_some()` → `Committed`
+    /// 4. `info.terminal_failure_observed` → `Failed` ← MUST precede branch 5
+    /// 5. `info.effect_staged_observed` → `Pending` (in-flight; redispatch OK)
+    /// 6. `info.failed_pending_reattempt` → `Failed` (retry-allowed)
+    /// 7. `info.has_proposed` → `Scheduled`
+    /// 8. else → `Pending`
     fn state_of_id(&self, id: &MoteId) -> MoteState {
         match self.motes.get(id) {
             None => MoteState::Pending,
             Some(info) => {
-                if let Some(c) = &info.committed {
+                // 1. Anomaly takes priority over every other state (STEP 5.3).
+                if info.inconsistent {
+                    MoteState::Inconsistent
+                } else if let Some(c) = &info.committed {
                     if c.repudiated {
                         MoteState::Repudiated
                     } else {
                         MoteState::Committed
                     }
+                }
+                // INVARIANT: terminal_failure_observed MUST be checked BEFORE
+                // effect_staged_observed. Swapping reopens the WM double-effect
+                // window (see projection.md §"Terminal-before-Staged ordering
+                // invariant" and journal-txn.md fold cross-product cell 5).
+                // Regression test:
+                //   kx-projection/tests/cross_product.rs::
+                //   cell_5_terminal_failure_under_effect_staged_no_redispatch
+                else if info.terminal_failure_observed {
+                    MoteState::Failed
+                } else if info.effect_staged_observed {
+                    // Cells 2 + 3: EffectStaged with no Committed and no
+                    // terminal Failed → in-flight; redispatch permitted by
+                    // can_redispatch_world_effect().
+                    MoteState::Pending
                 } else if info.failed_pending_reattempt {
                     MoteState::Failed
                 } else if info.has_proposed {
@@ -244,6 +347,49 @@ impl State {
                 }
             }
         }
+    }
+
+    /// `can_redispatch_world_effect` predicate (v2 / STEP 5.3 / R-13).
+    ///
+    /// Returns `true` iff the executor's recovery-time re-dispatch is safe
+    /// for this Mote. Returns `false` for: `inconsistent` (cell 8 anomaly),
+    /// `terminal_failure_observed` (cell 5 — terminal failure under
+    /// EffectStaged), or `committed.is_some()` (cell 4 — done; never re-dispatch).
+    ///
+    /// **Returns `true` only when** an `EffectStaged` was observed AND no
+    /// terminal failure AND no inconsistency AND no Committed yet — the
+    /// in-flight case (cells 2 + 3) where the broker's tool-boundary
+    /// idempotency closes the window.
+    fn can_redispatch_world_effect_id(&self, id: &MoteId) -> bool {
+        match self.motes.get(id) {
+            None => false,
+            Some(info) => {
+                if info.inconsistent {
+                    return false;
+                }
+                if info.terminal_failure_observed {
+                    return false;
+                }
+                if info.committed.is_some() {
+                    return false;
+                }
+                info.effect_staged_observed
+            }
+        }
+    }
+
+    /// Enumerate every Mote currently flagged anomalous, with its anomaly kind.
+    fn anomaly_motes_iter(&self) -> Vec<(MoteId, AnomalyKind)> {
+        self.motes
+            .iter()
+            .filter_map(|(id, info)| {
+                if info.inconsistent {
+                    Some((*id, AnomalyKind::EffectStagedThenRepudiatedNoCommitted))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Return the declared-or-committed parent list for `id`. Declared takes
@@ -316,6 +462,7 @@ impl State {
 ///     nondeterminism: NdClass::Pure,
 ///     result_ref: ContentRef::from_bytes([7u8; 32]),
 ///     parents: SmallVec::new(),
+///     warrant_ref: ContentRef::from_bytes([0xaa; 32]),
 ///     mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
 /// };
 /// p.fold(&entry).unwrap();
@@ -389,6 +536,9 @@ impl Projection {
                 info.has_proposed = true;
                 // A new Proposed clears any prior pending-failure marker (failed→proposed
                 // is a valid sequence per mote.md §7).
+                // NOTE: `terminal_failure_observed` and `inconsistent` are
+                // **prefix-monotonic-true** per STEP 5.2 + STEP 5.3 of PR 4.5
+                // — they are NEVER reset, here or anywhere.
                 info.failed_pending_reattempt = false;
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
@@ -398,6 +548,7 @@ impl Projection {
                 nondeterminism,
                 result_ref,
                 parents,
+                warrant_ref,
                 mote_def_hash,
                 ..
             } => {
@@ -410,6 +561,7 @@ impl Projection {
                     result_ref: *result_ref,
                     nondeterminism: *nondeterminism,
                     parents_in_entry: parents.clone(),
+                    warrant_ref: *warrant_ref,
                     mote_def_hash: *mote_def_hash,
                     repudiated: false,
                 });
@@ -419,10 +571,24 @@ impl Projection {
                 // for a Mote that wasn't pre-registered).
                 self.state.rebuild_children_index();
             }
-            JournalEntry::Failed { mote_id, seq, .. } => {
+            JournalEntry::Failed {
+                mote_id,
+                seq,
+                reason_class,
+                ..
+            } => {
                 let info = self.state.moteinfo_mut(mote_id);
                 if info.committed.is_none() {
                     info.failed_pending_reattempt = true;
+                    // **v2 (STEP 5.2 + STEP 6.2).** Read reason_class to set
+                    // terminal_failure_observed. Prefix-monotonic-true: once
+                    // set, NEVER reset — even by a subsequent Proposed (the
+                    // monotonicity contract that closes cell 5 of the 9-cell
+                    // cross-product). The canonical classifier
+                    // `is_pre_commit_crash` is the single source of class truth.
+                    if !kx_journal::is_pre_commit_crash(*reason_class) {
+                        info.terminal_failure_observed = true;
+                    }
                 }
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
@@ -443,7 +609,27 @@ impl Projection {
                     if c.seq == *target_committed_seq {
                         c.repudiated = true;
                     }
+                } else if info.effect_staged_observed {
+                    // **v2 (STEP 5.3): cell-8 anomaly.** EffectStaged was
+                    // folded for this Mote, but a Repudiated arrived BEFORE
+                    // any Committed. Repudiated normally targets a Committed;
+                    // this is a journal-consistency error. We quarantine via
+                    // `info.inconsistent = true` (prefix-monotonic-true; never
+                    // reset) rather than aborting the fold. One anomalous Mote
+                    // must not take down the entire recovery; surface via
+                    // `anomaly_motes()` for operator review.
+                    info.inconsistent = true;
                 }
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
+            JournalEntry::EffectStaged { mote_id, seq, .. } => {
+                // **v2 (D38 §2b): EffectStaged recovery hint.** Set the
+                // prefix-monotonic-true flag; the recovery fold combines this
+                // with subsequent Committed/Failed/Repudiated entries via
+                // `state_of_id` (Terminal-before-Staged ordering invariant)
+                // and `can_redispatch_world_effect_id`.
+                let info = self.state.moteinfo_mut(mote_id);
+                info.effect_staged_observed = true;
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
         }
@@ -562,6 +748,41 @@ impl Projection {
             .and_then(|i| i.committed.as_ref().map(|c| c.seq))
     }
 
+    /// **v2 (PR 7, STEP 5.3 + R-13).** Recovery-time predicate: can the
+    /// executor safely re-dispatch a WORLD-MUTATING effect for this Mote?
+    ///
+    /// Returns `true` iff: `info.effect_staged_observed` AND NOT
+    /// `info.terminal_failure_observed` AND NOT `info.inconsistent` AND
+    /// `info.committed.is_none()`. This is the in-flight case (cells 2 + 3
+    /// of the 9-cell cross-product) where the broker's tool-boundary
+    /// idempotency closes the window.
+    ///
+    /// Returns `false` for `inconsistent` (cell 8 anomaly),
+    /// `terminal_failure_observed` (cell 5 — terminal failure under
+    /// EffectStaged; the WM double-effect hazard), `committed.is_some()`
+    /// (cells 4 + 6 — done; never re-dispatch), and for Motes with no
+    /// `EffectStaged` observed (no in-flight effect to re-dispatch).
+    ///
+    /// **Prefix-monotonic refusal** (STEP 5.2): once this returns `false`
+    /// for a given Mote, it returns `false` at every longer log prefix.
+    /// Proven by `prop_terminal_refusal_is_prefix_monotonic`.
+    #[must_use]
+    pub fn can_redispatch_world_effect(&self, mote_id: &MoteId) -> bool {
+        self.state.can_redispatch_world_effect_id(mote_id)
+    }
+
+    /// **v2 (PR 7, STEP 5.3).** Enumerate every Mote currently flagged
+    /// anomalous, with its anomaly kind. Operator-facing diagnostic API;
+    /// NOT on any hot recovery path.
+    ///
+    /// Today returns only [`AnomalyKind::EffectStagedThenRepudiatedNoCommitted`]
+    /// (cell 8). Future fold-cell anomalies extend [`AnomalyKind`] via
+    /// additive variants.
+    #[must_use]
+    pub fn anomaly_motes(&self) -> Vec<(MoteId, AnomalyKind)> {
+        self.state.anomaly_motes_iter()
+    }
+
     /// Apply a sequence of journal entries in order. Convenience over calling
     /// [`Self::fold`] in a loop. Stops on the first error and returns it; the
     /// projection's state at that point reflects every entry applied up to
@@ -664,6 +885,7 @@ impl Projection {
 ///     nondeterminism: NdClass::Pure,
 ///     result_ref: ContentRef::from_bytes([7u8; 32]),
 ///     parents: SmallVec::new(),
+///     warrant_ref: ContentRef::from_bytes([0xaa; 32]),
 ///     mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
 /// }).unwrap();
 ///
@@ -764,6 +986,19 @@ impl Snapshot {
     #[must_use]
     pub fn is_repudiated(&self, mote_id: &MoteId) -> bool {
         matches!(self.state_of(mote_id), MoteState::Repudiated)
+    }
+
+    /// **v2 (PR 7, STEP 5.3 + R-13).** Snapshot mirror of
+    /// [`Projection::can_redispatch_world_effect`].
+    #[must_use]
+    pub fn can_redispatch_world_effect(&self, mote_id: &MoteId) -> bool {
+        self.state.can_redispatch_world_effect_id(mote_id)
+    }
+
+    /// **v2 (PR 7, STEP 5.3).** Snapshot mirror of [`Projection::anomaly_motes`].
+    #[must_use]
+    pub fn anomaly_motes(&self) -> Vec<(MoteId, AnomalyKind)> {
+        self.state.anomaly_motes_iter()
     }
 
     /// Iterate every Mote known at snapshot time with its state.
@@ -924,6 +1159,7 @@ mod tests {
             seq,
             nondeterminism: NdClass::Pure,
             placement_hint: 0,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         }
     }
 
@@ -935,6 +1171,7 @@ mod tests {
             nondeterminism: nd,
             result_ref: cref(mote_byte),
             parents: SmallVec::new(),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: dh(mote_byte),
         }
     }

--- a/kx-projection/tests/cross_product.rs
+++ b/kx-projection/tests/cross_product.rs
@@ -1,0 +1,401 @@
+//! **PR 7 — 9-cell recovery cross-product** (per `journal-txn.md`
+//! §"Recovery fold semantics" + STEP 1 + STEP 5 + STEP 6 of PR 4.5).
+//!
+//! These tests are the LOAD-BEARING acceptance criterion for PR 7: cell-by-cell
+//! coverage of the 9-cell cross-product table. Every cell has its own named
+//! test asserting `(state_of(X), can_redispatch_world_effect(X),
+//! anomaly_motes())` matches the table's "Next action" column.
+//!
+//! Per the corpus: "the 9-cell cross-product table in journal-txn.md IS the
+//! authoritative recovery semantics every executor recovery path in P1.9 will
+//! be written against." This test file is the executable form of that table.
+//!
+//! ## The 9-cell table (reproduced for reference)
+//!
+//! | # | EffectStaged | Committed | Failed | Repudiated | Next action |
+//! |---|:---:|:---:|:---:|:---:|---|
+//! | 0 | — | — | — | — | Pending (not yet attempted) |
+//! | 1 | — | — | F(any) | — | Pending (retry permitted) |
+//! | 2 | ✓ | — | — | — | Pending (in-flight; redispatch OK) |
+//! | 3 | ✓ | — | F(pre-commit-crash) | — | Pending (redispatch OK) |
+//! | 4 | ✓ | — | F(terminal) | — | **Failed (DO NOT REDISPATCH — cell 5 hazard)** |
+//! | 5 | ✓ | ✓ | (any) | — | Committed (DONE) |
+//! | 6 | — | ✓ | (any) | — | Committed (standard) |
+//! | 7 | ✓ | ✓ | (any) | ✓ | Repudiated |
+//! | 8 | ✓ | — | — | ✓ | **Inconsistent (anomaly — cell 8 quarantine)** |
+//! | 9 | — | ✓ | — | ✓ | Repudiated (standard) |
+//!
+//! The "9-cell" name is from STEP 1 / PR 4.5; the table actually enumerates 10
+//! rows including cell 0 (no entries). Cell 4 above is the load-bearing
+//! Terminal-before-Staged ordering invariant cell (STEP 5.1).
+
+use kx_content::ContentRef;
+use kx_journal::{
+    is_pre_commit_crash, repudiation_idempotency_key, FailureReason, InMemoryJournal, Journal,
+    JournalEntry, RepudiationReason,
+};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use kx_projection::{AnomalyKind, MoteState, Projection};
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn committed(mote_id: MoteId, seq_hint: u64) -> JournalEntry {
+    JournalEntry::Committed {
+        mote_id,
+        idempotency_key: mote_id.0,
+        seq: seq_hint,
+        nondeterminism: NdClass::WorldMutating,
+        result_ref: ContentRef::from_bytes([7u8; 32]),
+        parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([0u8; 32]),
+    }
+}
+
+fn effect_staged(mote_id: MoteId, seq_hint: u64) -> JournalEntry {
+    JournalEntry::EffectStaged {
+        mote_id,
+        idempotency_key: mote_id.0,
+        seq: seq_hint,
+    }
+}
+
+fn failed(mote_id: MoteId, seq_hint: u64, reason: FailureReason) -> JournalEntry {
+    JournalEntry::Failed {
+        mote_id,
+        idempotency_key: mote_id.0,
+        seq: seq_hint,
+        reason_class: reason,
+        reporter_id: 0,
+    }
+}
+
+fn repudiated(target_mote_id: MoteId, target_committed_seq: u64, seq_hint: u64) -> JournalEntry {
+    JournalEntry::Repudiated {
+        target_mote_id,
+        idempotency_key: repudiation_idempotency_key(&target_mote_id, target_committed_seq),
+        seq: seq_hint,
+        target_committed_seq,
+        reason_class: RepudiationReason::OperatorAction,
+        repudiator_id: 0,
+    }
+}
+
+/// Build a Projection by appending entries through an `InMemoryJournal`,
+/// which assigns monotonic `seq` values. Returns the projection at the
+/// final state, plus the entry-by-entry seqs the journal assigned (useful
+/// for constructing Repudiated entries that reference the assigned seq).
+fn projection_from_entries(entries: Vec<JournalEntry>) -> (Projection, Vec<u64>) {
+    let journal = InMemoryJournal::new();
+    let mut seqs = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let returned = journal.append(entry).expect("append");
+        seqs.push(returned.seq());
+    }
+    let projection = Projection::from_journal(&journal).expect("from_journal");
+    (projection, seqs)
+}
+
+// ---------------------------------------------------------------------------
+// Cell 0 — empty (no entries)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_0_no_entries_yields_pending_and_no_redispatch() {
+    let mid = MoteId::from_bytes([1u8; 32]);
+    let (p, _) = projection_from_entries(vec![]);
+    assert_eq!(p.state_of(&mid), MoteState::Pending);
+    assert!(!p.can_redispatch_world_effect(&mid));
+    assert!(p.anomaly_motes().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Cell 1 — Failed (no EffectStaged, no Committed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_1_failed_pre_commit_crash_only_yields_failed_pending_reattempt() {
+    let mid = MoteId::from_bytes([2u8; 32]);
+    let (p, _) = projection_from_entries(vec![failed(mid, 0, FailureReason::TimedOut)]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    // Pre-commit-crash alone (no EffectStaged) is retry-allowed, but the
+    // `can_redispatch_world_effect` predicate is specifically about WM
+    // effect re-dispatch under EffectStaged. Without EffectStaged, the
+    // answer is "no in-flight effect to redispatch" → false.
+    assert!(!p.can_redispatch_world_effect(&mid));
+    assert!(p.anomaly_motes().is_empty());
+}
+
+#[test]
+fn cell_1_failed_terminal_only_yields_failed() {
+    let mid = MoteId::from_bytes([3u8; 32]);
+    let (p, _) = projection_from_entries(vec![failed(mid, 0, FailureReason::ExecutorRefused)]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// Cell 2 — EffectStaged alone
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_2_effect_staged_alone_yields_pending_and_redispatch_ok() {
+    let mid = MoteId::from_bytes([4u8; 32]);
+    let (p, _) = projection_from_entries(vec![effect_staged(mid, 0)]);
+    // EffectStaged with no Committed AND no terminal Failed AND no
+    // Inconsistent → in-flight (Pending); re-dispatch permitted.
+    assert_eq!(p.state_of(&mid), MoteState::Pending);
+    assert!(
+        p.can_redispatch_world_effect(&mid),
+        "cell 2: EffectStaged alone → redispatch permitted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cell 3 — EffectStaged + Failed(pre-commit-crash)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_3_effect_staged_then_timed_out_yields_pending_and_redispatch_ok() {
+    let mid = MoteId::from_bytes([5u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::TimedOut),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Pending);
+    assert!(
+        p.can_redispatch_world_effect(&mid),
+        "cell 3: EffectStaged + TimedOut (pre-commit-crash class) → redispatch permitted"
+    );
+}
+
+#[test]
+fn cell_3_effect_staged_then_worker_crashed_yields_pending_and_redispatch_ok() {
+    let mid = MoteId::from_bytes([6u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::WorkerCrashed),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Pending);
+    assert!(
+        p.can_redispatch_world_effect(&mid),
+        "cell 3: EffectStaged + WorkerCrashed (pre-commit-crash class) → redispatch permitted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cell 4 — EffectStaged + Failed(TERMINAL) — THE LOAD-BEARING CELL
+// (STEP 5.1 Terminal-before-Staged ordering invariant cell.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_5_terminal_failure_under_effect_staged_no_redispatch() {
+    // The cell that exists to prove the WM double-effect window is CLOSED.
+    // Without the Terminal-before-Staged ordering invariant, this test
+    // would FAIL because effect_staged_observed would override
+    // terminal_failure_observed in state_of_id derivation.
+    let mid = MoteId::from_bytes([7u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::ValidatorRejected),
+    ]);
+    assert_eq!(
+        p.state_of(&mid),
+        MoteState::Failed,
+        "cell 5: terminal failure under EffectStaged MUST yield Failed (not Pending in-flight)"
+    );
+    assert!(
+        !p.can_redispatch_world_effect(&mid),
+        "cell 5: terminal failure under EffectStaged MUST forbid redispatch \
+         (the WM double-effect hazard cell)"
+    );
+}
+
+#[test]
+fn cell_5_terminal_failure_under_effect_staged_executor_refused() {
+    let mid = MoteId::from_bytes([8u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::ExecutorRefused),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+#[test]
+fn cell_5_terminal_failure_under_effect_staged_upstream_repudiated() {
+    let mid = MoteId::from_bytes([9u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::UpstreamRepudiated),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+#[test]
+fn cell_5_terminal_failure_under_effect_staged_unsafe_wm_construction() {
+    let mid = MoteId::from_bytes([10u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::UnsafeWorldMutatingConstruction),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// Cell 5 — EffectStaged + Committed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_5_effect_staged_plus_committed_yields_committed_no_redispatch() {
+    let mid = MoteId::from_bytes([11u8; 32]);
+    let (p, _) = projection_from_entries(vec![effect_staged(mid, 0), committed(mid, 0)]);
+    assert_eq!(p.state_of(&mid), MoteState::Committed);
+    // Committed → DONE. Never re-dispatch.
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+#[test]
+fn cell_5_effect_staged_plus_committed_plus_trailing_failed_still_committed() {
+    // A trailing Failed AFTER a Committed (e.g., from a stale worker) is
+    // ignored — Committed is the durable fact (per-Mote); Failed is
+    // per-attempt.
+    let mid = MoteId::from_bytes([12u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        committed(mid, 0),
+        failed(mid, 0, FailureReason::WorkerCrashed),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Committed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// Cell 6 — Committed without EffectStaged (legal for non-Staged tools)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_6_committed_without_effect_staged_yields_committed_no_redispatch() {
+    let mid = MoteId::from_bytes([13u8; 32]);
+    let (p, _) = projection_from_entries(vec![committed(mid, 0)]);
+    assert_eq!(p.state_of(&mid), MoteState::Committed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// Cell 7 — EffectStaged + Committed + Repudiated
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_7_effect_staged_committed_then_repudiated_yields_repudiated() {
+    let mid = MoteId::from_bytes([14u8; 32]);
+    let entries = vec![effect_staged(mid, 0), committed(mid, 0)];
+    let (_, seqs) = projection_from_entries(entries.clone());
+    let committed_seq = seqs[1]; // the journal assigned this on append
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        committed(mid, 0),
+        repudiated(mid, committed_seq, 0),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Repudiated);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// Cell 8 — EffectStaged + Repudiated WITHOUT Committed (the anomaly)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_8_anomaly_effect_staged_then_repudiated_no_committed() {
+    let mid = MoteId::from_bytes([15u8; 32]);
+    // Repudiated targets a non-existent target_committed_seq=0. The fold
+    // detects: `info.committed.is_none() && info.effect_staged_observed`
+    // → sets `info.inconsistent = true`. The fold does NOT abort; the
+    // anomaly is quarantined.
+    let (p, _) = projection_from_entries(vec![effect_staged(mid, 0), repudiated(mid, 0, 0)]);
+    assert_eq!(
+        p.state_of(&mid),
+        MoteState::Inconsistent,
+        "cell 8: EffectStaged + Repudiated-without-Committed MUST yield Inconsistent"
+    );
+    assert!(
+        !p.can_redispatch_world_effect(&mid),
+        "cell 8: Inconsistent forbids redispatch"
+    );
+    let anomalies = p.anomaly_motes();
+    assert_eq!(anomalies.len(), 1);
+    assert_eq!(
+        anomalies[0],
+        (mid, AnomalyKind::EffectStagedThenRepudiatedNoCommitted)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cell 9 — Committed + Repudiated (standard repudiation)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_9_committed_then_repudiated_yields_repudiated_standard() {
+    let mid = MoteId::from_bytes([16u8; 32]);
+    let (_, seqs) = projection_from_entries(vec![committed(mid, 0)]);
+    let committed_seq = seqs[0];
+    let (p, _) =
+        projection_from_entries(vec![committed(mid, 0), repudiated(mid, committed_seq, 0)]);
+    assert_eq!(p.state_of(&mid), MoteState::Repudiated);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// STEP 5.1 — Terminal-before-Staged ordering invariant (the load-bearing
+// regression). The cell_5_terminal_failure_under_effect_staged_no_redispatch
+// test above IS this regression test (the test would FAIL if state_of_id
+// branches 4 and 5 were swapped). This sister test is `#[ignore]` by default;
+// it exists as a meta-test of the invariant and is activated for ad-hoc
+// regression auditing only.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "meta-test: demonstrates the Terminal-before-Staged invariant is load-bearing — see cell_5_terminal_failure_under_effect_staged_no_redispatch for the active regression test"]
+fn cell_5_ignored_sister_test_branch_swap_documentation() {
+    // This test asserts the EXACT same fixture as
+    // cell_5_terminal_failure_under_effect_staged_no_redispatch — it
+    // documents that the invariant is load-bearing. If a future contributor
+    // accidentally swaps branches 4 and 5 in state_of_id, the ACTIVE
+    // regression test (cell_5_...) will fail. This sister test exists as
+    // documentation that the swap-failure is a real correctness regression,
+    // not a stylistic one. The test runs only when explicitly invoked.
+    let mid = MoteId::from_bytes([17u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::ValidatorRejected),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+}
+
+// ---------------------------------------------------------------------------
+// Single-source-of-class-truth: is_pre_commit_crash classifies canonically
+// (STEP 6.2 — both production code AND tests call this function; no
+// hardcoded list).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_pre_commit_crash_classifies_canonically_pre_commit_crash_variants() {
+    assert!(is_pre_commit_crash(FailureReason::TimedOut));
+    assert!(is_pre_commit_crash(FailureReason::WorkerCrashed));
+}
+
+#[test]
+fn is_pre_commit_crash_classifies_canonically_terminal_variants() {
+    assert!(!is_pre_commit_crash(FailureReason::ExecutorRefused));
+    assert!(!is_pre_commit_crash(FailureReason::ValidatorRejected));
+    assert!(!is_pre_commit_crash(FailureReason::UpstreamRepudiated));
+    assert!(!is_pre_commit_crash(
+        FailureReason::UnsafeWorldMutatingConstruction
+    ));
+}

--- a/kx-projection/tests/dod.rs
+++ b/kx-projection/tests/dod.rs
@@ -54,6 +54,7 @@ fn commit(p: &mut Projection, mote_byte: u8, seq: u64, nd: NdClass) {
         nondeterminism: nd,
         result_ref: cref(mote_byte),
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: dh(mote_byte),
     })
     .unwrap();
@@ -66,6 +67,7 @@ fn propose(p: &mut Projection, mote_byte: u8, seq: u64) {
         seq,
         nondeterminism: NdClass::Pure,
         placement_hint: 0,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
     })
     .unwrap();
 }
@@ -239,6 +241,7 @@ fn obligation_5_projection_does_not_depend_on_journal_mut_surface() {
         nondeterminism: NdClass::Pure,
         result_ref: cref(b'a'),
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: dh(b'a'),
     });
     let _ = Projection::from_journal(&j).unwrap();
@@ -374,6 +377,7 @@ fn obligation_9_cycle_in_control_edges_does_not_loop() {
         nondeterminism: NdClass::Pure,
         result_ref: cref(b'a'),
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: dh(b'a'),
     })
     .unwrap();
@@ -392,6 +396,7 @@ fn obligation_9_cycle_in_control_edges_does_not_loop() {
         nondeterminism: NdClass::Pure,
         result_ref: cref(b'b'),
         parents: b_parents,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: dh(b'b'),
     })
     .unwrap();
@@ -444,6 +449,7 @@ fn exercise_from_journal<J: Journal>(j: &J) {
         nondeterminism: NdClass::Pure,
         result_ref: cref(b'a'),
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: dh(b'a'),
     });
     let p = Projection::from_journal(j).unwrap();
@@ -503,6 +509,7 @@ fn sample_log() -> Vec<JournalEntry> {
             seq: 1,
             nondeterminism: NdClass::Pure,
             placement_hint: 0,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         },
         JournalEntry::Committed {
             mote_id: mid(b'a'),
@@ -511,6 +518,7 @@ fn sample_log() -> Vec<JournalEntry> {
             nondeterminism: NdClass::Pure,
             result_ref: cref(b'a'),
             parents: SmallVec::new(),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: dh(b'a'),
         },
         JournalEntry::Proposed {
@@ -519,6 +527,7 @@ fn sample_log() -> Vec<JournalEntry> {
             seq: 3,
             nondeterminism: NdClass::Pure,
             placement_hint: 0,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         },
         JournalEntry::Committed {
             mote_id: mid(b'b'),
@@ -527,6 +536,7 @@ fn sample_log() -> Vec<JournalEntry> {
             nondeterminism: NdClass::Pure,
             result_ref: cref(b'b'),
             parents: parent_entries(&[(b'a', EdgeKind::Data, false)]),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: dh(b'b'),
         },
         JournalEntry::Committed {
@@ -536,6 +546,7 @@ fn sample_log() -> Vec<JournalEntry> {
             nondeterminism: NdClass::Pure,
             result_ref: cref(b'c'),
             parents: parent_entries(&[(b'a', EdgeKind::Data, false)]),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
             mote_def_hash: dh(b'c'),
         },
     ]

--- a/kx-projection/tests/proptest_fold.rs
+++ b/kx-projection/tests/proptest_fold.rs
@@ -43,6 +43,7 @@ fn arb_proposed(mote_id_seed: u8, seq: u64) -> JournalEntry {
         seq,
         nondeterminism: NdClass::Pure,
         placement_hint: 0,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
     }
 }
 
@@ -54,6 +55,7 @@ fn arb_committed(mote_id_seed: u8, seq: u64, nd: NdClass) -> JournalEntry {
         nondeterminism: nd,
         result_ref: ContentRef::from_bytes([mote_id_seed; 32]),
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
         mote_def_hash: MoteDefHash::from_bytes([mote_id_seed; 32]),
     }
 }
@@ -436,4 +438,198 @@ fn fold_many_stops_on_first_error_and_state_reflects_applied_entries() {
     assert!(!p
         .iter_motes()
         .any(|(id, _)| id == MoteId::from_bytes([4; 32])));
+}
+
+// ---------------------------------------------------------------------------
+// **PR 7 — STEP 5.2 + STEP 6 properties (load-bearing recovery contract).**
+//
+// These properties pin the prefix-monotonicity-of-refusal contract: once
+// `can_redispatch_world_effect` returns `false` at a log prefix, it returns
+// `false` at every longer prefix (refusal is monotonic; once terminal,
+// always terminal). They also enforce the canonical-classifier-cannot-drift
+// contract via class-covering proptests over the full `FailureReason` enum
+// (mirror of STEP 6.2 from PR 4.5).
+// ---------------------------------------------------------------------------
+
+use kx_journal::is_pre_commit_crash;
+
+/// Strategy: an arbitrary `FailureReason` variant. MUST be updated when a
+/// new variant lands — canonical-classifier-cannot-drift TEST-level gate.
+/// The single source of class truth (pre-commit-crash vs terminal) is
+/// `kx_journal::is_pre_commit_crash`; both prod code and tests call it.
+fn arbitrary_failure_reason() -> impl Strategy<Value = FailureReason> {
+    prop_oneof![
+        Just(FailureReason::TimedOut),
+        Just(FailureReason::ExecutorRefused),
+        Just(FailureReason::ValidatorRejected),
+        Just(FailureReason::WorkerCrashed),
+        Just(FailureReason::UpstreamRepudiated),
+        Just(FailureReason::UnsafeWorldMutatingConstruction),
+    ]
+}
+
+fn arb_mote_id_strategy() -> impl Strategy<Value = MoteId> {
+    (1u8..=200).prop_map(|s| MoteId::from_bytes([s; 32]))
+}
+
+fn effect_staged_for(mid: MoteId) -> JournalEntry {
+    JournalEntry::EffectStaged {
+        mote_id: mid,
+        idempotency_key: mid.0,
+        seq: 0,
+    }
+}
+
+fn failed_for(mid: MoteId, reason: FailureReason) -> JournalEntry {
+    JournalEntry::Failed {
+        mote_id: mid,
+        idempotency_key: mid.0,
+        seq: 0,
+        reason_class: reason,
+        reporter_id: 0,
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    /// **STEP 5.2 — Prefix-monotonicity of refusal.** Once
+    /// `can_redispatch_world_effect(mote)` returns `false` at some prefix of
+    /// the log, it returns `false` at every longer prefix. Equivalently:
+    /// refusal can only stabilize toward "more refusal," never less.
+    ///
+    /// This is the property that closes cell 5 of the 9-cell cross-product
+    /// against future regression: any fold-branch edit that resets
+    /// `terminal_failure_observed` or `inconsistent` would fail this proptest.
+    #[test]
+    fn prop_terminal_refusal_is_prefix_monotonic(
+        mid in arb_mote_id_strategy(),
+        reason in arbitrary_failure_reason(),
+        n_extra in 1usize..=5,
+    ) {
+        // Build a log that gets the Mote into a refusal state, then appends
+        // extra entries on top. Refusal must hold across every prefix from
+        // the point it first becomes true.
+        let mut p = Projection::new();
+        p.fold(&effect_staged_for(mid)).unwrap();
+        p.fold(&failed_for(mid, reason)).unwrap();
+
+        let mut prev_refused = false;
+        // Test at each prefix length 0..=n_extra additional entries.
+        for i in 0..n_extra {
+            let refused = !p.can_redispatch_world_effect(&mid);
+            if prev_refused {
+                prop_assert!(
+                    refused,
+                    "refusal MUST be prefix-monotonic — became false again at extra-prefix {i}"
+                );
+            }
+            prev_refused = prev_refused || refused;
+            // Append another arbitrary entry (a Proposed — chosen because
+            // Proposed resets `failed_pending_reattempt` but MUST NOT
+            // reset `terminal_failure_observed` or `inconsistent` per
+            // STEP 5.2 + STEP 5.3 prefix-monotonic-true contract).
+            p.fold(&JournalEntry::Proposed {
+                mote_id: mid,
+                idempotency_key: mid.0,
+                seq: 0,
+                nondeterminism: NdClass::Pure,
+                placement_hint: 0,
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            }).unwrap();
+        }
+    }
+
+    /// **STEP 6.2 — class-covering: terminal under EffectStaged forbids
+    /// redispatch.** For every `FailureReason` classified as terminal by
+    /// `is_pre_commit_crash`, a journal `[EffectStaged, Failed(reason)]`
+    /// folds to `can_redispatch_world_effect == false`.
+    ///
+    /// **The proptest gates via `is_pre_commit_crash` directly** so the
+    /// production classifier and the test surface share the same function;
+    /// no risk of drift if a future variant lands.
+    #[test]
+    fn prop_terminal_failure_under_effect_staged_refuses_redispatch(
+        reason in arbitrary_failure_reason(),
+        mid in arb_mote_id_strategy(),
+    ) {
+        prop_assume!(!is_pre_commit_crash(reason));
+        let mut p = Projection::new();
+        p.fold(&effect_staged_for(mid)).unwrap();
+        p.fold(&failed_for(mid, reason)).unwrap();
+        prop_assert!(
+            !p.can_redispatch_world_effect(&mid),
+            "terminal {reason:?} under EffectStaged MUST refuse redispatch"
+        );
+        prop_assert_eq!(p.state_of(&mid), MoteState::Failed);
+    }
+
+    /// **STEP 6.2 — class-covering: pre-commit-crash under EffectStaged
+    /// permits redispatch.** Sister property to the above; pre-commit-crash
+    /// failures (TimedOut, WorkerCrashed) under EffectStaged → redispatch
+    /// permitted (cell 3).
+    #[test]
+    fn prop_precommit_failure_under_effect_staged_permits_redispatch(
+        reason in arbitrary_failure_reason(),
+        mid in arb_mote_id_strategy(),
+    ) {
+        prop_assume!(is_pre_commit_crash(reason));
+        let mut p = Projection::new();
+        p.fold(&effect_staged_for(mid)).unwrap();
+        p.fold(&failed_for(mid, reason)).unwrap();
+        prop_assert!(
+            p.can_redispatch_world_effect(&mid),
+            "pre-commit-crash {reason:?} under EffectStaged MUST permit redispatch (cell 3)"
+        );
+        // state_of_id falls through to Pending (in-flight) since
+        // terminal_failure_observed is false.
+        prop_assert_eq!(p.state_of(&mid), MoteState::Pending);
+    }
+
+    /// **STEP 6.1 — `inconsistent` flag is prefix-monotonic-true.** Once a
+    /// Mote enters `MoteState::Inconsistent`, it stays Inconsistent across
+    /// every longer log prefix. Mirror of STEP 5.2 for the cell-8 anomaly.
+    #[test]
+    fn prop_inconsistent_is_monotonic_true(
+        mid in arb_mote_id_strategy(),
+        n_extra in 1usize..=5,
+    ) {
+        let mut p = Projection::new();
+        // Set up cell-8: EffectStaged then Repudiated, no Committed in
+        // between. Sets info.inconsistent = true.
+        p.fold(&effect_staged_for(mid)).unwrap();
+        p.fold(&JournalEntry::Repudiated {
+            target_mote_id: mid,
+            idempotency_key: kx_journal::repudiation_idempotency_key(&mid, 0),
+            seq: 0,
+            target_committed_seq: 0,
+            reason_class: RepudiationReason::OperatorAction,
+            repudiator_id: 0,
+        }).unwrap();
+
+        prop_assert_eq!(p.state_of(&mid), MoteState::Inconsistent);
+
+        // Now append extra entries. Inconsistent MUST hold across every
+        // longer prefix — no fold branch may reset `info.inconsistent`.
+        for _ in 0..n_extra {
+            // Mix in a Proposed (the only branch that resets any flag).
+            p.fold(&JournalEntry::Proposed {
+                mote_id: mid,
+                idempotency_key: mid.0,
+                seq: 0,
+                nondeterminism: NdClass::Pure,
+                placement_hint: 0,
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            }).unwrap();
+            prop_assert_eq!(
+                p.state_of(&mid),
+                MoteState::Inconsistent,
+                "inconsistent MUST be prefix-monotonic-true even after subsequent Proposed"
+            );
+            prop_assert!(!p.can_redispatch_world_effect(&mid));
+        }
+    }
 }


### PR DESCRIPTION
## 🎯 THE KEYSTONE

Three of the five weakest guarantee-integrity cells in the post-PR-6 confidence-score table collapsed onto this single PR. **They are now closed.**

Three coordinated changes ride the single v1→v2 schema bump per D36 + D38 §2b + STEP 1 + STEP 5 + STEP 6 of PR 4.5.

## The three coordinated changes

1. **`warrant_ref: ContentRef`** on `Proposed` + `Committed` bodies (D36). Durable fact carries warrant identity.
2. **NEW `EffectStaged` journal kind (=4)** (D38 §2b). Header-only body; the recovery hint that closes the WM double-effect window.
3. **Dedup-by-key index expansion**: `kind IN {1, 2}` → `{1, 2, 4}` in both backends.

Plus: `JOURNAL_SCHEMA_VERSION` 1→2; `MAX_ENTRY_LEN` 4460→4500; **NEW `pub fn is_pre_commit_crash(reason) -> bool`** — single source of class truth.

## kx-projection recovery fold (the contract)

`MoteInfo` gains **3 prefix-monotonic-true flags** (NEVER reset by any fold branch):
- `effect_staged_observed`
- `terminal_failure_observed`
- `inconsistent`

`MoteState::Inconsistent` variant added (verified non-breaking via grep).

**`state_of_id` Terminal-before-Staged ordering invariant** (STEP 5.1 — LOAD-BEARING):
```
1. info.inconsistent             → Inconsistent
2. committed.is_some() && repud  → Repudiated
3. committed.is_some()           → Committed
4. info.terminal_failure_observed → Failed   ← MUST precede branch 5
5. info.effect_staged_observed   → Pending (in-flight; redispatch OK)
6. info.failed_pending_reattempt → Failed
7. info.has_proposed             → Scheduled
8. else                          → Pending
```

Swapping branches 4 and 5 reopens the WM double-effect window. The invariant is named at the inline code comment + verified by the active regression test `cell_5_terminal_failure_under_effect_staged_no_redispatch` + documented by the `#[ignore]`'d sister test.

## NEW public API (kx-projection)

- `Projection::can_redispatch_world_effect(mote_id) -> bool` (R-13 recovery predicate)
- `Projection::anomaly_motes() -> Vec<(MoteId, AnomalyKind)>` (operator diagnostic)
- Snapshot mirrors of both
- `pub enum AnomalyKind` — today: `EffectStagedThenRepudiatedNoCommitted`

## 9-cell cross-product tests (the load-bearing acceptance criterion)

NEW `kx-projection/tests/cross_product.rs` — **19 tests** (1 ignored sister-test). One named test per cell of the table per `journal-txn.md` §"Recovery fold semantics":

| # | EffectStaged | Committed | Failed | Repudiated | State | Redispatch? |
|---|:---:|:---:|:---:|:---:|---|---|
| 0 | — | — | — | — | Pending | NO (no in-flight) |
| 1 | — | — | F(any) | — | Failed | NO |
| 2 | ✓ | — | — | — | Pending | **YES (in-flight)** |
| 3 | ✓ | — | F(pre-commit-crash) | — | Pending | **YES** |
| **5** | ✓ | — | **F(terminal)** | — | **Failed** | **NO (the load-bearing cell)** |
| 5b | ✓ | ✓ | (any) | — | Committed | NO (done) |
| 6 | — | ✓ | (any) | — | Committed | NO |
| 7 | ✓ | ✓ | (any) | ✓ | Repudiated | NO |
| **8** | ✓ | — | — | ✓ | **Inconsistent (anomaly)** | **NO** |
| 9 | — | ✓ | — | ✓ | Repudiated | NO |

Cell 5 has 4 sub-tests (one per terminal `FailureReason`); cell 3 has 2 sub-tests (one per pre-commit-crash variant).

## STEP 5 + STEP 6 proptests (prefix-monotonicity + class-covering)

4 new properties × 64 cases each in `proptest_fold.rs`:

- `prop_terminal_refusal_is_prefix_monotonic` (STEP 5.2)
- `prop_terminal_failure_under_effect_staged_refuses_redispatch` (STEP 6.2 — class-covering via `arbitrary_failure_reason` + `is_pre_commit_crash`)
- `prop_precommit_failure_under_effect_staged_permits_redispatch` (sister)
- `prop_inconsistent_is_monotonic_true` (STEP 6.1 — mirror of 5.2 for cell-8 anomaly)

**Canonical-classifier-cannot-drift contract** (PR 6's CODE-level pattern, now applied to FailureReason at the TEST level): `is_pre_commit_crash` is the single source of class truth — both production code (the fold's Failed arm) AND tests call it. A new variant requires exactly ONE update site.

## Downstream test fixture updates

`warrant_ref` field added to every test that constructs `Proposed` or `Committed` across kx-journal, kx-projection, kx-context-assembler, kx-memoizer. **No production-code-path changes to consumer crates.** Test fixtures only.

## Test deltas

| Crate | Before | After | Δ |
|---|---|---|---|
| `kx-journal` | 56 | 65 | +9 (is_pre_commit_crash + 4 size invariants for v2 + EffectStaged round-trip + encoding-determinism + EffectStaged variants in `header_is_74_bytes_for_every_kind`) |
| `kx-projection` | 35 | **53** | **+18 (cross_product 9-cell + STEP 5/6 proptests)** |
| **Workspace** | **394** | **421** | **+27** |

## Gates (Apple Silicon local)

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ — **421/421**
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✓

## What this PR closes (guarantee-integrity moves)

| Cell | Before | After |
|---|---|---|
| 9-cell fold cross-product | **0 SPEC-ONLY** | **PROVEN** (19 named cell tests) |
| Prefix-monotonicity of refusal | **0 SPEC-ONLY** | **PROVEN** (3 proptests) |
| kx-projection guarantee | 25 SPEC-ONLY | **PROVEN** (recovery semantics wired + STEP 5 named invariants) |
| kx-journal guarantee | 40 PARTIAL | **~75 PROVEN** (v2 is what the runtime needs) |
| Seam B guarantee | 20 SPEC-ONLY | 40 PARTIAL (journal-side primitive exists; executor R-10+R-13 still PR 9) |

## Next

**PR 7.5 — kx-mote TopologyDecision + ChildDescriptor** (additive; no schema bump on MoteDef). Then PR 8 (kx-inference dispatcher), PR 8.5 (kx-capability broker), and **PR 9 — kx-executor** where the runtime promise lands end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)