### PR TITLE
PR 8 (P1.8): kx-inference dispatcher (D35) + forward-compat hooks for multimodal & constrained generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-inference"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "kx-content",
+ "kx-context-assembler",
+ "kx-journal",
+ "kx-llamacpp",
+ "kx-memoizer",
+ "kx-model-validator",
+ "kx-mote",
+ "kx-projection",
+ "kx-tool-registry",
+ "kx-warrant",
+ "proptest",
+ "serde",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-journal"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/kx-context-assembler",
     "crates/kx-memoizer",
     "crates/kx-normalizer",
+    "crates/kx-inference",
 ]
 exclude = [
     "kx-cloud",
@@ -68,6 +69,7 @@ kx-tool-registry     = { path = "crates/kx-tool-registry",     version = "0.0.1"
 kx-context-assembler = { path = "crates/kx-context-assembler", version = "0.0.1" }
 kx-memoizer          = { path = "crates/kx-memoizer",          version = "0.0.1" }
 kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.0.1" }
+kx-inference         = { path = "crates/kx-inference",         version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-inference/Cargo.toml
+++ b/crates/kx-inference/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name         = "kx-inference"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx inference dispatcher (P1.8, D35) — user-names-model, runtime enforces scope. NO automatic model selection in OSS v0.1. Wraps kx-llamacpp as the in-process OSS backend; cloud backends ride the same InferenceBackend trait. PR 8 reserves forward-compat hooks for multimodal + constrained generation (InferenceInput::Multimodal + InferenceParams.grammar)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-content           = { workspace = true }
+kx-mote              = { workspace = true }
+kx-warrant           = { workspace = true }
+kx-model-validator   = { workspace = true }
+kx-memoizer          = { workspace = true }
+kx-projection        = { workspace = true }
+kx-context-assembler = { workspace = true }
+kx-llamacpp          = { workspace = true }
+serde                = { workspace = true }
+thiserror            = { workspace = true }
+tracing              = { workspace = true }
+smallvec             = { workspace = true }
+
+[dev-dependencies]
+kx-journal         = { workspace = true }
+kx-tool-registry   = { workspace = true }
+proptest           = { workspace = true }
+tempfile           = { workspace = true }
+tracing-subscriber = { workspace = true }
+bytes              = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-inference/src/backend.rs
+++ b/crates/kx-inference/src/backend.rs
@@ -1,0 +1,101 @@
+// The `InferenceBackend` trait — the seam every model-serving
+// implementation rides.
+//
+// CRITICAL (D35 + D28): the trait MUST carry NO in-process or
+// in-binary assumptions in its signature. Triton (out-of-process),
+// vLLM (out-of-process), remote APIs (cross-network), and the OSS
+// in-process llama.cpp backend must all fit behind this trait WITHOUT
+// trait change. If you find yourself wanting to add a method that
+// only makes sense for an in-process backend, that method belongs on
+// a more specific type, not on this trait.
+
+use kx_mote::ModelId;
+use kx_warrant::WarrantSpec;
+
+use crate::types::{InferenceError, InferenceInput, InferenceOutput, InferenceParams};
+
+/// A single dispatch request, packaged as a reference-tuple so
+/// `batch_dispatch` doesn't force clones.
+#[derive(Debug)]
+pub struct BatchItem<'a> {
+    /// Model identity for this item.
+    pub model_id: &'a ModelId,
+    /// Input prompt / multimodal package.
+    pub input: &'a InferenceInput,
+    /// Sampling + token-limit parameters.
+    pub params: &'a InferenceParams,
+    /// Warrant whose scope the backend enforces.
+    pub warrant: &'a WarrantSpec,
+}
+
+/// The model-serving seam.
+///
+/// Every backend impl (OSS local `LlamaInferenceBackend`, future
+/// `kx-cloud-inference-*` crates for vLLM / Triton / remote APIs)
+/// implements this trait. The dispatcher (`Dispatcher`) holds a set
+/// of backends and routes each call to the one that `supports` the
+/// requested `ModelId`.
+///
+/// **Dyn-compatible**: methods have no generics, no `Self` in the
+/// return type, and no associated types. The dispatcher holds
+/// `Box<dyn InferenceBackend>` or `Arc<dyn InferenceBackend>` so a
+/// runtime-configurable backend set is supported.
+pub trait InferenceBackend: Send + Sync {
+    /// Run a single inference request.
+    ///
+    /// The backend MUST honour `warrant.resource_ceiling.wall_clock_ms`
+    /// as the timeout — exceeding it returns
+    /// `Err(InferenceError::Timeout)`.
+    ///
+    /// The backend MUST return `Err(InferenceError::Unsupported)` on
+    /// any input variant or param it does not implement. Future
+    /// variants (`InferenceInput::Multimodal`,
+    /// `InferenceParams.grammar = Some(_)`) are deliberate
+    /// not-implemented-yet seams in OSS v0.1.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InferenceError::Unsupported` for the reserved v0.1
+    /// variants, `InferenceError::WarrantDeniesModel` when the model
+    /// id does not match the warrant's route, `ScopeViolation` when
+    /// params overshoot the warrant's ceilings, `ModelNotFound` when
+    /// the backend cannot serve the requested model, `Timeout` on
+    /// wall-clock expiry, and `BackendFailure` on any backend-internal
+    /// failure.
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        input: &InferenceInput,
+        params: &InferenceParams,
+        warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError>;
+
+    /// Whether this backend can serve the named model.
+    ///
+    /// The dispatcher uses this to choose which backend to route a
+    /// given `dispatch_mote` call to. Backends MUST return `false` for
+    /// model ids they have not been configured with (so the dispatcher
+    /// can probe a backend set deterministically).
+    fn supports(&self, model_id: &ModelId) -> bool;
+
+    /// Backend identity string for diagnostics + audit-trail logging.
+    /// Echoed back in `InferenceOutput.backend_name`.
+    fn name(&self) -> &'static str;
+
+    /// Batched dispatch.
+    ///
+    /// Default impl calls `dispatch` per item. Future cloud backends
+    /// (vLLM, Triton) override this to exploit true server-side
+    /// batching. The default exists so every backend can be used in a
+    /// batched context without re-implementation; the seam is what's
+    /// load-bearing (D35).
+    fn batch_dispatch(
+        &self,
+        items: &[BatchItem<'_>],
+    ) -> Vec<Result<InferenceOutput, InferenceError>> {
+        items
+            .iter()
+            .map(|item| self.dispatch(item.model_id, item.input, item.params, item.warrant))
+            .collect()
+    }
+}

--- a/crates/kx-inference/src/dispatcher.rs
+++ b/crates/kx-inference/src/dispatcher.rs
@@ -1,0 +1,212 @@
+// The `Dispatcher` — D35's "router is a dispatcher with capability
+// enforcement, NOT a model selector."
+//
+// Dispatch flow (per 02-crate-specs.md:467-478, locked):
+//   1. kx-model-validator::check(provided, required) →
+//      TypeOk | DegradedSubtype | TypeError(refuse).
+//   2. kx-memoizer::lookup(mote, snapshot) →
+//      Some(CacheHit) (return; broker handles WM re-dispatch) | None.
+//   3. On miss: route to the registered backend that `supports(model_id)`,
+//      construct InferenceParams from warrant, dispatch with
+//      `wall_clock_ms` timeout.
+//   4. Return DispatchOutcome::Fresh(output) to the caller (executor
+//      stages the result + commits).
+//
+// NO model-selection logic anywhere. The dispatcher takes
+// `warrant.model_route.model_id` as the canonical name; if no backend
+// supports it the call fails with `ModelNotFound`. The dispatcher never
+// substitutes a different model.
+
+use std::sync::Arc;
+
+use kx_context_assembler::AssembledContext;
+use kx_memoizer::CacheHit;
+use kx_model_validator::{check, ModelRegistry, RequiredCapabilities};
+use kx_mote::Mote;
+use kx_projection::Snapshot;
+use kx_warrant::WarrantSpec;
+
+use crate::backend::InferenceBackend;
+use crate::types::{InferenceError, InferenceInput, InferenceOutput, InferenceParams};
+
+/// What `Dispatcher::dispatch_mote` returns when it succeeds.
+///
+/// `CacheHit` means the memoizer found a prior committed result for an
+/// identity-equivalent Mote (exact cryptographic equality per SN-8);
+/// the executor either returns it as-is (`Pure` / `ReadOnlyNondet`) or
+/// uses it as the canonical result while the broker re-dispatches the
+/// world-mutating effect (`WorldMutating { redispatch_effect: true }`).
+///
+/// `Fresh` means the backend produced a new inference result; the
+/// executor stages it through `kx-content::ContentStore` and the
+/// resulting `ContentRef` becomes `Committed.result_ref`.
+#[derive(Debug, Clone)]
+pub enum DispatchOutcome {
+    /// Cached identity-match.
+    CacheHit(CacheHit),
+    /// Fresh backend output.
+    Fresh(InferenceOutput),
+}
+
+/// Configuration for a `Dispatcher`.
+#[derive(Clone)]
+pub struct DispatcherConfig {
+    /// Registry the dispatcher queries to obtain `ProvidedCapabilities`
+    /// at bind-time validation. Provided as an `Arc<dyn ...>` so the
+    /// dispatcher stays dyn-compatible across thread boundaries.
+    pub model_registry: Arc<dyn ModelRegistry>,
+}
+
+impl std::fmt::Debug for DispatcherConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DispatcherConfig")
+            .field("model_registry", &"<dyn ModelRegistry>")
+            .finish()
+    }
+}
+
+/// The router that ties together model-validator + memoizer + warrant
+/// scope + a backend set.
+///
+/// # Examples
+///
+/// ```
+/// use kx_inference::{Dispatcher, DispatcherConfig, LlamaInferenceBackend};
+/// use kx_model_validator::InMemoryModelRegistry;
+/// use std::sync::Arc;
+///
+/// let mut dispatcher = Dispatcher::new(DispatcherConfig {
+///     model_registry: Arc::new(InMemoryModelRegistry::new()),
+/// });
+/// dispatcher.register_backend(Arc::new(LlamaInferenceBackend::new()));
+/// assert_eq!(dispatcher.backend_count(), 1);
+/// ```
+#[derive(Clone)]
+pub struct Dispatcher {
+    backends: Vec<Arc<dyn InferenceBackend>>,
+    config: DispatcherConfig,
+}
+
+impl std::fmt::Debug for Dispatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dispatcher")
+            .field("backend_count", &self.backends.len())
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl Dispatcher {
+    /// Construct an empty dispatcher. Register backends with
+    /// `register_backend` before calling `dispatch_mote`.
+    #[must_use]
+    pub fn new(config: DispatcherConfig) -> Self {
+        Self {
+            backends: Vec::new(),
+            config,
+        }
+    }
+
+    /// Add a backend to the dispatcher's routing set.
+    ///
+    /// Backends are queried in insertion order; the first to return
+    /// `true` from `supports(model_id)` wins.
+    pub fn register_backend(&mut self, backend: Arc<dyn InferenceBackend>) {
+        self.backends.push(backend);
+    }
+
+    /// Number of registered backends.
+    #[must_use]
+    pub fn backend_count(&self) -> usize {
+        self.backends.len()
+    }
+
+    /// Run the full dispatch protocol for a Mote.
+    ///
+    /// See module docs for the four-step flow.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InferenceError::WarrantDeniesModel` if `mote.def.model_id`
+    /// disagrees with `warrant.model_route.model_id`,
+    /// `InferenceError::ModelNotFound` when no backend supports the model
+    /// (or the registry has no entry), `InferenceError::ModelValidation`
+    /// on `ValidatorOutcome::TypeError`, and any backend error verbatim.
+    pub fn dispatch_mote(
+        &self,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+        context: &AssembledContext,
+        required_capabilities: &RequiredCapabilities,
+        snapshot: &Snapshot,
+    ) -> Result<DispatchOutcome, InferenceError> {
+        // ---- 0. Warrant model-route check (cheapest; fail fast) -----------
+        if mote.def.model_id != warrant.model_route.model_id {
+            return Err(InferenceError::WarrantDeniesModel {
+                model_id: mote.def.model_id.0.clone(),
+                route: warrant.model_route.model_id.0.clone(),
+            });
+        }
+
+        // ---- 1. Bind-time validator (D29) ---------------------------------
+        let provided = self
+            .config
+            .model_registry
+            .lookup(&mote.def.model_id)
+            .ok_or_else(|| InferenceError::ModelNotFound {
+                model_id: mote.def.model_id.0.clone(),
+            })?;
+
+        let outcome = check(&provided, required_capabilities);
+        if outcome.is_type_error() {
+            return Err(InferenceError::ModelValidation {
+                message: format!("{outcome:?}"),
+            });
+        }
+        // `TypeOk` and `DegradedSubtype` both proceed; the latter carries
+        // a soft-flag the caller may surface in logs.
+
+        // ---- 2. Memoizer lookup (D33) -------------------------------------
+        if let Some(hit) = kx_memoizer::lookup(mote, snapshot) {
+            return Ok(DispatchOutcome::CacheHit(hit));
+        }
+
+        // ---- 3. Fresh dispatch --------------------------------------------
+        let input = InferenceInput::Text(serialize_context(context));
+        let params = InferenceParams::from_warrant(warrant);
+
+        let backend = self
+            .backends
+            .iter()
+            .find(|b| b.supports(&mote.def.model_id))
+            .ok_or_else(|| InferenceError::ModelNotFound {
+                model_id: mote.def.model_id.0.clone(),
+            })?;
+
+        let output = backend.dispatch(&mote.def.model_id, &input, &params, warrant)?;
+        Ok(DispatchOutcome::Fresh(output))
+    }
+}
+
+/// Serialise an `AssembledContext` into a single UTF-8 prompt string.
+///
+/// v0.1 convention: each item rendered as `LABEL:\n<utf8-lossy bytes>\n\n`,
+/// concatenated in `AssembledContext.items` order (which is deterministic
+/// per D33). Workflow authors who need chat-template structure embed it
+/// in their `AssembledContext` at build time (e.g., a preceding `system:`
+/// item carries `<|im_start|>system\n...`).
+///
+/// The dispatcher is the right place for this convention because the
+/// `InferenceBackend` trait's `Text(String)` input is the canonical
+/// stable seam — making each backend re-implement the same default
+/// would invite drift.
+fn serialize_context(ctx: &AssembledContext) -> String {
+    let mut out = String::new();
+    for item in &ctx.items {
+        out.push_str(&item.label);
+        out.push_str(":\n");
+        out.push_str(&String::from_utf8_lossy(&item.bytes));
+        out.push_str("\n\n");
+    }
+    out
+}

--- a/crates/kx-inference/src/lib.rs
+++ b/crates/kx-inference/src/lib.rs
@@ -1,0 +1,49 @@
+//! kortecx inference dispatcher (P1.8, D35).
+//!
+//! Per D35, the router is a DISPATCHER WITH CAPABILITY ENFORCEMENT — NOT a
+//! model selector. The workflow author (or SDK) NAMES the model in
+//! `warrant.model_route.model_id`; the dispatcher obeys, checks scope, and
+//! times out per `warrant.resource_ceiling.wall_clock_ms`. The model id
+//! participates in the idempotency key (kx-mote → `MoteDef.model_id`) so
+//! model changes correctly bust the cache.
+//!
+//! PR 8 ships two forward-compat trait-shape hooks to prevent breaking
+//! trait changes when multimodal + constrained-generation features land:
+//! `InferenceInput::Multimodal` (reserved variant) and
+//! `InferenceParams.grammar` (reserved Option field). The OSS v0.1
+//! `LlamaInferenceBackend` returns `Err(InferenceError::Unsupported)` on
+//! either path — see `roadmap-multimodal-synthesis-post-pr9` for the
+//! future-PR sequencing commitment.
+//!
+//! # Quick example
+//!
+//! ```
+//! use kx_inference::{Dispatcher, DispatcherConfig, LlamaInferenceBackend};
+//! use kx_model_validator::InMemoryModelRegistry;
+//! use std::sync::Arc;
+//!
+//! // Construct an empty dispatcher with an empty registry. Register
+//! // backends with `register_backend` and `Arc<dyn ModelRegistry>`
+//! // with a populated registry when wiring real inference.
+//! let dispatcher = Dispatcher::new(DispatcherConfig {
+//!     model_registry: Arc::new(InMemoryModelRegistry::new()),
+//! });
+//! assert_eq!(dispatcher.backend_count(), 0);
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)
+)]
+
+mod backend;
+mod dispatcher;
+mod llama;
+mod types;
+
+pub use backend::{BatchItem, InferenceBackend};
+pub use dispatcher::{DispatchOutcome, Dispatcher, DispatcherConfig};
+pub use llama::LlamaInferenceBackend;
+pub use types::{Grammar, InferenceError, InferenceInput, InferenceOutput, InferenceParams};

