### PR TITLE
PR 9a-hardening-1: per-axis SBPL profile mapping (D46 §6) + std::process::Command clippy lint

### DIFF
--- a/crates/kx-executor/clippy.toml
+++ b/crates/kx-executor/clippy.toml
@@ -1,0 +1,20 @@
+# Per-crate clippy config — enforces kx-executor's NO `std::process::Command`
+# discipline (per `02-crate-specs.md` §`kx-executor` DoD; D31 spawn-protocol
+# rule). The executor MUST use platform-specific spawn primitives (bwrap
+# execvp on Linux + posix_spawn / fork+sandbox_init+execvp on macOS) so the
+# sandbox load happens BEFORE the body's exec — `std::process::Command`
+# offers no hook for inter-fork-and-exec policy load, and on some macOS
+# configurations routes the spawn via the shell (which would apply the
+# sandbox to the wrong process).
+#
+# The lint fires on every reference to `std::process::Command` in the
+# kx-executor source tree. The PR 9a-hardening-2 real-spawn implementation
+# uses `nix::unistd::execvp` + `libc::sandbox_init` directly.
+
+disallowed-methods = [
+    { path = "std::process::Command::new", reason = "kx-executor MUST NOT use std::process::Command — per D31 spawn protocol + 02-crate-specs.md §kx-executor DoD; the inter-fork-and-exec sandbox-load hook requires direct execvp / posix_spawn primitives. Use nix::unistd::execvp or libc::posix_spawn under a documented `unsafe { ... }` block with a `// SAFETY:` comment." },
+]
+
+disallowed-types = [
+    { path = "std::process::Command", reason = "kx-executor MUST NOT use std::process::Command (see disallowed-methods reason for Command::new)." },
+]

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -87,12 +87,30 @@ const DENY_DEFAULT_TEMPLATE: &[u8] = b"(version 1)\n(deny default)\n";
 /// Pure / total / deterministic mapping from a `WarrantSpec` to an
 /// `SbplProfile` per D46.
 ///
-/// **PR 9a placeholder.** Returns the deny-default template only — no
-/// per-axis allows. The full per-axis mapping (`fs_scope` →
-/// `(allow file-read*/file-write* (subpath …))`; `net_scope` →
-/// `(allow network-outbound (remote ip "<host>:*"))`; etc.) ships in the
-/// PR 9a-hardening follow-up. The function's signature, purity contract, and
-/// return type are stable from PR 9a forward.
+/// Pure / total / deterministic: same `WarrantSpec` in → byte-identical
+/// `SbplProfile` out. No I/O; no clocks; no `Result` (every WarrantSpec is
+/// representable — under-declared axes produce the strictest possible rule
+/// via the deny-default template).
+///
+/// **Per-axis mapping (D46 §6):**
+/// - `fs_scope.mounts` — per entry: `ReadOnly` →
+///   `(allow file-read* (subpath "<path>"))`; `ReadWrite` →
+///   `(allow file-read* ...)` + `(allow file-write* ...)`; `ExecOnly` →
+///   `(allow file-read-metadata ...)` + `(allow process-exec ...)`. Paths
+///   are emitted via the BTreeMap's canonical iteration order so the
+///   resulting bytes are deterministic.
+/// - `net_scope` — `None` → no rules (deny-default holds);
+///   `EgressAllowlist(hosts)` → per-host
+///   `(allow network-outbound (remote ip "<host>:*"))` emitted in
+///   BTreeSet iteration order.
+/// - `syscall_profile_ref` — opaque per-platform. The reference is NOT
+///   resolved here (the content store call lives in `MacOsSandboxExecutor::
+///   run`); the profile carries a `;; syscall-profile-ref: <hex>` comment
+///   line for audit-trail visibility. The PR 9a-hardening follow-up to
+///   THIS PR adds resolution + body-byte appending.
+/// - `resource_ceiling` — NOT in the SBPL profile (D46 §6.4: SBPL = access
+///   control; `LocalResourceManager` via `setrlimit` = resource control).
+/// - `executor_class` — tag-only; no profile-affecting semantic.
 ///
 /// # Examples
 ///
