### PR TITLE
PR 9b-7 (P1.9b-7): R-13 recovery wiring — redispatch_wm_mote + WmRedispatchOracle (D38 §2b)

### DIFF
--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -300,8 +300,8 @@ pub use fact_zero::{
 };
 pub use factory::{default_executor, executor_for_class};
 pub use lifecycle::{
-    run_pure_mote, run_wm_mote, LifecycleCommit, LifecycleError, TestMoteExecutor,
-    WmLifecycleCommit,
+    redispatch_wm_mote, run_pure_mote, run_wm_mote, LifecycleCommit, LifecycleError,
+    TestMoteExecutor, WmLifecycleCommit, WmRedispatchOracle,
 };
 pub use refusal::{
     refusal_from_narrowing, validate_submission, validate_submission_with_idempotency,

--- a/crates/kx-executor/src/lifecycle.rs
+++ b/crates/kx-executor/src/lifecycle.rs
@@ -206,6 +206,182 @@ where
     })
 }
 
+/// Recovery-time oracle consulted by [`redispatch_wm_mote`] before any
+/// re-dispatch of a WORLD-MUTATING tool effect. Returns `true` iff the
+/// re-dispatch is safe (D38 §2b + STEP 5.2 + STEP 5.4 + R-13).
+///
+/// **Returns `false` for**: `inconsistent` (cell 8 anomaly),
+/// `terminal_failure_observed` (cell 5 — terminal failure under
+/// EffectStaged), `committed.is_some()` (cells 4 + 6 — done; never
+/// re-dispatch), and Motes with no observed EffectStaged (nothing to
+/// re-dispatch).
+///
+/// `kx_projection::Projection` implements this trait directly; tests
+/// stub it.
+pub trait WmRedispatchOracle: Send + Sync {
+    /// Returns `true` iff re-dispatch of `mote_id`'s WM effect is safe.
+    fn can_redispatch_world_effect(&self, mote_id: &MoteId) -> bool;
+}
+
+impl WmRedispatchOracle for kx_projection::Projection {
+    fn can_redispatch_world_effect(&self, mote_id: &MoteId) -> bool {
+        kx_projection::Projection::can_redispatch_world_effect(self, mote_id)
+    }
+}
+
+/// Recovery-time WORLD-MUTATING Mote re-dispatch path. **PR 9b-7
+/// scope**: consults a [`WmRedispatchOracle`] BEFORE invoking
+/// `commit_protocol.commit()` and refuses re-dispatch with
+/// `LifecycleError::CommitProtocol(CommitProtocolError::R13WmReDispatchRefused
+/// { ... })` when the oracle returns `false`.
+///
+/// Two semantic differences from [`run_wm_mote`]:
+/// 1. The oracle's veto fires R-13 BEFORE the broker is consulted.
+///    The lifecycle does not append a fresh `Proposed` entry on
+///    refusal (the journal already carries the previous attempt's
+///    Proposed; this is a recovery scenario, not fresh dispatch).
+/// 2. On Ok-path (oracle approves), the journal already has the
+///    previous attempt's `Proposed` + `EffectStaged` entries. This
+///    function does NOT re-append Proposed; the broker's
+///    tool-boundary idempotency (D38 §1 token-class) closes the
+///    double-dispatch window — the remote API dedupes on
+///    `idempotency_key`. `commit_protocol.commit()` proceeds to call
+///    `broker.dispatch`, verify R-11, and append `Committed`.
+///
+/// # Errors
+///
+/// - `LifecycleError::CommitProtocol(R13WmReDispatchRefused)` when the
+///   oracle returns `false`.
+/// - `LifecycleError::ResourceAcquire(_)` if `acquire` fails.
+/// - `LifecycleError::CommitProtocol(_)` for downstream commit-protocol
+///   failures.
+/// - `LifecycleError::JournalAppend(_)` for critic-Proposed write failures.
+/// - `LifecycleError::Internal(_)` for PURE Motes (caller bug) or
+///   missing Committed-readback after the protocol returned Ok.
+#[allow(clippy::too_many_arguments)]
+pub fn redispatch_wm_mote<J, R, CP, O>(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    capability: ToolName,
+    effect_request: EffectRequest,
+    submission_motes: &BTreeMap<MoteId, Mote>,
+    journal: &J,
+    resource_manager: &R,
+    commit_protocol: &CP,
+    oracle: &O,
+) -> Result<WmLifecycleCommit, LifecycleError>
+where
+    J: Journal + ?Sized,
+    R: ResourceManager + ?Sized,
+    CP: CommitProtocol + ?Sized,
+    O: WmRedispatchOracle + ?Sized,
+{
+    if mote.nd_class() == NdClass::Pure {
+        return Err(LifecycleError::Internal(format!(
+            "redispatch_wm_mote handles WM/ReadOnlyNondet only; got Pure mote {:?}",
+            mote.id
+        )));
+    }
+
+    // Step 0 (NEW in 9b-7): R-13 recovery consultation. If the oracle
+    // refuses, propagate without touching journal/broker/resource.
+    if !oracle.can_redispatch_world_effect(&mote.id) {
+        return Err(LifecycleError::CommitProtocol(
+            CommitProtocolError::R13WmReDispatchRefused {
+                mote_id: mote.id,
+                reason: "WmRedispatchOracle returned false (terminal_failure_observed / inconsistent / already committed / no effect_staged_observed)".into(),
+            },
+        ));
+    }
+
+    // Step 2: acquire resource slot.
+    let slot = resource_manager.acquire(&warrant.resource_ceiling)?;
+
+    let warrant_ref = kx_warrant::warrant_ref_of(warrant);
+    let mote_def_hash = mote.def.hash();
+    let idempotency_key = *mote.id.as_bytes();
+
+    // Note: NO fresh Proposed entry on the recovery path. The previous
+    // attempt's Proposed (+ optionally EffectStaged) is already in the
+    // journal — appending another would double-record the dispatch
+    // intent. The broker's idempotency_key dedup is the load-bearing
+    // safety here.
+
+    // Step 4: commit_protocol routes per effect_pattern.
+    let commit_input = CommitInput {
+        mote,
+        warrant,
+        capability,
+        effect_request,
+        warrant_ref,
+        mote_def_hash,
+        idempotency_key,
+        parents: SmallVec::new(),
+        diagnostic_context: "lifecycle::redispatch_wm_mote",
+    };
+    let committed_seq = match commit_protocol.commit(commit_input) {
+        Ok(seq) => seq,
+        Err(e) => {
+            let _ = resource_manager.release(slot);
+            return Err(LifecycleError::CommitProtocol(e));
+        }
+    };
+
+    // Step 5: critic-Mote child scheduling (same as run_wm_mote).
+    let critic_proposed_seq =
+        if mote.def.effect_pattern == kx_mote::EffectPattern::ValidateThenCommit {
+            let critic = submission_motes
+                .values()
+                .find(|sibling| sibling.def.critic_for == Some(mote.id));
+            match critic {
+                Some(critic_mote) => {
+                    let critic_proposed = JournalEntry::Proposed {
+                        mote_id: critic_mote.id,
+                        idempotency_key: *critic_mote.id.as_bytes(),
+                        seq: 0,
+                        nondeterminism: critic_mote.def.nd_class,
+                        placement_hint: 0,
+                        warrant_ref,
+                    };
+                    match journal.append(critic_proposed) {
+                        Ok(entry) => Some(entry.seq()),
+                        Err(e) => {
+                            let _ = resource_manager.release(slot);
+                            return Err(LifecycleError::JournalAppend(format!(
+                                "critic Proposed (recovery): {e:?}"
+                            )));
+                        }
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
+    let result_ref = journal
+        .read_committed(&mote.id)
+        .map_err(|e| LifecycleError::JournalAppend(format!("read Committed: {e:?}")))?
+        .and_then(|e| match e {
+            JournalEntry::Committed { result_ref, .. } => Some(result_ref),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            LifecycleError::Internal(format!(
+                "commit_protocol returned Ok({committed_seq}) but no Committed entry visible"
+            ))
+        })?;
+
+    resource_manager.release(slot)?;
+
+    Ok(WmLifecycleCommit {
+        committed_seq,
+        result_ref,
+        mote_id: mote.id,
+        critic_proposed_seq,
+    })
+}
+
 /// Run a single WORLD-MUTATING Mote end-to-end via the commit_protocol.
 /// **PR 9b-6 scope**: ships the lifecycle's invocation of
 /// `CommitProtocol::commit` for non-PURE Motes + critic-Mote child

--- a/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
+++ b/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
@@ -1,0 +1,380 @@
+//! End-to-end integration tests for the PR 9b-7 `redispatch_wm_mote`
+//! recovery-time orchestrator. Verifies that R-13's oracle consultation
+//! fires BEFORE any broker dispatch, that the journal stays unchanged
+//! on refusal, and that the approve-path produces the same Committed
+//! shape as the fresh-dispatch `run_wm_mote`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{
+    redispatch_wm_mote, CommitProtocolError, LifecycleError, LocalResourceManager,
+    StandardCommitProtocol, WmRedispatchOracle,
+};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
+    PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_mote(seed: u8, pattern: EffectPattern) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: pattern,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request(pattern: EffectPattern) -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+/// Test oracle with a fixed answer.
+struct StubOracle {
+    can_redispatch: bool,
+    /// Tracks whether the oracle was actually consulted (PR 9b-7's
+    /// load-bearing assertion: R-13 fires BEFORE broker.dispatch).
+    consulted: AtomicBool,
+}
+
+impl WmRedispatchOracle for StubOracle {
+    fn can_redispatch_world_effect(&self, _mote_id: &MoteId) -> bool {
+        self.consulted.store(true, Ordering::SeqCst);
+        self.can_redispatch
+    }
+}
+
+struct HappyBroker {
+    store: Arc<InMemoryContentStore>,
+    /// Tracks whether dispatch was actually called (must be false on
+    /// the refusal path; R-13 must short-circuit before the broker).
+    dispatched: AtomicBool,
+}
+impl std::fmt::Debug for HappyBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HappyBroker").finish()
+    }
+}
+impl CapabilityBroker for HappyBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        self.dispatched.store(true, Ordering::SeqCst);
+        let r = self.store.put(b"redispatch-resp").expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("redispatch".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+// ============================================================================
+// R-13: oracle refuses → R13WmReDispatchRefused; broker not consulted;
+// journal unchanged.
+// ============================================================================
+
+#[test]
+fn r13_fires_before_broker_dispatch_when_oracle_refuses() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        dispatched: AtomicBool::new(false),
+    });
+    let broker_ref = broker.clone();
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let oracle = StubOracle {
+        can_redispatch: false,
+        consulted: AtomicBool::new(false),
+    };
+
+    let mote = wm_mote(0x01, EffectPattern::StageThenCommit);
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((mote.id, mote.clone())).collect();
+
+    let err = redispatch_wm_mote(
+        &mote,
+        &warrant(),
+        ToolName("test".into()),
+        empty_request(EffectPattern::StageThenCommit),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &oracle,
+    )
+    .expect_err("R-13 must fire");
+
+    // R-13 surfaces through LifecycleError::CommitProtocol(R13...)
+    match err {
+        LifecycleError::CommitProtocol(CommitProtocolError::R13WmReDispatchRefused {
+            mote_id,
+            reason,
+        }) => {
+            assert_eq!(mote_id, mote.id);
+            assert!(reason.contains("Oracle") || reason.contains("oracle"));
+        }
+        other => panic!("expected R-13 CommitProtocol error, got {other:?}"),
+    }
+
+    // Load-bearing: oracle WAS consulted; broker WAS NOT.
+    assert!(oracle.consulted.load(Ordering::SeqCst));
+    assert!(
+        !broker_ref.dispatched.load(Ordering::SeqCst),
+        "R-13 must short-circuit BEFORE broker.dispatch",
+    );
+
+    // Journal is unchanged — R-13 fires before any append.
+    assert_eq!(journal.count_entries().unwrap(), 0);
+    // Content store is unchanged too.
+    assert_eq!(store.len(), 0);
+}
+
+// ============================================================================
+// Oracle approves → commit_protocol proceeds → Committed entry lands.
+// No fresh Proposed entry on the recovery path (the previous attempt's
+// Proposed is in the journal already; this test starts from a
+// fresh-state journal for simplicity, asserting only the no-fresh-Proposed
+// invariant for THIS function's contract).
+// ============================================================================
+
+#[test]
+fn oracle_approves_then_commit_protocol_proceeds_no_fresh_proposed() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        dispatched: AtomicBool::new(false),
+    });
+    let broker_ref = broker.clone();
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let oracle = StubOracle {
+        can_redispatch: true,
+        consulted: AtomicBool::new(false),
+    };
+
+    let mote = wm_mote(0x02, EffectPattern::IdempotentByConstruction);
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((mote.id, mote.clone())).collect();
+
+    let result = redispatch_wm_mote(
+        &mote,
+        &warrant(),
+        ToolName("test".into()),
+        empty_request(EffectPattern::IdempotentByConstruction),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &oracle,
+    )
+    .expect("oracle-approved re-dispatch must succeed");
+
+    assert_eq!(result.mote_id, mote.id);
+    assert!(oracle.consulted.load(Ordering::SeqCst));
+    assert!(broker_ref.dispatched.load(Ordering::SeqCst));
+
+    // The journal has exactly one entry: the Committed produced by the
+    // commit_protocol. NO fresh Proposed (PR 9b-7's contract: recovery
+    // path trusts the existing Proposed from the previous attempt).
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(entries.len(), 1, "recovery path appends Committed only");
+    assert!(matches!(&entries[0], JournalEntry::Committed { .. }));
+}
+
+// ============================================================================
+// PURE Mote refused on recovery path same as fresh path.
+// ============================================================================
+
+#[test]
+fn redispatch_wm_mote_refuses_pure_motes() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        dispatched: AtomicBool::new(false),
+    });
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let oracle = StubOracle {
+        can_redispatch: true,
+        consulted: AtomicBool::new(false),
+    };
+
+    let mut pure = wm_mote(0x03, EffectPattern::IdempotentByConstruction);
+    let mut def = pure.def.clone();
+    def.nd_class = NdClass::Pure;
+    pure = Mote::new(
+        def,
+        pure.input_data_id,
+        pure.graph_position.clone(),
+        pure.parents.clone(),
+    );
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((pure.id, pure.clone())).collect();
+
+    let err = redispatch_wm_mote(
+        &pure,
+        &warrant(),
+        ToolName("never-called".into()),
+        empty_request(EffectPattern::IdempotentByConstruction),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &oracle,
+    )
+    .expect_err("PURE Mote must be refused on recovery path");
+    assert!(matches!(err, LifecycleError::Internal(_)));
+    assert_eq!(journal.count_entries().unwrap(), 0);
+    // Oracle not consulted — PURE refusal short-circuits earlier.
+    assert!(!oracle.consulted.load(Ordering::SeqCst));
+}
+
+// ============================================================================
+// Oracle approval + ValidateThenCommit producer → critic Proposed entry
+// lands (same as run_wm_mote).
+// ============================================================================
+
+#[test]
+fn redispatch_validate_then_commit_schedules_critic_proposed() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(HappyBroker {
+        store: store.clone(),
+        dispatched: AtomicBool::new(false),
+    });
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let oracle = StubOracle {
+        can_redispatch: true,
+        consulted: AtomicBool::new(false),
+    };
+
+    let producer = wm_mote(0x04, EffectPattern::ValidateThenCommit);
+    // Critic Mote with critic_for = producer.id, Pure-class per R-9.
+    let critic_def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: Some(producer.id),
+        is_topology_shaper: false,
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    let critic = Mote::new(
+        critic_def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![0x05]),
+        SmallVec::new(),
+    );
+    let mut submission_motes = BTreeMap::new();
+    submission_motes.insert(producer.id, producer.clone());
+    submission_motes.insert(critic.id, critic.clone());
+
+    let result = redispatch_wm_mote(
+        &producer,
+        &warrant(),
+        ToolName("test".into()),
+        empty_request(EffectPattern::ValidateThenCommit),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &oracle,
+    )
+    .expect("re-dispatch must succeed");
+
+    let critic_seq = result
+        .critic_proposed_seq
+        .expect("critic must be scheduled");
+    assert!(critic_seq > result.committed_seq);
+
+    let entries: Vec<JournalEntry> = journal
+        .read_entries_by_seq(0..u64::MAX)
+        .expect("scan")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        2,
+        "recovery path: Committed(producer) + Proposed(critic)"
+    );
+    assert!(matches!(&entries[0], JournalEntry::Committed { .. }));
+    assert!(matches!(&entries[1], JournalEntry::Proposed { .. }));
+}


