### PR TITLE
PR 9a-hardening-5: BodyResolver trait + ContentStoreBodyResolver + tempfile materialization

### DIFF
--- a/crates/kx-executor/Cargo.toml
+++ b/crates/kx-executor/Cargo.toml
@@ -28,6 +28,7 @@ blake3               = { workspace = true }
 bytes                = { workspace = true }
 serde                = { workspace = true }
 smallvec             = { workspace = true }
+tempfile             = { workspace = true }
 thiserror            = { workspace = true }
 tracing              = { workspace = true }
 

--- a/crates/kx-executor/src/backends/bwrap.rs
+++ b/crates/kx-executor/src/backends/bwrap.rs
@@ -14,6 +14,7 @@
 //! Linux machines without bwrap.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use kx_mote::Mote;
 use kx_warrant::{ExecutorClass, WarrantSpec};
@@ -21,10 +22,12 @@ use kx_warrant::{ExecutorClass, WarrantSpec};
 #[cfg(target_os = "linux")]
 use kx_warrant::{FsMode, NetScope};
 
+use crate::body_resolver::BodyResolver;
+
 use crate::executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
 
 /// Bubblewrap-based sandbox executor (Linux default per D41).
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 #[allow(clippy::struct_field_names)] // each *_path field carries distinct semantics
 pub struct BwrapExecutor {
     /// Absolute path to the body binary the spawned child will execvp into
@@ -41,6 +44,25 @@ pub struct BwrapExecutor {
     /// via `PATH`); production callers can override.
     #[allow(dead_code)] // read only on target_os = "linux" via `run_linux`
     bwrap_path: PathBuf,
+    /// Optional `BodyResolver` (PR 9a-hardening-5). When set + `body_path`
+    /// is None, the executor resolves `mote.def.logic_ref` via the
+    /// resolver at run time + materializes to a tempfile.
+    #[allow(dead_code)] // read only on target_os = "linux" via `run_linux`
+    body_resolver: Option<Arc<dyn BodyResolver>>,
+}
+
+impl std::fmt::Debug for BwrapExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BwrapExecutor")
+            .field("body_path", &self.body_path)
+            .field("input_path", &self.input_path)
+            .field("bwrap_path", &self.bwrap_path)
+            .field(
+                "body_resolver",
+                &self.body_resolver.as_ref().map(|_| "<dyn BodyResolver>"),
+            )
+            .finish()
+    }
 }
 
 impl BwrapExecutor {
@@ -53,6 +75,7 @@ impl BwrapExecutor {
             body_path: None,
             input_path: None,
             bwrap_path: PathBuf::from("bwrap"),
+            body_resolver: None,
         }
     }
 
@@ -65,7 +88,19 @@ impl BwrapExecutor {
             body_path: Some(body_path),
             input_path: None,
             bwrap_path: PathBuf::from("bwrap"),
+            body_resolver: None,
         }
+    }
+
+    /// Configure the executor with a `BodyResolver` (PR 9a-hardening-5).
+    /// At run time, the executor resolves `mote.def.logic_ref` via the
+    /// resolver, materializes the body bytes to a tempfile, chmods +x,
+    /// and feeds the tempfile path to bwrap. The `body_path` constructor
+    /// argument is ignored when a resolver is set.
+    #[must_use]
+    pub fn with_body_resolver(mut self, resolver: Arc<dyn BodyResolver>) -> Self {
+        self.body_resolver = Some(resolver);
+        self
     }
 
     /// Set the input file path passed as the body's `argv[1]`.
