### PR TITLE
P2.3 (2/2): kx-worker — the CoordinatorClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-worker"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-coordinator",
+ "kx-executor",
+ "kx-journal",
+ "kx-mote",
+ "kx-proto",
+ "kx-warrant",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/kx-runtime",
     "crates/kx-proto",
     "crates/kx-coordinator",
+    "crates/kx-worker",
 ]
 exclude = [
     "kx-cloud",
@@ -86,6 +87,7 @@ kx-executor          = { path = "crates/kx-executor",          version = "0.0.1"
 kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.0.1" }
 kx-proto             = { path = "crates/kx-proto",             version = "0.0.1" }
 kx-coordinator       = { path = "crates/kx-coordinator",       version = "0.0.1" }
+kx-worker            = { path = "crates/kx-worker",            version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-worker/Cargo.toml
+++ b/crates/kx-worker/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "kx-worker"
+version = "0.0.1"
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+description = "kortecx P2.3 worker — a gRPC client of the coordinator that hosts the P1 executor (and, transitively, inference) verbatim: it registers, pulls ready PURE Motes (LeaseWork), runs them, and PROPOSES commits via ReportCommit (the coordinator is the sole journal writer, D40)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The gRPC schema + generated client + the tested proto<->domain conversions.
+kx-proto = { workspace = true }
+# Hosted VERBATIM (P2 thesis test): the worker runs Motes through `run_pure_mote`;
+# kx-executor transitively hosts kx-inference (its backends). Neither crate's
+# source changes — distribution is wiring, not a rewrite.
+kx-executor = { workspace = true }
+# A THROWAWAY in-memory journal: the executor's commit protocol needs a `Journal`
+# to append to, but a worker never writes the coordinator's journal (D40). Only the
+# result_ref crosses back, to be PROPOSED via ReportCommit.
+kx-journal = { workspace = true }
+kx-mote = { workspace = true }
+kx-warrant = { workspace = true }
+kx-content = { workspace = true }
+tonic = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+# The e2e test hosts a real CoordinatorService over an in-process gRPC server and
+# drives the full register -> lease -> run -> propose-commit loop against it.
+kx-coordinator = { workspace = true }
+# `time` is additive over the workspace tokio features — the e2e uses a short
+# connect-retry sleep while the in-process server binds (the kx-proto pattern).
+tokio = { workspace = true, features = ["time"] }
+smallvec = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-worker/src/client.rs
+++ b/crates/kx-worker/src/client.rs
@@ -1,0 +1,100 @@
+//! [`WorkerClient`] — a thin typed wrapper over the generated gRPC
+//! `CoordinatorClient`. Each method converts at the boundary and unwraps the
+//! response; the [`Worker`](crate::Worker) drives them.
+
+use kx_proto::proto;
+use kx_proto::proto::coordinator_client::CoordinatorClient;
+use kx_warrant::ExecutorClass;
+use tonic::transport::Channel;
+
+use crate::error::WorkerError;
+
+/// A worker's connection to the coordinator (the four worker-facing RPCs:
+/// register / heartbeat / lease / report-commit).
+#[derive(Clone)]
+pub struct WorkerClient {
+    inner: CoordinatorClient<Channel>,
+}
+
+impl WorkerClient {
+    /// Connect to a coordinator at `endpoint` (`http://host:port` for TCP across
+    /// nodes, or a Unix-socket URI locally).
+    pub async fn connect(endpoint: impl Into<String>) -> Result<Self, WorkerError> {
+        let inner = CoordinatorClient::connect(endpoint.into()).await?;
+        Ok(Self { inner })
+    }
+
+    /// Wrap an already-established channel (e.g. an in-process test transport).
+    #[must_use]
+    pub fn from_channel(channel: Channel) -> Self {
+        Self {
+            inner: CoordinatorClient::new(channel),
+        }
+    }
+
+    /// Register as a worker for `executor_class`, reachable at `endpoint`. Returns
+    /// the coordinator-assigned worker id.
+    pub async fn register_worker(
+        &mut self,
+        executor_class: ExecutorClass,
+        endpoint: impl Into<String>,
+    ) -> Result<u64, WorkerError> {
+        let resp = self
+            .inner
+            .register_worker(proto::RegisterWorkerRequest {
+                executor_class: proto::ExecutorClass::from(executor_class) as i32,
+                endpoint: endpoint.into(),
+            })
+            .await?
+            .into_inner();
+        Ok(resp.worker_id)
+    }
+
+    /// Report liveness: `timestamp_ms` is wall-clock (liveness only, never hashed),
+    /// `in_flight` the number of Motes currently executing. Returns the ack.
+    pub async fn heartbeat(
+        &mut self,
+        worker_id: u64,
+        timestamp_ms: u64,
+        in_flight: u32,
+    ) -> Result<bool, WorkerError> {
+        let resp = self
+            .inner
+            .heartbeat(proto::HeartbeatRequest {
+                worker_id,
+                timestamp_ms,
+                in_flight,
+            })
+            .await?
+            .into_inner();
+        Ok(resp.ack)
+    }
+
+    /// Pull up to `max_motes` ready PURE Motes runnable on `executor_class`.
+    pub async fn lease_work(
+        &mut self,
+        worker_id: u64,
+        executor_class: ExecutorClass,
+        max_motes: u32,
+    ) -> Result<Vec<proto::WorkItem>, WorkerError> {
+        let resp = self
+            .inner
+            .lease_work(proto::LeaseWorkRequest {
+                worker_id,
+                executor_class: proto::ExecutorClass::from(executor_class) as i32,
+                max_motes,
+            })
+            .await?
+            .into_inner();
+        Ok(resp.items)
+    }
+
+    /// Propose a commit. The coordinator validates + appends (sole writer, D40) and
+    /// returns the assigned seq + outcome.
+    pub async fn report_commit(
+        &mut self,
+        request: proto::ReportCommitRequest,
+    ) -> Result<proto::ReportCommitResponse, WorkerError> {
+        Ok(self.inner.report_commit(request).await?.into_inner())
+    }
+}

--- a/crates/kx-worker/src/commit_builder.rs
+++ b/crates/kx-worker/src/commit_builder.rs
@@ -1,0 +1,37 @@
+//! Building the `ReportCommit` proposal for a PURE Mote the worker just ran.
+
+use kx_content::ContentRef;
+use kx_mote::Mote;
+use kx_proto::proto;
+use kx_warrant::{warrant_ref_of, WarrantSpec};
+
+/// Assemble the `ReportCommit` proposal from the held `Mote` + `warrant` and the
+/// executor's output `result_ref`.
+///
+/// Every metadata field is **re-derived from the Mote/warrant** — the same
+/// canonical construction the coordinator uses to build the durable `Committed`
+/// entry — so the proposal cannot diverge from what the coordinator expects:
+/// `nd_class` and `parents` come from the Mote itself (NOT from the throwaway
+/// journal, which records `parents = empty` / `nd_class = Pure`). Only
+/// `result_ref` is new information from the run.
+///
+/// `idempotency_key == mote_id` is the identity invariant the coordinator's
+/// `commit::assemble` enforces.
+pub(crate) fn report_commit_request(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    result_ref: ContentRef,
+    worker_id: u64,
+) -> proto::ReportCommitRequest {
+    let id = mote.id.as_bytes().to_vec();
+    proto::ReportCommitRequest {
+        mote_id: id.clone(),
+        idempotency_key: id,
+        result_ref: result_ref.as_bytes().to_vec(),
+        warrant_ref: warrant_ref_of(warrant).as_bytes().to_vec(),
+        mote_def_hash: mote.def.hash().as_bytes().to_vec(),
+        nd_class: proto::NdClass::from(mote.nd_class()) as i32,
+        parents: mote.parents.iter().copied().map(Into::into).collect(),
+        worker_id,
+    }
+}

--- a/crates/kx-worker/src/error.rs
+++ b/crates/kx-worker/src/error.rs
@@ -1,0 +1,55 @@
+//! [`WorkerError`] — the worker's failure vocabulary.
+
+use thiserror::Error;
+
+/// Errors raised while a worker registers, leases, runs, or proposes commits.
+///
+/// The transport / RPC / executor sources are boxed: `tonic::Status` alone is
+/// ~176 bytes, and an un-boxed variant would bloat every `Result` the worker
+/// returns (`clippy::result_large_err`).
+#[derive(Debug, Error)]
+pub enum WorkerError {
+    /// Establishing the gRPC channel to the coordinator failed.
+    #[error("coordinator transport error: {0}")]
+    Transport(Box<tonic::transport::Error>),
+
+    /// A coordinator RPC returned an error status (e.g. an unregistered worker, a
+    /// rejected proposal).
+    #[error("coordinator RPC failed: {0}")]
+    Rpc(Box<tonic::Status>),
+
+    /// A `proto -> domain` conversion of a leased Mote/warrant failed.
+    #[error("wire conversion failed: {0}")]
+    Convert(#[from] kx_proto::ConvertError),
+
+    /// A leased `WorkItem` was missing a required field (the coordinator always
+    /// sends both, so this is a malformed response).
+    #[error("a leased WorkItem was missing its {0}")]
+    MissingField(&'static str),
+
+    /// Running a leased Mote through the hosted executor failed.
+    #[error("executing a leased Mote failed: {0}")]
+    Execute(Box<kx_executor::LifecycleError>),
+
+    /// The coordinator accepted the request but rejected the commit proposal.
+    #[error("coordinator rejected the commit: {0}")]
+    CommitRejected(String),
+}
+
+impl From<tonic::transport::Error> for WorkerError {
+    fn from(error: tonic::transport::Error) -> Self {
+        Self::Transport(Box::new(error))
+    }
+}
+
+impl From<tonic::Status> for WorkerError {
+    fn from(status: tonic::Status) -> Self {
+        Self::Rpc(Box::new(status))
+    }
+}
+
+impl From<kx_executor::LifecycleError> for WorkerError {
+    fn from(error: kx_executor::LifecycleError) -> Self {
+        Self::Execute(Box::new(error))
+    }
+}

--- a/crates/kx-worker/src/lib.rs
+++ b/crates/kx-worker/src/lib.rs
@@ -1,0 +1,63 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::return_self_not_must_use
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-worker — the kortecx P2.3 worker (the `CoordinatorClient`)
+//!
+//! A worker is a gRPC **client** of the coordinator. It:
+//!
+//! 1. **registers** with the coordinator ([`Worker::register`] → `RegisterWorker`),
+//!    declaring the executor backend it can run;
+//! 2. **pulls** ready work ([`Worker::run_once`] → `LeaseWork`) — the coordinator
+//!    returns ready PURE Motes runnable on this backend, each with its warrant;
+//! 3. **runs** each Mote through the **hosted P1 executor** ([`kx_executor`],
+//!    verbatim — which transitively hosts `kx-inference`);
+//! 4. **proposes** the result back (`ReportCommit`); the coordinator is the SOLE
+//!    journal writer (D13 / D40) and assigns the committed seq.
+//!
+//! ## Sole-writer, by construction
+//!
+//! The worker never writes the coordinator's journal. The executor's commit
+//! protocol needs *a* [`kx_journal::Journal`] to append to, so the worker hands it
+//! a **throwaway in-memory journal** (see `run`); only the `result_ref` crosses
+//! back over gRPC. The metadata of the `ReportCommit` proposal is **re-derived**
+//! from the held Mote + warrant (the canonical construction the coordinator also
+//! uses) — not read back from the throwaway journal, which would lose the Mote's
+//! parents and flatten its nd_class.
+//!
+//! ## Scope (P2.3)
+//!
+//! PURE Motes only. A PURE Mote has no real-world effect, so running it on the
+//! worker and proposing its commit is sound. WORLD-MUTATING Motes need a durable
+//! staged-intent RPC (so the coordinator records the `EffectStaged` recovery hint
+//! before the effect fires) — deferred. Placement v2 (locality / GPU-slot) is P2.5;
+//! worker provisioning / liveness-driven scale is P3 (D47).
+//!
+//! ## Thesis test
+//!
+//! `kx-scheduler` / `kx-executor` / `kx-inference` source is **unchanged** —
+//! distribution is wiring. kx-worker is a new leaf crate; it adds the client and
+//! the propose-don't-write glue, nothing more.
+
+/// The gRPC schema + generated client (re-exported for callers that build wire
+/// types directly, e.g. tests).
+pub use kx_proto::proto;
+
+mod client;
+mod commit_builder;
+mod error;
+mod run;
+mod worker;
+
+pub use client::WorkerClient;
+pub use error::WorkerError;
+pub use worker::Worker;

--- a/crates/kx-worker/src/run.rs
+++ b/crates/kx-worker/src/run.rs
@@ -1,0 +1,32 @@
+//! Running a leased PURE Mote through the hosted executor.
+
+use kx_content::ContentRef;
+use kx_executor::{run_pure_mote, MoteExecutor, ResourceManager};
+use kx_journal::InMemoryJournal;
+use kx_mote::Mote;
+use kx_warrant::WarrantSpec;
+
+use crate::error::WorkerError;
+
+/// Run a PURE Mote via [`run_pure_mote`] (kx-executor, verbatim) and return its
+/// `result_ref`.
+///
+/// The executor's commit protocol appends a `Proposed` + `Committed` pair to the
+/// `Journal` it is given; the worker hands it a **throwaway** [`InMemoryJournal`]
+/// so it never touches the coordinator's durable journal (D40 sole-writer). The
+/// local seq is meaningless and discarded — only the body's `result_ref` is real
+/// (and is what the worker PROPOSES via `ReportCommit`).
+pub(crate) fn run_pure<E, R>(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    executor: &E,
+    resource_manager: &R,
+) -> Result<ContentRef, WorkerError>
+where
+    E: MoteExecutor + ?Sized,
+    R: ResourceManager + ?Sized,
+{
+    let scratch = InMemoryJournal::new();
+    let commit = run_pure_mote(mote, warrant, &scratch, resource_manager, executor)?;
+    Ok(commit.result_ref)
+}

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -1,0 +1,112 @@
+//! [`Worker`] — registers with the coordinator, then leases / runs / proposes.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use kx_executor::{LocalResourceManager, MoteExecutor};
+use kx_mote::Mote;
+use kx_proto::proto;
+use kx_warrant::{ExecutorClass, WarrantSpec};
+
+use crate::client::WorkerClient;
+use crate::error::WorkerError;
+use crate::{commit_builder, run};
+
+/// A registered worker bound to one coordinator. Holds the hosted executor + a
+/// resource manager (the verbatim P1 execution stack) and the dispatch knobs.
+pub struct Worker {
+    client: WorkerClient,
+    id: u64,
+    executor_class: ExecutorClass,
+    executor: Arc<dyn MoteExecutor>,
+    resource_manager: LocalResourceManager,
+    max_lease: u32,
+}
+
+impl Worker {
+    /// Register `client` with the coordinator as a worker for `executor_class`,
+    /// reachable at `endpoint`, and return a ready worker. `executor` +
+    /// `resource_manager` host the P1 execution stack verbatim; `max_lease` bounds
+    /// how many Motes a single [`run_once`](Self::run_once) pulls.
+    pub async fn register(
+        mut client: WorkerClient,
+        executor_class: ExecutorClass,
+        endpoint: impl Into<String>,
+        executor: Arc<dyn MoteExecutor>,
+        resource_manager: LocalResourceManager,
+        max_lease: u32,
+    ) -> Result<Self, WorkerError> {
+        let id = client.register_worker(executor_class, endpoint).await?;
+        Ok(Self {
+            client,
+            id,
+            executor_class,
+            executor,
+            resource_manager,
+            max_lease,
+        })
+    }
+
+    /// The coordinator-assigned worker id.
+    #[must_use]
+    pub fn worker_id(&self) -> u64 {
+        self.id
+    }
+
+    /// Lease one batch of ready PURE Motes, run each through the hosted executor,
+    /// and propose its commit. Returns the number of commits the coordinator
+    /// accepted this round (0 when no ready work matches).
+    pub async fn run_once(&mut self) -> Result<usize, WorkerError> {
+        let items = self
+            .client
+            .lease_work(self.id, self.executor_class, self.max_lease)
+            .await?;
+
+        let mut committed = 0usize;
+        for item in items {
+            let mote: Mote = item
+                .mote
+                .ok_or(WorkerError::MissingField("mote"))?
+                .try_into()?;
+            let warrant: WarrantSpec = item
+                .warrant
+                .ok_or(WorkerError::MissingField("warrant"))?
+                .try_into()?;
+
+            let result_ref =
+                run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)?;
+            let request =
+                commit_builder::report_commit_request(&mote, &warrant, result_ref, self.id);
+            let response = self.client.report_commit(request).await?;
+
+            match proto::CommitOutcome::try_from(response.outcome) {
+                Ok(proto::CommitOutcome::Committed | proto::CommitOutcome::AlreadyCommitted) => {
+                    tracing::info!(
+                        worker_id = self.id,
+                        seq = response.committed_seq,
+                        mote = ?mote.id,
+                        "commit proposal accepted"
+                    );
+                    committed += 1;
+                }
+                _ => return Err(WorkerError::CommitRejected(response.detail)),
+            }
+        }
+        Ok(committed)
+    }
+
+    /// Send a liveness heartbeat with the current wall-clock and `in_flight` count.
+    /// Returns the coordinator's ack.
+    pub async fn heartbeat(&mut self, in_flight: u32) -> Result<bool, WorkerError> {
+        self.client.heartbeat(self.id, now_ms(), in_flight).await
+    }
+}
+
+/// Wall-clock milliseconds since the Unix epoch (liveness only; never hashed).
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| u64::try_from(d.as_millis()).ok())
+        .unwrap_or(0)
+}

--- a/crates/kx-worker/tests/common/mod.rs
+++ b/crates/kx-worker/tests/common/mod.rs
@@ -1,0 +1,97 @@
+//! Compact PURE fixtures for the worker e2e: a parentless PURE root + a PURE
+//! child, and a warrant whose `executor_class` matches the worker the test
+//! registers. Built from the real `kx-mote` / `kx-warrant` types.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    dead_code,
+    unreachable_pub
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_mote::{
+    EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
+    MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    WarrantSpec,
+};
+use smallvec::SmallVec;
+
+/// The executor backend the worker registers as and the warrant requires.
+pub const WORKER_CLASS: ExecutorClass = ExecutorClass::MacOsSandbox;
+
+fn pure_def() -> MoteDef {
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+/// A PURE Mote, made unique by `seed`, with optional data-edge parents.
+#[must_use]
+pub fn pure_mote(seed: u8, parent_ids: &[MoteId]) -> Mote {
+    let parents: SmallVec<[ParentRef; 4]> = parent_ids
+        .iter()
+        .map(|id| ParentRef {
+            parent_id: *id,
+            edge: EdgeMeta::data(),
+        })
+        .collect();
+    Mote::new(
+        pure_def(),
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        parents,
+    )
+}
+
+/// A warrant a [`WORKER_CLASS`] worker can run.
+#[must_use]
+pub fn pure_warrant() -> WarrantSpec {
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist({
+            let mut h = BTreeSet::new();
+            h.insert(Host("api.example.com:443".into()));
+            h
+        }),
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: WORKER_CLASS,
+    }
+}

--- a/crates/kx-worker/tests/e2e.rs
+++ b/crates/kx-worker/tests/e2e.rs
@@ -1,0 +1,119 @@
+//! End-to-end P2.3 exit-gate witness: a worker **registers**, **pulls** a ready
+//! Mote, runs it through the hosted executor, and **proposes** its commit — all
+//! through the coordinator over real gRPC. Then the committed parent unblocks the
+//! child, which the worker pulls and commits on the next round.
+//!
+//! The coordinator is a real [`CoordinatorService`] hosted on an in-process gRPC
+//! server (ephemeral TCP loopback). Submission is done in-process via a service
+//! clone (standing in for an external submitter); everything the *worker* does —
+//! register / lease / report-commit — rides the gRPC client. The service is the
+//! sole journal writer (D40): the worker only proposes.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_coordinator::proto::coordinator_server::{Coordinator, CoordinatorServer};
+use kx_coordinator::{CoordinatorService, MoteState, WorkerId};
+use kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor};
+use kx_journal::InMemoryJournal;
+use kx_worker::{Worker, WorkerClient};
+use tonic::transport::Server;
+use tonic::Request;
+
+/// Submit a Mote + warrant in-process (test setup — an external submitter would
+/// use the SubmitMote RPC).
+async fn submit(svc: &CoordinatorService, mote: &kx_mote::Mote, warrant: &kx_warrant::WarrantSpec) {
+    svc.submit_mote(Request::new(kx_coordinator::proto::SubmitMoteRequest {
+        mote: Some(mote.clone().into()),
+        warrant: Some(warrant.clone().into()),
+    }))
+    .await
+    .unwrap();
+}
+
+async fn connect_worker(endpoint: String) -> Worker {
+    // Brief retry while the in-process server binds (the kx-proto pattern).
+    let mut client = None;
+    for _ in 0..100 {
+        match WorkerClient::connect(endpoint.clone()).await {
+            Ok(c) => {
+                client = Some(c);
+                break;
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+        }
+    }
+    let client = client.expect("worker connects to the coordinator");
+    let executor: Arc<dyn MoteExecutor> = Arc::new(TestMoteExecutor::deterministic());
+    Worker::register(
+        client,
+        common::WORKER_CLASS,
+        "inproc://worker-1",
+        executor,
+        LocalResourceManager::dev_defaults(),
+        16,
+    )
+    .await
+    .expect("worker registers")
+}
+
+#[tokio::test]
+async fn worker_registers_pulls_runs_and_proposes_a_dag() {
+    // One service, two clones sharing the same orchestration core: one hosts the
+    // gRPC server, one stays here for submission + read-side assertions.
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let server_svc = svc.clone();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(CoordinatorServer::new(server_svc))
+            .serve(addr)
+            .await
+            .unwrap();
+    });
+
+    // A 2-Mote PURE DAG: root -> child.
+    let root = common::pure_mote(1, &[]);
+    let child = common::pure_mote(2, &[root.id]);
+    let warrant = common::pure_warrant();
+    submit(&svc, &root, &warrant).await;
+    submit(&svc, &child, &warrant).await;
+
+    let mut worker = connect_worker(format!("http://{addr}")).await;
+
+    // Round 1: only the root is ready; the worker leases, runs, and proposes it.
+    let n = worker.run_once().await.unwrap();
+    assert_eq!(n, 1, "the root is committed this round");
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+    assert_eq!(svc.state_of(root.id).await.unwrap(), MoteState::Committed);
+
+    // Round 2: the committed root unblocks the child.
+    let n = worker.run_once().await.unwrap();
+    assert_eq!(n, 1, "the child is committed once its parent is");
+    assert_eq!(svc.committed_count().await.unwrap(), 2);
+    assert_eq!(svc.state_of(child.id).await.unwrap(), MoteState::Committed);
+
+    // Round 3: nothing ready remains.
+    assert_eq!(worker.run_once().await.unwrap(), 0, "the DAG is drained");
+
+    // Heartbeat advances the registry liveness clock (0 at registration).
+    assert!(
+        worker.heartbeat(0).await.unwrap(),
+        "coordinator acks heartbeat"
+    );
+    let record = svc
+        .registry()
+        .get(WorkerId(worker.worker_id()))
+        .expect("worker is registered");
+    assert!(
+        record.last_heartbeat_ms > 0,
+        "heartbeat recorded a wall-clock timestamp"
+    );
+}

