### PR TITLE
PR 9b-5 (P1.9b-5): StandardCommitProtocol ValidateThenCommit path (D39 §a/§c + D20; critic scheduling → lifecycle)

### DIFF
--- a/crates/kx-executor/src/commit_protocol.rs
+++ b/crates/kx-executor/src/commit_protocol.rs
@@ -10,21 +10,33 @@
 //! `broker.dispatch → R-11 verify → journal.append(Committed)` (per D39
 //! §a/§c).
 //!
-//! **PR 9b-4** (this PR) extends `StandardCommitProtocol` with the
+//! **PR 9b-4** extended `StandardCommitProtocol` with the
 //! `StageThenCommit` path (per D38 §2b):
 //! `journal.append(EffectStaged) → broker.dispatch → R-11 verify →
-//! journal.append(Committed)`. The `EffectStaged` entry is the recovery
-//! hint that closes the WORLD-MUTATING double-effect window; it MUST be
-//! appended BEFORE `broker.dispatch` so the recovery fold sees the
-//! dispatch intent durably recorded. Adds the
-//! `JournalAppendEffectStagedFailed` variant to `CommitProtocolError`.
-//! `ValidateThenCommit` remains an `Internal { reason }` stub until
-//! PR 9b-5.
+//! journal.append(Committed)`. Added the
+//! `JournalAppendEffectStagedFailed` variant.
 //!
-//! **PR 9b-5+ scope** (NOT in this PR): the `ValidateThenCommit` body
-//! (broker.dispatch → R-11 → Committed + critic-Mote child scheduling per
-//! D20), lifecycle wiring, 9-cell recovery cross-product, Test A/B,
-//! and WORLD-MUTATING Mote E2E.
+//! **PR 9b-5** (this PR) extends `StandardCommitProtocol` with the
+//! `ValidateThenCommit` path (per D39 §a/§c + D20):
+//! `broker.dispatch → R-11 verify → journal.append(Committed)`. **The
+//! commit-step semantics are identical to IdempotentByConstruction**; the
+//! distinction is at scheduling: a ValidateThenCommit producer Mote
+//! requires a sibling **critic Mote** (R-2 enforces this at submission
+//! time) whose own commit (or repudiation) gates downstream consumers
+//! from acting on the producer's `Committed` entry per D20.
+//!
+//! **Critic-Mote child scheduling is the lifecycle layer's
+//! responsibility** — `commit_protocol` returns `Ok(seq)` when the
+//! producer's `Committed` entry lands, and the lifecycle reads the
+//! producer's Mote shape (`critic_for` references inverted via the
+//! submission map) to schedule the critic. PR 9b-6+ wires this; PR 9a's
+//! refusal predicates (R-2 / R-4 / R-5 / R-6 / R-7 / R-9) already
+//! enforce the critic-shape invariants at submission time.
+//!
+//! **PR 9b-6+ scope** (NOT in this PR): lifecycle wiring (including
+//! critic-Mote scheduling), 9-cell recovery cross-product at the
+//! executor layer, Test A re-use + Test B (executor commit-protocol
+//! trust), WORLD-MUTATING Mote crash-recovery E2E.
 //!
 //! # Why a separate error type from `SubmissionRefusal` and `MoteExecutorError`
 //!
@@ -397,10 +409,7 @@ where
         match pattern {
             EffectPattern::IdempotentByConstruction => self.commit_idempotent(input),
             EffectPattern::StageThenCommit => self.commit_stage_then_commit(input),
-            EffectPattern::ValidateThenCommit => Err(CommitProtocolError::Internal {
-                mote_id: input.mote.id,
-                reason: "ValidateThenCommit path lands in PR 9b-5 (broker.dispatch → put → append(Committed) + critic-Mote child scheduling per D20)".into(),
-            }),
+            EffectPattern::ValidateThenCommit => self.commit_validate_then_commit(input),
         }
     }
 }
@@ -540,6 +549,86 @@ where
         // both the EffectStaged and the Committed sharing the same
         // `idempotency_key`; per the v2 dedup index `{1, 2, 4}` they are
         // distinct entry kinds, so both land.