@@ -120,18 +155,36 @@ impl BwrapExecutor {
     /// result_ref, returns `MoteExecutionResult`.
     fn run_linux(
         &self,
-        _mote: &Mote,
+        mote: &Mote,
         warrant: &WarrantSpec,
         _env: Option<&Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
-        let body_path = self
-            .body_path
-            .as_ref()
-            .ok_or(MoteExecutorError::BackendUnsupported {
-                class: ExecutorClass::Bwrap,
-                reason: "no body_path configured — construct via BwrapExecutor::with_body(path)"
-                    .into(),
-            })?;
+        // Resolve the body path: prefer `body_resolver` over `body_path`.
+        // The MaterializedBody guard is held alive until end-of-run_linux;
+        // its Drop removes the tempfile.
+        let materialized = if let Some(resolver) = &self.body_resolver {
+            Some(resolver.resolve(&mote.def.logic_ref).map_err(|e| {
+                MoteExecutorError::Internal {
+                    reason: format!("body_resolver: {e}"),
+                }
+            })?)
+        } else {
+            None
+        };
+        let body_path_owned: PathBuf = if let Some(m) = &materialized {
+            m.path().to_path_buf()
+        } else {
+            self.body_path
+                .as_ref()
+                .ok_or(MoteExecutorError::BackendUnsupported {
+                    class: ExecutorClass::Bwrap,
+                    reason:
+                        "no body source configured — construct via BwrapExecutor::with_body(path) or .with_body_resolver(resolver)"
+                            .into(),
+                })?
+                .clone()
+        };
+        let body_path = &body_path_owned;
         let input_path = self
             .input_path
             .as_ref()

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -10,6 +10,7 @@
 //! workspace's `kx-executor-pure-body` example binary.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -17,11 +18,13 @@ use kx_content::ContentRef;
 use kx_mote::Mote;
 use kx_warrant::{ExecutorClass, WarrantSpec};
 
+use crate::body_resolver::BodyResolver;
+
 use crate::executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
 
 /// macOS sandbox-exec / Seatbelt-based sandbox executor (macOS default per
 /// D41).
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct MacOsSandboxExecutor {
     /// Absolute path to the body binary the spawned child will execvp into.
     /// When `None`, `run()` returns `BackendUnsupported` (the PR 9a
@@ -42,6 +45,27 @@ pub struct MacOsSandboxExecutor {
     /// `MoteDef.config_subset` in a future hardening sweep.
     #[allow(dead_code)] // read only on target_os = "macos" via `run_macos`
     extra_args: Vec<String>,
+    /// Optional `BodyResolver` (PR 9a-hardening-5). When set + `body_path`
+    /// is None, the executor resolves `mote.def.logic_ref` via the
+    /// resolver at run time, materializes the bytes to a tempfile, chmods
+    /// +x, and execvps the tempfile. The MaterializedBody guard is
+    /// held alive for the spawn's duration; `Drop` removes the tempfile.
+    #[allow(dead_code)] // read only on target_os = "macos" via `run_macos`
+    body_resolver: Option<Arc<dyn BodyResolver>>,
+}
+
+impl std::fmt::Debug for MacOsSandboxExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MacOsSandboxExecutor")
+            .field("body_path", &self.body_path)
+            .field("input_path", &self.input_path)
+            .field("extra_args", &self.extra_args)
+            .field(
+                "body_resolver",
+                &self.body_resolver.as_ref().map(|_| "<dyn BodyResolver>"),
+            )
+            .finish()
+    }
 }
 
 impl MacOsSandboxExecutor {
@@ -53,6 +77,7 @@ impl MacOsSandboxExecutor {
             body_path: None,
             input_path: None,
             extra_args: Vec::new(),
+            body_resolver: None,
         }
     }
 
@@ -65,7 +90,22 @@ impl MacOsSandboxExecutor {
             body_path: Some(body_path),
             input_path: None,
             extra_args: Vec::new(),
+            body_resolver: None,
         }
+    }
+
+    /// Configure the executor with a `BodyResolver` (PR 9a-hardening-5).
+    /// At run time, the executor resolves `mote.def.logic_ref` via the
+    /// resolver, materializes the body bytes to a tempfile, chmods +x,
+    /// and execvps the tempfile path. The `body_path` constructor argument
+    /// is ignored when a resolver is set; production callers typically
+    /// configure either `with_body(path)` (static path; tests) OR
+    /// `with_body_resolver(resolver)` (production; per-Mote dynamic
+    /// resolution from `logic_ref`).
+    #[must_use]
+    pub fn with_body_resolver(mut self, resolver: Arc<dyn BodyResolver>) -> Self {
+        self.body_resolver = Some(resolver);
+        self
     }
 
     /// Set the input file path passed as the body's `argv[1]`. Production