--- a/crates/kx-inference/src/llama.rs
+++ b/crates/kx-inference/src/llama.rs
@@ -1,0 +1,258 @@
+// `LlamaInferenceBackend` — the OSS v0.1 in-process llama.cpp backend.
+//
+// Per D28 (OSS stays lean) this is the ONLY backend that ships in the OSS
+// repo. Out-of-process backends (Triton, vLLM, remote APIs) ride the same
+// `InferenceBackend` trait but live in private `kx-cloud/*` crates.
+//
+// v0.1 design choices:
+//   - Model registry is a frozen-at-construction `HashMap<ModelId, PathBuf>`.
+//     Reloading a different model is a `kx-llamacpp` constructor reset; the
+//     runtime doesn't reload models per-dispatch (they're heavyweight).
+//   - LlamaBackend is RAII-ref-counted inside kx-llamacpp; we call ::new()
+//     per dispatch since the type is `!Send + !Sync` and we cannot hold it
+//     long-term in a Send + Sync backend struct. The internal mutex makes
+//     repeated `LlamaBackend::new()` calls cheap (subsequent calls just
+//     bump a ref-count; the actual `llama_backend_init` runs once).
+//   - The Model load IS expensive (seconds for a 7B GGUF). Future PRs may
+//     introduce a long-lived `LoadedModel` cache (via worker thread + mpsc
+//     channel to dodge the `!Send` constraint). v0.1 ships the simpler
+//     per-call path because the OSS critical-path goal is the seam,
+//     not throughput.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use kx_mote::ModelId;
+use kx_warrant::WarrantSpec;
+
+use crate::backend::InferenceBackend;
+use crate::types::{InferenceError, InferenceInput, InferenceOutput, InferenceParams};
+
+/// Backend name reported in `InferenceOutput.backend_name`.
+const BACKEND_NAME: &str = "kx-llamacpp";
+
+/// Default context window. Per llama.cpp convention, 0 means "use the
+/// model's own `n_ctx_train`". We pick a conservative cap so v0.1 doesn't
+/// silently allocate huge KV caches.
+const DEFAULT_N_CTX: u32 = 4096;
+
+/// Convert a `kx_llamacpp::LlamaError` into our public error enum.
+///
+/// Localised to one place so the dispatcher's error surface stays
+/// stable as `kx-llamacpp`'s error variants evolve. Takes the error
+/// by value so it can be used directly as `.map_err(map_llama_err)`
+/// in the dispatch path; the underlying error's `Display` is what
+/// we ultimately surface so consuming the original is fine.
+#[allow(clippy::needless_pass_by_value)]
+fn map_llama_err(err: kx_llamacpp::LlamaError) -> InferenceError {
+    InferenceError::BackendFailure {
+        backend: BACKEND_NAME,
+        message: format!("{err}"),
+    }
+}
+
+/// OSS v0.1 in-process inference backend wrapping `kx-llamacpp`.
+///
+/// **What it implements**:
+///   - `InferenceInput::Text(prompt)` — runs the prompt through the
+///     loaded model.
+///   - `InferenceParams.grammar = None` — vanilla sampling (greedy when
+///     `temperature_bps == 0`, otherwise temp + top-k + top-p).
+///
+/// **What it returns `Err(Unsupported)` on** (deliberate seam):
+///   - `InferenceInput::Multimodal { .. }` — reserved for future PRs.
+///   - `InferenceParams.grammar = Some(_)` — reserved for future PRs.
+///
+/// See `roadmap-multimodal-synthesis-post-pr9` for the sequencing
+/// commitment.
+#[derive(Debug, Clone)]
+pub struct LlamaInferenceBackend {
+    model_paths: Arc<HashMap<ModelId, PathBuf>>,
+    n_ctx: u32,
+}
+
+impl LlamaInferenceBackend {
+    /// Construct a backend with no registered models. Useful for unit
+    /// tests where every dispatch is expected to return `ModelNotFound`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            model_paths: Arc::new(HashMap::new()),
+            n_ctx: DEFAULT_N_CTX,
+        }
+    }
+
+    /// Construct a backend with a single model registered.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kx_inference::LlamaInferenceBackend;
+    /// use kx_mote::ModelId;
+    /// use std::path::PathBuf;
+    ///
+    /// let backend = LlamaInferenceBackend::with_model(
+    ///     ModelId("llama-3-8b-instruct".into()),
+    ///     PathBuf::from("/tmp/llama-3-8b-instruct.gguf"),
+    /// );
+    /// // The model file does NOT need to exist at construction time;
+    /// // it's only opened on the first dispatch that requests this
+    /// // model id. Construction is lazy on purpose.
+    /// let _ = backend;
+    /// ```
+    #[must_use]
+    pub fn with_model(id: ModelId, path: PathBuf) -> Self {
+        let mut map = HashMap::new();
+        map.insert(id, path);
+        Self {
+            model_paths: Arc::new(map),
+            n_ctx: DEFAULT_N_CTX,
+        }
+    }
+
+    /// Construct a backend with multiple model ids registered.
+    #[must_use]
+    pub fn with_models(models: HashMap<ModelId, PathBuf>) -> Self {
+        Self {
+            model_paths: Arc::new(models),
+            n_ctx: DEFAULT_N_CTX,
+        }
+    }
+
+    /// Override the default context window.
+    #[must_use]
+    pub fn with_n_ctx(mut self, n_ctx: u32) -> Self {
+        self.n_ctx = n_ctx;
+        self
+    }
+}
+
+impl Default for LlamaInferenceBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InferenceBackend for LlamaInferenceBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        input: &InferenceInput,
+        params: &InferenceParams,
+        warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        // ---- Forward-compat reservation gates (PR 8 plan) -----------------
+        let prompt = match input {
+            InferenceInput::Text(s) => s.as_str(),
+            InferenceInput::Multimodal { .. } => {
+                return Err(InferenceError::Unsupported {
+                    reason: "multimodal input reserved for post-PR-9; see HANDOFF §3.8",
+                });
+            }
+        };
+        if params.grammar.is_some() {
+            return Err(InferenceError::Unsupported {
+                reason: "constrained generation (grammar) reserved for post-PR-9; see HANDOFF §3.8",
+            });
+        }
+
+        // ---- Warrant gates (D30 + D35) ------------------------------------
+        if model_id != &warrant.model_route.model_id {
+            return Err(InferenceError::WarrantDeniesModel {
+                model_id: model_id.0.clone(),
+                route: warrant.model_route.model_id.0.clone(),
+            });
+        }
+        params.check_within(warrant)?;
+
+        // ---- Resolve registered path --------------------------------------
+        let path = self
+            .model_paths
+            .get(model_id)
+            .ok_or_else(|| InferenceError::ModelNotFound {
+                model_id: model_id.0.clone(),
+            })?;
+
+        // ---- Timeout setup -------------------------------------------------
+        let start = Instant::now();
+        let timeout = Duration::from_millis(warrant.resource_ceiling.wall_clock_ms);
+        let check_timeout = |elapsed: Duration| -> Result<(), InferenceError> {
+            if elapsed >= timeout {
+                Err(InferenceError::Timeout {
+                    wall_clock_ms: warrant.resource_ceiling.wall_clock_ms,
+                })
+            } else {
+                Ok(())
+            }
+        };
+
+        // ---- llama.cpp setup (per-call; see module docs) ------------------
+        let backend = kx_llamacpp::LlamaBackend::new().map_err(map_llama_err)?;
+        let model = kx_llamacpp::Model::load(&backend, path).map_err(map_llama_err)?;
+        check_timeout(start.elapsed())?;
+
+        let ctx_params = kx_llamacpp::ContextParams::new().with_n_ctx(self.n_ctx);
+        let mut ctx =
+            kx_llamacpp::Context::new_with_params(&model, &ctx_params).map_err(map_llama_err)?;
+        let vocab = model.vocab();
+
+        let prompt_tokens = vocab.tokenize(prompt, true, false).map_err(map_llama_err)?;
+        check_timeout(start.elapsed())?;
+
+        // ---- Sampler chain -------------------------------------------------
+        let mut sampler = if params.temperature_bps == 0 {
+            kx_llamacpp::Sampler::greedy(&backend).map_err(map_llama_err)?
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let temp = (params.temperature_bps as f32) / 10_000.0;
+            #[allow(clippy::cast_precision_loss)]
+            let top_p = (params.top_p_bps as f32) / 10_000.0;
+            #[allow(clippy::cast_possible_wrap)]
+            let top_k = params.top_k as i32;
+            kx_llamacpp::Sampler::typical(&backend, temp, top_k, top_p, params.seed)
+                .map_err(map_llama_err)?
+        };
+
+        // ---- Generation loop ----------------------------------------------
+        let generator = kx_llamacpp::Generator::new(&mut ctx, &mut sampler, &vocab, prompt_tokens)
+            .map_err(map_llama_err)?;
+
+        let mut output_bytes: Vec<u8> = Vec::with_capacity(
+            usize::try_from(params.max_output_tokens.saturating_mul(4)).unwrap_or(2048),
+        );
+        let mut output_tokens: u32 = 0;
+
+        for token_result in generator {
+            check_timeout(start.elapsed())?;
+            let token = token_result.map_err(map_llama_err)?;
+            vocab
+                .token_to_piece_into(token, 0, false, &mut output_bytes)
+                .map_err(map_llama_err)?;
+            output_tokens = output_tokens.saturating_add(1);
+            if output_tokens >= params.max_output_tokens {
+                break;
+            }
+            if vocab.is_eog(token) {
+                break;
+            }
+        }
+
+        Ok(InferenceOutput {
+            bytes: output_bytes,
+            output_tokens,
+            backend_name: BACKEND_NAME,
+            model_id: model_id.clone(),
+            elapsed: start.elapsed(),
+        })
+    }
+
+    fn supports(&self, model_id: &ModelId) -> bool {
+        self.model_paths.contains_key(model_id)
+    }
+
+    fn name(&self) -> &'static str {
+        BACKEND_NAME
+    }
+}

