### PR TITLE
P2.4 (1/2): ReadEntries — distributed journal-read seam

### DIFF
--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use kx_journal::Journal;
+use kx_journal::{Journal, JournalEntry};
 use kx_mote::{Mote, MoteId};
 use kx_projection::MoteState;
 use kx_proto::proto;
@@ -193,5 +193,70 @@ impl Coordinator for CoordinatorService {
             })
             .collect();
         Ok(Response::new(proto::LeaseWorkResponse { items }))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn read_entries(
+        &self,
+        request: Request<proto::ReadEntriesRequest>,
+    ) -> Result<Response<proto::ReadEntriesResponse>, Status> {
+        let req = request.into_inner();
+        // Cap the page so one poll cannot ask for an unbounded response; `0` means
+        // "coordinator default". The journal-read itself is bounded by current_seq.
+        let max = match usize::try_from(req.max).unwrap_or(READ_ENTRIES_MAX) {
+            0 => READ_ENTRIES_DEFAULT,
+            n => n.min(READ_ENTRIES_MAX),
+        };
+        let (entries, next_seq) = self.core.read_entries(req.since_seq, max).await?;
+        let entries = entries.into_iter().filter_map(committed_to_proto).collect();
+        Ok(Response::new(proto::ReadEntriesResponse {
+            entries,
+            next_seq,
+        }))
+    }
+}
+
+/// Default page size when a client passes `max = 0`.
+const READ_ENTRIES_DEFAULT: usize = 256;
+/// Hard ceiling on a single `ReadEntries` page (bounds response size).
+const READ_ENTRIES_MAX: usize = 4096;
+
+/// Map a `Committed` journal entry to its wire form. Returns `None` for any other
+/// entry kind (the core already filters to `Committed`, so this is just an
+/// exhaustiveness guard) — the wire `JournalEntry.oneof` carries only `Committed`
+/// in P2.4 (D55; other kinds are reserved for P3).
+fn committed_to_proto(entry: JournalEntry) -> Option<proto::JournalEntry> {
+    match entry {
+        JournalEntry::Committed {
+            mote_id,
+            idempotency_key,
+            seq,
+            nondeterminism,
+            result_ref,
+            parents,
+            warrant_ref,
+            mote_def_hash,
+        } => {
+            let parents = parents
+                .into_iter()
+                .filter_map(|p| p.to_parent_ref().map(proto::ParentRef::from))
+                .collect();
+            Some(proto::JournalEntry {
+                seq,
+                kind: Some(proto::journal_entry::Kind::Committed(
+                    proto::CommittedEntry {
+                        mote_id: mote_id.as_bytes().to_vec(),
+                        idempotency_key: idempotency_key.to_vec(),
+                        seq,
+                        nd_class: proto::NdClass::from(nondeterminism) as i32,
+                        result_ref: result_ref.as_bytes().to_vec(),
+                        parents,
+                        warrant_ref: warrant_ref.as_bytes().to_vec(),
+                        mote_def_hash: mote_def_hash.as_bytes().to_vec(),
+                    },
+                )),
+            })
+        }
+        _ => None,
     }
 }

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -80,6 +80,11 @@ pub(crate) enum Command {
         max: usize,
         reply: oneshot::Sender<Vec<(Mote, WarrantSpec)>>,
     },
+    ReadEntries {
+        since_seq: u64,
+        max: usize,
+        reply: oneshot::Sender<Result<(Vec<JournalEntry>, u64), CoordinatorError>>,
+    },
 }
 
 /// Handle to the orchestration core. Cloneable + `Send + Sync` (it is just the
@@ -174,6 +179,27 @@ impl CoreHandle {
             .map_err(|_| CoordinatorError::CoreUnavailable)
     }
 
+    /// Read up to `max` committed journal entries with seq `> since_seq`, plus the
+    /// cursor (`next_seq`) to pass on the next poll. The distributed-read surface
+    /// (D55): peers pull committed-entry deltas and fold a local read model rather
+    /// than round-tripping per result.
+    pub(crate) async fn read_entries(
+        &self,
+        since_seq: u64,
+        max: usize,
+    ) -> Result<(Vec<JournalEntry>, u64), CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::ReadEntries {
+            since_seq,
+            max,
+            reply,
+        })
+        .await?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)?
+    }
+
     async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
         self.commands
             .send(command)
