### PR TITLE
PR 12 / P1.12 — tag-driven storage tiering (kx-tiering)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-tiering"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-journal",
+ "kx-mote",
+ "kx-projection",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kx-tool-registry"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/kx-capability",
     "crates/kx-executor",
     "crates/kx-scheduler",
+    "crates/kx-tiering",
 ]
 exclude = [
     "kx-cloud",

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -4,7 +4,7 @@
 
 use kx_content::ContentRef;
 use kx_journal::{Journal, JournalEntry};
-use kx_mote::{EdgeMeta, MoteId};
+use kx_mote::{EdgeMeta, MoteId, NdClass};
 use smallvec::SmallVec;
 
 use crate::enums::{AnomalyKind, MoteState, PromotionState};
@@ -381,6 +381,21 @@ impl Projection {
             .motes
             .get(mote_id)
             .and_then(|i| i.committed.as_ref().map(|c| c.result_ref))
+    }
+
+    /// The Mote's committed non-determinism tag ([`NdClass`]), if it has a
+    /// `Committed` entry; `None` otherwise.
+    ///
+    /// Mirrors [`Projection::result_ref_of`]. The tag drives P1.12 tag-driven
+    /// storage tiering: `kx-tiering` joins this with `result_ref_of` to decide
+    /// evictability (PURE payloads are droppable + recomputable; READ-ONLY-NONDET
+    /// and WORLD-MUTATING are always persisted) without exposing `CommittedInfo`.
+    #[must_use]
+    pub fn nondeterminism_of(&self, mote_id: &MoteId) -> Option<NdClass> {
+        self.state
+            .motes
+            .get(mote_id)
+            .and_then(|i| i.committed.as_ref().map(|c| c.nondeterminism))
     }
 
     /// Motes whose parents are all `Committed-and-not-Repudiated` AND whose

--- a/crates/kx-projection/src/snapshot.rs
+++ b/crates/kx-projection/src/snapshot.rs
@@ -3,7 +3,7 @@
 //! semantics.
 
 use kx_content::ContentRef;
-use kx_mote::{EdgeMeta, MoteId};
+use kx_mote::{EdgeMeta, MoteId, NdClass};
 use smallvec::SmallVec;
 
 use crate::enums::{AnomalyKind, MoteState, PromotionState};
@@ -117,6 +117,25 @@ impl Snapshot {
             .motes
             .get(mote_id)
             .and_then(|i| i.committed.as_ref().map(|c| c.result_ref))
+    }
+
+    /// Committed non-determinism tag. See
+    /// [`crate::Projection::nondeterminism_of`].
+    #[must_use]
+    pub fn nondeterminism_of(&self, mote_id: &MoteId) -> Option<NdClass> {
+        self.state
+            .motes
+            .get(mote_id)
+            .and_then(|i| i.committed.as_ref().map(|c| c.nondeterminism))
+    }
+
+    /// Committed-entry `seq`. See [`crate::Projection::committed_seq_of`].
+    #[must_use]
+    pub fn committed_seq_of(&self, mote_id: &MoteId) -> Option<u64> {
+        self.state
+            .motes
+            .get(mote_id)
+            .and_then(|i| i.committed.as_ref().map(|c| c.seq))
     }
 
     /// Declared-or-committed warrant_ref for the Mote. See

--- a/crates/kx-projection/tests/dod.rs
+++ b/crates/kx-projection/tests/dod.rs
@@ -463,6 +463,17 @@ fn exercise_from_journal<J: Journal>(j: &J) {
     let p = Projection::from_journal(j).unwrap();
     assert_eq!(p.state_of(&mid(b'a')), MoteState::Committed);
     assert_eq!(p.result_ref_of(&mid(b'a')), Some(cref(b'a')));
+
+    // P1.12 tiering tag source: nondeterminism_of mirrors result_ref_of and
+    // returns the committed NdClass; None for an unknown / uncommitted Mote.
+    assert_eq!(p.nondeterminism_of(&mid(b'a')), Some(NdClass::Pure));
+    assert_eq!(p.nondeterminism_of(&mid(b'z')), None);
+    // The snapshot mirror agrees.
+    assert_eq!(
+        p.snapshot().nondeterminism_of(&mid(b'a')),
+        Some(NdClass::Pure)
+    );
+    assert_eq!(p.snapshot().nondeterminism_of(&mid(b'z')), None);
 }
 
 #[test]

--- a/crates/kx-tiering/Cargo.toml
+++ b/crates/kx-tiering/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name         = "kx-tiering"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx tag-driven storage tiering (P1.12) — evicts PURE (droppable + recomputable) payloads under simulated memory pressure; READ-ONLY-NONDET + WORLD-MUTATING are never evicted. The content store stays tag-blind; the tiering pass joins the projection's per-Mote NdClass with the store's refs and shares the idempotent delete() primitive with orphan-GC."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+kx-content    = { workspace = true }
+kx-mote       = { workspace = true }
+kx-projection = { workspace = true }
+thiserror     = { workspace = true }
+tracing       = { workspace = true }
+
+[dev-dependencies]
+kx-journal = { workspace = true }
+smallvec   = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-tiering/src/candidate.rs
+++ b/crates/kx-tiering/src/candidate.rs
@@ -1,0 +1,215 @@
+//! Tag-driven selection of evictable PURE payload refs.
+
+use std::collections::BTreeMap;
+
+use kx_content::ContentRef;
+use kx_mote::NdClass;
+use kx_projection::{MoteState, Snapshot};
+
+/// One evictable PURE result_ref together with its eviction-order key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvictionCandidate {
+    /// The content ref backing one or more committed PURE Motes.
+    pub result_ref: ContentRef,
+    /// The smallest committing `seq` among the PURE Motes that resolve to this
+    /// ref. Eviction is oldest-first, so candidates are returned ascending by
+    /// this key (ties broken by `result_ref` for determinism).
+    pub min_seq: u64,
+}
+
+/// Per-ref accumulator while folding the snapshot.
+#[derive(Clone, Copy)]
+struct RefTally {
+    /// `true` while every committed contributor seen so far is PURE.
+    all_pure: bool,
+    /// Smallest committing `seq` seen for this ref.
+    min_seq: u64,
+}
+
+/// Compute the eviction-ordered list of PURE-only candidate refs from a
+/// projection snapshot.
+///
+/// A ref is a candidate **iff every committed, non-repudiated Mote that resolves
+/// to it is [`NdClass::Pure`]**. Content-addressed dedup means a PURE and a
+/// WORLD-MUTATING / READ-ONLY-NONDET Mote can share a ref; any non-PURE
+/// contributor protects the ref from eviction. Repudiated Motes neither protect
+/// nor offer a ref — their payloads are governed by orphan-GC/retention, not
+/// tiering — so only `MoteState::Committed` Motes vote.
+///
+/// Pure tag logic: this does **not** touch the content store. Result is ordered
+/// oldest-committing-`seq` first (the eviction order [`crate::run_pass`] consumes).
+#[must_use]
+pub fn select_candidates(snapshot: &Snapshot) -> Vec<EvictionCandidate> {
+    let mut refs: BTreeMap<ContentRef, RefTally> = BTreeMap::new();
+
+    for (mote_id, state) in snapshot.iter_motes() {
+        // Only committed-and-not-repudiated Motes vote.
+        if state != MoteState::Committed {
+            continue;
+        }
+        // A Committed state without a folded result_ref/nd is not expected;
+        // skip defensively rather than guess.
+        let (Some(result_ref), Some(nd)) = (
+            snapshot.result_ref_of(&mote_id),
+            snapshot.nondeterminism_of(&mote_id),
+        ) else {
+            continue;
+        };
+        let seq = snapshot.committed_seq_of(&mote_id).unwrap_or(u64::MAX);
+        let is_pure = nd == NdClass::Pure;
+
+        refs.entry(result_ref)
+            .and_modify(|t| {
+                t.all_pure &= is_pure;
+                t.min_seq = t.min_seq.min(seq);
+            })
+            .or_insert(RefTally {
+                all_pure: is_pure,
+                min_seq: seq,
+            });
+    }
+
+    let mut candidates: Vec<EvictionCandidate> = refs
+        .into_iter()
+        .filter(|(_, t)| t.all_pure)
+        .map(|(result_ref, t)| EvictionCandidate {
+            result_ref,
+            min_seq: t.min_seq,
+        })
+        .collect();
+    // Oldest-commit-first; deterministic tie-break by ref.
+    candidates.sort_by(|a, b| {
+        a.min_seq
+            .cmp(&b.min_seq)
+            .then_with(|| a.result_ref.cmp(&b.result_ref))
+    });
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_content::ContentRef;
+    use kx_journal::{InMemoryJournal, Journal, JournalEntry, RepudiationReason};
+    use kx_mote::{MoteDefHash, MoteId};
+    use smallvec::SmallVec;
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+    fn cref(b: u8) -> ContentRef {
+        ContentRef::from_bytes([b; 32])
+    }
+    fn dh(b: u8) -> MoteDefHash {
+        MoteDefHash::from_bytes([b; 32])
+    }
+
+    /// Append a Committed entry; returns the journal-assigned seq.
+    fn commit(j: &InMemoryJournal, mote: u8, result: u8, nd: NdClass) -> u64 {
+        let e = j
+            .append(JournalEntry::Committed {
+                mote_id: mid(mote),
+                idempotency_key: [mote; 32],
+                seq: 0, // ignored; the journal assigns
+                nondeterminism: nd,
+                result_ref: cref(result),
+                parents: SmallVec::new(),
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+                mote_def_hash: dh(mote),
+            })
+            .unwrap();
+        e.seq()
+    }
+
+    fn repudiate(j: &InMemoryJournal, mote: u8, target_seq: u64) {
+        j.append(JournalEntry::Repudiated {
+            target_mote_id: mid(mote),
+            idempotency_key: [0xee ^ mote; 32],
+            seq: 0,
+            target_committed_seq: target_seq,
+            reason_class: RepudiationReason::OperatorAction,
+            repudiator_id: 1,
+        })
+        .unwrap();
+    }
+
+    fn snapshot_of(j: &InMemoryJournal) -> Snapshot {
+        kx_projection::Projection::from_journal(j)
+            .unwrap()
+            .snapshot()
+    }
+
+    #[test]
+    fn pure_only_ref_is_evictable() {
+        let j = InMemoryJournal::new();
+        commit(&j, b'a', b'a', NdClass::Pure);
+        let c = select_candidates(&snapshot_of(&j));
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].result_ref, cref(b'a'));
+    }
+
+    #[test]
+    fn wm_ref_never_selected() {
+        let j = InMemoryJournal::new();
+        commit(&j, b'a', b'a', NdClass::WorldMutating);
+        assert!(select_candidates(&snapshot_of(&j)).is_empty());
+    }
+
+    #[test]
+    fn rond_ref_never_selected() {
+        let j = InMemoryJournal::new();
+        commit(&j, b'a', b'a', NdClass::ReadOnlyNondet);
+        assert!(select_candidates(&snapshot_of(&j)).is_empty());
+    }
+
+    #[test]
+    fn shared_ref_pure_plus_wm_is_protected() {
+        // Two distinct Motes, identical payload bytes => same ContentRef.
+        let j = InMemoryJournal::new();
+        commit(&j, b'a', b'x', NdClass::Pure);
+        commit(&j, b'b', b'x', NdClass::WorldMutating);
+        // The shared ref is protected by its WM contributor.
+        assert!(select_candidates(&snapshot_of(&j)).is_empty());
+    }
+
+    #[test]
+    fn shared_ref_pure_plus_pure_is_evictable() {
+        let j = InMemoryJournal::new();
+        commit(&j, b'a', b'x', NdClass::Pure);
+        commit(&j, b'b', b'x', NdClass::Pure);
+        let c = select_candidates(&snapshot_of(&j));
+        assert_eq!(c.len(), 1, "deduped to a single ref");
+        assert_eq!(c[0].result_ref, cref(b'x'));
+    }
+
+    #[test]
+    fn repudiated_pure_mote_excluded_from_voting() {
+        // A repudiated PURE Mote must NOT make a WM-shared ref evictable...
+        let j = InMemoryJournal::new();
+        let pure_seq = commit(&j, b'a', b'x', NdClass::Pure);
+        commit(&j, b'b', b'x', NdClass::WorldMutating);
+        repudiate(&j, b'a', pure_seq); // PURE side repudiated
+                                       // ...the live WM contributor still protects the ref.
+        assert!(select_candidates(&snapshot_of(&j)).is_empty());
+
+        // ...and a repudiated-only PURE ref offers nothing (no live contributor).
+        let j2 = InMemoryJournal::new();
+        let s = commit(&j2, b'c', b'y', NdClass::Pure);
+        repudiate(&j2, b'c', s);
+        assert!(select_candidates(&snapshot_of(&j2)).is_empty());
+    }
+
+    #[test]
+    fn candidates_ordered_oldest_seq_first() {
+        let j = InMemoryJournal::new();
+        commit(&j, b'a', b'a', NdClass::Pure); // seq 0
+        commit(&j, b'b', b'b', NdClass::Pure); // seq 1
+        commit(&j, b'c', b'c', NdClass::Pure); // seq 2
+        let c = select_candidates(&snapshot_of(&j));
+        let seqs: Vec<u64> = c.iter().map(|x| x.min_seq).collect();
+        let mut sorted = seqs.clone();
+        sorted.sort_unstable();
+        assert_eq!(seqs, sorted, "ascending by min_seq");
+        assert_eq!(c[0].result_ref, cref(b'a'));
+    }
+}