+        let entry = JournalEntry::Committed {
+            mote_id,
+            idempotency_key: input.idempotency_key,
+            seq: 0, // journal-assigned
+            nondeterminism: input.mote.def.nd_class,
+            result_ref,
+            parents: input.parents,
+            warrant_ref: input.warrant_ref,
+            mote_def_hash: input.mote_def_hash,
+        };
+        let written = self.journal.append(entry).map_err(|e| {
+            CommitProtocolError::JournalAppendCommittedFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            }
+        })?;
+
+        Ok(written.seq())
+    }
+
+    /// `ValidateThenCommit` path (D39 §a/§c + D20):
+    /// `broker.dispatch → R-11 verify → journal.append(Committed)`.
+    ///
+    /// **Commit-step semantics are identical to
+    /// `IdempotentByConstruction`** — the producer Mote's `Committed`
+    /// entry lands the same way. The distinction is at scheduling: the
+    /// producer Mote has a sibling **critic Mote** (R-2 enforces this
+    /// at submission time) whose own commit (or repudiation) gates
+    /// downstream consumers from acting on the producer's `Committed`
+    /// entry per D20.
+    ///
+    /// **Critic-Mote child scheduling is the lifecycle layer's
+    /// responsibility**, not the commit protocol's. PR 9b-6+ wires the
+    /// runtime scheduling that reads the producer Mote's
+    /// submission-map sibling references and dispatches the critic
+    /// after this method returns `Ok(seq)`. PR 9a's submission-time
+    /// refusal predicates (R-2 + R-4 + R-5 + R-6 + R-7 + R-9) already
+    /// enforce the critic-shape invariants (sibling critic exists, the
+    /// critic targets a WORLD-MUTATING producer, no multi-critic, the
+    /// critic chain terminates at a Pure critic).
+    ///
+    /// **No `EffectStaged` entry** — unlike `StageThenCommit`, the
+    /// `ValidateThenCommit` pattern does not pre-record the dispatch
+    /// intent in the journal. The dispatch is structurally observable
+    /// via the sibling-critic relationship: if the producer's
+    /// `Committed` entry exists but the critic has not yet committed,
+    /// downstream consumers MUST treat the producer's result as
+    /// `MoteState::ValidationPending` (lifecycle responsibility).
+    fn commit_validate_then_commit(
+        &self,
+        input: CommitInput<'_>,
+    ) -> Result<u64, CommitProtocolError> {
+        let mote_id = input.mote.id;
+
+        // Step 1: broker dispatch. The broker enforces the per-call
+        // contract: capability ∈ tool_contract, supported pattern,
+        // capability ∈ warrant.tool_grants, request scopes ⊆ warrant
+        // scopes. The broker stages the response payload to the content
+        // store and returns the staged ref.
+        let handle = self
+            .broker
+            .dispatch(
+                input.mote,
+                input.warrant,
+                &input.capability,
+                input.effect_request,
+            )
+            .map_err(|e| CommitProtocolError::BrokerDispatchFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            })?;
+        let result_ref = handle.staged_ref;
+
+        // Step 2: R-11 verify. Same enforcement as the other paths
+        // (shared `enforce_r11` helper).
+        enforce_r11(&*self.store, mote_id, &result_ref)?;
+
+        // Step 3: append Committed. The journal's dedup-by-key index
+        // enforces at-most-one Committed per `idempotency_key`. Critic
+        // scheduling is deferred to the lifecycle layer (PR 9b-6+).
         let entry = JournalEntry::Committed {
             mote_id,
             idempotency_key: input.idempotency_key,

--- a/crates/kx-executor/tests/integration_idempotent_commit.rs
+++ b/crates/kx-executor/tests/integration_idempotent_commit.rs
@@ -319,7 +319,10 @@ fn stage_then_commit_returns_internal_pr_9b_4_placeholder() {
 // ValidateThenCommit returns Internal { reason: "PR 9b-5 ..." } stub.
 // ============================================================================
 
+// Note: the ValidateThenCommit path now ships in PR 9b-5; this stub-shape
+// test is superseded by `tests/integration_validate_then_commit.rs`.
 #[test]
+#[ignore = "superseded by integration_validate_then_commit::validate_then_commit_path_commits_correctly (PR 9b-5 ships the path)"]
 fn validate_then_commit_returns_internal_pr_9b_5_placeholder() {
     let store = Arc::new(InMemoryContentStore::new());
     let journal = Arc::new(InMemoryJournal::new());

--- a/crates/kx-executor/tests/integration_validate_then_commit.rs
+++ b/crates/kx-executor/tests/integration_validate_then_commit.rs
@@ -1,0 +1,374 @@
+//! End-to-end integration tests for the PR 9b-5 `StandardCommitProtocol`
+//! `ValidateThenCommit` path:
+//! `broker.dispatch → R-11 verify → journal.append(Committed)` (D39
+//! §a/§c + D20).
+//!
+//! The commit-step semantics are identical to `IdempotentByConstruction`
+//! — the producer Mote's `Committed` entry lands the same way. The
+//! distinction is at scheduling: the producer requires a sibling critic
+//! Mote whose own commit (or repudiation) gates downstream consumers per
+//! D20. **Critic-Mote child scheduling is the lifecycle layer's
+//! responsibility** (lands in PR 9b-6+); these tests verify only the
+//! commit-step behavior.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_validate_then_commit_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::ValidateThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::ValidateThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+enum BrokerMode {
+    HappyPath {
+        store: Arc<InMemoryContentStore>,
+        response_bytes: Vec<u8>,
+    },
+    HostileStagedRefMissing,
+    DispatchError,
+}
+
+struct TestBroker(BrokerMode);
+
+impl std::fmt::Debug for TestBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestBroker").finish()
+    }
+}
+
+impl CapabilityBroker for TestBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        match &self.0 {
+            BrokerMode::HappyPath {
+                store,
+                response_bytes,
+            } => {
+                let r = store.put(response_bytes).expect("put");
+                Ok(BrokerHandle {
+                    staged_ref: r,
+                    capability: ToolName("test".into()),
+                    capability_version: ToolVersion("0.1.0".into()),
+                })
+            }
+            BrokerMode::HostileStagedRefMissing => Ok(BrokerHandle {
+                staged_ref: ContentRef::from_bytes([0xFE; 32]),
+                capability: ToolName("hostile".into()),
+                capability_version: ToolVersion("0".into()),
+            }),
+            BrokerMode::DispatchError => Err(BrokerError::SandboxRefused {
+                capability: ToolName("test".into()),
+                reason: "test-induced dispatch failure".into(),
+            }),
+        }
+    }
+
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+fn input_for<'a>(mote: &'a Mote, warrant: &'a WarrantSpec, diagnostic: &'a str) -> CommitInput<'a> {
+    CommitInput {
+        mote,
+        warrant,
+        capability: ToolName("test-capability".into()),
+        effect_request: empty_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([3; 32]),
+        idempotency_key: [5; 32],
+        parents: SmallVec::new(),
+        diagnostic_context: diagnostic,
+    }
+}
+
+// ============================================================================
+// Happy path: ValidateThenCommit commits the producer; no EffectStaged
+// entry (unlike StageThenCommit); exactly one Committed entry lands.
+// ============================================================================
+
+#[test]
+fn validate_then_commit_path_commits_correctly() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"vtc-response".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+    let mote = wm_validate_then_commit_mote(0x10);
+    let warrant = warrant();
+    let seq = protocol
+        .commit(input_for(&mote, &warrant, "happy-vtc"))
+        .expect("ValidateThenCommit must succeed");
+
+    // Exactly one entry — the Committed for the producer. No EffectStaged
+    // (per the path's contract; unlike StageThenCommit).
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "ValidateThenCommit appends exactly one Committed (no EffectStaged); critic scheduling is lifecycle's job",
+    );
+    match &entries[0] {
+        JournalEntry::Committed {
+            mote_id,
+            seq: s,
+            result_ref,
+            ..
+        } => {
+            assert_eq!(*mote_id, mote.id);
+            assert_eq!(*s, seq);
+            let bytes = store.get(result_ref).expect("store get");
+            assert_eq!(&*bytes, b"vtc-response");
+        }
+        other => panic!("expected Committed, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// R-11 fires same as IdempotentByConstruction / StageThenCommit.
+// ============================================================================
+
+#[test]
+fn r11_fires_on_validate_then_commit_when_broker_stages_missing_ref() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HostileStagedRefMissing));
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+    let mote = wm_validate_then_commit_mote(0x11);
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "r11-vtc"))
+        .expect_err("R-11 must fire");
+    match err {
+        CommitProtocolError::R11ResultRefIncomplete {
+            mote_id,
+            result_ref,
+        } => {
+            assert_eq!(mote_id, mote.id);
+            assert_eq!(result_ref, ContentRef::from_bytes([0xFE; 32]));
+        }
+        other => panic!("expected R-11, got {other:?}"),
+    }
+
+    // No Committed entry — and no EffectStaged either (unlike StageThenCommit
+    // where R-11 leaves the EffectStaged hint behind).
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        0,
+        "ValidateThenCommit R-11 must leave the journal empty (no EffectStaged in this pattern)",
+    );
+}
+
+// ============================================================================
+// BrokerDispatchFailed wraps broker errors.
+// ============================================================================
+
+#[test]
+fn broker_dispatch_error_wraps_as_broker_dispatch_failed_on_validate_then_commit() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::DispatchError));
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+    let mote = wm_validate_then_commit_mote(0x12);
+    let warrant = warrant();
+    let err = protocol
+        .commit(input_for(&mote, &warrant, "dispatch-err-vtc"))
+        .expect_err("dispatch error must surface");
+    assert!(matches!(
+        err,
+        CommitProtocolError::BrokerDispatchFailed { mote_id, .. } if mote_id == mote.id
+    ));
+    assert!(journal.read_committed(&mote.id).unwrap().is_none());
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        0,
+        "ValidateThenCommit dispatch error must leave the journal empty",
+    );
+}
+
+// ============================================================================
+// Determinism: same input → byte-identical Committed entry across two
+// independent protocol instances.
+// ============================================================================
+
+#[test]
+fn validate_then_commit_is_deterministic_across_independent_runs() {
+    let mote = wm_validate_then_commit_mote(0x13);
+    let warrant = warrant();
+    let response = b"stable-vtc".to_vec();
+
+    let do_commit = || -> JournalEntry {
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+            store: store.clone(),
+            response_bytes: response.clone(),
+        }));
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+        let _ = protocol
+            .commit(input_for(&mote, &warrant, "det-vtc"))
+            .expect("commit must succeed");
+        journal.read_committed(&mote.id).unwrap().unwrap()
+    };
+
+    let e1 = do_commit();
+    let e2 = do_commit();
+    match (&e1, &e2) {
+        (
+            JournalEntry::Committed {
+                result_ref: r1,
+                idempotency_key: k1,
+                warrant_ref: w1,
+                mote_def_hash: h1,
+                ..
+            },
+            JournalEntry::Committed {
+                result_ref: r2,
+                idempotency_key: k2,
+                warrant_ref: w2,
+                mote_def_hash: h2,
+                ..
+            },
+        ) => {
+            assert_eq!(r1, r2);
+            assert_eq!(k1, k2);
+            assert_eq!(w1, w2);
+            assert_eq!(h1, h2);
+        }
+        _ => panic!("both entries must be Committed"),
+    }
+}
+
+// ============================================================================
+// Structural difference from StageThenCommit: NO EffectStaged entry on
+// the happy path. This is the load-bearing distinction at the journal
+// layer between the two patterns. (D20: the critic-Mote relationship
+// supersedes the EffectStaged hint for ValidateThenCommit's recovery
+// semantics; downstream consumers consult the critic's commit state, not
+// the producer's alone.)
+// ============================================================================
+
+#[test]
+fn validate_then_commit_does_not_append_effect_staged() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(TestBroker(BrokerMode::HappyPath {
+        store: store.clone(),
+        response_bytes: b"no-staged".to_vec(),
+    }));
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+    let mote = wm_validate_then_commit_mote(0x14);
+    let warrant = warrant();
+    let _ = protocol
+        .commit(input_for(&mote, &warrant, "no-staged-vtc"))
+        .expect("commit must succeed");
+
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 1);
+    assert!(
+        !matches!(&entries[0], JournalEntry::EffectStaged { .. }),
+        "ValidateThenCommit must NOT append EffectStaged (that's StageThenCommit-only)",
+    );
+    assert!(
+        matches!(&entries[0], JournalEntry::Committed { .. }),
+        "the one entry must be Committed",
+    );
+}