@@ -233,6 +259,38 @@ fn lease_ready(
         }
     }
     items
+}
+
+/// Read up to `max` `Committed` entries with seq in `(since_seq, current_seq]`, in
+/// seq order, plus the cursor to resume from. The cursor (`next_seq`) advances past
+/// everything scanned: it is `current_seq` when the whole range was scanned (the peer
+/// is caught up), or the last collected entry's seq when the `max` cap was hit (so the
+/// next poll resumes right after it — no entry is skipped or re-scanned). Non-committed
+/// entries (e.g. `Proposed`) are skipped but still advance the scan, so a peer that only
+/// wants committed results never re-reads them. The whole journal below `current_seq` is
+/// immutable + append-only, so this read is consistent without locking the writer.
+fn read_committed_since<J: Journal>(
+    journal: &J,
+    since_seq: u64,
+    max: usize,
+) -> Result<(Vec<JournalEntry>, u64), CoordinatorError> {
+    let current = journal.current_seq()?;
+    if since_seq >= current || max == 0 {
+        return Ok((Vec::new(), current));
+    }
+    let mut entries = Vec::new();
+    let mut next_seq = current;
+    for entry in journal.read_entries_by_seq((since_seq + 1)..(current + 1))? {
+        if matches!(entry, JournalEntry::Committed { .. }) {
+            if entries.len() == max {
+                // Cap hit: stop one short and resume after the last collected entry.
+                next_seq = entries.last().map_or(since_seq, JournalEntry::seq);
+                break;
+            }
+            entries.push(entry);
+        }
+    }
+    Ok((entries, next_seq))
 }
 
 /// The owner-thread loop. Recovers the projection from the journal, then services
@@ -322,6 +380,13 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
                 } => {
                     let items = lease_ready(&projection, &submitted_defs, executor_class, max);
                     let _ = reply.send(items);
+                }
+                Command::ReadEntries {
+                    since_seq,
+                    max,
+                    reply,
+                } => {
+                    let _ = reply.send(read_committed_since(journal, since_seq, max));
                 }
             }
         }

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -240,3 +240,26 @@ pub async fn lease_work(
         .into_inner()
         .items
 }