--- a/crates/kx-tiering/src/error.rs
+++ b/crates/kx-tiering/src/error.rs
@@ -1,0 +1,16 @@
+//! The tiering-pass error type.
+
+use kx_content::StoreError;
+
+/// A failure during a tiering pass.
+///
+/// Note that a [`NotFound`](kx_content::NotFound) while *sizing* a candidate is
+/// **not** an error — an already-absent PURE payload (evicted by a prior pass or
+/// the orphan-GC walker) is simply skipped. Only a genuine store/IO failure on
+/// [`delete`](kx_content::ContentStore::delete) surfaces here.
+#[derive(Debug, thiserror::Error)]
+pub enum TieringError {
+    /// A `ContentStore::delete` call failed.
+    #[error("content store delete failed: {0}")]
+    Delete(#[from] StoreError),
+}

--- a/crates/kx-tiering/src/lib.rs
+++ b/crates/kx-tiering/src/lib.rs
@@ -1,0 +1,70 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+// Inline test modules are exempted from the workspace deny on `unwrap_used` /
+// `expect_used`. Integration tests under tests/*.rs carry per-file allows.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-tiering — tag-driven storage tiering (P1.12)
+//!
+//! Reuses the per-Mote [`NdClass`](kx_mote::NdClass) tag for memory management.
+//! The tag already does double duty in the runtime — a recovery gate *and* a
+//! tiering signal (`mote.md` §6):
+//!
+//! - **PURE** — output is a deterministic function of inputs, so the payload is
+//!   **droppable + recomputable**. Under memory pressure it may be evicted; a
+//!   later read returns [`NotFound`](kx_content::NotFound) and the consumer
+//!   recomputes the Mote by re-running its deterministic logic (re-running re-puts
+//!   bit-identical bytes → the *same* content ref, by content-addressing).
+//! - **READ-ONLY-NONDET** and **WORLD-MUTATING** — not recomputable, so the
+//!   payload is **always persisted** and is *never* evicted by tiering.
+//!
+//! ## The content store stays tag-blind
+//!
+//! Per `content-store.md` §7 the [`ContentStore`](kx_content::ContentStore) only
+//! stores / retrieves / deletes bytes by ref and must not depend on the journal.
+//! This crate is the **tiering pass**: it reads a projection
+//! [`Snapshot`](kx_projection::Snapshot) to learn which committed `result_ref`s
+//! belong to PURE Motes, then directs the store to [`delete`](kx_content::ContentStore::delete)
+//! them. Tiering and the orphan-GC walker share that one idempotent `delete(ref)`
+//! primitive; the store does not distinguish eviction-by-tiering from
+//! deletion-by-orphan-GC.
+//!
+//! ## Shared-ref protection (content-addressed dedup)
+//!
+//! Because refs are content-addressed BLAKE3, two distinct committed Motes with
+//! identical payload bytes resolve to the **same** ref. A ref is evictable **iff
+//! every committed, non-repudiated Mote that resolves to it is PURE** — any
+//! WORLD-MUTATING / READ-ONLY-NONDET contributor protects the ref. See
+//! [`select_candidates`].
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use kx_tiering::{run_pass, TieringBudget};
+//! # fn demo<S: kx_content::ContentStore>(snapshot: &kx_projection::Snapshot, store: &S)
+//! #   -> Result<(), kx_tiering::TieringError> {
+//! // Keep at most 64 resident PURE payload objects; evict oldest-commit-first.
+//! let report = run_pass(snapshot, store, TieringBudget::MaxObjects(64))?;
+//! println!("evicted {} refs, reclaimed {} bytes", report.evicted.len(), report.bytes_reclaimed);
+//! # Ok(())
+//! # }
+//! ```
+
+mod candidate;
+mod error;
+mod pass;
+mod policy;
+
+pub use candidate::{select_candidates, EvictionCandidate};
+pub use error::TieringError;
+pub use pass::{run_pass, EvictionReport};
+pub use policy::{ResidentUsage, TieringBudget};

--- a/crates/kx-tiering/src/pass.rs
+++ b/crates/kx-tiering/src/pass.rs
@@ -1,0 +1,94 @@
+//! The tiering pass: budget-driven eviction of PURE payloads.
+
+use kx_content::{ContentRef, ContentStore};
+use kx_projection::Snapshot;
+
+use crate::candidate::select_candidates;
+use crate::error::TieringError;
+use crate::policy::{ResidentUsage, TieringBudget};
+
+/// The outcome of one tiering pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EvictionReport {
+    /// Refs deleted from the store during this pass, in eviction order.
+    pub evicted: Vec<ContentRef>,
+    /// Total bytes reclaimed (sum of the evicted payloads' sizes).
+    pub bytes_reclaimed: u64,
+    /// Number of PURE-only candidate refs the snapshot offered.
+    pub candidates_considered: usize,
+    /// Candidates already absent from the store (skipped — a prior pass or the
+    /// orphan-GC walker already removed them; deletion is idempotent).
+    pub skipped_absent: usize,
+    /// Resident PURE footprint before eviction.
+    pub usage_before: ResidentUsage,
+    /// Resident PURE footprint after eviction.
+    pub usage_after: ResidentUsage,
+}
+
+/// One resident PURE payload, sized for budgeting.
+struct Resident {
+    result_ref: ContentRef,
+    size: u64,
+}
+
+/// Run one tiering pass: select PURE-only candidates (shared-ref-protected,
+/// repudiated-excluded — see [`select_candidates`]), then delete them
+/// oldest-commit-first until the resident PURE footprint is within `budget`.
+///
+/// WORLD-MUTATING and READ-ONLY-NONDET refs are never candidates, so they are
+/// never deleted — regardless of how tight the budget is (a `MaxObjects(0)` /
+/// `MaxBytes(0)` budget evicts every PURE payload and leaves the protected tags
+/// untouched). The pass is idempotent: re-running after eviction finds the
+/// already-deleted refs absent and reports them as `skipped_absent`.
+#[tracing::instrument(skip(snapshot, store), fields(budget = ?budget))]
+pub fn run_pass<S: ContentStore>(
+    snapshot: &Snapshot,
+    store: &S,
+    budget: TieringBudget,
+) -> Result<EvictionReport, TieringError> {
+    let candidates = select_candidates(snapshot);
+    let candidates_considered = candidates.len();
+
+    // Size each candidate against the store (oldest-first order preserved).
+    // A NotFound is a normal outcome — the payload is already gone — not an error.
+    let mut resident: Vec<Resident> = Vec::with_capacity(candidates.len());
+    let mut skipped_absent = 0usize;
+    for c in &candidates {
+        match store.get(&c.result_ref) {
+            Ok(payload) => resident.push(Resident {
+                result_ref: c.result_ref,
+                size: u64::try_from(payload.len()).unwrap_or(u64::MAX),
+            }),
+            Err(_not_found) => skipped_absent += 1,
+        }
+    }
+
+    let usage_before = ResidentUsage {
+        objects: resident.len(),
+        bytes: resident.iter().map(|r| r.size).sum(),
+    };
+
+    let mut current = usage_before;
+    let mut evicted = Vec::new();
+    let mut bytes_reclaimed = 0u64;
+
+    // Evict oldest-first until within budget (or nothing left to evict).
+    let mut iter = resident.into_iter();
+    while !budget.is_satisfied(current) {
+        let Some(r) = iter.next() else { break };
+        store.delete(&r.result_ref)?;
+        evicted.push(r.result_ref);
+        bytes_reclaimed += r.size;
+        current.objects -= 1;
+        current.bytes -= r.size;
+    }
+
+    Ok(EvictionReport {
+        evicted,
+        bytes_reclaimed,
+        candidates_considered,
+        skipped_absent,
+        usage_before,
+        usage_after: current,
+    })
+}

