### PR TITLE
PR 10 / P1.10 — kx-scheduler (dependency resolution + placement seam)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-scheduler"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-executor",
+ "kx-journal",
+ "kx-mote",
+ "kx-projection",
+ "kx-warrant",
+ "proptest",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kx-tool-registry"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/kx-inference",
     "crates/kx-capability",
     "crates/kx-executor",
+    "crates/kx-scheduler",
 ]
 exclude = [
     "kx-cloud",
@@ -74,6 +75,7 @@ kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.0.1"
 kx-inference         = { path = "crates/kx-inference",         version = "0.0.1" }
 kx-capability        = { path = "crates/kx-capability",        version = "0.0.1" }
 kx-executor          = { path = "crates/kx-executor",          version = "0.0.1" }
+kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-scheduler/Cargo.toml
+++ b/crates/kx-scheduler/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name         = "kx-scheduler"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx P1.10 scheduler — decides what is ready and hands it to the executor, reading only the projection. Placement is a trait seam (LocalPlacement + RoundRobinPlacement); the scheduler does no execution, never writes the journal, and never reads the journal directly. kx-journal is a dev-dependency only, which structurally enforces the no-write-journal invariant in production code."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-mote       = { workspace = true }
+kx-projection = { workspace = true }
+kx-executor   = { workspace = true }
+kx-warrant    = { workspace = true }
+thiserror     = { workspace = true }
+tracing       = { workspace = true }
+smallvec      = { workspace = true }
+
+[dev-dependencies]
+kx-journal = { workspace = true }
+kx-content = { workspace = true }
+proptest   = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-scheduler/src/errors.rs
+++ b/crates/kx-scheduler/src/errors.rs
@@ -1,0 +1,20 @@
+//! [`SchedulerError`] — the scheduler's failure vocabulary.
+
+use kx_mote::MoteId;
+use thiserror::Error;
+
+/// Errors surfaced by [`crate::Scheduler::submit`] / [`crate::Scheduler::tick`].
+///
+/// The scheduler does not interpret per-Mote dispatch outcomes — those are
+/// surfaced on [`crate::DispatchedMote::result`] as the executor's typed
+/// `MoteExecutorError`. `SchedulerError` covers only failures of the scheduler's
+/// own bookkeeping (e.g., duplicate registrations).
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SchedulerError {
+    /// `submit` was called twice for the same `MoteId` before the first
+    /// instance was dispatched. The submitter should de-duplicate at the
+    /// workflow layer; the scheduler's pending map is keyed on `MoteId` and
+    /// admits exactly one (mote, warrant) pair per id at a time.
+    #[error("mote {0:?} already submitted and not yet dispatched")]
+    DuplicateSubmission(MoteId),
+}

--- a/crates/kx-scheduler/src/lib.rs
+++ b/crates/kx-scheduler/src/lib.rs
@@ -1,0 +1,72 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+// Inline test modules are exempted from the workspace deny on `unwrap_used` /
+// `expect_used`. Integration tests under tests/*.rs carry per-file allows.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-scheduler — dependency resolution + dispatch (P1.10)
+//!
+//! Per the P1.10 crate spec: *"decide what is ready and hand it to the executor —
+//! **only by reading the projection***."*
+//!
+//! The scheduler is the placement-and-dispatch layer between the workflow author
+//! (who submits Motes) and the executor (which runs them). On each [`Scheduler::tick`]
+//! it asks the [`Projection`](kx_projection::Projection) which submitted Motes are
+//! ready (parents all `Committed-and-not-Repudiated`), routes each through a
+//! [`Placement`] policy, and hands the Mote + warrant to the
+//! [`kx_executor::MoteExecutor`].
+//!
+//! ## Hard constraints (the P1.10 exit gate)
+//!
+//! - **Never writes the journal.** The crate has no `kx-journal` production
+//!   dependency; the type literally cannot be imported in src/. (kx-journal is a
+//!   dev-dep, used by tests to construct synthesized `JournalEntry` values to
+//!   feed `Projection::fold`.)
+//! - **Reads only the projection.** Orchestration decisions come from
+//!   `Projection::ready_set()`, never from a direct journal read.
+//! - **Does no execution.** Dispatch is delegated to `MoteExecutor::run`; the
+//!   scheduler does not invoke inference, dispatch tools, or open the content store.
+//! - **Does not message producers.** No async tasks, no channels, no actor
+//!   plumbing. Dispatch is a synchronous call on each `tick`.
+//!
+//! ## What lives here
+//!
+//! - [`Scheduler`] — the per-run dispatch state machine (placement + pending map).
+//! - [`Placement`] trait + [`LocalPlacement`] + [`RoundRobinPlacement`]
+//!   (the "trivial local impl" plus the "second trivial impl" the DoD requires).
+//! - [`WorkerId`] — opaque worker identifier returned by a placement.
+//! - [`DispatchSummary`] / [`DispatchedMote`] — per-tick outcome shapes.
+//! - [`SchedulerError`] — the scheduler's failure vocabulary.
+//!
+//! ## What does NOT live here
+//!
+//! - Journal append/read (executor's job).
+//! - Input recomputation, parent `result_ref` lookup, or input-set rebuilds
+//!   (the executor reads what it needs from the journal directly — see
+//!   `kx-executor/src/lifecycle.rs` recovery path).
+//! - Topology-decision child materialization (P1.11 — `is_topology_shaper`
+//!   Motes are dispatched here exactly like any other Mote; child rebuilding
+//!   happens in the projection on Commit per `projection.md` §5).
+//! - Workers / process supervision (P1.13 binary owns that).
+
+mod errors;
+mod placement;
+mod scheduler;
+mod worker;
+
+pub use errors::SchedulerError;
+pub use placement::{LocalPlacement, Placement, RoundRobinPlacement};
+pub use scheduler::{DispatchSummary, DispatchedMote, Scheduler};
+pub use worker::WorkerId;
+
+#[cfg(test)]
+mod tests;

--- a/crates/kx-scheduler/src/placement.rs
+++ b/crates/kx-scheduler/src/placement.rs
@@ -1,0 +1,127 @@
+//! Placement policy trait + two trivial impls.
+//!
+//! Per the P1.10 crate spec, placement is a **trait seam**:
+//! the scheduler holds a single `P: Placement` and the impl decides which
+//! `WorkerId` each Mote routes to. The DoD requires a "trivial local impl"
+//! plus a "second trivial impl" to prove the trait is substitutable;
+//! [`LocalPlacement`] and [`RoundRobinPlacement`] fill those slots.
+//!
+//! Placement does NOT see Mote bodies, parents, or warrants — only the
+//! `MoteId`. This keeps the trait small enough that a P5 cloud impl
+//! (rack-locality-aware, KV-cache-affinity-aware, NUMA-aware) can fit behind
+//! the same surface without leaking placement-internal state into the
+//! scheduler.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use kx_mote::MoteId;
+
+use crate::worker::WorkerId;
+
+/// Trait seam: decide which [`WorkerId`] receives a ready Mote.
+///
+/// **Inputs.** Only the `MoteId`. Placement decisions do not depend on the
+/// Mote's body, its parents, or its warrant — those concerns live in
+/// `kx-warrant` (capability scope) and `kx-executor` (resource fit).
+///
+/// **Determinism is NOT required.** [`RoundRobinPlacement`] mutates an
+/// internal counter; that's allowed. The scheduler relies on the projection
+/// for deterministic *ordering* (the projection's ready_set is deterministic
+/// in the journal-fold prefix); placement is a *routing* concern and may
+/// carry state.
+///
+/// `Send + Sync` is required: the P5 cloud impl will be shared across
+/// dispatch threads via `Arc<dyn Placement>`.
+///
+/// ```
+/// use kx_mote::MoteId;
+/// use kx_scheduler::{LocalPlacement, Placement, WorkerId};
+///
+/// // The trait shape is small — `place` takes a MoteId and returns a WorkerId.
+/// fn route<P: Placement>(p: &P, id: &MoteId) -> WorkerId {
+///     p.place(id)
+/// }
+/// let w = route(&LocalPlacement, &MoteId::from_bytes([0u8; 32]));
+/// assert_eq!(w, WorkerId(0));
+/// ```
+pub trait Placement: Send + Sync {
+    /// Choose a worker for the given Mote. Called once per dispatch.
+    fn place(&self, mote_id: &MoteId) -> WorkerId;
+}
+
+/// The trivial local placement — every Mote routes to `WorkerId(0)`.
+///
+/// Used by the P1 single-process runtime. The local executor runs
+/// in-process and there is exactly one worker; placement is a no-op
+/// decoration over that fact.
+///
+/// # Examples
+///
+/// ```
+/// use kx_mote::MoteId;
+/// use kx_scheduler::{LocalPlacement, Placement, WorkerId};
+///
+/// let p = LocalPlacement;
+/// assert_eq!(p.place(&MoteId::from_bytes([0u8; 32])), WorkerId(0));
+/// assert_eq!(p.place(&MoteId::from_bytes([0xff; 32])), WorkerId(0));
+/// ```
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LocalPlacement;
+
+impl Placement for LocalPlacement {
+    fn place(&self, _mote_id: &MoteId) -> WorkerId {
+        WorkerId(0)
+    }
+}
+
+/// The second trivial impl required by the DoD's "placement-trait swap" test.
+///
+/// Cycles ready Motes through `0..n_workers` in dispatch order via an
+/// atomic counter. Useful for tests + as a worked example that the trait
+/// seam is real (a second impl actually substitutes for the first).
+///
+/// # Examples
+///
+/// ```
+/// use kx_mote::MoteId;
+/// use kx_scheduler::{Placement, RoundRobinPlacement, WorkerId};
+///
+/// let p = RoundRobinPlacement::new(3);
+/// // The counter advances independently of `mote_id` content.
+/// assert_eq!(p.place(&MoteId::from_bytes([1u8; 32])), WorkerId(0));
+/// assert_eq!(p.place(&MoteId::from_bytes([2u8; 32])), WorkerId(1));
+/// assert_eq!(p.place(&MoteId::from_bytes([3u8; 32])), WorkerId(2));
+/// assert_eq!(p.place(&MoteId::from_bytes([4u8; 32])), WorkerId(0));
+/// ```
+#[derive(Debug)]
+pub struct RoundRobinPlacement {
+    n_workers: u64,
+    next: AtomicU64,
+}
+
+impl RoundRobinPlacement {
+    /// Construct a round-robin placement cycling through `n_workers` workers.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n_workers == 0` — a placement that returns no worker is
+    /// not a valid placement.
+    #[must_use]
+    pub fn new(n_workers: u64) -> Self {
+        assert!(
+            n_workers > 0,
+            "RoundRobinPlacement requires at least one worker"
+        );
+        Self {
+            n_workers,
+            next: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Placement for RoundRobinPlacement {
+    fn place(&self, _mote_id: &MoteId) -> WorkerId {
+        let i = self.next.fetch_add(1, Ordering::Relaxed);
+        WorkerId(i % self.n_workers)
+    }
+}

--- a/crates/kx-scheduler/src/scheduler.rs
+++ b/crates/kx-scheduler/src/scheduler.rs
@@ -1,0 +1,194 @@
+//! [`Scheduler`] — the per-run dispatch state machine.
+//!
+//! On each [`Scheduler::tick`] the scheduler asks the
+//! [`Projection`](kx_projection::Projection) which submitted Motes are ready
+//! (parents all `Committed-and-not-Repudiated`), routes each through the
+//! [`Placement`] policy, and hands the Mote + warrant to the
+//! [`kx_executor::MoteExecutor`].
+//!
+//! The scheduler owns no journal handle and no content-store handle; it
+//! never appends to the journal, never reconstructs Mote inputs, never
+//! looks up parent `result_ref`s. The executor reads what it needs from the
+//! journal directly (see `kx-executor/src/lifecycle.rs` recovery path).
+
+use std::collections::BTreeMap;
+
+use kx_executor::{MoteExecutionResult, MoteExecutor, MoteExecutorError};
+use kx_mote::{Mote, MoteId};
+use kx_projection::{Projection, RegisterMote};
+use kx_warrant::WarrantSpec;
+
+use crate::errors::SchedulerError;
+use crate::placement::Placement;
+use crate::worker::WorkerId;
+
+/// One row of [`DispatchSummary`]: the outcome of a single
+/// [`MoteExecutor::run`] invocation during a tick.
+///
+/// The scheduler does not interpret `result` — the caller (P1.13 binary or
+/// test harness) is responsible for translating successes into `Committed`
+/// journal entries and failures into `Failed` entries, then folding those
+/// into the [`Projection`] before the next tick.
+#[derive(Debug)]
+pub struct DispatchedMote {
+    /// The Mote that was dispatched.
+    pub mote_id: MoteId,
+    /// Where the [`Placement`] routed it.
+    pub worker: WorkerId,
+    /// The executor's typed outcome. The scheduler surfaces this verbatim.
+    pub result: Result<MoteExecutionResult, MoteExecutorError>,
+}
+
+/// Per-tick outcome — one [`DispatchedMote`] for each Mote dispatched.
+///
+/// An empty `dispatched` vector means the tick was a no-op (no ready Motes
+/// in the projection's submitted set). Caller may sleep and tick again, or
+/// fold new journal entries first.
+#[derive(Debug, Default)]
+pub struct DispatchSummary {
+    /// One row per Mote dispatched during the tick.
+    pub dispatched: Vec<DispatchedMote>,
+}
+
+/// The per-run scheduler — placement + pending submitted Motes.
+///
+/// **No journal handle. No content-store handle. No projection ownership.**
+/// The caller (P1.13 binary or test harness) owns the [`Projection`] and
+/// passes it in on each call. This makes "never writes the journal" and
+/// "reads only the projection" structural: the scheduler crate cannot
+/// reach a `Journal` because the type is not in its production deps.
+///
+/// # End-to-end usage
+///
+/// ```
+/// use kx_mote::MoteId;
+/// use kx_projection::Projection;
+/// use kx_scheduler::{LocalPlacement, Scheduler};
+///
+/// // The caller owns the projection (P1.13 runtime binary's role).
+/// let projection = Projection::new();
+/// let scheduler = Scheduler::new(LocalPlacement);
+///
+/// // Brand-new scheduler has nothing pending and nothing ready.
+/// assert_eq!(scheduler.pending_count(), 0);
+/// assert!(projection.ready_set().is_empty());
+/// # let _ = MoteId::from_bytes([0u8; 32]);
+/// ```
+///
+/// Full submit + tick flows live in `tests/integration_dag_ordering.rs`
+/// (linear-chain + diamond + multi-root cases).
+#[derive(Debug)]
+pub struct Scheduler<P: Placement> {
+    placement: P,
+    pending: BTreeMap<MoteId, (Mote, WarrantSpec)>,
+}
+
+impl<P: Placement> Scheduler<P> {
+    /// Construct a scheduler with the given placement policy.
+    ///
+    /// ```
+    /// use kx_scheduler::{LocalPlacement, Scheduler};
+    /// let s = Scheduler::new(LocalPlacement);
+    /// assert_eq!(s.pending_count(), 0);
+    /// ```
+    #[must_use]
+    pub fn new(placement: P) -> Self {
+        Self {
+            placement,
+            pending: BTreeMap::new(),
+        }
+    }
+
+    /// Number of Motes currently in the pending map.
+    ///
+    /// A Mote enters the map on [`Scheduler::submit`] and leaves on
+    /// [`Scheduler::tick`] once dispatched. This count is for diagnostics
+    /// only — orchestration decisions go through the [`Projection`].
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Register a workflow-declared Mote with the projection and store it
+    /// for later dispatch.
+    ///
+    /// Two side effects:
+    ///
+    /// 1. Calls `projection.register_mote(...)` so the projection's
+    ///    `state_of(mote.id)` returns [`kx_projection::MoteState::Pending`]
+    ///    and `ready_set` will yield this Mote once its parents commit.
+    /// 2. Inserts `(mote, warrant)` into the scheduler's pending map keyed
+    ///    on `mote.id`.
+    ///
+    /// Returns [`SchedulerError::DuplicateSubmission`] if the id is already
+    /// in the pending map (i.e., submitted twice before dispatch). The
+    /// projection's `register_mote` itself is idempotent (per
+    /// `kx-projection/src/projection.rs:84-101`), so re-submitting a Mote
+    /// after it has been dispatched is fine — the projection just updates
+    /// the declared info, and the scheduler stores the new (mote, warrant)
+    /// pair.
+    pub fn submit(
+        &mut self,
+        mote: Mote,
+        warrant: WarrantSpec,
+        projection: &mut Projection,
+    ) -> Result<(), SchedulerError> {
+        if self.pending.contains_key(&mote.id) {
+            return Err(SchedulerError::DuplicateSubmission(mote.id));
+        }
+        projection.register_mote(RegisterMote {
+            mote_id: mote.id,
+            nd_class: mote.def.nd_class,
+            effect_pattern: mote.def.effect_pattern,
+            critic_for: mote.def.critic_for,
+            is_topology_shaper: mote.def.is_topology_shaper,
+            parents: mote.parents.clone(),
+        });
+        self.pending.insert(mote.id, (mote, warrant));
+        Ok(())
+    }
+
+    /// Drive one round of dispatch.
+    ///
+    /// 1. Read `projection.ready_set()` — the canonical "parents all
+    ///    Committed-and-not-Repudiated AND WORLD-MUTATING parents promoted"
+    ///    filter, sourced from `projection.md` §7.
+    /// 2. For each ready `MoteId` that is also in the scheduler's pending
+    ///    map: ask placement which worker, then hand the Mote + warrant to
+    ///    `executor.run(&mote, &warrant, None)`.
+    /// 3. Collect every per-Mote outcome into [`DispatchSummary`].
+    ///
+    /// Note the `None` environment argument: P1 dispatches without an
+    /// explicit rootfs ref; the executor's pre-spawn step derives rootfs
+    /// from `warrant.environment_ref` when that lands at PR 11+.
+    ///
+    /// The dispatched Mote is removed from the pending map regardless of
+    /// the executor's outcome. The caller is responsible for translating
+    /// `Ok(MoteExecutionResult)` into a `Committed` journal entry and
+    /// `Err(MoteExecutorError)` into a `Failed` entry; the scheduler does
+    /// not journal anything itself.
+    pub fn tick<E: MoteExecutor>(
+        &mut self,
+        projection: &Projection,
+        executor: &E,
+    ) -> Result<DispatchSummary, SchedulerError> {
+        let ready = projection.ready_set();
+        let mut dispatched = Vec::new();
+        for mote_id in ready {
+            // Skip ready ids the scheduler has no pending entry for — those
+            // were either submitted to a different scheduler instance or
+            // already dispatched in a prior tick.
+            let Some((mote, warrant)) = self.pending.remove(&mote_id) else {
+                continue;
+            };
+            let worker = self.placement.place(&mote_id);
+            let result = executor.run(&mote, &warrant, None);
+            dispatched.push(DispatchedMote {
+                mote_id,
+                worker,
+                result,
+            });
+        }
+        Ok(DispatchSummary { dispatched })
+    }
+}

--- a/crates/kx-scheduler/src/tests.rs
+++ b/crates/kx-scheduler/src/tests.rs
@@ -1,0 +1,50 @@
+//! Inline unit tests covering small properties of [`crate::WorkerId`],
+//! [`crate::Placement`] impls, and [`crate::SchedulerError`].
+//!
+//! Larger DoD-bearing scenarios live in `tests/integration_*.rs`.
+
+use kx_mote::MoteId;
+
+use crate::errors::SchedulerError;
+use crate::placement::{LocalPlacement, Placement, RoundRobinPlacement};
+use crate::worker::WorkerId;
+
+#[test]
+fn worker_id_is_ord_for_btreemap_keys() {
+    let mut ids = [WorkerId(3), WorkerId(1), WorkerId(2)];
+    ids.sort();
+    assert_eq!(ids, [WorkerId(1), WorkerId(2), WorkerId(3)]);
+}
+
+#[test]
+fn local_placement_always_returns_worker_zero() {
+    let p = LocalPlacement;
+    assert_eq!(p.place(&MoteId::from_bytes([0u8; 32])), WorkerId(0));
+    assert_eq!(p.place(&MoteId::from_bytes([1u8; 32])), WorkerId(0));
+    assert_eq!(p.place(&MoteId::from_bytes([0xff; 32])), WorkerId(0));
+}
+
+#[test]
+fn round_robin_placement_cycles_through_workers() {
+    let p = RoundRobinPlacement::new(3);
+    let any = MoteId::from_bytes([0u8; 32]);
+    assert_eq!(p.place(&any), WorkerId(0));
+    assert_eq!(p.place(&any), WorkerId(1));
+    assert_eq!(p.place(&any), WorkerId(2));
+    assert_eq!(p.place(&any), WorkerId(0));
+    assert_eq!(p.place(&any), WorkerId(1));
+}
+
+#[test]
+#[should_panic(expected = "RoundRobinPlacement requires at least one worker")]
+fn round_robin_placement_rejects_zero_workers() {
+    let _ = RoundRobinPlacement::new(0);
+}
+
+#[test]
+fn scheduler_error_display_includes_mote_id() {
+    let id = MoteId::from_bytes([7u8; 32]);
+    let err = SchedulerError::DuplicateSubmission(id);
+    let s = format!("{err}");
+    assert!(s.contains("already submitted"), "got: {s}");
+}

--- a/crates/kx-scheduler/src/worker.rs
+++ b/crates/kx-scheduler/src/worker.rs
@@ -1,0 +1,18 @@
+//! [`WorkerId`] — opaque worker identifier returned by a [`crate::Placement`].
+
+/// Opaque worker identifier returned by a [`crate::Placement`] implementation.
+///
+/// Semantic interpretation is the placement's; the scheduler treats it as a
+/// black-box value and surfaces it back on [`crate::DispatchedMote::worker`].
+/// The P1 single-process runtime uses `WorkerId(0)` for the local executor; a
+/// multi-worker placement (P2) would issue distinct ids per remote worker.
+///
+/// ```
+/// use kx_scheduler::WorkerId;
+/// let w = WorkerId(7);
+/// assert_eq!(w.0, 7);
+/// // `Ord` is derived for use as a BTreeMap key.
+/// assert!(WorkerId(1) < WorkerId(2));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WorkerId(pub u64);

--- a/crates/kx-scheduler/tests/common/mod.rs
+++ b/crates/kx-scheduler/tests/common/mod.rs
@@ -1,0 +1,188 @@
+//! Shared fixtures across the kx-scheduler integration tests.
+//!
+//! Provides a [`MockExecutor`] (records dispatched MoteIds, returns
+//! deterministic results), warrant + Mote builders, and helpers to
+//! synthesize `Committed` / `Failed` journal entries for the test harness
+//! to fold into a [`Projection`].
+//!
+//! The fixture deliberately keeps the test code itself responsible for
+//! constructing and folding journal entries — the scheduler under test
+//! never sees a `Journal` handle (the production crate doesn't depend on
+//! `kx-journal`), so the test layer plays the role the executor's
+//! lifecycle layer plays in production.
+
+#![allow(dead_code)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Mutex;
+
+use kx_content::ContentRef;
+use kx_executor::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
+use kx_journal::{FailureReason, JournalEntry, ParentEntry};
+use kx_mote::{
+    EdgeKind, EdgeMeta, EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote,
+    MoteDef, MoteDefHash, MoteId, NdClass, ParentRef, PromptTemplateHash,
+};
+use kx_projection::Projection;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+/// A test executor that records every dispatched MoteId and returns a
+/// deterministic `result_ref` derived from `mote.id`. Does NOT actually
+/// execute anything; serves as the seam-respecting dispatch target.
+///
+/// The executor's outputs are owned by the executor — the scheduler never
+/// asks this struct for a result_ref or a parent lookup; it only passes
+/// the executor's verbatim outcome through `DispatchedMote.result`.
+#[derive(Default)]
+pub(crate) struct MockExecutor {
+    pub(crate) calls: Mutex<Vec<MoteId>>,
+}
+
+impl MoteExecutor for MockExecutor {
+    fn run(
+        &self,
+        mote: &Mote,
+        _warrant: &WarrantSpec,
+        _env: Option<Rootfs>,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        self.calls.lock().unwrap().push(mote.id);
+        let result_ref = ContentRef::of(mote.id.as_bytes());
+        Ok(MoteExecutionResult {
+            result_ref,
+            started_at_epoch_ms: 0,
+            finished_at_epoch_ms: 0,
+        })
+    }
+
+    fn supports(&self, _executor_class: kx_warrant::ExecutorClass) -> bool {
+        true
+    }
+}
+
+impl MockExecutor {
+    pub(crate) fn dispatched_ids(&self) -> Vec<MoteId> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    pub(crate) fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+}
+
+/// Construct a permissive warrant suitable for the scheduler's PURE
+/// integration tests. The mock executor doesn't enforce any of these,
+/// but real `WarrantSpec` requires every field, so the helper exists to
+/// keep the test code tight.
+pub(crate) fn permissive_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("test".into()),
+            max_input_tokens: 1000,
+            max_output_tokens: 1000,
+            max_calls: 1,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 28,
+            wall_clock_ms: 5000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// Construct a PURE Mote with the given `position` and `parents`. The
+/// `input_data_id` is derived from `position` so different positions
+/// yield distinct `MoteId`s without ceremony.
+pub(crate) fn pure_mote(position: &[u8], parents: SmallVec<[ParentRef; 4]>) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([0u8; 32]),
+        model_id: ModelId("test".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([0u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        schema_version: 3,
+    };
+    let mut input_data = [0u8; 32];
+    let len = position.len().min(32);
+    input_data[..len].copy_from_slice(&position[..len]);
+    Mote::new(
+        def,
+        InputDataId::from_bytes(input_data),
+        GraphPosition(position.to_vec()),
+        parents,
+    )
+}
+
+/// Build a Data-edge [`ParentRef`] pointing at `parent`.
+pub(crate) fn data_parent(parent: &Mote) -> ParentRef {
+    ParentRef {
+        parent_id: parent.id,
+        edge: EdgeMeta {
+            kind: EdgeKind::Data,
+            non_cascade: false,
+        },
+    }
+}
+
+/// Synthesize a `Committed` entry for the given Mote at the given `seq`.
+///
+/// In production the executor's lifecycle layer builds and appends this;
+/// the scheduler's tests do it themselves so the projection has the
+/// committed fact to surface through `ready_set()`. The test owns the
+/// `result_ref` end-to-end — the scheduler never asks anyone for it.
+pub(crate) fn committed_entry(mote: &Mote, seq: u64) -> JournalEntry {
+    let parents = mote
+        .parents
+        .iter()
+        .map(ParentEntry::from_parent_ref)
+        .collect();
+    JournalEntry::Committed {
+        mote_id: mote.id,
+        idempotency_key: *mote.id.as_bytes(),
+        seq,
+        nondeterminism: mote.def.nd_class,
+        result_ref: ContentRef::of(mote.id.as_bytes()),
+        parents,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([0u8; 32]),
+    }
+}
+
+/// Synthesize a non-terminal (pre-commit-crash) `Failed` entry at the
+/// given `seq`. Per `kx_journal::is_pre_commit_crash`, `WorkerCrashed`
+/// leaves `terminal_failure_observed` unset — the projection treats the
+/// Mote as still-Pending (retry-allowed); ready_set still excludes
+/// children because the Mote is not Committed.
+pub(crate) fn failed_worker_crashed(mote: &Mote, seq: u64) -> JournalEntry {
+    JournalEntry::Failed {
+        mote_id: mote.id,
+        idempotency_key: *mote.id.as_bytes(),
+        seq,
+        reason_class: FailureReason::WorkerCrashed,
+        reporter_id: 0,
+    }
+}
+
+/// Fold an entry into the projection, panicking on error (test helper).
+pub(crate) fn fold_or_panic(projection: &mut Projection, entry: &JournalEntry) {
+    projection
+        .fold(entry)
+        .expect("test-synthesized journal entry must fold cleanly");
+}

--- a/crates/kx-scheduler/tests/concurrency.rs
+++ b/crates/kx-scheduler/tests/concurrency.rs
@@ -1,0 +1,102 @@
+//! SN-4 v2 #6 — concurrency tests for `kx-scheduler`.
+//!
+//! Two concerns:
+//!
+//! - Compile-time `Send + Sync` over the full public-type set, including
+//!   `Arc<dyn Placement>` (proves the trait shape admits a P5 cloud impl
+//!   behind the same handle).
+//! - 4-thread thread-independence of [`Placement::place`] on
+//!   [`RoundRobinPlacement`] (proves the atomic counter is correct under
+//!   contention — no torn reads, no missed advances).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::sync::Arc;
+use std::thread;
+
+use kx_mote::MoteId;
+use kx_scheduler::{
+    DispatchSummary, DispatchedMote, LocalPlacement, Placement, RoundRobinPlacement, Scheduler,
+    SchedulerError, WorkerId,
+};
+
+// ---------------------------------------------------------------------------
+// Compile-time Send + Sync over the public surface (SN-4 v2 #6 part 1)
+// ---------------------------------------------------------------------------
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn public_types_are_send_and_sync() {
+    // Worker + error vocabulary.
+    assert_send_sync::<WorkerId>();
+    assert_send_sync::<SchedulerError>();
+
+    // Placement impls + the dyn trait.
+    assert_send_sync::<LocalPlacement>();
+    assert_send_sync::<RoundRobinPlacement>();
+    assert_send_sync::<Arc<dyn Placement>>();
+
+    // Dispatch summary shapes.
+    assert_send_sync::<DispatchedMote>();
+    assert_send_sync::<DispatchSummary>();
+
+    // The Scheduler over a concrete placement.
+    assert_send_sync::<Scheduler<LocalPlacement>>();
+    assert_send_sync::<Scheduler<RoundRobinPlacement>>();
+}
+
+// ---------------------------------------------------------------------------
+// 4-thread RoundRobinPlacement contention (SN-4 v2 #6 part 2)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_robin_place_is_thread_safe_under_contention() {
+    const N_THREADS: usize = 4;
+    const PLACES_PER_THREAD: usize = 50;
+    const N_WORKERS: u64 = 3;
+
+    let placement = Arc::new(RoundRobinPlacement::new(N_WORKERS));
+    let handles: Vec<_> = (0..N_THREADS)
+        .map(|_| {
+            let p = Arc::clone(&placement);
+            thread::spawn(move || {
+                let mut out = Vec::with_capacity(PLACES_PER_THREAD);
+                let id = MoteId::from_bytes([0u8; 32]);
+                for _ in 0..PLACES_PER_THREAD {
+                    out.push(p.place(&id));
+                }
+                out
+            })
+        })
+        .collect();
+
+    let mut all: Vec<WorkerId> = Vec::with_capacity(N_THREADS * PLACES_PER_THREAD);
+    for h in handles {
+        all.extend(h.join().expect("worker did not panic"));
+    }
+
+    // Total assignments equal total calls (atomic counter advanced exactly
+    // N_THREADS * PLACES_PER_THREAD times).
+    assert_eq!(all.len(), N_THREADS * PLACES_PER_THREAD);
+
+    // Worker distribution is exactly balanced — every worker received the
+    // same number of placements. With N_WORKERS=3 and 200 calls total,
+    // each worker gets exactly 200 / 3 = 66.66… → 67/67/66 in some order
+    // because 200 % 3 = 2. Assert the multiset spread sums correctly and
+    // every count is within ±1 of mean.
+    let mut counts = [0usize; N_WORKERS as usize];
+    for w in &all {
+        counts[w.0 as usize] += 1;
+    }
+    let total: usize = counts.iter().sum();
+    assert_eq!(total, N_THREADS * PLACES_PER_THREAD);
+    let mean = (N_THREADS * PLACES_PER_THREAD) as f64 / N_WORKERS as f64;
+    for c in counts {
+        let delta = (c as f64 - mean).abs();
+        assert!(
+            delta <= 1.0,
+            "worker count {c} too far from mean {mean}; full counts: {counts:?}"
+        );
+    }
+}

--- a/crates/kx-scheduler/tests/integration_blocked_until_committed.rs
+++ b/crates/kx-scheduler/tests/integration_blocked_until_committed.rs
@@ -1,0 +1,129 @@
+//! **DoD test 2** (per the P1.10 crate spec): the scheduler honors
+//! "blocked until committed" rules. A child Mote whose parent has only
+//! Failed (no Committed) is not dispatched; once the parent commits, the
+//! child becomes ready on the next tick.
+//!
+//! Uses [`kx_journal::FailureReason::WorkerCrashed`] (a pre-commit-crash
+//! per `is_pre_commit_crash`) so the projection treats the parent as still
+//! pending (retry-allowed), then a real Committed to unblock the child.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_projection::Projection;
+use kx_scheduler::{LocalPlacement, Scheduler};
+use smallvec::{smallvec, SmallVec};
+
+use crate::common::{
+    committed_entry, data_parent, failed_worker_crashed, fold_or_panic, permissive_warrant,
+    pure_mote, MockExecutor,
+};
+
+#[test]
+fn child_blocked_while_parent_only_failed_then_dispatches_on_parent_commit() {
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let executor = MockExecutor::default();
+    let warrant = permissive_warrant();
+
+    let parent = pure_mote(b"/parent", SmallVec::new());
+    let child = pure_mote(b"/child", smallvec![data_parent(&parent)]);
+
+    scheduler
+        .submit(parent.clone(), warrant.clone(), &mut projection)
+        .unwrap();
+    scheduler
+        .submit(child.clone(), warrant.clone(), &mut projection)
+        .unwrap();
+
+    // Tick 1: parent dispatches (no parents of its own). Child blocked.
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    let ids: Vec<_> = s.dispatched.iter().map(|d| d.mote_id).collect();
+    assert_eq!(
+        ids,
+        vec![parent.id],
+        "parent must dispatch; child blocked on parent commit"
+    );
+
+    // Test harness records the parent's attempt as a non-terminal failure.
+    // Per `is_pre_commit_crash`, WorkerCrashed leaves the Mote retry-eligible
+    // and NOT terminal-failed; the projection's `state_of_id` returns Pending
+    // (failed_pending_reattempt = true). The child remains blocked because
+    // the parent is NOT Committed.
+    fold_or_panic(&mut projection, &failed_worker_crashed(&parent, 1));
+
+    // Tick 2: child still blocked — parent is not Committed. The parent is
+    // also not re-dispatched because the scheduler removed it from the
+    // pending map on Tick 1; only a fresh submit would put it back.
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    assert!(
+        s.dispatched.is_empty(),
+        "child must remain blocked while parent is only Failed (not Committed)"
+    );
+
+    // Now record the parent's eventual commit.
+    fold_or_panic(&mut projection, &committed_entry(&parent, 2));
+
+    // Tick 3: child ready.
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    let ids: Vec<_> = s.dispatched.iter().map(|d| d.mote_id).collect();
+    assert_eq!(
+        ids,
+        vec![child.id],
+        "child must dispatch once parent commits"
+    );
+
+    assert_eq!(executor.dispatched_ids(), vec![parent.id, child.id]);
+}
+
+#[test]
+fn submitted_mote_with_unsubmitted_parent_never_dispatches() {
+    // The parent is referenced by `data_parent` but never submitted to the
+    // scheduler AND never registered with the projection. ready_set requires
+    // the parent's state to be Committed; an unknown parent reads as not-
+    // Committed; the child stays blocked forever.
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let executor = MockExecutor::default();
+    let warrant = permissive_warrant();
+
+    let phantom_parent = pure_mote(b"/phantom", SmallVec::new());
+    let child = pure_mote(b"/child", smallvec![data_parent(&phantom_parent)]);
+
+    scheduler
+        .submit(child, warrant, &mut projection)
+        .expect("submit child");
+
+    // Tick: child blocked because phantom_parent isn't Committed (it isn't
+    // anywhere — not in scheduler, not in projection, not in journal).
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    assert!(
+        s.dispatched.is_empty(),
+        "child with an unknown parent must not dispatch"
+    );
+    assert_eq!(executor.call_count(), 0);
+}
+
+#[test]
+fn duplicate_submit_returns_error() {
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let warrant = permissive_warrant();
+
+    let m = pure_mote(b"/m", SmallVec::new());
+
+    scheduler
+        .submit(m.clone(), warrant.clone(), &mut projection)
+        .expect("first submit ok");
+
+    let err = scheduler
+        .submit(m.clone(), warrant, &mut projection)
+        .expect_err("second submit must error");
+
+    match err {
+        kx_scheduler::SchedulerError::DuplicateSubmission(id) => {
+            assert_eq!(id, m.id);
+        }
+    }
+}

--- a/crates/kx-scheduler/tests/integration_dag_ordering.rs
+++ b/crates/kx-scheduler/tests/integration_dag_ordering.rs
@@ -1,0 +1,180 @@
+//! **DoD test 1** (per the P1.10 crate spec): the scheduler resolves a
+//! multi-Mote DAG in correct order from the projection alone.
+//!
+//! Linear chain M1 → M2 → M3 (Data edges). Submit all three; tick once
+//! per Mote; assert each tick dispatches only the next-ready Mote and
+//! that no out-of-order dispatch occurs.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_mote::Mote;
+use kx_projection::Projection;
+use kx_scheduler::{LocalPlacement, Scheduler};
+use smallvec::{smallvec, SmallVec};
+
+use crate::common::{
+    committed_entry, data_parent, fold_or_panic, permissive_warrant, pure_mote, MockExecutor,
+};
+
+#[test]
+fn linear_chain_dispatches_in_parent_then_child_order() {
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let executor = MockExecutor::default();
+    let warrant = permissive_warrant();
+
+    let m1 = pure_mote(b"/m1", SmallVec::new());
+    let m2 = pure_mote(b"/m2", smallvec![data_parent(&m1)]);
+    let m3 = pure_mote(b"/m3", smallvec![data_parent(&m2)]);
+
+    scheduler
+        .submit(m1.clone(), warrant.clone(), &mut projection)
+        .expect("submit m1");
+    scheduler
+        .submit(m2.clone(), warrant.clone(), &mut projection)
+        .expect("submit m2");
+    scheduler
+        .submit(m3.clone(), warrant.clone(), &mut projection)
+        .expect("submit m3");
+
+    assert_eq!(scheduler.pending_count(), 3);
+
+    // Tick 1: only M1 is ready (no parents). M2 and M3 wait for M1's commit.
+    let summary = scheduler.tick(&projection, &executor).expect("tick 1");
+    let dispatched: Vec<_> = summary.dispatched.iter().map(|d| d.mote_id).collect();
+    assert_eq!(
+        dispatched,
+        vec![m1.id],
+        "tick 1 must dispatch only M1; M2 and M3 are blocked on M1's commit"
+    );
+    assert_eq!(scheduler.pending_count(), 2);
+
+    // Test harness folds M1's Committed (in production the executor's
+    // lifecycle layer would do this).
+    fold_or_panic(&mut projection, &committed_entry(&m1, 1));
+
+    // Tick 2: M2 now ready.
+    let summary = scheduler.tick(&projection, &executor).expect("tick 2");
+    let dispatched: Vec<_> = summary.dispatched.iter().map(|d| d.mote_id).collect();
+    assert_eq!(
+        dispatched,
+        vec![m2.id],
+        "tick 2 must dispatch only M2; M3 still blocked on M2's commit"
+    );
+    assert_eq!(scheduler.pending_count(), 1);
+
+    fold_or_panic(&mut projection, &committed_entry(&m2, 2));
+
+    // Tick 3: M3 ready.
+    let summary = scheduler.tick(&projection, &executor).expect("tick 3");
+    let dispatched: Vec<_> = summary.dispatched.iter().map(|d| d.mote_id).collect();
+    assert_eq!(dispatched, vec![m3.id], "tick 3 must dispatch M3");
+    assert_eq!(scheduler.pending_count(), 0);
+
+    fold_or_panic(&mut projection, &committed_entry(&m3, 3));
+
+    // Tick 4: no work left.
+    let summary = scheduler.tick(&projection, &executor).expect("tick 4");
+    assert!(
+        summary.dispatched.is_empty(),
+        "tick 4 must be a no-op; pending map is empty"
+    );
+
+    // Total dispatch order observed by the executor:
+    assert_eq!(executor.dispatched_ids(), vec![m1.id, m2.id, m3.id]);
+}
+
+#[test]
+fn two_root_motes_both_dispatch_on_first_tick() {
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let executor = MockExecutor::default();
+    let warrant = permissive_warrant();
+
+    let m1 = pure_mote(b"/root-a", SmallVec::new());
+    let m2 = pure_mote(b"/root-b", SmallVec::new());
+
+    scheduler
+        .submit(m1.clone(), warrant.clone(), &mut projection)
+        .expect("submit m1");
+    scheduler
+        .submit(m2.clone(), warrant.clone(), &mut projection)
+        .expect("submit m2");
+
+    let summary = scheduler.tick(&projection, &executor).expect("tick");
+    let dispatched: std::collections::BTreeSet<_> =
+        summary.dispatched.iter().map(|d| d.mote_id).collect();
+    let expected: std::collections::BTreeSet<_> = [m1.id, m2.id].into_iter().collect();
+    assert_eq!(
+        dispatched, expected,
+        "both root Motes (no parents) must dispatch on the first tick"
+    );
+}
+
+#[test]
+fn diamond_dag_dispatches_in_correct_order() {
+    //   M1  (root)
+    //   / \
+    // M2   M3
+    //   \ /
+    //   M4
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let executor = MockExecutor::default();
+    let warrant = permissive_warrant();
+
+    let m1 = pure_mote(b"/m1", SmallVec::new());
+    let m2 = pure_mote(b"/m2", smallvec![data_parent(&m1)]);
+    let m3 = pure_mote(b"/m3", smallvec![data_parent(&m1)]);
+    let m4 = pure_mote(b"/m4", smallvec![data_parent(&m2), data_parent(&m3)]);
+
+    for m in [&m1, &m2, &m3, &m4] {
+        scheduler
+            .submit(Mote::clone(m), warrant.clone(), &mut projection)
+            .unwrap();
+    }
+
+    // Tick 1: only M1.
+    let s1 = scheduler.tick(&projection, &executor).unwrap();
+    assert_eq!(
+        s1.dispatched.iter().map(|d| d.mote_id).collect::<Vec<_>>(),
+        vec![m1.id]
+    );
+
+    fold_or_panic(&mut projection, &committed_entry(&m1, 1));
+
+    // Tick 2: M2 and M3 both ready (siblings under M1).
+    let s2 = scheduler.tick(&projection, &executor).unwrap();
+    let s2_ids: std::collections::BTreeSet<_> = s2.dispatched.iter().map(|d| d.mote_id).collect();
+    assert_eq!(
+        s2_ids,
+        [m2.id, m3.id].into_iter().collect(),
+        "M2 and M3 must both dispatch — they share M1 as parent and have no other deps"
+    );
+
+    fold_or_panic(&mut projection, &committed_entry(&m2, 2));
+    // Tick 3 with only M2 committed: M4 still blocked on M3.
+    let s3 = scheduler.tick(&projection, &executor).unwrap();
+    assert!(s3.dispatched.is_empty(), "M4 still blocked on M3");
+
+    fold_or_panic(&mut projection, &committed_entry(&m3, 3));
+    // Tick 4: M4 now ready.
+    let s4 = scheduler.tick(&projection, &executor).unwrap();
+    assert_eq!(
+        s4.dispatched.iter().map(|d| d.mote_id).collect::<Vec<_>>(),
+        vec![m4.id]
+    );
+}
+
+#[test]
+fn empty_tick_returns_empty_summary() {
+    let projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    let executor = MockExecutor::default();
+
+    let summary = scheduler.tick(&projection, &executor).expect("tick");
+    assert!(summary.dispatched.is_empty());
+    assert_eq!(executor.call_count(), 0);
+}

--- a/crates/kx-scheduler/tests/integration_placement_swap.rs
+++ b/crates/kx-scheduler/tests/integration_placement_swap.rs
@@ -1,0 +1,92 @@
+//! **DoD test 3** (per the P1.10 crate spec): the placement policy is
+//! behind a trait, and a second trivial impl substitutes for the first
+//! without changing dispatch order or correctness.
+//!
+//! Same DAG; first run under [`LocalPlacement`], second run under
+//! [`RoundRobinPlacement::new(3)`]. Assert worker IDs differ across the
+//! two runs; assert dispatch ordering is identical.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_projection::Projection;
+use kx_scheduler::{LocalPlacement, Placement, RoundRobinPlacement, Scheduler, WorkerId};
+use smallvec::{smallvec, SmallVec};
+
+use crate::common::{
+    committed_entry, data_parent, fold_or_panic, permissive_warrant, pure_mote, MockExecutor,
+};
+
+fn run_chain<P: Placement>(placement: P) -> (Vec<kx_mote::MoteId>, Vec<WorkerId>) {
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(placement);
+    let executor = MockExecutor::default();
+    let warrant = permissive_warrant();
+
+    let m1 = pure_mote(b"/m1", SmallVec::new());
+    let m2 = pure_mote(b"/m2", smallvec![data_parent(&m1)]);
+    let m3 = pure_mote(b"/m3", smallvec![data_parent(&m2)]);
+
+    for m in [&m1, &m2, &m3] {
+        scheduler
+            .submit(kx_mote::Mote::clone(m), warrant.clone(), &mut projection)
+            .unwrap();
+    }
+
+    let mut order = Vec::new();
+    let mut workers = Vec::new();
+
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    for d in s.dispatched {
+        order.push(d.mote_id);
+        workers.push(d.worker);
+    }
+    fold_or_panic(&mut projection, &committed_entry(&m1, 1));
+
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    for d in s.dispatched {
+        order.push(d.mote_id);
+        workers.push(d.worker);
+    }
+    fold_or_panic(&mut projection, &committed_entry(&m2, 2));
+
+    let s = scheduler.tick(&projection, &executor).unwrap();
+    for d in s.dispatched {
+        order.push(d.mote_id);
+        workers.push(d.worker);
+    }
+    fold_or_panic(&mut projection, &committed_entry(&m3, 3));
+
+    (order, workers)
+}
+
+#[test]
+fn local_and_round_robin_produce_same_dispatch_order_with_different_workers() {
+    let (local_order, local_workers) = run_chain(LocalPlacement);
+    let (rr_order, rr_workers) = run_chain(RoundRobinPlacement::new(3));
+
+    // Same MoteIds in the same order under both policies — placement
+    // does not change dispatch sequence (ordering is the projection's job).
+    assert_eq!(
+        local_order, rr_order,
+        "dispatch order must be identical across placements; placement does not change ordering"
+    );
+
+    // LocalPlacement → every dispatched Mote went to worker 0.
+    assert!(
+        local_workers.iter().all(|w| *w == WorkerId(0)),
+        "LocalPlacement must route every Mote to WorkerId(0); got: {local_workers:?}"
+    );
+
+    // RoundRobinPlacement(3) → workers cycle 0, 1, 2 across the 3 dispatches.
+    assert_eq!(
+        rr_workers,
+        vec![WorkerId(0), WorkerId(1), WorkerId(2)],
+        "RoundRobinPlacement(3) must cycle workers in dispatch order"
+    );
+
+    // The two impls produced DIFFERENT worker sequences — proves the
+    // trait is actually substitutable and not a hardcoded behavior.
+    assert_ne!(local_workers, rr_workers);
+}

--- a/crates/kx-scheduler/tests/proptest_scheduler.rs
+++ b/crates/kx-scheduler/tests/proptest_scheduler.rs
@@ -1,0 +1,125 @@
+//! SN-4 v2 #5 — property tests covering the DAG-ordering invariant
+//! across arbitrary linear chains and small diamond shapes.
+//!
+//! **The load-bearing property**: every dispatched Mote had all its
+//! Data-edge parents in `Committed` state at the moment of dispatch.
+//! That property is sourced from `Projection::ready_set()` — the
+//! scheduler's job is only to honor it. The proptest is the
+//! per-arbitrary-input executable form of "DAG ordering is correct."
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_projection::{MoteState, Projection};
+use kx_scheduler::{LocalPlacement, Scheduler};
+use proptest::prelude::*;
+use smallvec::{smallvec, SmallVec};
+
+use crate::common::{
+    committed_entry, data_parent, fold_or_panic, permissive_warrant, pure_mote, MockExecutor,
+};
+
+proptest! {
+    /// Build a linear chain of N (2..=8) PURE Motes M1 → M2 → ... → MN.
+    /// Submit all, then loop: tick, fold a Committed for each dispatched
+    /// Mote, tick again. At steady state every Mote has been dispatched
+    /// exactly once and every dispatched Mote's parents were Committed
+    /// at the moment of dispatch.
+    #[test]
+    fn linear_chain_dispatches_in_parent_committed_order(
+        n in 2usize..=8
+    ) {
+        let mut projection = Projection::new();
+        let mut scheduler = Scheduler::new(LocalPlacement);
+        let executor = MockExecutor::default();
+        let warrant = permissive_warrant();
+
+        // Build the chain.
+        let mut motes = Vec::with_capacity(n);
+        let mut prev: Option<kx_mote::Mote> = None;
+        for i in 0..n {
+            let pos = format!("/chain-{i}");
+            let parents: SmallVec<[kx_mote::ParentRef; 4]> = match &prev {
+                Some(p) => smallvec![data_parent(p)],
+                None => SmallVec::new(),
+            };
+            let m = pure_mote(pos.as_bytes(), parents);
+            motes.push(m.clone());
+            prev = Some(m);
+        }
+
+        for m in &motes {
+            scheduler.submit(kx_mote::Mote::clone(m), warrant.clone(), &mut projection).unwrap();
+        }
+
+        // Drain.
+        let mut seq: u64 = 1;
+        let mut total_dispatched = 0usize;
+        let max_rounds = n * 2 + 4;
+        let mut round = 0;
+        while round < max_rounds {
+            let s = scheduler.tick(&projection, &executor).unwrap();
+            if s.dispatched.is_empty() {
+                break;
+            }
+            for d in &s.dispatched {
+                // Property: at dispatch, every Data-edge parent was Committed.
+                let mote = motes.iter().find(|m| m.id == d.mote_id).unwrap();
+                for p in &mote.parents {
+                    prop_assert_eq!(
+                        projection.state_of(&p.parent_id),
+                        MoteState::Committed,
+                        "parent of dispatched Mote must be Committed at dispatch time"
+                    );
+                }
+                // Fold a Committed for this dispatched Mote so its children
+                // can become ready.
+                fold_or_panic(&mut projection, &committed_entry(mote, seq));
+                seq += 1;
+                total_dispatched += 1;
+            }
+            round += 1;
+        }
+        prop_assert_eq!(total_dispatched, n, "every Mote in the chain must be dispatched exactly once");
+        prop_assert_eq!(scheduler.pending_count(), 0, "pending map must be empty after drain");
+    }
+
+    /// Build a small fan-out (one root, K children) and assert all K
+    /// children dispatch on the tick AFTER the root commits.
+    #[test]
+    fn fanout_dispatches_all_children_after_root_commits(
+        k in 1usize..=6
+    ) {
+        let mut projection = Projection::new();
+        let mut scheduler = Scheduler::new(LocalPlacement);
+        let executor = MockExecutor::default();
+        let warrant = permissive_warrant();
+
+        let root = pure_mote(b"/fan-root", SmallVec::new());
+        scheduler.submit(root.clone(), warrant.clone(), &mut projection).unwrap();
+
+        let mut children = Vec::with_capacity(k);
+        for i in 0..k {
+            let pos = format!("/fan-child-{i}");
+            let c = pure_mote(pos.as_bytes(), smallvec![data_parent(&root)]);
+            scheduler.submit(c.clone(), warrant.clone(), &mut projection).unwrap();
+            children.push(c);
+        }
+
+        // Tick 1: only root.
+        let s = scheduler.tick(&projection, &executor).unwrap();
+        prop_assert_eq!(s.dispatched.len(), 1);
+        prop_assert_eq!(s.dispatched[0].mote_id, root.id);
+
+        fold_or_panic(&mut projection, &committed_entry(&root, 1));
+
+        // Tick 2: all k children ready and dispatched.
+        let s = scheduler.tick(&projection, &executor).unwrap();
+        prop_assert_eq!(s.dispatched.len(), k, "all children must dispatch on the tick after root commits");
+        let dispatched: std::collections::BTreeSet<_> =
+            s.dispatched.iter().map(|d| d.mote_id).collect();
+        let expected: std::collections::BTreeSet<_> = children.iter().map(|c| c.id).collect();
+        prop_assert_eq!(dispatched, expected);
+    }
+}


### PR DESCRIPTION
## Summary

- NEW crate `crates/kx-scheduler/` shipped born-compliant per all four Golden Rules of Engineering Discipline from commit 1 — first feature ticket under the post-Phase-B discipline.
- The runtime is now **DAG-driven end-to-end**: workflow author submits a Mote DAG → `Scheduler::tick` reads `Projection::ready_set()` → routes each ready Mote through `Placement` → dispatches via `MoteExecutor::run` → executor's already-shipped commit-protocol + recovery + broker-idempotency complete the loop.
- **+23 net tests** in kx-scheduler. Workspace **668 / 0 failed / 8 ignored** on Apple Silicon (was 645/8 post-Phase-B-7).

## Public surface

- `Scheduler<P: Placement>` with `new` / `submit(mote, warrant, &mut Projection)` / `tick(&Projection, &E: MoteExecutor) → DispatchSummary` / `pending_count`.
- `Placement` trait (object-safe + `Send + Sync`) with two trivial impls: `LocalPlacement` (P1 single-worker → `WorkerId(0)`) and `RoundRobinPlacement::new(n)` (atomic-counter cycle — the "second trivial impl" the DoD requires to prove the trait seam is genuinely substitutable).
- `WorkerId(pub u64)` / `DispatchedMote` / `DispatchSummary` / `SchedulerError::DuplicateSubmission(MoteId)` (single variant — surface scoped tight).

## Layering pins (structural, not test-pinned)

- **`kx-journal` is in `[dev-dependencies]` only.** Production code in `src/` cannot construct a `JournalEntry` or hold a `Journal` because the type is not in scope. The "scheduler never writes the journal" DoD constraint is a compile-time impossibility, not a runtime assertion.
- **No `compute_inputs_from_parents` / `rebuild_mote_inputs` / `reconstruct_for_replay` helper anywhere in `src/`** (verified by grep). The pre-implementation seam audit confirmed inputs are committed facts; the executor reads parent committed `result_ref`s from the journal directly. The scheduler only confirms parents are Committed and dispatches.
- **No scheduler-local cache of parent outputs.** Content-store ownership lives in `kx-content`.
- **No memory / retrieval / semantic-search concept anywhere** (verified: zero hits for `qdrant|embedding|relevance`). The future retrieval-checkpoint feature will materialize as explicit READ-ONLY-NONDET parent Motes, requiring no scheduler change.

## Workspace `Cargo.toml`

Exactly two added lines, zero modifications to any other line:
- `"crates/kx-scheduler"` in `[workspace] members`.
- `kx-scheduler = { path = "crates/kx-scheduler", version = "0.0.1" }` in `[workspace.dependencies]`.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean across all 16 crates.
- [x] `cargo test --workspace --all-features` → 668 passed / 0 failed / 8 ignored (94 binaries).
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` clean.
- [x] DoD integration tests pass: `integration_dag_ordering` (linear chain + 2-root + diamond + empty tick) / `integration_blocked_until_committed` (parent-only-Failed-then-Committed + phantom parent + duplicate submit) / `integration_placement_swap` (LocalPlacement vs RoundRobinPlacement — same dispatch order, different workers).
- [x] SN-4 v2 #5 proptest + #6 concurrency green.

Born-compliant + thin-`lib.rs`-from-commit-1 pattern now **eight-times-proven** (P1.7.5 / 7.6 / 7.7 / 7.8 / 7.9 / 7.10 / 8.5 / 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)