### PR TITLE
feat(kx-journal): Journal::append_batch — the group-commit primitive

### DIFF
--- a/crates/kx-journal/src/in_memory.rs
+++ b/crates/kx-journal/src/in_memory.rs
@@ -104,6 +104,56 @@ impl Journal for InMemoryJournal {
         Ok(entry)
     }
 
+    fn append_batch(&self, entries: Vec<JournalEntry>) -> Result<Vec<JournalEntry>, JournalError> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Hold the write lock for the whole batch and stage all results before
+        // committing them to `state`, so the batch is atomic (all-or-nothing) and
+        // isolated from concurrent readers/writers. Within-batch duplicates dedupe
+        // against both the committed log and the staged entries.
+        let mut state = self.state.write().expect("poisoned lock");
+        let mut next_seq = state.next_seq;
+        let mut staged: Vec<JournalEntry> = Vec::new();
+        let mut durable = Vec::with_capacity(entries.len());
+
+        for mut entry in entries {
+            if let JournalEntry::Repudiated {
+                target_mote_id,
+                target_committed_seq,
+                ref mut idempotency_key,
+                ..
+            } = entry
+            {
+                *idempotency_key =
+                    repudiation_idempotency_key(&target_mote_id, target_committed_seq);
+            }
+
+            let kind = entry.kind();
+            if kind == KIND_COMMITTED || kind == KIND_REPUDIATED || kind == KIND_EFFECT_STAGED {
+                let key = *entry.idempotency_key();
+                if let Some(existing) = state
+                    .entries
+                    .iter()
+                    .chain(staged.iter())
+                    .find(|e| e.kind() == kind && *e.idempotency_key() == key)
+                {
+                    durable.push(existing.clone());
+                    continue;
+                }
+            }
+
+            next_seq += 1;
+            set_seq(&mut entry, next_seq);
+            staged.push(entry.clone());
+            durable.push(entry);
+        }
+
+        state.entries.extend(staged);
+        state.next_seq = next_seq;
+        Ok(durable)
+    }
+
     fn read_committed(&self, mote_id: &MoteId) -> Result<Option<JournalEntry>, JournalError> {
         let state = self.state.read().expect("poisoned lock");
         Ok(state

--- a/crates/kx-journal/src/lib.rs
+++ b/crates/kx-journal/src/lib.rs
@@ -201,6 +201,25 @@ pub trait Journal {
     ///   the original `seq`. The second call is a no-op.
     fn append(&self, entry: JournalEntry) -> Result<JournalEntry, JournalError>;
 
+    /// Append many entries as **one atomic unit** (the group-commit primitive).
+    ///
+    /// Either every entry is durably appended — each assigned the next monotonic
+    /// `seq`, in input order — or none is. Per-entry dedup-by-key applies exactly
+    /// as in [`append`](Journal::append): a duplicate (by `idempotency_key`, for the
+    /// deduped kinds `Committed`/`Repudiated`/`EffectStaged`) yields its pre-existing
+    /// durable form and consumes no new `seq`; duplicates *within the same batch*
+    /// dedupe against earlier entries in that batch. Returns the durable form of
+    /// each input entry, in input order (so the result length always equals the
+    /// input length). An empty batch is a no-op that returns an empty vector.
+    ///
+    /// Backends that can amortize the commit (e.g. one transaction over N entries)
+    /// override this. **The default loops [`append`](Journal::append) and is
+    /// therefore NOT atomic across entries** — a backend that needs batch atomicity
+    /// MUST override it (both shipped backends do).
+    fn append_batch(&self, entries: Vec<JournalEntry>) -> Result<Vec<JournalEntry>, JournalError> {
+        entries.into_iter().map(|e| self.append(e)).collect()
+    }
+
     /// Look up the (at most one) `Committed` entry for a Mote identity.
     ///
     /// Returns `None` if no Committed entry exists for the Mote yet. Used by the

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -202,95 +202,31 @@ impl SqliteJournal {
 }
 
 impl Journal for SqliteJournal {
-    fn append(&self, mut entry: JournalEntry) -> Result<JournalEntry, JournalError> {
-        // For Repudiated entries, derive the idempotency_key from the target before
-        // we touch the database — this is the dedupe-by-target rule from D15.
-        if let JournalEntry::Repudiated {
-            target_mote_id,
-            target_committed_seq,
-            ref mut idempotency_key,
-            ..
-        } = entry
-        {
-            *idempotency_key = repudiation_idempotency_key(&target_mote_id, target_committed_seq);
-        }
-
+    fn append(&self, entry: JournalEntry) -> Result<JournalEntry, JournalError> {
         let mut conn = self.conn.lock().expect("poisoned mutex");
         let txn = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-
-        // v2 (D38 §2b): dedupe-by-key index expands from {1, 2} to {1, 2, 4}.
-        // EffectStaged participates; Failed is intentionally out.
-        let kind = entry.kind();
-        if kind == KIND_COMMITTED || kind == KIND_REPUDIATED || kind == KIND_EFFECT_STAGED {
-            let key = *entry.idempotency_key();
-            let existing = txn
-                .query_row(
-                    "SELECT entry_bytes, mote_def_hash
-                       FROM entries
-                      WHERE idempotency_key = ?1 AND kind = ?2",
-                    params![&key[..], kind as i64],
-                    |r| {
-                        let bytes: Vec<u8> = r.get(0)?;
-                        let dh: Option<Vec<u8>> = r.get(1)?;
-                        Ok((bytes, dh))
-                    },
-                )
-                .optional()?;
-            if let Some((bytes, dh)) = existing {
-                let def_hash = vec_to_mote_def_hash(dh);
-                txn.commit()?;
-                return decode_entry_with_def_hash(&bytes, def_hash).map_err(Into::into);
-            }
-        }
-
-        // Assign next monotonic seq.
-        let next_seq: i64 =
-            txn.query_row("SELECT COALESCE(MAX(seq), 0) + 1 FROM entries", [], |r| {
-                r.get(0)
-            })?;
-        #[allow(clippy::cast_sign_loss)]
-        let next_seq_u64 = next_seq as u64;
-
-        // Inject the assigned seq into the entry before encoding.
-        set_seq(&mut entry, next_seq_u64);
-
-        let bytes = encode_entry(&entry)?;
-        if bytes.len() > MAX_ENTRY_LEN {
-            return Err(JournalError::EntryTooLarge { got: bytes.len() });
-        }
-
-        let mote_id_owned = entry.mote_id();
-        let mote_id_bytes: &[u8; 32] = mote_id_owned.as_bytes();
-        let idem_key: [u8; 32] = *entry.idempotency_key();
-        let nd_byte = match &entry {
-            JournalEntry::Proposed { nondeterminism, .. }
-            | JournalEntry::Committed { nondeterminism, .. } => nondeterminism.as_u8(),
-            _ => 0,
-        } as i64;
-        let def_hash_bytes: Option<Vec<u8>> = match &entry {
-            JournalEntry::Committed { mote_def_hash, .. } => {
-                Some(mote_def_hash.as_bytes().to_vec())
-            }
-            _ => None,
-        };
-
-        txn.execute(
-            "INSERT INTO entries
-                 (seq, kind, mote_id, idempotency_key, nondeterminism, mote_def_hash, entry_bytes)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![
-                next_seq,
-                kind as i64,
-                &mote_id_bytes[..],
-                &idem_key[..],
-                nd_byte,
-                def_hash_bytes,
-                &bytes[..],
-            ],
-        )?;
-
+        let durable = append_one(&txn, entry)?;
         txn.commit()?;
-        Ok(entry)
+        Ok(durable)
+    }
+
+    fn append_batch(&self, entries: Vec<JournalEntry>) -> Result<Vec<JournalEntry>, JournalError> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut conn = self.conn.lock().expect("poisoned mutex");
+        // One BEGIN IMMEDIATE transaction for the whole batch (group commit):
+        // every entry's dedupe SELECT + `seq` assignment + INSERT see the prior
+        // in-batch inserts (so within-batch duplicates dedupe and seqs stay
+        // contiguous), and the first error short-circuits before `commit`, so the
+        // `Transaction`'s Drop rolls the entire batch back — all-or-nothing.
+        let txn = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let mut durable = Vec::with_capacity(entries.len());
+        for entry in entries {
+            durable.push(append_one(&txn, entry)?);
+        }
+        txn.commit()?;
+        Ok(durable)
     }
 
     fn read_committed(&self, mote_id: &MoteId) -> Result<Option<JournalEntry>, JournalError> {
@@ -424,6 +360,103 @@ impl Journal for SqliteJournal {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Append one entry **within an already-open transaction** — the shared core of
+/// [`SqliteJournal::append`] and [`SqliteJournal::append_batch`]. Does NOT begin
+/// or commit the transaction (the caller owns those), so the same logic is atomic
+/// for a single append and for a whole batch.
+///
+/// Mirrors the per-entry contract: derive the `Repudiated` key (D15), dedupe by
+/// `(idempotency_key, kind)` for the deduped kinds (returning the pre-existing
+/// durable entry without consuming a `seq`), else assign `MAX(seq)+1`, size-check,
+/// and INSERT. Because the dedupe SELECT and the `MAX(seq)` query run inside the
+/// caller's transaction, they see earlier inserts from the same batch.
+fn append_one(
+    txn: &rusqlite::Transaction<'_>,
+    mut entry: JournalEntry,
+) -> Result<JournalEntry, JournalError> {
+    // For Repudiated entries, derive the idempotency_key from the target before
+    // we touch the database — this is the dedupe-by-target rule from D15.
+    if let JournalEntry::Repudiated {
+        target_mote_id,
+        target_committed_seq,
+        ref mut idempotency_key,
+        ..
+    } = entry
+    {
+        *idempotency_key = repudiation_idempotency_key(&target_mote_id, target_committed_seq);
+    }
+
+    // v2 (D38 §2b): dedupe-by-key index expands from {1, 2} to {1, 2, 4}.
+    // EffectStaged participates; Failed is intentionally out.
+    let kind = entry.kind();
+    if kind == KIND_COMMITTED || kind == KIND_REPUDIATED || kind == KIND_EFFECT_STAGED {
+        let key = *entry.idempotency_key();
+        let existing = txn
+            .query_row(
+                "SELECT entry_bytes, mote_def_hash
+                   FROM entries
+                  WHERE idempotency_key = ?1 AND kind = ?2",
+                params![&key[..], kind as i64],
+                |r| {
+                    let bytes: Vec<u8> = r.get(0)?;
+                    let dh: Option<Vec<u8>> = r.get(1)?;
+                    Ok((bytes, dh))
+                },
+            )
+            .optional()?;
+        if let Some((bytes, dh)) = existing {
+            let def_hash = vec_to_mote_def_hash(dh);
+            return decode_entry_with_def_hash(&bytes, def_hash).map_err(Into::into);
+        }
+    }
+
+    // Assign next monotonic seq.
+    let next_seq: i64 =
+        txn.query_row("SELECT COALESCE(MAX(seq), 0) + 1 FROM entries", [], |r| {
+            r.get(0)
+        })?;
+    #[allow(clippy::cast_sign_loss)]
+    let next_seq_u64 = next_seq as u64;
+
+    // Inject the assigned seq into the entry before encoding.
+    set_seq(&mut entry, next_seq_u64);
+
+    let bytes = encode_entry(&entry)?;
+    if bytes.len() > MAX_ENTRY_LEN {
+        return Err(JournalError::EntryTooLarge { got: bytes.len() });
+    }
+
+    let mote_id_owned = entry.mote_id();
+    let mote_id_bytes: &[u8; 32] = mote_id_owned.as_bytes();
+    let idem_key: [u8; 32] = *entry.idempotency_key();
+    let nd_byte = i64::from(match &entry {
+        JournalEntry::Proposed { nondeterminism, .. }
+        | JournalEntry::Committed { nondeterminism, .. } => nondeterminism.as_u8(),
+        _ => 0,
+    });
+    let def_hash_bytes: Option<Vec<u8>> = match &entry {
+        JournalEntry::Committed { mote_def_hash, .. } => Some(mote_def_hash.as_bytes().to_vec()),
+        _ => None,
+    };
+
+    txn.execute(
+        "INSERT INTO entries
+             (seq, kind, mote_id, idempotency_key, nondeterminism, mote_def_hash, entry_bytes)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            next_seq,
+            kind as i64,
+            &mote_id_bytes[..],
+            &idem_key[..],
+            nd_byte,
+            def_hash_bytes,
+            &bytes[..],
+        ],
+    )?;
+
+    Ok(entry)
+}
 
 /// Inject an assigned `seq` into an entry just before encoding.
 fn set_seq(entry: &mut JournalEntry, new_seq: u64) {

--- a/crates/kx-journal/tests/append_batch.rs
+++ b/crates/kx-journal/tests/append_batch.rs
@@ -1,0 +1,265 @@
+// Integration test (separate crate) — inherits the workspace deny on
+// unwrap/expect; tests legitimately use them for fixtures.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! `Journal::append_batch` — the group-commit primitive. Verified on BOTH shipped
+//! backends (InMemoryJournal + SqliteJournal):
+//!
+//! - contiguous monotonic seqs in input order;
+//! - parity with looping `append`;
+//! - dedup-by-key within a single batch and across batches;
+//! - `Proposed`/`Failed` are NOT deduped (each is its own attempt);
+//! - empty batch is a no-op;
+//! - readback through `read_entries_by_seq` / `read_committed`;
+//! - **all-or-nothing atomicity**: a mid-batch failure (Sqlite) rolls the whole
+//!   batch back, leaving the journal untouched.
+
+use kx_content::ContentRef;
+use kx_journal::{InMemoryJournal, Journal, JournalEntry, ParentEntry, SqliteJournal, MAX_PARENTS};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use smallvec::SmallVec;
+
+fn committed(id: u8, key: u8) -> JournalEntry {
+    JournalEntry::Committed {
+        mote_id: MoteId::from_bytes([id; 32]),
+        idempotency_key: [key; 32],
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([id ^ 0x5a; 32]),
+        parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([id; 32]),
+    }
+}
+
+fn proposed(id: u8, key: u8) -> JournalEntry {
+    JournalEntry::Proposed {
+        mote_id: MoteId::from_bytes([id; 32]),
+        idempotency_key: [key; 32],
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        placement_hint: 0,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+    }
+}
+
+/// A `Committed` whose parent count exceeds `MAX_PARENTS` — `encode_entry` rejects
+/// it (`TooManyParents`), giving a deterministic mid-batch failure (SqliteJournal).
+fn poison() -> JournalEntry {
+    let parents: SmallVec<[ParentEntry; 4]> = (0..=MAX_PARENTS as u32)
+        .map(|i| ParentEntry {
+            parent_id: MoteId::from_bytes([u8::try_from(i % 256).unwrap(); 32]),
+            edge_kind: 0,
+            non_cascade: 0,
+        })
+        .collect();
+    JournalEntry::Committed {
+        mote_id: MoteId::from_bytes([0xEE; 32]),
+        idempotency_key: [0xEE; 32],
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([0xEE; 32]),
+        parents,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([0xEE; 32]),
+    }
+}
+
+fn seqs(entries: &[JournalEntry]) -> Vec<u64> {
+    entries.iter().map(JournalEntry::seq).collect()
+}
+
+// --- contiguous monotonic seqs ---------------------------------------------
+
+fn check_contiguous(j: &impl Journal) {
+    let out = j
+        .append_batch(vec![committed(1, 1), committed(2, 2), committed(3, 3)])
+        .unwrap();
+    assert_eq!(seqs(&out), vec![1, 2, 3], "seqs assigned in input order");
+    assert_eq!(j.current_seq().unwrap(), 3);
+    assert_eq!(j.count_entries().unwrap(), 3);
+}
+
+#[test]
+fn contiguous_seqs_in_memory() {
+    check_contiguous(&InMemoryJournal::new());
+}
+
+#[test]
+fn contiguous_seqs_sqlite() {
+    check_contiguous(&SqliteJournal::open_in_memory().unwrap());
+}
+
+// --- parity with looped append ---------------------------------------------
+
+fn check_parity(batched: &impl Journal, looped: &impl Journal) {
+    let entries = vec![proposed(1, 1), committed(2, 2), committed(3, 3)];
+    let batch_out = batched.append_batch(entries.clone()).unwrap();
+    let loop_out: Vec<JournalEntry> = entries
+        .into_iter()
+        .map(|e| looped.append(e).unwrap())
+        .collect();
+    assert_eq!(seqs(&batch_out), seqs(&loop_out));
+    assert_eq!(
+        batched.current_seq().unwrap(),
+        looped.current_seq().unwrap()
+    );
+    assert_eq!(
+        batched.count_entries().unwrap(),
+        looped.count_entries().unwrap()
+    );
+    // The durable log is identical entry-for-entry.
+    let b: Vec<JournalEntry> = batched.read_entries_by_seq(0..4).unwrap().collect();
+    let l: Vec<JournalEntry> = looped.read_entries_by_seq(0..4).unwrap().collect();
+    assert_eq!(b, l);
+}
+
+#[test]
+fn parity_in_memory() {
+    check_parity(&InMemoryJournal::new(), &InMemoryJournal::new());
+}
+
+#[test]
+fn parity_sqlite() {
+    check_parity(
+        &SqliteJournal::open_in_memory().unwrap(),
+        &SqliteJournal::open_in_memory().unwrap(),
+    );
+}
+
+// --- dedup within a single batch -------------------------------------------
+
+fn check_dedup_within(j: &impl Journal) {
+    // Same idempotency_key twice in one batch: the second dedupes to the first.
+    let out = j
+        .append_batch(vec![committed(1, 7), committed(1, 7)])
+        .unwrap();
+    assert_eq!(out.len(), 2, "result length always equals input length");
+    assert_eq!(out[0].seq(), 1);
+    assert_eq!(out[1].seq(), 1, "duplicate returns the pre-existing seq");
+    assert_eq!(j.current_seq().unwrap(), 1, "only one seq consumed");
+    assert_eq!(j.count_entries().unwrap(), 1);
+}
+
+#[test]
+fn dedup_within_batch_in_memory() {
+    check_dedup_within(&InMemoryJournal::new());
+}
+
+#[test]
+fn dedup_within_batch_sqlite() {
+    check_dedup_within(&SqliteJournal::open_in_memory().unwrap());
+}
+
+// --- dedup across batches --------------------------------------------------
+
+fn check_dedup_across(j: &impl Journal) {
+    let first = j.append_batch(vec![committed(1, 1)]).unwrap();
+    let second = j
+        .append_batch(vec![committed(1, 1), committed(2, 2)])
+        .unwrap();
+    assert_eq!(second[0].seq(), first[0].seq(), "re-seen key dedupes");
+    assert_eq!(second[1].seq(), 2, "new key gets the next seq");
+    assert_eq!(j.current_seq().unwrap(), 2);
+    assert_eq!(j.count_entries().unwrap(), 2);
+}
+
+#[test]
+fn dedup_across_batches_in_memory() {
+    check_dedup_across(&InMemoryJournal::new());
+}
+
+#[test]
+fn dedup_across_batches_sqlite() {
+    check_dedup_across(&SqliteJournal::open_in_memory().unwrap());
+}
+
+// --- Proposed is NOT deduped (each attempt is its own fact) -----------------
+
+fn check_proposed_not_deduped(j: &impl Journal) {
+    let out = j
+        .append_batch(vec![proposed(1, 1), proposed(1, 1), committed(2, 2)])
+        .unwrap();
+    assert_eq!(
+        seqs(&out),
+        vec![1, 2, 3],
+        "both Proposed land; nothing deduped"
+    );
+    assert_eq!(j.count_entries().unwrap(), 3);
+}
+
+#[test]
+fn proposed_not_deduped_in_memory() {
+    check_proposed_not_deduped(&InMemoryJournal::new());
+}
+
+#[test]
+fn proposed_not_deduped_sqlite() {
+    check_proposed_not_deduped(&SqliteJournal::open_in_memory().unwrap());
+}
+
+// --- empty batch is a no-op ------------------------------------------------
+
+fn check_empty(j: &impl Journal) {
+    let out = j.append_batch(Vec::new()).unwrap();
+    assert!(out.is_empty());
+    assert_eq!(j.current_seq().unwrap(), 0);
+    assert_eq!(j.count_entries().unwrap(), 0);
+}
+
+#[test]
+fn empty_batch_in_memory() {
+    check_empty(&InMemoryJournal::new());
+}
+
+#[test]
+fn empty_batch_sqlite() {
+    check_empty(&SqliteJournal::open_in_memory().unwrap());
+}
+
+// --- readback through the query API ----------------------------------------
+
+fn check_readback(j: &impl Journal) {
+    j.append_batch(vec![committed(1, 1), proposed(2, 2), committed(3, 3)])
+        .unwrap();
+    let all: Vec<JournalEntry> = j.read_entries_by_seq(0..4).unwrap().collect();
+    assert_eq!(seqs(&all), vec![1, 2, 3]);
+    let c = j.read_committed(&MoteId::from_bytes([3; 32])).unwrap();
+    assert!(matches!(c, Some(JournalEntry::Committed { .. })));
+}
+
+#[test]
+fn readback_in_memory() {
+    check_readback(&InMemoryJournal::new());
+}
+
+#[test]
+fn readback_sqlite() {
+    check_readback(&SqliteJournal::open_in_memory().unwrap());
+}
+
+// --- all-or-nothing atomicity (Sqlite mid-batch failure → full rollback) ----
+
+#[test]
+fn sqlite_batch_is_atomic_on_failure() {
+    let j = SqliteJournal::open_in_memory().unwrap();
+    // Prime with one good entry so we can prove the failed batch changes nothing.
+    j.append(committed(5, 5)).unwrap();
+    assert_eq!(j.current_seq().unwrap(), 1);
+
+    // A batch whose middle entry fails to encode (too many parents).
+    let result = j.append_batch(vec![committed(6, 6), poison(), committed(7, 7)]);
+    assert!(result.is_err(), "the batch must fail as a unit");
+
+    // Nothing from the failed batch landed: seq + count unchanged, neither good
+    // sibling persisted (all-or-nothing rollback).
+    assert_eq!(j.current_seq().unwrap(), 1, "seq did not advance");
+    assert_eq!(j.count_entries().unwrap(), 1, "no batch entry persisted");
+    assert!(j
+        .read_committed(&MoteId::from_bytes([6; 32]))
+        .unwrap()
+        .is_none());
+    assert!(j
+        .read_committed(&MoteId::from_bytes([7; 32]))
+        .unwrap()
+        .is_none());
+}


### PR DESCRIPTION
## Summary

Adds an **atomic batch-append** to the `Journal` trait — the seam group commit needs (designed in the P2.2 perf/group-commit corpus note). Lands as its own PR per Golden Rule 1/6 (journal core = max strictness; seam changes are dedicated, rigorously-tested PRs). Independent of #63.

Contract: either every entry in a batch is durably appended (each assigned the next monotonic `seq`, in input order) or none is. Per-entry dedup-by-key applies exactly as in `append`, including duplicates **within** a batch (they dedupe against earlier entries in the same batch). Result length always equals input length.

- **Trait**: default `append_batch` loops `append` (documented as NOT atomic) so future backends keep working; both shipped backends override for atomicity.
- **SqliteJournal**: one `BEGIN IMMEDIATE` transaction over the whole batch. Extracted a shared `append_one(txn, entry)` helper so single- and batch-append run identical dedupe/seq/encode/insert logic inside the caller's transaction — in-transaction `SELECT`/`MAX(seq)` see prior in-batch inserts; the first error short-circuits before commit so the `Transaction`'s Drop rolls the whole batch back.
- **InMemoryJournal**: stages results under the write lock, commits to state only at the end (atomic + isolated; within-batch dedup against staged).

## Tests (15, both backends)

contiguous monotonic seqs · parity with looped `append` · dedup within + across batches · `Proposed` not deduped · empty-batch no-op · readback · **all-or-nothing atomicity** (a mid-batch encode failure on Sqlite rolls back the entire batch: seq/count unchanged, no sibling persisted). Full kx-journal regression unchanged.

## Not in this PR

The kx-coordinator batch-drain consumer (drain N `Commit` commands → one `append_batch`) is the follow-up that realizes the throughput win; it depends on #63 (coordinator) + this seam.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, doc, ffi-link, byte-determinism)
- [ ] Confirm existing append/journal behavior unchanged (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)