--- a/crates/kx-tiering/src/policy.rs
+++ b/crates/kx-tiering/src/policy.rs
@@ -1,0 +1,90 @@
+//! The simulated memory-pressure budget applied to resident PURE payloads.
+
+/// A simulated memory-pressure budget over the resident PURE payload footprint.
+///
+/// Only PURE payloads are subject to a budget — they are the sole recomputable
+/// class (`mote.md` §6). READ-ONLY-NONDET and WORLD-MUTATING payloads are never
+/// counted toward usage and never evicted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TieringBudget {
+    /// Keep at most this many resident PURE payload objects.
+    MaxObjects(usize),
+    /// Keep at most this many resident PURE payload bytes.
+    MaxBytes(u64),
+}
+
+/// The resident PURE-payload footprint measured during a pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ResidentUsage {
+    /// Number of resident PURE payload objects.
+    pub objects: usize,
+    /// Total bytes of resident PURE payloads.
+    pub bytes: u64,
+}
+
+impl TieringBudget {
+    /// `true` when `usage` is within budget — no eviction needed.
+    #[must_use]
+    pub fn is_satisfied(self, usage: ResidentUsage) -> bool {
+        match self {
+            TieringBudget::MaxObjects(n) => usage.objects <= n,
+            TieringBudget::MaxBytes(b) => usage.bytes <= b,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_objects_under_and_over_budget() {
+        let b = TieringBudget::MaxObjects(2);
+        assert!(b.is_satisfied(ResidentUsage {
+            objects: 0,
+            bytes: 999
+        }));
+        assert!(b.is_satisfied(ResidentUsage {
+            objects: 2,
+            bytes: 999
+        }));
+        assert!(!b.is_satisfied(ResidentUsage {
+            objects: 3,
+            bytes: 0
+        }));
+    }
+
+    #[test]
+    fn max_bytes_under_and_over_budget() {
+        let b = TieringBudget::MaxBytes(100);
+        assert!(b.is_satisfied(ResidentUsage {
+            objects: 999,
+            bytes: 0
+        }));
+        assert!(b.is_satisfied(ResidentUsage {
+            objects: 999,
+            bytes: 100
+        }));
+        assert!(!b.is_satisfied(ResidentUsage {
+            objects: 0,
+            bytes: 101
+        }));
+    }
+
+    #[test]
+    fn zero_budget_is_only_satisfied_when_empty() {
+        let objs = TieringBudget::MaxObjects(0);
+        assert!(objs.is_satisfied(ResidentUsage::default()));
+        assert!(!objs.is_satisfied(ResidentUsage {
+            objects: 1,
+            bytes: 0
+        }));
+
+        let bytes = TieringBudget::MaxBytes(0);
+        assert!(bytes.is_satisfied(ResidentUsage::default()));
+        assert!(!bytes.is_satisfied(ResidentUsage {
+            objects: 0,
+            bytes: 1
+        }));
+    }
+}

--- a/crates/kx-tiering/tests/candidate_selection.rs
+++ b/crates/kx-tiering/tests/candidate_selection.rs
@@ -1,0 +1,49 @@
+//! Integration: candidate selection over a realistic mixed projection
+//! (PURE / READ-ONLY-NONDET / WORLD-MUTATING / repudiated + a dedup collision),
+//! built by folding a real in-memory journal.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use common::Fixture;
+use kx_mote::NdClass;
+use kx_tiering::select_candidates;
+
+#[test]
+fn selects_exactly_pure_only_refs_in_oldest_seq_order() {
+    let fx = Fixture::new();
+
+    // seq 0: PURE, unique payload  -> evictable
+    let (r_pure_a, _) = fx.commit_payload(b'a', b"alpha", NdClass::Pure);
+    // seq 1: READ-ONLY-NONDET      -> protected
+    let (_r_rond, _) = fx.commit_payload(b'r', b"sampled-output", NdClass::ReadOnlyNondet);
+    // seq 2: WORLD-MUTATING        -> protected
+    let (_r_wm, _) = fx.commit_payload(b'w', b"world-effect", NdClass::WorldMutating);
+    // seq 3: PURE, unique payload  -> evictable (younger than r_pure_a)
+    let (r_pure_b, _) = fx.commit_payload(b'b', b"bravo", NdClass::Pure);
+
+    // seq 4 + 5: dedup collision — two PURE Motes, identical bytes => one ref.
+    let (r_shared_pure, _) = fx.commit_payload(b'c', b"shared", NdClass::Pure);
+    let (r_shared_pure2, _) = fx.commit_payload(b'd', b"shared", NdClass::Pure);
+    assert_eq!(r_shared_pure, r_shared_pure2, "content-addressed dedup");
+
+    // seq 6 + 7: dedup collision — PURE + WM share a ref => protected.
+    let (r_mixed, _) = fx.commit_payload(b'e', b"mixed", NdClass::Pure);
+    let (r_mixed2, _) = fx.commit_payload(b'f', b"mixed", NdClass::WorldMutating);
+    assert_eq!(r_mixed, r_mixed2);
+
+    // seq 8: PURE then repudiated  -> no live contributor, offers nothing.
+    let (_r_dead, dead_seq) = fx.commit_payload(b'g', b"dead", NdClass::Pure);
+    fx.repudiate(b'g', dead_seq);
+
+    let candidates = select_candidates(&fx.snapshot());
+    let got: Vec<_> = candidates.iter().map(|c| c.result_ref).collect();
+
+    // Exactly the three evictable PURE-only refs: a, b, and the all-PURE shared ref.
+    assert_eq!(got, vec![r_pure_a, r_pure_b, r_shared_pure]);
+    // Oldest-seq-first (journal seq is 1-based, append order): a (seq 1) before
+    // b (seq 4) before the all-PURE shared ref (min of seq 5 and 6 = 5).
+    let seqs: Vec<u64> = candidates.iter().map(|c| c.min_seq).collect();
+    assert_eq!(seqs, vec![1, 4, 5]);
+}

--- a/crates/kx-tiering/tests/common/mod.rs
+++ b/crates/kx-tiering/tests/common/mod.rs
@@ -1,0 +1,78 @@
+//! Shared fixtures for the kx-tiering integration tests.
+//!
+//! A [`Fixture`] owns an in-memory content store + journal and commits Motes
+//! whose `result_ref` is the *real* content-addressed ref of the payload bytes
+//! (so eviction actually targets a stored object). This mirrors the runtime's
+//! put-then-commit discipline closely enough to exercise the tiering contract.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, dead_code, unreachable_pub)]
+
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry, RepudiationReason};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use kx_projection::{Projection, Snapshot};
+use smallvec::SmallVec;
+
+pub fn mid(b: u8) -> MoteId {
+    MoteId::from_bytes([b; 32])
+}
+pub fn dh(b: u8) -> MoteDefHash {
+    MoteDefHash::from_bytes([b; 32])
+}
+
+pub struct Fixture {
+    pub store: InMemoryContentStore,
+    pub journal: InMemoryJournal,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        Self {
+            store: InMemoryContentStore::new(),
+            journal: InMemoryJournal::new(),
+        }
+    }
+
+    /// Put `payload` and commit Mote `mote` (tag `nd`) referencing it by its
+    /// real content-addressed ref. Returns the ref and the journal-assigned seq.
+    pub fn commit_payload(&self, mote: u8, payload: &[u8], nd: NdClass) -> (ContentRef, u64) {
+        let result_ref = self.store.put(payload).unwrap();
+        let seq = self.commit_ref(mote, result_ref, nd);
+        (result_ref, seq)
+    }
+
+    /// Commit Mote `mote` (tag `nd`) referencing an already-known ref (no put).
+    /// Useful for shared-ref / already-absent scenarios. Returns the seq.
+    pub fn commit_ref(&self, mote: u8, result_ref: ContentRef, nd: NdClass) -> u64 {
+        self.journal
+            .append(JournalEntry::Committed {
+                mote_id: mid(mote),
+                idempotency_key: [mote; 32],
+                seq: 0, // ignored; journal assigns
+                nondeterminism: nd,
+                result_ref,
+                parents: SmallVec::new(),
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+                mote_def_hash: dh(mote),
+            })
+            .unwrap()
+            .seq()
+    }
+
+    pub fn repudiate(&self, mote: u8, target_seq: u64) {
+        self.journal
+            .append(JournalEntry::Repudiated {
+                target_mote_id: mid(mote),
+                idempotency_key: [0xee ^ mote; 32],
+                seq: 0,
+                target_committed_seq: target_seq,
+                reason_class: RepudiationReason::OperatorAction,
+                repudiator_id: 1,
+            })
+            .unwrap();
+    }
+
+    pub fn snapshot(&self) -> Snapshot {
+        Projection::from_journal(&self.journal).unwrap().snapshot()
+    }
+}

