### PR TITLE
feat(kx-coordinator): group-commit batch-drain via Journal::append_batch

### DIFF
--- a/crates/kx-coordinator/src/commit.rs
+++ b/crates/kx-coordinator/src/commit.rs
@@ -8,7 +8,7 @@
 //! job (`crate::state`), where the seq is assigned.
 
 use kx_content::ContentRef;
-use kx_journal::ParentEntry;
+use kx_journal::{ParentEntry, MAX_PARENTS};
 use kx_mote::{MoteDefHash, MoteId, NdClass, ParentRef};
 use kx_proto::proto;
 use kx_proto::ConvertError;
@@ -64,6 +64,22 @@ pub(crate) fn assemble(
         .into_iter()
         .map(|p| ParentRef::try_from(p).map(|pr| ParentEntry::from_parent_ref(&pr)))
         .collect::<Result<_, ConvertError>>()?;
+
+    // Validate the journal's encoder invariants up front so a malformed proposal is
+    // rejected individually (INVALID_ARGUMENT) and can never fail — and thereby
+    // roll back — an entire group-commit batch downstream.
+    if parents.len() > MAX_PARENTS {
+        return Err(CoordinatorError::TooManyParents {
+            got: parents.len(),
+            max: MAX_PARENTS,
+        });
+    }
+    if parents
+        .iter()
+        .any(|p| p.edge_kind == 0 && p.non_cascade != 0)
+    {
+        return Err(CoordinatorError::DataEdgeNonCascade);
+    }
 
     Ok(CommitProposal {
         mote_id,

--- a/crates/kx-coordinator/src/error.rs
+++ b/crates/kx-coordinator/src/error.rs
@@ -45,6 +45,22 @@ pub enum CoordinatorError {
     #[error("unknown mote {0:?} (never submitted)")]
     UnknownMote(MoteId),
 
+    /// A `ReportCommit` declared more parents than the journal encodes. Validated
+    /// up front so a malformed proposal cannot poison a group-commit batch.
+    #[error("commit declares {got} parents, exceeds the maximum {max}")]
+    TooManyParents {
+        /// Parents declared by the request.
+        got: usize,
+        /// The journal's per-entry maximum.
+        max: usize,
+    },
+
+    /// A `ReportCommit` carried a `Data` edge marked `non_cascade` — forbidden by
+    /// `journal-entry.md` §11 (the encoder would reject it). Validated up front so a
+    /// malformed proposal cannot poison a group-commit batch.
+    #[error("commit has a Data-edge parent marked non_cascade (forbidden)")]
+    DataEdgeNonCascade,
+
     /// Hosted-scheduler bookkeeping failure (e.g. duplicate submission).
     #[error(transparent)]
     Scheduler(#[from] SchedulerError),
@@ -62,6 +78,13 @@ pub enum CoordinatorError {
     /// re-folds from it.
     #[error("coordinator orchestration core is unavailable")]
     CoreUnavailable,
+
+    /// A group-commit batch failed at the durable layer (journal/projection). The
+    /// batch is atomic, so nothing was written; every waiter in the batch receives
+    /// this so it can retry. Carries the underlying error's message (the source
+    /// error is not `Clone`, so it is stringified to fan out to all waiters).
+    #[error("group commit failed: {0}")]
+    CommitFailed(String),
 }
 
 impl From<CoordinatorError> for tonic::Status {
@@ -73,10 +96,12 @@ impl From<CoordinatorError> for tonic::Status {
             | CoordinatorError::Convert(_)
             | CoordinatorError::UnknownWorker(_)
             | CoordinatorError::UnknownMote(_)
+            | CoordinatorError::TooManyParents { .. }
+            | CoordinatorError::DataEdgeNonCascade
             | CoordinatorError::Scheduler(_) => Self::invalid_argument(message),
-            CoordinatorError::Journal(_) | CoordinatorError::Projection(_) => {
-                Self::internal(message)
-            }
+            CoordinatorError::Journal(_)
+            | CoordinatorError::Projection(_)
+            | CoordinatorError::CommitFailed(_) => Self::internal(message),
             CoordinatorError::CoreUnavailable => Self::unavailable(message),
         }
     }

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -33,6 +33,11 @@ use crate::error::CoordinatorError;
 /// instead of letting an unbounded queue grow without limit under a flood of RPCs.
 const COMMAND_BUFFER: usize = 1024;
 
+/// Max commands the core drains per wake. Consecutive `Commit`s within a drain
+/// coalesce into one journal transaction (group commit); this bounds the size of
+/// that transaction.
+const MAX_DRAIN: usize = 256;
+
 /// Outcome of a `SubmitMote`: the canonically re-derived id and whether it was a
 /// duplicate (idempotent re-submit before commit).
 #[derive(Debug, Clone, Copy)]
@@ -177,68 +182,100 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
         .map(|(id, _)| id)
         .collect();
 
-    while let Some(command) = inbox.blocking_recv() {
-        match command {
-            Command::Submit {
-                mote,
-                warrant,
-                reply,
-            } => {
-                let mote_id = mote.id;
-                let duplicate = match scheduler.submit(*mote, *warrant, &mut projection) {
-                    Ok(()) => {
-                        submitted.insert(mote_id);
-                        false
-                    }
-                    Err(SchedulerError::DuplicateSubmission(_)) => true,
-                };
-                let _ = reply.send(SubmitOutcome { mote_id, duplicate });
-            }
-            Command::Commit { proposal, reply } => {
-                let result = apply_commit(
-                    journal,
-                    &mut projection,
-                    &mut folded_through,
-                    &submitted,
-                    *proposal,
-                );
-                let _ = reply.send(result);
-            }
-            Command::StateOf { mote_id, reply } => {
-                let _ = reply.send(projection.state_of(&mote_id));
-            }
-            Command::CommittedCount { reply } => {
-                let _ = reply.send(projection.snapshot().committed_count());
-            }
-            Command::ReadySet { reply } => {
-                let _ = reply.send(projection.ready_set());
+    while let Some(first) = inbox.blocking_recv() {
+        // Drain everything immediately available (up to MAX_DRAIN) so consecutive
+        // ReportCommits coalesce into one journal transaction (group commit).
+        let mut drained = vec![first];
+        while drained.len() < MAX_DRAIN {
+            match inbox.try_recv() {
+                Ok(command) => drained.push(command),
+                Err(_) => break,
             }
         }
+
+        // Process in arrival order, accumulating a run of consecutive `Commit`s and
+        // flushing it (as one group commit) whenever a non-`Commit` command is
+        // reached — so `Submit`s and reads keep their exact in-order semantics
+        // (a read or submit always observes the commits queued before it).
+        let mut pending: Vec<PendingCommit> = Vec::new();
+        for command in drained {
+            match command {
+                Command::Commit { proposal, reply } => {
+                    pending.push((*proposal, reply));
+                }
+                Command::Submit {
+                    mote,
+                    warrant,
+                    reply,
+                } => {
+                    flush_commits(
+                        journal,
+                        &mut projection,
+                        &mut folded_through,
+                        &submitted,
+                        &mut pending,
+                    );
+                    let mote_id = mote.id;
+                    let duplicate = match scheduler.submit(*mote, *warrant, &mut projection) {
+                        Ok(()) => {
+                            submitted.insert(mote_id);
+                            false
+                        }
+                        Err(SchedulerError::DuplicateSubmission(_)) => true,
+                    };
+                    let _ = reply.send(SubmitOutcome { mote_id, duplicate });
+                }
+                Command::StateOf { mote_id, reply } => {
+                    flush_commits(
+                        journal,
+                        &mut projection,
+                        &mut folded_through,
+                        &submitted,
+                        &mut pending,
+                    );
+                    let _ = reply.send(projection.state_of(&mote_id));
+                }
+                Command::CommittedCount { reply } => {
+                    flush_commits(
+                        journal,
+                        &mut projection,
+                        &mut folded_through,
+                        &submitted,
+                        &mut pending,
+                    );
+                    let _ = reply.send(projection.snapshot().committed_count());
+                }
+                Command::ReadySet { reply } => {
+                    flush_commits(
+                        journal,
+                        &mut projection,
+                        &mut folded_through,
+                        &submitted,
+                        &mut pending,
+                    );
+                    let _ = reply.send(projection.ready_set());
+                }
+            }
+        }
+        flush_commits(
+            journal,
+            &mut projection,
+            &mut folded_through,
+            &submitted,
+            &mut pending,
+        );
     }
 }
 
-/// Assemble + append the `Committed` entry (the sole-writer step), then fold it
-/// into the projection. Refuses commits for never-submitted Motes.
-///
-/// Dedup is delegated to the journal's own dedup-by-key contract (the single
-/// source of truth): `append` is a no-op that returns the pre-existing entry on a
-/// duplicate. We detect that — without a second lookup — by comparing the returned
-/// seq against the seq captured before the append: a fresh write advances the seq,
-/// a dedup hit returns an older one. On a dedup hit we skip the fold (the entry is
-/// already folded; re-folding would trip `DuplicateCommitted`).
-fn apply_commit<J: Journal>(
-    journal: &J,
-    projection: &mut Projection,
-    folded_through: &mut u64,
-    submitted: &BTreeSet<MoteId>,
-    proposal: CommitProposal,
-) -> Result<CommitApplied, CoordinatorError> {
-    if !submitted.contains(&proposal.mote_id) {
-        return Err(CoordinatorError::UnknownMote(proposal.mote_id));
-    }
+/// One queued `ReportCommit`: its validated proposal + the reply channel.
+type PendingCommit = (
+    CommitProposal,
+    oneshot::Sender<Result<CommitApplied, CoordinatorError>>,
+);
 
-    let seq_before = journal.current_seq()?;
-    let durable = journal.append(JournalEntry::Committed {
+/// Build the durable `Committed` entry from a validated proposal.
+fn committed_entry(proposal: CommitProposal) -> JournalEntry {
+    JournalEntry::Committed {
         mote_id: proposal.mote_id,
         idempotency_key: proposal.idempotency_key,
         seq: 0,
@@ -247,22 +284,91 @@ fn apply_commit<J: Journal>(
         parents: proposal.parents,
         warrant_ref: proposal.warrant_ref,
         mote_def_hash: proposal.mote_def_hash,
-    })?;
-    // `append` of a `Committed` always returns a `Committed`; the other arm is
-    // unreachable by construction.
-    let committed_seq = match durable {
-        JournalEntry::Committed { seq, .. } => seq,
-        _ => 0,
-    };
-
-    let already_committed = committed_seq <= seq_before;
-    if !already_committed {
-        fold_new(journal, projection, folded_through)?;
     }
-    Ok(CommitApplied {
-        committed_seq,
-        already_committed,
-    })
+}
+
+/// Flush a run of queued commits as ONE group commit
+/// ([`Journal::append_batch`](kx_journal::Journal::append_batch) — a single journal
+/// transaction), then fold the new range once. Never-submitted Motes are rejected
+/// individually with no write; the admitted ones are appended atomically.
+fn flush_commits<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    submitted: &BTreeSet<MoteId>,
+    pending: &mut Vec<PendingCommit>,
+) {
+    if pending.is_empty() {
+        return;
+    }
+    let batch = std::mem::take(pending);
+
+    // Admission guard per proposal: reject never-submitted Motes (no write) so one
+    // inadmissible commit never blocks its valid batch-mates.
+    let mut entries: Vec<JournalEntry> = Vec::with_capacity(batch.len());
+    let mut replies: Vec<oneshot::Sender<Result<CommitApplied, CoordinatorError>>> =
+        Vec::with_capacity(batch.len());
+    for (proposal, reply) in batch {
+        if submitted.contains(&proposal.mote_id) {
+            entries.push(committed_entry(proposal));
+            replies.push(reply);
+        } else {
+            let _ = reply.send(Err(CoordinatorError::UnknownMote(proposal.mote_id)));
+        }
+    }
+    if entries.is_empty() {
+        return;
+    }
+
+    match apply_batch(journal, projection, folded_through, entries) {
+        Ok(applied) => {
+            for (reply, applied) in replies.into_iter().zip(applied) {
+                let _ = reply.send(Ok(applied));
+            }
+        }
+        Err(message) => {
+            // The batch is atomic, so on failure nothing was durably written; report
+            // the same fault to every waiter (they may retry).
+            for reply in replies {
+                let _ = reply.send(Err(CoordinatorError::CommitFailed(message.clone())));
+            }
+        }
+    }
+}
+
+/// Append a pre-validated, pre-admitted batch in one transaction, fold the new
+/// range once, and derive each entry's [`CommitApplied`].
+///
+/// Per-entry dedup detection (no extra lookup): `append_batch` returns each
+/// entry's durable form. A commit is **newly committed** iff its returned seq is
+/// past the pre-batch watermark AND is the first occurrence of that seq in this
+/// batch — a re-report (across batches → older seq; within the batch → an
+/// already-seen seq) is `already_committed`. Returns a stringified error (so it can
+/// be relayed to every waiter) only on a catastrophic journal/projection fault;
+/// the batch is atomic, so on error nothing was durably written.
+fn apply_batch<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    entries: Vec<JournalEntry>,
+) -> Result<Vec<CommitApplied>, String> {
+    let seq_before = journal.current_seq().map_err(|e| e.to_string())?;
+    let durable = journal.append_batch(entries).map_err(|e| e.to_string())?;
+    fold_new(journal, projection, folded_through).map_err(|e| e.to_string())?;
+
+    let mut new_seqs = BTreeSet::new();
+    let applied = durable
+        .into_iter()
+        .map(|entry| {
+            let seq = entry.seq();
+            let already_committed = !(seq > seq_before && new_seqs.insert(seq));
+            CommitApplied {
+                committed_seq: seq,
+                already_committed,
+            }
+        })
+        .collect();
+    Ok(applied)
 }
 
 /// Fold journal entries appended since `folded_through` into `projection`,

--- a/crates/kx-coordinator/tests/edge_cases.rs
+++ b/crates/kx-coordinator/tests/edge_cases.rs
@@ -196,3 +196,33 @@ async fn report_commit_unknown_mote_with_nondefault_nd_class() {
     assert_eq!(err.code(), Code::InvalidArgument);
     assert_eq!(svc.committed_count().await.unwrap(), 0);
 }
+
+#[tokio::test]
+async fn too_many_parents_rejected_no_write() {
+    // > 128 parents would fail the journal encoder — validated up front so it
+    // can't poison a group-commit batch. Rejected individually, no write.
+    let (svc, worker, mote) = ready_to_report().await;
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.parents = (0..129u32)
+        .map(|i| proto::ParentRef {
+            parent_id: vec![u8::try_from(i % 256).unwrap(); 32],
+            edge_kind: proto::EdgeKind::Data as i32,
+            non_cascade: false,
+        })
+        .collect();
+    assert_commit_rejected(&svc, bad).await;
+}
+
+#[tokio::test]
+async fn data_edge_non_cascade_rejected_no_write() {
+    // A Data edge marked non_cascade is forbidden by the encoder; validated up
+    // front so it can't poison a group-commit batch.
+    let (svc, worker, mote) = ready_to_report().await;
+    let mut bad = common::report_commit_request(&mote, worker);
+    bad.parents = vec![proto::ParentRef {
+        parent_id: vec![1u8; 32],
+        edge_kind: proto::EdgeKind::Data as i32,
+        non_cascade: true,
+    }];
+    assert_commit_rejected(&svc, bad).await;
+}

--- a/crates/kx-coordinator/tests/load.rs
+++ b/crates/kx-coordinator/tests/load.rs
@@ -1,19 +1,22 @@
-//! Throughput / load. These run over the production `SqliteJournal` backend (the
-//! in-memory variant) so the journal's dedup + read paths are indexed (O(log n)),
-//! and assert the coordinator scales **linearly** — the incremental projection
-//! fold must not regress to O(n²). Bounds are generous (machine-independent); the
-//! point is to catch a pathological regression, not to benchmark.
+//! Throughput / load over the production `SqliteJournal` backend. The in-memory
+//! variant exercises the indexed (O(log n)) dedup/read paths and asserts the
+//! coordinator scales **linearly** (the incremental fold must not regress to
+//! O(n²)); the on-disk variant exercises the durable path (fsync per transaction)
+//! where **group commit** amortizes fsync by coalescing concurrent commits.
+//! Bounds are generous (machine-independent) — the point is to catch a pathological
+//! regression, not to benchmark (precise tracking belongs in a criterion bench).
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
 
 mod common;
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use kx_coordinator::proto::CommitOutcome;
 use kx_coordinator::CoordinatorService;
 use kx_journal::SqliteJournal;
 use kx_mote::NdClass;
+use tempfile::tempdir;
 
 #[tokio::test]
 async fn sequential_submit_and_commit_throughput() {
@@ -77,5 +80,80 @@ async fn concurrent_commit_at_scale_is_exactly_once() {
         svc.committed_count().await.unwrap(),
         n as usize,
         "every distinct Mote committed exactly once under concurrency"
+    );
+}
+
+/// Commit `motes` on `svc` either sequentially (await each) or concurrently (fan
+/// out, then join). Returns the wall time for the commit phase.
+async fn time_commits(
+    svc: &CoordinatorService,
+    motes: &[kx_mote::Mote],
+    concurrent: bool,
+) -> Duration {
+    let worker = common::register(svc, "w").await;
+    let warrant = common::sample_warrant();
+    for m in motes {
+        common::submit(svc, m, &warrant).await;
+    }
+    let start = Instant::now();
+    if concurrent {
+        let mut handles = Vec::new();
+        for m in motes {
+            let s = svc.clone();
+            let m = m.clone();
+            handles.push(tokio::spawn(
+                async move { common::commit(&s, &m, worker).await },
+            ));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap().outcome, CommitOutcome::Committed as i32);
+        }
+    } else {
+        for m in motes {
+            assert_eq!(
+                common::commit(svc, m, worker).await.outcome,
+                CommitOutcome::Committed as i32
+            );
+        }
+    }
+    start.elapsed()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn group_commit_speeds_up_concurrent_durable_commits() {
+    // The group-commit win shows on the DURABLE path: an on-disk journal fsyncs
+    // per transaction (synchronous=FULL), so coalescing N concurrent commits into
+    // shared transactions amortizes the fsync cost. (In-memory has no fsync, so
+    // there is nothing to amortize — that is expected.)
+    let n: u64 = 1_000;
+    let dir = tempdir().unwrap();
+    let motes: Vec<_> = (0..n)
+        .map(|i| common::mote_indexed(i, NdClass::Pure))
+        .collect();
+
+    let seq_svc = CoordinatorService::new(SqliteJournal::open(dir.path().join("seq.db")).unwrap());
+    let sequential = time_commits(&seq_svc, &motes, false).await;
+    assert_eq!(seq_svc.committed_count().await.unwrap(), n as usize);
+
+    let conc_svc =
+        CoordinatorService::new(SqliteJournal::open(dir.path().join("conc.db")).unwrap());
+    let concurrent = time_commits(&conc_svc, &motes, true).await;
+    assert_eq!(conc_svc.committed_count().await.unwrap(), n as usize);
+
+    let speedup = sequential.as_secs_f64() / concurrent.as_secs_f64();
+    eprintln!(
+        "on-disk {n} commits — sequential {sequential:?}, concurrent (group-commit) {concurrent:?} \
+         ({speedup:.1}x)"
+    );
+    // The exact speedup is hardware/fsync-dependent (precise tracking belongs in a
+    // criterion bench), so assert only that the group-commit path stays bounded and
+    // is not pathologically worse than the per-commit path.
+    assert!(
+        concurrent.as_secs() < 30,
+        "concurrent commits should stay bounded"
+    );
+    assert!(
+        concurrent.as_secs_f64() <= sequential.as_secs_f64() * 2.0,
+        "group commit must not regress badly vs per-commit: seq={sequential:?} conc={concurrent:?}"
     );
 }


### PR DESCRIPTION
## Summary

Realizes the group-commit throughput win on top of the merged `Journal::append_batch` seam (#64). The orchestration core drains up to `MAX_DRAIN` commands per wake and **coalesces consecutive `ReportCommit`s into one journal transaction** (`append_batch`), folds the new range once, and replies to every waiter.

- **Ordering preserved**: a run of consecutive commits is flushed (as one group commit) whenever a non-`Commit` (Submit/read) is reached — so Submits and reads keep exact in-order semantics. A single commit is a batch of one.
- **Exactly-once preserved**: per-entry dedup detection with no extra lookup — a commit is *newly committed* iff its returned seq is past the pre-batch watermark AND the first occurrence of that seq in the batch (re-reports, across or within a batch, return an older/already-seen seq).
- **One bad apple can't reject its batch-mates**: `commit::assemble` now validates the encoder invariants up front (parent count ≤ `MAX_PARENTS`; no `Data`-edge `non_cascade`) and rejects them individually (`INVALID_ARGUMENT`), so `append_batch` only fails on a catastrophic durable fault — where the atomic batch rolls back and every waiter is told to retry.

New error variants: `TooManyParents`, `DataEdgeNonCascade` (invalid_argument), `CommitFailed(String)` (internal, fanned out to all batch waiters).

## Performance (honest)

Group commit amortizes **fsync** on the durable path; it's neutral on the no-fsync in-memory backend. On-disk local measurement (1000 commits): sequential 713ms → concurrent (group-commit) 587ms (**~1.2×** on this hardware; the win scales with fsync cost — bigger on slower disks / `synchronous=FULL` under load). The per-commit coordination (channel/oneshot/assemble/registry-lock) is the remaining cost; precise tracking belongs in a future criterion bench.

## Tests (+3 → 34)

Two new refusals (too-many-parents, data-edge-non_cascade) + an on-disk sequential-vs-concurrent group-commit comparison. All existing concurrency/exactly-once tests now exercise the batched path unchanged. clippy/fmt/doc clean; thesis-test diff (scheduler/executor/inference) still empty.

## Test plan

- [ ] CI green (fmt, clippy, test, deny, doc, ffi-link, byte-determinism)
- [ ] Confirm exactly-once holds under the batched path (concurrency tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)