### PR TITLE
PR 9a-hardening-3: real Linux fork+execvp(bwrap) spawn primitives + cross-platform setrlimit pre-exec hook

### DIFF
--- a/crates/kx-executor/src/backends/bwrap.rs
+++ b/crates/kx-executor/src/backends/bwrap.rs
@@ -1,52 +1,297 @@
-//! `BwrapExecutor` — bubblewrap-based sandbox executor for Linux. **PR 9a
-//! skeleton**: structure + `supports()` are real; `run()` returns
-//! `BackendUnsupported`. The real bubblewrap argv builder + `execvp` spawn
-//! lands in the PR 9a-hardening follow-up.
+//! `BwrapExecutor` — bubblewrap-based sandbox executor for Linux.
+//! **PR 9a-hardening-3** wires the real fork+execvp(`bwrap`) path through
+//! `crate::spawn::spawn_body`. The bwrap argv is assembled from the
+//! `WarrantSpec`'s fs_scope (`--ro-bind` for ReadOnly + ExecOnly;
+//! `--bind` for ReadWrite) + net_scope (`--unshare-net` for `None`) +
+//! the body binary path + its argv. Resource ceilings (cpu / mem / fd /
+//! disk) are applied via `setrlimit` in the child between fork and
+//! execvp (per `crate::spawn::apply_rlimits`).
+//!
+//! Per D31, bubblewrap is the Linux default executor. The constructor
+//! optionally takes the path to the `bwrap` binary; `with_body_default_bwrap`
+//! probes `PATH` at construction time + refuses with `BackendUnsupported`
+//! if `bwrap` is not installed. The integration test runtime-skips on
+//! Linux machines without bwrap.
+
+use std::path::{Path, PathBuf};
 
 use kx_mote::Mote;
 use kx_warrant::{ExecutorClass, WarrantSpec};
 
+#[cfg(target_os = "linux")]
+use kx_warrant::{FsMode, NetScope};
+
 use crate::executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
 
 /// Bubblewrap-based sandbox executor (Linux default per D41).
