### PR TITLE
P2.3 (1/2): LeaseWork RPC — the worker pull seam

### DIFF
--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -31,11 +31,13 @@
 //! projection, and scheduler live on one owner thread (see `state`), which keeps
 //! the gRPC service `Send + Sync` and makes single-writer structural.
 //!
-//! ## Scope (P2.2)
+//! ## Scope (P2.2 + P2.3 dispatch)
 //!
-//! Passive control plane: the four RPCs, the registry, and the sole-writer commit
-//! path. Active dispatch — pushing/pulling ready Motes to workers — is **P2.3**
-//! (`kx-worker`), and placement v2 is P2.5.
+//! The control plane: registration / heartbeat / admission, the sole-writer commit
+//! path, **and the `LeaseWork` dispatch surface** (P2.3) — a worker polls for ready
+//! PURE Motes runnable on its backend, runs them, and proposes the result via
+//! `ReportCommit`. Selection is trivial (ready ∩ PURE ∩ executor_class); placement
+//! v2 (locality / GPU-slot awareness) is P2.5, and worker provisioning is P3 (D47).
 
 pub use kx_projection::MoteState;
 pub use kx_proto::proto;

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -166,4 +166,32 @@ impl Coordinator for CoordinatorService {
             detail: String::new(),
         }))
     }
+
+    #[tracing::instrument(skip_all)]
+    async fn lease_work(
+        &self,
+        request: Request<proto::LeaseWorkRequest>,
+    ) -> Result<Response<proto::LeaseWorkResponse>, Status> {
+        let req = request.into_inner();
+        // Admission: only a registered worker may lease (mirrors report_commit).
+        let worker = WorkerId(req.worker_id);
+        if self.registry.get(worker).is_none() {
+            return Err(CoordinatorError::UnknownWorker(worker).into());
+        }
+        let proto_class = proto::ExecutorClass::try_from(req.executor_class).map_err(|_| {
+            Status::invalid_argument(format!("unknown executor_class {}", req.executor_class))
+        })?;
+        let executor_class =
+            kx_warrant::ExecutorClass::try_from(proto_class).map_err(CoordinatorError::from)?;
+        let max = usize::try_from(req.max_motes).unwrap_or(usize::MAX);
+        let work = self.core.lease_work(executor_class, max).await?;
+        let items = work
+            .into_iter()
+            .map(|(mote, warrant)| proto::WorkItem {
+                mote: Some(mote.into()),
+                warrant: Some(warrant.into()),
+            })
+            .collect();
+        Ok(Response::new(proto::LeaseWorkResponse { items }))
+    }
 }

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -16,13 +16,13 @@
 //! Registration routes through [`kx_scheduler::Scheduler::submit`] exactly as the
 //! single-node `kx-runtime` engine does — the scheduler source is unchanged.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use kx_journal::{Journal, JournalEntry};
-use kx_mote::{Mote, MoteId};
+use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Scheduler, SchedulerError};
-use kx_warrant::WarrantSpec;
+use kx_warrant::{ExecutorClass, WarrantSpec};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::commit::CommitProposal;
@@ -74,6 +74,11 @@ pub(crate) enum Command {
     },
     ReadySet {
         reply: oneshot::Sender<Vec<MoteId>>,
+    },
+    LeaseWork {
+        executor_class: ExecutorClass,
+        max: usize,
+        reply: oneshot::Sender<Vec<(Mote, WarrantSpec)>>,
     },
 }
 
@@ -148,6 +153,27 @@ impl CoreHandle {
             .map_err(|_| CoordinatorError::CoreUnavailable)
     }
 
+    /// Lease up to `max` ready PURE Motes runnable on `executor_class`, returning
+    /// each with the warrant it was submitted under (the dispatch surface the
+    /// worker pulls). No lease/lock is held: double execution is harmless under
+    /// the journal's dedupe-by-key, and provisioning is reserved for P3 (D47).
+    pub(crate) async fn lease_work(
+        &self,
+        executor_class: ExecutorClass,
+        max: usize,
+    ) -> Result<Vec<(Mote, WarrantSpec)>, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::LeaseWork {
+            executor_class,
+            max,
+            reply,
+        })
+        .await?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+
     async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
         self.commands
             .send(command)
