### PR TITLE
PR 14 / P2.1 — kx-proto (tonic gRPC schema)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,10 +42,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -328,6 +414,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,10 +441,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -425,6 +532,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +594,106 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -570,6 +802,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -831,6 +1073,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-proto"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-mote",
+ "kx-warrant",
+ "proptest",
+ "prost",
+ "protoc-bin-vendored",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "kx-runtime"
 version = "0.0.1"
 dependencies = [
@@ -979,16 +1238,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "munge"
@@ -1063,6 +1351,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,14 +1439,130 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "ptr_meta"
@@ -1188,12 +1622,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1203,7 +1658,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1221,7 +1685,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1285,7 +1749,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -1489,6 +1953,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1994,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1590,6 +2080,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +2279,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1763,6 +2399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,7 +2493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1861,7 +2506,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -2005,7 +2650,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2036,7 +2681,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2055,7 +2700,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/kx-scheduler",
     "crates/kx-tiering",
     "crates/kx-runtime",
+    "crates/kx-proto",
 ]
 exclude = [
     "kx-cloud",
@@ -78,6 +79,7 @@ kx-inference         = { path = "crates/kx-inference",         version = "0.0.1"
 kx-capability        = { path = "crates/kx-capability",        version = "0.0.1" }
 kx-executor          = { path = "crates/kx-executor",          version = "0.0.1" }
 kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.0.1" }
+kx-proto             = { path = "crates/kx-proto",             version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }
@@ -87,6 +89,17 @@ sha2               = "0.10"
 # shims; no extra C deps land.
 libc               = "0.2"
 nix                = { version = "0.29", features = ["process", "signal", "resource", "fs"] }
+# Distribution (P2) gRPC stack — kx-proto is the first async + network crate.
+# tonic default features (transport + codegen + prost) are kept; TLS is NOT
+# enabled (no `ring`/`rustls`) — P2 is plaintext Unix-socket / TCP, hardening is
+# a later step. tonic 0.12 pairs with prost 0.13 and the stable tonic-build API.
+# protoc is supplied build-time by the pinned `protoc-bin-vendored` binary (no
+# system protoc on CI or local; deterministic; ships linux-x86_64 + macos-aarch64).
+tonic              = "0.12"
+prost              = "0.13"
+tokio              = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tonic-build        = "0.12"
+protoc-bin-vendored = "3"
 
 [profile.release]
 strip         = "symbols"

--- a/crates/kx-proto/Cargo.toml
+++ b/crates/kx-proto/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "kx-proto"
+version = "0.0.1"
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+description = "kortecx P2.1 gRPC schema (tonic/prost) — the coordinator/worker distribution boundary and cross-language (Rust/Python/TypeScript) contract: submit Mote, report commit, heartbeat, register worker."
+build = "build.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tonic = { workspace = true }
+prost = { workspace = true }
+thiserror = { workspace = true }
+# Domain crates — kx-proto owns the single tested proto<->domain mapping +
+# the identity round-trip (MoteId / warrant_ref reconstructed Rust-side). It
+# does NOT depend on kx-journal: a commit proposal is decoded to kx-mote /
+# kx-content typed fields and assembled into a journal entry coordinator-side
+# (P2.2), where the seq is assigned.
+kx-mote = { workspace = true }
+kx-content = { workspace = true }
+kx-warrant = { workspace = true }
+smallvec = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }
+protoc-bin-vendored = { workspace = true }
+
+[dev-dependencies]
+# `time` is additive over the workspace tokio features — the skeleton test uses
+# a short connect-retry sleep while the in-process server binds.
+tokio = { workspace = true, features = ["time"] }
+proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-proto/build.rs
+++ b/crates/kx-proto/build.rs
@@ -1,0 +1,20 @@
+//! Build script: compile the gRPC schema with `tonic-build`, using the pinned
+//! **vendored** `protoc` so neither CI nor local dev needs a system protobuf
+//! compiler (SN-7: ships linux-x86_64 + macos-aarch64). Generation is
+//! deterministic — pinned protoc + fixed `.proto` produce byte-identical Rust
+//! across the two clean release builds of the byte-determinism gate (I1.c).
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Point tonic-build / prost-build at the vendored protoc binary instead of
+    // requiring one on PATH. `set_var` is safe on edition 2021.
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    std::env::set_var("PROTOC", protoc);
+
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(&["proto/kortecx/v1/coordinator.proto"], &["proto"])?;
+
+    println!("cargo:rerun-if-changed=proto/kortecx/v1/coordinator.proto");
+    Ok(())
+}

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -1,0 +1,282 @@
+syntax = "proto3";
+
+// ===========================================================================
+// kortecx P2.1 — coordinator/worker gRPC schema.
+//
+// This .proto is the SINGLE cross-language contract: protoc/buf generate native
+// Rust, Python, and TypeScript types from it. Design is MIRRORED FIELDS (not an
+// opaque bincode envelope) so non-Rust clients construct messages with their
+// generated types.
+//
+// IDENTITY INVARIANT (load-bearing). MoteId / warrant_ref / content refs are
+// computed Rust-side, by the coordinator, from the RECONSTRUCTED canonical
+// (bincode) form of the domain type. Protobuf wire bytes are NEVER hashed and
+// clients NEVER compute a MoteId. Protobuf carries field VALUES only. A
+// round-trip identity test in kx-proto pins the proto<->Rust mapping.
+//
+// Every enum carries an explicit *_UNSPECIFIED = 0 sentinel: proto3's
+// zero-default must NOT silently denote a real class (e.g. an unset nd_class
+// must not mean Pure, which would mis-recover a WorldMutating Mote). The Rust
+// TryFrom boundary REJECTS UNSPECIFIED. Domain discriminants are therefore
+// shifted by +1 on the wire.
+//
+// 32-byte BLAKE3 hashes are `bytes`; the Rust boundary validates length == 32.
+// `map<>` fields reconstruct into BTreeMap / BTreeSet so canonical order (and
+// thus the identity hash) is independent of protobuf wire order.
+// ===========================================================================
+
+package kortecx.v1;
+
+// ---------------------------------------------------------------------------
+// Enums (mirror the domain enums; +1-shifted to reserve 0 = UNSPECIFIED)
+// ---------------------------------------------------------------------------
+
+// Mirrors kx_mote::NdClass (Pure / ReadOnlyNondet / WorldMutating).
+enum NdClass {
+  ND_CLASS_UNSPECIFIED = 0;
+  ND_CLASS_PURE = 1;
+  ND_CLASS_READ_ONLY_NONDET = 2;
+  ND_CLASS_WORLD_MUTATING = 3;
+}
+
+// Mirrors kx_mote::EffectPattern.
+enum EffectPattern {
+  EFFECT_PATTERN_UNSPECIFIED = 0;
+  EFFECT_PATTERN_IDEMPOTENT_BY_CONSTRUCTION = 1;
+  EFFECT_PATTERN_STAGE_THEN_COMMIT = 2;
+  EFFECT_PATTERN_VALIDATE_THEN_COMMIT = 3;
+}
+
+// Mirrors kx_mote::EdgeKind.
+enum EdgeKind {
+  EDGE_KIND_UNSPECIFIED = 0;
+  EDGE_KIND_DATA = 1;
+  EDGE_KIND_CONTROL = 2;
+}
+
+// Mirrors kx_warrant::MoteClass (warrant-side non-determinism axis).
+enum MoteClass {
+  MOTE_CLASS_UNSPECIFIED = 0;
+  MOTE_CLASS_PURE = 1;
+  MOTE_CLASS_READ_ONLY_NONDET = 2;
+  MOTE_CLASS_WORLD_MUTATING = 3;
+}
+
+// Mirrors kx_warrant::FsMode.
+enum FsMode {
+  FS_MODE_UNSPECIFIED = 0;
+  FS_MODE_READ_ONLY = 1;
+  FS_MODE_READ_WRITE = 2;
+  FS_MODE_EXEC_ONLY = 3;
+}
+
+// Mirrors kx_warrant::ExecutorClass.
+enum ExecutorClass {
+  EXECUTOR_CLASS_UNSPECIFIED = 0;
+  EXECUTOR_CLASS_BWRAP = 1;
+  EXECUTOR_CLASS_OCI_DAEMON = 2;
+  EXECUTOR_CLASS_CLOUD_MICRO_VM = 3;
+  EXECUTOR_CLASS_MACOS_SANDBOX = 4;
+}
+
+// ---------------------------------------------------------------------------
+// Mote value messages (mirror kx_mote)
+// ---------------------------------------------------------------------------
+
+// Mirrors kx_mote::InferenceParams (D50 decoding params; identity-bearing).
+message InferenceParams {
+  uint32 max_output_tokens = 1;
+  uint32 temperature_bps = 2;
+  uint32 top_p_bps = 3;
+  uint32 top_k = 4;
+  uint32 seed = 5;
+  repeated string stop_tokens = 6;
+  // Reserved (kx_mote::Grammar): opaque constrained-generation payload.
+  // Absent => None. OSS v0.1 backends reject Some(_).
+  optional string grammar = 7;
+}
+
+// Mirrors kx_mote::MoteDef (schema_version 4).
+message MoteDef {
+  bytes logic_ref = 1;                  // 32B
+  string model_id = 2;
+  bytes prompt_template_hash = 3;       // 32B
+  map<string, string> tool_contract = 4;
+  NdClass nd_class = 5;
+  map<string, bytes> config_subset = 6;
+  EffectPattern effect_pattern = 7;
+  optional bytes critic_for = 8;        // 32B MoteId when present
+  bool is_topology_shaper = 9;
+  InferenceParams inference_params = 10;
+  uint32 schema_version = 11;           // u16 domain; validated <= u16::MAX
+}
+
+// Mirrors kx_mote::ParentRef (parent_id + edge meta).
+message ParentRef {
+  bytes parent_id = 1;                  // 32B MoteId
+  EdgeKind edge_kind = 2;
+  bool non_cascade = 3;                 // only valid for CONTROL edges
+}
+
+// Mirrors kx_mote::Mote. `mote_id` is an advisory routing key; the coordinator
+// RE-DERIVES identity Rust-side from def + input_data_id + graph_position and
+// never trusts this field as authoritative on its own.
+message Mote {
+  bytes mote_id = 1;                    // 32B (advisory routing key)
+  MoteDef def = 2;
+  bytes input_data_id = 3;              // 32B
+  bytes graph_position = 4;             // opaque bytes
+  repeated ParentRef parents = 5;
+}
+
+// ---------------------------------------------------------------------------
+// Warrant value messages (mirror kx_warrant)
+// ---------------------------------------------------------------------------
+
+message ToolGrant {
+  string tool_id = 1;
+  string tool_version = 2;
+}
+
+message ModelRoute {
+  string model_id = 1;
+  uint32 max_input_tokens = 2;
+  uint32 max_output_tokens = 3;
+  uint32 max_calls = 4;
+}
+
+message ResourceCeiling {
+  uint32 cpu_milli = 1;
+  uint64 mem_bytes = 2;
+  uint64 wall_clock_ms = 3;
+  uint32 fd_count = 4;
+  uint64 disk_bytes = 5;
+}
+
+// One (path, mode) entry of an FsScope. Reconstructs into BTreeMap<PathBuf, FsMode>.
+message FsMount {
+  string path = 1;                      // PathBuf as UTF-8
+  FsMode mode = 2;
+}
+
+message FsScope {
+  repeated FsMount mounts = 1;
+}
+
+// kx_warrant::NetScope: None (no egress) or an exact host allowlist.
+message NetScope {
+  oneof scope {
+    NetScopeNone none = 1;
+    HostAllowlist allowlist = 2;
+  }
+}
+
+// Presence marker for NetScope::None (a message-typed oneof arm needs a type).
+message NetScopeNone {}
+
+message HostAllowlist {
+  repeated string hosts = 1;            // reconstructs into BTreeSet<Host>
+}
+
+// Mirrors kx_warrant::WarrantSpec (10 axes).
+message WarrantSpec {
+  MoteClass mote_class = 1;
+  MoteClass nd_class = 2;
+  FsScope fs_scope = 3;
+  NetScope net_scope = 4;
+  bytes syscall_profile_ref = 5;        // 32B
+  repeated ToolGrant tool_grants = 6;
+  ModelRoute model_route = 7;
+  ResourceCeiling resource_ceiling = 8;
+  optional bytes environment_ref = 9;   // 32B when present
+  ExecutorClass executor_class = 10;
+}
+
+// ---------------------------------------------------------------------------
+// RPC (1) — submit Mote
+// ---------------------------------------------------------------------------
+
+message SubmitMoteRequest {
+  Mote mote = 1;
+  WarrantSpec warrant = 2;
+}
+
+enum SubmitStatus {
+  SUBMIT_STATUS_UNSPECIFIED = 0;
+  SUBMIT_STATUS_ACCEPTED = 1;
+  SUBMIT_STATUS_DUPLICATE = 2;          // already known (idempotent resubmit)
+  SUBMIT_STATUS_REJECTED = 3;           // a refusal predicate fired
+}
+
+message SubmitMoteResponse {
+  bytes mote_id = 1;                    // 32B — coordinator-derived identity
+  SubmitStatus status = 2;
+  string detail = 3;                    // human-readable; empty on accept
+}
+
+// ---------------------------------------------------------------------------
+// RPC (2) — report commit. The worker PROPOSES; the coordinator is the SOLE
+// journal writer (D40). The coordinator assigns the committed seq.
+// ---------------------------------------------------------------------------
+
+message ReportCommitRequest {
+  bytes mote_id = 1;                    // 32B
+  bytes idempotency_key = 2;            // 32B
+  bytes result_ref = 3;                 // 32B
+  bytes warrant_ref = 4;                // 32B
+  bytes mote_def_hash = 5;              // 32B
+  NdClass nd_class = 6;
+  repeated ParentRef parents = 7;
+  uint64 worker_id = 8;                 // the proposing worker
+}
+
+enum CommitOutcome {
+  COMMIT_OUTCOME_UNSPECIFIED = 0;
+  COMMIT_OUTCOME_COMMITTED = 1;         // newly appended
+  COMMIT_OUTCOME_ALREADY_COMMITTED = 2; // dedup-by-key hit (first-wins)
+  COMMIT_OUTCOME_REJECTED = 3;
+}
+
+message ReportCommitResponse {
+  uint64 committed_seq = 1;             // journal seq assigned by the coordinator
+  CommitOutcome outcome = 2;
+  string detail = 3;
+}
+
+// ---------------------------------------------------------------------------
+// RPC (3) — heartbeat (worker liveness)
+// ---------------------------------------------------------------------------
+
+message HeartbeatRequest {
+  uint64 worker_id = 1;
+  uint64 timestamp_ms = 2;              // wall-clock; liveness only, NEVER hashed
+  uint32 in_flight = 3;                 // Motes currently executing on the worker
+}
+
+message HeartbeatResponse {
+  bool ack = 1;
+}
+
+// ---------------------------------------------------------------------------
+// RPC (4) — register worker
+// ---------------------------------------------------------------------------
+
+message RegisterWorkerRequest {
+  ExecutorClass executor_class = 1;     // backend the worker can run
+  string endpoint = 2;                  // how the coordinator reaches the worker
+}
+
+message RegisterWorkerResponse {
+  uint64 worker_id = 1;                 // coordinator-assigned
+}
+
+// ---------------------------------------------------------------------------
+// Service — hosted by the coordinator; workers are clients.
+// ---------------------------------------------------------------------------
+
+service Coordinator {
+  rpc RegisterWorker(RegisterWorkerRequest) returns (RegisterWorkerResponse);
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+  rpc SubmitMote(SubmitMoteRequest) returns (SubmitMoteResponse);
+  rpc ReportCommit(ReportCommitRequest) returns (ReportCommitResponse);
+}