--- a/crates/kx-tiering/tests/eviction_pass.rs
+++ b/crates/kx-tiering/tests/eviction_pass.rs
@@ -1,0 +1,83 @@
+//! Integration: the budget-driven eviction pass — oldest-first eviction,
+//! protected-tag invariant under maximal pressure, and idempotence.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use common::Fixture;
+use kx_content::ContentStore;
+use kx_mote::NdClass;
+use kx_tiering::{run_pass, TieringBudget};
+
+#[test]
+fn max_objects_evicts_oldest_pure_first_until_under_budget() {
+    let fx = Fixture::new();
+    let (r0, _) = fx.commit_payload(b'a', b"p0", NdClass::Pure); // seq 0 (oldest)
+    let (r1, _) = fx.commit_payload(b'b', b"p1", NdClass::Pure); // seq 1
+    let (r2, _) = fx.commit_payload(b'c', b"p2", NdClass::Pure); // seq 2 (youngest)
+
+    let report = run_pass(&fx.snapshot(), &fx.store, TieringBudget::MaxObjects(1)).unwrap();
+
+    assert_eq!(report.candidates_considered, 3);
+    assert_eq!(report.usage_before.objects, 3);
+    assert_eq!(report.usage_after.objects, 1);
+    // Oldest two evicted; youngest retained.
+    assert_eq!(report.evicted, vec![r0, r1]);
+    assert!(!fx.store.contains(&r0));
+    assert!(!fx.store.contains(&r1));
+    assert!(fx.store.contains(&r2));
+}
+
+#[test]
+fn max_bytes_evicts_until_footprint_within_budget() {
+    let fx = Fixture::new();
+    // Three 4-byte PURE payloads = 12 bytes resident.
+    let (r0, _) = fx.commit_payload(b'a', b"aaaa", NdClass::Pure);
+    let (r1, _) = fx.commit_payload(b'b', b"bbbb", NdClass::Pure);
+    let (_r2, _) = fx.commit_payload(b'c', b"cccc", NdClass::Pure);
+
+    // Budget 4 bytes => must drop two oldest (12 -> 4).
+    let report = run_pass(&fx.snapshot(), &fx.store, TieringBudget::MaxBytes(4)).unwrap();
+
+    assert_eq!(report.usage_before.bytes, 12);
+    assert_eq!(report.bytes_reclaimed, 8);
+    assert_eq!(report.usage_after.bytes, 4);
+    assert_eq!(report.evicted, vec![r0, r1]);
+}
+
+#[test]
+fn protected_tags_never_evicted_under_maximal_pressure() {
+    let fx = Fixture::new();
+    let (r_pure, _) = fx.commit_payload(b'p', b"pure", NdClass::Pure);
+    let (r_wm, _) = fx.commit_payload(b'w', b"world", NdClass::WorldMutating);
+    let (r_rond, _) = fx.commit_payload(b'r', b"rng", NdClass::ReadOnlyNondet);
+
+    // Zero-byte budget = maximal pressure: evict every PURE payload.
+    let report = run_pass(&fx.snapshot(), &fx.store, TieringBudget::MaxBytes(0)).unwrap();
+
+    assert_eq!(report.evicted, vec![r_pure]);
+    assert!(!fx.store.contains(&r_pure), "PURE dropped");
+    // The protected tags are untouched no matter how tight the budget.
+    assert!(fx.store.contains(&r_wm), "WORLD-MUTATING never evicted");
+    assert!(fx.store.contains(&r_rond), "READ-ONLY-NONDET never evicted");
+}
+
+#[test]
+fn pass_is_idempotent() {
+    let fx = Fixture::new();
+    fx.commit_payload(b'a', b"p0", NdClass::Pure);
+    fx.commit_payload(b'b', b"p1", NdClass::Pure);
+
+    let snap = fx.snapshot();
+    let first = run_pass(&snap, &fx.store, TieringBudget::MaxObjects(0)).unwrap();
+    assert_eq!(first.evicted.len(), 2);
+    assert_eq!(first.skipped_absent, 0);
+
+    // Re-running over the same snapshot finds the candidates already absent.
+    let second = run_pass(&snap, &fx.store, TieringBudget::MaxObjects(0)).unwrap();
+    assert!(second.evicted.is_empty());
+    assert_eq!(second.candidates_considered, 2);
+    assert_eq!(second.skipped_absent, 2);
+    assert_eq!(second.usage_before.objects, 0);
+}