@@ -156,31 +182,73 @@ impl CoreHandle {
     }
 }
 
-/// The owner-thread loop. Recovers the projection from the journal, then services
-/// commands until every sender drops (the channel closes on coordinator shutdown).
-fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
-    let mut projection = match Projection::from_journal(journal) {
+/// Recover the read-side from the durable journal at startup: fold the log into a
+/// projection, read the current seq watermark, and seed the admission set from the
+/// already-committed Motes (on recovery, committed Motes count as admitted). Returns
+/// `None` (after logging) on a durable-layer fault, which stops the core — the
+/// journal stays the truth and a restart re-folds from it.
+fn recover<J: Journal>(journal: &J) -> Option<(Projection, u64, BTreeSet<MoteId>)> {
+    let projection = match Projection::from_journal(journal) {
         Ok(projection) => projection,
         Err(error) => {
             tracing::error!(%error, "coordinator core failed to recover the projection");
-            return;
+            return None;
         }
     };
-    let mut folded_through = match journal.current_seq() {
+    let folded_through = match journal.current_seq() {
         Ok(seq) => seq,
         Err(error) => {
             tracing::error!(%error, "coordinator core failed to read the journal seq");
-            return;
+            return None;
         }
     };
-    let mut scheduler = Scheduler::new(LocalPlacement);
-    // Motes this coordinator has admitted (submitted). Seeds the `ReportCommit`
-    // admission guard; on recovery, already-committed Motes count as admitted.
-    let mut submitted: BTreeSet<MoteId> = projection
+    let submitted = projection
         .snapshot()
         .iter_motes()
         .map(|(id, _)| id)
         .collect();
+    Some((projection, folded_through, submitted))
+}
+
+/// Select up to `max` ready PURE Motes runnable on `executor_class`, each paired
+/// with the warrant it was submitted under (the dispatch surface a worker pulls).
+/// Ready = parents-all-committed (the dispatch precondition); PURE is the only
+/// class the worker executes-then-proposes in P2.3 (WM needs a durable staged-intent
+/// RPC, deferred); the warrant's executor_class must match the worker's backend.
+fn lease_ready(
+    projection: &Projection,
+    submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    executor_class: ExecutorClass,
+    max: usize,
+) -> Vec<(Mote, WarrantSpec)> {
+    let mut items = Vec::new();
+    for mote_id in projection.ready_set() {
+        if items.len() >= max {
+            break;
+        }
+        if let Some((mote, warrant)) = submitted_defs.get(&mote_id) {
+            if mote.nd_class() == NdClass::Pure && warrant.executor_class == executor_class {
+                items.push((mote.clone(), warrant.clone()));
+            }
+        }
+    }
+    items
+}
+
+/// The owner-thread loop. Recovers the projection from the journal, then services
+/// commands until every sender drops (the channel closes on coordinator shutdown).
+fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
+    let Some((mut projection, mut folded_through, mut submitted)) = recover(journal) else {
+        return;
+    };
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    // Definitions of admitted-but-not-yet-committed Motes, kept so `LeaseWork` can
+    // hand a worker the Mote + warrant to run. (kx-scheduler consumes the Mote on
+    // submit and exposes no get-by-id accessor — and is frozen by the thesis test —
+    // so the coordinator retains its own copy.) Recovery does not repopulate this:
+    // committed Motes are never ready, and pending work lost to a crash is a P3
+    // concern.
+    let mut submitted_defs: BTreeMap<MoteId, (Mote, WarrantSpec)> = BTreeMap::new();
 
     while let Some(first) = inbox.blocking_recv() {
         // Drain everything immediately available (up to MAX_DRAIN) so consecutive
@@ -199,61 +267,61 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
         // (a read or submit always observes the commits queued before it).
         let mut pending: Vec<PendingCommit> = Vec::new();
         for command in drained {
-            match command {
+            // `Commit`s accumulate into the pending run; every other command must
+            // observe the commits queued before it, so flush the run first (one
+            // group commit), then handle the command.
+            let command = match command {
                 Command::Commit { proposal, reply } => {
                     pending.push((*proposal, reply));
+                    continue;
                 }
+                other => other,
+            };
+            flush_commits(
+                journal,
+                &mut projection,
+                &mut folded_through,
+                &submitted,
+                &mut submitted_defs,
+                &mut pending,
+            );
+            match command {
+                Command::Commit { .. } => unreachable!("Commit is handled above"),
                 Command::Submit {
                     mote,
                     warrant,
                     reply,
                 } => {
-                    flush_commits(
-                        journal,
-                        &mut projection,
-                        &mut folded_through,
-                        &submitted,
-                        &mut pending,
-                    );
                     let mote_id = mote.id;
-                    let duplicate = match scheduler.submit(*mote, *warrant, &mut projection) {
-                        Ok(()) => {
-                            submitted.insert(mote_id);
-                            false
-                        }
-                        Err(SchedulerError::DuplicateSubmission(_)) => true,
-                    };
+                    let mote = *mote;
+                    let warrant = *warrant;
+                    let duplicate =
+                        match scheduler.submit(mote.clone(), warrant.clone(), &mut projection) {
+                            Ok(()) => {
+                                submitted.insert(mote_id);
+                                submitted_defs.insert(mote_id, (mote, warrant));
+                                false
+                            }
+                            Err(SchedulerError::DuplicateSubmission(_)) => true,
+                        };
                     let _ = reply.send(SubmitOutcome { mote_id, duplicate });
                 }
                 Command::StateOf { mote_id, reply } => {
-                    flush_commits(
-                        journal,
-                        &mut projection,
-                        &mut folded_through,
-                        &submitted,
-                        &mut pending,
-                    );
                     let _ = reply.send(projection.state_of(&mote_id));
                 }
                 Command::CommittedCount { reply } => {
-                    flush_commits(
-                        journal,
-                        &mut projection,
-                        &mut folded_through,
-                        &submitted,
-                        &mut pending,
-                    );
                     let _ = reply.send(projection.snapshot().committed_count());
                 }
                 Command::ReadySet { reply } => {
-                    flush_commits(
-                        journal,
-                        &mut projection,
-                        &mut folded_through,
-                        &submitted,
-                        &mut pending,
-                    );
                     let _ = reply.send(projection.ready_set());
+                }
+                Command::LeaseWork {
+                    executor_class,
+                    max,
+                    reply,
+                } => {
+                    let items = lease_ready(&projection, &submitted_defs, executor_class, max);
+                    let _ = reply.send(items);
                 }
             }
         }
@@ -262,6 +330,7 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
             &mut projection,
             &mut folded_through,
             &submitted,
+            &mut submitted_defs,
             &mut pending,
         );
     }
@@ -296,6 +365,7 @@ fn flush_commits<J: Journal>(
     projection: &mut Projection,
     folded_through: &mut u64,
     submitted: &BTreeSet<MoteId>,
+    submitted_defs: &mut BTreeMap<MoteId, (Mote, WarrantSpec)>,
     pending: &mut Vec<PendingCommit>,
 ) {
     if pending.is_empty() {
@@ -308,8 +378,10 @@ fn flush_commits<J: Journal>(
     let mut entries: Vec<JournalEntry> = Vec::with_capacity(batch.len());
     let mut replies: Vec<oneshot::Sender<Result<CommitApplied, CoordinatorError>>> =
         Vec::with_capacity(batch.len());
+    let mut committed_ids: Vec<MoteId> = Vec::with_capacity(batch.len());
     for (proposal, reply) in batch {
         if submitted.contains(&proposal.mote_id) {
+            committed_ids.push(proposal.mote_id);
             entries.push(committed_entry(proposal));
             replies.push(reply);
         } else {
@@ -322,6 +394,12 @@ fn flush_commits<J: Journal>(
 
     match apply_batch(journal, projection, folded_through, entries) {
         Ok(applied) => {
+            // The defs are no longer leasable once committed (a committed Mote is
+            // never in the ready-set); free them to keep the map bounded by
+            // in-flight work, not total submissions.
+            for id in &committed_ids {
+                submitted_defs.remove(id);
+            }
             for (reply, applied) in replies.into_iter().zip(applied) {
                 let _ = reply.send(Ok(applied));
             }

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -221,3 +221,22 @@ pub async fn commit(
         .unwrap()
         .into_inner()
 }
+
+/// Lease ready PURE work for `worker_id` on `executor_class` through the service.
+pub async fn lease_work(
+    service: &CoordinatorService,
+    worker_id: u64,
+    executor_class: proto::ExecutorClass,
+    max_motes: u32,
+) -> Vec<proto::WorkItem> {
+    service
+        .lease_work(Request::new(proto::LeaseWorkRequest {
+            worker_id,
+            executor_class: executor_class as i32,
+            max_motes,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .items
+}

--- a/crates/kx-coordinator/tests/lease_work.rs
+++ b/crates/kx-coordinator/tests/lease_work.rs
@@ -1,0 +1,171 @@
+//! `LeaseWork` serving (P2.3 dispatch surface): the coordinator hands a worker
+//! the ready PURE Motes it can run, each with the warrant it was submitted under.
+//!
+//! Selection contract exercised here:
+//! - **ready** — only Motes whose parents are all committed (the dispatch
+//!   precondition; tracks the projection ready-set as parents commit);
+//! - **PURE** — WORLD-MUTATING / READ-ONLY-NONDET are NOT leased (P2.3 runs the
+//!   PURE path only; WM needs a durable staged-intent RPC, deferred);
+//! - **executor_class** — only Motes whose warrant matches the worker's backend;
+//! - **max_motes** — the worker bounds how many it pulls per call;
+//! - **admission** — only a registered worker may lease.
+//!
+//! The returned `WorkItem` carries a full Mote + warrant; identity must survive
+//! the wire mapping so the worker can re-derive a `ReportCommit` the coordinator
+//! accepts.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::proto::ExecutorClass;
+use kx_coordinator::CoordinatorService;
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+use kx_warrant::warrant_ref_of;
+use tonic::{Code, Request};
+
+fn coordinator() -> CoordinatorService {
+    CoordinatorService::new(InMemoryJournal::new())
+}
+
+#[tokio::test]
+async fn leases_the_ready_root_then_advances_as_parents_commit() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant(); // executor_class = MacOsSandbox
+    let worker = common::register(&svc, "w").await; // registers MacosSandbox
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    common::submit(&svc, &a, &warrant).await;
+    common::submit(&svc, &b, &warrant).await;
+
+    // Only the root is ready; the lease returns it with its warrant.
+    let leased = common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16).await;
+    assert_eq!(leased.len(), 1, "only the root is leasable");
+    let item = &leased[0];
+    let leased_mote: kx_mote::Mote = item.mote.clone().unwrap().try_into().unwrap();
+    let leased_warrant: kx_warrant::WarrantSpec = item.warrant.clone().unwrap().try_into().unwrap();
+    assert_eq!(leased_mote.id, a.id, "leased the ready root");
+    assert_eq!(
+        warrant_ref_of(&leased_warrant),
+        warrant_ref_of(&warrant),
+        "warrant identity survives the lease"
+    );
+
+    // Commit the root; the child becomes leasable.
+    common::commit(&svc, &a, worker).await;
+    let leased = common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16).await;
+    assert_eq!(leased.len(), 1);
+    let leased_mote: kx_mote::Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(leased_mote.id, b.id, "child leasable once parent committed");
+
+    // Commit the child; nothing left to lease.
+    common::commit(&svc, &b, worker).await;
+    assert!(
+        common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16)
+            .await
+            .is_empty(),
+        "no work remains once the DAG is committed"
+    );
+}
+
+#[tokio::test]
+async fn does_not_lease_non_pure_motes() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // A ready (parentless) WORLD-MUTATING Mote: in the ready-set, but the PURE
+    // gate must keep it out of the lease.
+    let wm = common::mote(7, NdClass::WorldMutating, &[]);
+    common::submit(&svc, &wm, &warrant).await;
+
+    assert!(
+        common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16)
+            .await
+            .is_empty(),
+        "WORLD-MUTATING Motes are not leased in P2.3"
+    );
+}
+
+#[tokio::test]
+async fn does_not_lease_across_executor_class() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant(); // executor_class = MacOsSandbox
+    let worker = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    common::submit(&svc, &a, &warrant).await;
+
+    // A Bwrap worker cannot run a MacOsSandbox-warranted Mote.
+    assert!(
+        common::lease_work(&svc, worker, ExecutorClass::Bwrap, 16)
+            .await
+            .is_empty(),
+        "a mismatched executor_class leases nothing"
+    );
+    // The matching class does.
+    assert_eq!(
+        common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16)
+            .await
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn max_motes_bounds_the_lease() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // Two independent ready PURE roots.
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[]);
+    common::submit(&svc, &a, &warrant).await;
+    common::submit(&svc, &b, &warrant).await;
+
+    assert_eq!(
+        common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 1)
+            .await
+            .len(),
+        1,
+        "max_motes caps the batch"
+    );
+    assert_eq!(
+        common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16)
+            .await
+            .len(),
+        2,
+        "both roots leasable without the cap"
+    );
+}
+
+#[tokio::test]
+async fn unregistered_worker_cannot_lease() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let _registered = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    common::submit(&svc, &a, &warrant).await;
+
+    // worker_id 999 was never registered.
+    let status = svc
+        .lease_work(Request::new(kx_coordinator::proto::LeaseWorkRequest {
+            worker_id: 999,
+            executor_class: ExecutorClass::MacosSandbox as i32,
+            max_motes: 16,
+        }))
+        .await
+        .map(|_| ())
+        .unwrap_err();
+    // UnknownWorker is an inadmissible request → INVALID_ARGUMENT (see error.rs).
+    assert_eq!(
+        status.code(),
+        Code::InvalidArgument,
+        "unregistered workers are refused"
+    );
+}

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -271,6 +271,32 @@ message RegisterWorkerResponse {
 }
 
 // ---------------------------------------------------------------------------
+// RPC (5) — lease work. The worker PULLS ready Motes to execute. This is a
+// poll (the worker asks); the coordinator returns Motes whose parents are all
+// committed (projection ready-set) that match the worker's executor_class. No
+// lease/lock is held — double execution is harmless under journal
+// dedupe-by-key, and worker provisioning is reserved for P3 (D47). The
+// returned WorkItem reuses the Mote + WarrantSpec value messages; the worker
+// re-runs the executor verbatim and PROPOSES the result via ReportCommit.
+// ---------------------------------------------------------------------------
+
+message LeaseWorkRequest {
+  uint64 worker_id = 1;                 // the requesting worker (from RegisterWorker)
+  ExecutorClass executor_class = 2;     // only Motes runnable on this backend
+  uint32 max_motes = 3;                 // upper bound on items returned this call
+}
+
+// One unit of work: the Mote to run plus the warrant it runs under.
+message WorkItem {
+  Mote mote = 1;
+  WarrantSpec warrant = 2;
+}
+
+message LeaseWorkResponse {
+  repeated WorkItem items = 1;          // empty when no ready work matches
+}
+
+// ---------------------------------------------------------------------------
 // Service — hosted by the coordinator; workers are clients.
 // ---------------------------------------------------------------------------
 
@@ -279,4 +305,5 @@ service Coordinator {
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
   rpc SubmitMote(SubmitMoteRequest) returns (SubmitMoteResponse);
   rpc ReportCommit(ReportCommitRequest) returns (ReportCommitResponse);
+  rpc LeaseWork(LeaseWorkRequest) returns (LeaseWorkResponse);
 }

--- a/crates/kx-proto/tests/dod.rs
+++ b/crates/kx-proto/tests/dod.rs
@@ -98,6 +98,31 @@ fn obligation_1_register_worker_round_trips() {
     roundtrip(&proto::RegisterWorkerResponse { worker_id: 7 });
 }
 
+#[test]
+fn obligation_1_lease_work_request_round_trips() {
+    roundtrip(&proto::LeaseWorkRequest {
+        worker_id: 7,
+        executor_class: proto::ExecutorClass::Bwrap as i32,
+        max_motes: 16,
+    });
+}
+
+#[test]
+fn obligation_1_lease_work_response_round_trips() {
+    let resp = proto::LeaseWorkResponse {
+        items: vec![proto::WorkItem {
+            mote: Some(sample_mote().into()),
+            warrant: Some(sample_warrant().into()),
+        }],
+    };
+    roundtrip(&resp);
+}
+
+#[test]
+fn obligation_1_lease_work_response_empty_round_trips() {
+    roundtrip(&proto::LeaseWorkResponse { items: vec![] });
+}
+
 // --- Obligation 2: same-instance encode determinism ------------------------
 
 #[test]
@@ -175,6 +200,43 @@ fn obligation_3_full_wire_pipeline_preserves_identity() {
         warrant_ref_of(&warrant),
         warrant_ref_of(&back_warrant),
         "warrant_ref survives the full pipeline"
+    );
+}
+
+#[test]
+fn obligation_3_work_item_preserves_identity() {
+    // The worker pulls a WorkItem and re-derives MoteId / warrant_ref from it to
+    // build a ReportCommit the coordinator will accept; the wire mapping must
+    // preserve both through encode + decode.
+    let mote = sample_mote();
+    let warrant = sample_warrant();
+    let resp = proto::LeaseWorkResponse {
+        items: vec![proto::WorkItem {
+            mote: Some(mote.clone().into()),
+            warrant: Some(warrant.clone().into()),
+        }],
+    };
+
+    let bytes = resp.encode_to_vec();
+    let decoded = proto::LeaseWorkResponse::decode(&bytes[..]).expect("decode");
+    let item = decoded.items.into_iter().next().expect("one item");
+
+    let back_mote: kx_mote::Mote = item
+        .mote
+        .expect("mote present")
+        .try_into()
+        .expect("convert");
+    let back_warrant: kx_warrant::WarrantSpec = item
+        .warrant
+        .expect("warrant present")
+        .try_into()
+        .expect("convert");
+
+    assert_eq!(mote.id, back_mote.id, "MoteId survives the lease pipeline");
+    assert_eq!(
+        warrant_ref_of(&warrant),
+        warrant_ref_of(&back_warrant),
+        "warrant_ref survives the lease pipeline"
     );
 }
 

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -1,6 +1,6 @@
 //! Proves the tonic service **skeleton builds and serves**: a no-op
 //! `Coordinator` impl is hosted over a real TCP endpoint and a generated client
-//! reaches all four RPCs. This goes beyond "compiles" — it exercises the
+//! reaches every RPC. This goes beyond "compiles" — it exercises the
 //! generated server trait, the `CoordinatorServer`/`CoordinatorClient` types,
 //! and the transport. No coordinator *behavior* is implemented (that is P2.2/2.3).
 
@@ -14,9 +14,9 @@ use common::{sample_mote, sample_warrant};
 use kx_proto::proto::coordinator_client::CoordinatorClient;
 use kx_proto::proto::coordinator_server::{Coordinator, CoordinatorServer};
 use kx_proto::proto::{
-    CommitOutcome, ExecutorClass, HeartbeatRequest, HeartbeatResponse, RegisterWorkerRequest,
-    RegisterWorkerResponse, ReportCommitRequest, ReportCommitResponse, SubmitMoteRequest,
-    SubmitMoteResponse, SubmitStatus,
+    CommitOutcome, ExecutorClass, HeartbeatRequest, HeartbeatResponse, LeaseWorkRequest,
+    LeaseWorkResponse, RegisterWorkerRequest, RegisterWorkerResponse, ReportCommitRequest,
+    ReportCommitResponse, SubmitMoteRequest, SubmitMoteResponse, SubmitStatus, WorkItem,
 };
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
@@ -64,10 +64,26 @@ impl Coordinator for NoopCoordinator {
             detail: String::new(),
         }))
     }
