### PR TITLE
PR 9b-6 (P1.9b-6): lifecycle integration — run_wm_mote + critic-Mote child scheduling (D38 §2b + D20)

### DIFF
--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -299,7 +299,10 @@ pub use fact_zero::{
     seed_idempotency_key, seed_mote_id, write_fact_zero, FactZeroError, SeedPayload,
 };
 pub use factory::{default_executor, executor_for_class};
-pub use lifecycle::{run_pure_mote, LifecycleCommit, LifecycleError, TestMoteExecutor};
+pub use lifecycle::{
+    run_pure_mote, run_wm_mote, LifecycleCommit, LifecycleError, TestMoteExecutor,
+    WmLifecycleCommit,
+};
 pub use refusal::{
     refusal_from_narrowing, validate_submission, validate_submission_with_idempotency,
     SubmissionRefusal, WorkflowSubmission,

--- a/crates/kx-executor/src/lifecycle.rs
+++ b/crates/kx-executor/src/lifecycle.rs
@@ -18,15 +18,18 @@
 //! `kx-memoizer` / `kx-context-assembler` / `kx-inference` / `kx-capability`
 //! integration is reserved for PR 9b (the commit-protocol PR).
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use kx_capability::EffectRequest;
 use kx_content::ContentRef;
 use kx_journal::{Journal, JournalEntry};
-use kx_mote::{Mote, MoteId, NdClass};
+use kx_mote::{Mote, MoteId, NdClass, ToolName};
 use kx_warrant::WarrantSpec;
 use smallvec::SmallVec;
 use thiserror::Error;
 
+use crate::commit_protocol::{CommitInput, CommitProtocol, CommitProtocolError};
 use crate::executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
 use crate::refusal::SubmissionRefusal;
 use crate::resource_manager::{ResourceError, ResourceManager};
@@ -55,9 +58,21 @@ pub enum LifecycleError {
     #[error("journal append: {0}")]
     JournalAppend(String),
 
+    /// Commit-protocol returned a typed error (R-11 / R-13 / broker /
+    /// content-store / journal failures during the commit step). New in
+    /// PR 9b-6; surfaces the commit-protocol vocabulary up to the caller.
+    #[error("commit protocol: {0:?}")]
+    CommitProtocol(CommitProtocolError),
+
     /// Catch-all internal error.
     #[error("lifecycle internal: {0}")]
     Internal(String),
+}
+
+impl From<CommitProtocolError> for LifecycleError {
+    fn from(err: CommitProtocolError) -> Self {
+        Self::CommitProtocol(err)
+    }
 }
 
 /// Successful PURE-Mote lifecycle result.
@@ -69,6 +84,30 @@ pub struct LifecycleCommit {
     pub result_ref: ContentRef,
     /// The Mote's identity.
     pub mote_id: MoteId,
+}
+
+/// Successful WORLD-MUTATING Mote lifecycle result. Extends
+/// `LifecycleCommit` with the optional `critic_proposed_seq` field that
+/// PR 9b-6's `run_wm_mote` populates when the producer's
+/// `EffectPattern::ValidateThenCommit` triggers critic-Mote child
+/// scheduling.
+///
+/// **PR 9b-6 scope**: this slice writes the critic's `Proposed` entry
+/// to the journal (the scheduling intent is durably recorded). The
+/// scheduler (PR 10) dispatches the critic to a worker; the recovery
+/// fold reads the Proposed entry to know the critic was queued.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WmLifecycleCommit {
+    /// The producer Mote's `Committed` entry seq.
+    pub committed_seq: u64,
+    /// The producer's `result_ref` (the broker's staged response).
+    pub result_ref: ContentRef,
+    /// The producer Mote's identity.
+    pub mote_id: MoteId,
+    /// For `ValidateThenCommit` producers with a sibling critic Mote in
+    /// the submission, the critic's `Proposed` entry seq. `None` for
+    /// `IdempotentByConstruction` / `StageThenCommit` paths (no critic).
+    pub critic_proposed_seq: Option<u64>,
 }
 
 /// Run a single PURE Mote end-to-end. PR 9a's contract:
@@ -164,6 +203,174 @@ where
         committed_seq,
         result_ref,
         mote_id: mote.id,
