### PR TITLE
PR 9b-3 (P1.9b-3): StandardCommitProtocol IdempotentByConstruction path + R-11 enforcement (D39 §a/§c)

### DIFF
--- a/crates/kx-executor/src/commit_protocol.rs
+++ b/crates/kx-executor/src/commit_protocol.rs
@@ -1,14 +1,21 @@
-//! Commit-protocol error surface + scaffolding for PR 9b's atomic
-//! stage→commit path.
+//! Commit-protocol error surface + `StandardCommitProtocol` impl for the
+//! atomic stage→commit path.
 //!
-//! **PR 9b-2 scope**: this module ships the closed `CommitProtocolError`
-//! vocabulary (R-11 / R-12 / R-13 per `docs/design/validate-then-commit.md`
-//! §7 + D38 §2b + D39 §a/§c/§d) plus the trait-shape scaffolding that
-//! 9b-3+ will implement.
+//! **PR 9b-2** shipped the closed `CommitProtocolError` vocabulary
+//! (R-11 / R-12 / R-13 per `docs/design/validate-then-commit.md` §7 + D38
+//! §2b + D39 §a/§c/§d) plus the `CommitProtocol` trait scaffolding.
 //!
-//! **PR 9b-3+ scope** (NOT in this PR): the per-`EffectPattern`
-//! `CommitProtocol::commit` implementation, lifecycle wiring, 9-cell
-//! recovery cross-product, Test A/B, and WORLD-MUTATING Mote E2E.
+//! **PR 9b-3** (this PR) ships `StandardCommitProtocol<S, J, B>` — the
+//! per-`EffectPattern` impl for the `IdempotentByConstruction` path:
+//! `broker.dispatch → R-11 verify → journal.append(Committed)` (per D39
+//! §a/§c). The `StageThenCommit` and `ValidateThenCommit` paths are
+//! intentionally unimplemented in this slice (return
+//! `CommitProtocolError::Internal { reason }`); they ship in PR 9b-4 and
+//! PR 9b-5.
+//!
+//! **PR 9b-4+ scope** (NOT in this PR): the remaining `EffectPattern`
+//! bodies, lifecycle wiring, 9-cell recovery cross-product, Test A/B,
+//! and WORLD-MUTATING Mote E2E.
 //!
 //! # Why a separate error type from `SubmissionRefusal` and `MoteExecutorError`
 //!
@@ -29,8 +36,12 @@
 //! vocabularies + matched-arm exhaustiveness make the contract auditable
 //! at the call sites.
 
-use kx_content::ContentRef;
-use kx_mote::MoteId;
+use kx_capability::{CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore};
+use kx_journal::{Journal, JournalEntry};
+use kx_mote::{EffectPattern, Mote, MoteDefHash, MoteId, ToolName};
+use kx_warrant::WarrantSpec;
+use smallvec::SmallVec;
 use thiserror::Error;
 
 /// Commit-time + recovery-time refusal vocabulary.