### PR DESCRIPTION
## Summary

Seventh slice of **PR 9b**. Adds recovery-time R-13 enforcement.

### NEW \`WmRedispatchOracle\` trait + \`Projection\` impl

\`\`\`rust
pub trait WmRedispatchOracle: Send + Sync {
    fn can_redispatch_world_effect(&self, mote_id: &MoteId) -> bool;
}

impl WmRedispatchOracle for kx_projection::Projection { ... }
\`\`\`

### NEW \`redispatch_wm_mote\` orchestrator

Two semantic differences from \`run_wm_mote\`:

1. **Oracle veto fires R-13 BEFORE any side effect** — refusal path leaves journal + content store unchanged; broker.dispatch is NOT called.
2. **No fresh Proposed entry on Ok-path** — the previous attempt's Proposed is in the journal already; the broker's deterministic \`idempotency_key\` closes the double-dispatch window.

### Tests (4 new in \`tests/integration_redispatch_wm_mote.rs\`)

- R-13 fires before broker.dispatch when oracle refuses (load-bearing AtomicBool assertion)
- Oracle approves → no fresh Proposed; only Committed lands
- PURE Mote refused before oracle consultation
- ValidateThenCommit critic-Proposed scheduling on recovery path

## Test plan

- [x] \`cargo build -p kx-executor\` clean
- [x] \`cargo test --workspace --all-features\`: 629/629 + 8 ignored (+4 net)
- [x] fmt / clippy / deny / doc clean
- [ ] CI on Kortecx/kortecx
- [ ] SN-2 post-merge 404 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)