--- a/crates/kx-proto/src/convert.rs
+++ b/crates/kx-proto/src/convert.rs
@@ -1,0 +1,566 @@
+//! Typed conversions between the generated wire ([`crate::proto`]) types and the
+//! canonical Rust domain types (`kx-mote` / `kx-warrant` / `kx-content`).
+//!
+//! Direction matters:
+//! - **`domain -> proto`** ([`From`]) is total — a valid domain value always has
+//!   a wire representation.
+//! - **`proto -> domain`** ([`TryFrom`]) is the **untrusted boundary**: it
+//!   validates 32-byte hash lengths, rejects the `*_UNSPECIFIED` enum sentinel,
+//!   requires present message fields, and reconstructs `BTreeMap`/`BTreeSet`
+//!   (restoring canonical order regardless of protobuf wire order).
+//!
+//! ## Identity invariant
+//!
+//! [`kx_mote::Mote`] is rebuilt via [`kx_mote::Mote::new`], which **re-derives**
+//! the [`kx_mote::MoteId`] from `def + input_data_id + graph_position`. The wire
+//! `mote_id` is advisory routing only and is never trusted as the identity. A
+//! caller that wants `warrant_ref` recomputes it with
+//! [`kx_warrant::warrant_ref_of`] over the reconstructed [`kx_warrant::WarrantSpec`].
+//! Protobuf bytes are never hashed.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_mote::{
+    ConfigKey, ConfigVal, EdgeKind, EdgeMeta, EffectPattern, Grammar, GraphPosition,
+    InferenceParams, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass, ParentRef,
+    PromptTemplateHash, ToolName, ToolVersion,
+};
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    ToolGrant, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+use crate::error::ConvertError;
+use crate::proto;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Validate that a wire `bytes` field is exactly a 32-byte hash.
+fn hash32(bytes: &[u8], field: &'static str) -> Result<[u8; 32], ConvertError> {
+    <[u8; 32]>::try_from(bytes).map_err(|_| ConvertError::BadHashLength {
+        field,
+        len: bytes.len(),
+    })
+}
+
+/// Decode an `i32` wire enum value into its domain enum: first into the proto
+/// enum (rejecting unknown values), then into the domain enum (rejecting the
+/// `*_UNSPECIFIED` sentinel).
+fn decode_enum<P, D>(value: i32, enum_name: &'static str) -> Result<D, ConvertError>
+where
+    P: TryFrom<i32>,
+    D: TryFrom<P, Error = ConvertError>,
+{
+    let p = P::try_from(value).map_err(|_| ConvertError::UnknownEnum { enum_name, value })?;
+    D::try_from(p)
+}
+
+// ---------------------------------------------------------------------------
+// enums
+// ---------------------------------------------------------------------------
+
+impl From<NdClass> for proto::NdClass {
+    fn from(d: NdClass) -> Self {
+        match d {
+            NdClass::Pure => Self::Pure,
+            NdClass::ReadOnlyNondet => Self::ReadOnlyNondet,
+            NdClass::WorldMutating => Self::WorldMutating,
+        }
+    }
+}
+
+impl TryFrom<proto::NdClass> for NdClass {
+    type Error = ConvertError;
+    fn try_from(p: proto::NdClass) -> Result<Self, Self::Error> {
+        match p {
+            proto::NdClass::Unspecified => Err(ConvertError::UnspecifiedEnum {
+                enum_name: "NdClass",
+            }),
+            proto::NdClass::Pure => Ok(Self::Pure),
+            proto::NdClass::ReadOnlyNondet => Ok(Self::ReadOnlyNondet),
+            proto::NdClass::WorldMutating => Ok(Self::WorldMutating),
+        }
+    }
+}
+
+impl From<EffectPattern> for proto::EffectPattern {
+    fn from(d: EffectPattern) -> Self {
+        match d {
+            EffectPattern::IdempotentByConstruction => Self::IdempotentByConstruction,
+            EffectPattern::StageThenCommit => Self::StageThenCommit,
+            EffectPattern::ValidateThenCommit => Self::ValidateThenCommit,
+        }
+    }
+}
+
+impl TryFrom<proto::EffectPattern> for EffectPattern {
+    type Error = ConvertError;
+    fn try_from(p: proto::EffectPattern) -> Result<Self, Self::Error> {
+        match p {
+            proto::EffectPattern::Unspecified => Err(ConvertError::UnspecifiedEnum {
+                enum_name: "EffectPattern",
+            }),
+            proto::EffectPattern::IdempotentByConstruction => Ok(Self::IdempotentByConstruction),
+            proto::EffectPattern::StageThenCommit => Ok(Self::StageThenCommit),
+            proto::EffectPattern::ValidateThenCommit => Ok(Self::ValidateThenCommit),
+        }
+    }
+}
+
+impl From<EdgeKind> for proto::EdgeKind {
+    fn from(d: EdgeKind) -> Self {
+        match d {
+            EdgeKind::Data => Self::Data,
+            EdgeKind::Control => Self::Control,
+        }
+    }
+}
+
+impl TryFrom<proto::EdgeKind> for EdgeKind {
+    type Error = ConvertError;
+    fn try_from(p: proto::EdgeKind) -> Result<Self, Self::Error> {
+        match p {
+            proto::EdgeKind::Unspecified => Err(ConvertError::UnspecifiedEnum {
+                enum_name: "EdgeKind",
+            }),
+            proto::EdgeKind::Data => Ok(Self::Data),
+            proto::EdgeKind::Control => Ok(Self::Control),
+        }
+    }
+}
+
+impl From<MoteClass> for proto::MoteClass {
+    fn from(d: MoteClass) -> Self {
+        match d {
+            MoteClass::Pure => Self::Pure,
+            MoteClass::ReadOnlyNondet => Self::ReadOnlyNondet,
+            MoteClass::WorldMutating => Self::WorldMutating,
+        }
+    }
+}
+
+impl TryFrom<proto::MoteClass> for MoteClass {
+    type Error = ConvertError;
+    fn try_from(p: proto::MoteClass) -> Result<Self, Self::Error> {
+        match p {
+            proto::MoteClass::Unspecified => Err(ConvertError::UnspecifiedEnum {
+                enum_name: "MoteClass",
+            }),
+            proto::MoteClass::Pure => Ok(Self::Pure),
+            proto::MoteClass::ReadOnlyNondet => Ok(Self::ReadOnlyNondet),
+            proto::MoteClass::WorldMutating => Ok(Self::WorldMutating),
+        }
+    }
+}
+
+impl From<FsMode> for proto::FsMode {
+    fn from(d: FsMode) -> Self {
+        match d {
+            FsMode::ReadOnly => Self::ReadOnly,
+            FsMode::ReadWrite => Self::ReadWrite,
+            FsMode::ExecOnly => Self::ExecOnly,
+        }
+    }
+}
+
+impl TryFrom<proto::FsMode> for FsMode {
+    type Error = ConvertError;
+    fn try_from(p: proto::FsMode) -> Result<Self, Self::Error> {
+        match p {
+            proto::FsMode::Unspecified => Err(ConvertError::UnspecifiedEnum {
+                enum_name: "FsMode",
+            }),
+            proto::FsMode::ReadOnly => Ok(Self::ReadOnly),
+            proto::FsMode::ReadWrite => Ok(Self::ReadWrite),
+            proto::FsMode::ExecOnly => Ok(Self::ExecOnly),
+        }
+    }
+}
+
+impl From<ExecutorClass> for proto::ExecutorClass {
+    fn from(d: ExecutorClass) -> Self {
+        match d {
+            ExecutorClass::Bwrap => Self::Bwrap,
+            ExecutorClass::OciDaemon => Self::OciDaemon,
+            ExecutorClass::CloudMicroVm => Self::CloudMicroVm,
+            ExecutorClass::MacOsSandbox => Self::MacosSandbox,
+        }
+    }
+}
+
+impl TryFrom<proto::ExecutorClass> for ExecutorClass {
+    type Error = ConvertError;
+    fn try_from(p: proto::ExecutorClass) -> Result<Self, Self::Error> {
+        match p {
+            proto::ExecutorClass::Unspecified => Err(ConvertError::UnspecifiedEnum {
+                enum_name: "ExecutorClass",
+            }),
+            proto::ExecutorClass::Bwrap => Ok(Self::Bwrap),
+            proto::ExecutorClass::OciDaemon => Ok(Self::OciDaemon),
+            proto::ExecutorClass::CloudMicroVm => Ok(Self::CloudMicroVm),
+            proto::ExecutorClass::MacosSandbox => Ok(Self::MacOsSandbox),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// mote value messages
+// ---------------------------------------------------------------------------
+
+impl From<InferenceParams> for proto::InferenceParams {
+    fn from(d: InferenceParams) -> Self {
+        Self {
+            max_output_tokens: d.max_output_tokens,
+            temperature_bps: d.temperature_bps,
+            top_p_bps: d.top_p_bps,
+            top_k: d.top_k,
+            seed: d.seed,
+            stop_tokens: d.stop_tokens.into_iter().collect(),
+            grammar: d.grammar.map(|g| g.raw),
+        }
+    }
+}
+
+impl TryFrom<proto::InferenceParams> for InferenceParams {
+    type Error = ConvertError;
+    fn try_from(p: proto::InferenceParams) -> Result<Self, Self::Error> {
+        Ok(Self {
+            max_output_tokens: p.max_output_tokens,
+            temperature_bps: p.temperature_bps,
+            top_p_bps: p.top_p_bps,
+            top_k: p.top_k,
+            seed: p.seed,
+            stop_tokens: p.stop_tokens.into_iter().collect(),
+            grammar: p.grammar.map(Grammar::new),
+        })
+    }
+}
+
+impl From<MoteDef> for proto::MoteDef {
+    fn from(d: MoteDef) -> Self {
+        Self {
+            logic_ref: d.logic_ref.as_bytes().to_vec(),
+            model_id: d.model_id.0,
+            prompt_template_hash: d.prompt_template_hash.as_bytes().to_vec(),
+            tool_contract: d
+                .tool_contract
+                .into_iter()
+                .map(|(k, v)| (k.0, v.0))
+                .collect(),
+            nd_class: proto::NdClass::from(d.nd_class) as i32,
+            config_subset: d
+                .config_subset
+                .into_iter()
+                .map(|(k, v)| (k.0, v.0))
+                .collect(),
+            effect_pattern: proto::EffectPattern::from(d.effect_pattern) as i32,
+            critic_for: d.critic_for.map(|m| m.as_bytes().to_vec()),
+            is_topology_shaper: d.is_topology_shaper,
+            inference_params: Some(d.inference_params.into()),
+            schema_version: u32::from(d.schema_version),
+        }
+    }
+}
+
+impl TryFrom<proto::MoteDef> for MoteDef {
+    type Error = ConvertError;
+    fn try_from(p: proto::MoteDef) -> Result<Self, Self::Error> {
+        let schema_version =
+            u16::try_from(p.schema_version).map_err(|_| ConvertError::OutOfRange {
+                field: "MoteDef.schema_version",
+                value: u64::from(p.schema_version),
+            })?;
+        let critic_for = match p.critic_for {
+            Some(b) => Some(MoteId::from_bytes(hash32(&b, "MoteDef.critic_for")?)),
+            None => None,
+        };
+        let inference_params = p
+            .inference_params
+            .ok_or(ConvertError::MissingField {
+                field: "MoteDef.inference_params",
+            })?
+            .try_into()?;
+        Ok(Self {
+            logic_ref: LogicRef::from_bytes(hash32(&p.logic_ref, "MoteDef.logic_ref")?),
+            model_id: ModelId(p.model_id),
+            prompt_template_hash: PromptTemplateHash::from_bytes(hash32(
+                &p.prompt_template_hash,
+                "MoteDef.prompt_template_hash",
+            )?),
+            tool_contract: p
+                .tool_contract
+                .into_iter()
+                .map(|(k, v)| (ToolName(k), ToolVersion(v)))
+                .collect(),
+            nd_class: decode_enum::<proto::NdClass, NdClass>(p.nd_class, "NdClass")?,
+            config_subset: p
+                .config_subset
+                .into_iter()
+                .map(|(k, v)| (ConfigKey(k), ConfigVal(v)))
+                .collect(),
+            effect_pattern: decode_enum::<proto::EffectPattern, EffectPattern>(
+                p.effect_pattern,
+                "EffectPattern",
+            )?,
+            critic_for,
+            is_topology_shaper: p.is_topology_shaper,
+            inference_params,
+            schema_version,
+        })
+    }
+}
+
+impl From<ParentRef> for proto::ParentRef {
+    fn from(d: ParentRef) -> Self {
+        Self {
+            parent_id: d.parent_id.as_bytes().to_vec(),
+            edge_kind: proto::EdgeKind::from(d.edge.kind) as i32,
+            non_cascade: d.edge.non_cascade,
+        }
+    }
+}
+
+impl TryFrom<proto::ParentRef> for ParentRef {
+    type Error = ConvertError;
+    fn try_from(p: proto::ParentRef) -> Result<Self, Self::Error> {
+        Ok(Self {
+            parent_id: MoteId::from_bytes(hash32(&p.parent_id, "ParentRef.parent_id")?),
+            edge: EdgeMeta {
+                kind: decode_enum::<proto::EdgeKind, EdgeKind>(p.edge_kind, "EdgeKind")?,
+                non_cascade: p.non_cascade,
+            },
+        })
+    }
+}
+
+impl From<Mote> for proto::Mote {
+    fn from(d: Mote) -> Self {
+        Self {
+            mote_id: d.id.as_bytes().to_vec(),
+            def: Some(d.def.into()),
+            input_data_id: d.input_data_id.as_bytes().to_vec(),
+            graph_position: d.graph_position.0,
+            parents: d.parents.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl TryFrom<proto::Mote> for Mote {
+    type Error = ConvertError;
+    fn try_from(p: proto::Mote) -> Result<Self, Self::Error> {
+        let def = p
+            .def
+            .ok_or(ConvertError::MissingField { field: "Mote.def" })?
+            .try_into()?;
+        let input_data_id =
+            InputDataId::from_bytes(hash32(&p.input_data_id, "Mote.input_data_id")?);
+        let graph_position = GraphPosition(p.graph_position);
+        let parents: SmallVec<[ParentRef; 4]> = p
+            .parents
+            .into_iter()
+            .map(ParentRef::try_from)
+            .collect::<Result<_, _>>()?;
+        // IDENTITY INVARIANT: re-derive MoteId Rust-side. The wire `mote_id` is
+        // advisory routing only and is intentionally not trusted here.
+        Ok(Mote::new(def, input_data_id, graph_position, parents))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// warrant messages
+// ---------------------------------------------------------------------------
+
+impl From<ToolGrant> for proto::ToolGrant {
+    fn from(d: ToolGrant) -> Self {
+        Self {
+            tool_id: d.tool_id.0,
+            tool_version: d.tool_version.0,
+        }
+    }
+}
+
+impl From<proto::ToolGrant> for ToolGrant {
+    fn from(p: proto::ToolGrant) -> Self {
+        Self {
+            tool_id: ToolName(p.tool_id),
+            tool_version: ToolVersion(p.tool_version),
+        }
+    }
+}
+
+impl From<ModelRoute> for proto::ModelRoute {
+    fn from(d: ModelRoute) -> Self {
+        Self {
+            model_id: d.model_id.0,
+            max_input_tokens: d.max_input_tokens,
+            max_output_tokens: d.max_output_tokens,
+            max_calls: d.max_calls,
+        }
+    }
+}
+
+impl From<proto::ModelRoute> for ModelRoute {
+    fn from(p: proto::ModelRoute) -> Self {
+        Self {
+            model_id: ModelId(p.model_id),
+            max_input_tokens: p.max_input_tokens,
+            max_output_tokens: p.max_output_tokens,
+            max_calls: p.max_calls,
+        }
+    }
+}
+
+impl From<ResourceCeiling> for proto::ResourceCeiling {
+    fn from(d: ResourceCeiling) -> Self {
+        Self {
+            cpu_milli: d.cpu_milli,
+            mem_bytes: d.mem_bytes,
+            wall_clock_ms: d.wall_clock_ms,
+            fd_count: d.fd_count,
+            disk_bytes: d.disk_bytes,
+        }
+    }
+}
+
+impl From<proto::ResourceCeiling> for ResourceCeiling {
+    fn from(p: proto::ResourceCeiling) -> Self {
+        Self {
+            cpu_milli: p.cpu_milli,
+            mem_bytes: p.mem_bytes,
+            wall_clock_ms: p.wall_clock_ms,
+            fd_count: p.fd_count,
+            disk_bytes: p.disk_bytes,
+        }
+    }
+}
+
+impl From<FsScope> for proto::FsScope {
+    fn from(d: FsScope) -> Self {
+        Self {
+            mounts: d
+                .mounts
+                .into_iter()
+                .map(|(path, mode)| proto::FsMount {
+                    path: path.to_string_lossy().into_owned(),
+                    mode: proto::FsMode::from(mode) as i32,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<proto::FsScope> for FsScope {
+    type Error = ConvertError;
+    fn try_from(p: proto::FsScope) -> Result<Self, Self::Error> {
+        let mut mounts = BTreeMap::new();
+        for m in p.mounts {
+            mounts.insert(
+                PathBuf::from(m.path),
+                decode_enum::<proto::FsMode, FsMode>(m.mode, "FsMode")?,
+            );
+        }
+        Ok(Self { mounts })
+    }
+}
+
+impl From<NetScope> for proto::NetScope {
+    fn from(d: NetScope) -> Self {
+        let scope = match d {
+            NetScope::None => proto::net_scope::Scope::None(proto::NetScopeNone {}),
+            NetScope::EgressAllowlist(hosts) => {
+                proto::net_scope::Scope::Allowlist(proto::HostAllowlist {
+                    hosts: hosts.into_iter().map(|h| h.0).collect(),
+                })
+            }
+        };
+        Self { scope: Some(scope) }
+    }
+}
+
+impl TryFrom<proto::NetScope> for NetScope {
+    type Error = ConvertError;
+    fn try_from(p: proto::NetScope) -> Result<Self, Self::Error> {
+        match p.scope.ok_or(ConvertError::MissingField {
+            field: "NetScope.scope",
+        })? {
+            proto::net_scope::Scope::None(_) => Ok(Self::None),
+            proto::net_scope::Scope::Allowlist(a) => Ok(Self::EgressAllowlist(
+                a.hosts.into_iter().map(Host).collect(),
+            )),
+        }
+    }
+}
+
+impl From<WarrantSpec> for proto::WarrantSpec {
+    fn from(d: WarrantSpec) -> Self {
+        Self {
+            mote_class: proto::MoteClass::from(d.mote_class) as i32,
+            nd_class: proto::MoteClass::from(d.nd_class) as i32,
+            fs_scope: Some(d.fs_scope.into()),
+            net_scope: Some(d.net_scope.into()),
+            syscall_profile_ref: d.syscall_profile_ref.as_bytes().to_vec(),
+            tool_grants: d.tool_grants.into_iter().map(Into::into).collect(),
+            model_route: Some(d.model_route.into()),
+            resource_ceiling: Some(d.resource_ceiling.into()),
+            environment_ref: d.environment_ref.map(|r| r.as_bytes().to_vec()),
+            executor_class: proto::ExecutorClass::from(d.executor_class) as i32,
+        }
+    }
+}
+
+impl TryFrom<proto::WarrantSpec> for WarrantSpec {
+    type Error = ConvertError;
+    fn try_from(p: proto::WarrantSpec) -> Result<Self, Self::Error> {
+        let environment_ref = match p.environment_ref {
+            Some(b) => Some(ContentRef::from_bytes(hash32(
+                &b,
+                "WarrantSpec.environment_ref",
+            )?)),
+            None => None,
+        };
+        let tool_grants: BTreeSet<ToolGrant> = p.tool_grants.into_iter().map(Into::into).collect();
+        Ok(Self {
+            mote_class: decode_enum::<proto::MoteClass, MoteClass>(p.mote_class, "MoteClass")?,
+            nd_class: decode_enum::<proto::MoteClass, MoteClass>(p.nd_class, "MoteClass")?,
+            fs_scope: p
+                .fs_scope
+                .ok_or(ConvertError::MissingField {
+                    field: "WarrantSpec.fs_scope",
+                })?
+                .try_into()?,
+            net_scope: p
+                .net_scope
+                .ok_or(ConvertError::MissingField {
+                    field: "WarrantSpec.net_scope",
+                })?
+                .try_into()?,
+            syscall_profile_ref: ContentRef::from_bytes(hash32(
+                &p.syscall_profile_ref,
+                "WarrantSpec.syscall_profile_ref",
+            )?),
+            tool_grants,
+            model_route: p
+                .model_route
+                .ok_or(ConvertError::MissingField {
+                    field: "WarrantSpec.model_route",
+                })?
+                .into(),
+            resource_ceiling: p
+                .resource_ceiling
+                .ok_or(ConvertError::MissingField {
+                    field: "WarrantSpec.resource_ceiling",
+                })?
+                .into(),
+            environment_ref,
+            executor_class: decode_enum::<proto::ExecutorClass, ExecutorClass>(
+                p.executor_class,
+                "ExecutorClass",
+            )?,
+        })
+    }
+}

--- a/crates/kx-proto/src/error.rs
+++ b/crates/kx-proto/src/error.rs
@@ -1,0 +1,54 @@
+//! [`ConvertError`] — the typed failure for decoding a wire (protobuf) message
+//! into its canonical Rust domain type.
+//!
+//! Every variant is a **boundary rejection**: the wire is untrusted, so the
+//! `proto -> domain` direction validates 32-byte hash lengths, rejects the
+//! `*_UNSPECIFIED` enum sentinel, and requires present message fields. The
+//! reverse (`domain -> proto`) is total and never errors.
+
+/// Failure decoding a protobuf message into its canonical Rust domain type.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConvertError {
+    /// A `bytes` field that must hold a 32-byte BLAKE3 hash had the wrong length.
+    #[error("field `{field}`: expected 32-byte hash, got {len} bytes")]
+    BadHashLength {
+        /// The offending field's dotted name (e.g. `MoteDef.logic_ref`).
+        field: &'static str,
+        /// The actual byte length received on the wire.
+        len: usize,
+    },
+
+    /// A required nested message field was absent (`None`) on the wire.
+    #[error("field `{field}`: required message was absent")]
+    MissingField {
+        /// The offending field's dotted name (e.g. `SubmitMoteRequest.mote`).
+        field: &'static str,
+    },
+
+    /// An enum field was left at its `*_UNSPECIFIED = 0` sentinel. proto3's
+    /// zero-default must not silently denote a real class, so it is rejected.
+    #[error("enum `{enum_name}`: value left UNSPECIFIED (must be set explicitly)")]
+    UnspecifiedEnum {
+        /// The enum type name (e.g. `NdClass`).
+        enum_name: &'static str,
+    },
+
+    /// An enum field carried an `i32` outside the known set of wire values.
+    #[error("enum `{enum_name}`: unknown wire value {value}")]
+    UnknownEnum {
+        /// The enum type name (e.g. `NdClass`).
+        enum_name: &'static str,
+        /// The unrecognized wire value.
+        value: i32,
+    },
+
+    /// A scalar exceeded the domain type's range (e.g. `schema_version` is `u16`
+    /// in the domain but `uint32` on the wire).
+    #[error("field `{field}`: value {value} out of range for the domain type")]
+    OutOfRange {
+        /// The offending field's dotted name.
+        field: &'static str,
+        /// The out-of-range value.
+        value: u64,
+    },
+}

--- a/crates/kx-proto/src/lib.rs
+++ b/crates/kx-proto/src/lib.rs
@@ -1,0 +1,58 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-proto — kortecx P2.1 gRPC schema (the distribution boundary)
+//!
+//! tonic/prost gRPC schema for the coordinator/worker control plane: **submit
+//! Mote**, **report commit**, **heartbeat**, **register worker**. This is the
+//! first step of P2 (coordinator/worker distribution) and the **cross-language
+//! contract** — `protoc`/`buf` generate native Rust, Python, and TypeScript
+//! types from the same `proto/kortecx/v1/coordinator.proto`.
+//!
+//! ## Mirrored fields, Rust-side identity
+//!
+//! The schema mirrors the domain types as real protobuf messages (not opaque
+//! bincode blobs) so non-Rust clients can build them with generated types. The
+//! load-bearing correctness rule:
+//!
+//! > `MoteId`, `warrant_ref`, and content refs are computed **Rust-side** from
+//! > the *reconstructed canonical* form ([`kx_mote::canonical_config`] bincode).
+//! > Protobuf wire bytes are **never** hashed; clients **never** compute a
+//! > `MoteId`.
+//!
+//! Protobuf carries field *values*; the typed `TryFrom`/`From` conversions (on
+//! the generated [`proto`] types) rebuild the exact canonical Rust struct, and
+//! the round-trip identity test pins the mapping so the schema cannot silently
+//! drift from the domain types. A failed decode surfaces as a [`ConvertError`].
+
+/// Generated gRPC message + service types (tonic/prost codegen from
+/// `proto/kortecx/v1/coordinator.proto`). Includes the `Coordinator` service
+/// server (`coordinator_server`) and client (`coordinator_client`).
+pub mod proto {
+    // Generated code is exempt from the workspace lint policy: documentation and
+    // style live in the `.proto`, not in the machine-generated Rust.
+    #![allow(
+        missing_docs,
+        unreachable_pub,
+        clippy::all,
+        clippy::pedantic,
+        clippy::nursery
+    )]
+    #![allow(rustdoc::all)]
+    tonic::include_proto!("kortecx.v1");
+}
+
+mod convert;
+mod error;
+
+pub use error::ConvertError;

--- a/crates/kx-proto/tests/common/mod.rs
+++ b/crates/kx-proto/tests/common/mod.rs
@@ -1,0 +1,131 @@
+//! Shared fixtures: representative domain values used by the round-trip and
+//! identity tests. Built from the real `kx-mote` / `kx-warrant` / `kx-content`
+//! types so the proto<->domain mapping is exercised against genuine inputs.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    dead_code,
+    unreachable_pub
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_mote::{
+    ConfigKey, ConfigVal, EdgeMeta, EffectPattern, Grammar, GraphPosition, InferenceParams,
+    InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash,
+    ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    ToolGrant, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+#[must_use]
+pub fn sample_inference_params() -> InferenceParams {
+    InferenceParams {
+        max_output_tokens: 256,
+        temperature_bps: 700,
+        top_p_bps: 9_000,
+        top_k: 40,
+        seed: 12_345,
+        stop_tokens: ["STOP".to_string(), "END".to_string()]
+            .into_iter()
+            .collect(),
+        grammar: Some(Grammar::new(r#"{"type":"object"}"#)),
+    }
+}
+
+#[must_use]
+pub fn sample_mote_def() -> MoteDef {
+    let mut tool_contract = BTreeMap::new();
+    tool_contract.insert(ToolName("fs-read".into()), ToolVersion("1.2.0".into()));
+    tool_contract.insert(
+        ToolName("text-summarize".into()),
+        ToolVersion("0.9.0".into()),
+    );
+
+    let mut config_subset = BTreeMap::new();
+    config_subset.insert(ConfigKey("max_depth".into()), ConfigVal(vec![3]));
+
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract,
+        nd_class: NdClass::WorldMutating,
+        config_subset,
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: Some(MoteId::from_bytes([3u8; 32])),
+        is_topology_shaper: false,
+        inference_params: sample_inference_params(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+#[must_use]
+pub fn sample_mote() -> Mote {
+    let parents: SmallVec<[ParentRef; 4]> = [
+        ParentRef {
+            parent_id: MoteId::from_bytes([1u8; 32]),
+            edge: EdgeMeta::data(),
+        },
+        ParentRef {
+            parent_id: MoteId::from_bytes([2u8; 32]),
+            edge: EdgeMeta::control_non_cascading(),
+        },
+    ]
+    .into_iter()
+    .collect();
+
+    Mote::new(
+        sample_mote_def(),
+        InputDataId::from_bytes([5u8; 32]),
+        GraphPosition(vec![0, 1, 2]),
+        parents,
+    )
+}
+
+#[must_use]
+pub fn sample_warrant() -> WarrantSpec {
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+    mounts.insert(PathBuf::from("/tmp/out"), FsMode::ReadWrite);
+
+    let mut hosts = BTreeSet::new();
+    hosts.insert(Host("api.example.com:443".into()));
+
+    let mut tool_grants = BTreeSet::new();
+    tool_grants.insert(ToolGrant {
+        tool_id: ToolName("fs-read".into()),
+        tool_version: ToolVersion("1.2.0".into()),
+    });
+
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(hosts),
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}

--- a/crates/kx-proto/tests/dod.rs
+++ b/crates/kx-proto/tests/dod.rs
@@ -1,0 +1,255 @@
+//! Definition-of-Done for kx-proto (P2.1).
+//!
+//! Obligations:
+//! 1. **Per-message round-trip** — every gRPC request/response prost-encodes and
+//!    decodes back to an equal value.
+//! 2. **Same-instance encode determinism** — encoding one value twice is stable
+//!    (sanity check; protobuf bytes are NOT a canonical hash input — see #3).
+//! 3. **Identity round-trip (keystone)** — domain -> proto -> domain preserves
+//!    `MoteId` / `mote_def_hash` / `warrant_ref`. This is what proves the
+//!    mirrored-fields schema honors the Rust-side identity invariant.
+//! 4. **Boundary rejections** — UNSPECIFIED enums, wrong-length hashes, missing
+//!    required messages, unknown enum values, and out-of-range scalars are typed
+//!    errors, not silent coercions.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use common::{sample_mote, sample_mote_def, sample_warrant};
+use kx_proto::proto;
+use kx_proto::ConvertError;
+use kx_warrant::warrant_ref_of;
+use prost::Message;
+
+fn roundtrip<M>(m: &M)
+where
+    M: Message + Default + PartialEq + std::fmt::Debug,
+{
+    let bytes = m.encode_to_vec();
+    let decoded = M::decode(&bytes[..]).expect("decode");
+    assert_eq!(*m, decoded);
+}
+
+// --- Obligation 1: per-message round-trip ----------------------------------
+
+#[test]
+fn obligation_1_submit_mote_request_round_trips() {
+    let req = proto::SubmitMoteRequest {
+        mote: Some(sample_mote().into()),
+        warrant: Some(sample_warrant().into()),
+    };
+    roundtrip(&req);
+}
+
+#[test]
+fn obligation_1_submit_mote_response_round_trips() {
+    roundtrip(&proto::SubmitMoteResponse {
+        mote_id: vec![0xAB; 32],
+        status: proto::SubmitStatus::Accepted as i32,
+        detail: String::new(),
+    });
+}
+
+#[test]
+fn obligation_1_report_commit_request_round_trips() {
+    let req = proto::ReportCommitRequest {
+        mote_id: vec![1; 32],
+        idempotency_key: vec![2; 32],
+        result_ref: vec![3; 32],
+        warrant_ref: vec![4; 32],
+        mote_def_hash: vec![5; 32],
+        nd_class: proto::NdClass::ReadOnlyNondet as i32,
+        parents: vec![proto::ParentRef {
+            parent_id: vec![6; 32],
+            edge_kind: proto::EdgeKind::Data as i32,
+            non_cascade: false,
+        }],
+        worker_id: 42,
+    };
+    roundtrip(&req);
+}
+
+#[test]
+fn obligation_1_report_commit_response_round_trips() {
+    roundtrip(&proto::ReportCommitResponse {
+        committed_seq: 99,
+        outcome: proto::CommitOutcome::Committed as i32,
+        detail: "ok".into(),
+    });
+}
+
+#[test]
+fn obligation_1_heartbeat_round_trips() {
+    roundtrip(&proto::HeartbeatRequest {
+        worker_id: 7,
+        timestamp_ms: 1_700_000_000_000,
+        in_flight: 3,
+    });
+    roundtrip(&proto::HeartbeatResponse { ack: true });
+}
+
+#[test]
+fn obligation_1_register_worker_round_trips() {
+    roundtrip(&proto::RegisterWorkerRequest {
+        executor_class: proto::ExecutorClass::Bwrap as i32,
+        endpoint: "http://10.0.0.2:50051".into(),
+    });
+    roundtrip(&proto::RegisterWorkerResponse { worker_id: 7 });
+}
+
+// --- Obligation 2: same-instance encode determinism ------------------------
+
+#[test]
+fn obligation_2_encoding_same_value_is_stable() {
+    let req = proto::SubmitMoteRequest {
+        mote: Some(sample_mote().into()),
+        warrant: Some(sample_warrant().into()),
+    };
+    assert_eq!(req.encode_to_vec(), req.encode_to_vec());
+}
+
+// --- Obligation 3: identity round-trip (the keystone) ----------------------
+
+#[test]
+fn obligation_3_mote_def_identity_round_trips() {
+    let def = sample_mote_def();
+    let wire: proto::MoteDef = def.clone().into();
+    let back: kx_mote::MoteDef = wire.try_into().expect("convert");
+    assert_eq!(def, back, "structural equality");
+    assert_eq!(
+        def.hash(),
+        back.hash(),
+        "mote_def_hash identity preserved across the wire mapping"
+    );
+}
+
+#[test]
+fn obligation_3_mote_id_identity_round_trips() {
+    let mote = sample_mote();
+    let wire: proto::Mote = mote.clone().into();
+    let back: kx_mote::Mote = wire.try_into().expect("convert");
+    assert_eq!(mote, back, "structural equality incl. re-derived MoteId");
+    assert_eq!(mote.id, back.id, "MoteId identity preserved");
+}
+
+#[test]
+fn obligation_3_warrant_ref_identity_round_trips() {
+    let w = sample_warrant();
+    let wire: proto::WarrantSpec = w.clone().into();
+    let back: kx_warrant::WarrantSpec = wire.try_into().expect("convert");
+    assert_eq!(w, back, "structural equality");
+    assert_eq!(
+        warrant_ref_of(&w),
+        warrant_ref_of(&back),
+        "warrant_ref identity preserved"
+    );
+}
+
+#[test]
+fn obligation_3_full_wire_pipeline_preserves_identity() {
+    let mote = sample_mote();
+    let warrant = sample_warrant();
+    let req = proto::SubmitMoteRequest {
+        mote: Some(mote.clone().into()),
+        warrant: Some(warrant.clone().into()),
+    };
+
+    // Through the actual gRPC wire bytes and back.
+    let bytes = req.encode_to_vec();
+    let decoded = proto::SubmitMoteRequest::decode(&bytes[..]).expect("decode");
+
+    let back_mote: kx_mote::Mote = decoded
+        .mote
+        .expect("mote present")
+        .try_into()
+        .expect("convert");
+    let back_warrant: kx_warrant::WarrantSpec = decoded
+        .warrant
+        .expect("warrant present")
+        .try_into()
+        .expect("convert");
+
+    assert_eq!(mote.id, back_mote.id, "MoteId survives the full pipeline");
+    assert_eq!(
+        warrant_ref_of(&warrant),
+        warrant_ref_of(&back_warrant),
+        "warrant_ref survives the full pipeline"
+    );
+}
+
+#[test]
+fn obligation_3_net_scope_none_round_trips() {
+    let w = kx_warrant::WarrantSpec {
+        net_scope: kx_warrant::NetScope::None,
+        ..sample_warrant()
+    };
+    let wire: proto::WarrantSpec = w.clone().into();
+    let back: kx_warrant::WarrantSpec = wire.try_into().expect("convert");
+    assert_eq!(w, back);
+    assert_eq!(warrant_ref_of(&w), warrant_ref_of(&back));
+}
+
+// --- Obligation 4: boundary rejections -------------------------------------
+
+#[test]
+fn obligation_4_unspecified_enum_rejected() {
+    let mut wire: proto::MoteDef = sample_mote_def().into();
+    wire.nd_class = proto::NdClass::Unspecified as i32;
+    let err = kx_mote::MoteDef::try_from(wire).unwrap_err();
+    assert_eq!(
+        err,
+        ConvertError::UnspecifiedEnum {
+            enum_name: "NdClass"
+        }
+    );
+}
+
+#[test]
+fn obligation_4_bad_hash_length_rejected() {
+    let mut wire: proto::MoteDef = sample_mote_def().into();
+    wire.logic_ref = vec![0u8; 31];
+    let err = kx_mote::MoteDef::try_from(wire).unwrap_err();
+    assert_eq!(
+        err,
+        ConvertError::BadHashLength {
+            field: "MoteDef.logic_ref",
+            len: 31
+        }
+    );
+}
+
+#[test]
+fn obligation_4_missing_required_message_rejected() {
+    let wire = proto::Mote {
+        mote_id: vec![],
+        def: None,
+        input_data_id: vec![0; 32],
+        graph_position: vec![],
+        parents: vec![],
+    };
+    let err = kx_mote::Mote::try_from(wire).unwrap_err();
+    assert_eq!(err, ConvertError::MissingField { field: "Mote.def" });
+}
+
+#[test]
+fn obligation_4_unknown_enum_value_rejected() {
+    let mut wire: proto::MoteDef = sample_mote_def().into();
+    wire.nd_class = 99;
+    let err = kx_mote::MoteDef::try_from(wire).unwrap_err();
+    assert_eq!(
+        err,
+        ConvertError::UnknownEnum {
+            enum_name: "NdClass",
+            value: 99
+        }
+    );
+}
+
+#[test]
+fn obligation_4_schema_version_out_of_range_rejected() {
+    let mut wire: proto::MoteDef = sample_mote_def().into();
+    wire.schema_version = u32::from(u16::MAX) + 1;
+    let err = kx_mote::MoteDef::try_from(wire).unwrap_err();
+    assert!(matches!(err, ConvertError::OutOfRange { .. }));
+}

--- a/crates/kx-proto/tests/proptest_messages.rs
+++ b/crates/kx-proto/tests/proptest_messages.rs
@@ -1,0 +1,299 @@
+//! Property tests: the proto<->domain mapping is the identity for the
+//! identity-bearing types (and preserves `MoteId` / `mote_def_hash` /
+//! `warrant_ref`), and the prost wire encoding round-trips, across 64 random
+//! cases per property.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_content::ContentRef;
+use kx_mote::{
+    ConfigKey, ConfigVal, EdgeMeta, EffectPattern, Grammar, GraphPosition, InferenceParams,
+    InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash,
+    ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_proto::proto;
+use kx_warrant::{
+    warrant_ref_of, ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope,
+    ResourceCeiling, ToolGrant, WarrantSpec,
+};
+use proptest::prelude::*;
+use prost::Message;
+use smallvec::SmallVec;
+use std::path::PathBuf;
+
+// --- leaf strategies --------------------------------------------------------
+
+fn arb_hash() -> impl Strategy<Value = [u8; 32]> {
+    proptest::array::uniform32(any::<u8>())
+}
+
+fn arb_string() -> impl Strategy<Value = String> {
+    proptest::string::string_regex("[a-zA-Z0-9 /._-]{0,12}").unwrap()
+}
+
+fn arb_nd() -> impl Strategy<Value = NdClass> {
+    prop_oneof![
+        Just(NdClass::Pure),
+        Just(NdClass::ReadOnlyNondet),
+        Just(NdClass::WorldMutating),
+    ]
+}
+
+fn arb_effect() -> impl Strategy<Value = EffectPattern> {
+    prop_oneof![
+        Just(EffectPattern::IdempotentByConstruction),
+        Just(EffectPattern::StageThenCommit),
+        Just(EffectPattern::ValidateThenCommit),
+    ]
+}
+
+fn arb_mote_class() -> impl Strategy<Value = MoteClass> {
+    prop_oneof![
+        Just(MoteClass::Pure),
+        Just(MoteClass::ReadOnlyNondet),
+        Just(MoteClass::WorldMutating),
+    ]
+}
+
+fn arb_fs_mode() -> impl Strategy<Value = FsMode> {
+    prop_oneof![
+        Just(FsMode::ReadOnly),
+        Just(FsMode::ReadWrite),
+        Just(FsMode::ExecOnly),
+    ]
+}
+
+fn arb_executor() -> impl Strategy<Value = ExecutorClass> {
+    prop_oneof![
+        Just(ExecutorClass::Bwrap),
+        Just(ExecutorClass::OciDaemon),
+        Just(ExecutorClass::CloudMicroVm),
+        Just(ExecutorClass::MacOsSandbox),
+    ]
+}
+
+fn arb_edge_meta() -> impl Strategy<Value = EdgeMeta> {
+    prop_oneof![
+        Just(EdgeMeta::data()),
+        Just(EdgeMeta::control()),
+        Just(EdgeMeta::control_non_cascading()),
+    ]
+}
+
+// --- composite strategies ---------------------------------------------------
+
+fn arb_inference_params() -> impl Strategy<Value = InferenceParams> {
+    (
+        any::<u32>(),
+        any::<u32>(),
+        any::<u32>(),
+        any::<u32>(),
+        any::<u32>(),
+        prop::collection::vec(arb_string(), 0..4),
+        prop::option::of(arb_string()),
+    )
+        .prop_map(|(mo, t, tp, tk, s, stops, gram)| InferenceParams {
+            max_output_tokens: mo,
+            temperature_bps: t,
+            top_p_bps: tp,
+            top_k: tk,
+            seed: s,
+            stop_tokens: stops.into_iter().collect(),
+            grammar: gram.map(Grammar::new),
+        })
+}
+
+fn arb_mote_def() -> impl Strategy<Value = MoteDef> {
+    (
+        (arb_hash(), arb_hash(), prop::option::of(arb_hash())),
+        arb_string(),
+        prop::collection::btree_map(arb_string(), arb_string(), 0..3),
+        arb_nd(),
+        prop::collection::btree_map(arb_string(), prop::collection::vec(any::<u8>(), 0..4), 0..3),
+        arb_effect(),
+        any::<bool>(),
+        arb_inference_params(),
+    )
+        .prop_map(
+            |((logic, pth, critic), model, tools, nd, cfg, eff, shaper, inf)| MoteDef {
+                logic_ref: LogicRef::from_bytes(logic),
+                model_id: ModelId(model),
+                prompt_template_hash: PromptTemplateHash::from_bytes(pth),
+                tool_contract: tools
+                    .into_iter()
+                    .map(|(k, v)| (ToolName(k), ToolVersion(v)))
+                    .collect(),
+                nd_class: nd,
+                config_subset: cfg
+                    .into_iter()
+                    .map(|(k, v)| (ConfigKey(k), ConfigVal(v)))
+                    .collect(),
+                effect_pattern: eff,
+                critic_for: critic.map(MoteId::from_bytes),
+                is_topology_shaper: shaper,
+                inference_params: inf,
+                schema_version: MOTE_DEF_SCHEMA_VERSION,
+            },
+        )
+}
+
+fn arb_parents() -> impl Strategy<Value = SmallVec<[ParentRef; 4]>> {
+    prop::collection::vec(
+        (arb_hash(), arb_edge_meta()).prop_map(|(pid, edge)| ParentRef {
+            parent_id: MoteId::from_bytes(pid),
+            edge,
+        }),
+        0..4,
+    )
+    .prop_map(|v| v.into_iter().collect())
+}
+
+fn arb_mote() -> impl Strategy<Value = Mote> {
+    (
+        arb_mote_def(),
+        arb_hash(),
+        prop::collection::vec(any::<u8>(), 0..6),
+        arb_parents(),
+    )
+        .prop_map(|(def, idid, gp, parents)| {
+            Mote::new(
+                def,
+                InputDataId::from_bytes(idid),
+                GraphPosition(gp),
+                parents,
+            )
+        })
+}
+
+fn arb_model_route() -> impl Strategy<Value = ModelRoute> {
+    (arb_string(), any::<u32>(), any::<u32>(), any::<u32>()).prop_map(|(m, i, o, c)| ModelRoute {
+        model_id: ModelId(m),
+        max_input_tokens: i,
+        max_output_tokens: o,
+        max_calls: c,
+    })
+}
+
+fn arb_resource_ceiling() -> impl Strategy<Value = ResourceCeiling> {
+    (
+        any::<u32>(),
+        any::<u64>(),
+        any::<u64>(),
+        any::<u32>(),
+        any::<u64>(),
+    )
+        .prop_map(|(cpu, mem, wall, fd, disk)| ResourceCeiling {
+            cpu_milli: cpu,
+            mem_bytes: mem,
+            wall_clock_ms: wall,
+            fd_count: fd,
+            disk_bytes: disk,
+        })
+}
+
+fn arb_fs_scope() -> impl Strategy<Value = FsScope> {
+    prop::collection::btree_map(arb_string().prop_map(PathBuf::from), arb_fs_mode(), 0..4)
+        .prop_map(|mounts| FsScope { mounts })
+}
+
+fn arb_net_scope() -> impl Strategy<Value = NetScope> {
+    prop_oneof![
+        Just(NetScope::None),
+        prop::collection::btree_set(arb_string().prop_map(Host), 0..4)
+            .prop_map(NetScope::EgressAllowlist),
+    ]
+}
+
+fn arb_tool_grants() -> impl Strategy<Value = std::collections::BTreeSet<ToolGrant>> {
+    prop::collection::btree_set(
+        (arb_string(), arb_string()).prop_map(|(a, b)| ToolGrant {
+            tool_id: ToolName(a),
+            tool_version: ToolVersion(b),
+        }),
+        0..4,
+    )
+}
+
+fn arb_warrant() -> impl Strategy<Value = WarrantSpec> {
+    (
+        (
+            arb_mote_class(),
+            arb_mote_class(),
+            arb_hash(),
+            prop::option::of(arb_hash()),
+            arb_executor(),
+        ),
+        arb_fs_scope(),
+        arb_net_scope(),
+        arb_tool_grants(),
+        arb_model_route(),
+        arb_resource_ceiling(),
+    )
+        .prop_map(
+            |((mc, nd, syscall, env, exec), fs, net, tools, mr, rc)| WarrantSpec {
+                mote_class: mc,
+                nd_class: nd,
+                fs_scope: fs,
+                net_scope: net,
+                syscall_profile_ref: ContentRef::from_bytes(syscall),
+                tool_grants: tools,
+                model_route: mr,
+                resource_ceiling: rc,
+                environment_ref: env.map(ContentRef::from_bytes),
+                executor_class: exec,
+            },
+        )
+}
+
+// --- properties -------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    #[test]
+    fn prop_inference_params_round_trips(p in arb_inference_params()) {
+        let wire: proto::InferenceParams = p.clone().into();
+        let back: InferenceParams = wire.try_into().expect("convert");
+        prop_assert_eq!(p, back);
+    }
+
+    #[test]
+    fn prop_mote_def_round_trips(def in arb_mote_def()) {
+        let wire: proto::MoteDef = def.clone().into();
+        let back: MoteDef = wire.try_into().expect("convert");
+        prop_assert_eq!(&def, &back);
+        prop_assert_eq!(def.hash(), back.hash());
+    }
+
+    #[test]
+    fn prop_mote_round_trips(mote in arb_mote()) {
+        let wire: proto::Mote = mote.clone().into();
+        let back: Mote = wire.try_into().expect("convert");
+        prop_assert_eq!(&mote, &back);
+        prop_assert_eq!(mote.id, back.id);
+    }
+
+    #[test]
+    fn prop_warrant_round_trips(w in arb_warrant()) {
+        let wire: proto::WarrantSpec = w.clone().into();
+        let back: WarrantSpec = wire.try_into().expect("convert");
+        prop_assert_eq!(&w, &back);
+        prop_assert_eq!(warrant_ref_of(&w), warrant_ref_of(&back));
+    }
+
+    #[test]
+    fn prop_mote_def_wire_round_trips(def in arb_mote_def()) {
+        let wire: proto::MoteDef = def.into();
+        let bytes = wire.encode_to_vec();
+        let decoded = proto::MoteDef::decode(&bytes[..]).expect("decode");
+        prop_assert_eq!(wire, decoded);
+    }
+
+    #[test]
+    fn prop_warrant_wire_round_trips(w in arb_warrant()) {
+        let wire: proto::WarrantSpec = w.into();
+        let bytes = wire.encode_to_vec();
+        let decoded = proto::WarrantSpec::decode(&bytes[..]).expect("decode");
+        prop_assert_eq!(wire, decoded);
+    }
+}

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -1,0 +1,154 @@
+//! Proves the tonic service **skeleton builds and serves**: a no-op
+//! `Coordinator` impl is hosted over a real TCP endpoint and a generated client
+//! reaches all four RPCs. This goes beyond "compiles" — it exercises the
+//! generated server trait, the `CoordinatorServer`/`CoordinatorClient` types,
+//! and the transport. No coordinator *behavior* is implemented (that is P2.2/2.3).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::time::Duration;
+
+use common::{sample_mote, sample_warrant};
+use kx_proto::proto::coordinator_client::CoordinatorClient;
+use kx_proto::proto::coordinator_server::{Coordinator, CoordinatorServer};
+use kx_proto::proto::{
+    CommitOutcome, ExecutorClass, HeartbeatRequest, HeartbeatResponse, RegisterWorkerRequest,
+    RegisterWorkerResponse, ReportCommitRequest, ReportCommitResponse, SubmitMoteRequest,
+    SubmitMoteResponse, SubmitStatus,
+};
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+#[derive(Default)]
+struct NoopCoordinator;
+
+#[tonic::async_trait]
+impl Coordinator for NoopCoordinator {
+    async fn register_worker(
+        &self,
+        _req: Request<RegisterWorkerRequest>,
+    ) -> Result<Response<RegisterWorkerResponse>, Status> {
+        Ok(Response::new(RegisterWorkerResponse { worker_id: 7 }))
+    }
+
+    async fn heartbeat(
+        &self,
+        _req: Request<HeartbeatRequest>,
+    ) -> Result<Response<HeartbeatResponse>, Status> {
+        Ok(Response::new(HeartbeatResponse { ack: true }))
+    }
+
+    async fn submit_mote(
+        &self,
+        req: Request<SubmitMoteRequest>,
+    ) -> Result<Response<SubmitMoteResponse>, Status> {
+        // Echo back the wire mote_id so the test confirms the payload arrived
+        // intact. (Identity is re-derived coordinator-side in P2.2; not here.)
+        let mote_id = req.into_inner().mote.map(|m| m.mote_id).unwrap_or_default();
+        Ok(Response::new(SubmitMoteResponse {
+            mote_id,
+            status: SubmitStatus::Accepted as i32,
+            detail: String::new(),
+        }))
+    }
+
+    async fn report_commit(
+        &self,
+        _req: Request<ReportCommitRequest>,
+    ) -> Result<Response<ReportCommitResponse>, Status> {
+        Ok(Response::new(ReportCommitResponse {
+            committed_seq: 1,
+            outcome: CommitOutcome::Committed as i32,
+            detail: String::new(),
+        }))
+    }
+}
+
+#[tokio::test]
+async fn coordinator_skeleton_serves_all_four_rpcs() {
+    // Ephemeral port; serve in the background.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener); // free it for tonic to re-bind
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(CoordinatorServer::new(NoopCoordinator))
+            .serve(addr)
+            .await
+            .unwrap();
+    });
+
+    // Connect with a brief retry while the server binds.
+    let endpoint = format!("http://{addr}");
+    let mut client = None;
+    for _ in 0..100 {
+        match CoordinatorClient::connect(endpoint.clone()).await {
+            Ok(c) => {
+                client = Some(c);
+                break;
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+        }
+    }
+    let mut client = client.expect("client connects to the skeleton server");
+
+    // (4) register worker
+    let reg = client
+        .register_worker(RegisterWorkerRequest {
+            executor_class: ExecutorClass::Bwrap as i32,
+            endpoint: "http://10.0.0.2:50051".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(reg.worker_id, 7);
+
+    // (3) heartbeat
+    let hb = client
+        .heartbeat(HeartbeatRequest {
+            worker_id: 7,
+            timestamp_ms: 1,
+            in_flight: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(hb.ack);
+
+    // (1) submit Mote — full domain Mote + warrant over the wire.
+    let submit = client
+        .submit_mote(SubmitMoteRequest {
+            mote: Some(sample_mote().into()),
+            warrant: Some(sample_warrant().into()),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(submit.status, SubmitStatus::Accepted as i32);
+    assert_eq!(
+        submit.mote_id.len(),
+        32,
+        "mote_id round-tripped over the wire"
+    );
+
+    // (2) report commit
+    let commit = client
+        .report_commit(ReportCommitRequest {
+            mote_id: vec![1; 32],
+            idempotency_key: vec![2; 32],
+            result_ref: vec![3; 32],
+            warrant_ref: vec![4; 32],
+            mote_def_hash: vec![5; 32],
+            nd_class: kx_proto::proto::NdClass::ReadOnlyNondet as i32,
+            parents: vec![],
+            worker_id: 7,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(commit.outcome, CommitOutcome::Committed as i32);
+    assert_eq!(commit.committed_seq, 1);
+}


### PR DESCRIPTION
## Summary

First step of **P2 (coordinator/worker distribution)**: the new `kx-proto` crate — the tonic gRPC schema for the four control-plane message families (**submit Mote · report commit · heartbeat · register worker**) over Unix socket locally / TCP across nodes. Additive only; `kx-scheduler` / `kx-executor` / `kx-inference` source is untouched (the P2 "distribution is wiring" thesis test holds by construction — this is a brand-new leaf crate).

This crate is also the **cross-language contract**: the runtime will be consumed from Python + TypeScript bindings (React/Next.js frontend). Two decisions follow:

- **Mirrored protobuf fields** (not an opaque bincode envelope) so `protoc`/`buf` generate native Rust/Python/TS types from `proto/kortecx/v1/coordinator.proto`. Opaque bincode would be Rust-only.
- **Identity invariant** (load-bearing): `MoteId` / `warrant_ref` / content refs are recomputed **Rust-side** from the reconstructed canonical bincode form. Protobuf wire bytes are **never** hashed; clients **never** compute a `MoteId`. `Mote::new` re-derives the id on decode (wire `mote_id` is advisory). Every enum has an explicit `*_UNSPECIFIED = 0` sentinel rejected at the `TryFrom` boundary (an unset `nd_class` must not silently mean `Pure`).
- **Vendored protoc** (`protoc-bin-vendored`) in `build.rs` — no system protoc on CI or local; pinned + deterministic; ships linux-x86_64 + macos-aarch64 (SN-7). No CI workflow change needed.

## What's in it

- `.proto`: `Coordinator` service (4 RPCs) + mirrored `MoteDef` / `InferenceParams` / `WarrantSpec` / `Mote` / `ParentRef` + fixed-field request/response messages.
- `convert` module: typed `TryFrom`/`From` between proto and `kx-mote`/`kx-warrant`/`kx-content` (validates 32-byte hashes, rejects `UNSPECIFIED`, restores `BTreeMap`/`BTreeSet` canonical order). `ConvertError` via `thiserror`.
- First async + network crate in the workspace (tonic 0.12 / prost 0.13 / tokio 1); TLS deliberately **not** enabled (plaintext P2; no `ring`).

## Test plan

- [x] DoD: per-message prost round-trip for every request/response
- [x] Keystone identity round-trips: `domain → proto → domain` preserves `mote_def_hash` / `MoteId` / `warrant_ref` (incl. full encode→decode pipeline)
- [x] Boundary rejections: UNSPECIFIED / bad-hash-length / missing-field / unknown-enum / out-of-range
- [x] proptest (64 cases): round-trip + identity properties
- [x] Live tonic server↔client skeleton exercises all four RPCs
- [x] `fmt` · `clippy --workspace --all-targets -D warnings` · workspace test (40 suites, 0 failures) · `cargo deny` (new async tree clean) · `doc -D warnings` · `check-reproducible` (I1.c byte-determinism) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)