@@ -124,19 +164,37 @@ impl MacOsSandboxExecutor {
     /// waitpids, returns the result.
     fn run_macos(
         &self,
-        _mote: &Mote,
+        mote: &Mote,
         warrant: &WarrantSpec,
         _env: Option<&Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
-        let body_path = self
-            .body_path
-            .as_ref()
-            .ok_or(MoteExecutorError::BackendUnsupported {
-                class: ExecutorClass::MacOsSandbox,
-                reason:
-                    "no body_path configured — construct via MacOsSandboxExecutor::with_body(path)"
-                        .into(),
-            })?;
+        // Resolve the body path: prefer `body_resolver` (production) over
+        // `body_path` (tests / static configuration). The MaterializedBody
+        // guard is held alive until the end of `run_macos`; its Drop
+        // removes the tempfile.
+        let materialized = if let Some(resolver) = &self.body_resolver {
+            Some(resolver.resolve(&mote.def.logic_ref).map_err(|e| {
+                MoteExecutorError::Internal {
+                    reason: format!("body_resolver: {e}"),
+                }
+            })?)
+        } else {
+            None
+        };
+        let body_path_owned: PathBuf = if let Some(m) = &materialized {
+            m.path().to_path_buf()
+        } else {
+            self.body_path
+                .as_ref()
+                .ok_or(MoteExecutorError::BackendUnsupported {
+                    class: ExecutorClass::MacOsSandbox,
+                    reason:
+                        "no body source configured — construct via MacOsSandboxExecutor::with_body(path) or .with_body_resolver(resolver)"
+                            .into(),
+                })?
+                .clone()
+        };
+        let body_path = &body_path_owned;
         let input_path = self
             .input_path
             .as_ref()

--- a/crates/kx-executor/src/body_resolver.rs
+++ b/crates/kx-executor/src/body_resolver.rs
@@ -1,0 +1,150 @@
+//! Resolve a Mote's `logic_ref` to a runnable body path on disk.
+//!
+//! Production callers configure the executor with an `Arc<dyn BodyResolver>`;
+//! at run time the executor calls `resolve(&logic_ref)` to materialize the
+//! body bytes (from a `ContentStore`) into a tempfile + chmod +x + return
+//! the path. The caller execvps the path; the spawned child inherits
+//! through to the body binary.
+//!
+//! The trait exists because `ContentStore` has an associated `Payload`
+//! type that makes `dyn ContentStore` unworkable. `BodyResolver` is
+//! object-safe (no generics, no associated types) so executors can hold
+//! `Arc<dyn BodyResolver>` while concrete impls like
+//! `ContentStoreBodyResolver<S: ContentStore>` carry the generic.
+
+use std::io::Write;
+use std::path::Path;
+
+use kx_content::{ContentRef, ContentStore};
+use kx_mote::LogicRef;
+use thiserror::Error;
+
+/// Errors from resolving a Mote's `logic_ref` to a runnable body path.
+#[derive(Debug, Error)]
+pub enum BodyResolverError {
+    /// The configured `ContentStore` doesn't have the bytes the `logic_ref`
+    /// points at. Production callers should pre-populate the store before
+    /// dispatching the Mote.
+    #[error("logic_ref content not in store: {hex}")]
+    NotInStore {
+        /// Lowercase-hex of the logic_ref bytes (32 bytes × 2 = 64 chars).
+        hex: String,
+    },
+    /// Filesystem error materializing the body bytes (tempfile creation,
+    /// write, or flush).
+    #[error("materialize body: {0}")]
+    Io(String),
+    /// `chmod +x` on the materialized tempfile failed.
+    #[error("chmod +x on body path failed: {0}")]
+    ChmodFailed(String),
+}
+
+/// Resolve a Mote's `logic_ref` to a runnable body path. Object-safe +
+/// `Send + Sync` so callers hold `Arc<dyn BodyResolver>`.
+pub trait BodyResolver: Send + Sync {
+    /// Resolve `logic_ref` to a `MaterializedBody` whose `path()` is safe
+    /// to execvp. The caller MUST keep the `MaterializedBody` alive until
+    /// the spawned process has been reaped — its `Drop` removes the
+    /// underlying tempfile.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BodyResolverError` variants when the content store lookup
+    /// fails (`NotInStore`), the tempfile write fails (`Io`), or the
+    /// permissions update fails (`ChmodFailed`).
+    fn resolve(&self, logic_ref: &LogicRef) -> Result<MaterializedBody, BodyResolverError>;
+}
+
+/// A body binary materialized to a temporary file. `Drop` removes the
+/// file. Callers `execvp` `path()` then keep `Self` alive until waitpid
+/// reaps the child.
+pub struct MaterializedBody {
+    file: tempfile::NamedTempFile,
+}
+
+impl MaterializedBody {
+    /// The path on disk the executor can `execvp`. Lives until `Drop`
+    /// removes the file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        self.file.path()
+    }
+}
+
+impl std::fmt::Debug for MaterializedBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MaterializedBody")
+            .field("path", &self.file.path())
+            .finish()
+    }
+}
+
+/// `BodyResolver` impl backed by a `ContentStore`. Generic over the
+/// concrete `ContentStore` since `ContentStore::Payload` is an associated
+/// type that prevents `dyn ContentStore` directly.
+pub struct ContentStoreBodyResolver<S: ContentStore> {
+    store: S,
+}
+
+impl<S: ContentStore> ContentStoreBodyResolver<S> {
+    /// Construct a resolver wrapping the given `ContentStore`.
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+}
+
+impl<S> std::fmt::Debug for ContentStoreBodyResolver<S>
+where
+    S: ContentStore,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContentStoreBodyResolver").finish()
+    }
+}
+
+impl<S> BodyResolver for ContentStoreBodyResolver<S>
+where
+    S: ContentStore + Send + Sync,
+    S::Payload: Send + Sync,
+{
+    fn resolve(&self, logic_ref: &LogicRef) -> Result<MaterializedBody, BodyResolverError> {
+        let content_ref = ContentRef::from_bytes(*logic_ref.as_bytes());
+        let bytes_handle =
+            self.store
+                .get(&content_ref)
+                .map_err(|_| BodyResolverError::NotInStore {
+                    hex: hex_of(logic_ref.as_bytes()),
+                })?;
+
+        let mut file = tempfile::NamedTempFile::new()
+            .map_err(|e| BodyResolverError::Io(format!("tempfile: {e}")))?;
+        file.write_all(&bytes_handle)
+            .map_err(|e| BodyResolverError::Io(format!("write: {e}")))?;
+        file.flush()
+            .map_err(|e| BodyResolverError::Io(format!("flush: {e}")))?;
+
+        // chmod +x — required for execvp to honor the binary as
+        // executable. On Unix this is `Permissions::from_mode(0o755)`;
+        // production callers may want stricter modes (0o700) if the
+        // tempfile dir is shared with other UIDs.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o755))
+                .map_err(|e| BodyResolverError::ChmodFailed(e.to_string()))?;
+        }
+
+        Ok(MaterializedBody { file })
+    }
+}
+
+/// Lowercase-hex encode a 32-byte hash for error messages.
+fn hex_of(bytes: &[u8; 32]) -> String {
+    const NIBBLES: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        out.push(NIBBLES[(byte >> 4) as usize] as char);
+        out.push(NIBBLES[(byte & 0x0F) as usize] as char);
+    }
+    out
+}

