### PR TITLE
PR 9b-4 (P1.9b-4): StandardCommitProtocol StageThenCommit path + JournalAppendEffectStagedFailed (D38 §2b)

### DIFF
--- a/crates/kx-executor/src/commit_protocol.rs
+++ b/crates/kx-executor/src/commit_protocol.rs
@@ -5,16 +5,25 @@
 //! (R-11 / R-12 / R-13 per `docs/design/validate-then-commit.md` §7 + D38
 //! §2b + D39 §a/§c/§d) plus the `CommitProtocol` trait scaffolding.
 //!
-//! **PR 9b-3** (this PR) ships `StandardCommitProtocol<S, J, B>` — the
+//! **PR 9b-3** shipped `StandardCommitProtocol<S, J, B>` — the
 //! per-`EffectPattern` impl for the `IdempotentByConstruction` path:
 //! `broker.dispatch → R-11 verify → journal.append(Committed)` (per D39
-//! §a/§c). The `StageThenCommit` and `ValidateThenCommit` paths are
-//! intentionally unimplemented in this slice (return
-//! `CommitProtocolError::Internal { reason }`); they ship in PR 9b-4 and
+//! §a/§c).
+//!
+//! **PR 9b-4** (this PR) extends `StandardCommitProtocol` with the
+//! `StageThenCommit` path (per D38 §2b):
+//! `journal.append(EffectStaged) → broker.dispatch → R-11 verify →
+//! journal.append(Committed)`. The `EffectStaged` entry is the recovery
+//! hint that closes the WORLD-MUTATING double-effect window; it MUST be
+//! appended BEFORE `broker.dispatch` so the recovery fold sees the
+//! dispatch intent durably recorded. Adds the
+//! `JournalAppendEffectStagedFailed` variant to `CommitProtocolError`.
+//! `ValidateThenCommit` remains an `Internal { reason }` stub until
 //! PR 9b-5.
 //!
-//! **PR 9b-4+ scope** (NOT in this PR): the remaining `EffectPattern`
-//! bodies, lifecycle wiring, 9-cell recovery cross-product, Test A/B,
+//! **PR 9b-5+ scope** (NOT in this PR): the `ValidateThenCommit` body
+//! (broker.dispatch → R-11 → Committed + critic-Mote child scheduling per
+//! D20), lifecycle wiring, 9-cell recovery cross-product, Test A/B,
 //! and WORLD-MUTATING Mote E2E.
 //!
 //! # Why a separate error type from `SubmissionRefusal` and `MoteExecutorError`
@@ -149,6 +158,27 @@ pub enum CommitProtocolError {
         reason: String,
     },
 
+    /// The journal's `append(EffectStaged)` call returned an error
+    /// BEFORE `broker.dispatch` ran. The recovery hint was not durably
+    /// recorded; the commit protocol short-circuits + propagates this
+    /// error so the lifecycle layer surfaces a `Failed` entry. Because
+    /// the broker has not yet dispatched, there is no WM effect to
+    /// reconcile — recovery sees no `EffectStaged` entry and treats this
+    /// as a normal pre-commit crash (cell 1 / cell 2 of the 9-cell
+    /// cross-product per `journal-txn.md`).
+    ///
+    /// Symmetric with [`Self::JournalAppendCommittedFailed`]; needed
+    /// because PR 9b-4's `StageThenCommit` path appends `EffectStaged`
+    /// BEFORE `broker.dispatch` (per D38 §2b), so the failure mode is
+    /// distinct from the post-dispatch `Committed`-append failure.
+    #[error("journal append(EffectStaged) failed for Mote {mote_id:?}: {reason}")]
+    JournalAppendEffectStagedFailed {
+        /// The Mote whose EffectStaged append failed.
+        mote_id: MoteId,
+        /// Diagnostic from the journal.
+        reason: String,
+    },
+
     /// Anything else — fail-closed catch-all. Operator-facing diagnostic
     /// surfaces the root cause.
     #[error("commit protocol internal error for Mote {mote_id:?}: {reason}")]