--- a/crates/kx-tiering/tests/recompute_roundtrip.rs
+++ b/crates/kx-tiering/tests/recompute_roundtrip.rs
@@ -1,0 +1,65 @@
+//! The P1.12 headline exit-gate test: under memory pressure a PURE payload is
+//! dropped and recomputed on demand, a sibling WORLD-MUTATING payload is never
+//! dropped, and correctness is unaffected by dropping the PURE payload.
+//!
+//! Recompute is modelled faithfully to the content-store contract: a PURE Mote's
+//! payload is a deterministic function of its inputs, so re-running that logic
+//! yields bit-identical bytes which content-addressing maps back to the *same*
+//! `ContentRef`. (The executor's production put-then-commit recompute wiring
+//! lands with the kx-runtime binary at P1.13; the property proven here — that
+//! recompute restores the identical ref — is what makes that wiring sound.)
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use common::Fixture;
+use kx_content::{ContentStore, NotFound};
+use kx_mote::NdClass;
+use kx_tiering::{run_pass, TieringBudget};
+
+/// The deterministic logic of a PURE Mote. Re-running it on the same input is
+/// the "recompute" the tiering contract relies on.
+fn recompute_pure(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut counter: u8 = 0;
+    for b in input {
+        out.push(b.wrapping_add(counter));
+        counter = counter.wrapping_add(1);
+    }
+    out
+}
+
+#[test]
+fn pure_payload_evicted_then_recomputed_bit_identical() {
+    let fx = Fixture::new();
+
+    let input = b"deterministic-input";
+    let payload = recompute_pure(input);
+
+    // A PURE Mote backed by the computed payload, plus a sibling WM Mote.
+    let (r_pure, _) = fx.commit_payload(b'p', &payload, NdClass::Pure);
+    let (r_wm, _) = fx.commit_payload(b'w', b"irreversible-effect", NdClass::WorldMutating);
+
+    // Memory pressure drops the PURE payload.
+    let report = run_pass(&fx.snapshot(), &fx.store, TieringBudget::MaxObjects(0)).unwrap();
+    assert_eq!(report.evicted, vec![r_pure]);
+
+    // The evicted ref reads as NotFound — the normal "recompute me" signal.
+    assert_eq!(fx.store.get(&r_pure), Err(NotFound));
+    // The WORLD-MUTATING payload was never touched.
+    assert!(fx.store.contains(&r_wm), "WM payload never evicted");
+
+    // Recompute on demand: re-run the deterministic logic and re-put.
+    let recomputed = recompute_pure(input);
+    let restored_ref = fx.store.put(&recomputed).unwrap();
+
+    // Content-addressing: recompute restores the SAME ref...
+    assert_eq!(
+        restored_ref, r_pure,
+        "recompute yields the same content ref"
+    );
+    // ...and a read now returns bit-identical bytes. Correctness unaffected.
+    let got = fx.store.get(&r_pure).unwrap();
+    assert_eq!(&got[..], &payload[..]);
+}


