### PR TITLE
PR 15 / P2.2 — kx-coordinator (coordinator service: hosts scheduler verbatim, sole journal writer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-coordinator"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-journal",
+ "kx-mote",
+ "kx-projection",
+ "kx-proto",
+ "kx-scheduler",
+ "kx-warrant",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "kx-executor"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/kx-tiering",
     "crates/kx-runtime",
     "crates/kx-proto",
+    "crates/kx-coordinator",
 ]
 exclude = [
     "kx-cloud",
@@ -80,6 +81,7 @@ kx-capability        = { path = "crates/kx-capability",        version = "0.0.1"
 kx-executor          = { path = "crates/kx-executor",          version = "0.0.1" }
 kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.0.1" }
 kx-proto             = { path = "crates/kx-proto",             version = "0.0.1" }
+kx-coordinator       = { path = "crates/kx-coordinator",       version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-coordinator/Cargo.toml
+++ b/crates/kx-coordinator/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "kx-coordinator"
+version = "0.0.1"
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+description = "kortecx P2.2 coordinator service — hosts the P1 scheduler verbatim, owns the worker registry (behind a trait), and is the sole journal writer per run. Implements the kx-proto gRPC Coordinator service (the distribution control plane)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The gRPC schema + generated server/client + the tested proto<->domain
+# conversions (identity re-derived Rust-side, D53).
+kx-proto = { workspace = true }
+# Hosted VERBATIM (P2 thesis test): registration routes through Scheduler::submit;
+# placement is the kx-scheduler trait.
+kx-scheduler = { workspace = true }
+# The coordinator is the SOLE journal writer per run (D13 / D40): it assembles the
+# Committed entry from a worker's ReportCommit proposal and appends it.
+kx-journal = { workspace = true }
+kx-projection = { workspace = true }
+kx-mote = { workspace = true }
+kx-content = { workspace = true }
+kx-warrant = { workspace = true }
+# `sync` (mpsc + oneshot) is additive over the workspace tokio features: the async
+# RPC handlers funnel commands to a single orchestration thread that owns the
+# journal + projection + scheduler. The Projection holds a non-`Send` trait object
+# (`Box<dyn TopologyMaterializer>`), so single-owner-thread + channel is how the
+# coordinator keeps a `Send + Sync` gRPC service without a kx-projection refactor —
+# and it makes the D40 sole-writer invariant structural (one thread owns the log).
+tonic = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+smallvec = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+# `time` is additive over the workspace tokio features — the e2e tests use a short
+# connect-retry sleep while the in-process server binds (the kx-proto pattern).
+tokio = { workspace = true, features = ["time"] }
+# Temp Sqlite file for the restart/recovery integration test.
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-coordinator/src/commit.rs
+++ b/crates/kx-coordinator/src/commit.rs
@@ -1,0 +1,77 @@
+//! `ReportCommit` → validated [`CommitProposal`] (the D40 sole-writer path, step 1).
+//!
+//! This module is **pure**: it converts an untrusted `proto::ReportCommitRequest`
+//! into the typed fields needed to build a `JournalEntry::Committed`, validating
+//! every 32-byte hash length, rejecting `*_UNSPECIFIED` enums, and enforcing the
+//! `idempotency_key == MoteId` identity invariant. It never touches the journal
+//! or projection — assembling and appending the entry is the orchestration core's
+//! job (`crate::state`), where the seq is assigned.
+
+use kx_content::ContentRef;
+use kx_journal::ParentEntry;
+use kx_mote::{MoteDefHash, MoteId, NdClass, ParentRef};
+use kx_proto::proto;
+use kx_proto::ConvertError;
+use smallvec::SmallVec;
+
+use crate::error::CoordinatorError;
+
+/// The typed, validated commit proposal extracted from a `ReportCommit` request.
+///
+/// Every field is already canonical: 32-byte refs are length-checked, the enum is
+/// not the `UNSPECIFIED` sentinel, and `idempotency_key == mote_id`.
+pub(crate) struct CommitProposal {
+    pub(crate) mote_id: MoteId,
+    pub(crate) idempotency_key: [u8; 32],
+    pub(crate) result_ref: ContentRef,
+    pub(crate) warrant_ref: ContentRef,
+    pub(crate) mote_def_hash: MoteDefHash,
+    pub(crate) nd_class: NdClass,
+    pub(crate) parents: SmallVec<[ParentEntry; 4]>,
+}
+
+/// Validate that a wire `bytes` field is exactly a 32-byte hash.
+fn hash32(bytes: &[u8], field: &'static str) -> Result<[u8; 32], CoordinatorError> {
+    <[u8; 32]>::try_from(bytes).map_err(|_| CoordinatorError::BadHashLength {
+        field,
+        len: bytes.len(),
+    })
+}
+
+/// Convert + validate a `ReportCommit` request into a [`CommitProposal`].
+pub(crate) fn assemble(
+    req: proto::ReportCommitRequest,
+) -> Result<CommitProposal, CoordinatorError> {
+    let mote_id = MoteId::from_bytes(hash32(&req.mote_id, "ReportCommit.mote_id")?);
+    let idempotency_key = hash32(&req.idempotency_key, "ReportCommit.idempotency_key")?;
+    if &idempotency_key != mote_id.as_bytes() {
+        return Err(CoordinatorError::IdentityMismatch(mote_id));
+    }
+    let result_ref = ContentRef::from_bytes(hash32(&req.result_ref, "ReportCommit.result_ref")?);
+    let warrant_ref = ContentRef::from_bytes(hash32(&req.warrant_ref, "ReportCommit.warrant_ref")?);
+    let mote_def_hash =
+        MoteDefHash::from_bytes(hash32(&req.mote_def_hash, "ReportCommit.mote_def_hash")?);
+
+    let proto_nd =
+        proto::NdClass::try_from(req.nd_class).map_err(|_| ConvertError::UnknownEnum {
+            enum_name: "NdClass",
+            value: req.nd_class,
+        })?;
+    let nd_class = NdClass::try_from(proto_nd)?;
+
+    let parents: SmallVec<[ParentEntry; 4]> = req
+        .parents
+        .into_iter()
+        .map(|p| ParentRef::try_from(p).map(|pr| ParentEntry::from_parent_ref(&pr)))
+        .collect::<Result<_, ConvertError>>()?;
+
+    Ok(CommitProposal {
+        mote_id,
+        idempotency_key,
+        result_ref,
+        warrant_ref,
+        mote_def_hash,
+        nd_class,
+        parents,
+    })
+}

--- a/crates/kx-coordinator/src/error.rs
+++ b/crates/kx-coordinator/src/error.rs
@@ -1,0 +1,83 @@
+//! [`CoordinatorError`] — the coordinator's failure vocabulary plus its mapping
+//! to [`tonic::Status`] at the gRPC boundary.
+//!
+//! Direction of blame drives the status code: malformed or inadmissible client
+//! requests (bad hash lengths, `*_UNSPECIFIED` enums, identity mismatch, unknown
+//! worker / Mote, duplicate submission) map to `INVALID_ARGUMENT`; durable-layer
+//! faults (journal / projection) map to `INTERNAL`; a downed orchestration core
+//! maps to `UNAVAILABLE`.
+
+use kx_journal::JournalError;
+use kx_mote::MoteId;
+use kx_projection::ProjectionError;
+use kx_proto::ConvertError;
+use kx_scheduler::{SchedulerError, WorkerId};
+use thiserror::Error;
+
+/// Errors raised while servicing a coordinator RPC.
+#[derive(Debug, Error)]
+pub enum CoordinatorError {
+    /// A flat 32-byte wire field on a `ReportCommit` request was the wrong length.
+    #[error("field {field} expected 32 bytes, got {len}")]
+    BadHashLength {
+        /// Which wire field failed validation.
+        field: &'static str,
+        /// The actual byte length received.
+        len: usize,
+    },
+
+    /// The reported `idempotency_key` did not equal the Mote's identity bytes.
+    /// The journal dedupes `Committed` entries by `idempotency_key`, and the
+    /// identity substrate fixes `idempotency_key == MoteId` (`idempotency.md`),
+    /// so a mismatch is a malformed proposal, not a recoverable state.
+    #[error("idempotency_key does not match mote_id for {0:?}")]
+    IdentityMismatch(MoteId),
+
+    /// A `proto -> domain` conversion failed at the untrusted boundary.
+    #[error(transparent)]
+    Convert(#[from] ConvertError),
+
+    /// The worker named in the request has not registered.
+    #[error("unknown worker {0:?}")]
+    UnknownWorker(WorkerId),
+
+    /// The Mote named in a `ReportCommit` was never submitted to this coordinator.
+    #[error("unknown mote {0:?} (never submitted)")]
+    UnknownMote(MoteId),
+
+    /// Hosted-scheduler bookkeeping failure (e.g. duplicate submission).
+    #[error(transparent)]
+    Scheduler(#[from] SchedulerError),
+
+    /// The journal append (the sole-writer path) failed.
+    #[error(transparent)]
+    Journal(#[from] JournalError),
+
+    /// Folding the new entry into the read-side projection failed.
+    #[error(transparent)]
+    Projection(#[from] ProjectionError),
+
+    /// The orchestration core thread is not reachable (it exited, e.g. on a
+    /// startup recovery failure). The journal is the durable truth; a restart
+    /// re-folds from it.
+    #[error("coordinator orchestration core is unavailable")]
+    CoreUnavailable,
+}
+
+impl From<CoordinatorError> for tonic::Status {
+    fn from(error: CoordinatorError) -> Self {
+        let message = error.to_string();
+        match error {
+            CoordinatorError::BadHashLength { .. }
+            | CoordinatorError::IdentityMismatch(_)
+            | CoordinatorError::Convert(_)
+            | CoordinatorError::UnknownWorker(_)
+            | CoordinatorError::UnknownMote(_)
+            | CoordinatorError::Scheduler(_) => Self::invalid_argument(message),
+            CoordinatorError::Journal(_) | CoordinatorError::Projection(_) => {
+                Self::internal(message)
+            }
+            CoordinatorError::CoreUnavailable => Self::unavailable(message),
+        }
+    }
+}

--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -1,0 +1,52 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-coordinator — the kortecx P2.2 coordinator service (the control plane)
+//!
+//! The coordinator is the hub of a distributed run. It:
+//!
+//! 1. **hosts the P1 scheduler verbatim** — submitted Motes are registered through
+//!    [`kx_scheduler::Scheduler::submit`], exactly as the single-node engine does
+//!    (the P2 thesis test: distribution must not change `kx-scheduler` source);
+//! 2. **owns the worker registry behind a trait** ([`WorkerRegistry`]) — register
+//!    / heartbeat / admission for `ReportCommit`;
+//! 3. **is the sole journal writer per run** (D13 / D40) — remote workers PROPOSE
+//!    commits via the [`SubmitMote`](proto::coordinator_server::Coordinator::submit_mote)
+//!    /
+//!    [`ReportCommit`](proto::coordinator_server::Coordinator::report_commit) RPCs;
+//!    the coordinator assembles the canonical `Committed` entry and appends it (the
+//!    only place a seq is assigned).
+//!
+//! It implements the [`kx_proto`] gRPC `Coordinator` service. The journal,
+//! projection, and scheduler live on one owner thread (see `state`), which keeps
+//! the gRPC service `Send + Sync` and makes single-writer structural.
+//!
+//! ## Scope (P2.2)
+//!
+//! Passive control plane: the four RPCs, the registry, and the sole-writer commit
+//! path. Active dispatch — pushing/pulling ready Motes to workers — is **P2.3**
+//! (`kx-worker`), and placement v2 is P2.5.
+
+pub use kx_projection::MoteState;
+pub use kx_proto::proto;
+pub use kx_scheduler::WorkerId;
+
+mod commit;
+mod error;
+mod registry;
+mod service;
+mod state;
+
+pub use error::CoordinatorError;
+pub use registry::{InMemoryWorkerRegistry, RegistryError, WorkerRecord, WorkerRegistry};
+pub use service::CoordinatorService;

--- a/crates/kx-coordinator/src/registry.rs
+++ b/crates/kx-coordinator/src/registry.rs
@@ -1,0 +1,129 @@
+//! The worker registry — the coordinator's view of registered workers, **behind a
+//! trait** (P2.2 DoD item 2) so the in-memory default can be swapped for a
+//! distributed / persistent store later without touching the service.
+//!
+//! In P2.2 the coordinator never dispatches work (that is P2.3): the registry is
+//! liveness bookkeeping plus the **admission oracle** for `ReportCommit` — an
+//! unregistered worker cannot propose a commit.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError};
+
+use kx_scheduler::WorkerId;
+use kx_warrant::ExecutorClass;
+
+/// One worker's registration plus its last-known liveness.
+#[derive(Debug, Clone)]
+pub struct WorkerRecord {
+    /// Coordinator-assigned identity.
+    pub id: WorkerId,
+    /// The sandbox backend this worker can run (D41 executor classes).
+    pub executor_class: ExecutorClass,
+    /// How the coordinator reaches the worker (host:port / URL / socket path).
+    pub endpoint: String,
+    /// Wall-clock ms of the most recent heartbeat (liveness only; never hashed).
+    pub last_heartbeat_ms: u64,
+    /// Motes the worker reported executing at its last heartbeat.
+    pub in_flight: u32,
+}
+
+/// Errors from the worker registry.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RegistryError {
+    /// An operation named a worker that never registered.
+    #[error("unknown worker {0:?}")]
+    UnknownWorker(WorkerId),
+}
+
+/// The worker-registry seam.
+///
+/// All methods take `&self`: the registry lives behind an `Arc` shared across the
+/// async RPC handlers, so it owns its interior mutability.
+pub trait WorkerRegistry: Send + Sync {
+    /// Register a worker, assigning a fresh monotonic [`WorkerId`].
+    fn register(&self, executor_class: ExecutorClass, endpoint: String) -> WorkerId;
+
+    /// Record a heartbeat. Returns [`RegistryError::UnknownWorker`] if the id was
+    /// never registered.
+    fn heartbeat(&self, worker: WorkerId, now_ms: u64, in_flight: u32)
+        -> Result<(), RegistryError>;
+
+    /// Look up a worker's current record.
+    fn get(&self, worker: WorkerId) -> Option<WorkerRecord>;
+
+    /// Number of registered workers.
+    fn len(&self) -> usize;
+
+    /// Whether no worker has registered yet.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// In-memory [`WorkerRegistry`] — the OSS default.
+///
+/// `BTreeMap` for deterministic iteration order; an [`AtomicU64`] hands out
+/// monotonic ids starting at `0`. A poisoned lock is recovered (not panicked):
+/// the registry's invariants survive a panicking critic elsewhere.
+#[derive(Debug, Default)]
+pub struct InMemoryWorkerRegistry {
+    next_id: AtomicU64,
+    workers: Mutex<BTreeMap<WorkerId, WorkerRecord>>,
+}
+
+impl InMemoryWorkerRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl WorkerRegistry for InMemoryWorkerRegistry {
+    fn register(&self, executor_class: ExecutorClass, endpoint: String) -> WorkerId {
+        let id = WorkerId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let record = WorkerRecord {
+            id,
+            executor_class,
+            endpoint,
+            last_heartbeat_ms: 0,
+            in_flight: 0,
+        };
+        self.workers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(id, record);
+        id
+    }
+
+    fn heartbeat(
+        &self,
+        worker: WorkerId,
+        now_ms: u64,
+        in_flight: u32,
+    ) -> Result<(), RegistryError> {
+        let mut guard = self.workers.lock().unwrap_or_else(PoisonError::into_inner);
+        let record = guard
+            .get_mut(&worker)
+            .ok_or(RegistryError::UnknownWorker(worker))?;
+        record.last_heartbeat_ms = now_ms;
+        record.in_flight = in_flight;
+        Ok(())
+    }
+
+    fn get(&self, worker: WorkerId) -> Option<WorkerRecord> {
+        self.workers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&worker)
+            .cloned()
+    }
+
+    fn len(&self) -> usize {
+        self.workers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len()
+    }
+}

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -1,0 +1,159 @@
+//! [`CoordinatorService`] — the gRPC `Coordinator` server implementation.
+//!
+//! Holds the worker registry (behind a trait) and a handle to the single
+//! orchestration core thread (which owns the journal + projection + hosted
+//! scheduler). The four RPCs are thin adapters: convert at the untrusted boundary,
+//! route to the registry or the core, map errors to [`tonic::Status`].
+
+use std::sync::Arc;
+
+use kx_journal::Journal;
+use kx_mote::{Mote, MoteId};
+use kx_projection::MoteState;
+use kx_proto::proto;
+use kx_proto::proto::coordinator_server::Coordinator;
+use kx_scheduler::WorkerId;
+use kx_warrant::WarrantSpec;
+use tonic::{Request, Response, Status};
+
+use crate::commit;
+use crate::error::CoordinatorError;
+use crate::registry::{InMemoryWorkerRegistry, RegistryError, WorkerRegistry};
+use crate::state::CoreHandle;
+
+/// The coordinator gRPC service: hosts the scheduler, owns the worker registry,
+/// and is the sole journal writer per run.
+#[derive(Clone)]
+pub struct CoordinatorService {
+    core: CoreHandle,
+    registry: Arc<dyn WorkerRegistry>,
+}
+
+impl CoordinatorService {
+    /// Build a coordinator over `journal` with the default in-memory worker
+    /// registry. Takes sole ownership of the journal (the single-writer handle).
+    pub fn new<J: Journal + Send + 'static>(journal: J) -> Self {
+        Self::with_registry(journal, Arc::new(InMemoryWorkerRegistry::new()))
+    }
+
+    /// Build a coordinator over `journal` with a caller-supplied worker registry.
+    pub fn with_registry<J: Journal + Send + 'static>(
+        journal: J,
+        registry: Arc<dyn WorkerRegistry>,
+    ) -> Self {
+        Self {
+            core: CoreHandle::spawn(journal),
+            registry,
+        }
+    }
+
+    /// Read-side accessor: the current [`MoteState`] of `mote_id` in the
+    /// coordinator's projection (the journal's folded read view).
+    pub async fn state_of(&self, mote_id: MoteId) -> Result<MoteState, CoordinatorError> {
+        self.core.state_of(mote_id).await
+    }
+
+    /// Read-side accessor: the number of `Committed` (non-repudiated) Motes.
+    pub async fn committed_count(&self) -> Result<usize, CoordinatorError> {
+        self.core.committed_count().await
+    }
+
+    /// Read-side accessor: the current ready set — submitted Motes whose parents
+    /// are all `Committed`-and-not-`Repudiated`. The dispatch surface P2.3 consumes.
+    pub async fn ready_set(&self) -> Result<Vec<MoteId>, CoordinatorError> {
+        self.core.ready_set().await
+    }
+
+    /// Borrow the worker registry (diagnostics / operator queries).
+    #[must_use]
+    pub fn registry(&self) -> &dyn WorkerRegistry {
+        self.registry.as_ref()
+    }
+}
+
+#[tonic::async_trait]
+impl Coordinator for CoordinatorService {
+    async fn register_worker(
+        &self,
+        request: Request<proto::RegisterWorkerRequest>,
+    ) -> Result<Response<proto::RegisterWorkerResponse>, Status> {
+        let req = request.into_inner();
+        let proto_class = proto::ExecutorClass::try_from(req.executor_class).map_err(|_| {
+            Status::invalid_argument(format!("unknown executor_class {}", req.executor_class))
+        })?;
+        let executor_class =
+            kx_warrant::ExecutorClass::try_from(proto_class).map_err(CoordinatorError::from)?;
+        let id = self.registry.register(executor_class, req.endpoint);
+        Ok(Response::new(proto::RegisterWorkerResponse {
+            worker_id: id.0,
+        }))
+    }
+
+    async fn heartbeat(
+        &self,
+        request: Request<proto::HeartbeatRequest>,
+    ) -> Result<Response<proto::HeartbeatResponse>, Status> {
+        let req = request.into_inner();
+        self.registry
+            .heartbeat(WorkerId(req.worker_id), req.timestamp_ms, req.in_flight)
+            .map_err(|RegistryError::UnknownWorker(worker)| {
+                CoordinatorError::UnknownWorker(worker)
+            })?;
+        Ok(Response::new(proto::HeartbeatResponse { ack: true }))
+    }
+
+    async fn submit_mote(
+        &self,
+        request: Request<proto::SubmitMoteRequest>,
+    ) -> Result<Response<proto::SubmitMoteResponse>, Status> {
+        let req = request.into_inner();
+        // IDENTITY INVARIANT (D53): `TryFrom<proto::Mote>` re-derives the MoteId
+        // Rust-side; the wire `mote_id` is advisory and never trusted.
+        let mote: Mote = req
+            .mote
+            .ok_or_else(|| Status::invalid_argument("SubmitMote.mote is required"))?
+            .try_into()
+            .map_err(CoordinatorError::from)?;
+        let warrant: WarrantSpec = req
+            .warrant
+            .ok_or_else(|| Status::invalid_argument("SubmitMote.warrant is required"))?
+            .try_into()
+            .map_err(CoordinatorError::from)?;
+
+        let outcome = self.core.submit(mote, warrant).await?;
+        let status = if outcome.duplicate {
+            proto::SubmitStatus::Duplicate
+        } else {
+            proto::SubmitStatus::Accepted
+        };
+        Ok(Response::new(proto::SubmitMoteResponse {
+            mote_id: outcome.mote_id.as_bytes().to_vec(),
+            status: status as i32,
+            detail: String::new(),
+        }))
+    }
+
+    async fn report_commit(
+        &self,
+        request: Request<proto::ReportCommitRequest>,
+    ) -> Result<Response<proto::ReportCommitResponse>, Status> {
+        let req = request.into_inner();
+        // D40 admission: only a registered worker may propose a commit.
+        let worker = WorkerId(req.worker_id);
+        if self.registry.get(worker).is_none() {
+            return Err(CoordinatorError::UnknownWorker(worker).into());
+        }
+        let proposal = commit::assemble(req)?;
+        let applied = self.core.commit(proposal).await?;
+        let outcome = if applied.already_committed {
+            proto::CommitOutcome::AlreadyCommitted
+        } else {
+            proto::CommitOutcome::Committed
+        };
+        Ok(Response::new(proto::ReportCommitResponse {
+            committed_seq: applied.committed_seq,
+            outcome: outcome as i32,
+            detail: String::new(),
+        }))
+    }
+}

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -73,6 +73,7 @@ impl CoordinatorService {
 
 #[tonic::async_trait]
 impl Coordinator for CoordinatorService {
+    #[tracing::instrument(skip_all)]
     async fn register_worker(
         &self,
         request: Request<proto::RegisterWorkerRequest>,
@@ -84,11 +85,13 @@ impl Coordinator for CoordinatorService {
         let executor_class =
             kx_warrant::ExecutorClass::try_from(proto_class).map_err(CoordinatorError::from)?;
         let id = self.registry.register(executor_class, req.endpoint);
+        tracing::info!(worker_id = id.0, ?executor_class, "worker registered");
         Ok(Response::new(proto::RegisterWorkerResponse {
             worker_id: id.0,
         }))
     }
 
+    #[tracing::instrument(skip_all)]
     async fn heartbeat(
         &self,
         request: Request<proto::HeartbeatRequest>,
@@ -102,6 +105,7 @@ impl Coordinator for CoordinatorService {
         Ok(Response::new(proto::HeartbeatResponse { ack: true }))
     }
 
+    #[tracing::instrument(skip_all)]
     async fn submit_mote(
         &self,
         request: Request<proto::SubmitMoteRequest>,
@@ -133,6 +137,7 @@ impl Coordinator for CoordinatorService {
         }))
     }
 
+    #[tracing::instrument(skip_all)]
     async fn report_commit(
         &self,
         request: Request<proto::ReportCommitRequest>,
@@ -150,6 +155,11 @@ impl Coordinator for CoordinatorService {
         } else {
             proto::CommitOutcome::Committed
         };
+        tracing::info!(
+            seq = applied.committed_seq,
+            already_committed = applied.already_committed,
+            "commit recorded"
+        );
         Ok(Response::new(proto::ReportCommitResponse {
             committed_seq: applied.committed_seq,
             outcome: outcome as i32,

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -1,0 +1,273 @@
+//! The orchestration core — a single owner thread holding the run's journal,
+//! projection, and hosted scheduler, driven by a command channel.
+//!
+//! ## Why a thread, not a shared mutex
+//!
+//! [`kx_projection::Projection`] holds a non-`Send` `Box<dyn TopologyMaterializer>`,
+//! so it cannot live inside a `Send + Sync` tonic service. Rather than refactor
+//! the P1 `kx-projection` crate (Rule 1 — upstream refactors are their own PR), the
+//! coordinator confines the projection (and the journal and scheduler) to one owner
+//! thread. The async RPC handlers send [`Command`]s over an `mpsc` channel and await
+//! a `oneshot` reply. This also makes the **D40 sole-writer invariant structural**:
+//! there is exactly one thread, and it is the only code that ever appends.
+//!
+//! ## Hosting the scheduler verbatim (thesis test)
+//!
+//! Registration routes through [`kx_scheduler::Scheduler::submit`] exactly as the
+//! single-node `kx-runtime` engine does — the scheduler source is unchanged.
+
+use std::collections::BTreeSet;
+
+use kx_journal::{Journal, JournalEntry};
+use kx_mote::{Mote, MoteId};
+use kx_projection::{MoteState, Projection};
+use kx_scheduler::{LocalPlacement, Scheduler, SchedulerError};
+use kx_warrant::WarrantSpec;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::commit::CommitProposal;
+use crate::error::CoordinatorError;
+
+/// Outcome of a `SubmitMote`: the canonically re-derived id and whether it was a
+/// duplicate (idempotent re-submit before commit).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SubmitOutcome {
+    pub(crate) mote_id: MoteId,
+    pub(crate) duplicate: bool,
+}
+
+/// Outcome of a `ReportCommit`: the journal-assigned seq and whether the commit
+/// was newly appended or a dedup-by-key hit (first-wins).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CommitApplied {
+    pub(crate) committed_seq: u64,
+    pub(crate) already_committed: bool,
+}
+
+/// Messages the async handlers send to the owner thread.
+pub(crate) enum Command {
+    Submit {
+        mote: Box<Mote>,
+        warrant: Box<WarrantSpec>,
+        reply: oneshot::Sender<SubmitOutcome>,
+    },
+    Commit {
+        proposal: Box<CommitProposal>,
+        reply: oneshot::Sender<Result<CommitApplied, CoordinatorError>>,
+    },
+    StateOf {
+        mote_id: MoteId,
+        reply: oneshot::Sender<MoteState>,
+    },
+    CommittedCount {
+        reply: oneshot::Sender<usize>,
+    },
+    ReadySet {
+        reply: oneshot::Sender<Vec<MoteId>>,
+    },
+}
+
+/// Handle to the orchestration core. Cloneable + `Send + Sync` (it is just the
+/// channel sender), so the gRPC service that holds it is too.
+#[derive(Clone)]
+pub(crate) struct CoreHandle {
+    commands: mpsc::UnboundedSender<Command>,
+}
+
+impl CoreHandle {
+    /// Spawn the owner thread, taking sole ownership of `journal`.
+    pub(crate) fn spawn<J: Journal + Send + 'static>(journal: J) -> Self {
+        let (commands, inbox) = mpsc::unbounded_channel();
+        std::thread::spawn(move || core_loop(&journal, inbox));
+        Self { commands }
+    }
+
+    pub(crate) async fn submit(
+        &self,
+        mote: Mote,
+        warrant: WarrantSpec,
+    ) -> Result<SubmitOutcome, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::Submit {
+            mote: Box::new(mote),
+            warrant: Box::new(warrant),
+            reply,
+        })?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+
+    pub(crate) async fn commit(
+        &self,
+        proposal: CommitProposal,
+    ) -> Result<CommitApplied, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::Commit {
+            proposal: Box::new(proposal),
+            reply,
+        })?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)?
+    }
+
+    pub(crate) async fn state_of(&self, mote_id: MoteId) -> Result<MoteState, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::StateOf { mote_id, reply })?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+
+    pub(crate) async fn committed_count(&self) -> Result<usize, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::CommittedCount { reply })?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+
+    pub(crate) async fn ready_set(&self) -> Result<Vec<MoteId>, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::ReadySet { reply })?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+
+    fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
+        self.commands
+            .send(command)
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+}
+
+/// The owner-thread loop. Recovers the projection from the journal, then services
+/// commands until every sender drops (the channel closes on coordinator shutdown).
+fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::UnboundedReceiver<Command>) {
+    let mut projection = match Projection::from_journal(journal) {
+        Ok(projection) => projection,
+        Err(error) => {
+            tracing::error!(%error, "coordinator core failed to recover the projection");
+            return;
+        }
+    };
+    let mut folded_through = match journal.current_seq() {
+        Ok(seq) => seq,
+        Err(error) => {
+            tracing::error!(%error, "coordinator core failed to read the journal seq");
+            return;
+        }
+    };
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    // Motes this coordinator has admitted (submitted). Seeds the `ReportCommit`
+    // admission guard; on recovery, already-committed Motes count as admitted.
+    let mut submitted: BTreeSet<MoteId> = projection
+        .snapshot()
+        .iter_motes()
+        .map(|(id, _)| id)
+        .collect();
+
+    while let Some(command) = inbox.blocking_recv() {
+        match command {
+            Command::Submit {
+                mote,
+                warrant,
+                reply,
+            } => {
+                let mote_id = mote.id;
+                let duplicate = match scheduler.submit(*mote, *warrant, &mut projection) {
+                    Ok(()) => {
+                        submitted.insert(mote_id);
+                        false
+                    }
+                    Err(SchedulerError::DuplicateSubmission(_)) => true,
+                };
+                let _ = reply.send(SubmitOutcome { mote_id, duplicate });
+            }
+            Command::Commit { proposal, reply } => {
+                let result = apply_commit(
+                    journal,
+                    &mut projection,
+                    &mut folded_through,
+                    &submitted,
+                    *proposal,
+                );
+                let _ = reply.send(result);
+            }
+            Command::StateOf { mote_id, reply } => {
+                let _ = reply.send(projection.state_of(&mote_id));
+            }
+            Command::CommittedCount { reply } => {
+                let _ = reply.send(projection.snapshot().committed_count());
+            }
+            Command::ReadySet { reply } => {
+                let _ = reply.send(projection.ready_set());
+            }
+        }
+    }
+}
+
+/// Assemble + append the `Committed` entry (the sole-writer step), then fold it
+/// into the projection. Refuses commits for never-submitted Motes; dedupes by
+/// returning the existing seq when a `Committed` already exists for the id.
+fn apply_commit<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    submitted: &BTreeSet<MoteId>,
+    proposal: CommitProposal,
+) -> Result<CommitApplied, CoordinatorError> {
+    if !submitted.contains(&proposal.mote_id) {
+        return Err(CoordinatorError::UnknownMote(proposal.mote_id));
+    }
+    if let Some(JournalEntry::Committed { seq, .. }) = journal.read_committed(&proposal.mote_id)? {
+        return Ok(CommitApplied {
+            committed_seq: seq,
+            already_committed: true,
+        });
+    }
+
+    let durable = journal.append(JournalEntry::Committed {
+        mote_id: proposal.mote_id,
+        idempotency_key: proposal.idempotency_key,
+        seq: 0,
+        nondeterminism: proposal.nd_class,
+        result_ref: proposal.result_ref,
+        parents: proposal.parents,
+        warrant_ref: proposal.warrant_ref,
+        mote_def_hash: proposal.mote_def_hash,
+    })?;
+    // `append` of a `Committed` always returns a `Committed`; the other arm is
+    // unreachable by construction.
+    let committed_seq = match durable {
+        JournalEntry::Committed { seq, .. } => seq,
+        _ => 0,
+    };
+
+    fold_new(journal, projection, folded_through)?;
+    Ok(CommitApplied {
+        committed_seq,
+        already_committed: false,
+    })
+}
+
+/// Fold journal entries appended since `folded_through` into `projection`,
+/// advancing the watermark. Incremental (bounded range), mirroring the single-node
+/// engine's fold so re-scans never go O(n²).
+fn fold_new<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+) -> Result<(), CoordinatorError> {
+    let current = journal.current_seq()?;
+    if current <= *folded_through {
+        return Ok(());
+    }
+    for entry in journal.read_entries_by_seq((*folded_through + 1)..(current + 1))? {
+        projection.fold(&entry)?;
+    }
+    *folded_through = current;
+    Ok(())
+}

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -28,6 +28,11 @@ use tokio::sync::{mpsc, oneshot};
 use crate::commit::CommitProposal;
 use crate::error::CoordinatorError;
 