+
+/// Read committed journal entries after `since_seq` through the service.
+pub async fn read_entries(
+    service: &CoordinatorService,
+    since_seq: u64,
+    max: u32,
+) -> proto::ReadEntriesResponse {
+    service
+        .read_entries(Request::new(proto::ReadEntriesRequest { since_seq, max }))
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+/// The `mote_id` + `result_ref` of a committed entry (test convenience).
+#[must_use]
+pub fn committed_view(entry: &proto::JournalEntry) -> (Vec<u8>, Vec<u8>, u64) {
+    match entry.kind.as_ref().unwrap() {
+        proto::journal_entry::Kind::Committed(c) => {
+            (c.mote_id.clone(), c.result_ref.clone(), c.seq)
+        }
+    }
+}

--- a/crates/kx-coordinator/tests/read_entries.rs
+++ b/crates/kx-coordinator/tests/read_entries.rs
@@ -1,0 +1,129 @@
+//! `ReadEntries` serving (P2.4 distributed journal access, D55): a peer pulls
+//! committed-entry deltas from a cursor and folds a local read model, so reads
+//! scale off the coordinator's hot path while the journal stays single-writer.
+//!
+//! Contract exercised here:
+//! - committed entries are returned in seq order, carrying the `result_ref`;
+//! - `since_seq` is a cursor — a second poll returns only the delta;
+//! - `next_seq` advances to `current_seq` once caught up;
+//! - `max` caps a page and `next_seq` resumes right after the last returned entry;
+//! - reads observe commits proposed before them (owner-thread flush ordering).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_coordinator::CoordinatorService;
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+
+fn coordinator() -> CoordinatorService {
+    CoordinatorService::new(InMemoryJournal::new())
+}
+
+#[tokio::test]
+async fn reads_committed_entries_in_seq_order_with_result_ref() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    common::submit(&svc, &a, &warrant).await;
+    common::submit(&svc, &b, &warrant).await;
+    common::commit(&svc, &a, worker).await;
+    common::commit(&svc, &b, worker).await;
+
+    let resp = common::read_entries(&svc, 0, 16).await;
+    assert_eq!(resp.entries.len(), 2, "both committed entries returned");
+
+    let (id0, ref0, seq0) = common::committed_view(&resp.entries[0]);
+    let (id1, _ref1, seq1) = common::committed_view(&resp.entries[1]);
+    assert!(seq0 < seq1, "entries are in ascending seq order");
+    assert_eq!(id0, a.id.as_bytes().to_vec(), "first committed is the root");
+    assert_eq!(id1, b.id.as_bytes().to_vec());
+    assert_eq!(ref0.len(), 32, "result_ref rides the wire");
+    assert_eq!(
+        resp.next_seq, seq1,
+        "cursor caught up to the last committed seq"
+    );
+
+    // A second poll from the cursor returns no new work.
+    let delta = common::read_entries(&svc, resp.next_seq, 16).await;
+    assert!(delta.entries.is_empty(), "nothing new after the cursor");
+}
+
+#[tokio::test]
+async fn since_seq_returns_only_the_delta() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    common::submit(&svc, &a, &warrant).await;
+    common::commit(&svc, &a, worker).await;
+
+    let first = common::read_entries(&svc, 0, 16).await;
+    assert_eq!(first.entries.len(), 1);
+
+    // Commit a second Mote, then poll from the prior cursor: only the new one.
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    common::submit(&svc, &b, &warrant).await;
+    common::commit(&svc, &b, worker).await;
+
+    let delta = common::read_entries(&svc, first.next_seq, 16).await;
+    assert_eq!(
+        delta.entries.len(),
+        1,
+        "only the entry committed after the cursor"
+    );
+    let (id, _, _) = common::committed_view(&delta.entries[0]);
+    assert_eq!(id, b.id.as_bytes().to_vec());
+}
+
+#[tokio::test]
+async fn max_caps_the_page_and_cursor_resumes() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // Three independent ready PURE roots, all committed.
+    let motes: Vec<_> = (1u8..=3)
+        .map(|s| common::mote(s, NdClass::Pure, &[]))
+        .collect();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+    for m in &motes {
+        common::commit(&svc, m, worker).await;
+    }
+
+    // Page of 2, then the cursor yields the remaining 1.
+    let page1 = common::read_entries(&svc, 0, 2).await;
+    assert_eq!(page1.entries.len(), 2, "first page capped at max");
+    let page2 = common::read_entries(&svc, page1.next_seq, 2).await;
+    assert_eq!(page2.entries.len(), 1, "remaining entry on the next page");
+
+    // Pages do not overlap and cover all three.
+    let mut ids: Vec<Vec<u8>> = page1
+        .entries
+        .iter()
+        .chain(&page2.entries)
+        .map(|e| common::committed_view(e).0)
+        .collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        3,
+        "the two pages cover all three commits, no overlap"
+    );
+}
+
+#[tokio::test]
+async fn empty_journal_reads_empty() {
+    let svc = coordinator();
+    let resp = common::read_entries(&svc, 0, 16).await;
+    assert!(resp.entries.is_empty());
+    assert_eq!(resp.next_seq, 0);
+}

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -297,6 +297,50 @@ message LeaseWorkResponse {
 }
 
 // ---------------------------------------------------------------------------
