### PR TITLE
PR 9a-hardening-4: wall-clock watcher thread (SIGKILL after wall_clock_ms)

### DIFF
--- a/crates/kx-executor/examples/pure_body.rs
+++ b/crates/kx-executor/examples/pure_body.rs
@@ -1,8 +1,12 @@
 //! `kx-executor-pure-body` — the example Mote body binary exercised by
-//! PR 9a-hardening-2's integration tests. **NOT a production binary.**
+//! PR 9a-hardening-2+'s integration tests. **NOT a production binary.**
 //!
 //! Contract:
 //! - Reads input bytes from the file path passed in `argv[1]`.
+//! - If `argv[2] == "--sleep"`, sleeps for `argv[3]` milliseconds AFTER
+//!   reading the input + BEFORE writing the result. The PR 9a-hardening-4
+//!   wall-clock integration test uses this to verify the parent-side
+//!   `wall_clock_ms` watcher SIGKILLs the child after the budget elapses.
 //! - Computes the `result_ref` as `BLAKE3("kx-executor-pure-body-result" || input_bytes)`.
 //! - Writes the `result_ref` hex (64 ASCII chars, lowercase, no trailing newline)
 //!   to stdout.
@@ -19,6 +23,8 @@ use std::env;
 use std::fs;
 use std::io::Write;
 use std::process::ExitCode;
+use std::thread;
+use std::time::Duration;
 
 const NIBBLES: &[u8; 16] = b"0123456789abcdef";
 
@@ -37,6 +43,15 @@ fn main() -> ExitCode {
             return ExitCode::from(1);
         }
     };
+
+    // Optional --sleep <ms> for wall-clock budget testing.
+    if args.len() >= 4 && args[2] == "--sleep" {
+        let Ok(sleep_ms) = args[3].parse::<u64>() else {
+            eprintln!("pure_body: --sleep value must be a non-negative integer");
+            return ExitCode::from(2);
+        };
+        thread::sleep(Duration::from_millis(sleep_ms));
+    }
 
     // Result derivation — content-addressed: same input → same hex.
     let mut hasher = blake3::Hasher::new();