@@ -187,6 +217,7 @@ impl CommitProtocolError {
             | Self::BrokerDispatchFailed { mote_id, .. }
             | Self::ContentStorePutFailed { mote_id, .. }
             | Self::JournalAppendCommittedFailed { mote_id, .. }
+            | Self::JournalAppendEffectStagedFailed { mote_id, .. }
             | Self::Internal { mote_id, .. } => *mote_id,
         }
     }
@@ -365,10 +396,7 @@ where
         let pattern = input.mote.def.effect_pattern;
         match pattern {
             EffectPattern::IdempotentByConstruction => self.commit_idempotent(input),
-            EffectPattern::StageThenCommit => Err(CommitProtocolError::Internal {
-                mote_id: input.mote.id,
-                reason: "StageThenCommit path lands in PR 9b-4 (journal.append(EffectStaged) → broker.dispatch → put → append(Committed))".into(),
-            }),
+            EffectPattern::StageThenCommit => self.commit_stage_then_commit(input),
             EffectPattern::ValidateThenCommit => Err(CommitProtocolError::Internal {
                 mote_id: input.mote.id,
                 reason: "ValidateThenCommit path lands in PR 9b-5 (broker.dispatch → put → append(Committed) + critic-Mote child scheduling per D20)".into(),
@@ -424,6 +452,94 @@ where
         // Step 3: Journal append Committed. The journal assigns the
         // monotonic `seq` and dedup-by-`idempotency_key` enforces at-most-
         // one Committed per identity.
+        let entry = JournalEntry::Committed {
+            mote_id,
+            idempotency_key: input.idempotency_key,
+            seq: 0, // journal-assigned
+            nondeterminism: input.mote.def.nd_class,
+            result_ref,
+            parents: input.parents,
+            warrant_ref: input.warrant_ref,
+            mote_def_hash: input.mote_def_hash,
+        };
+        let written = self.journal.append(entry).map_err(|e| {
+            CommitProtocolError::JournalAppendCommittedFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            }
+        })?;
+
+        Ok(written.seq())
+    }
+
+    /// `StageThenCommit` path (D38 §2b):
+    /// `journal.append(EffectStaged) → broker.dispatch → R-11 verify →
+    /// journal.append(Committed)`.
+    ///
+    /// The `EffectStaged` entry is the recovery hint that closes the
+    /// WORLD-MUTATING double-effect window. It MUST be appended BEFORE
+    /// `broker.dispatch` so the recovery fold (per `journal-txn.md`
+    /// 9-cell cross-product) sees the dispatch intent durably recorded:
+    ///
+    /// - `EffectStaged` + `Committed` (cell 4) → done; never re-dispatch.
+    /// - `EffectStaged` + `Failed(pre_commit_crash)` (cell 3) → re-dispatch
+    ///   permitted; tool-boundary idempotency closes the window.
+    /// - `EffectStaged` + `Failed(terminal)` (cell 5) → terminal failure;
+    ///   R-13 refuses re-dispatch.
+    /// - `EffectStaged` + `Repudiated` (no Committed; cell 8) → anomaly;
+    ///   quarantine via `MoteState::Inconsistent`.
+    ///
+    /// **PR 9b-4 scope**: ships the happy stage→dispatch→commit path +
+    /// the EffectStaged-append failure surface. Recovery wiring
+    /// (`can_redispatch_world_effect` consultation per R-13) + lifecycle
+    /// integration land in PR 9b-6+.
+    fn commit_stage_then_commit(&self, input: CommitInput<'_>) -> Result<u64, CommitProtocolError> {
+        let mote_id = input.mote.id;
+
+        // Step 1: append EffectStaged BEFORE broker.dispatch. The recovery
+        // fold reads presence to set `effect_staged_observed` on MoteInfo.
+        // If the broker subsequently fails / the executor crashes, the
+        // EffectStaged entry is the durable signal that "an effect may
+        // have happened" — recovery uses this to decide re-dispatch
+        // safety.
+        let staged = JournalEntry::EffectStaged {
+            mote_id,
+            idempotency_key: input.idempotency_key,
+            seq: 0, // journal-assigned
+        };
+        self.journal.append(staged).map_err(|e| {
+            CommitProtocolError::JournalAppendEffectStagedFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            }
+        })?;
+
+        // Step 2: broker dispatch. Same per-call contract as
+        // IdempotentByConstruction; the broker enforces capability ∈
+        // tool_contract, supported pattern, capability ∈ warrant.tool_grants,
+        // request scopes ⊆ warrant scopes.
+        let handle = self
+            .broker
+            .dispatch(
+                input.mote,
+                input.warrant,
+                &input.capability,
+                input.effect_request,
+            )
+            .map_err(|e| CommitProtocolError::BrokerDispatchFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            })?;
+        let result_ref = handle.staged_ref;
+
+        // Step 3: R-11 verify. Same enforcement as IdempotentByConstruction
+        // (shared `enforce_r11` helper).
+        enforce_r11(&*self.store, mote_id, &result_ref)?;
+
+        // Step 4: append Committed. The journal's dedup-by-key index sees
+        // both the EffectStaged and the Committed sharing the same
+        // `idempotency_key`; per the v2 dedup index `{1, 2, 4}` they are
+        // distinct entry kinds, so both land.
         let entry = JournalEntry::Committed {
             mote_id,
             idempotency_key: input.idempotency_key,

--- a/crates/kx-executor/tests/integration_commit_protocol.rs
+++ b/crates/kx-executor/tests/integration_commit_protocol.rs
@@ -152,6 +152,17 @@ fn journal_append_committed_failed_variant_constructs() {
 }
 
 #[test]
+fn journal_append_effect_staged_failed_variant_constructs() {
+    let err = CommitProtocolError::JournalAppendEffectStagedFailed {
+        mote_id: sample_mote_id(),
+        reason: "sqlite busy".into(),
+    };
+    assert!(err
+        .to_string()
+        .contains("journal append(EffectStaged) failed"));
+}
+
+#[test]
 fn internal_variant_constructs() {
     let err = CommitProtocolError::Internal {
         mote_id: sample_mote_id(),
@@ -236,6 +247,10 @@ fn is_recovery_refusal_identifies_r13_only() {
             reason: "r".into(),
         },
         CommitProtocolError::JournalAppendCommittedFailed {
+            mote_id: mid,
+            reason: "r".into(),
+        },
+        CommitProtocolError::JournalAppendEffectStagedFailed {
             mote_id: mid,
             reason: "r".into(),
         },

--- a/crates/kx-executor/tests/integration_idempotent_commit.rs
+++ b/crates/kx-executor/tests/integration_idempotent_commit.rs
@@ -277,7 +277,10 @@ fn broker_dispatch_error_wraps_as_broker_dispatch_failed() {
 // StageThenCommit returns Internal { reason: "PR 9b-4 ..." } stub.
 // ============================================================================
 
+// Note: the StageThenCommit path now ships in PR 9b-4; this stub-shape
+// test is superseded by `tests/integration_stage_then_commit.rs`.
 #[test]
+#[ignore = "superseded by integration_stage_then_commit::stage_then_commit_path_commits_correctly (PR 9b-4 ships the path)"]
 fn stage_then_commit_returns_internal_pr_9b_4_placeholder() {
     let store = Arc::new(InMemoryContentStore::new());
     let journal = Arc::new(InMemoryJournal::new());

--- a/crates/kx-executor/tests/integration_stage_then_commit.rs
+++ b/crates/kx-executor/tests/integration_stage_then_commit.rs
@@ -1,0 +1,426 @@
+//! End-to-end integration tests for the PR 9b-4 `StandardCommitProtocol`
+//! `StageThenCommit` path:
+//! `journal.append(EffectStaged) → broker.dispatch → R-11 verify →
+//! journal.append(Committed)` (D38 §2b).
+//!
+//! The EffectStaged entry is appended BEFORE broker.dispatch so the
+//! recovery fold (per `journal-txn.md` 9-cell cross-product) sees the
+//! dispatch intent durably recorded. The tests cover the happy path
+//! (both entries land in order) + the failure modes that leave only the
+//! staged entry (recovery scenario where re-dispatch may or may not be
+//! permitted depending on the subsequent Failed entry's classification).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_stage_then_commit_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+enum BrokerMode {
+    HappyPath {
+        store: Arc<InMemoryContentStore>,
+        response_bytes: Vec<u8>,
+    },
+    HostileStagedRefMissing,
+    DispatchError,
+}
+
+struct TestBroker(BrokerMode);
+
+impl std::fmt::Debug for TestBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestBroker").finish()
+    }
+}
+
+impl CapabilityBroker for TestBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        match &self.0 {
+            BrokerMode::HappyPath {
+                store,
+                response_bytes,
+            } => {
+                let r = store.put(response_bytes).expect("put");
+                Ok(BrokerHandle {
+                    staged_ref: r,
+                    capability: ToolName("test".into()),
+                    capability_version: ToolVersion("0.1.0".into()),
+                })
+            }
+            BrokerMode::HostileStagedRefMissing => Ok(BrokerHandle {
+                staged_ref: ContentRef::from_bytes([0xEE; 32]),
+                capability: ToolName("hostile".into()),
+                capability_version: ToolVersion("0".into()),
+            }),
+            BrokerMode::DispatchError => Err(BrokerError::SandboxRefused {
+                capability: ToolName("test".into()),
+                reason: "test-induced dispatch failure".into(),
+            }),
+        }
+    }
+
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+fn input_for<'a>(mote: &'a Mote, warrant: &'a WarrantSpec, diagnostic: &'a str) -> CommitInput<'a> {
+    CommitInput {
+        mote,
+        warrant,
+        capability: ToolName("test-capability".into()),
+        effect_request: empty_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([3; 32]),
+        idempotency_key: [5; 32],
+        parents: SmallVec::new(),
+        diagnostic_context: diagnostic,
+    }
+}
+
+// ============================================================================
+// Happy path: EffectStaged + Committed land in order; broker stages bytes;
+// content store has the response.
+// ============================================================================
+
+#[test]
+fn stage_then_commit_path_commits_correctly() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"stc-response".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+    let mote = wm_stage_then_commit_mote(0x01);
+    let warrant = warrant();
+    let committed_seq = protocol
+        .commit(input_for(&mote, &warrant, "happy-stc"))
+        .expect("StageThenCommit must succeed");
+
+    // Two entries: EffectStaged at seq 1, Committed at seq 2 (or whatever
+    // the journal assigned, but EffectStaged MUST precede Committed).
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("journal scan")
+        .collect();
+    assert_eq!(entries.len(), 2, "EffectStaged + Committed must both land");
+
+    let staged_seq = match &entries[0] {
+        JournalEntry::EffectStaged { mote_id, seq, .. } => {
+            assert_eq!(*mote_id, mote.id);
+            *seq
+        }
+        other => panic!("first entry must be EffectStaged, got {other:?}"),
+    };
+
+    match &entries[1] {
+        JournalEntry::Committed {
+            mote_id,
+            seq,
+            result_ref,
+            ..
+        } => {
+            assert_eq!(*mote_id, mote.id);
+            assert_eq!(*seq, committed_seq);
+            assert!(
+                *seq > staged_seq,
+                "Committed seq ({}) must be > EffectStaged seq ({})",
+                seq,
+                staged_seq,
+            );
+            // result_ref points at "stc-response" in the store.
+            let bytes = store.get(result_ref).expect("store get");
+            assert_eq!(&*bytes, b"stc-response");
+        }
+        other => panic!("second entry must be Committed, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// EffectStaged entry IS recorded even when broker.dispatch subsequently
+// fails. Recovery uses this hint to decide re-dispatch safety (cell 3 vs
+// cell 5 of the 9-cell cross-product).
+// ============================================================================
+
+#[test]
+fn effect_staged_entry_persists_when_broker_dispatch_fails() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::DispatchError));
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+    let mote = wm_stage_then_commit_mote(0x02);
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "broker-fail-after-stage"))
+        .expect_err("broker dispatch error must surface");
+    assert!(matches!(
+        err,
+        CommitProtocolError::BrokerDispatchFailed { mote_id, .. } if mote_id == mote.id
+    ));
+
+    // The EffectStaged entry must remain — that's the recovery hint.
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("journal scan")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "EffectStaged must remain; no Committed entry on broker failure",
+    );
+    assert!(matches!(
+        &entries[0],
+        JournalEntry::EffectStaged { mote_id, .. } if *mote_id == mote.id,
+    ));
+    // No Committed yet.
+    assert!(journal.read_committed(&mote.id).unwrap().is_none());
+}
+
+// ============================================================================
+// R-11 fires AFTER EffectStaged has been recorded. The EffectStaged entry
+// remains; the Committed entry does not land. Recovery sees this as cell 3
+// or cell 5 depending on the subsequent Failed entry's classification (the
+// lifecycle layer is responsible for emitting Failed).
+// ============================================================================
+
+#[test]
+fn r11_fires_after_effect_staged_when_broker_stages_missing_ref() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HostileStagedRefMissing));
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+    let mote = wm_stage_then_commit_mote(0x03);
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "r11-after-stage"))
+        .expect_err("R-11 must fire");
+    match err {
+        CommitProtocolError::R11ResultRefIncomplete {
+            mote_id,
+            result_ref,
+        } => {
+            assert_eq!(mote_id, mote.id);
+            assert_eq!(result_ref, ContentRef::from_bytes([0xEE; 32]));
+        }
+        other => panic!("expected R-11, got {other:?}"),
+    }
+
+    // EffectStaged remains; no Committed.
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("journal scan")
+        .collect();
+    assert_eq!(entries.len(), 1);
+    assert!(matches!(&entries[0], JournalEntry::EffectStaged { .. }));
+    assert!(journal.read_committed(&mote.id).unwrap().is_none());
+}
+
+// ============================================================================
+// Determinism: two independent protocol instances on a StageThenCommit
+// Mote produce stable EffectStaged + Committed shapes.
+// ============================================================================
+
+#[test]
+fn stage_then_commit_is_deterministic_across_independent_runs() {
+    let mote = wm_stage_then_commit_mote(0x04);
+    let warrant = warrant();
+    let response = b"stable-stc".to_vec();
+
+    let do_commit = || -> (JournalEntry, JournalEntry) {
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+            store: store.clone(),
+            response_bytes: response.clone(),
+        }));
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+        let _ = protocol
+            .commit(input_for(&mote, &warrant, "det-stc"))
+            .expect("commit must succeed");
+        let entries: Vec<JournalEntry> = journal
+            .read_entries_by_seq(0..u64::MAX)
+            .expect("scan")
+            .collect();
+        assert_eq!(entries.len(), 2);
+        (entries[0].clone(), entries[1].clone())
+    };
+
+    let (s1, c1) = do_commit();
+    let (s2, c2) = do_commit();
+
+    // EffectStaged: idempotency_key + mote_id must be stable.
+    match (&s1, &s2) {
+        (
+            JournalEntry::EffectStaged {
+                mote_id: m1,
+                idempotency_key: k1,
+                ..
+            },
+            JournalEntry::EffectStaged {
+                mote_id: m2,
+                idempotency_key: k2,
+                ..
+            },
+        ) => {
+            assert_eq!(m1, m2);
+            assert_eq!(k1, k2);
+        }
+        _ => panic!("both first entries must be EffectStaged"),
+    }
+
+    // Committed: result_ref + idempotency_key + warrant_ref + mote_def_hash
+    // must be stable across two independent runs.
+    match (&c1, &c2) {
+        (
+            JournalEntry::Committed {
+                result_ref: r1,
+                idempotency_key: k1,
+                warrant_ref: w1,
+                mote_def_hash: h1,
+                ..
+            },
+            JournalEntry::Committed {
+                result_ref: r2,
+                idempotency_key: k2,
+                warrant_ref: w2,
+                mote_def_hash: h2,
+                ..
+            },
+        ) => {
+            assert_eq!(r1, r2);
+            assert_eq!(k1, k2);
+            assert_eq!(w1, w2);
+            assert_eq!(h1, h2);
+        }
+        _ => panic!("both second entries must be Committed"),
+    }
+}
+
+// ============================================================================
+// EffectStaged + Committed share the same idempotency_key (v2 dedup index
+// {1, 2, 4} treats them as distinct kinds so both land).
+// ============================================================================
+
+#[test]
+fn effect_staged_and_committed_share_idempotency_key() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"key-share".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+    let mote = wm_stage_then_commit_mote(0x05);
+    let warrant = warrant();
+    let _ = protocol
+        .commit(input_for(&mote, &warrant, "key-share"))
+        .expect("commit must succeed");
+
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 2);
+    let staged_key = match &entries[0] {
+        JournalEntry::EffectStaged {
+            idempotency_key, ..
+        } => *idempotency_key,
+        _ => panic!("first must be EffectStaged"),
+    };
+    let committed_key = match &entries[1] {
+        JournalEntry::Committed {
+            idempotency_key, ..
+        } => *idempotency_key,
+        _ => panic!("second must be Committed"),
+    };
+    assert_eq!(
+        staged_key, committed_key,
+        "EffectStaged + Committed must share idempotency_key for dedup index {{1,2,4}}",
+    );
+}