+// RPC (6) — read committed journal entries (distributed journal access, D55).
+// A peer PULLS committed-entry deltas from `since_seq` and folds a LOCAL read
+// model, instead of round-tripping the coordinator per result — the journal
+// stays single-writer-coordinator (D13), but READS scale horizontally (cursor
+// paging + lock-free; the coordinator is off the hot read path). Bytes are NOT
+// returned here: a committed entry carries the 32-byte `result_ref`, and the
+// payload is read from the shared content-addressed store (D17).
+// ---------------------------------------------------------------------------
+
+message ReadEntriesRequest {
+  uint64 since_seq = 1;                 // return committed entries with seq > since_seq (0 = from the start)
+  uint32 max = 2;                       // upper bound on entries returned this call (0 = coordinator default)
+}
+
+// Mirrors kx_journal::JournalEntry::Committed (field-for-field; the identity
+// substrate stays Rust-side per D53 — refs are bytes, never re-hashed here).
+message CommittedEntry {
+  bytes mote_id = 1;                    // 32B
+  bytes idempotency_key = 2;            // 32B
+  uint64 seq = 3;                       // coordinator-assigned journal seq
+  NdClass nd_class = 4;
+  bytes result_ref = 5;                 // 32B — the payload's address in the shared store
+  repeated ParentRef parents = 6;
+  bytes warrant_ref = 7;                // 32B
+  bytes mote_def_hash = 8;              // 32B
+}
+
+// One journal entry on the wire. EXTENSIBLE: P2.4 carries only `Committed`;
+// `proposed` / `effect_staged` / `repudiated` / `failed` slot into the oneof
+// (fields 3+) in P3 without a wire break, when peers need the full log to fold
+// a faithful projection (e.g. for fault tolerance / coordinator failover).
+message JournalEntry {
+  uint64 seq = 1;
+  oneof kind {
+    CommittedEntry committed = 2;
+  }
+}
+
+message ReadEntriesResponse {
+  repeated JournalEntry entries = 1;    // committed entries with seq in (since_seq, next_seq], in seq order
+  uint64 next_seq = 2;                  // cursor: pass as `since_seq` on the next poll
+}
+
+// ---------------------------------------------------------------------------
 // Service — hosted by the coordinator; workers are clients.
 // ---------------------------------------------------------------------------
 
@@ -306,4 +350,5 @@ service Coordinator {
   rpc SubmitMote(SubmitMoteRequest) returns (SubmitMoteResponse);
   rpc ReportCommit(ReportCommitRequest) returns (ReportCommitResponse);
   rpc LeaseWork(LeaseWorkRequest) returns (LeaseWorkResponse);
+  rpc ReadEntries(ReadEntriesRequest) returns (ReadEntriesResponse);
 }

--- a/crates/kx-proto/tests/dod.rs
+++ b/crates/kx-proto/tests/dod.rs
@@ -123,6 +123,49 @@ fn obligation_1_lease_work_response_empty_round_trips() {
     roundtrip(&proto::LeaseWorkResponse { items: vec![] });
 }
 
+#[test]
+fn obligation_1_read_entries_request_round_trips() {
+    roundtrip(&proto::ReadEntriesRequest {
+        since_seq: 42,
+        max: 256,
+    });
+}
+
+#[test]
+fn obligation_1_read_entries_response_round_trips() {
+    let resp = proto::ReadEntriesResponse {
+        entries: vec![proto::JournalEntry {
+            seq: 7,
+            kind: Some(proto::journal_entry::Kind::Committed(
+                proto::CommittedEntry {
+                    mote_id: vec![1; 32],
+                    idempotency_key: vec![1; 32],
+                    seq: 7,
+                    nd_class: proto::NdClass::Pure as i32,
+                    result_ref: vec![2; 32],
+                    parents: vec![proto::ParentRef {
+                        parent_id: vec![6; 32],
+                        edge_kind: proto::EdgeKind::Data as i32,
+                        non_cascade: false,
+                    }],
+                    warrant_ref: vec![4; 32],
+                    mote_def_hash: vec![5; 32],
+                },
+            )),
+        }],
+        next_seq: 7,
+    };
+    roundtrip(&resp);
+}
+
+#[test]
+fn obligation_1_read_entries_response_empty_round_trips() {
+    roundtrip(&proto::ReadEntriesResponse {
+        entries: vec![],
+        next_seq: 0,
+    });
+}
+
 // --- Obligation 2: same-instance encode determinism ------------------------
 
 #[test]

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -14,9 +14,11 @@ use common::{sample_mote, sample_warrant};
 use kx_proto::proto::coordinator_client::CoordinatorClient;
 use kx_proto::proto::coordinator_server::{Coordinator, CoordinatorServer};
 use kx_proto::proto::{
-    CommitOutcome, ExecutorClass, HeartbeatRequest, HeartbeatResponse, LeaseWorkRequest,
-    LeaseWorkResponse, RegisterWorkerRequest, RegisterWorkerResponse, ReportCommitRequest,
-    ReportCommitResponse, SubmitMoteRequest, SubmitMoteResponse, SubmitStatus, WorkItem,
+    journal_entry, CommitOutcome, CommittedEntry, ExecutorClass, HeartbeatRequest,
+    HeartbeatResponse, JournalEntry, LeaseWorkRequest, LeaseWorkResponse, NdClass,
+    ReadEntriesRequest, ReadEntriesResponse, RegisterWorkerRequest, RegisterWorkerResponse,
+    ReportCommitRequest, ReportCommitResponse, SubmitMoteRequest, SubmitMoteResponse, SubmitStatus,
+    WorkItem,
 };
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
@@ -78,6 +80,31 @@ impl Coordinator for NoopCoordinator {
                 mote: Some(sample_mote().into()),
                 warrant: Some(sample_warrant().into()),
             }],