@@ -256,18 +267,215 @@ pub trait CommitProtocol: Send + Sync {
 /// committed plus the body's `result_ref` (the BLAKE3 of the body output
 /// that should be in the content store) plus the recovery context.
 ///
-/// **PR 9b-2 scope**: structural type only. Field set is closed for the
-/// 9b-2..9b-N rollout. Future PRs may add fields here; consumers
-/// constructing `CommitInput` directly will need to update.
+/// **Extended in PR 9b-3** to carry the dispatch context that the
+/// `StandardCommitProtocol` needs to run `broker.dispatch` + build the
+/// `Committed` journal entry. The trait surface remains the same — only
+/// the carrier shape grows.
+///
+/// **Pre-alpha field-set discipline**: not `#[non_exhaustive]` — consumers
+/// constructing `CommitInput` directly will need to update when fields
+/// are added. Will be revisited when the surface stabilizes for SDK
+/// callers (P4).
 #[derive(Debug, Clone)]
 pub struct CommitInput<'a> {
-    /// The Mote being committed.
-    pub mote_id: MoteId,
-    /// The body's output `result_ref` — must point at complete bytes in
-    /// the content store before `journal.append(Committed)` lands (R-11).
-    pub result_ref: ContentRef,
+    /// The Mote being committed. Carries `effect_pattern`, `nd_class`,
+    /// `tool_contract`, etc.
+    pub mote: &'a Mote,
+    /// The active warrant. The broker's per-call contract checks reference
+    /// this; the resulting `Committed` entry's `warrant_ref` is derived
+    /// from it.
+    pub warrant: &'a WarrantSpec,
+    /// Which tool in `mote.def.tool_contract` is being dispatched. Must be
+    /// present in the Mote's `tool_contract`; the broker enforces this.
+    pub capability: ToolName,
+    /// The effect request payload (built from the Mote's body output).
+    /// Carries the per-call scopes (subset of warrant scopes) + the
+    /// idempotency token (D38 §1) when applicable.
+    pub effect_request: EffectRequest,
+    /// `warrant_ref` for the `Committed` entry's `warrant_ref` field.
+    /// Pre-computed by the lifecycle layer via
+    /// `kx_warrant::warrant_ref_of(&warrant)`.
+    pub warrant_ref: ContentRef,
+    /// `mote_def_hash` for the `Committed` entry's non-canonical metadata
+    /// (D22 `list_committed_by_mote_def_hash`). Pre-computed by the
+    /// lifecycle layer.
+    pub mote_def_hash: MoteDefHash,
+    /// Per-call idempotency key for the `Committed` entry. Derived per
+    /// `idempotency.md`; the journal's dedup index uses this to enforce
+    /// "at most one Committed per `idempotency_key`."
+    pub idempotency_key: [u8; 32],
+    /// Declared parents with edge metadata. Carried into the `Committed`
+    /// entry's `parents` field.
+    pub parents: SmallVec<[kx_journal::ParentEntry; 4]>,
     /// Operator-facing context string (carried into error variants when
     /// commit refuses). Lifecycle layer constructs from
     /// `(workflow_id, mote_id.to_hex())`.
     pub diagnostic_context: &'a str,
+}
+
+/// The standard `CommitProtocol` implementation — wires
+/// `CapabilityBroker` + `ContentStore` + `Journal` together via the
+/// per-`EffectPattern` paths defined in D38 + D39.
+///
+/// **PR 9b-3 scope**: only the `IdempotentByConstruction` path is
+/// implemented (D39 §a — `broker.dispatch → R-11 verify →
+/// journal.append(Committed)`). `StageThenCommit` returns
+/// `CommitProtocolError::Internal { reason: "PR 9b-4 ..." }` and
+/// `ValidateThenCommit` returns
+/// `CommitProtocolError::Internal { reason: "PR 9b-5 ..." }`.
+///
+/// **Generic over** `(S, J, B)` — concrete impls of `ContentStore` /
+/// `Journal` / `CapabilityBroker`. Held by `Arc<S>` / `Arc<J>` / `Arc<B>`
+/// so the protocol can be cloned cheaply + shared across threads.
+///
+/// **Object safety**: the outer `CommitProtocol` trait is object-safe.
+/// `StandardCommitProtocol<S, J, B>` carries the generics; callers hold
+/// `Arc<dyn CommitProtocol>` to erase them.
+#[derive(Debug)]
+pub struct StandardCommitProtocol<S, J, B> {
+    store: std::sync::Arc<S>,
+    journal: std::sync::Arc<J>,
+    broker: std::sync::Arc<B>,
+}
+
+impl<S, J, B> StandardCommitProtocol<S, J, B> {
+    /// Construct a new `StandardCommitProtocol` carrying the three seams.
+    /// The protocol holds `Arc`s so it can be cloned cheaply.
+    #[must_use]
+    pub fn new(
+        store: std::sync::Arc<S>,
+        journal: std::sync::Arc<J>,
+        broker: std::sync::Arc<B>,
+    ) -> Self {
+        Self {
+            store,
+            journal,
+            broker,
+        }
+    }
+}
+
+impl<S, J, B> CommitProtocol for StandardCommitProtocol<S, J, B>
+where
+    S: ContentStore + Send + Sync,
+    J: Journal + Send + Sync,
+    B: CapabilityBroker + Send + Sync,
+{
+    fn commit(&self, input: CommitInput<'_>) -> Result<u64, CommitProtocolError> {
+        let pattern = input.mote.def.effect_pattern;
+        match pattern {
+            EffectPattern::IdempotentByConstruction => self.commit_idempotent(input),
+            EffectPattern::StageThenCommit => Err(CommitProtocolError::Internal {
+                mote_id: input.mote.id,
+                reason: "StageThenCommit path lands in PR 9b-4 (journal.append(EffectStaged) → broker.dispatch → put → append(Committed))".into(),
+            }),
+            EffectPattern::ValidateThenCommit => Err(CommitProtocolError::Internal {
+                mote_id: input.mote.id,
+                reason: "ValidateThenCommit path lands in PR 9b-5 (broker.dispatch → put → append(Committed) + critic-Mote child scheduling per D20)".into(),
+            }),
+        }
+    }
+}
+
+impl<S, J, B> StandardCommitProtocol<S, J, B>
+where
+    S: ContentStore + Send + Sync,
+    J: Journal + Send + Sync,
+    B: CapabilityBroker + Send + Sync,
+{
+    /// `IdempotentByConstruction` path (D39 §a):
+    /// `broker.dispatch → R-11 verify → journal.append(Committed)`.
+    ///
+    /// `IdempotentByConstruction` is the safe path for token-class tools:
+    /// the remote API's idempotency contract backstops the dispatch, so
+    /// the executor can dispatch without a journal entry first. The
+    /// post-dispatch R-11 verify is the executor's defense against a
+    /// hostile broker that returns a `staged_ref` without actually
+    /// staging the bytes.
+    fn commit_idempotent(&self, input: CommitInput<'_>) -> Result<u64, CommitProtocolError> {
+        let mote_id = input.mote.id;
+
+        // Step 1: broker dispatch. The broker runs its per-call contract
+        // checks (capability in tool_contract, supported pattern, capability
+        // in warrant.tool_grants, request scopes ⊆ warrant scopes) and
+        // routes to the named capability.
+        let handle = self
+            .broker
+            .dispatch(
+                input.mote,
+                input.warrant,
+                &input.capability,
+                input.effect_request,
+            )
+            .map_err(|e| CommitProtocolError::BrokerDispatchFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            })?;
+        let result_ref = handle.staged_ref;
+
+        // Step 2: R-11 verify (D39 §a/§c). The broker claims it staged the
+        // response payload; the executor verifies the ref is durable in
+        // the store before journaling `Committed`. Two failure modes:
+        // (a) the ref isn't in the store (`contains` is false); (b) `get`
+        // returns NotFound. Both indicate a hostile / buggy broker that
+        // violated the staging contract.
+        enforce_r11(&*self.store, mote_id, &result_ref)?;
+
+        // Step 3: Journal append Committed. The journal assigns the
+        // monotonic `seq` and dedup-by-`idempotency_key` enforces at-most-
+        // one Committed per identity.
+        let entry = JournalEntry::Committed {
+            mote_id,
+            idempotency_key: input.idempotency_key,
+            seq: 0, // journal-assigned
+            nondeterminism: input.mote.def.nd_class,
+            result_ref,
+            parents: input.parents,
+            warrant_ref: input.warrant_ref,
+            mote_def_hash: input.mote_def_hash,
+        };
+        let written = self.journal.append(entry).map_err(|e| {
+            CommitProtocolError::JournalAppendCommittedFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            }
+        })?;
+
+        Ok(written.seq())
+    }
+}
+
+/// R-11 enforcement helper. Verifies a `result_ref` is durable in the
+/// content store before the caller appends `Committed` to the journal.
+///
+/// Two failure cases both surface as `R11ResultRefIncomplete`:
+/// - `store.contains(&result_ref)` is `false` (the ref isn't in the store)
+/// - `store.get(&result_ref)` returns `NotFound` (the ref is registered
+///   but the backing bytes are missing or have been reclaimed)
+///
+/// Exposed as `pub(crate)` so the other per-pattern paths (PR 9b-4 /
+/// PR 9b-5) reuse the same check.
+///
+/// # Errors
+///
+/// Returns `CommitProtocolError::R11ResultRefIncomplete { mote_id,
+/// result_ref }` when either check fails.
+pub(crate) fn enforce_r11<S: ContentStore + ?Sized>(
+    store: &S,
+    mote_id: MoteId,
+    result_ref: &ContentRef,
+) -> Result<(), CommitProtocolError> {
+    if !store.contains(result_ref) {
+        return Err(CommitProtocolError::R11ResultRefIncomplete {
+            mote_id,
+            result_ref: *result_ref,
+        });
+    }
+    if store.get(result_ref).is_err() {
+        return Err(CommitProtocolError::R11ResultRefIncomplete {
+            mote_id,
+            result_ref: *result_ref,
+        });
+    }
+    Ok(())
 }