+/// Bound on in-flight commands queued to the orchestration core. A bounded
+/// channel applies backpressure: when the core is saturated, `dispatch` awaits
+/// instead of letting an unbounded queue grow without limit under a flood of RPCs.
+const COMMAND_BUFFER: usize = 1024;
+
 /// Outcome of a `SubmitMote`: the canonically re-derived id and whether it was a
 /// duplicate (idempotent re-submit before commit).
 #[derive(Debug, Clone, Copy)]
@@ -71,13 +76,13 @@ pub(crate) enum Command {
 /// channel sender), so the gRPC service that holds it is too.
 #[derive(Clone)]
 pub(crate) struct CoreHandle {
-    commands: mpsc::UnboundedSender<Command>,
+    commands: mpsc::Sender<Command>,
 }
 
 impl CoreHandle {
     /// Spawn the owner thread, taking sole ownership of `journal`.
     pub(crate) fn spawn<J: Journal + Send + 'static>(journal: J) -> Self {
-        let (commands, inbox) = mpsc::unbounded_channel();
+        let (commands, inbox) = mpsc::channel(COMMAND_BUFFER);
         std::thread::spawn(move || core_loop(&journal, inbox));
         Self { commands }
     }
@@ -92,7 +97,8 @@ impl CoreHandle {
             mote: Box::new(mote),
             warrant: Box::new(warrant),
             reply,
-        })?;
+        })
+        .await?;
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)
@@ -106,7 +112,8 @@ impl CoreHandle {
         self.dispatch(Command::Commit {
             proposal: Box::new(proposal),
             reply,
-        })?;
+        })
+        .await?;
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)?
@@ -114,7 +121,7 @@ impl CoreHandle {
 
     pub(crate) async fn state_of(&self, mote_id: MoteId) -> Result<MoteState, CoordinatorError> {
         let (reply, response) = oneshot::channel();
-        self.dispatch(Command::StateOf { mote_id, reply })?;
+        self.dispatch(Command::StateOf { mote_id, reply }).await?;
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)
@@ -122,7 +129,7 @@ impl CoreHandle {
 
     pub(crate) async fn committed_count(&self) -> Result<usize, CoordinatorError> {
         let (reply, response) = oneshot::channel();
-        self.dispatch(Command::CommittedCount { reply })?;
+        self.dispatch(Command::CommittedCount { reply }).await?;
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)
@@ -130,22 +137,23 @@ impl CoreHandle {
 
     pub(crate) async fn ready_set(&self) -> Result<Vec<MoteId>, CoordinatorError> {
         let (reply, response) = oneshot::channel();
-        self.dispatch(Command::ReadySet { reply })?;
+        self.dispatch(Command::ReadySet { reply }).await?;
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)
     }
 
-    fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
+    async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
         self.commands
             .send(command)
+            .await
             .map_err(|_| CoordinatorError::CoreUnavailable)
     }
 }
 
 /// The owner-thread loop. Recovers the projection from the journal, then services
 /// commands until every sender drops (the channel closes on coordinator shutdown).
-fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::UnboundedReceiver<Command>) {
+fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
     let mut projection = match Projection::from_journal(journal) {
         Ok(projection) => projection,
         Err(error) => {
@@ -210,8 +218,14 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::UnboundedReceiver<Command
 }
 
 /// Assemble + append the `Committed` entry (the sole-writer step), then fold it
-/// into the projection. Refuses commits for never-submitted Motes; dedupes by
-/// returning the existing seq when a `Committed` already exists for the id.
+/// into the projection. Refuses commits for never-submitted Motes.
+///
+/// Dedup is delegated to the journal's own dedup-by-key contract (the single
+/// source of truth): `append` is a no-op that returns the pre-existing entry on a
+/// duplicate. We detect that — without a second lookup — by comparing the returned
+/// seq against the seq captured before the append: a fresh write advances the seq,
+/// a dedup hit returns an older one. On a dedup hit we skip the fold (the entry is
+/// already folded; re-folding would trip `DuplicateCommitted`).
 fn apply_commit<J: Journal>(
     journal: &J,
     projection: &mut Projection,
@@ -222,13 +236,8 @@ fn apply_commit<J: Journal>(
     if !submitted.contains(&proposal.mote_id) {
         return Err(CoordinatorError::UnknownMote(proposal.mote_id));
     }
-    if let Some(JournalEntry::Committed { seq, .. }) = journal.read_committed(&proposal.mote_id)? {
-        return Ok(CommitApplied {
-            committed_seq: seq,
-            already_committed: true,
-        });
-    }
 
+    let seq_before = journal.current_seq()?;
     let durable = journal.append(JournalEntry::Committed {
         mote_id: proposal.mote_id,
         idempotency_key: proposal.idempotency_key,
@@ -246,10 +255,13 @@ fn apply_commit<J: Journal>(
         _ => 0,
     };
 
-    fold_new(journal, projection, folded_through)?;
+    let already_committed = committed_seq <= seq_before;
+    if !already_committed {
+        fold_new(journal, projection, folded_through)?;
+    }
     Ok(CommitApplied {
         committed_seq,
-        already_committed: false,
+        already_committed,
     })
 }
 

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -1,0 +1,223 @@
+//! Shared fixtures for the coordinator integration tests: parameterized Motes
+//! (nd_class + data-edge parents + a per-seed unique identity), a representative
+//! warrant, and a faithful `ReportCommit` request built from a Mote. Built from
+//! the real `kx-mote` / `kx-warrant` types so the proto<->domain mapping is
+//! exercised against genuine inputs.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    dead_code,
+    unreachable_pub
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::CoordinatorService;
+use tonic::Request;
+
+use kx_mote::{
+    ConfigKey, ConfigVal, EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId,
+    LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, ToolName,
+    ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    ToolGrant, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+#[must_use]
+pub fn sample_inference_params() -> InferenceParams {
+    InferenceParams {
+        max_output_tokens: 256,
+        temperature_bps: 0,
+        top_p_bps: 9_000,
+        top_k: 40,
+        seed: 12_345,
+        stop_tokens: SmallVec::new(),
+        grammar: None,
+    }
+}
+
+/// A `MoteDef` for the given nd_class. The effect pattern follows the class
+/// (WORLD-MUTATING stages-then-commits; PURE / READ-ONLY-NONDET are idempotent).
+#[must_use]
+pub fn mote_def(nd_class: NdClass) -> MoteDef {
+    let effect_pattern = match nd_class {
+        NdClass::WorldMutating => EffectPattern::StageThenCommit,
+        NdClass::Pure | NdClass::ReadOnlyNondet => EffectPattern::IdempotentByConstruction,
+    };
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class,
+        config_subset: {
+            let mut c = BTreeMap::new();
+            c.insert(ConfigKey("max_depth".into()), ConfigVal(vec![3]));
+            c
+        },
+        effect_pattern,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: sample_inference_params(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+/// Build a Mote with the given nd_class and data-edge parents, made unique by
+/// `seed` (distinct `graph_position` + `input_data_id`). The id is derived by
+/// `Mote::new` from `def + input_data_id + graph_position`.
+#[must_use]
+pub fn mote(seed: u8, nd_class: NdClass, parent_ids: &[MoteId]) -> Mote {
+    let parents: SmallVec<[ParentRef; 4]> = parent_ids
+        .iter()
+        .map(|id| ParentRef {
+            parent_id: *id,
+            edge: EdgeMeta::data(),
+        })
+        .collect();
+    Mote::new(
+        mote_def(nd_class),
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        parents,
+    )
+}
+
+/// The canonical parentless PURE root Mote.
+#[must_use]
+pub fn pure_root_mote() -> Mote {
+    mote(0, NdClass::Pure, &[])
+}
+
+/// A parentless Mote uniquely identified by a `u64` index (for load tests that
+/// need more than 256 distinct Motes). Encodes the index into both
+/// `input_data_id` and `graph_position` so each id is distinct.
+#[must_use]
+pub fn mote_indexed(index: u64, nd_class: NdClass) -> Mote {
+    let mut input = [0u8; 32];
+    input[..8].copy_from_slice(&index.to_le_bytes());
+    Mote::new(
+        mote_def(nd_class),
+        InputDataId::from_bytes(input),
+        GraphPosition(index.to_le_bytes().to_vec()),
+        SmallVec::new(),
+    )
+}
+
+/// A valid warrant that round-trips through the proto schema.
+#[must_use]
+pub fn sample_warrant() -> WarrantSpec {
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+
+    let mut hosts = BTreeSet::new();
+    hosts.insert(Host("api.example.com:443".into()));
+
+    let mut tool_grants = BTreeSet::new();
+    tool_grants.insert(ToolGrant {
+        tool_id: ToolName("fs-read".into()),
+        tool_version: ToolVersion("1.2.0".into()),
+    });
+
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(hosts),
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}
+
+/// A faithful `ReportCommit` request proposing the commit of `mote` by `worker`.
+/// `idempotency_key == mote_id` (the identity invariant); `nd_class` and `parents`
+/// mirror the Mote; `result_ref` is an arbitrary 32-byte value (P2.2 does not
+/// re-validate it against content).
+#[must_use]
+pub fn report_commit_request(mote: &Mote, worker_id: u64) -> proto::ReportCommitRequest {
+    let id = mote.id.as_bytes().to_vec();
+    proto::ReportCommitRequest {
+        mote_id: id.clone(),
+        idempotency_key: id,
+        result_ref: vec![3u8; 32],
+        warrant_ref: vec![4u8; 32],
+        mote_def_hash: vec![5u8; 32],
+        nd_class: proto::NdClass::from(mote.def.nd_class) as i32,
+        parents: mote.parents.iter().cloned().map(Into::into).collect(),
+        worker_id,
+    }
+}
+
+/// A `RegisterWorker` request with a macOS-sandbox executor class.
+#[must_use]
+pub fn register_request(endpoint: &str) -> proto::RegisterWorkerRequest {
+    proto::RegisterWorkerRequest {
+        executor_class: proto::ExecutorClass::MacosSandbox as i32,
+        endpoint: endpoint.into(),
+    }
+}
+
+// --- direct-call helpers (in-process, no network) for happy-path test setup ---
+
+/// Register a worker through the service; returns its assigned id.
+pub async fn register(service: &CoordinatorService, endpoint: &str) -> u64 {
+    service
+        .register_worker(Request::new(register_request(endpoint)))
+        .await
+        .unwrap()
+        .into_inner()
+        .worker_id
+}
+
+/// Submit a Mote + warrant through the service.
+pub async fn submit(
+    service: &CoordinatorService,
+    mote: &Mote,
+    warrant: &WarrantSpec,
+) -> proto::SubmitMoteResponse {
+    service
+        .submit_mote(Request::new(proto::SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(warrant.clone().into()),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+/// Report a commit for `mote` by `worker_id` through the service.
+pub async fn commit(
+    service: &CoordinatorService,
+    mote: &Mote,
+    worker_id: u64,
+) -> proto::ReportCommitResponse {
+    service
+        .report_commit(Request::new(report_commit_request(mote, worker_id)))
+        .await
+        .unwrap()
+        .into_inner()
+}

--- a/crates/kx-coordinator/tests/concurrency.rs
+++ b/crates/kx-coordinator/tests/concurrency.rs
@@ -1,0 +1,134 @@
+//! Concurrency + exactly-once proofs. The orchestration core serializes all
+//! writes (single owner thread), so these assert the product's central promise:
+//! under concurrent workers, an effect commits exactly once.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use kx_coordinator::proto::{CommitOutcome, SubmitStatus};
+use kx_coordinator::CoordinatorService;
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+
+fn coordinator() -> CoordinatorService {
+    CoordinatorService::new(InMemoryJournal::new())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_registration_assigns_distinct_ids() {
+    let svc = coordinator();
+    let mut handles = Vec::new();
+    for i in 0..32u32 {
+        let s = svc.clone();
+        handles.push(tokio::spawn(async move {
+            common::register(&s, &format!("w{i}")).await
+        }));
+    }
+    let mut ids = Vec::new();
+    for h in handles {
+        ids.push(h.await.unwrap());
+    }
+    let unique: BTreeSet<u64> = ids.iter().copied().collect();
+    assert_eq!(unique.len(), 32, "every worker got a distinct id");
+    assert_eq!(svc.registry().len(), 32);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_commits_of_distinct_motes_all_land() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let motes: Vec<_> = (1..=32u8)
+        .map(|seed| common::mote(seed, NdClass::Pure, &[]))
+        .collect();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    let mut handles = Vec::new();
+    for m in &motes {
+        let s = svc.clone();
+        let m = m.clone();
+        handles.push(tokio::spawn(
+            async move { common::commit(&s, &m, worker).await },
+        ));
+    }
+    for h in handles {
+        let resp = h.await.unwrap();
+        assert_eq!(resp.outcome, CommitOutcome::Committed as i32);
+    }
+    assert_eq!(svc.committed_count().await.unwrap(), 32);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_duplicate_commit_of_same_mote_is_exactly_once() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let mote = common::pure_root_mote();
+    common::submit(&svc, &mote, &warrant).await;
+
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let s = svc.clone();
+        let m = mote.clone();
+        handles.push(tokio::spawn(
+            async move { common::commit(&s, &m, worker).await },
+        ));
+    }
+
+    let mut newly_committed = 0;
+    let mut already = 0;
+    let mut seqs = BTreeSet::new();
+    for h in handles {
+        let resp = h.await.unwrap();
+        seqs.insert(resp.committed_seq);
+        if resp.outcome == CommitOutcome::Committed as i32 {
+            newly_committed += 1;
+        } else if resp.outcome == CommitOutcome::AlreadyCommitted as i32 {
+            already += 1;
+        }
+    }
+    assert_eq!(newly_committed, 1, "exactly one report newly committed");
+    assert_eq!(already, 31, "the rest were dedup-by-key hits");
+    assert_eq!(seqs.len(), 1, "all reports observe the same committed seq");
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_duplicate_submit_is_idempotent() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let mote = common::pure_root_mote();
+
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let s = svc.clone();
+        let m = mote.clone();
+        let w = warrant.clone();
+        handles.push(tokio::spawn(
+            async move { common::submit(&s, &m, &w).await },
+        ));
+    }
+
+    let mut accepted = 0;
+    let mut duplicate = 0;
+    for h in handles {
+        let resp = h.await.unwrap();
+        if resp.status == SubmitStatus::Accepted as i32 {
+            accepted += 1;
+        } else if resp.status == SubmitStatus::Duplicate as i32 {
+            duplicate += 1;
+        }
+        // The re-derived id is identical on every concurrent submit.
+        assert_eq!(resp.mote_id, mote.id.as_bytes().to_vec());
+    }
+    assert_eq!(accepted, 1, "exactly one submission accepted");
+    assert_eq!(duplicate, 31);
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
+}

--- a/crates/kx-coordinator/tests/dod.rs
+++ b/crates/kx-coordinator/tests/dod.rs
@@ -1,0 +1,334 @@
+//! P2.2 exit-gate proofs (obligation-numbered):
+//!
+//! - **O1** — the coordinator is the sole journal writer: a worker (gRPC client
+//!   with no journal handle) drives a commit *only* through `ReportCommit`, and the
+//!   coordinator's own read view reflects it; re-report is an idempotent dedup hit.
+//! - **O2** — the worker registry lives behind a trait: distinct ids + heartbeat
+//!   tracking through the default impl, and a second `WorkerRegistry` impl proves
+//!   the seam.
+//! - **O3** — the identity invariant (D53): a bogus wire `mote_id` is ignored; the
+//!   coordinator re-derives the canonical id Rust-side.
+//! - **O4** — refusals: unknown worker / unknown Mote / bad hash length /
+//!   `UNSPECIFIED` enum are rejected with no journal write.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_coordinator::proto::coordinator_client::CoordinatorClient;
+use kx_coordinator::proto::coordinator_server::CoordinatorServer;
+use kx_coordinator::proto::{
+    self, CommitOutcome, ExecutorClass, HeartbeatRequest, RegisterWorkerRequest, SubmitMoteRequest,
+    SubmitStatus,
+};
+use kx_coordinator::{
+    CoordinatorService, InMemoryWorkerRegistry, MoteState, RegistryError, WorkerId, WorkerRecord,
+    WorkerRegistry,
+};
+use kx_journal::InMemoryJournal;
+use tonic::transport::{Channel, Server};
+use tonic::Code;
+
+/// Spawn the real `CoordinatorServer` over an ephemeral TCP port and return a
+/// connected client (the "worker"). The caller keeps the `service` handle for
+/// read-side assertions (the client itself never touches the journal).
+async fn start(service: CoordinatorService) -> CoordinatorClient<Channel> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(CoordinatorServer::new(service))
+            .serve(addr)
+            .await
+            .unwrap();
+    });
+
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(client) = CoordinatorClient::connect(endpoint.clone()).await {
+            return client;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client never connected to the coordinator");
+}
+
+fn register_req(endpoint: &str) -> RegisterWorkerRequest {
+    RegisterWorkerRequest {
+        executor_class: ExecutorClass::MacosSandbox as i32,
+        endpoint: endpoint.into(),
+    }
+}
+
+#[tokio::test]
+async fn o1_coordinator_is_sole_journal_writer() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service.clone()).await;
+
+    let worker = client
+        .register_worker(register_req("unix:///tmp/w0"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mote = common::pure_root_mote();
+    let expected_id = mote.id;
+    let submit = client
+        .submit_mote(SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(common::sample_warrant().into()),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(submit.status, SubmitStatus::Accepted as i32);
+    assert_eq!(submit.mote_id, expected_id.as_bytes().to_vec());
+
+    // Nothing committed until the worker reports.
+    assert_eq!(service.committed_count().await.unwrap(), 0);
+    assert_eq!(
+        service.state_of(expected_id).await.unwrap(),
+        MoteState::Pending
+    );
+
+    let commit = client
+        .report_commit(common::report_commit_request(&mote, worker.worker_id))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(commit.outcome, CommitOutcome::Committed as i32);
+    assert!(commit.committed_seq >= 1);
+
+    // The commit is visible through the coordinator's own read view — the client
+    // has no journal handle; the only path to the log was the RPC (D40).
+    assert_eq!(service.committed_count().await.unwrap(), 1);
+    assert_eq!(
+        service.state_of(expected_id).await.unwrap(),
+        MoteState::Committed
+    );
+
+    // Idempotent re-report: dedup-by-key hit, same seq, still exactly one.
+    let again = client
+        .report_commit(common::report_commit_request(&mote, worker.worker_id))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(again.outcome, CommitOutcome::AlreadyCommitted as i32);
+    assert_eq!(again.committed_seq, commit.committed_seq);
+    assert_eq!(service.committed_count().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn o2_registry_assigns_ids_and_tracks_heartbeat() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service.clone()).await;
+
+    let a = client
+        .register_worker(register_req("a"))
+        .await
+        .unwrap()
+        .into_inner();
+    let b = client
+        .register_worker(register_req("b"))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_ne!(a.worker_id, b.worker_id);
+
+    let hb = client
+        .heartbeat(HeartbeatRequest {
+            worker_id: a.worker_id,
+            timestamp_ms: 42,
+            in_flight: 3,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(hb.ack);
+
+    // Observed through the trait.
+    let record = service.registry().get(WorkerId(a.worker_id)).unwrap();
+    assert_eq!(record.last_heartbeat_ms, 42);
+    assert_eq!(record.in_flight, 3);
+    assert_eq!(service.registry().len(), 2);
+
+    // Heartbeat for an unregistered worker is refused.
+    let err = client
+        .heartbeat(HeartbeatRequest {
+            worker_id: 999,
+            timestamp_ms: 1,
+            in_flight: 0,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+}
+
+#[tokio::test]
+async fn o2_custom_registry_impl_is_the_seam() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct CountingRegistry {
+        registers: AtomicUsize,
+        inner: InMemoryWorkerRegistry,
+    }
+
+    impl WorkerRegistry for CountingRegistry {
+        fn register(
+            &self,
+            executor_class: kx_warrant::ExecutorClass,
+            endpoint: String,
+        ) -> WorkerId {
+            self.registers.fetch_add(1, Ordering::Relaxed);
+            self.inner.register(executor_class, endpoint)
+        }
+        fn heartbeat(
+            &self,
+            worker: WorkerId,
+            now_ms: u64,
+            in_flight: u32,
+        ) -> Result<(), RegistryError> {
+            self.inner.heartbeat(worker, now_ms, in_flight)
+        }
+        fn get(&self, worker: WorkerId) -> Option<WorkerRecord> {
+            self.inner.get(worker)
+        }
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+    }
+
+    let registry = Arc::new(CountingRegistry::default());
+    let service = CoordinatorService::with_registry(InMemoryJournal::new(), registry.clone());
+    let mut client = start(service).await;
+
+    client.register_worker(register_req("x")).await.unwrap();
+    assert_eq!(registry.registers.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn o3_mote_id_rederived_server_side() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service).await;
+
+    let mote = common::pure_root_mote();
+    let expected_id = mote.id;
+    let mut wire: proto::Mote = mote.into();
+    wire.mote_id = vec![0u8; 32]; // bogus advisory id
+
+    let submit = client
+        .submit_mote(SubmitMoteRequest {
+            mote: Some(wire),
+            warrant: Some(common::sample_warrant().into()),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        submit.mote_id,
+        expected_id.as_bytes().to_vec(),
+        "MoteId is re-derived Rust-side, not taken from the wire"
+    );
+}
+
+#[tokio::test]
+async fn o4_unknown_worker_rejected_no_write() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service.clone()).await;
+
+    // Mote is known (submitted) but no worker registered.
+    let mote = common::pure_root_mote();
+    client
+        .submit_mote(SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(common::sample_warrant().into()),
+        })
+        .await
+        .unwrap();
+
+    let err = client
+        .report_commit(common::report_commit_request(&mote, 999))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(service.committed_count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn o4_unknown_mote_rejected_no_write() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service.clone()).await;
+
+    let worker = client
+        .register_worker(register_req("w"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Never submitted.
+    let mote = common::pure_root_mote();
+    let err = client
+        .report_commit(common::report_commit_request(&mote, worker.worker_id))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(service.committed_count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn o4_bad_hash_length_rejected_no_write() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service.clone()).await;
+
+    let worker = client
+        .register_worker(register_req("w"))
+        .await
+        .unwrap()
+        .into_inner();
+    let mote = common::pure_root_mote();
+    client
+        .submit_mote(SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(common::sample_warrant().into()),
+        })
+        .await
+        .unwrap();
+
+    let mut bad = common::report_commit_request(&mote, worker.worker_id);
+    bad.result_ref = vec![3u8; 31]; // not 32 bytes
+    let err = client.report_commit(bad).await.unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(service.committed_count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn o4_unspecified_nd_class_rejected_no_write() {
+    let service = CoordinatorService::new(InMemoryJournal::new());
+    let mut client = start(service.clone()).await;
+
+    let worker = client
+        .register_worker(register_req("w"))
+        .await
+        .unwrap()
+        .into_inner();
+    let mote = common::pure_root_mote();
+    client
+        .submit_mote(SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(common::sample_warrant().into()),
+        })
+        .await
+        .unwrap();
+
+    let mut bad = common::report_commit_request(&mote, worker.worker_id);
+    bad.nd_class = proto::NdClass::Unspecified as i32; // 0 — the rejected sentinel
+    let err = client.report_commit(bad).await.unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(service.committed_count().await.unwrap(), 0);
+}

--- a/crates/kx-coordinator/tests/edge_cases.rs
+++ b/crates/kx-coordinator/tests/edge_cases.rs
@@ -1,0 +1,198 @@
+//! Exhaustive boundary / refusal coverage. Every malformed or inadmissible
+//! request is rejected with `INVALID_ARGUMENT` and leaves the journal untouched.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::{CoordinatorService, WorkerId};
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+use kx_warrant::ExecutorClass;
+use tonic::{Code, Request};
+
+fn coordinator() -> CoordinatorService {
+    CoordinatorService::new(InMemoryJournal::new())
+}
+
+/// Register a worker + submit a Mote so a `ReportCommit` reaches the validation
+/// boundary (past the worker-admission + mote-admission guards). Returns the
+/// service, the worker id, and the Mote.
+async fn ready_to_report() -> (CoordinatorService, u64, kx_mote::Mote) {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+    let mote = common::pure_root_mote();
+    common::submit(&svc, &mote, &warrant).await;
+    (svc, worker, mote)
+}
+
+async fn assert_commit_rejected(svc: &CoordinatorService, req: proto::ReportCommitRequest) {
+    let err = svc.report_commit(Request::new(req)).await.unwrap_err();
+    assert_eq!(
+        err.code(),
+        Code::InvalidArgument,
+        "expected INVALID_ARGUMENT"
+    );
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        0,
+        "a rejected ReportCommit must not write the journal"
+    );
+}
+
+#[tokio::test]
+async fn every_32_byte_field_is_length_validated() {
+    let (svc, worker, mote) = ready_to_report().await;
+
+    // mote_id wrong length. (idempotency_key follows mote_id, so corrupt both to
+    // isolate the mote_id check — otherwise the identity-mismatch check fires.)
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.mote_id = vec![1u8; 31];
+    bad.idempotency_key = vec![1u8; 31];
+    assert_commit_rejected(&svc, bad).await;
+
+    let corruptors: [fn(&mut proto::ReportCommitRequest); 4] = [
+        |r| r.idempotency_key = vec![2u8; 31],
+        |r| r.result_ref = vec![3u8; 33],
+        |r| r.warrant_ref = vec![4u8; 0],
+        |r| r.mote_def_hash = vec![5u8; 16],
+    ];
+    for corrupt in corruptors {
+        let mut req = common::report_commit_request(&mote, worker);
+        corrupt(&mut req);
+        assert_commit_rejected(&svc, req).await;
+    }
+}
+
+#[tokio::test]
+async fn idempotency_key_must_equal_mote_id() {
+    let (svc, worker, mote) = ready_to_report().await;
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.idempotency_key = vec![0xAB; 32]; // valid length, wrong value
+    assert_commit_rejected(&svc, bad).await;
+}
+
+#[tokio::test]
+async fn out_of_range_nd_class_is_rejected() {
+    let (svc, worker, mote) = ready_to_report().await;
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.nd_class = 12_345; // not a defined NdClass discriminant
+    assert_commit_rejected(&svc, bad).await;
+}
+
+#[tokio::test]
+async fn unspecified_nd_class_is_rejected() {
+    let (svc, worker, mote) = ready_to_report().await;
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.nd_class = proto::NdClass::Unspecified as i32; // 0 — the rejected sentinel
+    assert_commit_rejected(&svc, bad).await;
+}
+
+#[tokio::test]
+async fn bad_parent_id_length_is_rejected() {
+    let (svc, worker, mote) = ready_to_report().await;
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.parents = vec![proto::ParentRef {
+        parent_id: vec![1u8; 31], // not 32 bytes
+        edge_kind: proto::EdgeKind::Data as i32,
+        non_cascade: false,
+    }];
+    assert_commit_rejected(&svc, bad).await;
+}
+
+#[tokio::test]
+async fn submit_missing_mote_or_warrant_is_rejected() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let mote = common::pure_root_mote();
+
+    let err = svc
+        .submit_mote(Request::new(proto::SubmitMoteRequest {
+            mote: None,
+            warrant: Some(warrant.clone().into()),
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    let err = svc
+        .submit_mote(Request::new(proto::SubmitMoteRequest {
+            mote: Some(mote.into()),
+            warrant: None,
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn register_accepts_every_executor_class() {
+    let svc = coordinator();
+    for (proto_class, domain_class) in [
+        (proto::ExecutorClass::Bwrap, ExecutorClass::Bwrap),
+        (proto::ExecutorClass::OciDaemon, ExecutorClass::OciDaemon),
+        (
+            proto::ExecutorClass::CloudMicroVm,
+            ExecutorClass::CloudMicroVm,
+        ),
+        (
+            proto::ExecutorClass::MacosSandbox,
+            ExecutorClass::MacOsSandbox,
+        ),
+    ] {
+        let id = svc
+            .register_worker(Request::new(proto::RegisterWorkerRequest {
+                executor_class: proto_class as i32,
+                endpoint: "endpoint".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .worker_id;
+        let record = svc.registry().get(WorkerId(id)).unwrap();
+        assert_eq!(record.executor_class, domain_class);
+    }
+}
+
+#[tokio::test]
+async fn register_rejects_unspecified_and_unknown_executor_class() {
+    let svc = coordinator();
+
+    let err = svc
+        .register_worker(Request::new(proto::RegisterWorkerRequest {
+            executor_class: proto::ExecutorClass::Unspecified as i32, // 0
+            endpoint: "e".into(),
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    let err = svc
+        .register_worker(Request::new(proto::RegisterWorkerRequest {
+            executor_class: 9_999, // not a defined discriminant
+            endpoint: "e".into(),
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(svc.registry().len(), 0);
+}
+
+#[tokio::test]
+async fn report_commit_unknown_mote_with_nondefault_nd_class() {
+    // A WORLD-MUTATING commit for a never-submitted Mote is still refused (the
+    // admission guard fires before any write), regardless of nd_class.
+    let svc = coordinator();
+    let worker = common::register(&svc, "w").await;
+    let mote = common::mote(7, NdClass::WorldMutating, &[]);
+    let err = svc
+        .report_commit(Request::new(common::report_commit_request(&mote, worker)))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
+}

--- a/crates/kx-coordinator/tests/integration_dag.rs
+++ b/crates/kx-coordinator/tests/integration_dag.rs
@@ -1,0 +1,164 @@
+//! DAG integration scenarios driven through the coordinator (in-process, direct
+//! trait calls). These exercise the scheduler/projection integration: submitting
+//! a DAG registers edges, and committing parents advances `ready_set`. They also
+//! cover nd_class variety and parent-bearing commits.
+//!
+//! Note: P2.2 is the *passive* control plane — it does not gate `ReportCommit` on
+//! readiness (that is P2.3 dispatch). These tests commit in dependency order (the
+//! order a dispatching coordinator would hand work out) and assert the projection
+//! tracks readiness correctly.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_coordinator::{CoordinatorService, MoteState};
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+
+fn coordinator() -> CoordinatorService {
+    CoordinatorService::new(InMemoryJournal::new())
+}
+
+#[tokio::test]
+async fn linear_chain_a_b_c_progresses_ready_set() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    let c = common::mote(3, NdClass::Pure, &[b.id]);
+
+    for m in [&a, &b, &c] {
+        let r = common::submit(&svc, m, &warrant).await;
+        assert_eq!(
+            r.status,
+            kx_coordinator::proto::SubmitStatus::Accepted as i32
+        );
+    }
+
+    // Only the root is ready; B and C are blocked on uncommitted parents.
+    let ready = svc.ready_set().await.unwrap();
+    assert_eq!(ready, vec![a.id], "only the root is ready initially");
+
+    common::commit(&svc, &a, worker).await;
+    assert_eq!(svc.ready_set().await.unwrap(), vec![b.id]);
+
+    common::commit(&svc, &b, worker).await;
+    assert_eq!(svc.ready_set().await.unwrap(), vec![c.id]);
+
+    common::commit(&svc, &c, worker).await;
+    assert!(svc.ready_set().await.unwrap().is_empty());
+
+    assert_eq!(svc.committed_count().await.unwrap(), 3);
+    for m in [&a, &b, &c] {
+        assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
+    }
+}
+
+#[tokio::test]
+async fn diamond_dag_only_ready_when_all_parents_commit() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // A -> {B, C} -> D
+    let a = common::mote(10, NdClass::Pure, &[]);
+    let b = common::mote(11, NdClass::Pure, &[a.id]);
+    let c = common::mote(12, NdClass::Pure, &[a.id]);
+    let d = common::mote(13, NdClass::Pure, &[b.id, c.id]);
+    for m in [&a, &b, &c, &d] {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    common::commit(&svc, &a, worker).await;
+    // Both B and C become ready; D still blocked.
+    let mut ready = svc.ready_set().await.unwrap();
+    ready.sort();
+    let mut expected = vec![b.id, c.id];
+    expected.sort();
+    assert_eq!(ready, expected);
+
+    common::commit(&svc, &b, worker).await;
+    // D needs BOTH parents — still blocked after only B.
+    assert_eq!(svc.ready_set().await.unwrap(), vec![c.id]);
+
+    common::commit(&svc, &c, worker).await;
+    assert_eq!(svc.ready_set().await.unwrap(), vec![d.id]);
+
+    common::commit(&svc, &d, worker).await;
+    assert_eq!(svc.committed_count().await.unwrap(), 4);
+}
+
+#[tokio::test]
+async fn multi_root_dag_both_roots_ready() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // Two independent roots R1, R2 -> J (join).
+    let r1 = common::mote(20, NdClass::Pure, &[]);
+    let r2 = common::mote(21, NdClass::Pure, &[]);
+    let j = common::mote(22, NdClass::Pure, &[r1.id, r2.id]);
+    for m in [&r1, &r2, &j] {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    let mut ready = svc.ready_set().await.unwrap();
+    ready.sort();
+    let mut expected = vec![r1.id, r2.id];
+    expected.sort();
+    assert_eq!(ready, expected, "both roots ready");
+
+    common::commit(&svc, &r1, worker).await;
+    common::commit(&svc, &r2, worker).await;
+    assert_eq!(svc.ready_set().await.unwrap(), vec![j.id]);
+    common::commit(&svc, &j, worker).await;
+    assert_eq!(svc.committed_count().await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn nd_class_variety_round_trips_and_commits() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    for (seed, nd) in [
+        (30u8, NdClass::Pure),
+        (31, NdClass::ReadOnlyNondet),
+        (32, NdClass::WorldMutating),
+    ] {
+        let m = common::mote(seed, nd, &[]);
+        common::submit(&svc, &m, &warrant).await;
+        let commit = common::commit(&svc, &m, worker).await;
+        assert_eq!(
+            commit.outcome,
+            kx_coordinator::proto::CommitOutcome::Committed as i32
+        );
+        assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
+    }
+    assert_eq!(svc.committed_count().await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn parent_bearing_commit_preserves_edges() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let parent = common::mote(40, NdClass::Pure, &[]);
+    let child = common::mote(41, NdClass::Pure, &[parent.id]);
+    common::submit(&svc, &parent, &warrant).await;
+    common::submit(&svc, &child, &warrant).await;
+
+    common::commit(&svc, &parent, worker).await;
+    // The child carries a parent edge in its ReportCommit; committing it succeeds
+    // and the child becomes committed (its declared parent is committed).
+    let commit = common::commit(&svc, &child, worker).await;
+    assert_eq!(
+        commit.outcome,
+        kx_coordinator::proto::CommitOutcome::Committed as i32
+    );
+    assert_eq!(svc.state_of(child.id).await.unwrap(), MoteState::Committed);
+}

--- a/crates/kx-coordinator/tests/load.rs
+++ b/crates/kx-coordinator/tests/load.rs
@@ -1,0 +1,81 @@
+//! Throughput / load. These run over the production `SqliteJournal` backend (the
+//! in-memory variant) so the journal's dedup + read paths are indexed (O(log n)),
+//! and assert the coordinator scales **linearly** — the incremental projection
+//! fold must not regress to O(n²). Bounds are generous (machine-independent); the
+//! point is to catch a pathological regression, not to benchmark.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::time::Instant;
+
+use kx_coordinator::proto::CommitOutcome;
+use kx_coordinator::CoordinatorService;
+use kx_journal::SqliteJournal;
+use kx_mote::NdClass;
+
+#[tokio::test]
+async fn sequential_submit_and_commit_throughput() {
+    let n: u64 = 1_000;
+    let svc = CoordinatorService::new(SqliteJournal::open_in_memory().unwrap());
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let motes: Vec<_> = (0..n)
+        .map(|i| common::mote_indexed(i, NdClass::Pure))
+        .collect();
+
+    let start = Instant::now();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+    for m in &motes {
+        let commit = common::commit(&svc, m, worker).await;
+        assert_eq!(commit.outcome, CommitOutcome::Committed as i32);
+    }
+    let elapsed = start.elapsed();
+
+    assert_eq!(svc.committed_count().await.unwrap(), n as usize);
+    let ops = (2 * n) as f64 / elapsed.as_secs_f64();
+    eprintln!("throughput: {n} submit + {n} commit in {elapsed:?} ({ops:.0} ops/s)");
+    assert!(
+        elapsed.as_secs() < 20,
+        "1000 submit+commit should be well under 20s if linear; took {elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_commit_at_scale_is_exactly_once() {
+    let n: u64 = 500;
+    let svc = CoordinatorService::new(SqliteJournal::open_in_memory().unwrap());
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let motes: Vec<_> = (0..n)
+        .map(|i| common::mote_indexed(i, NdClass::Pure))
+        .collect();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    // Fan out commits across many concurrent clients.
+    let mut handles = Vec::new();
+    for m in &motes {
+        let s = svc.clone();
+        let m = m.clone();
+        handles.push(tokio::spawn(
+            async move { common::commit(&s, &m, worker).await },
+        ));
+    }
+    for h in handles {
+        let resp = h.await.unwrap();
+        assert_eq!(resp.outcome, CommitOutcome::Committed as i32);
+    }
+
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        n as usize,
+        "every distinct Mote committed exactly once under concurrency"
+    );
+}

--- a/crates/kx-coordinator/tests/recovery.rs
+++ b/crates/kx-coordinator/tests/recovery.rs
@@ -1,0 +1,81 @@
+//! Restart/recovery: a coordinator built over a persistent Sqlite journal,
+//! committed through, then dropped, and a fresh coordinator opened over the same
+//! file recovers the committed state (the projection re-folds from the log) and
+//! still dedupes a re-reported commit. This is the durable-recovery promise at the
+//! distribution boundary — the journal, not the process, is the source of truth.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_coordinator::proto::CommitOutcome;
+use kx_coordinator::{CoordinatorService, MoteState};
+use kx_journal::SqliteJournal;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn commit_survives_coordinator_restart() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let warrant = common::sample_warrant();
+    let mote = common::pure_root_mote();
+
+    let committed_seq;
+    {
+        let svc = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+        let worker = common::register(&svc, "w").await;
+        common::submit(&svc, &mote, &warrant).await;
+        let commit = common::commit(&svc, &mote, worker).await;
+        assert_eq!(commit.outcome, CommitOutcome::Committed as i32);
+        committed_seq = commit.committed_seq;
+        assert_eq!(svc.committed_count().await.unwrap(), 1);
+    } // svc dropped → orchestration core exits → Sqlite connection closed
+
+    // A fresh coordinator over the SAME journal file recovers the committed state.
+    let svc2 = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+    assert_eq!(
+        svc2.committed_count().await.unwrap(),
+        1,
+        "committed Mote recovered from the journal on restart"
+    );
+    assert_eq!(svc2.state_of(mote.id).await.unwrap(), MoteState::Committed);
+
+    // Re-reporting after restart is a dedup-by-key hit (the recovered Mote counts
+    // as admitted): same seq, no second write.
+    let worker2 = common::register(&svc2, "w2").await;
+    let again = common::commit(&svc2, &mote, worker2).await;
+    assert_eq!(again.outcome, CommitOutcome::AlreadyCommitted as i32);
+    assert_eq!(again.committed_seq, committed_seq);
+    assert_eq!(svc2.committed_count().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn multi_mote_state_recovered_after_restart() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let warrant = common::sample_warrant();
+
+    // Commit two of three submitted Motes, then restart.
+    let a = common::mote(1, kx_mote::NdClass::Pure, &[]);
+    let b = common::mote(2, kx_mote::NdClass::Pure, &[]);
+    let c = common::mote(3, kx_mote::NdClass::Pure, &[]);
+    {
+        let svc = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+        let worker = common::register(&svc, "w").await;
+        for m in [&a, &b, &c] {
+            common::submit(&svc, m, &warrant).await;
+        }
+        common::commit(&svc, &a, worker).await;
+        common::commit(&svc, &b, worker).await;
+        assert_eq!(svc.committed_count().await.unwrap(), 2);
+    }
+
+    let svc2 = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+    assert_eq!(svc2.committed_count().await.unwrap(), 2);
+    assert_eq!(svc2.state_of(a.id).await.unwrap(), MoteState::Committed);
+    assert_eq!(svc2.state_of(b.id).await.unwrap(), MoteState::Committed);
+    // C was never committed; after restart it has no journal entry, so the
+    // recovered projection has no record of it (uncommitted work is re-derivable
+    // from the workflow, not the log).
+    assert_eq!(svc2.state_of(c.id).await.unwrap(), MoteState::Pending);
+}

--- a/crates/kx-coordinator/tests/scheduler_verbatim.rs
+++ b/crates/kx-coordinator/tests/scheduler_verbatim.rs
@@ -1,0 +1,19 @@
+//! Thesis-test witness (compile-level): `kx-coordinator` builds against the real
+//! `kx-scheduler` types, hosting them verbatim. The *authoritative* proof that
+//! `kx-scheduler` / `kx-executor` / `kx-inference` source is unchanged is the PR
+//! diff (`git diff <merge-base> -- crates/kx-scheduler crates/kx-executor
+//! crates/kx-inference` is empty) — this test just pins the dependency direction.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_scheduler::{LocalPlacement, Placement, Scheduler, WorkerId};
+
+#[test]
+fn coordinator_depends_on_real_scheduler_types() {
+    // The exact constructor + placement the coordinator's orchestration core uses.
+    let _scheduler = Scheduler::new(LocalPlacement);
+    let worker = WorkerId(0);
+    // Placement is consumed as a trait (the seam P2.5 swaps).
+    let placed = LocalPlacement.place(&kx_mote::MoteId::from_bytes([0u8; 32]));
+    assert_eq!(placed, worker);
+}


### PR DESCRIPTION
## Summary

Second step of P2 (coordinator/worker distribution). New OSS crate **`kx-coordinator`** (20th workspace crate) implementing the `kx-proto` gRPC `Coordinator` service. Meets all three exit-gate obligations from `01-build-sequence.md` §2.2:

1. **kx-scheduler hosted verbatim** — registration routes through `Scheduler::submit` exactly as the single-node engine does. Thesis test: `git diff` over `kx-scheduler` / `kx-executor` / `kx-inference` is **empty**.
2. **Worker registry behind a trait** — `WorkerRegistry` + `InMemoryWorkerRegistry`, proven swappable by a second impl in tests.
3. **Coordinator is the sole journal writer per run** (D13/D40, now enforced at the gRPC boundary) — workers PROPOSE via `ReportCommit`; the coordinator assembles + appends the canonical `Committed` entry (the only seq-assigning site).

## Design

`kx_projection::Projection` holds a non-`Send` `Box<dyn TopologyMaterializer>`, so rather than refactor the P1 projection crate (Rule 1), the journal + projection + hosted scheduler live on a single owner thread driven by a command channel. This keeps the gRPC service `Send + Sync` **and makes the D40 single-writer invariant structural** — exactly one thread ever appends. Identity (D53) is re-derived Rust-side on `SubmitMote`; the wire `mote_id` is advisory.

Scope is exit-gate-minimal (passive control plane): the 4 RPCs + registry + sole-writer commit path. Active dispatch (pull/push of ready Motes) is P2.3; placement v2 is P2.5. A `ready_set` read accessor is added for the upcoming dispatch surface.

## Tests (31, all green)

- **DoD / exit gate** — sole-writer commit e2e over a real gRPC channel, registry-trait, identity re-derivation, refusals.
- **DAG integration** — chain / diamond / multi-root readiness progression; nd_class variety (Pure/ROND/WM); parent edges.
- **Concurrency / exactly-once** — concurrent registration (distinct ids), concurrent distinct-mote commits, concurrent same-mote commit (exactly one Committed, rest AlreadyCommitted, same seq), idempotent concurrent submit.
- **Recovery** — Sqlite restart: committed state re-folds from the journal; dedup survives restart.
- **Edge cases** — exhaustive: all five 32-byte field lengths, identity mismatch, unspecified/out-of-range enums, missing mote/warrant, bad parent length, all executor classes.
- **Throughput** — ~2.3k ops/s for 1000 submit+commit (linear; guards against O(n²) fold regression).

## Gate

`cargo clippy --workspace --all-targets -D warnings`, `fmt --check`, `doc -D warnings`, `deny check`, `test --workspace`, and scoped byte-determinism (I1.c) all pass locally. Thesis-test diff is empty.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, doc, ffi-link, check-reproducible)
- [ ] Confirm `kx-scheduler`/`kx-executor`/`kx-inference` unchanged (diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)