+
+    async fn lease_work(
+        &self,
+        req: Request<LeaseWorkRequest>,
+    ) -> Result<Response<LeaseWorkResponse>, Status> {
+        // Echo one work item back so the test confirms the Mote + warrant
+        // payload round-trips through the new RPC. (Ready-set selection is
+        // implemented coordinator-side in P2.3; not here.)
+        let _ = req.into_inner();
+        Ok(Response::new(LeaseWorkResponse {
+            items: vec![WorkItem {
+                mote: Some(sample_mote().into()),
+                warrant: Some(sample_warrant().into()),
+            }],
+        }))
+    }
 }
 
 #[tokio::test]
-async fn coordinator_skeleton_serves_all_four_rpcs() {
+async fn coordinator_skeleton_serves_all_rpcs() {
     // Ephemeral port; serve in the background.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -151,4 +167,23 @@ async fn coordinator_skeleton_serves_all_four_rpcs() {
         .into_inner();
     assert_eq!(commit.outcome, CommitOutcome::Committed as i32);
     assert_eq!(commit.committed_seq, 1);
+
+    // (5) lease work — a full Mote + warrant rides back over the new RPC.
+    let lease = client
+        .lease_work(LeaseWorkRequest {
+            worker_id: 7,
+            executor_class: ExecutorClass::Bwrap as i32,
+            max_motes: 8,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(lease.items.len(), 1, "one work item leased");
+    let item = &lease.items[0];
+    assert_eq!(
+        item.mote.as_ref().unwrap().mote_id.len(),
+        32,
+        "leased mote_id round-tripped over the wire"
+    );
+    assert!(item.warrant.is_some(), "leased warrant present");
 }


### PR DESCRIPTION
## Summary

First of two PRs for **P2.3 (`kx-worker`)**. Adds the gRPC seam a worker needs to **pull ready work** and wires the coordinator's serving side.

- **kx-proto**: new fifth `Coordinator` RPC `LeaseWork(LeaseWorkRequest) -> LeaseWorkResponse`. A worker polls with `worker_id` + `executor_class` + `max_motes`; the coordinator returns up to `max_motes` `WorkItem`s, each a `(Mote, WarrantSpec)` pair reusing the existing wire messages + conversions. None of the prior 4 RPCs carry a Mote *toward* a worker, so a new RPC is genuinely required.
- **kx-coordinator** (serving side, landed with the seam per the #64 journal-seam precedent — trait + all implementors together, no stubs): `Command::LeaseWork` + a `submitted_defs` map (kx-scheduler consumes the Mote on submit and is frozen by the thesis test, so the coordinator keeps its own copy; committed defs are freed on commit to stay bounded by in-flight work). Selection = **ready ∩ PURE ∩ executor_class**. The `lease_work` tonic handler admits only registered workers (mirrors `report_commit`).

### Design notes
- **Poll-only, no lease/lock**: double execution is harmless under the journal's dedupe-by-key; worker provisioning stays reserved for P3 (D47).
- **PURE-only scope**: the worker runs the executor verbatim and proposes via `ReportCommit` (D40 sole-writer). WM needs a durable staged-intent RPC — deferred.
- **Trivial placement**: locality / GPU-slot awareness is P2.5.
- `core_loop` refactor (extracted `recover()` + `lease_ready()`, hoisted the per-arm `flush_commits` to one call) is behavior-preserving dedup to fit the line lint.

### Thesis test
`kx-scheduler` / `kx-executor` / `kx-inference` source **unchanged** (`git diff main` empty for all three).

The new **`kx-worker` client crate** + end-to-end register→pull→run→commit test is PR 2/2.

## Test plan
- [x] `cargo test -p kx-proto -p kx-coordinator` (proto round-trips incl. WorkItem identity keystone; coordinator `lease_work` ready/PURE/class/max/admission)
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`, `cargo deny check`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] thesis diff empty: `git diff main -- crates/kx-executor crates/kx-inference crates/kx-scheduler`
- [ ] `ffi-link` + `check-reproducible` (I1.c) — run by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)