### PR DESCRIPTION
## P1.12 — tag-driven storage tiering

Reuses the per-Mote `NdClass` tag for memory management (`mote.md` §6, `content-store.md` §7): **PURE** payloads are droppable + recomputable; **READ-ONLY-NONDET** and **WORLD-MUTATING** are always persisted.

### New `kx-tiering` crate (the tiering pass)
- `select_candidates(&Snapshot)` — tag-only selection of PURE-only refs. **Shared-ref-protected** (content-addressed dedup means a ref shared with any WM/ROND committed Mote is never a candidate), repudiated-excluded, ordered oldest-commit-`seq` first. Does not touch the content store.
- `run_pass(&Snapshot, &store, budget)` — sizes candidates, evicts oldest-first via the shared **idempotent `delete()`** until within a simulated memory-pressure budget (`TieringBudget::{MaxObjects,MaxBytes}`); returns an `EvictionReport`. WM/ROND are never selected, so never deleted.

The content store stays **tag-blind** (`content-store.md` §7): the pass joins the projection's per-Mote `NdClass` with the store's refs.

### `kx-projection`
Adds public `nondeterminism_of()` on `Projection` + `Snapshot` (mirrors `result_ref_of`) — the only API the pass needs. `committed_seq_of` already existed.

### Exit gate
`tests/recompute_roundtrip.rs`: under simulated pressure a PURE payload is dropped, a read returns `NotFound`, recompute restores **bit-identical** bytes at the **same ref** (content-addressing), and a sibling WM payload is **never** dropped. 16 tiering tests (10 unit + 6 integration).

Full `just ci` mirror green locally — fmt, clippy `-D warnings`, test (workspace), deny, doc `-D warnings`, ffi-link, **I1.c byte-determinism PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)