--- a/crates/kx-executor/src/backends/bwrap.rs
+++ b/crates/kx-executor/src/backends/bwrap.rs
@@ -153,10 +153,16 @@ impl BwrapExecutor {
         // + capability drops).
         let started_at_epoch_ms = now_epoch_ms();
         let ceiling = warrant.resource_ceiling;
+        let wall_clock_ms = if warrant.resource_ceiling.wall_clock_ms > 0 {
+            Some(warrant.resource_ceiling.wall_clock_ms)
+        } else {
+            None
+        };
         let outcome = crate::spawn::spawn_body(
             &bwrap_path_str,
             &argv,
             Box::new(move || crate::spawn::apply_rlimits(&ceiling)),
+            wall_clock_ms,
         )?;
         let finished_at_epoch_ms = now_epoch_ms();
 

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -36,6 +36,12 @@ pub struct MacOsSandboxExecutor {
     /// committed parents.
     #[allow(dead_code)] // read only on target_os = "macos" via `run_macos`
     input_path: Option<PathBuf>,
+    /// Additional argv tokens appended after `argv[0]` (body) + `argv[1]`
+    /// (input_file). Used by integration tests (e.g., `--sleep <ms>` for
+    /// the wall-clock watcher). Production callers compose argv via
+    /// `MoteDef.config_subset` in a future hardening sweep.
+    #[allow(dead_code)] // read only on target_os = "macos" via `run_macos`
+    extra_args: Vec<String>,
 }
 
 impl MacOsSandboxExecutor {
@@ -46,6 +52,7 @@ impl MacOsSandboxExecutor {
         Self {
             body_path: None,
             input_path: None,
+            extra_args: Vec::new(),
         }
     }
 
@@ -57,6 +64,7 @@ impl MacOsSandboxExecutor {
         Self {
             body_path: Some(body_path),
             input_path: None,
+            extra_args: Vec::new(),
         }
     }
 
@@ -66,6 +74,18 @@ impl MacOsSandboxExecutor {
     #[must_use]
     pub fn with_input_file(mut self, input_path: PathBuf) -> Self {
         self.input_path = Some(input_path);
+        self
+    }
+
+    /// Append extra argv tokens to the spawned body's command line (after
+    /// `argv[0]` = body and `argv[1]` = input_file). The wall-clock
+    /// integration test uses `with_extra_args(vec!["--sleep", "60000"])`
+    /// to exercise the parent-side watcher's SIGKILL path. Production
+    /// production callers compose their argv via the workflow's
+    /// `MoteDef.config_subset` (a future hardening sweep wires this).
+    #[must_use]
+    pub fn with_extra_args(mut self, extra: Vec<String>) -> Self {
+        self.extra_args = extra;
         self
     }
 }
@@ -129,10 +149,13 @@ impl MacOsSandboxExecutor {
         let profile = profile_from_warrant(warrant);
         let profile_bytes = profile.as_bytes().to_vec();
 
-        // 2. Body argv (argv[0] = body name, argv[1] = input file path).
+        // 2. Body argv (argv[0] = body, argv[1] = input_file, ...extra_args).
         let body_path_str = body_path.to_string_lossy().into_owned();
         let input_path_str = input_path.to_string_lossy().into_owned();
-        let argv = vec![body_path_str.clone(), input_path_str];
+        let mut argv = Vec::with_capacity(2 + self.extra_args.len());
+        argv.push(body_path_str.clone());
+        argv.push(input_path_str);
+        argv.extend(self.extra_args.iter().cloned());
 
         // 3. Spawn — fork + pre-exec(sandbox_init + setrlimit) + execvp.
         // The pre-exec hook runs in the child between fork and execvp:
@@ -145,6 +168,11 @@ impl MacOsSandboxExecutor {
         // syscalls would fail the latter — system.sb covers this).
         let started_at_epoch_ms = now_epoch_ms();
         let ceiling = warrant.resource_ceiling;
+        let wall_clock_ms = if warrant.resource_ceiling.wall_clock_ms > 0 {
+            Some(warrant.resource_ceiling.wall_clock_ms)
+        } else {
+            None
+        };
         let outcome = crate::spawn::spawn_body(
             &body_path_str,
             &argv,
@@ -152,6 +180,7 @@ impl MacOsSandboxExecutor {
                 crate::spawn::load_profile(&profile_bytes)?;
                 crate::spawn::apply_rlimits(&ceiling)
             }),
+            wall_clock_ms,
         )?;
         let finished_at_epoch_ms = now_epoch_ms();
 

--- a/crates/kx-executor/src/spawn.rs
+++ b/crates/kx-executor/src/spawn.rs
@@ -15,7 +15,12 @@
 
 use std::ffi::CString;
 use std::os::fd::IntoRawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
+use nix::sys::signal::{kill, Signal};
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::{fork, pipe, ForkResult};
 
@@ -43,9 +48,12 @@ pub(crate) type PreExecHook = Box<dyn FnOnce() -> Result<(), i32> + Send>;
 /// `body_path` is the absolute path to the Mote body binary. `argv` is the
 /// argv to pass to execvp (argv\[0\] is conventionally the body's basename).
 /// `pre_exec` runs in the child after fork, before execvp — typically loads
-/// the sandbox profile (macOS) or applies setrlimit. `body_input` is the
-/// bytes piped to the child's stdin (so the body can read its input without
-/// touching the FS).
+/// the sandbox profile (macOS) or applies setrlimit. `wall_clock_ms` is the
+/// per-Mote wall-clock budget: when `Some(ms)`, a watcher thread spawned in
+/// the parent SIGKILLs the child after `ms` if it hasn't exited; the spawn
+/// returns `MoteExecutorError::WallClockTimedOut { budget_ms }` in that case.
+/// When `None` or `0`, no wall-clock enforcement is applied (the child runs
+/// indefinitely subject only to its other resource ceilings via setrlimit).
 ///
 /// # Safety
 ///
@@ -56,10 +64,15 @@ pub(crate) type PreExecHook = Box<dyn FnOnce() -> Result<(), i32> + Send>;
 /// safe; allocating Rust types in the child is NOT. This module enforces
 /// the discipline by calling `_exit` (NOT `std::process::exit` or `panic!`)
 /// from the child path on any error.
+// The fork/parent/child paths each have multiple unsafe-but-documented
+// segments; splitting into helpers would obscure the SAFETY-comment
+// adjacency that the kx-llamacpp precedent requires for unsafe FFI.
+#[allow(clippy::too_many_lines)]
 pub(crate) fn spawn_body(
     body_path: &str,
     argv: &[String],
     pre_exec: PreExecHook,
+    wall_clock_ms: Option<u64>,
 ) -> Result<BodyOutcome, MoteExecutorError> {
     // Pipe for the child's stdout → parent. We take ownership of both fd
     // ends via OwnedFd, then convert to RawFd so we can manually `libc::close`
@@ -139,13 +152,47 @@ pub(crate) fn spawn_body(
             unsafe { libc::_exit(71) };
         }
         ForkResult::Parent { child } => {
-            // Parent path: close the write end of the pipe, read child's
-            // stdout to EOF, then waitpid.
+            // Parent path: close the write end of the pipe, optionally
+            // spawn a wall-clock watcher that SIGKILLs after the budget,
+            // read child's stdout to EOF, then waitpid.
             // SAFETY: stdout_write is the parent's pipe-write fd; we no
             // longer need it (the child has its own duplicate).
             unsafe {
                 libc::close(stdout_write);
             }
+
+            // Wall-clock watcher: spawn a detached thread that sleeps for
+            // wall_clock_ms then SIGKILLs the child if it's still running.
+            // - `disarm` is set by the parent after waitpid reaps the child;
+            //   the watcher checks it on wake-up + exits without signaling
+            //   (closes the PID-reuse race).
+            // - `kill_fired` is set by the watcher iff it actually sent
+            //   SIGKILL; the parent reads it after waitpid to distinguish
+            //   "wall-clock timeout" from "body was SIGKILLed for some
+            //   other reason".
+            // The thread is NOT joined — joining would block until the
+            // sleep completes regardless of when the body actually exits,
+            // breaking the fast-body happy path. The thread either fires
+            // SIGKILL + records kill_fired or wakes up post-disarm + exits.
+            let disarm = Arc::new(AtomicBool::new(false));
+            let kill_fired = Arc::new(AtomicBool::new(false));
+            if let Some(budget_ms) = wall_clock_ms {
+                if budget_ms > 0 {
+                    let disarm_for_thread = Arc::clone(&disarm);
+                    let kill_fired_for_thread = Arc::clone(&kill_fired);
+                    let child_pid = child;
+                    thread::spawn(move || {
+                        thread::sleep(Duration::from_millis(budget_ms));
+                        if disarm_for_thread.load(Ordering::SeqCst) {
+                            return;
+                        }
+                        // Best-effort SIGKILL; ignore ESRCH (already exited).
+                        let _ = kill(child_pid, Signal::SIGKILL);
+                        kill_fired_for_thread.store(true, Ordering::SeqCst);
+                    });
+                }
+            }
+
             let read_fd = stdout_read;
             let mut stdout_bytes = Vec::with_capacity(64);
             let mut buf = [0u8; 4096];
@@ -181,8 +228,25 @@ pub(crate) fn spawn_body(
             let status = waitpid(child, None).map_err(|e| MoteExecutorError::Internal {
                 reason: format!("waitpid: {e}"),
             })?;
+
+            // Disarm the watcher: child has been reaped. The watcher's
+            // post-disarm thread.sleep wakes up + sees the flag + exits
+            // without sending SIGKILL (closes the PID-reuse race).
+            disarm.store(true, Ordering::SeqCst);
+            // Read whether the watcher already fired SIGKILL before we
+            // got here (informs the WallClockTimedOut branch below).
+            let watcher_killed = kill_fired.load(Ordering::SeqCst);
+
+            // Decide the outcome class.
             let exit_code = match status {
                 WaitStatus::Exited(_, code) => code,
+                WaitStatus::Signaled(_, Signal::SIGKILL, _) if watcher_killed => {
+                    // The watcher fired SIGKILL because wall_clock_ms
+                    // elapsed. Surface as the typed timeout error rather
+                    // than `BodyExited { code: 128+9 }`.
+                    let budget_ms = wall_clock_ms.unwrap_or(0);
+                    return Err(MoteExecutorError::WallClockTimedOut { budget_ms });
+                }
                 WaitStatus::Signaled(_, sig, _) => 128 + (sig as i32),
                 other => {
                     return Err(MoteExecutorError::Internal {

--- a/crates/kx-executor/tests/integration_wall_clock.rs
+++ b/crates/kx-executor/tests/integration_wall_clock.rs
@@ -1,0 +1,174 @@
+//! PR 9a-hardening-4 wall-clock-budget integration test.
+//!
+//! The parent-side watcher thread (introduced in `crate::spawn::spawn_body`'s
+//! `wall_clock_ms` parameter) MUST SIGKILL the child after the configured
+//! budget elapses. This integration test spawns the `pure_body` example
+//! with `--sleep 60000` (60 s) + a `wall_clock_ms: 500` warrant; the
+//! executor's `run()` MUST return `MoteExecutorError::WallClockTimedOut
+//! { budget_ms: 500 }` within a few seconds.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    use kx_content::ContentRef;
+    use kx_executor::{MacOsSandboxExecutor, MoteExecutor, MoteExecutorError};
+    use kx_mote::{
+        EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, NdClass,
+        PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    };
+    use kx_warrant::{
+        ExecutorClass, FsMode, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+        WarrantSpec,
+    };
+    use smallvec::SmallVec;
+
+    fn pure_body_binary_path() -> Option<PathBuf> {
+        let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")?;
+        let manifest_path = PathBuf::from(&manifest_dir);
+        let workspace_root = manifest_path.parent()?.parent()?;
+        for profile in ["debug", "release"] {
+            let candidate = workspace_root
+                .join("target")
+                .join(profile)
+                .join("examples")
+                .join("pure_body");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    fn warrant_with_wall_clock(
+        body_path: &std::path::Path,
+        input_dir: &std::path::Path,
+        wall_clock_ms: u64,
+    ) -> WarrantSpec {
+        let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+        mounts.insert(PathBuf::from("/"), FsMode::ReadOnly);
+        mounts.insert(body_path.to_path_buf(), FsMode::ExecOnly);
+        mounts.insert(input_dir.to_path_buf(), FsMode::ReadOnly);
+
+        WarrantSpec {
+            mote_class: MoteClass::Pure,
+            nd_class: MoteClass::Pure,
+            fs_scope: FsScope { mounts },
+            net_scope: NetScope::None,
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            tool_grants: BTreeSet::new(),
+            model_route: ModelRoute {
+                model_id: ModelId("local".into()),
+                max_input_tokens: 0,
+                max_output_tokens: 0,
+                max_calls: 0,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::MacOsSandbox,
+        }
+    }
+
+    fn build_pure_mote() -> Mote {
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([1; 32]),
+            model_id: ModelId("local".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::Pure,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([0; 32]),
+            GraphPosition(b"root".to_vec()),
+            SmallVec::new(),
+        )
+    }
+
+    #[test]
+    #[ignore = "real fork+spawn with --sleep + wall-clock watcher; requires `cargo build --example pure_body -p kx-executor` first; opt in with `cargo test -- --ignored`"]
+    fn body_exceeding_wall_clock_ms_is_sigkilled_by_watcher() {
+        let body_path = pure_body_binary_path().expect("pure_body example not built");
+
+        let mut input_file = tempfile::NamedTempFile::new().expect("tempfile");
+        input_file
+            .write_all(b"input bytes")
+            .expect("write input bytes");
+        input_file.flush().expect("flush");
+        let input_path = input_file.path().to_path_buf();
+        let input_dir = input_path.parent().expect("input parent dir").to_path_buf();
+
+        // 500ms wall-clock budget; body sleeps 60s. The watcher MUST kill
+        // the body well before the 60s sleep completes.
+        let warrant = warrant_with_wall_clock(&body_path, &input_dir, 500);
+        let mote = build_pure_mote();
+
+        // Construct the executor with the body + the `--sleep 60000` arg.
+        // We need a custom MacOsSandboxExecutor that passes the sleep arg;
+        // for PR 9a-hardening-4 we extend the existing constructor pattern
+        // to accept additional argv. As a stopgap, the test below uses the
+        // public `with_body` + `with_input_file` API and relies on the
+        // executor's argv builder to pass the input path as argv[1]. To
+        // get `--sleep 60000` into the body's argv, we would need a
+        // `with_extra_args` constructor on MacOsSandboxExecutor.
+        //
+        // For PR 9a-hardening-4 we ADD that constructor below. Until the
+        // constructor lands, this test asserts the watcher API contract
+        // at the SHAPE level (the wall_clock_ms field is read from the
+        // warrant + plumbed through to spawn_body's new parameter).
+        //
+        // The shape verification: construct the executor, call run with
+        // a warrant whose wall_clock_ms is 500, observe that the executor
+        // attempted to spawn (and returned either Success or
+        // WallClockTimedOut depending on whether the body finished in
+        // time). For the pure_body without --sleep, 500ms is plenty; the
+        // body finishes successfully. To exercise the actual TIMEOUT
+        // path, see the `with_extra_args` test that follows once the
+        // constructor lands.
+
+        let started = Instant::now();
+        let executor = MacOsSandboxExecutor::with_body(body_path.clone())
+            .with_input_file(input_path.clone())
+            .with_extra_args(vec!["--sleep".into(), "60000".into()]);
+        let result = executor.run(&mote, &warrant, None);
+        let elapsed = started.elapsed();
+
+        // The watcher MUST fire within ~1 second of the budget elapsing;
+        // the parent reaps the SIGKILLed child + returns WallClockTimedOut.
+        // We accept up to 5s elapsed for system noise.
+        assert!(
+            elapsed.as_secs() < 5,
+            "wall-clock test should complete in <5s; observed {elapsed:?}"
+        );
+        match result {
+            Err(MoteExecutorError::WallClockTimedOut { budget_ms }) => {
+                assert_eq!(budget_ms, 500, "budget_ms should round-trip");
+            }
+            other => panic!("expected WallClockTimedOut, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn integration_wall_clock_macos_only_placeholder() {
+    // The Linux wall-clock test ships in PR 9a-hardening-4+ (Linux real-spawn
+    // already shipped at hardening-3 — adding the wall-clock variant to the
+    // Linux integration test is a small follow-up).
+}


### PR DESCRIPTION
## Summary

Fourth slice of the PR 9a-hardening track. Wires parent-side wall-clock enforcement: `spawn_body` spawns a detached watcher thread that SIGKILLs the child after `wall_clock_ms`; the parent reads a shared `kill_fired` atomic + surfaces `MoteExecutorError::WallClockTimedOut { budget_ms }` instead of `BodyExited { code: 128+9 }` when the watcher caused the kill.

logic_ref body resolution + cgroup v2 cluster naturally in PR 9a-hardening-5 (both need new ContentStore-facing wiring + a `BodyResolver` trait).

## Files

- **`crates/kx-executor/src/spawn.rs`** — `spawn_body` extended with `wall_clock_ms: Option<u64>`; detached watcher thread + `disarm`/`kill_fired` shared atomics; `WallClockTimedOut` branch on signaled-by-watcher exit.
- **`crates/kx-executor/src/backends/{bwrap,macos_sandbox}.rs`** — read `warrant.resource_ceiling.wall_clock_ms`, pass `Some(ms)` when non-zero.
- **`crates/kx-executor/src/backends/macos_sandbox.rs::with_extra_args`** — new constructor appending argv tokens for the wall-clock integration test (`--sleep 60000`).
- **`crates/kx-executor/examples/pure_body.rs`** — optional `--sleep <ms>` arg.
- **`crates/kx-executor/tests/integration_wall_clock.rs`** (NEW) — opt-in (`#[ignore]`) integration test; passes in 0.51s on Apple Silicon.

## Tests

- Workspace: **561/561 passed + 5 ignored** (was 561 + 4; +1 ignored from new wall-clock test).
- macOS real-spawn test runs in 0.03s (body completes naturally; watcher is set up but doesn't fire); a bug where the parent blocked for the full wall_clock_ms was caught + fixed during PR development.
- macOS wall-clock test runs in 0.51s (body sleeps 60s; watcher fires at 500ms; `WallClockTimedOut { budget_ms: 500 }` returns).

## Gates green

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (561 passed, 0 failed, 5 ignored)
- `cargo deny check` ✓

## What's deferred to PR 9a-hardening-5

- Body-binary path resolution from `logic_ref` (new `BodyResolver` trait + ContentStoreBodyResolver + tempfile + chmod +x + fs_scope path discipline).
- Real cgroup v2 file I/O on Linux.
- Linux wall-clock integration test variant.