--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -270,6 +270,7 @@
 )]
 
 pub mod backends;
+pub mod body_resolver;
 pub mod executor_trait;
 pub mod fact_zero;
 pub mod factory;
@@ -284,6 +285,9 @@ pub mod resource_manager;
 pub(crate) mod spawn;
 
 // Re-exports — the executor's stable public API.
+pub use body_resolver::{
+    BodyResolver, BodyResolverError, ContentStoreBodyResolver, MaterializedBody,
+};
 pub use executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
 pub use fact_zero::{
     seed_idempotency_key, seed_mote_id, write_fact_zero, FactZeroError, SeedPayload,

--- a/crates/kx-executor/tests/integration_body_resolver.rs
+++ b/crates/kx-executor/tests/integration_body_resolver.rs
@@ -1,0 +1,246 @@
+//! PR 9a-hardening-5 integration tests for the `BodyResolver` trait +
+//! `ContentStoreBodyResolver` impl.
+//!
+//! Structural tests run cross-platform (verify the materialization
+//! contract + chmod +x); the real-spawn variant is opt-in (macOS for
+//! now) and proves the executor can spawn a body whose path was
+//! resolved from `logic_ref` at run time, not pre-configured via
+//! `with_body(path)`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::sync::Arc;
+
+use kx_content::{ContentStore, InMemoryContentStore};
+use kx_executor::{BodyResolver, BodyResolverError, ContentStoreBodyResolver, MaterializedBody};
+use kx_mote::LogicRef;
+
+// ============================================================================
+// Cross-platform structural tests
+// ============================================================================
+
+#[test]
+fn resolve_returns_materialized_body_pointing_at_the_bytes() {
+    let bytes = b"#!/bin/sh\necho hello\n".to_vec();
+    let store = InMemoryContentStore::new();
+    let content_ref = store.put(&bytes).expect("put");
+    let logic_ref = LogicRef::from_bytes(*content_ref.as_bytes());
+
+    let resolver = ContentStoreBodyResolver::new(store);
+    let materialized: MaterializedBody = resolver.resolve(&logic_ref).expect("resolve");
+
+    // The materialized file's bytes should equal the input bytes.
+    let on_disk = std::fs::read(materialized.path()).expect("read materialized");
+    assert_eq!(on_disk, bytes);
+}
+
+#[test]
+fn resolve_missing_logic_ref_returns_not_in_store() {
+    let store = InMemoryContentStore::new();
+    let resolver = ContentStoreBodyResolver::new(store);
+
+    let unknown = LogicRef::from_bytes([0xAB; 32]);
+    let err = resolver
+        .resolve(&unknown)
+        .expect_err("missing logic_ref must err");
+    assert!(matches!(err, BodyResolverError::NotInStore { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn materialized_body_has_executable_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+    let bytes = b"#!/bin/sh\necho hi\n".to_vec();
+    let store = InMemoryContentStore::new();
+    let content_ref = store.put(&bytes).expect("put");
+    let logic_ref = LogicRef::from_bytes(*content_ref.as_bytes());
+
+    let resolver = ContentStoreBodyResolver::new(store);
+    let materialized = resolver.resolve(&logic_ref).expect("resolve");
+
+    let mode = std::fs::metadata(materialized.path())
+        .expect("metadata")
+        .permissions()
+        .mode();
+    // 0o755 = owner rwx, group rx, other rx. We assert at least the
+    // owner-x bit is set (0o100) — the resolver's chmod target.
+    assert_ne!(mode & 0o100, 0, "owner-x must be set; got mode {mode:o}");
+}
+
+#[test]
+fn dropping_materialized_body_removes_the_tempfile() {
+    let bytes = b"transient".to_vec();
+    let store = InMemoryContentStore::new();
+    let content_ref = store.put(&bytes).expect("put");
+    let logic_ref = LogicRef::from_bytes(*content_ref.as_bytes());
+
+    let resolver = ContentStoreBodyResolver::new(store);
+    let materialized = resolver.resolve(&logic_ref).expect("resolve");
+    let path = materialized.path().to_path_buf();
+    assert!(
+        path.exists(),
+        "tempfile should exist while MaterializedBody is alive"
+    );
+
+    drop(materialized);
+    assert!(
+        !path.exists(),
+        "tempfile MUST be removed on MaterializedBody Drop"
+    );
+}
+
+#[test]
+fn resolver_object_safety_holds_via_arc_dyn() {
+    // `Arc<dyn BodyResolver>` MUST compile (object-safe trait).
+    let store = InMemoryContentStore::new();
+    let resolver = ContentStoreBodyResolver::new(store);
+    let _arc: Arc<dyn BodyResolver> = Arc::new(resolver);
+}
+
+// ============================================================================
+// Real-spawn variant — opt-in (macOS only for now; Linux equivalent ships
+// alongside the Linux wall-clock variant in integration_wall_clock_linux)
+// ============================================================================
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+    use kx_executor::{ContentStoreBodyResolver, MacOsSandboxExecutor, MoteExecutor};
+    use kx_mote::{
+        EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, NdClass,
+        PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    };
+    use kx_warrant::{
+        ExecutorClass, FsMode, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+        WarrantSpec,
+    };
+    use smallvec::SmallVec;
+
+    fn pure_body_bytes() -> Option<Vec<u8>> {
+        let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")?;
+        let manifest_path = PathBuf::from(&manifest_dir);
+        let workspace_root = manifest_path.parent()?.parent()?;
+        for profile in ["debug", "release"] {
+            let candidate = workspace_root
+                .join("target")
+                .join(profile)
+                .join("examples")
+                .join("pure_body");
+            if candidate.exists() {
+                return std::fs::read(&candidate).ok();
+            }
+        }
+        None
+    }
+
+    fn permissive_warrant(input_dir: &std::path::Path, tempdir: &std::path::Path) -> WarrantSpec {
+        // The resolver materializes the body into a tempfile under
+        // `tempdir`. Granting `/` ReadOnly covers dyld + libsystem +
+        // tempfile reads; the tempdir needs ExecOnly so SBPL's
+        // process-exec rule permits running the materialized binary.
+        let mut mounts: BTreeMap<PathBuf, FsMode> = BTreeMap::new();
+        mounts.insert(PathBuf::from("/"), FsMode::ReadOnly);
+        mounts.insert(input_dir.to_path_buf(), FsMode::ReadOnly);
+        mounts.insert(tempdir.to_path_buf(), FsMode::ExecOnly);
+        WarrantSpec {
+            mote_class: MoteClass::Pure,
+            nd_class: MoteClass::Pure,
+            fs_scope: FsScope { mounts },
+            net_scope: NetScope::None,
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            tool_grants: BTreeSet::new(),
+            model_route: ModelRoute {
+                model_id: ModelId("local".into()),
+                max_input_tokens: 0,
+                max_output_tokens: 0,
+                max_calls: 0,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 30_000,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::MacOsSandbox,
+        }
+    }
+
+    fn build_pure_mote(logic_ref: LogicRef) -> Mote {
+        let def = MoteDef {
+            logic_ref,
+            model_id: ModelId("local".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::Pure,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([0; 32]),
+            GraphPosition(b"root".to_vec()),
+            SmallVec::new(),
+        )
+    }
+
+    #[test]
+    #[ignore = "real fork+sandbox_init+execvp with BodyResolver tempfile; requires `cargo build --example pure_body` first; opt in with `cargo test -- --ignored`"]
+    fn pure_mote_runs_with_body_resolved_from_content_store() {
+        let bytes = pure_body_bytes().expect(
+            "pure_body example not built — run `cargo build --example pure_body -p kx-executor`",
+        );
+
+        // Put the body bytes into an InMemoryContentStore + capture the
+        // logic_ref. The store's ContentRef IS the BLAKE3 hash of the
+        // bytes; we use it as the logic_ref.
+        let store = InMemoryContentStore::new();
+        let content_ref = store.put(&bytes).expect("put bytes");
+        let logic_ref = LogicRef::from_bytes(*content_ref.as_bytes());
+
+        // Build the resolver, wrap in Arc<dyn BodyResolver>, give it to
+        // the executor.
+        let resolver: Arc<dyn kx_executor::BodyResolver> =
+            Arc::new(ContentStoreBodyResolver::new(store));
+
+        // Input file the body reads as argv[1].
+        let mut input_file = tempfile::NamedTempFile::new().expect("input tempfile");
+        let input_bytes = b"hello from hardening-5 BodyResolver";
+        input_file.write_all(input_bytes).expect("write input");
+        input_file.flush().expect("flush");
+        let input_path = input_file.path().to_path_buf();
+        let input_dir = input_path.parent().expect("parent").to_path_buf();
+
+        let executor = MacOsSandboxExecutor::new()
+            .with_body_resolver(Arc::clone(&resolver))
+            .with_input_file(input_path);
+        // `std::env::temp_dir()` reports `/var/folders/...` on macOS but
+        // the kernel resolves the canonical path to `/private/var/folders/
+        // ...` (a symlink). sandbox-exec's `subpath` matcher uses the
+        // canonical path, so we must canonicalize before granting
+        // ExecOnly — otherwise the SBPL allow rule misses + execvp
+        // returns 71 (execvp returned, the marker exit code).
+        let tempdir = std::fs::canonicalize(std::env::temp_dir()).expect("canonicalize tempdir");
+        let warrant = permissive_warrant(&input_dir, &tempdir);
+        let mote = build_pure_mote(logic_ref);
+
+        let result = executor.run(&mote, &warrant, None).expect("run");
+
+        // pure_body computes BLAKE3("kx-executor-pure-body-result" ||
+        // input_bytes); compare.
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"kx-executor-pure-body-result");
+        hasher.update(input_bytes);
+        let expected = ContentRef::from_bytes(*hasher.finalize().as_bytes());
+        assert_eq!(result.result_ref, expected);
+    }
+}


### PR DESCRIPTION
## Summary

Fifth slice of the PR 9a-hardening track. Wires production-grade body resolution: executors no longer need a pre-configured `body_path` per Mote; production callers register an `Arc<dyn BodyResolver>` once + the executor resolves `mote.def.logic_ref` to a materialized tempfile at run time.

cgroup v2 + Linux wall-clock variant cluster in PR 9a-hardening-6.

## Files

- **NEW `crates/kx-executor/src/body_resolver.rs`** — `BodyResolver` trait (object-safe, Send+Sync) + `MaterializedBody` guard (Drop removes tempfile) + `ContentStoreBodyResolver<S: ContentStore>` impl.
- **`MacOsSandboxExecutor::with_body_resolver` + `BwrapExecutor::with_body_resolver`** — new constructors; `run` resolves the body via the resolver before spawning when set.
- **NEW `crates/kx-executor/tests/integration_body_resolver.rs`** — 5 cross-platform structural tests + 1 opt-in macOS real-spawn test (~0.51s) that exercises the full `logic_ref → ContentStore → tempfile → execvp` round-trip.

## Subtle macOS bug caught during dev

macOS sandbox-exec's `subpath` matcher uses the kernel's canonical path. `std::env::temp_dir()` returns `/var/folders/...` but the kernel canonicalizes the tempfile to `/private/var/folders/...` (symlink). The SBPL allow rule for `/var/folders/...` misses the canonical path → execvp returns 71. Fix: canonicalize tempdir via `std::fs::canonicalize` before adding to fs_scope. Test documents this in-comment.

## Tests

- Workspace: **566 passed + 6 ignored** (was 561 + 5; +5 BodyResolver structural tests + 1 ignored real-spawn).
- All four opt-in real-spawn tests pass on Apple Silicon: `integration_real_spawn`, `integration_bwrap` (runtime-skips on macOS), `integration_wall_clock`, `integration_body_resolver::macos`.

## Gates green

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (566 passed, 0 failed, 6 ignored)
- `cargo deny check` ✓

## Test plan

- [ ] Linux CI runs all 9 jobs green.
- [ ] Apple Silicon: opt-in real-spawn passes.
- [ ] Branch retention: `gh pr merge --merge` (NO `--delete-branch`).

## What's deferred to PR 9a-hardening-6

- Real cgroup v2 file I/O on Linux.
- Linux variant of the wall-clock integration test.