--- a/crates/kx-executor/tests/proptest_commit_protocol.rs
+++ b/crates/kx-executor/tests/proptest_commit_protocol.rs
@@ -46,6 +46,9 @@ fn arb_commit_protocol_error() -> impl Strategy<Value = CommitProtocolError> {
         (arb_mote_id(), "[a-z]{0,16}").prop_map(|(mote_id, reason)| {
             CommitProtocolError::JournalAppendCommittedFailed { mote_id, reason }
         }),
+        (arb_mote_id(), "[a-z]{0,16}").prop_map(|(mote_id, reason)| {
+            CommitProtocolError::JournalAppendEffectStagedFailed { mote_id, reason }
+        }),
         (arb_mote_id(), "[a-z]{0,16}")
             .prop_map(|(mote_id, reason)| { CommitProtocolError::Internal { mote_id, reason } }),
     ]

--- a/crates/kx-executor/tests/proptest_stage_then_commit.rs
+++ b/crates/kx-executor/tests/proptest_stage_then_commit.rs
@@ -1,0 +1,341 @@
+//! Property tests on the PR 9b-4 `StandardCommitProtocol`
+//! `StageThenCommit` path. SN-4 v2 mandate: ≥3 proptest properties × 64
+//! cases.
+//!
+//! Properties:
+//! 1. Stage-then-commit ordering — for any input, the journal's first
+//!    EffectStaged entry's seq strictly precedes the Committed entry's
+//!    seq.
+//! 2. EffectStaged persistence on broker failure — when the broker
+//!    refuses dispatch, the EffectStaged entry remains in the journal
+//!    (the recovery hint is durably recorded).
+//! 3. EffectStaged + Committed share idempotency_key — under the v2 dedup
+//!    index `{1, 2, 4}`, both kinds participate but on different keys
+//!    (distinct kinds → both land).
+//! 4. R-11 fires AFTER EffectStaged in StageThenCommit, leaving exactly
+//!    one entry in the journal.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_stc_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+struct HappyBroker {
+    store: Arc<InMemoryContentStore>,
+    response_bytes: Vec<u8>,
+}
+impl std::fmt::Debug for HappyBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HappyBroker").finish()
+    }
+}
+impl CapabilityBroker for HappyBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        let r = self.store.put(&self.response_bytes).expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("happy-stc".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+struct FailingBroker;
+impl std::fmt::Debug for FailingBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FailingBroker").finish()
+    }
+}
+impl CapabilityBroker for FailingBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        Err(BrokerError::SandboxRefused {
+            capability: ToolName("failing".into()),
+            reason: "test failure".into(),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+struct HostileBroker {
+    fake_ref: ContentRef,
+}
+impl std::fmt::Debug for HostileBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostileBroker").finish()
+    }
+}
+impl CapabilityBroker for HostileBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        Ok(BrokerHandle {
+            staged_ref: self.fake_ref,
+            capability: ToolName("hostile".into()),
+            capability_version: ToolVersion("0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+fn input_for<'a>(
+    mote: &'a Mote,
+    warrant: &'a WarrantSpec,
+    idempotency_key: [u8; 32],
+) -> CommitInput<'a> {
+    CommitInput {
+        mote,
+        warrant,
+        capability: ToolName("test".into()),
+        effect_request: empty_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([3; 32]),
+        idempotency_key,
+        parents: SmallVec::new(),
+        diagnostic_context: "proptest",
+    }
+}
+
+proptest! {
+    /// Order invariant: in the StageThenCommit happy path, the journal's
+    /// EffectStaged entry seq strictly precedes the Committed entry seq.
+    #[test]
+    fn prop_stage_then_commit_ordering(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+        response in any::<Vec<u8>>().prop_filter("non-empty", |v| !v.is_empty()),
+    ) {
+        let mote = wm_stc_mote(seed);
+        let w = warrant();
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HappyBroker {
+            store: store.clone(),
+            response_bytes: response.clone(),
+        });
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let _ = protocol.commit(input_for(&mote, &w, idempotency_key))
+            .expect("happy-path commit must succeed");
+
+        let entries: Vec<JournalEntry> = journal
+            .read_entries_by_seq(0..u64::MAX)
+            .expect("scan").collect();
+        prop_assert_eq!(entries.len(), 2);
+        let staged_seq = match &entries[0] {
+            JournalEntry::EffectStaged { seq, .. } => *seq,
+            other => { prop_assert!(false, "first must be EffectStaged, got {:?}", other); 0 }
+        };
+        let committed_seq = match &entries[1] {
+            JournalEntry::Committed { seq, .. } => *seq,
+            other => { prop_assert!(false, "second must be Committed, got {:?}", other); 0 }
+        };
+        prop_assert!(staged_seq < committed_seq, "EffectStaged seq must precede Committed seq");
+    }
+
+    /// EffectStaged persistence: when the broker fails, the journal
+    /// contains exactly one EffectStaged entry (no Committed entry).
+    #[test]
+    fn prop_effect_staged_persists_on_broker_failure(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_stc_mote(seed);
+        let w = warrant();
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(FailingBroker);
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let err = protocol.commit(input_for(&mote, &w, idempotency_key))
+            .expect_err("broker failure must propagate");
+        let is_dispatch_failed = matches!(err, CommitProtocolError::BrokerDispatchFailed { .. });
+        prop_assert!(is_dispatch_failed);
+
+        let entries: Vec<JournalEntry> = journal
+            .read_entries_by_seq(0..u64::MAX)
+            .expect("scan").collect();
+        prop_assert_eq!(entries.len(), 1);
+        let first_is_staged = matches!(entries[0], JournalEntry::EffectStaged { .. });
+        prop_assert!(first_is_staged);
+        prop_assert!(journal.read_committed(&mote.id).unwrap().is_none());
+    }
+
+    /// R-11 leaves the EffectStaged entry in place (and exactly that one
+    /// entry); the Committed entry never lands.
+    #[test]
+    fn prop_r11_in_stc_path_leaves_exactly_effect_staged(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+        fake_ref_bytes in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_stc_mote(seed);
+        let w = warrant();
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HostileBroker {
+            fake_ref: ContentRef::from_bytes(fake_ref_bytes),
+        });
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let err = protocol.commit(input_for(&mote, &w, idempotency_key))
+            .expect_err("R-11 must fire");
+        let is_r11 = matches!(err, CommitProtocolError::R11ResultRefIncomplete { .. });
+        prop_assert!(is_r11);
+
+        let entries: Vec<JournalEntry> = journal
+            .read_entries_by_seq(0..u64::MAX)
+            .expect("scan").collect();
+        prop_assert_eq!(entries.len(), 1);
+        let first_is_staged = matches!(entries[0], JournalEntry::EffectStaged { .. });
+        prop_assert!(first_is_staged);
+    }
+
+    /// EffectStaged and Committed entries share the same idempotency_key.
+    /// Under the v2 dedup index {1, 2, 4} they are distinct kinds, so
+    /// both land — but they share the per-Mote identity key.
+    #[test]
+    fn prop_effect_staged_and_committed_share_idempotency_key(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_stc_mote(seed);
+        let w = warrant();
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HappyBroker {
+            store: store.clone(),
+            response_bytes: b"key-share".to_vec(),
+        });
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let _ = protocol.commit(input_for(&mote, &w, idempotency_key))
+            .expect("commit must succeed");
+
+        let entries: Vec<JournalEntry> = journal
+            .read_entries_by_seq(0..u64::MAX)
+            .expect("scan").collect();
+        prop_assert_eq!(entries.len(), 2);
+        let staged_key = match &entries[0] {
+            JournalEntry::EffectStaged { idempotency_key, .. } => *idempotency_key,
+            _ => { prop_assert!(false, "first must be EffectStaged"); [0u8; 32] }
+        };
+        let committed_key = match &entries[1] {
+            JournalEntry::Committed { idempotency_key, .. } => *idempotency_key,
+            _ => { prop_assert!(false, "second must be Committed"); [0u8; 32] }
+        };
+        prop_assert_eq!(staged_key, committed_key);
+        prop_assert_eq!(staged_key, idempotency_key);
+    }
+}