--- a/crates/kx-worker/tests/thesis_verbatim.rs
+++ b/crates/kx-worker/tests/thesis_verbatim.rs
@@ -1,0 +1,106 @@
+//! Thesis-test witness (compile-level): `kx-worker` hosts the real `kx-executor`
+//! (and, transitively, `kx-inference`) types verbatim — it runs Motes through the
+//! exact `run_pure_mote` entry point + `MoteExecutor` / `ResourceManager` seams the
+//! single-node `kx-runtime` uses, adding only the propose-don't-write glue.
+//!
+//! The *authoritative* proof that `kx-scheduler` / `kx-executor` / `kx-inference`
+//! source is unchanged is the PR diff (`git diff <merge-base> -- crates/kx-scheduler
+//! crates/kx-executor crates/kx-inference` is empty) — this test just pins the
+//! dependency direction so the hosting cannot silently drift.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_executor::{
+    run_pure_mote, LocalResourceManager, MoteExecutor, ResourceManager, TestMoteExecutor,
+};
+use kx_journal::InMemoryJournal;
+use kx_mote::{GraphPosition, InputDataId, Mote, MoteDef, NdClass};
+
+#[test]
+fn worker_runs_motes_through_the_real_executor_entry_point() {
+    // The exact stack the worker hosts: a throwaway journal, a real
+    // ResourceManager, and a MoteExecutor — driven by run_pure_mote verbatim.
+    let executor = TestMoteExecutor::deterministic();
+    let rm = LocalResourceManager::dev_defaults();
+    let scratch = InMemoryJournal::new();
+
+    let def = MoteDef {
+        nd_class: NdClass::Pure,
+        ..sample_pure_def()
+    };
+    let mote = Mote::new(
+        def,
+        InputDataId::from_bytes([1u8; 32]),
+        GraphPosition(vec![0]),
+        smallvec_empty(),
+    );
+    let warrant = sample_warrant();
+
+    // Hosted verbatim: this is the single-node executor entry point, called from a
+    // worker that will PROPOSE the result rather than treat the journal as durable.
+    let commit = run_pure_mote(&mote, &warrant, &scratch, &rm, &executor).expect("pure run");
+    assert_eq!(commit.mote_id, mote.id);
+    // And `MoteExecutor` / `ResourceManager` are consumed as the real traits.
+    assert!(MoteExecutor::supports(&executor, warrant.executor_class));
+    let slot = ResourceManager::acquire(&rm, &warrant.resource_ceiling).unwrap();
+    ResourceManager::release(&rm, slot).unwrap();
+}
+
+// --- minimal fixtures (kept local so the witness has no cross-test deps) -------
+
+fn smallvec_empty() -> smallvec::SmallVec<[kx_mote::ParentRef; 4]> {
+    smallvec::SmallVec::new()
+}
+
+fn sample_pure_def() -> MoteDef {
+    use kx_mote::{
+        EffectPattern, InferenceParams, LogicRef, ModelId, PromptTemplateHash,
+        MOTE_DEF_SCHEMA_VERSION,
+    };
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract: std::collections::BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: std::collections::BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+fn sample_warrant() -> kx_warrant::WarrantSpec {
+    use kx_content::ContentRef;
+    use kx_warrant::{
+        ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: kx_mote::ModelId("m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}


### PR DESCRIPTION
## Summary

Second of two PRs for **P2.3**. Adds the **`kx-worker`** crate — a gRPC client of the coordinator that completes the distributed execution loop. **Stacked on #67** (the `LeaseWork` seam); review/merge #67 first.

- **`kx-worker`**: registers with the coordinator, **pulls** ready PURE Motes via `LeaseWork`, runs each through the **hosted P1 executor** (`run_pure_mote`, verbatim), and **proposes** the result via `ReportCommit`. The coordinator stays the sole journal writer (D40) — the worker only proposes.
- **Propose-don't-write, by construction**:
  - `run.rs` hands the executor a **throwaway `InMemoryJournal`** so its commit protocol has a journal to append to without ever touching the coordinator's durable log; only `result_ref` crosses back.
  - `commit_builder.rs` **re-derives** every `ReportCommit` field from the held Mote+warrant (the canonical construction the coordinator also uses) — *not* read back from the throwaway journal, which records `parents=empty` / `nd_class=Pure` and would corrupt the coordinator's DAG fold. `idempotency_key == mote_id`.
- Modules: `client` (typed `CoordinatorClient` wrapper), `worker` (`register` / `run_once` / `heartbeat`), `run`, `commit_builder`, `error`. Thin `lib.rs`.

### Design notes
- **PURE-only scope**: sound to run-then-propose (no real-world effect). WM needs a durable staged-intent RPC — deferred.
- **Inference hosted transitively** through kx-executor (no direct/unused dep), matching how `kx-runtime` wires it.

### Thesis test
`git diff main -- crates/kx-executor crates/kx-inference crates/kx-scheduler` is **empty**. `tests/thesis_verbatim.rs` pins that the worker drives the real `run_pure_mote` + `MoteExecutor`/`ResourceManager` seams.

### Exit gate (P2.3 DoD)
`tests/e2e.rs`: a worker **registers → leases the ready root → runs → proposes** over real gRPC (in-process `CoordinatorService` on loopback); the committed root **unblocks the child**, leased + committed next round (`committed_count == 2`); heartbeat advances the registry clock.

## Test plan
- [x] `cargo test -p kx-worker` (e2e register→pull→run→propose DAG; verbatim witness)
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`, `cargo deny check`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] thesis diff empty for the three frozen crates
- [ ] `ffi-link` + `check-reproducible` (I1.c) — run by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)