--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -291,7 +291,9 @@ pub(crate) mod spawn;
 pub use body_resolver::{
     BodyResolver, BodyResolverError, ContentStoreBodyResolver, MaterializedBody,
 };
-pub use commit_protocol::{CommitInput, CommitProtocol, CommitProtocolError};
+pub use commit_protocol::{
+    CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol,
+};
 pub use executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
 pub use fact_zero::{
     seed_idempotency_key, seed_mote_id, write_fact_zero, FactZeroError, SeedPayload,

--- a/crates/kx-executor/tests/integration_commit_protocol.rs
+++ b/crates/kx-executor/tests/integration_commit_protocol.rs
@@ -8,11 +8,20 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use kx_capability::EffectRequest;
 use kx_content::ContentRef;
 use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError};
-use kx_mote::MoteId;
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    MoteId, NdClass, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
 
 fn sample_mote_id() -> MoteId {
     MoteId::from_bytes([0xAB; 32])
@@ -20,6 +29,63 @@ fn sample_mote_id() -> MoteId {
 
 fn sample_content_ref() -> ContentRef {
     ContentRef::from_bytes([0xCD; 32])
+}
+
+fn pure_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn build_idempotent_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_effect_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::IdempotentByConstruction,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
 }
 
 // ============================================================================
@@ -206,13 +272,21 @@ fn commit_protocol_error_is_clone_and_eq() {
 
 #[test]
 fn commit_input_constructs_with_required_fields() {
+    let mote = build_idempotent_mote(0xAB);
+    let warrant = pure_warrant();
+    let mote_def_hash = MoteDefHash::from_bytes([3; 32]);
     let input = CommitInput {
-        mote_id: sample_mote_id(),
-        result_ref: sample_content_ref(),
+        mote: &mote,
+        warrant: &warrant,
+        capability: kx_mote::ToolName("publish".into()),
+        effect_request: empty_effect_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash,
+        idempotency_key: [5; 32],
+        parents: SmallVec::new(),
         diagnostic_context: "test",
     };
-    assert_eq!(input.mote_id, sample_mote_id());
-    assert_eq!(input.result_ref, sample_content_ref());
+    assert_eq!(input.mote.id, mote.id);
     assert_eq!(input.diagnostic_context, "test");
 }
 
@@ -226,10 +300,9 @@ struct StubCommitProtocol;
 
 impl CommitProtocol for StubCommitProtocol {
     fn commit(&self, input: CommitInput<'_>) -> Result<u64, CommitProtocolError> {
-        // PR 9b-2: stub returns Internal — the per-pattern impl lands at 9b-3.
         Err(CommitProtocolError::Internal {
-            mote_id: input.mote_id,
-            reason: "stub — per-pattern impl lands in PR 9b-3".into(),
+            mote_id: input.mote.id,
+            reason: "stub for object-safety test".into(),
         })
     }
 }
@@ -238,14 +311,20 @@ fn assert_send_sync<T: Send + Sync>() {}
 
 #[test]
 fn commit_protocol_is_object_safe_send_sync() {
-    // Compile-time test: Arc<dyn CommitProtocol> requires object safety +
-    // Send + Sync. If the trait drops those constraints, this fails to compile.
     let dyn_protocol: Arc<dyn CommitProtocol> = Arc::new(StubCommitProtocol);
     assert_send_sync::<Arc<dyn CommitProtocol>>();
-    let mid = sample_mote_id();
+    let mote = build_idempotent_mote(0xAB);
+    let warrant = pure_warrant();
+    let mid = mote.id;
     let input = CommitInput {
-        mote_id: mid,
-        result_ref: sample_content_ref(),
+        mote: &mote,
+        warrant: &warrant,
+        capability: kx_mote::ToolName("publish".into()),
+        effect_request: empty_effect_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([3; 32]),
+        idempotency_key: [5; 32],
+        parents: SmallVec::new(),
         diagnostic_context: "stub-test",
     };
     let r = dyn_protocol.commit(input);

--- a/crates/kx-executor/tests/integration_idempotent_commit.rs
+++ b/crates/kx-executor/tests/integration_idempotent_commit.rs
@@ -1,0 +1,410 @@
+//! End-to-end integration tests for the PR 9b-3 `StandardCommitProtocol`
+//! `IdempotentByConstruction` path:
+//! `broker.dispatch → R-11 verify → journal.append(Committed)` (D39 §a/§c).
+//!
+//! The tests wire a real `InMemoryContentStore` + `InMemoryJournal` + a
+//! custom test `CapabilityBroker` that exercises both the happy path and
+//! the R-11 enforcement edge cases (hostile broker returning a staged_ref
+//! without actually staging the bytes).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_idempotent_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::IdempotentByConstruction,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+// ============================================================================
+// Test broker — exercises happy path + R-11 hostile path + error paths.
+// ============================================================================
+
+/// Behavior switch for the test broker. The broker shares the same
+/// `Arc<InMemoryContentStore>` as the protocol-under-test for the happy
+/// path; the hostile / failing modes deliberately desync.
+enum BrokerMode {
+    /// `dispatch` puts `response_bytes` into the shared store + returns
+    /// the resulting ref in the `BrokerHandle`.
+    HappyPath {
+        store: Arc<InMemoryContentStore>,
+        response_bytes: Vec<u8>,
+    },
+    /// `dispatch` returns a `BrokerHandle` with a fabricated `staged_ref`
+    /// that was NEVER put into the protocol's store. R-11 must fire.
+    HostileStagedRefMissing,
+    /// `dispatch` returns a `BrokerError` directly (e.g., the capability
+    /// failed). Protocol must wrap as `BrokerDispatchFailed`.
+    DispatchError,
+}
+
+struct TestBroker(BrokerMode);
+
+impl std::fmt::Debug for TestBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestBroker").finish()
+    }
+}
+
+impl CapabilityBroker for TestBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        match &self.0 {
+            BrokerMode::HappyPath {
+                store,
+                response_bytes,
+            } => {
+                let r = store.put(response_bytes).expect("put");
+                Ok(BrokerHandle {
+                    staged_ref: r,
+                    capability: ToolName("test-capability".into()),
+                    capability_version: ToolVersion("0.1.0".into()),
+                })
+            }
+            BrokerMode::HostileStagedRefMissing => Ok(BrokerHandle {
+                staged_ref: ContentRef::from_bytes([0xDD; 32]),
+                capability: ToolName("hostile".into()),
+                capability_version: ToolVersion("0".into()),
+            }),
+            BrokerMode::DispatchError => Err(BrokerError::SandboxRefused {
+                capability: ToolName("test-capability".into()),
+                reason: "test-induced dispatch failure".into(),
+            }),
+        }
+    }
+
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+fn input_for<'a>(mote: &'a Mote, warrant: &'a WarrantSpec, diagnostic: &'a str) -> CommitInput<'a> {
+    CommitInput {
+        mote,
+        warrant,
+        capability: ToolName("test-capability".into()),
+        effect_request: empty_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([3; 32]),
+        idempotency_key: [5; 32],
+        parents: SmallVec::new(),
+        diagnostic_context: diagnostic,
+    }
+}
+
+// ============================================================================
+// Happy path: IdempotentByConstruction commits successfully.
+// ============================================================================
+
+#[test]
+fn idempotent_path_commits_and_appends_committed_entry() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"test-response-payload".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+    let mote = wm_idempotent_mote(0x01);
+    let warrant = warrant();
+    let seq = protocol
+        .commit(input_for(&mote, &warrant, "happy-path"))
+        .expect("idempotent commit must succeed");
+
+    // The journal has one Committed entry at the returned seq.
+    assert!(seq > 0, "journal must assign a non-zero seq");
+    let entry = journal
+        .read_committed(&mote.id)
+        .expect("journal read")
+        .expect("Committed entry must exist after commit");
+    match entry {
+        JournalEntry::Committed {
+            mote_id, seq: s, ..
+        } => {
+            assert_eq!(mote_id, mote.id);
+            assert_eq!(s, seq);
+        }
+        other => panic!("expected Committed entry, got {other:?}"),
+    }
+
+    // The content store has the response bytes at the result_ref.
+    assert_eq!(store.len(), 1, "content store has the broker's response");
+}
+
+// ============================================================================
+// R-11: hostile broker returns a staged_ref that's not in the store.
+// ============================================================================
+
+#[test]
+fn r11_fires_when_broker_stages_a_ref_not_in_the_store() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HostileStagedRefMissing));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+    let mote = wm_idempotent_mote(0x02);
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "r11-test"))
+        .expect_err("R-11 must fire when broker desyncs from store");
+    match err {
+        CommitProtocolError::R11ResultRefIncomplete {
+            mote_id,
+            result_ref,
+        } => {
+            assert_eq!(mote_id, mote.id);
+            assert_eq!(result_ref, ContentRef::from_bytes([0xDD; 32]));
+        }
+        other => panic!("expected R-11, got {other:?}"),
+    }
+
+    // R-11 fired BEFORE the journal append; no Committed entry exists.
+    assert!(
+        journal.read_committed(&mote.id).unwrap().is_none(),
+        "R-11 must short-circuit before journal.append"
+    );
+}
+
+// ============================================================================
+// BrokerDispatchFailed: broker.dispatch returns a typed error.
+// ============================================================================
+
+#[test]
+fn broker_dispatch_error_wraps_as_broker_dispatch_failed() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::DispatchError));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+    let mote = wm_idempotent_mote(0x03);
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "dispatch-err"))
+        .expect_err("dispatch error must surface");
+    assert!(matches!(
+        err,
+        CommitProtocolError::BrokerDispatchFailed { mote_id, .. } if mote_id == mote.id
+    ));
+    assert!(
+        journal.read_committed(&mote.id).unwrap().is_none(),
+        "dispatch error must not write a Committed entry"
+    );
+}
+
+// ============================================================================
+// StageThenCommit returns Internal { reason: "PR 9b-4 ..." } stub.
+// ============================================================================
+
+#[test]
+fn stage_then_commit_returns_internal_pr_9b_4_placeholder() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"unused".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store, journal, broker);
+
+    let mut mote = wm_idempotent_mote(0x04);
+    let mut def = mote.def.clone();
+    def.effect_pattern = EffectPattern::StageThenCommit;
+    mote = Mote::new(
+        def,
+        mote.input_data_id,
+        mote.graph_position.clone(),
+        mote.parents.clone(),
+    );
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "stage-then-commit"))
+        .expect_err("StageThenCommit is unimplemented in PR 9b-3");
+    match err {
+        CommitProtocolError::Internal { mote_id, reason } => {
+            assert_eq!(mote_id, mote.id);
+            assert!(
+                reason.contains("PR 9b-4"),
+                "stub must reference PR 9b-4 for forward visibility; got: {reason}",
+            );
+        }
+        other => panic!("expected Internal stub, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// ValidateThenCommit returns Internal { reason: "PR 9b-5 ..." } stub.
+// ============================================================================
+
+#[test]
+fn validate_then_commit_returns_internal_pr_9b_5_placeholder() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"unused".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store, journal, broker);
+
+    let mut mote = wm_idempotent_mote(0x05);
+    let mut def = mote.def.clone();
+    def.effect_pattern = EffectPattern::ValidateThenCommit;
+    mote = Mote::new(
+        def,
+        mote.input_data_id,
+        mote.graph_position.clone(),
+        mote.parents.clone(),
+    );
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "validate-then-commit"))
+        .expect_err("ValidateThenCommit is unimplemented in PR 9b-3");
+    match err {
+        CommitProtocolError::Internal { mote_id, reason } => {
+            assert_eq!(mote_id, mote.id);
+            assert!(
+                reason.contains("PR 9b-5"),
+                "stub must reference PR 9b-5 for forward visibility; got: {reason}",
+            );
+        }
+        other => panic!("expected Internal stub, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// Determinism: same input → same outcome (the journal-assigned seq may
+// differ on re-run since journal is in-memory and seq is per-run-monotonic;
+// the committed entry's mote_id + result_ref must be stable across
+// independent protocol instances).
+// ============================================================================
+
+#[test]
+fn two_independent_protocol_instances_produce_stable_committed_shape() {
+    let mote = wm_idempotent_mote(0x06);
+    let warrant = warrant();
+    let response = b"stable-payload".to_vec();
+
+    let do_commit = || -> JournalEntry {
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+            store: store.clone(),
+            response_bytes: response.clone(),
+        }));
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+        let _ = protocol
+            .commit(input_for(&mote, &warrant, "determinism"))
+            .expect("commit must succeed");
+        journal.read_committed(&mote.id).unwrap().unwrap()
+    };
+
+    let e1 = do_commit();
+    let e2 = do_commit();
+    // mote_id + result_ref + warrant_ref + mote_def_hash + idempotency_key
+    // are deterministic; seq is per-run-monotonic and starts at 1 here so
+    // it should also match for two empty-journal-prefix scenarios.
+    match (&e1, &e2) {
+        (
+            JournalEntry::Committed {
+                result_ref: r1,
+                idempotency_key: k1,
+                warrant_ref: w1,
+                mote_def_hash: h1,
+                ..
+            },
+            JournalEntry::Committed {
+                result_ref: r2,
+                idempotency_key: k2,
+                warrant_ref: w2,
+                mote_def_hash: h2,
+                ..
+            },
+        ) => {
+            assert_eq!(r1, r2, "result_ref must be deterministic");
+            assert_eq!(k1, k2, "idempotency_key must be deterministic");
+            assert_eq!(w1, w2, "warrant_ref must be deterministic");
+            assert_eq!(h1, h2, "mote_def_hash must be deterministic");
+        }
+        _ => panic!("both entries must be Committed"),
+    }
+}