--- a/crates/kx-inference/src/types.rs
+++ b/crates/kx-inference/src/types.rs
@@ -1,0 +1,312 @@
+// Public types crossing the dispatcher / backend seam.
+//
+// Two forward-compat hooks live here per the PR 8 strategy plan:
+//   - `InferenceInput::Multimodal` reserved variant (no impl in v0.1).
+//   - `InferenceParams.grammar` reserved Option field (no impl in v0.1).
+//
+// Both return `InferenceError::Unsupported` when used against the OSS
+// `LlamaInferenceBackend` — the seam is exercised by tests so the
+// `Err(Unsupported)` path is documented, not merely declarative.
+
+use std::time::Duration;
+
+use kx_content::ContentRef;
+use kx_mote::ModelId;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+/// Input to a single inference dispatch.
+///
+/// `Text` is the v0.1 surface. `Multimodal` is **reserved for future
+/// cloud / local multimodal backends** — the OSS `LlamaInferenceBackend`
+/// returns `InferenceError::Unsupported` on this variant.
+///
+/// The `content_refs` on `Multimodal` are BLAKE3-keyed pointers into the
+/// `kx-content` store; future backends fetch the bytes and feed them
+/// alongside the text to a vision-capable model.
+///
+/// # Examples
+///
+/// ```
+/// use kx_inference::InferenceInput;
+///
+/// let prompt = InferenceInput::text("Hello, world!");
+/// match prompt {
+///     InferenceInput::Text(s) => assert_eq!(s, "Hello, world!"),
+///     InferenceInput::Multimodal { .. } => unreachable!(),
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InferenceInput {
+    /// Text-only prompt — the only variant any v0.1 backend handles.
+    Text(String),
+    /// Multimodal prompt (text + content refs to images / audio / etc).
+    /// Reserved; OSS v0.1 backends MUST return `Err(Unsupported)`.
+    Multimodal {
+        /// Text portion of the prompt (the multimodal model still
+        /// consumes a textual instruction alongside the content refs).
+        text: String,
+        /// BLAKE3-keyed pointers to binary content (images / audio /
+        /// other modalities) the multimodal backend will fetch from
+        /// `kx-content`.
+        content_refs: SmallVec<[ContentRef; 4]>,
+    },
+}
+
+impl InferenceInput {
+    /// Length of the textual portion of the input, in bytes. Used by the
+    /// dispatcher when checking against
+    /// `warrant.model_route.max_input_tokens` (the runtime treats the
+    /// limit as bytes — token counting is the backend's job; the byte
+    /// limit is a coarse upper bound that catches obvious overruns).
+    #[must_use]
+    pub fn text_len(&self) -> usize {
+        match self {
+            Self::Text(s) => s.len(),
+            Self::Multimodal { text, .. } => text.len(),
+        }
+    }
+
+    /// Construct a `Text` input from any string-like value.
+    pub fn text(s: impl Into<String>) -> Self {
+        Self::Text(s.into())
+    }
+}
+
+/// Reserved opaque grammar specification for constrained generation.
+///
+/// Future backends interpret the payload (GBNF for llama.cpp, JSON
+/// schema for cloud APIs). OSS v0.1 backends MUST return
+/// `Err(Unsupported)` if `InferenceParams.grammar` is `Some(_)`.
+///
+/// # Examples
+///
+/// ```
+/// use kx_inference::Grammar;
+///
+/// let g = Grammar::new(r#"{"type":"object"}"#);
+/// assert_eq!(g.raw, r#"{"type":"object"}"#);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Grammar {
+    /// Opaque serialized grammar payload. Encoding chosen by the
+    /// backend that will consume it (GBNF / JSON schema / etc).
+    pub raw: String,
+}
+
+impl Grammar {
+    /// Construct a grammar from any string-like value. The payload is
+    /// opaque to this crate; backends interpret.
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self { raw: raw.into() }
+    }
+}
+
+/// Per-dispatch generation parameters.
+///
+/// Defaults are **greedy + deterministic** because the runtime's
+/// content-addressed identity relies on inference outputs being
+/// reproducible across attempts. If a workflow author wants stochastic
+/// sampling, they widen these explicitly — at the cost of attempt
+/// reproducibility on retry.
+///
+/// # Examples
+///
+/// ```
+/// use kx_inference::InferenceParams;
+///
+/// // Defaults are greedy (temperature_bps == 0); grammar is reserved
+/// // for future PRs and defaults to None.
+/// let p = InferenceParams::default();
+/// assert_eq!(p.temperature_bps, 0);
+/// assert!(p.grammar.is_none());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceParams {
+    /// Maximum output tokens. Derived from
+    /// `warrant.model_route.max_output_tokens` when constructed via
+    /// `from_warrant`.
+    pub max_output_tokens: u32,
+
+    /// Sampling temperature in basis points (×10 000). Defaults to 0 —
+    /// greedy decoding, deterministic. Integer-encoded so this struct
+    /// is `Eq`-comparable and serializes to canonical bytes for
+    /// idempotency-key derivation.
+    pub temperature_bps: u32,
+
+    /// Top-p (nucleus) in basis points. Defaults to 10 000 (= 1.0); only
+    /// active when `temperature_bps > 0`.
+    pub top_p_bps: u32,
+
+    /// Top-k. 0 disables top-k. Active only when `temperature_bps > 0`.
+    pub top_k: u32,
+
+    /// Sampler seed. Locked at construction; same seed + same params +
+    /// same model = bit-identical output even when temperature > 0.
+    pub seed: u32,
+
+    /// Stop tokens / stop sequences. Empty = no stop.
+    pub stop_tokens: SmallVec<[String; 4]>,
+
+    /// **Reserved**: opaque grammar specification for constrained
+    /// generation (GBNF / JSON-schema). OSS v0.1 backends MUST return
+    /// `Err(Unsupported)` on `Some(_)`. The field exists ahead of
+    /// implementation so the trait stays additive when grammar support
+    /// lands.
+    pub grammar: Option<Grammar>,
+}
+
+impl Default for InferenceParams {
+    fn default() -> Self {
+        Self {
+            max_output_tokens: 512,
+            temperature_bps: 0,
+            top_p_bps: 10_000,
+            top_k: 0,
+            seed: 0,
+            stop_tokens: SmallVec::new(),
+            grammar: None,
+        }
+    }
+}
+
+impl InferenceParams {
+    /// Construct params with limits derived from the warrant.
+    ///
+    /// The warrant's `max_output_tokens` is the ceiling; downstream
+    /// authors can tighten further but not widen (the dispatcher
+    /// enforces this).
+    #[must_use]
+    pub fn from_warrant(warrant: &kx_warrant::WarrantSpec) -> Self {
+        Self {
+            max_output_tokens: warrant.model_route.max_output_tokens,
+            ..Self::default()
+        }
+    }
+
+    /// Check whether requested params stay within the warrant's
+    /// quantitative limits. Returns `Err(ScopeViolation)` on widen.
+    pub(crate) fn check_within(
+        &self,
+        warrant: &kx_warrant::WarrantSpec,
+    ) -> Result<(), InferenceError> {
+        if self.max_output_tokens > warrant.model_route.max_output_tokens {
+            return Err(InferenceError::ScopeViolation {
+                field: "max_output_tokens",
+                requested: u64::from(self.max_output_tokens),
+                ceiling: u64::from(warrant.model_route.max_output_tokens),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Result of a single inference dispatch.
+///
+/// `bytes` is the canonical serialization of the generated content
+/// (UTF-8 for text models). The executor stages it through
+/// `kx-content::ContentStore` and the resulting `ContentRef` is what
+/// the journal records as `Committed.result_ref`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceOutput {
+    /// Generated bytes (text models: UTF-8 of the completion).
+    pub bytes: Vec<u8>,
+
+    /// Number of output tokens actually emitted by the backend. Used
+    /// for cost accounting (cloud backends) + idempotency-key sanity
+    /// checks. Approximate for local llama.cpp (token count maps 1:1
+    /// to the tokens generated; reported as-is).
+    pub output_tokens: u32,
+
+    /// Backend identity that produced this output (e.g., `"kx-llamacpp"`
+    /// or `"kx-cloud-vllm"`). Audit-trail field.
+    pub backend_name: &'static str,
+
+    /// The model id that produced this output. Echoed back so callers
+    /// can confirm the dispatcher routed to the expected backend.
+    pub model_id: ModelId,
+
+    /// Wall-clock time spent inside the backend's dispatch. Excludes
+    /// dispatcher overhead (validator / memoizer / scope checks).
+    pub elapsed: Duration,
+}
+
+/// Failure modes surfaced by the dispatcher or any backend.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InferenceError {
+    /// The feature is reserved but not implemented in this backend.
+    ///
+    /// Returned by OSS v0.1 backends on:
+    ///   - `InferenceInput::Multimodal` (multimodal reserved for future PRs)
+    ///   - `InferenceParams.grammar = Some(_)` (constrained generation reserved)
+    ///
+    /// **Not** a bug — a deliberate seam-shape decision documented in
+    /// the PR 8 plan + the private-corpus HANDOFF §3.8.
+    #[error("unsupported in this backend: {reason}")]
+    Unsupported {
+        /// Static reason string describing what's reserved.
+        reason: &'static str,
+    },
+
+    /// The named `model_id` is not recognised by any registered backend.
+    #[error("model not found: {model_id}")]
+    ModelNotFound {
+        /// The model id that was requested but had no backend / registry entry.
+        model_id: String,
+    },
+
+    /// The named `model_id` does not match the warrant's `model_route`.
+    /// Per D35, the dispatcher refuses to call a model the warrant did
+    /// not authorise — even if the backend would serve it.
+    #[error("warrant denies model: {model_id} (warrant route: {route})")]
+    WarrantDeniesModel {
+        /// The model id the caller tried to dispatch.
+        model_id: String,
+        /// The model id the warrant authorises.
+        route: String,
+    },
+
+    /// Generic warrant-narrowing violation on a quantitative field
+    /// (e.g., `max_output_tokens > ceiling`).
+    #[error("scope violation on {field}: requested {requested}, ceiling {ceiling}")]
+    ScopeViolation {
+        /// The warrant field that was violated.
+        field: &'static str,
+        /// The requested value.
+        requested: u64,
+        /// The warrant's ceiling for this field.
+        ceiling: u64,
+    },
+
+    /// The bind-time model validator (D29) emitted `TypeError`.
+    #[error("model failed bind-time validation: {message}")]
+    ModelValidation {
+        /// Human-readable validation failure description.
+        message: String,
+    },
+
+    /// `wall_clock_ms` elapsed before the backend returned.
+    #[error("wall_clock timeout: {wall_clock_ms} ms")]
+    Timeout {
+        /// The wall-clock ceiling, in milliseconds.
+        wall_clock_ms: u64,
+    },
+
+    /// The backend returned an internal failure (load failed, decode
+    /// failed, sampler init failed, etc).
+    #[error("backend `{backend}` failed: {message}")]
+    BackendFailure {
+        /// Identifier of the backend that failed.
+        backend: &'static str,
+        /// Backend-specific failure detail.
+        message: String,
+    },
+
+    /// The dispatcher could not resolve a `ContentRef` from the content
+    /// store during input assembly.
+    #[error("content store miss: {content_ref:?}")]
+    ContentStoreMiss {
+        /// The content reference that could not be resolved.
+        content_ref: ContentRef,
+    },
+}

--- a/crates/kx-inference/tests/batching.rs
+++ b/crates/kx-inference/tests/batching.rs
@@ -1,0 +1,135 @@
+//! Batching-hook unit tests (PR 8 DoD: batching hook present + tested
+//! with a fake backend). Proves the seam: a backend can override
+//! `batch_dispatch` and the override is the one that runs; the default
+//! impl threads through `dispatch` per item.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use common::FakeBackend;
+use kx_content::ContentRef;
+use kx_inference::{BatchItem, InferenceBackend, InferenceInput, InferenceParams};
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+fn dummy_warrant(model_id: ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 2048,
+            max_output_tokens: 512,
+            max_calls: 10,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+#[test]
+fn batching_default_impl_dispatches_per_item() {
+    // Use a backend that does NOT override batch_dispatch; we wrap our
+    // FakeBackend in a transparent newtype that pins down the default
+    // impl.
+    struct DefaultBatchBackend(FakeBackend);
+    impl kx_inference::InferenceBackend for DefaultBatchBackend {
+        fn dispatch(
+            &self,
+            m: &ModelId,
+            i: &InferenceInput,
+            p: &InferenceParams,
+            w: &WarrantSpec,
+        ) -> Result<kx_inference::InferenceOutput, kx_inference::InferenceError> {
+            self.0.dispatch(m, i, p, w)
+        }
+        fn supports(&self, m: &ModelId) -> bool {
+            self.0.supports(m)
+        }
+        fn name(&self) -> &'static str {
+            "default-batch"
+        }
+        // NO batch_dispatch override — default impl applies.
+    }
+
+    let id = ModelId("test-model".into());
+    let inner = FakeBackend::new("fake").with_model(id.clone());
+    let dispatch_counter = inner.dispatch_calls.clone();
+    let backend = DefaultBatchBackend(inner);
+
+    let warrant = dummy_warrant(id.clone());
+    let prompt = InferenceInput::Text("hi".into());
+    let params = InferenceParams::default();
+
+    let items: Vec<BatchItem<'_>> = (0..3)
+        .map(|_| BatchItem {
+            model_id: &id,
+            input: &prompt,
+            params: &params,
+            warrant: &warrant,
+        })
+        .collect();
+
+    let results = backend.batch_dispatch(&items);
+    assert_eq!(results.len(), 3);
+    for r in results {
+        let out = r.expect("dispatch should succeed");
+        assert_eq!(out.bytes, b"FAKE OUTPUT");
+    }
+    assert_eq!(
+        dispatch_counter.load(std::sync::atomic::Ordering::SeqCst),
+        3,
+        "default batch_dispatch should call inner.dispatch once per item"
+    );
+}
+
+#[test]
+fn batching_override_runs_once_per_batch() {
+    // FakeBackend overrides batch_dispatch and bumps a separate counter
+    // each call. Per-item dispatch counter still ticks because the
+    // override forwards.
+    let id = ModelId("test-model".into());
+    let backend = FakeBackend::new("fake").with_model(id.clone());
+    let warrant = dummy_warrant(id.clone());
+    let prompt = InferenceInput::Text("hi".into());
+    let params = InferenceParams::default();
+
+    let items: Vec<BatchItem<'_>> = (0..4)
+        .map(|_| BatchItem {
+            model_id: &id,
+            input: &prompt,
+            params: &params,
+            warrant: &warrant,
+        })
+        .collect();
+
+    let results = backend.batch_dispatch(&items);
+    assert_eq!(results.len(), 4);
+    assert_eq!(backend.batch_count(), 1, "override called exactly once");
+    assert_eq!(
+        backend.dispatch_count(),
+        4,
+        "per-item dispatch should still tick"
+    );
+
+    let _ = PathBuf::new(); // silence unused import elsewhere
+}

--- a/crates/kx-inference/tests/common/mod.rs
+++ b/crates/kx-inference/tests/common/mod.rs
@@ -1,0 +1,126 @@
+//! Shared test fixture: a `FakeBackend` impl of `InferenceBackend`.
+//!
+//! Each test file `include!`s this so the fixture lives in exactly one place
+//! and stays consistent across the test suite. The fake is deliberately
+//! minimal — it does NOT load llama.cpp — so unit tests can run on every
+//! host (including hosts without GGUF model files).
+
+#![allow(
+    dead_code,
+    unreachable_pub,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic
+)]
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_inference::{
+    InferenceBackend, InferenceError, InferenceInput, InferenceOutput, InferenceParams,
+};
+use kx_mote::ModelId;
+use kx_warrant::WarrantSpec;
+
+/// Test backend that returns a canned output for any registered model.
+#[derive(Debug)]
+pub struct FakeBackend {
+    name: &'static str,
+    supported: HashSet<ModelId>,
+    /// Canned response bytes for any successful dispatch.
+    response_bytes: Vec<u8>,
+    /// Atomic invocation counter so tests can assert dispatch was called.
+    pub dispatch_calls: Arc<AtomicU64>,
+    /// Atomic batch_dispatch counter (separate from the per-item count).
+    pub batch_calls: Arc<AtomicU64>,
+}
+
+impl FakeBackend {
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            supported: HashSet::new(),
+            response_bytes: b"FAKE OUTPUT".to_vec(),
+            dispatch_calls: Arc::new(AtomicU64::new(0)),
+            batch_calls: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn with_model(mut self, id: ModelId) -> Self {
+        self.supported.insert(id);
+        self
+    }
+
+    pub fn with_response(mut self, bytes: Vec<u8>) -> Self {
+        self.response_bytes = bytes;
+        self
+    }
+
+    pub fn dispatch_count(&self) -> u64 {
+        self.dispatch_calls.load(Ordering::SeqCst)
+    }
+
+    pub fn batch_count(&self) -> u64 {
+        self.batch_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl InferenceBackend for FakeBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        input: &InferenceInput,
+        params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        self.dispatch_calls.fetch_add(1, Ordering::SeqCst);
+
+        // Honour the same reservation gates as a real backend.
+        if matches!(input, InferenceInput::Multimodal { .. }) {
+            return Err(InferenceError::Unsupported {
+                reason: "fake backend mirrors v0.1 multimodal reservation",
+            });
+        }
+        if params.grammar.is_some() {
+            return Err(InferenceError::Unsupported {
+                reason: "fake backend mirrors v0.1 grammar reservation",
+            });
+        }
+        if !self.supported.contains(model_id) {
+            return Err(InferenceError::ModelNotFound {
+                model_id: model_id.0.clone(),
+            });
+        }
+        Ok(InferenceOutput {
+            bytes: self.response_bytes.clone(),
+            output_tokens: 1,
+            backend_name: self.name,
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(1),
+        })
+    }
+
+    fn supports(&self, model_id: &ModelId) -> bool {
+        self.supported.contains(model_id)
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn batch_dispatch(
+        &self,
+        items: &[kx_inference::BatchItem<'_>],
+    ) -> Vec<Result<InferenceOutput, InferenceError>> {
+        // Count the batch call (separately from individual dispatches —
+        // the default impl forwards to dispatch, so per-item counters
+        // still tick).
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        items
+            .iter()
+            .map(|item| self.dispatch(item.model_id, item.input, item.params, item.warrant))
+            .collect()
+    }
+}

--- a/crates/kx-inference/tests/concurrency.rs
+++ b/crates/kx-inference/tests/concurrency.rs
@@ -1,0 +1,144 @@
+//! Concurrency contract — SN-4 v2:
+//!   - Send + Sync compile-time assertions on every public type.
+//!   - Thread-independence under `Arc<dyn InferenceBackend>` (4 threads,
+//!     each running disjoint dispatches; aggregated counters confirm
+//!     every thread's work landed).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::thread;
+
+use common::FakeBackend;
+use kx_content::ContentRef;
+use kx_inference::{
+    BatchItem, Dispatcher, DispatcherConfig, Grammar, InferenceBackend, InferenceError,
+    InferenceInput, InferenceOutput, InferenceParams, LlamaInferenceBackend,
+};
+use kx_model_validator::InMemoryModelRegistry;
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+/// Compile-time `Send` + `Sync` set — fails to compile if any public type
+/// silently loses these traits.
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn send_sync_set() {
+    assert_send::<InferenceInput>();
+    assert_sync::<InferenceInput>();
+    assert_send::<InferenceParams>();
+    assert_sync::<InferenceParams>();
+    assert_send::<InferenceOutput>();
+    assert_sync::<InferenceOutput>();
+    assert_send::<InferenceError>();
+    assert_sync::<InferenceError>();
+    assert_send::<Grammar>();
+    assert_sync::<Grammar>();
+    assert_send_sync::<LlamaInferenceBackend>();
+    assert_send_sync::<Dispatcher>();
+    // Trait-object form (what the dispatcher holds).
+    assert_send_sync::<Arc<dyn InferenceBackend>>();
+    assert_send_sync::<Box<dyn InferenceBackend>>();
+    assert_send_sync::<BatchItem<'_>>();
+}
+
+fn dummy_warrant(model_id: ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 2048,
+            max_output_tokens: 512,
+            max_calls: 100,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+#[test]
+fn four_thread_dispatch_independence() {
+    // Single backend, four threads, 100 dispatches each. Final counter
+    // MUST be 400 regardless of interleaving (proves thread-independence
+    // of dispatch under `Arc<dyn InferenceBackend>`).
+    const THREADS: usize = 4;
+    const PER_THREAD: usize = 100;
+
+    let id = ModelId("test-model".into());
+    let fake = FakeBackend::new("fake").with_model(id.clone());
+    let dispatch_counter = fake.dispatch_calls.clone();
+    let backend: Arc<dyn InferenceBackend> = Arc::new(fake);
+
+    let mut handles = Vec::with_capacity(THREADS);
+    for thread_idx in 0..THREADS {
+        let b = Arc::clone(&backend);
+        let id = id.clone();
+        let warrant = dummy_warrant(id.clone());
+        handles.push(thread::spawn(move || {
+            let prompt = InferenceInput::Text(format!("thread {thread_idx}"));
+            let params = InferenceParams::default();
+            for _ in 0..PER_THREAD {
+                let _out = b
+                    .dispatch(&id, &prompt, &params, &warrant)
+                    .expect("dispatch must succeed");
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    let total = THREADS * PER_THREAD;
+    assert_eq!(
+        dispatch_counter.load(std::sync::atomic::Ordering::SeqCst),
+        total as u64,
+        "every dispatch across all threads must be counted"
+    );
+}
+
+#[test]
+fn dispatcher_clone_is_shareable_across_threads() {
+    // Dispatcher is `Clone` (it holds Vec<Arc<...>> + Arc<dyn ...>);
+    // proving each clone can dispatch independently from another
+    // thread confirms the routing layer has no thread-local state.
+    let id = ModelId("test-model".into());
+    let fake = Arc::new(FakeBackend::new("fake").with_model(id.clone()));
+    let registry = Arc::new(InMemoryModelRegistry::new());
+
+    let mut dispatcher = Dispatcher::new(DispatcherConfig {
+        model_registry: registry,
+    });
+    dispatcher.register_backend(fake as Arc<dyn InferenceBackend>);
+
+    let h1 = thread::spawn({
+        let d = dispatcher.clone();
+        move || assert_eq!(d.backend_count(), 1)
+    });
+    let h2 = thread::spawn({
+        let d = dispatcher.clone();
+        move || assert_eq!(d.backend_count(), 1)
+    });
+    h1.join().unwrap();
+    h2.join().unwrap();
+}

--- a/crates/kx-inference/tests/proptest_dispatch.rs
+++ b/crates/kx-inference/tests/proptest_dispatch.rs
@@ -1,0 +1,173 @@
+//! Property-based tests for the dispatcher / backend seam — SN-4 v2:
+//! at least 3 proptest properties × 64 cases each.
+//!
+//! Properties exercised:
+//!   1. `Unsupported`-on-Multimodal is deterministic — for any prompt,
+//!      seed, and content-ref set, the backend returns the SAME error
+//!      string. (Reservation semantics are invariant across inputs.)
+//!   2. `Unsupported`-on-grammar=Some is deterministic — for any
+//!      `Grammar` payload, the backend returns the same error.
+//!   3. `WarrantDeniesModel` fires whenever `requested_model_id !=
+//!      warrant.model_route.model_id`, regardless of any other field.
+//!      (Prefix-monotonic on the model-route axis: changing other
+//!      fields cannot unset this refusal.)
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use common::FakeBackend;
+use kx_content::ContentRef;
+use kx_inference::{
+    Grammar, InferenceBackend, InferenceError, InferenceInput, InferenceParams,
+    LlamaInferenceBackend,
+};
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use proptest::collection::vec as prop_vec;
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+fn warrant_with_route(model_id: ModelId, max_output_tokens: u32) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 2048,
+            max_output_tokens,
+            max_calls: 100,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn arbitrary_content_refs() -> impl Strategy<Value = SmallVec<[ContentRef; 4]>> {
+    prop_vec(any::<[u8; 32]>().prop_map(ContentRef), 0..=4).prop_map(SmallVec::from_vec)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Property 1: `Unsupported` on Multimodal is deterministic
+    /// across any text + content-ref input. The reservation
+    /// `LlamaInferenceBackend` enforces is a pure property of the
+    /// variant, not of its payload.
+    #[test]
+    fn prop_multimodal_always_unsupported(
+        text in ".{0,256}",
+        refs in arbitrary_content_refs(),
+    ) {
+        let id = ModelId("any-model".into());
+        // Register the model so we know `ModelNotFound` cannot mask the
+        // Unsupported error; the multimodal gate fires earlier in the
+        // dispatch flow.
+        let backend = LlamaInferenceBackend::with_model(
+            id.clone(),
+            std::path::PathBuf::from("/dev/null"),
+        );
+        let warrant = warrant_with_route(id.clone(), 512);
+        let input = InferenceInput::Multimodal { text, content_refs: refs };
+        let params = InferenceParams::default();
+        let err = backend.dispatch(&id, &input, &params, &warrant)
+            .expect_err("multimodal must be Unsupported");
+        let is_unsupported = matches!(err, InferenceError::Unsupported { .. });
+        prop_assert!(is_unsupported);
+    }
+
+    /// Property 2: `Unsupported` on grammar=Some is deterministic
+    /// across any payload string. Same invariance argument as
+    /// Property 1 but on the grammar field.
+    #[test]
+    fn prop_grammar_some_always_unsupported(
+        raw in ".{0,256}",
+    ) {
+        let id = ModelId("any-model".into());
+        let backend = LlamaInferenceBackend::with_model(
+            id.clone(),
+            std::path::PathBuf::from("/dev/null"),
+        );
+        let warrant = warrant_with_route(id.clone(), 512);
+        let input = InferenceInput::Text("hi".into());
+        let params = InferenceParams {
+            grammar: Some(Grammar::new(raw)),
+            ..InferenceParams::default()
+        };
+        let err = backend.dispatch(&id, &input, &params, &warrant)
+            .expect_err("grammar=Some must be Unsupported");
+        let is_unsupported_grammar = matches!(err, InferenceError::Unsupported { .. });
+        prop_assert!(is_unsupported_grammar);
+    }
+
+    /// Property 3: `WarrantDeniesModel` is invariant on every other
+    /// dimension. Whenever the requested id and the warrant's route
+    /// disagree, the dispatcher refuses — regardless of params,
+    /// input, or registry membership. (Mirror of the prefix-
+    /// monotonicity-of-refusal property kx-projection already proves
+    /// for journal refusal.)
+    #[test]
+    fn prop_warrant_denies_other_models(
+        requested_id in "[a-z]{1,16}",
+        warrant_id in "[a-z]{1,16}",
+        max_tokens in 1u32..=1024,
+    ) {
+        prop_assume!(requested_id != warrant_id);
+        let req = ModelId(requested_id.clone());
+        // Register the requested model on the backend so model-not-
+        // found cannot mask the deny.
+        let backend = LlamaInferenceBackend::with_model(
+            req.clone(),
+            std::path::PathBuf::from("/dev/null"),
+        );
+        let warrant = warrant_with_route(ModelId(warrant_id.clone()), max_tokens);
+        let input = InferenceInput::Text("x".into());
+        let params = InferenceParams::default();
+        let err = backend.dispatch(&req, &input, &params, &warrant)
+            .expect_err("mismatched ids must deny");
+        let is_warrant_denies = matches!(err, InferenceError::WarrantDeniesModel { .. });
+        prop_assert!(is_warrant_denies);
+    }
+
+    /// Property 4 (bonus): the FakeBackend, registered for an exact
+    /// `ModelId`, always returns Ok for that id and `ModelNotFound`
+    /// for any other. Reinforces SN-8 "exact cryptographic equality"
+    /// — substring matches do not count.
+    #[test]
+    fn prop_fake_supports_is_exact(
+        registered in "[a-z]{1,8}",
+        queried in "[a-z]{1,8}",
+    ) {
+        let reg_id = ModelId(registered.clone());
+        let queried_id = ModelId(queried.clone());
+        let backend = FakeBackend::new("f").with_model(reg_id.clone());
+        let warrant = warrant_with_route(queried_id.clone(), 512);
+        let input = InferenceInput::Text("x".into());
+        let params = InferenceParams::default();
+        let result = backend.dispatch(&queried_id, &input, &params, &warrant);
+        if registered == queried {
+            prop_assert!(result.is_ok());
+        } else {
+            let err = result.expect_err("unrelated id must fail");
+            let is_not_found = matches!(err, InferenceError::ModelNotFound { .. });
+            prop_assert!(is_not_found);
+        }
+    }
+}

--- a/crates/kx-inference/tests/trait_seam.rs
+++ b/crates/kx-inference/tests/trait_seam.rs
@@ -1,0 +1,163 @@
+//! Trait-seam test (per D35 + 02-crate-specs.md DoD):
+//!
+//! Proves a backend with an OUT-OF-PROCESS-SHAPED internal pattern
+//! (here: a queue + worker-style indirection) compiles against the
+//! same `InferenceBackend` trait the in-process `LlamaInferenceBackend`
+//! uses. The point is to demonstrate that future cloud backends
+//! (vLLM, Triton, remote APIs) fit without trait change.
+//!
+//! The "out-of-process shape" is simulated by performing the dispatch
+//! through an internal channel + worker thread; from the caller's
+//! perspective, it's still a synchronous `dispatch()` call. This is
+//! the exact shape a Triton client would have if it blocked on its
+//! gRPC call internally.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use kx_content::ContentRef;
+use kx_inference::{
+    InferenceBackend, InferenceError, InferenceInput, InferenceOutput, InferenceParams,
+};
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+/// Out-of-process-shaped backend: every dispatch routes through an
+/// mpsc channel to a worker thread. The worker computes the canned
+/// output and returns it via a oneshot-style response channel. This
+/// is the typical shape an RPC client would take if it serialised
+/// blocking calls.
+struct ProxiedBackend {
+    sender: mpsc::SyncSender<(
+        ModelId,
+        mpsc::SyncSender<Result<InferenceOutput, InferenceError>>,
+    )>,
+    _worker: Arc<JoinHandle<()>>,
+}
+
+impl ProxiedBackend {
+    fn new(model_id: ModelId) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<(
+            ModelId,
+            mpsc::SyncSender<Result<InferenceOutput, InferenceError>>,
+        )>(4);
+        let target_id = model_id.clone();
+        let worker = thread::spawn(move || {
+            while let Ok((req_id, resp)) = rx.recv() {
+                let out = if req_id == target_id {
+                    Ok(InferenceOutput {
+                        bytes: b"PROXY OUTPUT".to_vec(),
+                        output_tokens: 2,
+                        backend_name: "proxy-backend",
+                        model_id: req_id,
+                        elapsed: Duration::from_millis(2),
+                    })
+                } else {
+                    Err(InferenceError::ModelNotFound {
+                        model_id: req_id.0.clone(),
+                    })
+                };
+                let _ = resp.send(out);
+            }
+        });
+        Self {
+            sender: tx,
+            _worker: Arc::new(worker),
+        }
+    }
+}
+
+impl InferenceBackend for ProxiedBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        let (tx, rx) = mpsc::sync_channel(1);
+        self.sender
+            .send((model_id.clone(), tx))
+            .map_err(|e| InferenceError::BackendFailure {
+                backend: "proxy-backend",
+                message: format!("worker channel disconnected: {e}"),
+            })?;
+        rx.recv().map_err(|e| InferenceError::BackendFailure {
+            backend: "proxy-backend",
+            message: format!("response channel disconnected: {e}"),
+        })?
+    }
+
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "proxy-backend"
+    }
+}
+
+fn dummy_warrant(model_id: ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 2048,
+            max_output_tokens: 512,
+            max_calls: 100,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+#[test]
+fn proxied_backend_satisfies_trait() {
+    let id = ModelId("proxy-model".into());
+    let backend: Arc<dyn InferenceBackend> = Arc::new(ProxiedBackend::new(id.clone()));
+    let warrant = dummy_warrant(id.clone());
+    let input = InferenceInput::Text("hello".into());
+    let params = InferenceParams::default();
+
+    let out = backend
+        .dispatch(&id, &input, &params, &warrant)
+        .expect("proxy dispatch should succeed");
+    assert_eq!(out.bytes, b"PROXY OUTPUT");
+    assert_eq!(out.backend_name, "proxy-backend");
+}
+
+#[test]
+fn proxied_backend_returns_model_not_found_on_unknown() {
+    let id = ModelId("proxy-model".into());
+    let other = ModelId("other-model".into());
+    let backend: Arc<dyn InferenceBackend> = Arc::new(ProxiedBackend::new(id.clone()));
+    // Warrant authorises 'other' but the proxy was constructed with 'proxy-model'.
+    let warrant = dummy_warrant(other.clone());
+    let input = InferenceInput::Text("hello".into());
+    let params = InferenceParams::default();
+    let err = backend
+        .dispatch(&other, &input, &params, &warrant)
+        .expect_err("unknown model must fail");
+    assert!(matches!(err, InferenceError::ModelNotFound { .. }));
+}


### PR DESCRIPTION
## Summary

Ships **`kx-inference`** — the D35 dispatcher. Per the locked design, the router is a DISPATCHER WITH CAPABILITY ENFORCEMENT, NOT a model selector. The workflow author NAMES the model in `warrant.model_route.model_id`; the dispatcher obeys, validates at bind-time (D29), consults the memoizer (D33), enforces warrant scope (D30), and times out per `warrant.resource_ceiling.wall_clock_ms`.

The crate also ships **two forward-compat trait-shape hooks** per the approved PR 8 strategy plan, so multimodal + constrained-generation features can land in upcoming PRs without breaking trait changes:

1. `InferenceInput::Multimodal { text, content_refs }` — reserved variant; OSS v0.1 returns `Err(Unsupported)`.
2. `InferenceParams.grammar: Option<Grammar>` — reserved field; `Some(_)` returns `Err(Unsupported)`.

Both hooks are exercised by unit + proptest coverage so the reserved-path is documented, not merely declarative.

## Public surface

- `InferenceBackend` trait — modality-agnostic, dyn-compatible, no in-process assumptions (Triton/vLLM/remote APIs fit later behind the same trait).
- `Dispatcher` + `DispatcherConfig` — wires validator + memoizer + warrant + backends.
- `LlamaInferenceBackend` — OSS v0.1 in-process backend wrapping `kx-llamacpp`. Per-call `LlamaBackend`/`Model` construction (the `!Send + !Sync` workaround; future PR adds a long-lived model cache).
- `InferenceInput`, `InferenceParams`, `InferenceOutput`, `InferenceError`, `Grammar`, `BatchItem`, `DispatchOutcome` — full type surface.
- Batching hook (`batch_dispatch` default impl + override) — the seam is what's load-bearing.

## SN-4 v2 + SN-7 born-compliant

- **4 proptest properties × 64 cases = 256 property runs**: multimodal-Unsupported invariance, grammar-Unsupported invariance, WarrantDeniesModel invariance, exact-id matching (SN-8 reinforcement).
- **Send + Sync compile-time set** on every public type (including `Arc<dyn InferenceBackend>` + `Box<dyn InferenceBackend>` + `BatchItem<'_>`).
- **4-thread × 100-dispatch concurrency test** under `Arc<dyn InferenceBackend>` — proves thread-independence.
- **Trait-seam test** with an out-of-process-shaped backend (mpsc + worker thread) — proves future cloud backends fit.
- **Batching test** with default impl + override impl.
- **6 doctests** on the public surface (lib-level + `Dispatcher` + `InferenceInput` + `InferenceParams` + `Grammar` + `LlamaInferenceBackend`).

## Local gates (all green)

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ — **482 total** (+17 from PR 8: 11 integration tests + 6 doctests; proptests counted as 4 tests but each runs 64 cases).
- `cargo doc --workspace --no-deps --all-features` ✓
- `cargo deny check` ✓ — advisories ok, bans ok, licenses ok, sources ok.

Cargo.lock delta: the new `kx-inference` package entry — no other dep moved.

## Test plan

- [ ] CI `fmt-check` ✓
- [ ] CI `clippy` ✓
- [ ] CI `test` ✓
- [ ] CI `cargo-deny` ✓
- [ ] CI `doc` ✓
- [ ] CI `byte-determinism (I1.c)` ✓
- [ ] CI `C++ FFI link (kx-llamacpp-sys → kx-llamacpp)` ✓
- [ ] CI `private-content-leak-check` ✓
- [ ] CI `smoke-test-with-model` ✓ (runs after test + ffi-link pass)

## Forward-PR roadmap (already locked in `HANDOFF.md §3.8`)

- Image input / multimodal inference → post-PR-9, likely `kx-cloud-inference-vision-*`. Seam: `InferenceInput::Multimodal`.
- Image generation as a tool → post-PR-9 user-layer via `kx-tool-registry`. No runtime change.
- Data synthesis → post-PR-9 WORKLOAD on the completed runtime.
- Constrained generation (GBNF / JSON-schema) → PR 8.x when a workload demands it. Seam: `InferenceParams.grammar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)