@@ -131,9 +149,90 @@ const DENY_DEFAULT_TEMPLATE: &[u8] = b"(version 1)\n(deny default)\n";
 /// assert_eq!(p1.as_bytes(), p2.as_bytes());
 /// ```
 #[must_use]
-pub fn profile_from_warrant(_spec: &WarrantSpec) -> SbplProfile {
-    // PR 9a returns the deny-default template only. PR 9a-hardening will
-    // append per-axis allows derived from `_spec.fs_scope` / `_spec.net_scope`
-    // / `_spec.syscall_profile_ref` per D46 §6.
-    SbplProfile(DENY_DEFAULT_TEMPLATE.to_vec())
+pub fn profile_from_warrant(spec: &WarrantSpec) -> SbplProfile {
+    let mut buf: Vec<u8> = Vec::with_capacity(DENY_DEFAULT_TEMPLATE.len() + 256);
+    buf.extend_from_slice(DENY_DEFAULT_TEMPLATE);
+
+    // fs_scope — BTreeMap iteration is by sorted key, so the resulting bytes
+    // are deterministic across runs / machines.
+    for (path, mode) in &spec.fs_scope.mounts {
+        let path_str = path.to_string_lossy();
+        let path_escaped = sbpl_escape(&path_str);
+        match mode {
+            kx_warrant::FsMode::ReadOnly => {
+                buf.extend_from_slice(b"(allow file-read* (subpath \"");
+                buf.extend_from_slice(path_escaped.as_bytes());
+                buf.extend_from_slice(b"\"))\n");
+            }
+            kx_warrant::FsMode::ReadWrite => {
+                buf.extend_from_slice(b"(allow file-read* (subpath \"");
+                buf.extend_from_slice(path_escaped.as_bytes());
+                buf.extend_from_slice(b"\"))\n");
+                buf.extend_from_slice(b"(allow file-write* (subpath \"");
+                buf.extend_from_slice(path_escaped.as_bytes());
+                buf.extend_from_slice(b"\"))\n");
+            }
+            kx_warrant::FsMode::ExecOnly => {
+                buf.extend_from_slice(b"(allow file-read-metadata (subpath \"");
+                buf.extend_from_slice(path_escaped.as_bytes());
+                buf.extend_from_slice(b"\"))\n");
+                buf.extend_from_slice(b"(allow process-exec (subpath \"");
+                buf.extend_from_slice(path_escaped.as_bytes());
+                buf.extend_from_slice(b"\"))\n");
+            }
+        }
+    }
+
+    // net_scope — BTreeSet iteration is by sorted value.
+    match &spec.net_scope {
+        kx_warrant::NetScope::None => {
+            // Deny-default holds; no rules emitted.
+        }
+        kx_warrant::NetScope::EgressAllowlist(hosts) => {
+            for host in hosts {
+                let host_escaped = sbpl_escape(&host.0);
+                buf.extend_from_slice(b"(allow network-outbound (remote ip \"");
+                buf.extend_from_slice(host_escaped.as_bytes());
+                buf.extend_from_slice(b":*\"))\n");
+            }
+        }
+    }
+
+    // syscall_profile_ref — emitted as an audit-trail comment. Resolution +
+    // body-byte appending ships in the PR 9a-hardening follow-up sweep
+    // (out of scope for this PR).
+    buf.extend_from_slice(b";; syscall-profile-ref: ");
+    for byte in &spec.syscall_profile_ref.0 {
+        let nibble_hi = NIBBLES[(byte >> 4) as usize];
+        let nibble_lo = NIBBLES[(byte & 0x0F) as usize];
+        buf.push(nibble_hi);
+        buf.push(nibble_lo);
+    }
+    buf.push(b'\n');
+
+    SbplProfile(buf)
+}
+
+/// Lowercase hex nibbles for the syscall_profile_ref comment line.
+const NIBBLES: &[u8; 16] = b"0123456789abcdef";
+
+/// Escape a path or host string for SBPL S-expression embedding.
+/// SBPL uses Lisp-style strings; the only mandatory escapes are `\"` and
+/// `\\`. Per the deny-default safety property (D46 §5): under-declared
+/// axes default-deny, so an aggressively-escaped string that produces a
+/// malformed rule is still safer than under-escaping that produces an
+/// over-permissive rule.
+fn sbpl_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            // Control characters become spaces (defensive; sandbox-exec
+            // rejects them anyway).
+            c if c.is_control() => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    out
 }