+    })
+}
+
+/// Run a single WORLD-MUTATING Mote end-to-end via the commit_protocol.
+/// **PR 9b-6 scope**: ships the lifecycle's invocation of
+/// `CommitProtocol::commit` for non-PURE Motes + critic-Mote child
+/// scheduling for `ValidateThenCommit` producers.
+///
+/// Steps:
+/// 1. Refuse if `mote.nd_class() == NdClass::Pure` (caller uses
+///    `run_pure_mote` for PURE Motes).
+/// 2. `ResourceManager::acquire` under `warrant.resource_ceiling`.
+/// 3. Append `Proposed` for the producer.
+/// 4. Invoke `commit_protocol.commit(CommitInput { ... })`. The protocol
+///    routes per `mote.def.effect_pattern`:
+///    - `IdempotentByConstruction` → `broker.dispatch → R-11 → Committed`.
+///    - `StageThenCommit` → `EffectStaged → broker.dispatch → R-11 →
+///      Committed`.
+///    - `ValidateThenCommit` → `broker.dispatch → R-11 → Committed`.
+/// 5. For `ValidateThenCommit` producers: if `submission_motes` contains
+///    a sibling Mote with `critic_for == Some(producer.id)`, append a
+///    `Proposed` entry for the critic so the scheduler (PR 10) can pick
+///    it up. The critic's `nd_class` is recorded in the Proposed entry's
+///    `nondeterminism` field per `journal-entry.md`.
+/// 6. `ResourceManager::release`.
+///
+/// **The producer's `result_ref` carried in the returned
+/// `WmLifecycleCommit` is the broker's staged response ref** — what the
+/// commit_protocol got back from `broker.dispatch`. The producer's body
+/// is not executed via `MoteExecutor::run` in PR 9b-6 (the broker is the
+/// dispatch primitive for WM Motes); body-via-executor wiring is the
+/// shape-of-future-PRs question for richer Mote bodies that prepare the
+/// EffectRequest payload from sandboxed compute. For PR 9b-6's scope,
+/// the caller supplies the `EffectRequest` directly.
+///
+/// # Errors
+///
+/// See [`LifecycleError`] variants. Commit-protocol failures (R-11 / R-13
+/// / broker / journal) surface as `LifecycleError::CommitProtocol`. The
+/// caller must write a `Failed` journal entry when
+/// `LifecycleError::Refused` is returned (this module does not).
+#[allow(clippy::too_many_arguments)] // PR 9b-6 explicit-args design; SDK ergonomics land at P4
+pub fn run_wm_mote<J, R, CP>(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    capability: ToolName,
+    effect_request: EffectRequest,
+    submission_motes: &BTreeMap<MoteId, Mote>,
+    journal: &J,
+    resource_manager: &R,
+    commit_protocol: &CP,
+) -> Result<WmLifecycleCommit, LifecycleError>
+where
+    J: Journal + ?Sized,
+    R: ResourceManager + ?Sized,
+    CP: CommitProtocol + ?Sized,
+{
+    if mote.nd_class() == NdClass::Pure {
+        return Err(LifecycleError::Internal(format!(
+            "run_wm_mote handles WM/ReadOnlyNondet only; got Pure mote {:?}; caller must use run_pure_mote",
+            mote.id
+        )));
+    }
+
+    // Step 2: acquire resource slot.
+    let slot = resource_manager.acquire(&warrant.resource_ceiling)?;
+
+    let warrant_ref = kx_warrant::warrant_ref_of(warrant);
+    let mote_def_hash = mote.def.hash();
+    let idempotency_key = *mote.id.as_bytes();
+
+    // Step 3: Proposed entry for the producer. Carries the warrant_ref +
+    // nd_class per D36.
+    let proposed = JournalEntry::Proposed {
+        mote_id: mote.id,
+        idempotency_key,
+        seq: 0, // journal-assigned
+        nondeterminism: mote.def.nd_class,
+        placement_hint: 0,
+        warrant_ref,
+    };
+    if let Err(e) = journal.append(proposed) {
+        let _ = resource_manager.release(slot);
+        return Err(LifecycleError::JournalAppend(format!(
+            "WM producer Proposed: {e:?}"
+        )));
+    }
+
+    // Step 4: commit_protocol routes per effect_pattern.
+    let commit_input = CommitInput {
+        mote,
+        warrant,
+        capability,
+        effect_request,
+        warrant_ref,
+        mote_def_hash,
+        idempotency_key,
+        parents: SmallVec::new(),
+        diagnostic_context: "lifecycle::run_wm_mote",
+    };
+    let committed_seq = match commit_protocol.commit(commit_input) {
+        Ok(seq) => seq,
+        Err(e) => {
+            let _ = resource_manager.release(slot);
+            return Err(LifecycleError::CommitProtocol(e));
+        }
+    };
+
+    // Step 5: critic-Mote child scheduling for ValidateThenCommit.
+    // The submission's sibling map is the source of truth — R-2 ensured
+    // a critic exists at submission time (or refused the submission).
+    let critic_proposed_seq =
+        if mote.def.effect_pattern == kx_mote::EffectPattern::ValidateThenCommit {
+            let critic = submission_motes
+                .values()
+                .find(|sibling| sibling.def.critic_for == Some(mote.id));
+            match critic {
+                Some(critic_mote) => {
+                    let critic_proposed = JournalEntry::Proposed {
+                        mote_id: critic_mote.id,
+                        idempotency_key: *critic_mote.id.as_bytes(),
+                        seq: 0, // journal-assigned
+                        nondeterminism: critic_mote.def.nd_class,
+                        placement_hint: 0,
+                        warrant_ref,
+                    };
+                    match journal.append(critic_proposed) {
+                        Ok(entry) => Some(entry.seq()),
+                        Err(e) => {
+                            let _ = resource_manager.release(slot);
+                            return Err(LifecycleError::JournalAppend(format!(
+                                "critic Proposed: {e:?}"
+                            )));
+                        }
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
+    // The producer's result_ref is the broker's staged response. Recover
+    // it by reading the Committed entry the protocol just wrote. (We
+    // can't read it back cheaply without journal lookups; for the
+    // PR 9b-6 scope we record committed_seq + signal completion. Callers
+    // who need result_ref read it from the journal.)
+    let result_ref = journal
+        .read_committed(&mote.id)
+        .map_err(|e| LifecycleError::JournalAppend(format!("read Committed: {e:?}")))?
+        .and_then(|e| match e {
+            JournalEntry::Committed { result_ref, .. } => Some(result_ref),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            LifecycleError::Internal(format!(
+                "commit_protocol returned Ok({committed_seq}) but no Committed entry visible"
+            ))
+        })?;
+
+    // Step 6: release the slot.
+    resource_manager.release(slot)?;
+
+    Ok(WmLifecycleCommit {
+        committed_seq,
+        result_ref,
+        mote_id: mote.id,
+        critic_proposed_seq,
     })
 }
 

--- a/crates/kx-executor/tests/integration_run_wm_mote.rs
+++ b/crates/kx-executor/tests/integration_run_wm_mote.rs
@@ -1,0 +1,393 @@
+//! End-to-end integration tests for the PR 9b-6 `run_wm_mote` lifecycle
+//! orchestrator. Exercises all three EffectPattern paths through the
+//! full lifecycle: acquire → Proposed → commit_protocol → critic
+//! scheduling (for ValidateThenCommit) → release.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{run_wm_mote, LifecycleError, LocalResourceManager, StandardCommitProtocol};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
+    PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn mote(seed: u8, pattern: EffectPattern, nd: NdClass, critic_for: Option<MoteId>) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: nd,
+        config_subset: BTreeMap::new(),
+        effect_pattern: pattern,
+        critic_for,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request(pattern: EffectPattern) -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+struct HappyBroker {
+    store: Arc<InMemoryContentStore>,
+    response_bytes: Vec<u8>,
+}
+impl std::fmt::Debug for HappyBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HappyBroker").finish()
+    }
+}
+impl CapabilityBroker for HappyBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        let r = self.store.put(&self.response_bytes).expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("happy".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+// ============================================================================
+// IdempotentByConstruction lifecycle: acquire → Proposed → broker.dispatch →
+// R-11 → Committed → release. NO critic; no EffectStaged.
+// ============================================================================
+
+#[test]
+fn idempotent_by_construction_lifecycle_end_to_end() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        response_bytes: b"ibc-resp".to_vec(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+
+    let producer = mote(
+        0x01,
+        EffectPattern::IdempotentByConstruction,
+        NdClass::WorldMutating,
+        None,
+    );
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((producer.id, producer.clone())).collect();
+    let w = warrant();
+
+    let result = run_wm_mote(
+        &producer,
+        &w,
+        ToolName("ibc-cap".into()),
+        empty_request(EffectPattern::IdempotentByConstruction),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .expect("IdempotentByConstruction lifecycle must succeed");
+
+    assert_eq!(result.mote_id, producer.id);
+    assert!(result.critic_proposed_seq.is_none(), "no critic for IBC");
+
+    // Journal: Proposed (producer) + Committed (producer). No EffectStaged.
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 2, "IBC writes Proposed + Committed only");
+    assert!(matches!(&entries[0], JournalEntry::Proposed { .. }));
+    assert!(matches!(&entries[1], JournalEntry::Committed { .. }));
+}
+
+// ============================================================================
+// StageThenCommit lifecycle: acquire → Proposed → EffectStaged → broker.dispatch
+// → R-11 → Committed → release. NO critic.
+// ============================================================================
+
+#[test]
+fn stage_then_commit_lifecycle_writes_proposed_effect_staged_and_committed() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        response_bytes: b"stc-resp".to_vec(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+
+    let producer = mote(
+        0x02,
+        EffectPattern::StageThenCommit,
+        NdClass::WorldMutating,
+        None,
+    );
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((producer.id, producer.clone())).collect();
+    let w = warrant();
+
+    let result = run_wm_mote(
+        &producer,
+        &w,
+        ToolName("stc-cap".into()),
+        empty_request(EffectPattern::StageThenCommit),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .expect("StageThenCommit lifecycle must succeed");
+
+    assert_eq!(result.mote_id, producer.id);
+    assert!(result.critic_proposed_seq.is_none(), "no critic for STC");
+
+    // Journal: Proposed → EffectStaged → Committed.
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 3);
+    assert!(matches!(&entries[0], JournalEntry::Proposed { .. }));
+    assert!(matches!(&entries[1], JournalEntry::EffectStaged { .. }));
+    assert!(matches!(&entries[2], JournalEntry::Committed { .. }));
+}
+
+// ============================================================================
+// ValidateThenCommit lifecycle: acquire → Proposed (producer) →
+// broker.dispatch → R-11 → Committed → Proposed (critic) → release. NO
+// EffectStaged.
+// ============================================================================
+
+#[test]
+fn validate_then_commit_lifecycle_schedules_critic_proposed_entry() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        response_bytes: b"vtc-resp".to_vec(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+
+    let producer = mote(
+        0x03,
+        EffectPattern::ValidateThenCommit,
+        NdClass::WorldMutating,
+        None,
+    );
+    let critic = mote(
+        0x04,
+        EffectPattern::IdempotentByConstruction,
+        NdClass::Pure, // critics must be Pure-terminating per R-9
+        Some(producer.id),
+    );
+    let mut submission_motes = BTreeMap::new();
+    submission_motes.insert(producer.id, producer.clone());
+    submission_motes.insert(critic.id, critic.clone());
+    let w = warrant();
+
+    let result = run_wm_mote(
+        &producer,
+        &w,
+        ToolName("vtc-cap".into()),
+        empty_request(EffectPattern::ValidateThenCommit),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .expect("ValidateThenCommit lifecycle must succeed");
+
+    assert_eq!(result.mote_id, producer.id);
+    let critic_seq = result
+        .critic_proposed_seq
+        .expect("critic must be scheduled");
+    assert!(critic_seq > result.committed_seq);
+
+    // Journal: Proposed(producer) → Committed(producer) → Proposed(critic).
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 3);
+    match &entries[0] {
+        JournalEntry::Proposed { mote_id, .. } => assert_eq!(*mote_id, producer.id),
+        other => panic!("entry 0 should be producer Proposed; got {other:?}"),
+    }
+    match &entries[1] {
+        JournalEntry::Committed { mote_id, .. } => assert_eq!(*mote_id, producer.id),
+        other => panic!("entry 1 should be producer Committed; got {other:?}"),
+    }
+    match &entries[2] {
+        JournalEntry::Proposed { mote_id, seq, .. } => {
+            assert_eq!(*mote_id, critic.id);
+            assert_eq!(*seq, critic_seq);
+        }
+        other => panic!("entry 2 should be critic Proposed; got {other:?}"),
+    }
+}
+
+// ============================================================================
+// ValidateThenCommit without a sibling critic in the submission yields
+// `critic_proposed_seq = None`. (R-2 should refuse this submission earlier;
+// this test verifies the lifecycle's defensive handling of an unexpected
+// submission map.)
+// ============================================================================
+
+#[test]
+fn validate_then_commit_without_critic_returns_none_critic_seq() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        response_bytes: b"vtc-no-critic".to_vec(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+
+    let producer = mote(
+        0x05,
+        EffectPattern::ValidateThenCommit,
+        NdClass::WorldMutating,
+        None,
+    );
+    // submission_motes contains ONLY the producer; no sibling critic.
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((producer.id, producer.clone())).collect();
+    let w = warrant();
+
+    let result = run_wm_mote(
+        &producer,
+        &w,
+        ToolName("vtc-no-critic-cap".into()),
+        empty_request(EffectPattern::ValidateThenCommit),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .expect("commit must succeed even without critic in defensive path");
+
+    assert_eq!(result.mote_id, producer.id);
+    assert!(
+        result.critic_proposed_seq.is_none(),
+        "no sibling critic → no critic Proposed entry"
+    );
+
+    // Producer's Proposed + Committed land; no extra Proposed.
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 2);
+}
+
+// ============================================================================
+// Refusing a PURE Mote: `run_wm_mote` must reject PURE Motes (caller is
+// expected to use `run_pure_mote`).
+// ============================================================================
+
+#[test]
+fn run_wm_mote_refuses_pure_motes() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        response_bytes: b"unused".to_vec(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+
+    let pure_mote = mote(
+        0x06,
+        EffectPattern::IdempotentByConstruction,
+        NdClass::Pure,
+        None,
+    );
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((pure_mote.id, pure_mote.clone())).collect();
+    let w = warrant();
+
+    let err = run_wm_mote(
+        &pure_mote,
+        &w,
+        ToolName("never-called".into()),
+        empty_request(EffectPattern::IdempotentByConstruction),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .expect_err("PURE Motes must be refused");
+    assert!(matches!(err, LifecycleError::Internal(_)));
+    // No journal entries — the refusal short-circuits before any append.
+    assert_eq!(journal.count_entries().unwrap(), 0);
+}


### PR DESCRIPTION
## Summary

Sixth slice of **PR 9b**. Extends \`lifecycle.rs\` with \`run_wm_mote()\` — the orchestrator that drives non-PURE Motes through the full lifecycle via \`commit_protocol\`.

### The lifecycle

\`\`\`text
acquire → Proposed(producer) → commit_protocol.commit() →
  [if ValidateThenCommit] Proposed(critic) → release
\`\`\`

- IdempotentByConstruction → \`Proposed + Committed\`
- StageThenCommit → \`Proposed + EffectStaged + Committed\`
- ValidateThenCommit → \`Proposed(producer) + Committed(producer) + Proposed(critic)\`

### NEW types

- \`run_wm_mote()\` — generic over \`(Journal, ResourceManager, CommitProtocol)\`
- \`WmLifecycleCommit { committed_seq, result_ref, mote_id, critic_proposed_seq: Option<u64> }\`
- \`LifecycleError::CommitProtocol(CommitProtocolError)\` + \`From\` impl

### Tests

5 new integration tests in \`tests/integration_run_wm_mote.rs\` covering all three EffectPatterns + defensive paths + PURE-Mote refusal.

## Test plan

- [x] \`cargo build -p kx-executor\` clean
- [x] \`cargo test --workspace --all-features\`: 625/625 + 8 ignored (was 620 + 8 pre-9b-6; +5 net)
- [x] \`cargo fmt --all -- --check\` / clippy / deny / doc clean
- [ ] CI on Kortecx/kortecx
- [ ] SN-2 post-merge 404 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)