+        }))
+    }
+
+    async fn read_entries(
+        &self,
+        req: Request<ReadEntriesRequest>,
+    ) -> Result<Response<ReadEntriesResponse>, Status> {
+        // Echo one committed entry back so the test confirms it rides the new
+        // RPC. (Real serving from the journal is coordinator-side in P2.4.)
+        let _ = req.into_inner();
+        Ok(Response::new(ReadEntriesResponse {
+            entries: vec![JournalEntry {
+                seq: 1,
+                kind: Some(journal_entry::Kind::Committed(CommittedEntry {
+                    mote_id: vec![1; 32],
+                    idempotency_key: vec![1; 32],
+                    seq: 1,
+                    nd_class: NdClass::Pure as i32,
+                    result_ref: vec![2; 32],
+                    parents: vec![],
+                    warrant_ref: vec![4; 32],
+                    mote_def_hash: vec![5; 32],
+                })),
+            }],
+            next_seq: 1,
         }))
     }
 }
@@ -186,4 +213,21 @@ async fn coordinator_skeleton_serves_all_rpcs() {
         "leased mote_id round-tripped over the wire"
     );
     assert!(item.warrant.is_some(), "leased warrant present");
+
+    // (6) read entries — a committed entry rides back over the new RPC.
+    let read = client
+        .read_entries(ReadEntriesRequest {
+            since_seq: 0,
+            max: 16,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(read.entries.len(), 1, "one committed entry read");
+    assert_eq!(read.next_seq, 1);
+    match read.entries[0].kind.as_ref().unwrap() {
+        journal_entry::Kind::Committed(c) => {
+            assert_eq!(c.result_ref.len(), 32, "committed result_ref round-tripped");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

First of two PRs for **P2.4 (distributed journal access)**. Adds the read seam a peer needs to discover committed results, and wires the coordinator's serving side.

- **kx-proto**: new 6th `Coordinator` RPC `ReadEntries(since_seq, max) -> {repeated JournalEntry, next_seq}`. A peer pulls committed-entry **deltas** from a cursor and folds a **local read model**, rather than round-tripping the coordinator per result. `CommittedEntry` mirrors `JournalEntry::Committed` field-for-field; `JournalEntry` is an **extensible `oneof`** carrying only `Committed` now (proposed/effect_staged/repudiated/failed reserved for P3's full-log fold — no wire break).
- **kx-coordinator** (serving folded in per the #64/LeaseWork precedent): `read_committed_since` reads `Committed` entries in `(since_seq, current_seq]`, caps at `max`, and returns a `next_seq` cursor that advances past everything scanned (no skip, no re-scan). `Command::ReadEntries` + `CoreHandle` accessor + the `read_entries` handler.

### Design notes (scalability)
- **Journal stays single-writer-coordinator (D13)**; reads scale off the hot path — the journal below `current_seq` is immutable/append-only, so the read needs no writer lock, and cursor paging keeps responses bounded + incremental.
- **Bytes are not served here** — a committed entry carries the 32-byte `result_ref`; the payload is read from the shared content-addressed store (D17), wired in PR 2.
- **No worker-admission on the read path** — committed facts are readable by any node in the run.

### Thesis test
`git diff main -- crates/kx-executor crates/kx-inference crates/kx-scheduler` is **empty**.

PR 2 adds: a shared `ContentStore` on the worker + coordinator, a storing executor (real bytes), coordinator-side `store.contains(result_ref)` verification, and the cross-node e2e (worker A's committed result read by the coordinator AND a peer worker B).

## Test plan
- [x] `cargo test -p kx-proto -p kx-coordinator` (round-trips; read_entries seq-order/cursor/paging/empty)
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [x] thesis diff empty for the three frozen crates
- [ ] `ffi-link` + `check-reproducible` (I1.c) + Linux CI — run by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)