### PR TITLE
PR 11.5 / P1.11.5 — KG-1 close: shaper-child warrant narrowing via RoleRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "kx-content",
  "kx-journal",
  "kx-mote",
+ "kx-warrant",
  "proptest",
  "smallvec",
  "tempfile",

--- a/crates/kx-projection/Cargo.toml
+++ b/crates/kx-projection/Cargo.toml
@@ -17,6 +17,7 @@ blake3     = { workspace = true }
 kx-content = { workspace = true }
 kx-journal = { workspace = true }
 kx-mote    = { workspace = true }
+kx-warrant = { workspace = true }
 smallvec   = { workspace = true }
 thiserror  = { workspace = true }
 tracing    = { workspace = true }

--- a/crates/kx-projection/src/errors.rs
+++ b/crates/kx-projection/src/errors.rs
@@ -1,7 +1,7 @@
 //! [`ProjectionError`] — errors raised by [`crate::Projection`] operations.
 
 use kx_content::ContentRef;
-use kx_mote::MoteId;
+use kx_mote::{MoteId, RoleId};
 
 /// Errors raised by [`crate::Projection`] operations.
 #[derive(Debug, thiserror::Error)]
@@ -41,6 +41,58 @@ pub enum ProjectionError {
         /// The result_ref whose bytes failed to decode.
         result_ref: ContentRef,
         /// Underlying bincode error formatted as a string.
+        details: String,
+    },
+
+    /// **PR 11.5 / KG-1-close.** The topology materializer tried to fetch a
+    /// shaper's [`kx_warrant::WarrantSpec`] from the content store (so it
+    /// could compute child warrants via D30's `intersect`) and the fetch
+    /// failed. The shaper's warrant_ref MUST resolve to its WarrantSpec
+    /// at fold time — workflow author / executor MUST `put` the spec
+    /// before the shaper commits.
+    #[error("warrant store fetch failed for shaper warrant_ref {warrant_ref:?}: {details}")]
+    WarrantStoreFetch {
+        /// The warrant_ref whose payload could not be retrieved.
+        warrant_ref: ContentRef,
+        /// Underlying error formatted as a string.
+        details: String,
+    },
+
+    /// **PR 11.5 / KG-1-close.** The materializer fetched a payload but
+    /// bincode-canonical deserialization as `WarrantSpec` failed. The
+    /// content store is corrupt or the wrong bytes were written under
+    /// the warrant_ref.
+    #[error("failed to deserialize WarrantSpec from warrant_ref {warrant_ref:?}: {details}")]
+    WarrantDecodeFailed {
+        /// The warrant_ref whose bytes failed to decode.
+        warrant_ref: ContentRef,
+        /// Underlying bincode error formatted as a string.
+        details: String,
+    },
+
+    /// **PR 11.5 / KG-1-close.** A child descriptor named a `RoleId` that
+    /// the [`kx_warrant::RoleRegistry`] does not know. The materializer
+    /// refuses to silently widen — the workflow author MUST register
+    /// every role referenced by any descriptor before submitting the
+    /// shaper.
+    #[error("role {role_id:?} (descriptor index {descriptor_index}) is not registered in the role registry")]
+    RoleNotRegistered {
+        /// The unresolved descriptor-side handle.
+        role_id: RoleId,
+        /// Index of the descriptor in `TopologyDecision.children`.
+        descriptor_index: usize,
+    },
+
+    /// **PR 11.5 / KG-1-close.** D30 `intersect(shaper.warrant,
+    /// role.spec)` returned a typed [`kx_warrant::NarrowingError`] —
+    /// the proposed role attempts to widen the shaper's warrant on
+    /// some axis. Surfaced as a fold error so the workflow author /
+    /// operator sees the offending descriptor + axis.
+    #[error("warrant narrowing failed for descriptor index {descriptor_index}: {details}")]
+    NarrowingFailed {
+        /// Index of the descriptor in `TopologyDecision.children`.
+        descriptor_index: usize,
+        /// The underlying [`kx_warrant::NarrowingError`] formatted as a string.
         details: String,
     },
 }

--- a/crates/kx-projection/src/materializer.rs
+++ b/crates/kx-projection/src/materializer.rs
@@ -1,25 +1,28 @@
 //! [`TopologyMaterializer`] — the seam that fires on a Committed shaper
 //! entry to read its [`kx_mote::TopologyDecision`] payload, derive each
-//! child's [`kx_mote::MoteId`] per D49, and yield a [`crate::RegisterMote`] per
-//! child for the projection to register.
+//! child's [`kx_mote::MoteId`] per D49, narrow each child's warrant per
+//! D30 + `topology.md` §13 KG-1-close (PR 11.5), and yield a
+//! [`crate::RegisterMote`] per child for the projection to register.
 //!
 //! Production callers wire a [`DefaultTopologyMaterializer`] (which
-//! composes a [`kx_content::ContentStore`] + a
-//! [`crate::MoteDefRegistry`] + a [`crate::ChildResolver`]). Tests may pass a
-//! lighter-weight stub.
+//! composes a [`kx_content::ContentStore`], a [`crate::MoteDefRegistry`],
+//! a [`crate::ChildResolver`], and a [`kx_warrant::RoleRegistry`]). Tests
+//! may pass a lighter-weight stub.
 //!
-//! See `docs/design/decisions.md` §D48 + §D49 (private corpus) for the
+//! See `docs/design/decisions.md` §D30 + §D48 + §D49 +
+//! `docs/design/topology.md` §13 KG-1 (private corpus) for the
 //! load-bearing properties this seam must preserve: R49
 //! reconstructibility, no-position-metadata, transitivity (P3),
-//! re-run distinctness.
+//! re-run distinctness, AND per-role warrant narrowing.
 
 use std::sync::Arc;
 
 use kx_content::{ContentRef, ContentStore};
 use kx_mote::{
-    derive_mote_id, EdgeKind, EdgeMeta, EffectPattern, GraphPosition, InputDataId, MoteDef,
-    MoteDefHash, MoteId, NdClass, ParentRef, TopologyDecision,
+    canonical_config, derive_mote_id, EdgeKind, EdgeMeta, EffectPattern, GraphPosition,
+    InputDataId, MoteDef, MoteDefHash, MoteId, NdClass, ParentRef, TopologyDecision,
 };
+use kx_warrant::{intersect, warrant_ref_of, RoleRegistry, WarrantSpec};
 use smallvec::smallvec;
 use tracing::warn;
 
@@ -33,30 +36,35 @@ use crate::register::RegisterMote;
 /// Invoked by [`crate::Projection::fold`] on every `Committed` journal
 /// entry. The materializer decides — by looking up the Mote's
 /// [`MoteDef`] via [`MoteDefRegistry`] — whether the Mote is a
-/// topology shaper; if so, it fetches the [`TopologyDecision`] payload,
-/// resolves each child's full [`MoteDef`] (D48), derives identity (D49),
+/// topology shaper; if so, it fetches the [`TopologyDecision`] payload
+/// together with the shaper's [`WarrantSpec`], resolves each child's
+/// full [`MoteDef`] (D48), narrows the child's warrant per D30 using a
+/// [`RoleRegistry`] (PR 11.5 / KG-1-close), derives identity (D49),
 /// and yields one [`RegisterMote`] per child.
 ///
 /// MUST be deterministic in `(shaper_mote_id, shaper_def_hash,
-/// shaper_result_ref)`. Replay-faithfulness rests on this.
+/// shaper_result_ref, shaper_warrant_ref)`. Replay-faithfulness rests
+/// on this.
 pub trait TopologyMaterializer: Send + Sync {
     /// Return `Ok(Some(children))` if the Mote is a shaper whose
     /// `TopologyDecision` was successfully read + decoded; `Ok(None)`
     /// if the Mote is not a shaper (the common case — fast path); or
     /// `Err(_)` if the Mote IS a shaper but its payload could not be
-    /// read or decoded.
+    /// read or decoded, or some descriptor's role is not registered, or
+    /// the role's spec attempts to widen the shaper's warrant.
     fn try_materialize(
         &self,
         shaper_mote_id: MoteId,
         shaper_def_hash: MoteDefHash,
         shaper_result_ref: ContentRef,
+        shaper_warrant_ref: ContentRef,
     ) -> Result<Option<Vec<RegisterMote>>, ProjectionError>;
 }
 
 /// Production [`TopologyMaterializer`] composing a content store, a
-/// [`MoteDefRegistry`], and a [`ChildResolver`].
+/// [`MoteDefRegistry`], a [`ChildResolver`], and a [`RoleRegistry`].
 ///
-/// Generic over the three seams so callers can swap impls without
+/// Generic over the four seams so callers can swap impls without
 /// touching the projection. The content store is held behind `Arc`
 /// (because [`ContentStore`]'s associated `Payload` type makes
 /// `dyn ContentStore` impractical — see the `BodyResolver` pattern in