--- a/crates/kx-executor/tests/proptest_idempotent_commit.rs
+++ b/crates/kx-executor/tests/proptest_idempotent_commit.rs
@@ -1,0 +1,289 @@
+//! Property tests on the PR 9b-3 `StandardCommitProtocol`
+//! `IdempotentByConstruction` path. SN-4 v2 mandate: ≥3 proptest
+//! properties × 64 cases.
+//!
+//! Properties:
+//! 1. Determinism — same `(mote_id, response_bytes, warrant_ref,
+//!    idempotency_key)` yields the same `Committed` entry shape across two
+//!    fresh protocol instances.
+//! 2. R-11 monotonicity — for any choice of `(mote_id, fake_ref)`, the
+//!    hostile-broker path's R-11 refusal carries the same `mote_id` +
+//!    `result_ref` the broker fabricated.
+//! 3. BrokerDispatchFailed surface — any broker error propagates as the
+//!    matching `BrokerDispatchFailed` variant carrying the Mote's id.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_idempotent_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::IdempotentByConstruction,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+struct HappyBroker {
+    store: Arc<InMemoryContentStore>,
+    response_bytes: Vec<u8>,
+}
+
+impl std::fmt::Debug for HappyBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HappyBroker").finish()
+    }
+}
+
+impl CapabilityBroker for HappyBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        let r = self.store.put(&self.response_bytes).expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("happy".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+struct HostileBroker {
+    fake_ref: ContentRef,
+}
+
+impl std::fmt::Debug for HostileBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostileBroker").finish()
+    }
+}
+
+impl CapabilityBroker for HostileBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        Ok(BrokerHandle {
+            staged_ref: self.fake_ref,
+            capability: ToolName("hostile".into()),
+            capability_version: ToolVersion("0".into()),
+        })
+    }
+
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+fn input_for<'a>(
+    mote: &'a Mote,
+    warrant: &'a WarrantSpec,
+    idempotency_key: [u8; 32],
+    warrant_ref: ContentRef,
+    mote_def_hash: MoteDefHash,
+) -> CommitInput<'a> {
+    CommitInput {
+        mote,
+        warrant,
+        capability: ToolName("test-capability".into()),
+        effect_request: empty_request(),
+        warrant_ref,
+        mote_def_hash,
+        idempotency_key,
+        parents: SmallVec::new(),
+        diagnostic_context: "proptest",
+    }
+}
+
+proptest! {
+    /// Determinism: two fresh protocol instances with identical inputs
+    /// produce a `Committed` entry with byte-identical `result_ref`,
+    /// `idempotency_key`, `warrant_ref`, and `mote_def_hash`.
+    #[test]
+    fn prop_idempotent_commit_is_deterministic(
+        seed in any::<u8>(),
+        response in any::<Vec<u8>>().prop_filter("non-empty", |v| !v.is_empty()),
+        idempotency_key in any::<[u8; 32]>(),
+        warrant_ref_bytes in any::<[u8; 32]>(),
+        mote_def_hash_bytes in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_idempotent_mote(seed);
+        let w = warrant();
+        let wref = ContentRef::from_bytes(warrant_ref_bytes);
+        let mdh = MoteDefHash::from_bytes(mote_def_hash_bytes);
+
+        let run = || -> JournalEntry {
+            let store = Arc::new(InMemoryContentStore::new());
+            let journal = Arc::new(InMemoryJournal::new());
+            let broker = Arc::new(HappyBroker {
+                store: store.clone(),
+                response_bytes: response.clone(),
+            });
+            let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+            let _ = protocol
+                .commit(input_for(&mote, &w, idempotency_key, wref, mdh))
+                .expect("commit must succeed");
+            journal.read_committed(&mote.id).unwrap().unwrap()
+        };
+
+        let e1 = run();
+        let e2 = run();
+        prop_assert_eq!(&e1, &e2, "two independent runs must produce equal Committed entries");
+    }
+
+    /// R-11 monotonicity: when the broker returns an arbitrary
+    /// `fake_ref`, the protocol's R-11 refusal carries that exact ref +
+    /// the Mote's id.
+    #[test]
+    fn prop_r11_carries_brokers_fake_ref(
+        seed in any::<u8>(),
+        fake_ref_bytes in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_idempotent_mote(seed);
+        let w = warrant();
+        let fake_ref = ContentRef::from_bytes(fake_ref_bytes);
+
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HostileBroker { fake_ref });
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let result = protocol.commit(input_for(
+            &mote,
+            &w,
+            [0; 32],
+            ContentRef::from_bytes([0; 32]),
+            MoteDefHash::from_bytes([0; 32]),
+        ));
+        match result {
+            Err(CommitProtocolError::R11ResultRefIncomplete { mote_id, result_ref }) => {
+                prop_assert_eq!(mote_id, mote.id);
+                prop_assert_eq!(result_ref, fake_ref);
+            }
+            other => prop_assert!(
+                false,
+                "expected R-11 with broker's fake_ref, got {:?}",
+                other,
+            ),
+        }
+        // No Committed entry on R-11 path.
+        prop_assert!(journal.read_committed(&mote.id).unwrap().is_none());
+    }
+
+    /// R-11 short-circuit: when R-11 fires, the journal stays empty for
+    /// this Mote (no Committed entry was written). Prefix-monotonicity of
+    /// the refusal — the protocol does not partially commit.
+    #[test]
+    fn prop_r11_does_not_partially_commit(
+        seed in any::<u8>(),
+        fake_ref_bytes in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_idempotent_mote(seed);
+        let w = warrant();
+        let fake_ref = ContentRef::from_bytes(fake_ref_bytes);
+
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HostileBroker { fake_ref });
+        let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+        let _ = protocol.commit(input_for(
+            &mote,
+            &w,
+            [0; 32],
+            ContentRef::from_bytes([0; 32]),
+            MoteDefHash::from_bytes([0; 32]),
+        ));
+
+        // The journal has zero entries; the store has zero objects.
+        prop_assert_eq!(journal.count_entries().unwrap(), 0);
+        prop_assert_eq!(store.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of **PR 9b**. Ships \`StandardCommitProtocol<S, J, B>\` — the per-\`EffectPattern\` commit protocol impl. **PR 9b-3 implements the \`IdempotentByConstruction\` path only**; \`StageThenCommit\` and \`ValidateThenCommit\` return \`CommitProtocolError::Internal { reason: \"PR 9b-4 ...\" / \"PR 9b-5 ...\" }\` stubs until those slices land.

### The path (D39 §a/§c)

\`\`\`text
broker.dispatch → R-11 verify → journal.append(Committed)
\`\`\`

1. \`broker.dispatch(mote, warrant, capability, request)\` → \`BrokerHandle\`. Errors wrap as \`BrokerDispatchFailed\`.
2. \`enforce_r11(store, mote_id, &handle.staged_ref)\` verifies the ref is durable. Two failure modes: \`!contains()\` or \`get().is_err()\` — both fire \`R11ResultRefIncomplete\`.
3. \`journal.append(Committed { mote_id, result_ref: handle.staged_ref, ... })\` returns the journal-assigned seq.

### CommitInput<'_> extended

Carries the dispatch context: \`mote: &Mote\`, \`warrant: &WarrantSpec\`, \`capability: ToolName\`, \`effect_request: EffectRequest\`, \`warrant_ref\`, \`mote_def_hash\`, \`idempotency_key\`, \`parents: SmallVec<[ParentEntry; 4]>\`, \`diagnostic_context: &str\`.

### Object safety preserved

The generics live on \`StandardCommitProtocol<S, J, B>\`; the outer \`CommitProtocol\` trait stays object-safe so consumers hold \`Arc<dyn CommitProtocol>\`.

### New \`enforce_r11\` helper

\`pub(crate) fn enforce_r11<S: ContentStore + ?Sized>(...)\` — reused by 9b-4 / 9b-5 paths so all three protocols share one R-11 implementation.

## Tests

- **6 new integration tests** (\`tests/integration_idempotent_commit.rs\`):
  - Happy path: broker stages bytes, R-11 passes, Committed lands
  - R-11 fires when hostile broker fabricates a \`staged_ref\` not in the store
  - BrokerDispatchFailed wraps broker errors
  - StageThenCommit + ValidateThenCommit stubs reference their target PR
  - Determinism: two independent protocol instances produce stable Committed entries
- **3 new proptests** (\`tests/proptest_idempotent_commit.rs\`):
  - \`prop_idempotent_commit_is_deterministic\`
  - \`prop_r11_carries_brokers_fake_ref\`
  - \`prop_r11_does_not_partially_commit\` (no partial state on R-11 path)
- **12 existing tests** in \`tests/integration_commit_protocol.rs\` migrated to the new CommitInput shape; **4 existing proptests** unchanged.

## Test plan

- [x] \`cargo build -p kx-executor\` clean
- [x] \`cargo test --workspace --all-features\`: 604 passed + 6 ignored (was 595 + 6 pre-9b-3; +9 net = 6 integration + 3 proptest)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo deny check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features\` clean
- [ ] CI on Kortecx/kortecx
- [ ] SN-2 post-merge 404 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)