--- a/crates/kx-executor/tests/integration_sbpl.rs
+++ b/crates/kx-executor/tests/integration_sbpl.rs
@@ -1,0 +1,226 @@
+//! Integration tests for `profile_from_warrant`'s per-axis SBPL mapping
+//! (PR 9a-hardening-1, D46 §6). Verifies the bytes emitted for each
+//! `WarrantSpec` axis match the locked spec.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_executor::profile_from_warrant;
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    WarrantSpec,
+};
+
+fn permissive_warrant_with(fs_scope: FsScope, net_scope: NetScope) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope,
+        net_scope,
+        syscall_profile_ref: ContentRef::from_bytes([0xAB; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}
+
+fn profile_text(w: &WarrantSpec) -> String {
+    String::from_utf8(profile_from_warrant(w).as_bytes().to_vec()).expect("UTF-8 profile")
+}
+
+// ============================================================================
+// fs_scope mappings (D46 §6.1)
+// ============================================================================
+
+#[test]
+fn fs_scope_read_only_emits_file_read_star() {
+    let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+    mounts.insert(PathBuf::from("/usr/local/share"), FsMode::ReadOnly);
+    let w = permissive_warrant_with(FsScope { mounts }, NetScope::None);
+    let text = profile_text(&w);
+    assert!(text.contains("(allow file-read* (subpath \"/usr/local/share\"))"));
+    assert!(!text.contains("file-write*"));
+    assert!(!text.contains("process-exec"));
+}
+
+#[test]
+fn fs_scope_read_write_emits_both_read_and_write() {
+    let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/workspace"), FsMode::ReadWrite);
+    let w = permissive_warrant_with(FsScope { mounts }, NetScope::None);
+    let text = profile_text(&w);
+    assert!(text.contains("(allow file-read* (subpath \"/tmp/workspace\"))"));
+    assert!(text.contains("(allow file-write* (subpath \"/tmp/workspace\"))"));
+}
+
+#[test]
+fn fs_scope_exec_only_emits_metadata_and_process_exec() {
+    let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+    mounts.insert(PathBuf::from("/opt/binaries"), FsMode::ExecOnly);
+    let w = permissive_warrant_with(FsScope { mounts }, NetScope::None);
+    let text = profile_text(&w);
+    assert!(text.contains("(allow file-read-metadata (subpath \"/opt/binaries\"))"));
+    assert!(text.contains("(allow process-exec (subpath \"/opt/binaries\"))"));
+    // ExecOnly MUST NOT emit file-read* or file-write* — would leak read/write
+    // privilege on the exec-only path.
+    assert!(!text.contains("(allow file-read* (subpath \"/opt/binaries\"))"));
+    assert!(!text.contains("(allow file-write* (subpath \"/opt/binaries\"))"));
+}
+
+#[test]
+fn fs_scope_emits_mounts_in_btreemap_iteration_order() {
+    // BTreeMap iterates by sorted key — same input set, byte-identical output.
+    let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+    mounts.insert(PathBuf::from("/z"), FsMode::ReadOnly);
+    mounts.insert(PathBuf::from("/a"), FsMode::ReadOnly);
+    mounts.insert(PathBuf::from("/m"), FsMode::ReadOnly);
+    let w = permissive_warrant_with(FsScope { mounts }, NetScope::None);
+    let text = profile_text(&w);
+    let a_pos = text.find("subpath \"/a\"").expect("a present");
+    let m_pos = text.find("subpath \"/m\"").expect("m present");
+    let z_pos = text.find("subpath \"/z\"").expect("z present");
+    assert!(a_pos < m_pos, "/a must precede /m");
+    assert!(m_pos < z_pos, "/m must precede /z");
+}
+
+// ============================================================================
+// net_scope mappings (D46 §6.2)
+// ============================================================================
+
+#[test]
+fn net_scope_none_emits_no_network_rules() {
+    let w = permissive_warrant_with(FsScope::empty(), NetScope::None);
+    let text = profile_text(&w);
+    assert!(
+        !text.contains("network-outbound"),
+        "NetScope::None must not emit any network-outbound allows"
+    );
+}
+
+#[test]
+fn net_scope_egress_allowlist_emits_per_host_rule() {
+    let mut hosts: BTreeSet<Host> = BTreeSet::new();
+    hosts.insert(Host("api.example.com".into()));
+    hosts.insert(Host("registry.internal".into()));
+    let w = permissive_warrant_with(FsScope::empty(), NetScope::EgressAllowlist(hosts));
+    let text = profile_text(&w);
+    assert!(text.contains("(allow network-outbound (remote ip \"api.example.com:*\"))"));
+    assert!(text.contains("(allow network-outbound (remote ip \"registry.internal:*\"))"));
+}
+
+#[test]
+fn net_scope_hosts_emit_in_btreeset_iteration_order() {
+    let mut hosts: BTreeSet<Host> = BTreeSet::new();
+    hosts.insert(Host("c.example".into()));
+    hosts.insert(Host("a.example".into()));
+    hosts.insert(Host("b.example".into()));
+    let w = permissive_warrant_with(FsScope::empty(), NetScope::EgressAllowlist(hosts));
+    let text = profile_text(&w);
+    let a_pos = text.find("a.example").expect("a present");
+    let b_pos = text.find("b.example").expect("b present");
+    let c_pos = text.find("c.example").expect("c present");
+    assert!(a_pos < b_pos);
+    assert!(b_pos < c_pos);
+}
+
+// ============================================================================
+// syscall_profile_ref audit-trail line (D46 §6.3 — opaque per-platform; the
+// PR 9a-hardening-2 follow-up resolves to body bytes; this PR ships the
+// audit-trail comment)
+// ============================================================================
+
+#[test]
+fn syscall_profile_ref_emits_audit_comment() {
+    let w = permissive_warrant_with(FsScope::empty(), NetScope::None);
+    let text = profile_text(&w);
+    // 0xAB byte pattern from `permissive_warrant_with`.
+    assert!(text.contains(";; syscall-profile-ref: "));
+    assert!(text.contains(&"ab".repeat(32)));
+}
+
+// ============================================================================
+// resource_ceiling NOT in profile (D46 §6.4)
+// ============================================================================
+
+#[test]
+fn resource_ceiling_does_not_appear_in_sbpl_profile() {
+    // Non-zero resource_ceiling MUST NOT produce any rules in the profile —
+    // resource enforcement is `LocalResourceManager` via setrlimit, not SBPL.
+    let mut w = permissive_warrant_with(FsScope::empty(), NetScope::None);
+    w.resource_ceiling = ResourceCeiling {
+        cpu_milli: 1000,
+        mem_bytes: 1 << 30,
+        wall_clock_ms: 60_000,
+        fd_count: 256,
+        disk_bytes: 1 << 30,
+    };
+    let text = profile_text(&w);
+    // None of these SBPL forms map resource limits; their absence is the
+    // layering boundary signal.
+    assert!(!text.contains("limit-"));
+    assert!(!text.contains("rlimit"));
+    assert!(!text.contains("cpu_milli"));
+}
+
+// ============================================================================
+// Deny-default template invariants (D46 §5)
+// ============================================================================
+
+#[test]
+fn deny_default_template_is_present_in_every_profile() {
+    let w = permissive_warrant_with(FsScope::empty(), NetScope::None);
+    let text = profile_text(&w);
+    assert!(text.starts_with("(version 1)\n(deny default)\n"));
+}
+
+#[test]
+fn empty_warrant_produces_minimal_profile_with_only_template_and_audit_line() {
+    let w = permissive_warrant_with(FsScope::empty(), NetScope::None);
+    let text = profile_text(&w);
+    // No allow rules (fs_scope empty + net_scope None) — only the deny-
+    // default template + the syscall-profile-ref audit comment.
+    assert!(!text.contains("(allow file-"));
+    assert!(!text.contains("(allow network-"));
+    assert!(!text.contains("(allow process-exec"));
+}
+
+// ============================================================================
+// Escaping (D46 §6.1 anti-injection)
+// ============================================================================
+
+#[test]
+fn paths_with_double_quotes_are_escaped() {
+    let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+    mounts.insert(PathBuf::from(r#"/tmp/"quoted""#), FsMode::ReadOnly);
+    let w = permissive_warrant_with(FsScope { mounts }, NetScope::None);
+    let text = profile_text(&w);
+    // The literal " in the path is escaped to \" — preserving the SBPL
+    // S-expression's quoting.
+    assert!(text.contains(r#"/tmp/\"quoted\""#));
+}
+
+#[test]
+fn paths_with_backslashes_are_escaped() {
+    let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+    mounts.insert(PathBuf::from(r"/tmp/with\backslash"), FsMode::ReadOnly);
+    let w = permissive_warrant_with(FsScope { mounts }, NetScope::None);
+    let text = profile_text(&w);
+    assert!(text.contains(r"/tmp/with\\backslash"));
+}


### PR DESCRIPTION
## Summary

First slice of the PR 9a-hardening track. The full corpus row for P1.9a-hardening (real spawn primitives + cgroup v2 + setrlimit + body binary) is being shipped in two sub-PRs to keep reviewer load manageable + keep each PR SN-4 v2 + SN-7 born-compliant on its own surface:

- **PR 9a-hardening-1** (this PR) — per-axis SBPL profile mapping per D46 §6 + `std::process::Command` clippy lint per the kx-executor DoD + 13 integration tests proving each axis is mapped correctly. ~350 LOC total. No unsafe code; no new crate deps.
- **PR 9a-hardening-2** (next session) — real fork+execvp on Linux + real fork+sandbox_init+execvp on macOS + real LocalResourceManager with setrlimit + cgroup v2 + `kx-executor-pure-body` example binary. ~1500 LOC + unsafe systems code; the clippy lint added in this PR is the canonical refusal source the hardening-2 implementation will route around (nix::unistd::execvp + libc::sandbox_init under documented unsafe blocks).

## Changes

- `crates/kx-executor/src/backends/macos_sandbox.rs` — `profile_from_warrant` replaced from the PR 9a deny-default-template-only placeholder with the full D46 §6 per-axis mapping (fs_scope ReadOnly/ReadWrite/ExecOnly → file-read*/file-write*/file-read-metadata+process-exec; net_scope EgressAllowlist → per-host network-outbound; syscall_profile_ref → audit-trail comment; resource_ceiling not in profile per the SBPL-vs-setrlimit layering boundary). BTreeMap/BTreeSet iteration provides deterministic ordering. SBPL string escaping for `"` / `\\` / control chars.
- `crates/kx-executor/clippy.toml` (NEW) — `disallowed-methods` + `disallowed-types` refuse `std::process::Command` + `Command::new` per the D31 spawn-protocol rule + the kx-executor DoD. The reason field cites the load-bearing rationale.
- `crates/kx-executor/tests/integration_sbpl.rs` (NEW) — 13 integration tests covering each axis mapping + escaping + deterministic ordering + deny-default invariant + the resource_ceiling-not-in-profile layering invariant.

## Workspace tests

**556 passed + 3 ignored** under `--all-features` on Apple Silicon (was 543 pre-PR; +13 net from the new SBPL integration tests).

## Gates green

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (556 passed, 0 failed, 3 ignored)
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` ✓
- `cargo deny check` ✓

## Test plan

- [ ] Linux CI runs all 9 jobs green (fmt-check / clippy / test / cargo-deny / doc / ffi-link / byte-determinism / smoke-test-with-model / private-content-leak-check).
- [ ] Apple Silicon local pass — 556/556 + 3 ignored.
- [ ] SN-2 pre-merge audit clean.
- [ ] Branch retention: merge with `gh pr merge --merge` (NO `--delete-branch`).