--- a/crates/kx-executor/tests/proptest_validate_then_commit.rs
+++ b/crates/kx-executor/tests/proptest_validate_then_commit.rs
@@ -1,0 +1,265 @@
+//! Property tests on the PR 9b-5 `StandardCommitProtocol`
+//! `ValidateThenCommit` path. SN-4 v2 mandate: ≥3 proptest properties ×
+//! 64 cases.
+//!
+//! Properties:
+//! 1. Single-entry commit — the happy path appends exactly one Committed
+//!    entry; NO EffectStaged entry (load-bearing structural distinction
+//!    from StageThenCommit).
+//! 2. R-11 leaves journal empty (no EffectStaged hint to remain, unlike
+//!    StageThenCommit).
+//! 3. Determinism — same input → byte-identical Committed entry across
+//!    two independent protocol instances.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{CommitInput, CommitProtocol, CommitProtocolError, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteDefHash,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_vtc_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::ValidateThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::ValidateThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+struct HappyBroker {
+    store: Arc<InMemoryContentStore>,
+    response_bytes: Vec<u8>,
+}
+impl std::fmt::Debug for HappyBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HappyBroker").finish()
+    }
+}
+impl CapabilityBroker for HappyBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        let r = self.store.put(&self.response_bytes).expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("happy-vtc".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+struct HostileBroker {
+    fake_ref: ContentRef,
+}
+impl std::fmt::Debug for HostileBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostileBroker").finish()
+    }
+}
+impl CapabilityBroker for HostileBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        Ok(BrokerHandle {
+            staged_ref: self.fake_ref,
+            capability: ToolName("hostile".into()),
+            capability_version: ToolVersion("0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+fn input_for<'a>(
+    mote: &'a Mote,
+    warrant: &'a WarrantSpec,
+    idempotency_key: [u8; 32],
+) -> CommitInput<'a> {
+    CommitInput {
+        mote,
+        warrant,
+        capability: ToolName("test".into()),
+        effect_request: empty_request(),
+        warrant_ref: ContentRef::from_bytes([4; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([3; 32]),
+        idempotency_key,
+        parents: SmallVec::new(),
+        diagnostic_context: "proptest",
+    }
+}
+
+proptest! {
+    /// Single-entry commit: the happy ValidateThenCommit path appends
+    /// exactly one Committed entry; NO EffectStaged entry. This is the
+    /// load-bearing structural distinction from StageThenCommit.
+    #[test]
+    fn prop_validate_then_commit_appends_exactly_one_committed(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+        response in any::<Vec<u8>>().prop_filter("non-empty", |v| !v.is_empty()),
+    ) {
+        let mote = wm_vtc_mote(seed);
+        let w = warrant();
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HappyBroker {
+            store: store.clone(),
+            response_bytes: response,
+        });
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let _ = protocol
+            .commit(input_for(&mote, &w, idempotency_key))
+            .expect("happy commit must succeed");
+
+        let entries: Vec<JournalEntry> = journal
+            .read_entries_by_seq(0..u64::MAX)
+            .expect("scan").collect();
+        prop_assert_eq!(entries.len(), 1);
+        let is_committed = matches!(entries[0], JournalEntry::Committed { .. });
+        let is_effect_staged = matches!(entries[0], JournalEntry::EffectStaged { .. });
+        prop_assert!(is_committed);
+        prop_assert!(!is_effect_staged);
+    }
+
+    /// R-11 leaves the journal empty (no EffectStaged hint, unlike the
+    /// StageThenCommit path). The hostile broker fabricates a ref; R-11
+    /// fires before any journal append.
+    #[test]
+    fn prop_r11_in_vtc_path_leaves_journal_empty(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+        fake_ref_bytes in any::<[u8; 32]>(),
+    ) {
+        let mote = wm_vtc_mote(seed);
+        let w = warrant();
+        let store = Arc::new(InMemoryContentStore::new());
+        let journal = Arc::new(InMemoryJournal::new());
+        let broker = Arc::new(HostileBroker {
+            fake_ref: ContentRef::from_bytes(fake_ref_bytes),
+        });
+        let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+
+        let err = protocol.commit(input_for(&mote, &w, idempotency_key))
+            .expect_err("R-11 must fire");
+        let is_r11 = matches!(err, CommitProtocolError::R11ResultRefIncomplete { .. });
+        prop_assert!(is_r11);
+
+        prop_assert_eq!(journal.count_entries().unwrap(), 0);
+    }
+
+    /// Determinism: two independent protocol instances on the same
+    /// ValidateThenCommit input produce byte-identical Committed
+    /// entries.
+    #[test]
+    fn prop_validate_then_commit_is_deterministic(
+        seed in any::<u8>(),
+        idempotency_key in any::<[u8; 32]>(),
+        response in any::<Vec<u8>>().prop_filter("non-empty", |v| !v.is_empty()),
+    ) {
+        let mote = wm_vtc_mote(seed);
+        let w = warrant();
+
+        let run = || -> JournalEntry {
+            let store = Arc::new(InMemoryContentStore::new());
+            let journal = Arc::new(InMemoryJournal::new());
+            let broker = Arc::new(HappyBroker {
+                store: store.clone(),
+                response_bytes: response.clone(),
+            });
+            let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+            let _ = protocol.commit(input_for(&mote, &w, idempotency_key))
+                .expect("commit must succeed");
+            journal.read_committed(&mote.id).unwrap().unwrap()
+        };
+
+        let e1 = run();
+        let e2 = run();
+        prop_assert_eq!(&e1, &e2);
+    }
+}


### PR DESCRIPTION
## Summary

Fifth slice of **PR 9b**. Completes the per-pattern protocol triad by extending \`StandardCommitProtocol\` with the \`ValidateThenCommit\` path:

\`\`\`text
broker.dispatch → R-11 verify → journal.append(Committed)
\`\`\`

**The commit-step semantics are identical to \`IdempotentByConstruction\`**; the distinction is at scheduling — a ValidateThenCommit producer Mote requires a sibling critic Mote (R-2 enforces this at submission time) whose own commit (or repudiation) gates downstream consumers per D20.

**Critic-Mote child scheduling is the lifecycle layer's responsibility** — \`commit_protocol\` returns \`Ok(seq)\` when the producer's Committed lands; PR 9b-6+ wires the runtime scheduling that reads the producer Mote's submission-map sibling references and dispatches the critic. PR 9a's refusal predicates (R-2/R-4/R-5/R-6/R-7/R-9) already enforce critic-shape invariants at submission time.

**No EffectStaged entry** on this path (unlike StageThenCommit). The dispatch is structurally observable via the sibling-critic relationship: if the producer's Committed exists but the critic has not yet committed, downstream consumers MUST treat the producer's result as \`MoteState::ValidationPending\` (lifecycle responsibility).

### Protocol triad complete

| Pattern | Path | Recovery hint |
|---|---|---|
| IdempotentByConstruction (9b-3) | dispatch → R-11 → Committed | none (token-class backstops) |
| StageThenCommit (9b-4) | EffectStaged → dispatch → R-11 → Committed | EffectStaged entry |
| ValidateThenCommit (9b-5) | dispatch → R-11 → Committed | sibling critic Mote |

## Tests

- **5 new integration tests** (\`tests/integration_validate_then_commit.rs\`):
  - Happy path: exactly one Committed entry; no EffectStaged
  - R-11 fires on hostile broker; **journal left EMPTY** (unlike StageThenCommit which leaves the EffectStaged hint)
  - BrokerDispatchFailed wraps broker errors
  - Determinism across two independent protocol instances
  - \`validate_then_commit_does_not_append_effect_staged\` (load-bearing structural distinction from StageThenCommit)
- **3 new proptests** (\`tests/proptest_validate_then_commit.rs\`):
  - Single-entry commit; no EffectStaged
  - R-11 leaves journal empty
  - Determinism
- **Existing stub test** in \`integration_idempotent_commit.rs\` moved to \`#[ignore]\` (superseded by the actual path).

## Test plan

- [x] \`cargo build -p kx-executor\` clean
- [x] \`cargo test --workspace --all-features\`: 620 passed + 8 ignored (was 613 + 7 pre-9b-5; +7 net = 5 integration + 3 proptest − 1 stub-to-ignore)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo deny check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features\` clean
- [ ] CI on Kortecx/kortecx
- [ ] SN-2 post-merge 404 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)