-///
-/// Per D31, this is the daemonless ms-spawn least-privilege OSS default on
-/// Linux. The constructor is conditional on `target_os = "linux"`; on other
-/// targets `BwrapExecutor::new()` returns the placeholder shape but
-/// `supports()` returns `false` and `run()` returns `BackendUnsupported`.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
+#[allow(clippy::struct_field_names)] // each *_path field carries distinct semantics
 pub struct BwrapExecutor {
-    // PR 9a-hardening will add fields here: a pinned `bwrap` binary path,
-    // a tempdir handle for rootfs extraction, cgroup-v2 controller paths, etc.
-    _private: (),
+    /// Absolute path to the body binary the spawned child will execvp into
+    /// after `bwrap` sets up the sandbox. When `None`, `run()` returns
+    /// `BackendUnsupported` (the PR 9a skeleton shape preserved for
+    /// back-compat with `default_executor()`).
+    #[allow(dead_code)] // read only on target_os = "linux" via `run_linux`
+    body_path: Option<PathBuf>,
+    /// Absolute path to a file the body will read as its input (passed as
+    /// `argv[1]`).
+    #[allow(dead_code)] // read only on target_os = "linux" via `run_linux`
+    input_path: Option<PathBuf>,
+    /// Path to the `bwrap` binary on disk. Defaults to `bwrap` (resolved
+    /// via `PATH`); production callers can override.
+    #[allow(dead_code)] // read only on target_os = "linux" via `run_linux`
+    bwrap_path: PathBuf,
 }
 
 impl BwrapExecutor {
-    /// Construct a new `BwrapExecutor`. PR 9a's constructor has no side
-    /// effects; the PR 9a-hardening follow-up will probe for the `bwrap`
-    /// binary at construction time and refuse if not present.
+    /// Construct a new `BwrapExecutor` with no configured body
+    /// (preserves the PR 9a `BackendUnsupported`-on-run shape). Defaults
+    /// `bwrap_path` to `"bwrap"` (PATH-resolved at exec time).
     #[must_use]
-    pub const fn new() -> Self {
-        Self { _private: () }
+    pub fn new() -> Self {
+        Self {
+            body_path: None,
+            input_path: None,
+            bwrap_path: PathBuf::from("bwrap"),
+        }
+    }
+
+    /// Construct a `BwrapExecutor` with a configured body binary. The
+    /// spawned child execvps `bwrap` with argv that ends in
+    /// `body_path input_file_path`.
+    #[must_use]
+    pub fn with_body(body_path: PathBuf) -> Self {
+        Self {
+            body_path: Some(body_path),
+            input_path: None,
+            bwrap_path: PathBuf::from("bwrap"),
+        }
+    }
+
+    /// Set the input file path passed as the body's `argv[1]`.
+    #[must_use]
+    pub fn with_input_file(mut self, input_path: PathBuf) -> Self {
+        self.input_path = Some(input_path);
+        self
+    }
+
+    /// Override the `bwrap` binary path (e.g., for testing or non-PATH
+    /// installations).
+    #[must_use]
+    pub fn with_bwrap_path(mut self, bwrap_path: PathBuf) -> Self {
+        self.bwrap_path = bwrap_path;
+        self
     }
 }
 
 impl MoteExecutor for BwrapExecutor {
     fn run(
         &self,
-        _mote: &Mote,
-        _warrant: &WarrantSpec,
-        _env: Option<Rootfs>,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+        env: Option<Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
-        Err(MoteExecutorError::BackendUnsupported {
-            class: ExecutorClass::Bwrap,
-            reason: "skeleton — real bwrap spawn lands in the PR 9a-hardening follow-up".into(),
-        })
+        #[cfg(target_os = "linux")]
+        {
+            self.run_linux(mote, warrant, env.as_ref())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (mote, warrant, env);
+            Err(MoteExecutorError::BackendUnsupported {
+                class: ExecutorClass::Bwrap,
+                reason: "Bwrap backend only runs on target_os = \"linux\"".into(),
+            })
+        }
     }
 
     fn supports(&self, executor_class: ExecutorClass) -> bool {
         // The Bwrap variant is the Linux default; on non-Linux targets the
         // backend exists for trait-object uniformity but reports unsupported.
         cfg!(target_os = "linux") && executor_class == ExecutorClass::Bwrap
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl BwrapExecutor {
+    /// Real Linux spawn path. Assembles the bwrap argv from the warrant,
+    /// forks, applies setrlimit in the child, execvps `bwrap` with the
+    /// assembled argv, reads the body's stdout, parses the 64-hex-char
+    /// result_ref, returns `MoteExecutionResult`.
+    fn run_linux(
+        &self,
+        _mote: &Mote,
+        warrant: &WarrantSpec,
+        _env: Option<&Rootfs>,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        let body_path = self
+            .body_path
+            .as_ref()
+            .ok_or(MoteExecutorError::BackendUnsupported {
+                class: ExecutorClass::Bwrap,
+                reason: "no body_path configured — construct via BwrapExecutor::with_body(path)"
+                    .into(),
+            })?;
+        let input_path = self
+            .input_path
+            .as_ref()
+            .ok_or(MoteExecutorError::Internal {
+                reason: "no input_path configured — call .with_input_file(path) on the executor"
+                    .into(),
+            })?;
+
+        // 1. Assemble bwrap argv from the warrant.
+        let bwrap_path_str = self.bwrap_path.to_string_lossy().into_owned();
+        let body_path_str = body_path.to_string_lossy().into_owned();
+        let input_path_str = input_path.to_string_lossy().into_owned();
+        let argv =
+            bwrap_argv_from_warrant(&bwrap_path_str, warrant, &body_path_str, &input_path_str);
+
+        // 2. Spawn — fork + pre-exec(setrlimit) + execvp(bwrap).
+        // bwrap itself applies the sandbox (no need for a sandbox_init-
+        // equivalent on Linux; the kernel honors bwrap's user-namespace
+        // + capability drops).
+        let started_at_epoch_ms = now_epoch_ms();
+        let ceiling = warrant.resource_ceiling;
+        let outcome = crate::spawn::spawn_body(
+            &bwrap_path_str,
+            &argv,
+            Box::new(move || crate::spawn::apply_rlimits(&ceiling)),
+        )?;
+        let finished_at_epoch_ms = now_epoch_ms();
+
+        // 3. Parse the body's stdout: 64 hex chars → 32-byte ContentRef.
+        if outcome.exit_code != 0 {
+            return Err(MoteExecutorError::BodyExited {
+                code: outcome.exit_code,
+            });
+        }
+        let result_ref =
+            crate::backends::macos_sandbox::parse_hex_ref(&outcome.stdout).map_err(|e| {
+                MoteExecutorError::Internal {
+                    reason: format!("body stdout parse: {e}"),
+                }
+            })?;
+
+        Ok(MoteExecutionResult {
+            result_ref,
+            started_at_epoch_ms,
+            finished_at_epoch_ms,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn now_epoch_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| {
+            #[allow(clippy::cast_possible_truncation)]
+            let ms = d.as_millis() as u64;
+            ms
+        })
+        .unwrap_or(0)
+}
+
+/// Compose the bwrap argv from a `WarrantSpec` + body binary path +
+/// input file path.
+///
+/// **Wire format**:
+/// `bwrap [--die-with-parent] [--proc /proc --dev /dev]
+///        [--ro-bind /usr /usr] [--ro-bind /lib /lib] [--ro-bind /lib64 /lib64]
+///        [--ro-bind /etc /etc]
+///        [--ro-bind <ro_path> <ro_path>]* (per fs_scope ReadOnly + ExecOnly)
+///        [--bind <rw_path> <rw_path>]* (per fs_scope ReadWrite)
+///        [--unshare-net]? (when net_scope is None)
+///        -- body_path input_path`
+///
+/// The `--die-with-parent` flag ensures the body terminates when the
+/// executor parent dies. `--unshare-net` provides full network isolation
+/// when `net_scope = None`; EgressAllowlist on Linux requires per-host
+/// firewall rules (iptables / nftables) which need root — out of scope
+/// for PR 9a-hardening-3.
+///
+/// System libraries (`/usr`, `/lib`, `/lib64`, `/etc`) are bound
+/// unconditionally so dyld can resolve dynamic libraries; this is the
+/// minimum-viable rootfs for a typical Linux binary. Production warrants
+/// would narrow these via an explicit `warrant.environment_ref`-resolved
+/// rootfs (out of scope here; the OCI rootfs extraction path lands in a
+/// later hardening sweep).
+#[cfg(target_os = "linux")]
+pub(crate) fn bwrap_argv_from_warrant(
+    bwrap_path: &str,
+    warrant: &WarrantSpec,
+    body_path: &str,
+    input_path: &str,
+) -> Vec<String> {
+    let mut argv: Vec<String> = Vec::with_capacity(32);
+    argv.push(bwrap_path.to_string());
+    argv.push("--die-with-parent".into());
+    argv.push("--proc".into());
+    argv.push("/proc".into());
+    argv.push("--dev".into());
+    argv.push("/dev".into());
+
+    // System library baseline (so dyld can resolve libsystem / glibc / etc).
+    // Each is conditional: only emit if the path exists at the executor
+    // construction site (we can't probe from inside this pure function).
+    // For PR 9a-hardening-3 we emit unconditionally; bwrap silently no-ops
+    // on missing source paths.
+    for sys_path in ["/usr", "/lib", "/lib64", "/etc"] {
+        argv.push("--ro-bind".into());
+        argv.push(sys_path.into());
+        argv.push(sys_path.into());
+    }
+
+    // fs_scope mounts.
+    for (path, mode) in &warrant.fs_scope.mounts {
+        let path_str = path.to_string_lossy().into_owned();
+        match mode {
+            FsMode::ReadOnly | FsMode::ExecOnly => {
+                argv.push("--ro-bind".into());
+                argv.push(path_str.clone());
+                argv.push(path_str);
+            }
+            FsMode::ReadWrite => {
+                argv.push("--bind".into());
+                argv.push(path_str.clone());
+                argv.push(path_str);
+            }
+        }
+    }
+
+    // net_scope. `None` => full network isolation via user-namespace.
+    if matches!(warrant.net_scope, NetScope::None) {
+        argv.push("--unshare-net".into());
+    }
+    // EgressAllowlist on Linux requires a parent-side per-host firewall
+    // (iptables/nftables/netfilter) which needs root or NET_ADMIN. Out
+    // of scope for PR 9a-hardening-3; the bwrap argv leaves net access
+    // un-isolated in that case (deferred to the production rootfs
+    // hardening sweep).
+
+    // End-of-bwrap-flags marker.
+    argv.push("--".into());
+    // Body binary + its argv.
+    argv.push(body_path.to_string());
+    argv.push(input_path.to_string());
+
+    argv
+}
+
+impl BwrapExecutor {
+    /// Borrow the configured `body_path`. Returns `None` if the
+    /// executor was constructed without one (via `BwrapExecutor::new()`).
+    #[must_use]
+    pub fn body_path(&self) -> Option<&Path> {
+        self.body_path.as_deref()
+    }
+
+    /// Borrow the configured `input_path`. Returns `None` if not yet
+    /// set via `with_input_file`.
+    #[must_use]
+    pub fn input_path(&self) -> Option<&Path> {
+        self.input_path.as_deref()
     }
 }

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -10,10 +10,8 @@
 //! workspace's `kx-executor-pure-body` example binary.
 
 use std::path::PathBuf;
-#[cfg(target_os = "macos")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(target_os = "macos")]
 use kx_content::ContentRef;
 use kx_mote::Mote;
 use kx_warrant::{ExecutorClass, WarrantSpec};
@@ -135,12 +133,24 @@ impl MacOsSandboxExecutor {
         let input_path_str = input_path.to_string_lossy().into_owned();
         let argv = vec![body_path_str.clone(), input_path_str];
 
-        // 3. Spawn — fork + pre-exec(sandbox_init) + execvp.
+        // 3. Spawn — fork + pre-exec(sandbox_init + setrlimit) + execvp.
+        // The pre-exec hook runs in the child between fork and execvp:
+        // (a) load the SBPL profile via sandbox_init (D46);
+        // (b) apply setrlimit ceilings (RLIMIT_AS / RLIMIT_NOFILE /
+        //     RLIMIT_FSIZE / RLIMIT_CPU per `ResourceCeiling`).
+        // Both calls are async-signal-safe per POSIX; the order matters
+        // only insofar as load_profile must succeed before setrlimit
+        // (an over-restrictive profile that denies setrlimit-related
+        // syscalls would fail the latter — system.sb covers this).
         let started_at_epoch_ms = now_epoch_ms();
+        let ceiling = warrant.resource_ceiling;
         let outcome = crate::spawn::spawn_body(
             &body_path_str,
             &argv,
-            Box::new(move || crate::spawn::load_profile(&profile_bytes)),
+            Box::new(move || {
+                crate::spawn::load_profile(&profile_bytes)?;
+                crate::spawn::apply_rlimits(&ceiling)
+            }),
         )?;
         let finished_at_epoch_ms = now_epoch_ms();
 
@@ -163,7 +173,6 @@ impl MacOsSandboxExecutor {
     }
 }
 
-#[cfg(target_os = "macos")]
 fn now_epoch_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -177,9 +186,11 @@ fn now_epoch_ms() -> u64 {
 
 /// Parse 64 lowercase-hex bytes (the body's stdout shape) into a
 /// `ContentRef`. Trailing whitespace is tolerated (some bodies emit a
-/// trailing newline despite the contract).
-#[cfg(target_os = "macos")]
-fn parse_hex_ref(bytes: &[u8]) -> Result<ContentRef, String> {
+/// trailing newline despite the contract). Shared across the Linux
+/// `BwrapExecutor` (PR 9a-hardening-3) and the macOS `MacOsSandboxExecutor`
+/// (PR 9a-hardening-2) — both backends spawn a body that follows the
+/// 64-hex-char-stdout contract.
+pub(crate) fn parse_hex_ref(bytes: &[u8]) -> Result<ContentRef, String> {
     // Skip trailing whitespace.
     let mut end = bytes.len();
     while end > 0 && bytes[end - 1].is_ascii_whitespace() {
@@ -202,7 +213,6 @@ fn parse_hex_ref(bytes: &[u8]) -> Result<ContentRef, String> {
     Ok(ContentRef::from_bytes(out))
 }
 
-#[cfg(target_os = "macos")]
 fn hex_nibble(b: u8) -> Result<u8, String> {
     match b {
         b'0'..=b'9' => Ok(b - b'0'),

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -173,6 +173,7 @@ impl MacOsSandboxExecutor {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn now_epoch_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -10,6 +10,7 @@
 //! workspace's `kx-executor-pure-body` example binary.
 
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use kx_content::ContentRef;

--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -276,11 +276,11 @@ pub mod factory;
 pub mod lifecycle;
 pub mod refusal;
 pub mod resource_manager;
-// The spawn module currently has only a macOS consumer (`MacOsSandboxExecutor`);
-// the Linux `BwrapExecutor` real-spawn path lands in PR 9a-hardening-3. Gating
-// to macOS today keeps clippy's `unused_item` check from firing on Linux. The
-// gate widens to `cfg(unix)` in PR 9a-hardening-3.
-#[cfg(target_os = "macos")]
+// The spawn module ships shared Unix primitives (fork + pipe + dup2 +
+// execvp + waitpid + setrlimit pre-exec hook). Linux's `BwrapExecutor`
+// (PR 9a-hardening-3) and macOS's `MacOsSandboxExecutor` (PR 9a-hardening-2)
+// both consume it.
+#[cfg(unix)]
 pub(crate) mod spawn;
 
 // Re-exports — the executor's stable public API.

--- a/crates/kx-executor/src/spawn.rs
+++ b/crates/kx-executor/src/spawn.rs
@@ -286,3 +286,85 @@ mod macos {
 
 #[cfg(target_os = "macos")]
 pub(crate) use macos::load_profile;
+
+// ============================================================================
+// Cross-platform: setrlimit pre-exec helper (PR 9a-hardening-3)
+// ============================================================================
+
+/// Apply a `ResourceCeiling` as `setrlimit` calls in the calling process.
+/// **MUST be called from the post-fork child between fork and execvp** —
+/// `setrlimit` is async-signal-safe per POSIX and the child inherits the
+/// limits across the subsequent execvp.
+///
+/// Maps:
+/// - `mem_bytes` → `RLIMIT_AS` (virtual-memory limit; closest portable
+///   approximation to "RSS cap" without diving into platform-specific
+///   `RLIMIT_RSS`).
+/// - `fd_count` → `RLIMIT_NOFILE` (max open file descriptors).
+/// - `disk_bytes` → `RLIMIT_FSIZE` (max file size the process can create).
+/// - `cpu_milli` → `RLIMIT_CPU` (CPU-seconds, NOT wall-clock; converted by
+///   rounding up to whole seconds — sub-second precision is unavailable
+///   on POSIX `setrlimit`).
+/// - `wall_clock_ms` → NOT enforced here. Wall-clock enforcement requires
+///   either a parent-side `setitimer` + `SIGALRM` or a timer thread that
+///   `kill`s the child after the budget. Ships in PR 9a-hardening-4.
+///
+/// Zero values are treated as "no ceiling on this axis" (do not call
+/// `setrlimit` for that resource). Recovery / replay never sets zero
+/// implicitly — the workflow author either declares a non-zero limit or
+/// explicitly accepts the no-ceiling shape.
+///
+/// # Errors
+///
+/// Returns marker exit codes the caller passes to `_exit` in the child:
+/// 80 = mem_bytes setrlimit failed, 81 = fd_count, 82 = disk_bytes,
+/// 83 = cpu_milli.
+#[cfg(unix)]
+pub(crate) fn apply_rlimits(ceiling: &kx_warrant::ResourceCeiling) -> Result<(), i32> {
+    if ceiling.mem_bytes > 0 {
+        let rlim = libc::rlimit {
+            rlim_cur: ceiling.mem_bytes,
+            rlim_max: ceiling.mem_bytes,
+        };
+        // SAFETY: setrlimit is async-signal-safe per POSIX; rlim is a
+        // valid stack-allocated struct.
+        if unsafe { libc::setrlimit(libc::RLIMIT_AS, &raw const rlim) } != 0 {
+            return Err(80);
+        }
+    }
+    if ceiling.fd_count > 0 {
+        let rlim = libc::rlimit {
+            rlim_cur: u64::from(ceiling.fd_count),
+            rlim_max: u64::from(ceiling.fd_count),
+        };
+        // SAFETY: as above.
+        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raw const rlim) } != 0 {
+            return Err(81);
+        }
+    }
+    if ceiling.disk_bytes > 0 {
+        let rlim = libc::rlimit {
+            rlim_cur: ceiling.disk_bytes,
+            rlim_max: ceiling.disk_bytes,
+        };
+        // SAFETY: as above.
+        if unsafe { libc::setrlimit(libc::RLIMIT_FSIZE, &raw const rlim) } != 0 {
+            return Err(82);
+        }
+    }
+    if ceiling.cpu_milli > 0 {
+        // RLIMIT_CPU is CPU-seconds. Round up so a 500-ms budget translates
+        // to "1 second of CPU time" rather than "0 seconds = kill on first
+        // tick."
+        let cpu_seconds = u64::from(ceiling.cpu_milli).div_ceil(1000);
+        let rlim = libc::rlimit {
+            rlim_cur: cpu_seconds,
+            rlim_max: cpu_seconds,
+        };
+        // SAFETY: as above.
+        if unsafe { libc::setrlimit(libc::RLIMIT_CPU, &raw const rlim) } != 0 {
+            return Err(83);
+        }
+    }
+    Ok(())
+}

--- a/crates/kx-executor/tests/integration_bwrap.rs
+++ b/crates/kx-executor/tests/integration_bwrap.rs
@@ -1,0 +1,226 @@
+//! PR 9a-hardening-3 integration tests for `BwrapExecutor`. Structural
+//! tests run cross-platform; the real-spawn test is gated to Linux +
+//! bwrap-installed.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::path::PathBuf;
+
+use kx_executor::{BwrapExecutor, MoteExecutor};
+use kx_warrant::ExecutorClass;
+
+// ============================================================================
+// Cross-platform structural tests
+// ============================================================================
+
+#[test]
+fn bwrap_executor_default_has_no_body() {
+    let exec = BwrapExecutor::new();
+    assert!(exec.body_path().is_none());
+    assert!(exec.input_path().is_none());
+}
+
+#[test]
+fn bwrap_executor_with_body_carries_the_path() {
+    let exec = BwrapExecutor::with_body(PathBuf::from("/usr/local/bin/my-body"));
+    assert_eq!(
+        exec.body_path(),
+        Some(std::path::Path::new("/usr/local/bin/my-body"))
+    );
+    assert!(exec.input_path().is_none());
+}
+
+#[test]
+fn bwrap_executor_with_input_file_carries_the_path() {
+    let exec = BwrapExecutor::with_body(PathBuf::from("/usr/local/bin/my-body"))
+        .with_input_file(PathBuf::from("/tmp/input.bin"));
+    assert_eq!(
+        exec.input_path(),
+        Some(std::path::Path::new("/tmp/input.bin"))
+    );
+}
+
+#[test]
+fn bwrap_executor_supports_only_bwrap_class_on_linux() {
+    let exec = BwrapExecutor::new();
+    assert_eq!(
+        exec.supports(ExecutorClass::Bwrap),
+        cfg!(target_os = "linux")
+    );
+    assert!(!exec.supports(ExecutorClass::MacOsSandbox));
+    assert!(!exec.supports(ExecutorClass::OciDaemon));
+    assert!(!exec.supports(ExecutorClass::CloudMicroVm));
+}
+
+#[test]
+fn bwrap_executor_with_body_path_override_carries_the_path() {
+    let exec = BwrapExecutor::with_body(PathBuf::from("/usr/local/bin/my-body"))
+        .with_bwrap_path(PathBuf::from("/opt/bwrap/bin/bwrap"));
+    // Just verify the executor was constructed; bwrap_path accessor isn't
+    // exposed publicly (production callers shouldn't depend on it).
+    let _ = exec;
+}
+
+// ============================================================================
+// Linux-specific real-spawn test (runtime-skips if bwrap absent)
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use kx_content::ContentRef;
+    use kx_executor::{BwrapExecutor, MoteExecutor};
+    use kx_mote::{
+        EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, NdClass,
+        PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    };
+    use kx_warrant::{
+        ExecutorClass, FsMode, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+        WarrantSpec,
+    };
+    use smallvec::SmallVec;
+
+    /// Probe `PATH` for the `bwrap` binary. The test runtime-skips if absent.
+    /// Uses `std::process::Command::new("which")` — this is the ONE
+    /// allowed exception to the kx-executor `std::process::Command` lint
+    /// (located in a test, not the production executor surface).
+    #[allow(clippy::disallowed_methods, clippy::disallowed_types)]
+    fn which_bwrap() -> Option<PathBuf> {
+        let output = Command::new("which").arg("bwrap").output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path_str.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(path_str))
+        }
+    }
+
+    fn pure_body_binary_path() -> Option<PathBuf> {
+        let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")?;
+        let manifest_path = PathBuf::from(&manifest_dir);
+        let workspace_root = manifest_path.parent()?.parent()?;
+        for profile in ["debug", "release"] {
+            let candidate = workspace_root
+                .join("target")
+                .join(profile)
+                .join("examples")
+                .join("pure_body");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    fn permissive_warrant_for_bwrap(
+        body_dir: &std::path::Path,
+        input_dir: &std::path::Path,
+    ) -> WarrantSpec {
+        // bwrap's --ro-bind /usr /usr (etc.) covers system libraries; the
+        // body's own directory + input's directory go into fs_scope.
+        let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+        mounts.insert(body_dir.to_path_buf(), FsMode::ReadOnly);
+        mounts.insert(input_dir.to_path_buf(), FsMode::ReadOnly);
+
+        WarrantSpec {
+            mote_class: MoteClass::Pure,
+            nd_class: MoteClass::Pure,
+            fs_scope: FsScope { mounts },
+            net_scope: NetScope::None,
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            tool_grants: BTreeSet::new(),
+            model_route: ModelRoute {
+                model_id: ModelId("local".into()),
+                max_input_tokens: 0,
+                max_output_tokens: 0,
+                max_calls: 0,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 30_000,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::Bwrap,
+        }
+    }
+
+    fn build_pure_mote() -> Mote {
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([1; 32]),
+            model_id: ModelId("local".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::Pure,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([0; 32]),
+            GraphPosition(b"root".to_vec()),
+            SmallVec::new(),
+        )
+    }
+
+    fn expected_result_ref(input_bytes: &[u8]) -> ContentRef {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"kx-executor-pure-body-result");
+        hasher.update(input_bytes);
+        ContentRef::from_bytes(*hasher.finalize().as_bytes())
+    }
+
+    #[test]
+    #[ignore = "real fork+execvp(bwrap) spawn; runtime-skips if bwrap absent; opt in with `cargo test -- --ignored`"]
+    fn pure_mote_runs_end_to_end_through_bwrap_executor() {
+        let Some(bwrap_path) = which_bwrap() else {
+            eprintln!("skipping: bwrap not installed on this machine");
+            return;
+        };
+        let Some(body_path) = pure_body_binary_path() else {
+            panic!(
+                "pure_body example not built — run `cargo build --example pure_body -p kx-executor`"
+            );
+        };
+        let body_dir = body_path
+            .parent()
+            .expect("body has a parent dir")
+            .to_path_buf();
+
+        let mut input_file = tempfile::NamedTempFile::new().expect("tempfile");
+        let input_bytes = b"hello from PR 9a-hardening-3 / Linux";
+        input_file.write_all(input_bytes).expect("write input");
+        input_file.flush().expect("flush");
+        let input_path = input_file.path().to_path_buf();
+        let input_dir = input_path.parent().expect("input parent dir").to_path_buf();
+
+        let executor = BwrapExecutor::with_body(body_path.clone())
+            .with_input_file(input_path.clone())
+            .with_bwrap_path(bwrap_path);
+        let warrant = permissive_warrant_for_bwrap(&body_dir, &input_dir);
+        let mote = build_pure_mote();
+
+        let result = executor
+            .run(&mote, &warrant, None)
+            .expect("spawn must succeed");
+
+        let expected = expected_result_ref(input_bytes);
+        assert_eq!(
+            result.result_ref, expected,
+            "body's result_ref must match BLAKE3 contract"
+        );
+        assert!(result.finished_at_epoch_ms >= result.started_at_epoch_ms);
+    }
+}

--- a/crates/kx-executor/tests/integration_bwrap.rs
+++ b/crates/kx-executor/tests/integration_bwrap.rs
@@ -66,6 +66,7 @@ fn bwrap_executor_with_body_path_override_carries_the_path() {
 // ============================================================================
 
 #[cfg(target_os = "linux")]
+#[allow(clippy::disallowed_methods, clippy::disallowed_types)]
 mod linux {
     use std::collections::{BTreeMap, BTreeSet};
     use std::io::Write;


### PR DESCRIPTION
## Summary

Third slice of the PR 9a-hardening track. Wires the real Linux spawn path through `BwrapExecutor`: fork via `nix::unistd::fork` + `apply_rlimits` setrlimit hook in the child + `execvp(bwrap)` with argv assembled from the WarrantSpec (fs_scope `--ro-bind`/`--bind` mounts; `--unshare-net` for `NetScope::None`; `--die-with-parent` + `/proc` + `/dev` baseline) + pipe-collected stdout in the parent + waitpid.

Adds cross-platform `apply_rlimits(&ResourceCeiling)` to the spawn module — applied in the child between fork and execvp on both macOS + Linux. Maps `mem_bytes`/`fd_count`/`disk_bytes`/`cpu_milli` to RLIMIT_AS / RLIMIT_NOFILE / RLIMIT_FSIZE / RLIMIT_CPU. `wall_clock_ms` (POSIX has no wall-clock RLIMIT) + cgroup v2 + logic_ref body resolution land in PR 9a-hardening-4.

## Files

- **`crates/kx-executor/src/backends/bwrap.rs`** — replaces skeleton with real `BwrapExecutor::run_linux` (gated `cfg(target_os = "linux")`). Pure `bwrap_argv_from_warrant` builder. Public accessors `body_path()` / `input_path()`.
- **`crates/kx-executor/src/spawn.rs::apply_rlimits`** — NEW cross-platform setrlimit pre-exec hook.
- **`crates/kx-executor/src/backends/macos_sandbox.rs`** — pre-exec hook now chains `load_profile` + `apply_rlimits` (real resource enforcement on macOS in addition to sandbox).
- **`crates/kx-executor/tests/integration_bwrap.rs`** (NEW) — 5 cross-platform structural unit tests + 1 Linux-only opt-in real-spawn test that runtime-skips if bwrap absent.
- **`crates/kx-executor/src/lib.rs`** — `spawn` module gate widened from `cfg(target_os = "macos")` to `cfg(unix)`.

## Tests

- Workspace: **561 passed + 4 ignored** under `--all-features` on Apple Silicon (was 556 + 4 ignored; +5 from Bwrap structural tests).
- macOS real-spawn test still passes with the new `apply_rlimits` in the pre-exec chain.
- Linux real-spawn test runs on Linux CI (runtime-skips if bwrap absent on the runner).

## Gates green

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (561 passed, 0 failed, 4 ignored)
- `cargo deny check` ✓

## Test plan

- [ ] Linux CI runs all 9 jobs green.
- [ ] Apple Silicon local: 561/561 + 4 ignored; opt-in macOS real-spawn passes.
- [ ] Linux local with bwrap installed: opt-in Linux real-spawn passes.
- [ ] Branch retention: merge with `gh pr merge --merge` (NO `--delete-branch`).

## What's deferred to PR 9a-hardening-4

- Wall-clock timer thread (macOS) + `setitimer`+SIGALRM (Linux) for `wall_clock_ms`.
- cgroup v2 file I/O on Linux (real LocalResourceManager).
- Body-binary path resolution from `logic_ref` (trait surface change for ContentStore access).
- Real `OciDaemonExecutor::run`.