### PR DESCRIPTION
## Summary

Fourth slice of **PR 9b**. Extends \`StandardCommitProtocol\` with the \`StageThenCommit\` path per D38 §2b:

\`\`\`text
journal.append(EffectStaged) → broker.dispatch → R-11 verify → journal.append(Committed)
\`\`\`

The \`EffectStaged\` entry is appended **BEFORE** \`broker.dispatch\` so the recovery fold (per \`journal-txn.md\` 9-cell cross-product) sees the dispatch intent durably recorded. This closes the WORLD-MUTATING double-effect window.

### Recovery semantics on the EffectStaged hint

| Subsequent entry | Cell | Decision |
|---|---|---|
| \`Committed\` | 4 | done; never re-dispatch |
| \`Failed(pre_commit_crash)\` | 3 | re-dispatch permitted (tool-boundary idempotency) |
| \`Failed(terminal)\` | 5 | R-13 refuses |
| \`Repudiated\` (no Committed) | 8 | anomaly — Inconsistent |

(Recovery wiring + the 9-cell cross-product integration tests land in PR 9b-6+.)

### NEW \`JournalAppendEffectStagedFailed\` variant

Symmetric with \`JournalAppendCommittedFailed\`. Needed because the StageThenCommit path appends EffectStaged BEFORE \`broker.dispatch\`; the failure mode is distinct.

### ValidateThenCommit

Remains an \`Internal { reason: \"PR 9b-5 ...\" }\` stub.

## Tests

- **5 new integration tests** (\`tests/integration_stage_then_commit.rs\`):
  - Happy path: EffectStaged + Committed land in order; result_ref points at broker's bytes
  - EffectStaged persists when broker.dispatch fails (recovery hint)
  - R-11 fires AFTER EffectStaged when broker fabricates a missing ref
  - Determinism across two independent protocol instances
  - EffectStaged + Committed share idempotency_key (v2 dedup index {1,2,4})
- **4 new proptests** (\`tests/proptest_stage_then_commit.rs\`):
  - \`prop_stage_then_commit_ordering\` (staged seq < committed seq)
  - \`prop_effect_staged_persists_on_broker_failure\`
  - \`prop_r11_in_stc_path_leaves_exactly_effect_staged\`
  - \`prop_effect_staged_and_committed_share_idempotency_key\`
- **Existing tests updated for new variant**: \`integration_commit_protocol.rs\` (variant constructibility + mote_id_extractor + is_recovery_refusal totality) and \`proptest_commit_protocol.rs\` (\`arb_commit_protocol_error\` enumeration; canonical-classifier-cannot-drift).

## Test plan

- [x] \`cargo build -p kx-executor\` clean
- [x] \`cargo test --workspace --all-features\`: 613 passed + 7 ignored (was 604 + 6 pre-9b-4; +10 net = 5 integration + 4 proptest + 1 variant test; one prior stub test moved to #[ignore])
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo deny check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features\` clean
- [ ] CI on Kortecx/kortecx
- [ ] SN-2 post-merge 404 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)