@@ -67,52 +75,60 @@ pub trait TopologyMaterializer: Send + Sync {
 /// ```no_run
 /// use std::sync::Arc;
 /// use kx_content::InMemoryContentStore;
+/// use kx_warrant::InMemoryRoleRegistry;
 /// use kx_projection::{
 ///     DefaultTopologyMaterializer, InheritFromShaperResolver,
 ///     InMemoryMoteDefRegistry,
 /// };
 ///
 /// let store = Arc::new(InMemoryContentStore::new());
-/// let registry = Arc::new(InMemoryMoteDefRegistry::new());
+/// let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+/// let role_registry = Arc::new(InMemoryRoleRegistry::new());
 /// let materializer = DefaultTopologyMaterializer::new(
 ///     store,
-///     registry,
+///     def_registry,
+///     role_registry,
 ///     InheritFromShaperResolver,
 /// );
 /// // pass `materializer` to `Projection::with_materializer(...)`.
 /// # let _ = materializer;
 /// ```
-pub struct DefaultTopologyMaterializer<S, D, R>
+pub struct DefaultTopologyMaterializer<S, D, Reg, R>
 where
     S: ContentStore + Send + Sync + 'static,
     D: MoteDefRegistry + 'static,
+    Reg: RoleRegistry + 'static,
     R: ChildResolver + 'static,
 {
     store: Arc<S>,
-    registry: Arc<D>,
+    def_registry: Arc<D>,
+    role_registry: Arc<Reg>,
     resolver: R,
 }
 
-impl<S, D, R> DefaultTopologyMaterializer<S, D, R>
+impl<S, D, Reg, R> DefaultTopologyMaterializer<S, D, Reg, R>
 where
     S: ContentStore + Send + Sync + 'static,
     D: MoteDefRegistry + 'static,
+    Reg: RoleRegistry + 'static,
     R: ChildResolver + 'static,
 {
-    /// Construct a materializer over the three seams.
-    pub fn new(store: Arc<S>, registry: Arc<D>, resolver: R) -> Self {
+    /// Construct a materializer over the four seams.
+    pub fn new(store: Arc<S>, def_registry: Arc<D>, role_registry: Arc<Reg>, resolver: R) -> Self {
         Self {
             store,
-            registry,
+            def_registry,
+            role_registry,
             resolver,
         }
     }
 }
 
-impl<S, D, R> TopologyMaterializer for DefaultTopologyMaterializer<S, D, R>
+impl<S, D, Reg, R> TopologyMaterializer for DefaultTopologyMaterializer<S, D, Reg, R>
 where
     S: ContentStore + Send + Sync + 'static,
     D: MoteDefRegistry + 'static,
+    Reg: RoleRegistry + 'static,
     R: ChildResolver + 'static,
 {
     fn try_materialize(
@@ -120,11 +136,12 @@ where
         shaper_mote_id: MoteId,
         shaper_def_hash: MoteDefHash,
         shaper_result_ref: ContentRef,
+        shaper_warrant_ref: ContentRef,
     ) -> Result<Option<Vec<RegisterMote>>, ProjectionError> {
         // 1. Look up shaper MoteDef. Unknown def → not a shaper from
         //    this materializer's perspective (silent skip, with a warn
         //    trace so misconfiguration is visible to operators).
-        let Some(shaper_def) = self.registry.get(&shaper_def_hash) else {
+        let Some(shaper_def) = self.def_registry.get(&shaper_def_hash) else {
             warn!(
                 shaper_mote_id = ?shaper_mote_id,
                 shaper_def_hash = ?shaper_def_hash,
@@ -151,15 +168,56 @@ where
         // 4. Decode as TopologyDecision via canonical bincode (the same
         //    encoding the shaper used to compute its result_ref hash).
         let (decision, _consumed): (TopologyDecision, usize) =
-            bincode::serde::decode_from_slice(payload.as_ref(), kx_mote::canonical_config())
-                .map_err(|e| ProjectionError::TopologyDecodeFailed {
+            bincode::serde::decode_from_slice(payload.as_ref(), canonical_config()).map_err(
+                |e| ProjectionError::TopologyDecodeFailed {
                     result_ref: shaper_result_ref,
+                    details: format!("{e}"),
+                },
+            )?;
+
+        // 5. **PR 11.5 / KG-1-close.** Fetch + decode the shaper's
+        //    WarrantSpec. Required for the per-child intersect call.
+        let warrant_payload = self.store.get(&shaper_warrant_ref).map_err(|e| {
+            ProjectionError::WarrantStoreFetch {
+                warrant_ref: shaper_warrant_ref,
+                details: format!("{e:?}"),
+            }
+        })?;
+        let (shaper_warrant, _consumed): (WarrantSpec, usize) =
+            bincode::serde::decode_from_slice(warrant_payload.as_ref(), canonical_config())
+                .map_err(|e| ProjectionError::WarrantDecodeFailed {
+                    warrant_ref: shaper_warrant_ref,
                     details: format!("{e}"),
                 })?;
 
-        // 5. Resolve + derive identity for each child.
+        // 6. Resolve + narrow + derive identity for each child.
         let mut children = Vec::with_capacity(decision.children.len());
         for (index, descriptor) in decision.children.iter().enumerate() {
+            // 6a. **PR 11.5 / KG-1-close.** Resolve the descriptor's
+            //     RoleId → Role via the role registry. Missing role is
+            //     a typed error — the materializer refuses to silently
+            //     widen.
+            let role = self
+                .role_registry
+                .resolve(&descriptor.role_id)
+                .ok_or_else(|| ProjectionError::RoleNotRegistered {
+                    role_id: descriptor.role_id.clone(),
+                    descriptor_index: index,
+                })?;
+
+            // 6b. **PR 11.5 / KG-1-close.** D30 monotonic narrowing.
+            //     Replaces PR 11's verbatim ref-copy with the actual
+            //     intersection. NarrowingError (widening attempt /
+            //     syscall mismatch / invalid model route) is a fold
+            //     error — the workflow author sees the offending axis.
+            let child_warrant = intersect(&shaper_warrant, &role).map_err(|e| {
+                ProjectionError::NarrowingFailed {
+                    descriptor_index: index,
+                    details: format!("{e}"),
+                }
+            })?;
+            let child_warrant_ref = warrant_ref_of(&child_warrant);
+
             children.push(derive_child_register_mote(
                 shaper_mote_id,
                 &shaper_def,
@@ -167,15 +225,17 @@ where
                 descriptor,
                 index,
                 &self.resolver,
+                child_warrant_ref,
             ));
         }
         Ok(Some(children))
     }
 }
 
-/// D49 identity derivation: compose a [`RegisterMote`] for one
-/// shaper-spawned child from the shaper's identity facts + the
-/// child's descriptor + the resolved child `MoteDef`.
+/// D49 identity derivation + KG-1-close warrant_ref population: compose
+/// a [`RegisterMote`] for one shaper-spawned child from the shaper's
+/// identity facts + the child's descriptor + the resolved child
+/// `MoteDef` + the per-role-narrowed `warrant_ref`.
 ///
 /// This is the **load-bearing function** for R49. Made `pub(crate)` so
 /// the [`DefaultTopologyMaterializer`] and tests can both call it
@@ -197,6 +257,7 @@ pub(crate) fn derive_child_register_mote(
     descriptor: &kx_mote::ChildDescriptor,
     index: usize,
     resolver: &dyn ChildResolver,
+    child_warrant_ref: ContentRef,
 ) -> RegisterMote {
     // D48 — compose child's full MoteDef.
     let child_def = resolver.resolve(shaper_def, descriptor);
@@ -235,6 +296,7 @@ pub(crate) fn derive_child_register_mote(
         critic_for: None,
         is_topology_shaper: false,
         parents,
+        warrant_ref: child_warrant_ref,
     }
 }
 
@@ -242,8 +304,13 @@ pub(crate) fn derive_child_register_mote(
 /// callers can derive child identity without going through the full
 /// [`TopologyMaterializer`] (e.g. when testing or pre-computing).
 ///
-/// Returns `(child_mote_id, child_def_hash)`. Same inputs → same outputs;
-/// no I/O.
+/// Returns `(child_mote_id, child_def_hash, child_nd_class,
+/// child_effect_pattern)`. Same inputs → same outputs; no I/O.
+///
+/// **Does NOT compute the child's narrowed warrant** — that requires a
+/// `RoleRegistry` + `intersect` call (see
+/// [`DefaultTopologyMaterializer::try_materialize`]). This helper
+/// exists for tests that only need to derive identity.
 #[must_use]
 pub fn derive_child_identity(
     shaper_mote_id: MoteId,

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -167,6 +167,7 @@ impl Projection {
             critic_for: reg.critic_for,
             is_topology_shaper: reg.is_topology_shaper,
             parents: reg.parents,
+            warrant_ref: reg.warrant_ref,
         });
         self.state.rebuild_children_index();
     }
@@ -222,24 +223,25 @@ impl Projection {
                 // for a Mote that wasn't pre-registered).
                 self.state.rebuild_children_index();
 
-                // **P1.11 / D48 + D49.** Topology materializer hook. If a
-                // materializer is wired AND the Mote is a shaper, fetch +
-                // decode the TopologyDecision payload from the content
-                // store and register every materialized child. R49
-                // requires this to be deterministic across replay; the
-                // materializer's purity guarantee delivers that.
+                // **P1.11 / D48 + D49 + PR 11.5 KG-1-close.** Topology
+                // materializer hook. If a materializer is wired AND the
+                // Mote is a shaper, fetch + decode the TopologyDecision
+                // payload + the shaper's WarrantSpec from the content
+                // store, narrow each child's warrant per D30
+                // intersect(shaper.warrant, role.spec), and register
+                // every materialized child with its per-role-narrowed
+                // warrant_ref. R49 requires this to be deterministic
+                // across replay; the materializer's purity guarantee
+                // delivers that (registry lookups are stable per the
+                // RoleRegistry contract).
                 let materialized = match self.materializer.as_ref() {
-                    Some(m) => m.try_materialize(*mote_id, *mote_def_hash, *result_ref)?,
+                    Some(m) => {
+                        m.try_materialize(*mote_id, *mote_def_hash, *result_ref, *warrant_ref)?
+                    }
                     None => None,
                 };
                 if let Some(children) = materialized {
                     for reg in children {
-                        // KG-1 safe-default: the materializer's RegisterMote
-                        // doesn't carry a warrant_ref; the child inherits the
-                        // shaper's warrant verbatim. Recovery / dispatch reads
-                        // the shaper's CommittedInfo.warrant_ref directly via
-                        // the projection's read API (kx-executor lifecycle).
-                        // KG-1-close (PR 11.5) will wire per-role narrowing.
                         self.register_mote(reg);
                     }
                 }
@@ -409,6 +411,28 @@ impl Projection {
     #[must_use]
     pub fn is_repudiated(&self, mote_id: &MoteId) -> bool {
         matches!(self.state_of(mote_id), MoteState::Repudiated)
+    }
+
+    /// The Mote's [`ContentRef`]-keyed warrant ref.
+    ///
+    /// **PR 11.5 / KG-1-close.** Returns the declared `warrant_ref` if the
+    /// Mote was registered (via [`Projection::register_mote`] or the
+    /// topology materializer's child registration), else the committed
+    /// entry's `warrant_ref` if any, else `None`.
+    ///
+    /// The dispatch path (executor, P1.9+) reads this to look up the
+    /// per-Mote [`kx_warrant::WarrantSpec`] from the content store. For
+    /// shaper-materialized children, this ref points at the *narrowed*
+    /// warrant computed via D30's `intersect(shaper.warrant, role.spec)`
+    /// — closing `topology.md` §13 KG-1's verbatim-inheritance gap.
+    #[must_use]
+    pub fn warrant_ref_of(&self, mote_id: &MoteId) -> Option<ContentRef> {
+        self.state.motes.get(mote_id).and_then(|i| {
+            i.declared
+                .as_ref()
+                .map(|d| d.warrant_ref)
+                .or_else(|| i.committed.as_ref().map(|c| c.warrant_ref))
+        })
     }
 
     /// The `seq` of the Mote's `Committed` entry, if present. Useful for callers

--- a/crates/kx-projection/src/register.rs
+++ b/crates/kx-projection/src/register.rs
@@ -1,6 +1,7 @@
 //! [`RegisterMote`] — workflow-author declaration of a Mote before any
 //! journal entry exists for it.
 
+use kx_content::ContentRef;
 use kx_mote::{EffectPattern, MoteId, NdClass, ParentRef};
 use smallvec::SmallVec;
 
@@ -25,4 +26,11 @@ pub struct RegisterMote {
     pub is_topology_shaper: bool,
     /// The Mote's declared parents with edge metadata. Up to 4 inline; spill heap.
     pub parents: SmallVec<[ParentRef; 4]>,
+    /// **PR 11.5 / KG-1-close.** The warrant the Mote will execute under,
+    /// content-addressed via [`kx_warrant::warrant_ref_of`]. Workflow-author
+    /// submissions populate this with `warrant_ref_of(&submitted_warrant)`.
+    /// Shaper-materialized children (D48 + D49) populate this with
+    /// `warrant_ref_of(&intersect(shaper.warrant, role.spec))` — the
+    /// closing of `topology.md` §13 KG-1's verbatim-inheritance gap.
+    pub warrant_ref: ContentRef,
 }

--- a/crates/kx-projection/src/snapshot.rs
+++ b/crates/kx-projection/src/snapshot.rs
@@ -119,6 +119,18 @@ impl Snapshot {
             .and_then(|i| i.committed.as_ref().map(|c| c.result_ref))
     }
 
+    /// Declared-or-committed warrant_ref for the Mote. See
+    /// [`crate::Projection::warrant_ref_of`].
+    #[must_use]
+    pub fn warrant_ref_of(&self, mote_id: &MoteId) -> Option<ContentRef> {
+        self.state.motes.get(mote_id).and_then(|i| {
+            i.declared
+                .as_ref()
+                .map(|d| d.warrant_ref)
+                .or_else(|| i.committed.as_ref().map(|c| c.warrant_ref))
+        })
+    }
+
     /// The ready set at the snapshot's `seq`.
     #[must_use]
     pub fn ready_set(&self) -> Vec<MoteId> {

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -78,16 +78,19 @@ pub(crate) struct MoteInfo {
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-// `nd_class`, `effect_pattern`, `critic_for`, `is_topology_shaper` are stored at
-// registration but unread in P1.5. P1.9 (the executor) consumes them via a MoteDef
-// registry lookup to compute the full 3c promotion behavior + the topology-shaper
-// materialization at P1.11.
+// `nd_class`, `effect_pattern`, `critic_for`, `is_topology_shaper`,
+// `warrant_ref` are stored at registration but unread in P1.5. P1.9 (the
+// executor) consumes them via a MoteDef registry lookup to compute the full
+// 3c promotion behavior + the topology-shaper materialization at P1.11.
+// `warrant_ref` is the PR-11.5 KG-1-close payload — the per-child narrowed
+// warrant ref the executor will dispatch under.
 pub(crate) struct DeclaredInfo {
     pub(crate) nd_class: NdClass,
     pub(crate) effect_pattern: EffectPattern,
     pub(crate) critic_for: Option<MoteId>,
     pub(crate) is_topology_shaper: bool,
     pub(crate) parents: SmallVec<[ParentRef; 4]>,
+    pub(crate) warrant_ref: ContentRef,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/kx-projection/src/tests.rs
+++ b/crates/kx-projection/src/tests.rs
@@ -133,6 +133,7 @@ fn register_mote_makes_it_pending() {
         critic_for: None,
         is_topology_shaper: false,
         parents: SmallVec::new(),
+        warrant_ref: kx_content::ContentRef::from_bytes([0xaa; 32]),
     });
     assert_eq!(p.state_of(&mid(1)), MoteState::Pending);
 }

--- a/crates/kx-projection/tests/cold_refold_topology.rs
+++ b/crates/kx-projection/tests/cold_refold_topology.rs
@@ -36,8 +36,12 @@ use kx_projection::{
     derive_child_identity, DefaultTopologyMaterializer, InMemoryMoteDefRegistry,
     InheritFromShaperResolver, MoteState, Projection,
 };
+use kx_warrant::{
+    warrant_ref_of, ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, Role,
+    RoleRegistry, WarrantSpec,
+};
 use smallvec::SmallVec;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -84,29 +88,96 @@ fn encode_topology(td: &TopologyDecision) -> Vec<u8> {
         .expect("TopologyDecision canonical bincode encodes infallibly")
 }
 
+/// Test-local [`RoleRegistry`] that returns the same [`Role`] for any
+/// `RoleId`. R49 cold-refold tests don't exercise per-role warrant
+/// narrowing — they just need a registry that doesn't fail. KG-1-close
+/// narrowing semantics are tested separately in
+/// `integration_topology_classes.rs`.
+struct PermissiveAnyRoleRegistry {
+    role: Role,
+}
+
+impl RoleRegistry for PermissiveAnyRoleRegistry {
+    fn resolve(&self, _role_id: &RoleId) -> Option<Role> {
+        Some(self.role.clone())
+    }
+}
+
+/// Build a permissive [`WarrantSpec`] suitable as the shaper's warrant
+/// and as every child role's spec (so [`kx_warrant::intersect`] succeeds
+/// with no widening). Same shape as the K-G-1 close tests' baseline.
+fn permissive_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("test-model".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 1024,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 20,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
 type TestMaterializer = DefaultTopologyMaterializer<
     InMemoryContentStore,
     InMemoryMoteDefRegistry,
+    PermissiveAnyRoleRegistry,
     InheritFromShaperResolver,
 >;
 
-/// Build the materializer wiring used by every test in this file.
+/// Build the materializer wiring used by every R49 test in this file.
+///
+/// Returns the staged content store, the def registry, the shaper's
+/// `warrant_ref` (used on the Committed entry), and the boxed
+/// materializer. The shaper's `WarrantSpec` is staged in the content
+/// store at the returned `warrant_ref` so the materializer can fetch +
+/// decode it during `try_materialize` (PR 11.5 / KG-1-close path).
 fn build_materializer(
     shaper_def_value: &MoteDef,
 ) -> (
     Arc<InMemoryContentStore>,
     Arc<InMemoryMoteDefRegistry>,
+    ContentRef,
     Box<TestMaterializer>,
 ) {
     let store = Arc::new(InMemoryContentStore::new());
-    let registry = Arc::new(InMemoryMoteDefRegistry::new());
-    registry.register(shaper_def_value.clone());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper_def_value.clone());
+    let warrant = permissive_warrant();
+    let warrant_bytes = bincode::serde::encode_to_vec(&warrant, canonical_config())
+        .expect("WarrantSpec canonical bincode encodes infallibly");
+    let shaper_warrant_ref = store.put(&warrant_bytes).expect("put succeeds");
+    // Sanity: the put-derived ref matches warrant_ref_of (same canonical
+    // bincode + blake3 chain). If this ever diverges, KG-1-close is wrong.
+    assert_eq!(shaper_warrant_ref, warrant_ref_of(&warrant));
+    let role = Role {
+        name: "test-default".into(),
+        version: 1,
+        spec: warrant,
+        description: String::new(),
+    };
+    let role_registry = Arc::new(PermissiveAnyRoleRegistry { role });
     let materializer = Box::new(DefaultTopologyMaterializer::new(
         Arc::clone(&store),
-        Arc::clone(&registry),
+        Arc::clone(&def_registry),
+        role_registry,
         InheritFromShaperResolver,
     ));
-    (store, registry, materializer)
+    (store, def_registry, shaper_warrant_ref, materializer)
 }
 
 /// Stage the `TopologyDecision` payload to the content store; return its `ContentRef`.
@@ -115,11 +186,14 @@ fn stage_topology(store: &InMemoryContentStore, td: &TopologyDecision) -> Conten
     store.put(&bytes).expect("put succeeds")
 }
 
-/// Build a Committed entry for the shaper that points at the topology payload.
+/// Build a Committed entry for the shaper that points at the topology
+/// payload AND carries the staged warrant_ref (PR 11.5 KG-1-close: the
+/// materializer fetches the WarrantSpec at this ref).
 fn shaper_committed_entry(
     shaper_id: MoteId,
     shaper_def_hash: MoteDefHash,
     topology_ref: ContentRef,
+    shaper_warrant_ref: ContentRef,
     seq: u64,
 ) -> JournalEntry {
     JournalEntry::Committed {
@@ -129,7 +203,7 @@ fn shaper_committed_entry(
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: topology_ref,
         parents: SmallVec::new(),
-        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        warrant_ref: shaper_warrant_ref,
         mote_def_hash: shaper_def_hash,
     }
 }
@@ -157,21 +231,21 @@ fn p1_cold_refold_rebuilds_identical_children_and_edges() {
     };
 
     // Live fold path: build projection with materializer, fold shaper commit.
-    let (store_live, _reg_live, materializer_live) = build_materializer(&shaper);
+    let (store_live, _reg_live, w_ref, materializer_live) = build_materializer(&shaper);
     let td_ref_live = stage_topology(&store_live, &td);
     let mut live = Projection::with_materializer(materializer_live);
-    let entry_live = shaper_committed_entry(shaper_id, shaper_hash, td_ref_live, 1);
+    let entry_live = shaper_committed_entry(shaper_id, shaper_hash, td_ref_live, w_ref, 1);
     live.fold(&entry_live).unwrap();
 
     // Cold re-fold path: write entry to a journal, then from_journal_with_materializer.
-    let (store_cold, _reg_cold, materializer_cold) = build_materializer(&shaper);
+    let (store_cold, _reg_cold, w_ref, materializer_cold) = build_materializer(&shaper);
     let td_ref_cold = stage_topology(&store_cold, &td);
     assert_eq!(
         td_ref_live, td_ref_cold,
         "content-addressed staging yields identical refs"
     );
     let journal = InMemoryJournal::new();
-    let entry_cold = shaper_committed_entry(shaper_id, shaper_hash, td_ref_cold, 1);
+    let entry_cold = shaper_committed_entry(shaper_id, shaper_hash, td_ref_cold, w_ref, 1);
     journal.append(entry_cold).unwrap();
     let cold = Projection::from_journal_with_materializer(&journal, materializer_cold).unwrap();
 
@@ -286,6 +360,7 @@ fn p2_no_graph_position_on_register_mote() {
         critic_for: None,
         is_topology_shaper: false,
         parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
     };
 }
 
@@ -516,16 +591,16 @@ fn p3_full_materializer_path_one_byte_descriptor_change_changes_child_ids() {
         )],
     };
 
-    let (store_a, _reg_a, materializer_a) = build_materializer(&shaper);
+    let (store_a, _reg_a, w_ref, materializer_a) = build_materializer(&shaper);
     let ref_a = stage_topology(&store_a, &td_a);
     let mut proj_a = Projection::with_materializer(materializer_a);
-    let entry_a = shaper_committed_entry(shaper_id, shaper_hash, ref_a, 1);
+    let entry_a = shaper_committed_entry(shaper_id, shaper_hash, ref_a, w_ref, 1);
     proj_a.fold(&entry_a).unwrap();
 
-    let (store_b, _reg_b, materializer_b) = build_materializer(&shaper);
+    let (store_b, _reg_b, w_ref, materializer_b) = build_materializer(&shaper);
     let ref_b = stage_topology(&store_b, &td_b);
     let mut proj_b = Projection::with_materializer(materializer_b);
-    let entry_b = shaper_committed_entry(shaper_id, shaper_hash, ref_b, 1);
+    let entry_b = shaper_committed_entry(shaper_id, shaper_hash, ref_b, w_ref, 1);
     proj_b.fold(&entry_b).unwrap();
 
     // Each projection has exactly one materialized child + the shaper = 2 Motes.
@@ -580,18 +655,30 @@ fn p4_different_topology_decisions_produce_different_child_sets() {
     };
     assert_ne!(td_a.hash(), td_b.hash());
 
-    let (store_a, _reg_a, materializer_a) = build_materializer(&shaper);
+    let (store_a, _reg_a, w_ref, materializer_a) = build_materializer(&shaper);
     let ref_a = stage_topology(&store_a, &td_a);
     let mut proj_a = Projection::with_materializer(materializer_a);
     proj_a
-        .fold(&shaper_committed_entry(shaper_id, shaper_hash, ref_a, 1))
+        .fold(&shaper_committed_entry(
+            shaper_id,
+            shaper_hash,
+            ref_a,
+            w_ref,
+            1,
+        ))
         .unwrap();
 
-    let (store_b, _reg_b, materializer_b) = build_materializer(&shaper);
+    let (store_b, _reg_b, w_ref, materializer_b) = build_materializer(&shaper);
     let ref_b = stage_topology(&store_b, &td_b);
     let mut proj_b = Projection::with_materializer(materializer_b);
     proj_b
-        .fold(&shaper_committed_entry(shaper_id, shaper_hash, ref_b, 1))
+        .fold(&shaper_committed_entry(
+            shaper_id,
+            shaper_hash,
+            ref_b,
+            w_ref,
+            1,
+        ))
         .unwrap();
 
     // Each projection has shaper + 2 children = 3 Motes.
@@ -645,19 +732,31 @@ fn p4_only_surviving_shaper_committed_materializes_children() {
         )],
     };
 
-    let (store, _reg, materializer) = build_materializer(&shaper);
+    let (store, _reg, w_ref, materializer) = build_materializer(&shaper);
     let ref_a = stage_topology(&store, &td_a);
     let ref_b = stage_topology(&store, &td_b);
     let mut proj = Projection::with_materializer(materializer);
 
-    proj.fold(&shaper_committed_entry(shaper_id, shaper_hash, ref_a, 1))
-        .unwrap();
+    proj.fold(&shaper_committed_entry(
+        shaper_id,
+        shaper_hash,
+        ref_a,
+        w_ref,
+        1,
+    ))
+    .unwrap();
     let len_after_a = proj.len();
     assert_eq!(len_after_a, 2, "shaper + 1 child after A");
 
     // Second Committed for same shaper_id: rejected with DuplicateCommitted.
     let err = proj
-        .fold(&shaper_committed_entry(shaper_id, shaper_hash, ref_b, 2))
+        .fold(&shaper_committed_entry(
+            shaper_id,
+            shaper_hash,
+            ref_b,
+            w_ref,
+            2,
+        ))
         .unwrap_err();
     assert!(
         matches!(err, kx_projection::ProjectionError::DuplicateCommitted(_)),
@@ -679,11 +778,17 @@ fn empty_topology_decision_materializes_zero_children() {
     let shaper_hash = shaper.hash();
     let td = TopologyDecision { children: vec![] };
 
-    let (store, _reg, materializer) = build_materializer(&shaper);
+    let (store, _reg, w_ref, materializer) = build_materializer(&shaper);
     let td_ref = stage_topology(&store, &td);
     let mut proj = Projection::with_materializer(materializer);
-    proj.fold(&shaper_committed_entry(shaper_id, shaper_hash, td_ref, 1))
-        .unwrap();
+    proj.fold(&shaper_committed_entry(
+        shaper_id,
+        shaper_hash,
+        td_ref,
+        w_ref,
+        1,
+    ))
+    .unwrap();
     assert_eq!(proj.len(), 1, "shaper only; no children");
     assert_eq!(proj.state_of(&shaper_id), MoteState::Committed);
 }
@@ -700,12 +805,23 @@ fn materializer_skips_when_shaper_def_not_registered() {
     let shaper_hash = shaper.hash();
 
     // Build materializer with EMPTY registry (do NOT call build_materializer
-    // which registers the shaper def).
+    // which registers the shaper def). The role registry is irrelevant —
+    // the materializer early-skips before touching it when the def is
+    // missing — but the materializer constructor needs one.
     let store = Arc::new(InMemoryContentStore::new());
     let registry = Arc::new(InMemoryMoteDefRegistry::new());
+    let role_registry = Arc::new(PermissiveAnyRoleRegistry {
+        role: Role {
+            name: "irrelevant".into(),
+            version: 1,
+            spec: permissive_warrant(),
+            description: String::new(),
+        },
+    });
     let materializer = Box::new(DefaultTopologyMaterializer::new(
         Arc::clone(&store),
         Arc::clone(&registry),
+        role_registry,
         InheritFromShaperResolver,
     ));
     let td = TopologyDecision {
@@ -716,9 +832,21 @@ fn materializer_skips_when_shaper_def_not_registered() {
         )],
     };
     let td_ref = stage_topology(&store, &td);
+    // Stage a permissive WarrantSpec so the entry carries a valid
+    // warrant_ref (though the materializer will early-skip before
+    // touching it).
+    let warrant_bytes = bincode::serde::encode_to_vec(permissive_warrant(), canonical_config())
+        .expect("WarrantSpec canonical bincode encodes infallibly");
+    let w_ref = store.put(&warrant_bytes).expect("put");
     let mut proj = Projection::with_materializer(materializer);
-    proj.fold(&shaper_committed_entry(shaper_id, shaper_hash, td_ref, 1))
-        .unwrap();
+    proj.fold(&shaper_committed_entry(
+        shaper_id,
+        shaper_hash,
+        td_ref,
+        w_ref,
+        1,
+    ))
+    .unwrap();
     assert_eq!(
         proj.len(),
         1,
@@ -736,7 +864,7 @@ fn materialization_propagates_content_store_get_failure() {
     let shaper_id = shaper_mote_id(&shaper);
     let shaper_hash = shaper.hash();
 
-    let (_store, _reg, materializer) = build_materializer(&shaper);
+    let (_store, _reg, w_ref, materializer) = build_materializer(&shaper);
     // Use a result_ref that was NEVER staged → content store fetch fails.
     let unstaged_ref = ContentRef::from_bytes([0xff; 32]);
     let mut proj = Projection::with_materializer(materializer);
@@ -745,6 +873,7 @@ fn materialization_propagates_content_store_get_failure() {
             shaper_id,
             shaper_hash,
             unstaged_ref,
+            w_ref,
             1,
         ))
         .unwrap_err();
@@ -767,7 +896,7 @@ fn materialization_propagates_topology_decode_failure() {
     let shaper_id = shaper_mote_id(&shaper);
     let shaper_hash = shaper.hash();
 
-    let (store, _reg, materializer) = build_materializer(&shaper);
+    let (store, _reg, w_ref, materializer) = build_materializer(&shaper);
     // Stage garbage that won't decode as a TopologyDecision. 4 bytes is
     // below the minimum 8-byte fixed-int length prefix, so bincode
     // rejects with UnexpectedEnd rather than attempting to allocate a
@@ -777,7 +906,13 @@ fn materialization_propagates_topology_decode_failure() {
 
     let mut proj = Projection::with_materializer(materializer);
     let err = proj
-        .fold(&shaper_committed_entry(shaper_id, shaper_hash, bad_ref, 1))
+        .fold(&shaper_committed_entry(
+            shaper_id,
+            shaper_hash,
+            bad_ref,
+            w_ref,
+            1,
+        ))
         .unwrap_err();
     assert!(
         matches!(

--- a/crates/kx-projection/tests/dod.rs
+++ b/crates/kx-projection/tests/dod.rs
@@ -50,6 +50,7 @@ fn register(p: &mut Projection, mote_byte: u8, nd: NdClass, parents: &[(u8, Edge
         critic_for: None,
         is_topology_shaper: false,
         parents,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
     });
 }
 

--- a/crates/kx-projection/tests/integration_planner_worker_shaper_e2e.rs
+++ b/crates/kx-projection/tests/integration_planner_worker_shaper_e2e.rs
@@ -28,8 +28,12 @@ use kx_projection::{
     DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
     Projection,
 };
+use kx_warrant::{
+    ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    Role, WarrantSpec,
+};
 use smallvec::SmallVec;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 fn planner_def() -> MoteDef {
     let mut tools = BTreeMap::new();
@@ -91,6 +95,55 @@ fn stage(store: &InMemoryContentStore, td: &TopologyDecision) -> ContentRef {
     store.put(&bytes).expect("put succeeds")
 }
 
+fn permissive_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("test-model".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 1024,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 20,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn stage_warrant(store: &InMemoryContentStore) -> ContentRef {
+    let bytes = bincode::serde::encode_to_vec(permissive_warrant(), canonical_config())
+        .expect("WarrantSpec canonical bincode encodes infallibly");
+    store.put(&bytes).expect("put succeeds")
+}
+
+fn build_role_registry(td: &TopologyDecision) -> Arc<InMemoryRoleRegistry> {
+    let registry = Arc::new(InMemoryRoleRegistry::new());
+    let role = Role {
+        name: "test-default".into(),
+        version: 1,
+        spec: permissive_warrant(),
+        description: String::new(),
+    };
+    // Register the same permissive role under every descriptor's RoleId
+    // (this E2E doesn't exercise per-role narrowing — `kg1_close_*`
+    // tests in `integration_topology_classes.rs` cover that).
+    for d in &td.children {
+        registry.register(d.role_id.clone(), role.clone());
+    }
+    registry
+}
+
 #[test]
 fn planner_worker_shaper_end_to_end_demonstrates_seam_a() {
     let planner = planner_def();
@@ -99,10 +152,12 @@ fn planner_worker_shaper_end_to_end_demonstrates_seam_a() {
 
     // 1. Stage the planner's mocked TopologyDecision to the content store.
     let store = Arc::new(InMemoryContentStore::new());
-    let registry = Arc::new(InMemoryMoteDefRegistry::new());
-    registry.register(planner.clone());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(planner.clone());
     let td = mocked_planner_output();
     let td_ref = stage(&store, &td);
+    let role_registry = build_role_registry(&td);
+    let planner_warrant_ref = stage_warrant(&store);
 
     // 2. Build the journal with the planner's Committed entry.
     let journal = InMemoryJournal::new();
@@ -113,7 +168,7 @@ fn planner_worker_shaper_end_to_end_demonstrates_seam_a() {
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: td_ref,
         parents: SmallVec::new(),
-        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        warrant_ref: planner_warrant_ref,
         mote_def_hash: planner_hash,
     };
     journal.append(planner_committed).unwrap();
@@ -121,7 +176,8 @@ fn planner_worker_shaper_end_to_end_demonstrates_seam_a() {
     // 3. Cold-fold from the journal with the materializer wired.
     let materializer = Box::new(DefaultTopologyMaterializer::new(
         Arc::clone(&store),
-        Arc::clone(&registry),
+        Arc::clone(&def_registry),
+        Arc::clone(&role_registry),
         InheritFromShaperResolver,
     ));
     let mut projection =
@@ -153,7 +209,7 @@ fn planner_worker_shaper_end_to_end_demonstrates_seam_a() {
             nondeterminism: NdClass::Pure,
             result_ref: ContentRef::from_bytes([(0x10 + i as u8); 32]),
             parents: SmallVec::new(),
-            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            warrant_ref: planner_warrant_ref,
             mote_def_hash: kx_mote::MoteDefHash::from_bytes([(0x20 + i as u8); 32]),
         };
         journal.append(worker_committed.clone()).unwrap();
@@ -173,7 +229,8 @@ fn planner_worker_shaper_end_to_end_demonstrates_seam_a() {
     //    (R49 — replay faithfulness end-to-end).
     let materializer_2 = Box::new(DefaultTopologyMaterializer::new(
         Arc::clone(&store),
-        Arc::clone(&registry),
+        Arc::clone(&def_registry),
+        Arc::clone(&role_registry),
         InheritFromShaperResolver,
     ));
     let re_projection =

--- a/crates/kx-projection/tests/integration_topology_classes.rs
+++ b/crates/kx-projection/tests/integration_topology_classes.rs
@@ -19,8 +19,12 @@ use kx_projection::{
     DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
     Projection,
 };
+use kx_warrant::{
+    warrant_ref_of, ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass, NetScope,
+    ResourceCeiling, Role, RoleRegistry, WarrantSpec,
+};
 use smallvec::SmallVec;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 fn shaper_def() -> MoteDef {
     MoteDef {
@@ -59,20 +63,88 @@ fn encode_topology(td: &TopologyDecision) -> Vec<u8> {
         .expect("TopologyDecision canonical bincode encodes infallibly")
 }
 
+/// Permissive [`WarrantSpec`] used as the shaper's warrant + as every
+/// child role's spec in the 9-edge-case tests (the narrowing path is a
+/// no-op when role.spec == shaper.warrant — exercise its semantics
+/// separately in the `kg1_close_*` tests).
+fn permissive_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("test-model".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 1024,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 20,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// Test-local [`RoleRegistry`] that returns the same [`Role`] for any
+/// `RoleId`. The 9-edge-case tests don't exercise per-role narrowing.
+struct PermissiveAnyRoleRegistry {
+    role: Role,
+}
+
+impl RoleRegistry for PermissiveAnyRoleRegistry {
+    fn resolve(&self, _role_id: &RoleId) -> Option<Role> {
+        Some(self.role.clone())
+    }
+}
+
+/// Stage a permissive [`WarrantSpec`] in `store` and return its
+/// [`ContentRef`]. The 9-edge-case tests need a valid warrant_ref on
+/// the shaper's Committed entry; the actual narrowing semantics are
+/// trivially satisfied by `role.spec == shaper.warrant`.
+fn stage_permissive_warrant(store: &InMemoryContentStore) -> ContentRef {
+    let bytes = bincode::serde::encode_to_vec(permissive_warrant(), canonical_config())
+        .expect("WarrantSpec canonical bincode encodes infallibly");
+    store.put(&bytes).expect("put succeeds")
+}
+
+fn permissive_role_registry() -> Arc<PermissiveAnyRoleRegistry> {
+    Arc::new(PermissiveAnyRoleRegistry {
+        role: Role {
+            name: "test-default".into(),
+            version: 1,
+            spec: permissive_warrant(),
+            description: String::new(),
+        },
+    })
+}
+
 fn build_projection_with_topology(
     shaper: &MoteDef,
     td: &TopologyDecision,
 ) -> (Arc<InMemoryContentStore>, Projection, MoteId, ContentRef) {
     let store = Arc::new(InMemoryContentStore::new());
-    let registry = Arc::new(InMemoryMoteDefRegistry::new());
-    registry.register(shaper.clone());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper.clone());
+    let role_registry = permissive_role_registry();
     let materializer = Box::new(DefaultTopologyMaterializer::new(
         Arc::clone(&store),
-        Arc::clone(&registry),
+        Arc::clone(&def_registry),
+        role_registry,
         InheritFromShaperResolver,
     ));
     let bytes = encode_topology(td);
     let td_ref = store.put(&bytes).expect("put");
+    // Stage the shaper's WarrantSpec in the same content store so the
+    // materializer can fetch + decode it at fold time (PR 11.5 path).
+    let shaper_warrant_ref = stage_permissive_warrant(&store);
     let shaper_id = shaper_mote_id(shaper);
     let mut proj = Projection::with_materializer(materializer);
     let entry = JournalEntry::Committed {
@@ -82,7 +154,7 @@ fn build_projection_with_topology(
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: td_ref,
         parents: SmallVec::new(),
-        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        warrant_ref: shaper_warrant_ref,
         mote_def_hash: shaper.hash(),
     };
     proj.fold(&entry).unwrap();
@@ -270,12 +342,14 @@ fn class7d_two_independent_shapers_in_same_workflow_each_materialize_independent
     shaper_b.logic_ref = LogicRef([20u8; 32]);
 
     let store = Arc::new(InMemoryContentStore::new());
-    let registry = Arc::new(InMemoryMoteDefRegistry::new());
-    registry.register(shaper_a.clone());
-    registry.register(shaper_b.clone());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper_a.clone());
+    def_registry.register(shaper_b.clone());
+    let role_registry = permissive_role_registry();
     let materializer = Box::new(DefaultTopologyMaterializer::new(
         Arc::clone(&store),
-        Arc::clone(&registry),
+        Arc::clone(&def_registry),
+        role_registry,
         InheritFromShaperResolver,
     ));
     let mut proj = Projection::with_materializer(materializer);
@@ -292,6 +366,7 @@ fn class7d_two_independent_shapers_in_same_workflow_each_materialize_independent
     };
     let ref_a = store.put(&encode_topology(&td_a)).unwrap();
     let ref_b = store.put(&encode_topology(&td_b)).unwrap();
+    let shaper_warrant_ref = stage_permissive_warrant(&store);
 
     let shaper_a_id = shaper_mote_id(&shaper_a);
     let shaper_b_id = shaper_mote_id(&shaper_b);
@@ -304,7 +379,7 @@ fn class7d_two_independent_shapers_in_same_workflow_each_materialize_independent
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: ref_a,
         parents: SmallVec::new(),
-        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        warrant_ref: shaper_warrant_ref,
         mote_def_hash: shaper_a.hash(),
     })
     .unwrap();
@@ -315,7 +390,7 @@ fn class7d_two_independent_shapers_in_same_workflow_each_materialize_independent
         nondeterminism: NdClass::ReadOnlyNondet,
         result_ref: ref_b,
         parents: SmallVec::new(),
-        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        warrant_ref: shaper_warrant_ref,
         mote_def_hash: shaper_b.hash(),
     })
     .unwrap();
@@ -467,52 +542,329 @@ fn class9_scale_structure_proptest_n_le_64() {
 }
 
 // ---------------------------------------------------------------------------
-// KG-1 mitigation — Warrant safe-default
+// KG-1-close (PR 11.5) — Shaper-spawned-child warrant narrowing
+//
+// `topology.md` §13 KG-1's verbatim-inheritance safe-default is replaced
+// by D30 `intersect(shaper.warrant, role.spec)`. The materializer
+// resolves each descriptor's role via a `RoleRegistry`, narrows, and
+// stamps the per-child `warrant_ref` on the materialized
+// `RegisterMote`. The four KG-1-close obligations (per topology.md §13
+// closing-ticket item 4):
+//
+//   (a) child.warrant strictly narrower than shaper.warrant on at
+//       least one axis when role narrows;
+//   (b) sibling roles produce different child warrants;
+//   (c) unregistered role is a typed error (no silent widening);
+//   (d) attempted-widen role is a typed error (NarrowingError
+//       propagated).
 // ---------------------------------------------------------------------------
 
-#[test]
-fn kg1_shaper_spawned_child_inherits_shaper_warrant_verbatim_kg1_safe_default() {
-    // PR 11 ships KG-1 safe-default: materialized children's warrant
-    // inheritance happens via the projection reading the shaper's
-    // CommittedInfo.warrant_ref. The materializer does NOT itself stamp
-    // a per-child warrant_ref. To verify the safe-default, we assert:
-    // (1) the shaper's warrant_ref is stored on its CommittedInfo;
-    // (2) the projection has no separate per-child warrant axis (the
-    //     executor reads shaper.warrant_ref when dispatching children
-    //     until KG-1-close lands in PR 11.5).
-    let shaper = shaper_def();
-    let td = TopologyDecision {
-        children: vec![descriptor(
-            7,
-            NdClass::Pure,
-            EffectPattern::IdempotentByConstruction,
-        )],
-    };
-    let (_store, proj, shaper_id, _r) = build_projection_with_topology(&shaper, &td);
+/// Build a [`Role`] whose `spec` equals the permissive baseline modulo
+/// an overridable mutation. Mutators tighten the spec (narrowing); the
+/// resulting child warrant_ref must differ from the shaper's.
+fn role_with_spec(name: &str, mut mutate: impl FnMut(&mut WarrantSpec)) -> Role {
+    let mut spec = permissive_warrant();
+    mutate(&mut spec);
+    Role {
+        name: name.into(),
+        version: 1,
+        spec,
+        description: String::new(),
+    }
+}
 
-    // Property: the shaper's warrant_ref is recorded on its committed entry
-    // (the projection holds it for downstream consumers).
-    let shaper_committed_seq = proj.committed_seq_of(&shaper_id);
-    assert!(
-        shaper_committed_seq.is_some(),
-        "shaper committed seq is recorded"
+/// Build a projection wired with an explicit `InMemoryRoleRegistry`.
+/// Returns the staged content store, the projection, the shaper id, the
+/// staged topology ref, and the staged shaper warrant_ref so the KG-1-
+/// close tests can compare `proj.warrant_ref_of(child)` against the
+/// shaper's known ref.
+fn build_projection_with_role_registry(
+    shaper: &MoteDef,
+    td: &TopologyDecision,
+    role_registry: Arc<InMemoryRoleRegistry>,
+) -> (
+    Arc<InMemoryContentStore>,
+    Projection,
+    MoteId,
+    ContentRef,
+    ContentRef,
+) {
+    let store = Arc::new(InMemoryContentStore::new());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper.clone());
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        Arc::clone(&store),
+        Arc::clone(&def_registry),
+        role_registry,
+        InheritFromShaperResolver,
+    ));
+    let td_ref = store.put(&encode_topology(td)).expect("put");
+    let shaper_warrant_ref = stage_permissive_warrant(&store);
+    let shaper_id = shaper_mote_id(shaper);
+    let mut proj = Projection::with_materializer(materializer);
+    proj.fold(&JournalEntry::Committed {
+        mote_id: shaper_id,
+        idempotency_key: shaper_id.0,
+        seq: 1,
+        nondeterminism: NdClass::ReadOnlyNondet,
+        result_ref: td_ref,
+        parents: SmallVec::new(),
+        warrant_ref: shaper_warrant_ref,
+        mote_def_hash: shaper.hash(),
+    })
+    .expect("shaper fold succeeds");
+    (store, proj, shaper_id, td_ref, shaper_warrant_ref)
+}
+
+#[test]
+fn kg1_close_child_warrant_strictly_narrower_than_shaper_when_role_narrows() {
+    // OBLIGATION (a). Shaper's permissive warrant (max_calls = 8). Role's
+    // spec tightens max_calls to 2. The materialized child's warrant_ref
+    // MUST differ from the shaper's, and the recomputed child warrant
+    // MUST have max_calls = 2 (per-axis min via D30 intersect).
+    let shaper = shaper_def();
+    let d = descriptor(7, NdClass::Pure, EffectPattern::IdempotentByConstruction);
+    let td = TopologyDecision {
+        children: vec![d.clone()],
+    };
+    let registry = Arc::new(InMemoryRoleRegistry::new());
+    let tightening_role = role_with_spec("tighter-max-calls", |s| {
+        s.model_route.max_calls = 2;
+    });
+    registry.register(d.role_id.clone(), tightening_role.clone());
+
+    let (_store, proj, shaper_id, _td_ref, shaper_warrant_ref) =
+        build_projection_with_role_registry(&shaper, &td, registry);
+
+    // shaper + 1 materialized child:
+    assert_eq!(proj.len(), 2);
+    let child_id = *proj.ready_set().first().expect("one materialized child");
+    let child_warrant_ref = proj
+        .warrant_ref_of(&child_id)
+        .expect("materialized child carries a warrant_ref");
+
+    // (a) — strictly different ref (because role narrows max_calls).
+    assert_ne!(
+        child_warrant_ref, shaper_warrant_ref,
+        "narrowing role produces a different child warrant_ref"
     );
 
-    // Property: the projection's per-Mote read API does NOT expose a
-    // separate warrant axis for materialized children. Until KG-1-close
-    // (PR 11.5) adds a `RoleRegistry` and the materializer's intersect
-    // call, the safe-default = child inherits shaper warrant verbatim
-    // is structural: there is no separate child warrant to inherit
-    // from. (If a future PR adds per-child warrant storage to
-    // DeclaredInfo, this test will compile and pass — KG-1 will need
-    // an explicit closing-PR audit.)
-    //
-    // Smoke check: every materialized child has a parent edge to the
-    // shaper (i.e., the materializer registered them correctly).
-    let ready = proj.ready_set();
-    assert_eq!(ready.len(), 1);
-    let child_id = ready[0];
-    let parents = proj.parents_of(&child_id);
-    assert_eq!(parents.len(), 1);
-    assert_eq!(parents[0].0, shaper_id);
+    // Re-derive the expected child warrant to pin per-axis narrowing.
+    let expected_child_warrant =
+        kx_warrant::intersect(&permissive_warrant(), &tightening_role).expect("narrow ok");
+    assert_eq!(expected_child_warrant.model_route.max_calls, 2);
+    assert_eq!(child_warrant_ref, warrant_ref_of(&expected_child_warrant));
+    // Shaper's own warrant_ref equally read back via the same API.
+    assert_eq!(proj.warrant_ref_of(&shaper_id), Some(shaper_warrant_ref));
+}
+
+#[test]
+fn kg1_close_sibling_children_with_different_roles_get_different_warrants() {
+    // OBLIGATION (b). Two children under two different roles get two
+    // different child warrant_refs — sibling roles narrow independently.
+    let shaper = shaper_def();
+    let d_a = ChildDescriptor {
+        role_id: RoleId("worker-a".into()),
+        logic_ref: LogicRef([10u8; 32]),
+        nd_class: NdClass::Pure,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+    };
+    let d_b = ChildDescriptor {
+        role_id: RoleId("worker-b".into()),
+        logic_ref: LogicRef([20u8; 32]),
+        nd_class: NdClass::Pure,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+    };
+    let td = TopologyDecision {
+        children: vec![d_a.clone(), d_b.clone()],
+    };
+    let registry = Arc::new(InMemoryRoleRegistry::new());
+    registry.register(
+        d_a.role_id.clone(),
+        role_with_spec("role-a", |s| s.model_route.max_calls = 2),
+    );
+    registry.register(
+        d_b.role_id.clone(),
+        role_with_spec("role-b", |s| s.model_route.max_calls = 4),
+    );
+
+    let (_store, proj, shaper_id, _td_ref, _shaper_warrant_ref) =
+        build_projection_with_role_registry(&shaper, &td, registry);
+
+    let children = proj.children_of(&shaper_id);
+    assert_eq!(children.len(), 2);
+    let mut refs: Vec<ContentRef> = children
+        .iter()
+        .map(|(id, _)| proj.warrant_ref_of(id).expect("child warrant_ref present"))
+        .collect();
+    refs.sort();
+    refs.dedup();
+    assert_eq!(
+        refs.len(),
+        2,
+        "two roles narrowing to different specs MUST produce two distinct child warrant_refs"
+    );
+}
+
+#[test]
+fn kg1_close_role_not_registered_returns_typed_error() {
+    // OBLIGATION (c). The materializer refuses to silently widen when a
+    // descriptor names a role the registry doesn't know — it surfaces
+    // ProjectionError::RoleNotRegistered with the offending role_id +
+    // descriptor index.
+    let shaper = shaper_def();
+    let d = descriptor(7, NdClass::Pure, EffectPattern::IdempotentByConstruction);
+    let td = TopologyDecision {
+        children: vec![d.clone()],
+    };
+    // Empty registry — role lookup will miss.
+    let registry = Arc::new(InMemoryRoleRegistry::new());
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper.clone());
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        Arc::clone(&store),
+        Arc::clone(&def_registry),
+        registry,
+        InheritFromShaperResolver,
+    ));
+    let td_ref = store.put(&encode_topology(&td)).expect("put");
+    let shaper_warrant_ref = stage_permissive_warrant(&store);
+    let shaper_id = shaper_mote_id(&shaper);
+    let mut proj = Projection::with_materializer(materializer);
+
+    let err = proj
+        .fold(&JournalEntry::Committed {
+            mote_id: shaper_id,
+            idempotency_key: shaper_id.0,
+            seq: 1,
+            nondeterminism: NdClass::ReadOnlyNondet,
+            result_ref: td_ref,
+            parents: SmallVec::new(),
+            warrant_ref: shaper_warrant_ref,
+            mote_def_hash: shaper.hash(),
+        })
+        .unwrap_err();
+
+    match err {
+        kx_projection::ProjectionError::RoleNotRegistered {
+            role_id,
+            descriptor_index,
+        } => {
+            assert_eq!(role_id, d.role_id);
+            assert_eq!(descriptor_index, 0);
+        }
+        other => panic!("expected RoleNotRegistered, got {other:?}"),
+    }
+}
+
+#[test]
+fn kg1_close_role_that_attempts_widen_returns_narrowing_error() {
+    // OBLIGATION (d). A role whose spec is wider than the shaper's
+    // warrant on any axis produces ProjectionError::NarrowingFailed
+    // wrapping kx_warrant::NarrowingError — the materializer refuses
+    // the widening attempt at materialization time.
+    let shaper = shaper_def();
+    let d = descriptor(7, NdClass::Pure, EffectPattern::IdempotentByConstruction);
+    let td = TopologyDecision {
+        children: vec![d.clone()],
+    };
+    let registry = Arc::new(InMemoryRoleRegistry::new());
+    // Permissive shaper has tool_grants = {}. A role granting "tool-x"
+    // is wider than the shaper's empty allowlist → AttemptedWiden.
+    let widening_role = role_with_spec("wider-tool-grants", |s| {
+        let mut grants = BTreeSet::new();
+        grants.insert(kx_warrant::ToolGrant {
+            tool_id: kx_mote::ToolName("tool-x".into()),
+            tool_version: kx_mote::ToolVersion("1.0".into()),
+        });
+        s.tool_grants = grants;
+    });
+    registry.register(d.role_id.clone(), widening_role);
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper.clone());
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        Arc::clone(&store),
+        Arc::clone(&def_registry),
+        registry,
+        InheritFromShaperResolver,
+    ));
+    let td_ref = store.put(&encode_topology(&td)).expect("put");
+    let shaper_warrant_ref = stage_permissive_warrant(&store);
+    let shaper_id = shaper_mote_id(&shaper);
+    let mut proj = Projection::with_materializer(materializer);
+
+    let err = proj
+        .fold(&JournalEntry::Committed {
+            mote_id: shaper_id,
+            idempotency_key: shaper_id.0,
+            seq: 1,
+            nondeterminism: NdClass::ReadOnlyNondet,
+            result_ref: td_ref,
+            parents: SmallVec::new(),
+            warrant_ref: shaper_warrant_ref,
+            mote_def_hash: shaper.hash(),
+        })
+        .unwrap_err();
+
+    match err {
+        kx_projection::ProjectionError::NarrowingFailed {
+            descriptor_index, ..
+        } => {
+            assert_eq!(descriptor_index, 0);
+        }
+        other => panic!("expected NarrowingFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn kg1_close_materializer_propagates_warrant_store_fetch_failure() {
+    // Boundary: the shaper's warrant_ref points at content that was
+    // never staged → WarrantStoreFetch. Workflow author / executor
+    // MUST `put` the WarrantSpec before the shaper commits; this
+    // boundary test guards the contract.
+    let shaper = shaper_def();
+    let d = descriptor(7, NdClass::Pure, EffectPattern::IdempotentByConstruction);
+    let td = TopologyDecision {
+        children: vec![d.clone()],
+    };
+    let registry = Arc::new(InMemoryRoleRegistry::new());
+    registry.register(d.role_id.clone(), role_with_spec("any", |_| {}));
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    def_registry.register(shaper.clone());
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        Arc::clone(&store),
+        Arc::clone(&def_registry),
+        registry,
+        InheritFromShaperResolver,
+    ));
+    let td_ref = store.put(&encode_topology(&td)).expect("put");
+    // Use a warrant_ref that was NEVER staged.
+    let unstaged_warrant_ref = ContentRef::from_bytes([0xff; 32]);
+    let shaper_id = shaper_mote_id(&shaper);
+    let mut proj = Projection::with_materializer(materializer);
+    let err = proj
+        .fold(&JournalEntry::Committed {
+            mote_id: shaper_id,
+            idempotency_key: shaper_id.0,
+            seq: 1,
+            nondeterminism: NdClass::ReadOnlyNondet,
+            result_ref: td_ref,
+            parents: SmallVec::new(),
+            warrant_ref: unstaged_warrant_ref,
+            mote_def_hash: shaper.hash(),
+        })
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            kx_projection::ProjectionError::WarrantStoreFetch { .. }
+        ),
+        "expected WarrantStoreFetch, got {err:?}"
+    );
 }

--- a/crates/kx-scheduler/src/scheduler.rs
+++ b/crates/kx-scheduler/src/scheduler.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use kx_executor::{MoteExecutionResult, MoteExecutor, MoteExecutorError};
 use kx_mote::{Mote, MoteId};
 use kx_projection::{Projection, RegisterMote};
-use kx_warrant::WarrantSpec;
+use kx_warrant::{warrant_ref_of, WarrantSpec};
 
 use crate::errors::SchedulerError;
 use crate::placement::Placement;
@@ -136,6 +136,7 @@ impl<P: Placement> Scheduler<P> {
         if self.pending.contains_key(&mote.id) {
             return Err(SchedulerError::DuplicateSubmission(mote.id));
         }
+        let warrant_ref = warrant_ref_of(&warrant);
         projection.register_mote(RegisterMote {
             mote_id: mote.id,
             nd_class: mote.def.nd_class,
@@ -143,6 +144,7 @@ impl<P: Placement> Scheduler<P> {
             critic_for: mote.def.critic_for,
             is_topology_shaper: mote.def.is_topology_shaper,
             parents: mote.parents.clone(),
+            warrant_ref,
         });
         self.pending.insert(mote.id, (mote, warrant));
         Ok(())

--- a/crates/kx-warrant/src/lib.rs
+++ b/crates/kx-warrant/src/lib.rs
@@ -85,6 +85,7 @@ mod errors;
 mod fields;
 mod narrow;
 mod refs;
+mod registry;
 mod scope;
 mod spec;
 
@@ -94,6 +95,7 @@ pub use errors::{NarrowingError, ToolDenied};
 pub use fields::{Host, WarrantField};
 pub use narrow::{intersect, narrow};
 pub use refs::{role_id_of, warrant_ref_of};
+pub use registry::{InMemoryRoleRegistry, RoleRegistry};
 pub use scope::{FsScope, NetScope};
 pub use spec::{ModelRoute, ResourceCeiling, Role, ToolGrant, ToolRequirement, WarrantSpec};
 

--- a/crates/kx-warrant/src/registry.rs
+++ b/crates/kx-warrant/src/registry.rs
@@ -1,0 +1,237 @@
+//! [`RoleRegistry`] — workflow-author-side lookup mapping a descriptor's
+//! `RoleId` handle to a versioned [`Role`].
+//!
+//! The D48 child resolver picks the heavy `MoteDef` axes for a materialized
+//! child; the **warrant** axis is independent — D30's monotonic narrowing
+//! requires `intersect(parent.warrant, child.role.spec)`. Computing
+//! `child.role.spec` needs a registry mapping the descriptor-side
+//! `RoleId(String)` handle to a concrete [`Role`] (with its `WarrantSpec`).
+//! This module ships the trait + the OSS-default in-memory impl.
+//!
+//! The closing of `topology.md` §13 KG-1 (the *shaper-spawned-child warrant
+//! narrowing not wired* gap) consists of:
+//! 1. This trait + the in-memory impl (in this module).
+//! 2. `kx_projection::DefaultTopologyMaterializer` taking a
+//!    `RoleRegistry` and calling [`crate::intersect`] in its
+//!    `try_materialize` path instead of the verbatim ref-copy.
+//!
+//! See `docs/design/topology.md` §13 KG-1 + `docs/design/decisions.md`
+//! §D30 / §D48 (private corpus) for the load-bearing properties.
+
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use kx_mote::RoleId;
+
+use crate::spec::Role;
+
+/// Lookup of descriptor-side `RoleId` handles → versioned [`Role`]s.
+///
+/// The descriptor's [`RoleId`] is a workflow-author-facing string handle
+/// (`kx_mote::RoleId(String)`); this trait resolves it to the concrete
+/// [`Role`] (carrying the [`crate::WarrantSpec`] template) used by
+/// `intersect(shaper.warrant, role)`.
+///
+/// MUST be deterministic over the lifetime of one workflow execution:
+/// resolving the same `RoleId` twice MUST return identical `Role`s.
+/// Replay-faithfulness rests on this — a non-deterministic registry
+/// silently breaks R49 (a re-fold could materialize children with
+/// different warrants than the live fold).
+///
+/// Object-safe + `Send + Sync` so the materializer can hold an
+/// `Arc<dyn RoleRegistry>` and share it across worker threads.
+pub trait RoleRegistry: Send + Sync {
+    /// Resolve a role by its descriptor-side handle. Returns `None` if the
+    /// role is not registered — the materializer turns this into a typed
+    /// projection error so the workflow author sees a loud failure rather
+    /// than silent warrant widening.
+    fn resolve(&self, role_id: &RoleId) -> Option<Role>;
+}
+
+/// OSS-default [`RoleRegistry`] backed by an in-memory `BTreeMap`.
+///
+/// Workflow authors register roles before submitting a shaper. The OSS
+/// runtime instantiates one of these per workflow and hands it to the
+/// projection's materializer; cloud-side impls may back the same trait
+/// with a content-addressed remote registry (see `decisions.md` §D48
+/// cloud forward-note for the multi-model-resolution case).
+///
+/// # Examples
+///
+/// ```
+/// use kx_mote::{ModelId, RoleId};
+/// use kx_warrant::{
+///     ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass,
+///     NetScope, ResourceCeiling, Role, RoleRegistry, WarrantSpec,
+/// };
+/// use kx_content::ContentRef;
+/// use std::collections::BTreeSet;
+///
+/// let spec = WarrantSpec {
+///     mote_class: MoteClass::Pure, nd_class: MoteClass::Pure,
+///     fs_scope: FsScope::empty(), net_scope: NetScope::None,
+///     syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+///     tool_grants: BTreeSet::new(),
+///     model_route: ModelRoute {
+///         model_id: ModelId("m".into()), max_input_tokens: 10,
+///         max_output_tokens: 10, max_calls: 1,
+///     },
+///     resource_ceiling: ResourceCeiling {
+///         cpu_milli: 1, mem_bytes: 1, wall_clock_ms: 1,
+///         fd_count: 1, disk_bytes: 1,
+///     },
+///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+/// };
+/// let role = Role {
+///     name: "worker".into(), version: 1, spec,
+///     description: String::new(),
+/// };
+///
+/// let reg = InMemoryRoleRegistry::new();
+/// reg.register(RoleId("worker".into()), role.clone());
+/// assert_eq!(reg.resolve(&RoleId("worker".into())), Some(role));
+/// assert_eq!(reg.resolve(&RoleId("unknown".into())), None);
+/// ```
+#[derive(Default, Debug)]
+pub struct InMemoryRoleRegistry {
+    roles: RwLock<BTreeMap<RoleId, Role>>,
+}
+
+impl InMemoryRoleRegistry {
+    /// Construct an empty registry.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a role under a descriptor-side handle. Overwriting the
+    /// same handle with a different role is permitted but is a workflow-
+    /// author smell — KG-1's determinism rests on the registered roles
+    /// staying stable across a workflow's lifetime.
+    pub fn register(&self, role_id: RoleId, role: Role) {
+        self.roles
+            .write()
+            .expect("InMemoryRoleRegistry poisoned")
+            .insert(role_id, role);
+    }
+
+    /// Number of registered roles. Useful for asserting setup in tests.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.roles
+            .read()
+            .expect("InMemoryRoleRegistry poisoned")
+            .len()
+    }
+
+    /// `true` if no roles are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.roles
+            .read()
+            .expect("InMemoryRoleRegistry poisoned")
+            .is_empty()
+    }
+}
+
+impl RoleRegistry for InMemoryRoleRegistry {
+    fn resolve(&self, role_id: &RoleId) -> Option<Role> {
+        self.roles
+            .read()
+            .expect("InMemoryRoleRegistry poisoned")
+            .get(role_id)
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+    };
+    use kx_content::ContentRef;
+    use kx_mote::ModelId;
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+    use std::thread;
+
+    fn sample_role(name: &str) -> Role {
+        let spec = WarrantSpec {
+            mote_class: MoteClass::Pure,
+            nd_class: MoteClass::Pure,
+            fs_scope: FsScope::empty(),
+            net_scope: NetScope::None,
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            tool_grants: BTreeSet::new(),
+            model_route: ModelRoute {
+                model_id: ModelId("m".into()),
+                max_input_tokens: 10,
+                max_output_tokens: 10,
+                max_calls: 1,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 1,
+                mem_bytes: 1,
+                wall_clock_ms: 1,
+                fd_count: 1,
+                disk_bytes: 1,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::Bwrap,
+        };
+        Role {
+            name: name.into(),
+            version: 1,
+            spec,
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn registry_resolves_registered_handles_and_returns_none_for_unknown() {
+        let reg = InMemoryRoleRegistry::new();
+        assert!(reg.is_empty());
+        let role = sample_role("worker");
+        reg.register(RoleId("worker".into()), role.clone());
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.resolve(&RoleId("worker".into())), Some(role));
+        assert_eq!(reg.resolve(&RoleId("nope".into())), None);
+    }
+
+    #[test]
+    fn registry_repeated_resolve_returns_same_role_determinism() {
+        let reg = InMemoryRoleRegistry::new();
+        let role = sample_role("planner");
+        reg.register(RoleId("planner".into()), role.clone());
+        for _ in 0..10 {
+            assert_eq!(reg.resolve(&RoleId("planner".into())), Some(role.clone()));
+        }
+    }
+
+    #[test]
+    fn registry_send_sync_compile_time() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<InMemoryRoleRegistry>();
+        assert_send_sync::<Arc<dyn RoleRegistry>>();
+    }
+
+    #[test]
+    fn registry_concurrent_readers_get_same_answer() {
+        let reg = Arc::new(InMemoryRoleRegistry::new());
+        reg.register(RoleId("r".into()), sample_role("r"));
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let reg = Arc::clone(&reg);
+                thread::spawn(move || reg.resolve(&RoleId("r".into())))
+            })
+            .collect();
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let first = results[0].clone();
+        assert!(first.is_some());
+        for r in &results {
+            assert_eq!(r, &first);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the `topology.md` §13 KG-1 known gap shipped as a safe-default in PR 11. Materialized children's warrants are now computed via D30 monotonic narrowing — `intersect(shaper.warrant, role.spec)` — instead of inheriting the shaper's `warrant_ref` verbatim. Composes against D30 + D48; no new D-number.

- **New `kx-warrant::RoleRegistry`** trait + `InMemoryRoleRegistry` OSS-default impl. Object-safe `Send + Sync`; resolves descriptor-side `RoleId(String)` handles to versioned `Role`s.
- **`kx-projection::DefaultTopologyMaterializer`** gains an `Arc<Reg: RoleRegistry>` parameter. On every shaper-committed entry it fetches the shaper's `WarrantSpec` from the content store, resolves each child's role from the registry, intersects, and stamps the per-child `warrant_ref` on the materialized `RegisterMote`.
- **`RegisterMote` + `DeclaredInfo`** now carry `warrant_ref: ContentRef`; new public read API `Projection::warrant_ref_of` (mirrored on `Snapshot`).
- **New typed errors** `RoleNotRegistered`, `NarrowingFailed`, `WarrantStoreFetch`, `WarrantDecodeFailed` — the materializer refuses to silently widen.
- **`kx-scheduler::Scheduler::submit`** computes `warrant_ref` via `warrant_ref_of` when registering a workflow-author Mote.

## Test surface (per topology.md §13 closing-ticket item 4)

- 4 new `RoleRegistry` unit tests in `kx-warrant`.
- 5 new KG-1-close integration tests in `kx-projection/tests/integration_topology_classes.rs`:
  - `kg1_close_child_warrant_strictly_narrower_than_shaper_when_role_narrows`
  - `kg1_close_sibling_children_with_different_roles_get_different_warrants`
  - `kg1_close_role_not_registered_returns_typed_error`
  - `kg1_close_role_that_attempts_widen_returns_narrowing_error`
  - `kg1_close_materializer_propagates_warrant_store_fetch_failure`
- Replaces the now-superseded KG-1 verbatim safe-default test.

The R49 cold-re-fold proof (`cold_refold_topology.rs`) is preserved via a `PermissiveAnyRoleRegistry` test helper — narrowing is a no-op when `role.spec == shaper.warrant`, so identity reconstructibility is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — **723 passed / 0 failed / 8 ignored** (was 714 + 8; +9 net) on Apple Silicon
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` — clean
- [ ] Linux CI inherits the same suite (this PR's CI)
- [ ] Once KG-1 closes, the release-note verbatim-inheritance disclosure drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)