### PR TITLE
P2.4 (2/2): shared content store + cross-node result reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "kx-proto",
  "kx-warrant",
  "smallvec",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/crates/kx-coordinator/src/error.rs
+++ b/crates/kx-coordinator/src/error.rs
@@ -45,6 +45,13 @@ pub enum CoordinatorError {
     #[error("unknown mote {0:?} (never submitted)")]
     UnknownMote(MoteId),
 
+    /// A `ReportCommit` proposed a `result_ref` whose bytes are not present in the
+    /// shared content store (D55 phantom-ref guard). When the coordinator is built
+    /// with a store handle, it verifies `store.contains(result_ref)` before
+    /// committing, so a worker cannot record a result it never published.
+    #[error("result_ref for mote {0:?} is absent from the content store")]
+    ResultRefAbsent(MoteId),
+
     /// A `ReportCommit` declared more parents than the journal encodes. Validated
     /// up front so a malformed proposal cannot poison a group-commit batch.
     #[error("commit declares {got} parents, exceeds the maximum {max}")]
@@ -96,6 +103,7 @@ impl From<CoordinatorError> for tonic::Status {
             | CoordinatorError::Convert(_)
             | CoordinatorError::UnknownWorker(_)
             | CoordinatorError::UnknownMote(_)
+            | CoordinatorError::ResultRefAbsent(_)
             | CoordinatorError::TooManyParents { .. }
             | CoordinatorError::DataEdgeNonCascade
             | CoordinatorError::Scheduler(_) => Self::invalid_argument(message),

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use kx_content::LocalFsContentStore;
 use kx_journal::{Journal, JournalEntry};
 use kx_mote::{Mote, MoteId};
 use kx_projection::MoteState;
@@ -33,7 +34,7 @@ impl CoordinatorService {
     /// Build a coordinator over `journal` with the default in-memory worker
     /// registry. Takes sole ownership of the journal (the single-writer handle).
     pub fn new<J: Journal + Send + 'static>(journal: J) -> Self {
-        Self::with_registry(journal, Arc::new(InMemoryWorkerRegistry::new()))
+        Self::build(journal, Arc::new(InMemoryWorkerRegistry::new()), None)
     }
 
     /// Build a coordinator over `journal` with a caller-supplied worker registry.
@@ -41,8 +42,31 @@ impl CoordinatorService {
         journal: J,
         registry: Arc<dyn WorkerRegistry>,
     ) -> Self {
+        Self::build(journal, registry, None)
+    }
+
+    /// Build a coordinator that shares the content data plane with its workers:
+    /// it **verifies each committed `result_ref` against `store`** before recording
+    /// the commit (D55 phantom-ref guard — a worker cannot record a result it never
+    /// published), and the same content-addressed store is where peers read results.
+    pub fn with_store<J: Journal + Send + 'static>(
+        journal: J,
+        store: Arc<LocalFsContentStore>,
+    ) -> Self {
+        Self::build(
+            journal,
+            Arc::new(InMemoryWorkerRegistry::new()),
+            Some(store),
+        )
+    }
+
+    fn build<J: Journal + Send + 'static>(
+        journal: J,
+        registry: Arc<dyn WorkerRegistry>,
+        store: Option<Arc<LocalFsContentStore>>,
+    ) -> Self {
         Self {
-            core: CoreHandle::spawn(journal),
+            core: CoreHandle::spawn(journal, store),
             registry,
         }
     }

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -17,7 +17,9 @@
 //! single-node `kx-runtime` engine does — the scheduler source is unchanged.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
+use kx_content::{ContentStore, LocalFsContentStore};
 use kx_journal::{Journal, JournalEntry};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
@@ -95,10 +97,16 @@ pub(crate) struct CoreHandle {
 }
 
 impl CoreHandle {
-    /// Spawn the owner thread, taking sole ownership of `journal`.
-    pub(crate) fn spawn<J: Journal + Send + 'static>(journal: J) -> Self {
+    /// Spawn the owner thread, taking sole ownership of `journal`. When `store` is
+    /// `Some`, the core verifies `store.contains(result_ref)` before committing a
+    /// proposal (D55 phantom-ref guard); when `None`, commits are not content-checked
+    /// (the P2.2/P2.3 behavior).
+    pub(crate) fn spawn<J: Journal + Send + 'static>(
+        journal: J,
+        store: Option<Arc<LocalFsContentStore>>,
+    ) -> Self {
         let (commands, inbox) = mpsc::channel(COMMAND_BUFFER);
-        std::thread::spawn(move || core_loop(&journal, inbox));
+        std::thread::spawn(move || core_loop(&journal, store.as_deref(), inbox));
         Self { commands }
     }
 
@@ -295,7 +303,11 @@ fn read_committed_since<J: Journal>(
 
 /// The owner-thread loop. Recovers the projection from the journal, then services
 /// commands until every sender drops (the channel closes on coordinator shutdown).
-fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
+fn core_loop<J: Journal>(
+    journal: &J,
+    store: Option<&LocalFsContentStore>,
+    mut inbox: mpsc::Receiver<Command>,
+) {
     let Some((mut projection, mut folded_through, mut submitted)) = recover(journal) else {
         return;
     };
@@ -337,6 +349,7 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
             };
             flush_commits(
                 journal,
+                store,
                 &mut projection,
                 &mut folded_through,
                 &submitted,
@@ -392,6 +405,7 @@ fn core_loop<J: Journal>(journal: &J, mut inbox: mpsc::Receiver<Command>) {
         }
         flush_commits(
             journal,
+            store,
             &mut projection,
             &mut folded_through,
             &submitted,
@@ -424,9 +438,13 @@ fn committed_entry(proposal: CommitProposal) -> JournalEntry {
 /// Flush a run of queued commits as ONE group commit
 /// ([`Journal::append_batch`](kx_journal::Journal::append_batch) — a single journal
 /// transaction), then fold the new range once. Never-submitted Motes are rejected
-/// individually with no write; the admitted ones are appended atomically.
+/// individually with no write; the admitted ones are appended atomically. When
+/// `store` is `Some`, each proposal's `result_ref` must be present in the content
+/// store (D55 phantom-ref guard) — an absent ref is rejected individually, never
+/// blocking its batch-mates.
 fn flush_commits<J: Journal>(
     journal: &J,
+    store: Option<&LocalFsContentStore>,
     projection: &mut Projection,
     folded_through: &mut u64,
     submitted: &BTreeSet<MoteId>,
@@ -438,19 +456,22 @@ fn flush_commits<J: Journal>(
     }
     let batch = std::mem::take(pending);
 
-    // Admission guard per proposal: reject never-submitted Motes (no write) so one
+    // Per-proposal admission: reject never-submitted Motes and (when a store is
+    // configured) results whose bytes were never published — neither writes, so one
     // inadmissible commit never blocks its valid batch-mates.
     let mut entries: Vec<JournalEntry> = Vec::with_capacity(batch.len());
     let mut replies: Vec<oneshot::Sender<Result<CommitApplied, CoordinatorError>>> =
         Vec::with_capacity(batch.len());
     let mut committed_ids: Vec<MoteId> = Vec::with_capacity(batch.len());
     for (proposal, reply) in batch {
-        if submitted.contains(&proposal.mote_id) {
+        if !submitted.contains(&proposal.mote_id) {
+            let _ = reply.send(Err(CoordinatorError::UnknownMote(proposal.mote_id)));
+        } else if store.is_some_and(|s| !s.contains(&proposal.result_ref)) {
+            let _ = reply.send(Err(CoordinatorError::ResultRefAbsent(proposal.mote_id)));
+        } else {
             committed_ids.push(proposal.mote_id);
             entries.push(committed_entry(proposal));
             replies.push(reply);
-        } else {
-            let _ = reply.send(Err(CoordinatorError::UnknownMote(proposal.mote_id)));
         }
     }
     if entries.is_empty() {

--- a/crates/kx-worker/Cargo.toml
+++ b/crates/kx-worker/Cargo.toml
@@ -37,6 +37,9 @@ kx-coordinator = { workspace = true }
 # connect-retry sleep while the in-process server binds (the kx-proto pattern).
 tokio = { workspace = true, features = ["time"] }
 smallvec = { workspace = true }
+# Shared on-disk content_root for the cross-node read e2e (worker A writes, the
+# coordinator verifies, peer B reads — all against one LocalFsContentStore root).
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kx-worker/src/client.rs
+++ b/crates/kx-worker/src/client.rs
@@ -97,4 +97,19 @@ impl WorkerClient {
     ) -> Result<proto::ReportCommitResponse, WorkerError> {
         Ok(self.inner.report_commit(request).await?.into_inner())
     }
+
+    /// Read up to `max` committed journal entries after `since_seq`. Returns the
+    /// entries + the `next_seq` cursor to resume from (D55 distributed-read).
+    pub async fn read_entries(
+        &mut self,
+        since_seq: u64,
+        max: u32,
+    ) -> Result<(Vec<proto::JournalEntry>, u64), WorkerError> {
+        let resp = self
+            .inner
+            .read_entries(proto::ReadEntriesRequest { since_seq, max })
+            .await?
+            .into_inner();
+        Ok((resp.entries, resp.next_seq))
+    }
 }

--- a/crates/kx-worker/src/error.rs
+++ b/crates/kx-worker/src/error.rs
@@ -34,6 +34,14 @@ pub enum WorkerError {
     /// The coordinator accepted the request but rejected the commit proposal.
     #[error("coordinator rejected the commit: {0}")]
     CommitRejected(String),
+
+    /// A peer read asked for a Mote that is not committed in the coordinator's log.
+    #[error("mote {0:?} is not committed")]
+    NotCommitted(kx_mote::MoteId),
+
+    /// A committed result's bytes are absent from the shared content store.
+    #[error("content {0:?} is missing from the shared store")]
+    ContentMissing(kx_content::ContentRef),
 }
 
 impl From<tonic::transport::Error> for WorkerError {

--- a/crates/kx-worker/src/lib.rs
+++ b/crates/kx-worker/src/lib.rs
@@ -55,6 +55,7 @@ pub use kx_proto::proto;
 mod client;
 mod commit_builder;
 mod error;
+mod read_model;
 mod run;
 mod worker;
 

--- a/crates/kx-worker/src/read_model.rs
+++ b/crates/kx-worker/src/read_model.rs
@@ -1,0 +1,60 @@
+//! [`ReadModel`] — a worker's local, incrementally-folded view of committed
+//! results, built from `ReadEntries` deltas.
+//!
+//! This is the scalable read path (D55): a worker resolves a committed Mote's
+//! `result_ref` from its own folded state instead of round-tripping the
+//! coordinator per lookup. P2.4 keeps it minimal — a `MoteId -> ContentRef` map
+//! over `Committed` entries; the forward seam (P3) is to fold the full journal
+//! log (Proposed / Repudiated / ...) into a faithful `kx-projection` once those
+//! entry kinds ride the wire (the `JournalEntry` oneof is reserved for them).
+
+use std::collections::BTreeMap;
+
+use kx_content::ContentRef;
+use kx_mote::MoteId;
+use kx_proto::proto;
+
+/// A worker-local index of committed results, advanced by a journal cursor.
+#[derive(Debug, Default)]
+pub(crate) struct ReadModel {
+    committed: BTreeMap<MoteId, ContentRef>,
+    cursor: u64,
+}
+
+impl ReadModel {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// The cursor to resume a `ReadEntries` poll from.
+    pub(crate) fn cursor(&self) -> u64 {
+        self.cursor
+    }
+
+    /// The committed result_ref of `mote_id`, if this model has folded its commit.
+    pub(crate) fn result_ref_of(&self, mote_id: &MoteId) -> Option<ContentRef> {
+        self.committed.get(mote_id).copied()
+    }
+
+    /// Fold a `ReadEntries` page: record each committed (mote_id -> result_ref) and
+    /// advance the cursor. Malformed entries (wrong-length hashes) are skipped — the
+    /// coordinator only emits well-formed committed entries, so this is a guard.
+    pub(crate) fn fold(&mut self, entries: Vec<proto::JournalEntry>, next_seq: u64) {
+        for entry in entries {
+            let Some(proto::journal_entry::Kind::Committed(c)) = entry.kind else {
+                continue;
+            };
+            if let (Ok(mote_id), Ok(result_ref)) = (to_array(&c.mote_id), to_array(&c.result_ref)) {
+                self.committed.insert(
+                    MoteId::from_bytes(mote_id),
+                    ContentRef::from_bytes(result_ref),
+                );
+            }
+        }
+        self.cursor = next_seq;
+    }
+}
+
+fn to_array(bytes: &[u8]) -> Result<[u8; 32], ()> {
+    bytes.try_into().map_err(|_| ())
+}

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -3,37 +3,49 @@
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use kx_content::{ContentStore, LocalFsContentStore};
 use kx_executor::{LocalResourceManager, MoteExecutor};
-use kx_mote::Mote;
+use kx_mote::{Mote, MoteId};
 use kx_proto::proto;
 use kx_warrant::{ExecutorClass, WarrantSpec};
 
 use crate::client::WorkerClient;
 use crate::error::WorkerError;
+use crate::read_model::ReadModel;
 use crate::{commit_builder, run};
 
+/// `ReadEntries` page size when folding the local read model.
+const READ_PAGE: u32 = 256;
+
 /// A registered worker bound to one coordinator. Holds the hosted executor + a
-/// resource manager (the verbatim P1 execution stack) and the dispatch knobs.
+/// resource manager (the verbatim P1 execution stack), the shared content store it
+/// reads peer results from (data plane), and a local read model of committed results
+/// folded incrementally from the coordinator's log (so reads stay off the hot path).
 pub struct Worker {
     client: WorkerClient,
     id: u64,
     executor_class: ExecutorClass,
     executor: Arc<dyn MoteExecutor>,
     resource_manager: LocalResourceManager,
+    store: Arc<LocalFsContentStore>,
+    read_model: ReadModel,
     max_lease: u32,
 }
 
 impl Worker {
     /// Register `client` with the coordinator as a worker for `executor_class`,
     /// reachable at `endpoint`, and return a ready worker. `executor` +
-    /// `resource_manager` host the P1 execution stack verbatim; `max_lease` bounds
-    /// how many Motes a single [`run_once`](Self::run_once) pulls.
+    /// `resource_manager` host the P1 execution stack verbatim; `store` is the shared
+    /// content-addressed store (the worker's executor publishes results to it and the
+    /// worker reads peer results from it); `max_lease` bounds how many Motes a single
+    /// [`run_once`](Self::run_once) pulls.
     pub async fn register(
         mut client: WorkerClient,
         executor_class: ExecutorClass,
         endpoint: impl Into<String>,
         executor: Arc<dyn MoteExecutor>,
         resource_manager: LocalResourceManager,
+        store: Arc<LocalFsContentStore>,
         max_lease: u32,
     ) -> Result<Self, WorkerError> {
         let id = client.register_worker(executor_class, endpoint).await?;
@@ -43,6 +55,8 @@ impl Worker {
             executor_class,
             executor,
             resource_manager,
+            store,
+            read_model: ReadModel::new(),
             max_lease,
         })
     }
@@ -51,6 +65,30 @@ impl Worker {
     #[must_use]
     pub fn worker_id(&self) -> u64 {
         self.id
+    }
+
+    /// Read a peer's committed result: fold the coordinator's committed-entry log
+    /// into the local read model until `mote_id`'s commit is seen, resolve its
+    /// `result_ref`, and fetch the bytes from the shared content store. This is the
+    /// distributed-read path (D55) — the journal stays single-writer, the content
+    /// store is the shared data plane.
+    pub async fn peer_read(&mut self, mote_id: MoteId) -> Result<Vec<u8>, WorkerError> {
+        loop {
+            if let Some(result_ref) = self.read_model.result_ref_of(&mote_id) {
+                let bytes = self
+                    .store
+                    .get(&result_ref)
+                    .map_err(|_| WorkerError::ContentMissing(result_ref))?;
+                return Ok(bytes.to_vec());
+            }
+            let cursor = self.read_model.cursor();
+            let (entries, next_seq) = self.client.read_entries(cursor, READ_PAGE).await?;
+            self.read_model.fold(entries, next_seq);
+            if next_seq == cursor {
+                // Caught up to current_seq without finding the commit.
+                return Err(WorkerError::NotCommitted(mote_id));
+            }
+        }
     }
 
     /// Lease one batch of ready PURE Motes, run each through the hosted executor,

--- a/crates/kx-worker/tests/e2e.rs
+++ b/crates/kx-worker/tests/e2e.rs
@@ -1,13 +1,13 @@
-//! End-to-end P2.3 exit-gate witness: a worker **registers**, **pulls** a ready
-//! Mote, runs it through the hosted executor, and **proposes** its commit — all
-//! through the coordinator over real gRPC. Then the committed parent unblocks the
-//! child, which the worker pulls and commits on the next round.
+//! End-to-end P2.4 exit-gate witness: a result committed via one worker is
+//! **readable by the coordinator and by another worker**, over real gRPC + a
+//! shared content-addressed store.
 //!
-//! The coordinator is a real [`CoordinatorService`] hosted on an in-process gRPC
-//! server (ephemeral TCP loopback). Submission is done in-process via a service
-//! clone (standing in for an external submitter); everything the *worker* does —
-//! register / lease / report-commit — rides the gRPC client. The service is the
-//! sole journal writer (D40): the worker only proposes.
+//! Topology: one in-process `CoordinatorService` built `with_store` (so it
+//! VERIFIES each committed `result_ref` against the shared store — D55) on
+//! loopback; worker A runs PURE Motes through a **storing** executor (real bytes
+//! land in the shared store before it proposes); worker B is a peer that only
+//! reads. The store is one `LocalFsContentStore` root all three share (single
+//! host now; the S3 backend is the cross-host impl at P5.5).
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
 
@@ -16,17 +16,37 @@ mod common;
 use std::sync::Arc;
 use std::time::Duration;
 
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_coordinator::proto::coordinator_server::{Coordinator, CoordinatorServer};
-use kx_coordinator::{CoordinatorService, MoteState, WorkerId};
+use kx_coordinator::{CoordinatorService, MoteState};
 use kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor};
 use kx_journal::InMemoryJournal;
+use kx_mote::Mote;
 use kx_worker::{Worker, WorkerClient};
+use tempfile::TempDir;
 use tonic::transport::Server;
 use tonic::Request;
 
-/// Submit a Mote + warrant in-process (test setup — an external submitter would
-/// use the SubmitMote RPC).
-async fn submit(svc: &CoordinatorService, mote: &kx_mote::Mote, warrant: &kx_warrant::WarrantSpec) {
+/// The deterministic result payload worker A's executor publishes for a Mote.
+fn result_bytes(mote: &Mote) -> Vec<u8> {
+    let mut v = b"kx-result:".to_vec();
+    v.extend_from_slice(mote.id.as_bytes());
+    v
+}
+
+/// A `MoteExecutor` that PUBLISHES its result bytes to the shared store and returns
+/// the ref — the correct producer for the PURE path (no R-11 gate; content-addressed
+/// so the committed ref == the stored object). Built via the existing public
+/// `TestMoteExecutor::new` constructor — kx-executor source is untouched.
+fn storing_executor(store: Arc<LocalFsContentStore>) -> Arc<dyn MoteExecutor> {
+    Arc::new(TestMoteExecutor::new(move |mote, _warrant| {
+        store
+            .put(&result_bytes(mote))
+            .expect("publish result bytes")
+    }))
+}
+
+async fn submit(svc: &CoordinatorService, mote: &Mote, warrant: &kx_warrant::WarrantSpec) {
     svc.submit_mote(Request::new(kx_coordinator::proto::SubmitMoteRequest {
         mote: Some(mote.clone().into()),
         warrant: Some(warrant.clone().into()),
@@ -35,39 +55,21 @@ async fn submit(svc: &CoordinatorService, mote: &kx_mote::Mote, warrant: &kx_war
     .unwrap();
 }
 
-async fn connect_worker(endpoint: String) -> Worker {
-    // Brief retry while the in-process server binds (the kx-proto pattern).
-    let mut client = None;
+async fn connect(endpoint: &str) -> WorkerClient {
     for _ in 0..100 {
-        match WorkerClient::connect(endpoint.clone()).await {
-            Ok(c) => {
-                client = Some(c);
-                break;
-            }
-            Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+        if let Ok(c) = WorkerClient::connect(endpoint.to_string()).await {
+            return c;
         }
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
-    let client = client.expect("worker connects to the coordinator");
-    let executor: Arc<dyn MoteExecutor> = Arc::new(TestMoteExecutor::deterministic());
-    Worker::register(
-        client,
-        common::WORKER_CLASS,
-        "inproc://worker-1",
-        executor,
-        LocalResourceManager::dev_defaults(),
-        16,
-    )
-    .await
-    .expect("worker registers")
+    panic!("worker connects to the coordinator");
 }
 
-#[tokio::test]
-async fn worker_registers_pulls_runs_and_proposes_a_dag() {
-    // One service, two clones sharing the same orchestration core: one hosts the
-    // gRPC server, one stays here for submission + read-side assertions.
-    let svc = CoordinatorService::new(InMemoryJournal::new());
+/// Spawn an in-process coordinator (built `with_store`) on loopback; return its
+/// service clone (for submission + assertions) and the endpoint URL.
+async fn spawn_coordinator(store: Arc<LocalFsContentStore>) -> (CoordinatorService, String) {
+    let svc = CoordinatorService::with_store(InMemoryJournal::new(), store);
     let server_svc = svc.clone();
-
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -78,42 +80,133 @@ async fn worker_registers_pulls_runs_and_proposes_a_dag() {
             .await
             .unwrap();
     });
+    (svc, format!("http://{addr}"))
+}
 
-    // A 2-Mote PURE DAG: root -> child.
+#[tokio::test]
+async fn committed_result_is_readable_by_coordinator_and_peer() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let (svc, endpoint) = spawn_coordinator(store.clone()).await;
+
+    // root -> child PURE DAG.
     let root = common::pure_mote(1, &[]);
     let child = common::pure_mote(2, &[root.id]);
     let warrant = common::pure_warrant();
     submit(&svc, &root, &warrant).await;
     submit(&svc, &child, &warrant).await;
 
-    let mut worker = connect_worker(format!("http://{addr}")).await;
+    // Worker A runs + proposes through the storing executor; the coordinator
+    // verifies each result_ref is present in the store before committing.
+    let mut worker_a = Worker::register(
+        connect(&endpoint).await,
+        common::WORKER_CLASS,
+        "inproc://worker-a",
+        storing_executor(store.clone()),
+        LocalResourceManager::dev_defaults(),
+        store.clone(),
+        16,
+    )
+    .await
+    .unwrap();
 
-    // Round 1: only the root is ready; the worker leases, runs, and proposes it.
-    let n = worker.run_once().await.unwrap();
-    assert_eq!(n, 1, "the root is committed this round");
-    assert_eq!(svc.committed_count().await.unwrap(), 1);
-    assert_eq!(svc.state_of(root.id).await.unwrap(), MoteState::Committed);
-
-    // Round 2: the committed root unblocks the child.
-    let n = worker.run_once().await.unwrap();
-    assert_eq!(n, 1, "the child is committed once its parent is");
+    assert_eq!(worker_a.run_once().await.unwrap(), 1, "root committed");
+    assert_eq!(
+        worker_a.run_once().await.unwrap(),
+        1,
+        "child committed once parent is"
+    );
     assert_eq!(svc.committed_count().await.unwrap(), 2);
     assert_eq!(svc.state_of(child.id).await.unwrap(), MoteState::Committed);
 
-    // Round 3: nothing ready remains.
-    assert_eq!(worker.run_once().await.unwrap(), 0, "the DAG is drained");
-
-    // Heartbeat advances the registry liveness clock (0 at registration).
-    assert!(
-        worker.heartbeat(0).await.unwrap(),
-        "coordinator acks heartbeat"
+    // (a) Readable by the coordinator: it serves the committed result_ref over
+    //     ReadEntries, and the bytes resolve from the store it was built with (the
+    //     same store.contains check it ran at commit time).
+    let mut observer = connect(&endpoint).await;
+    let (entries, _next) = observer.read_entries(0, 16).await.unwrap();
+    let root_ref = entries
+        .iter()
+        .find_map(|e| match e.kind.as_ref().unwrap() {
+            kx_coordinator::proto::journal_entry::Kind::Committed(c)
+                if c.mote_id == root.id.as_bytes().to_vec() =>
+            {
+                Some(ContentRef::from_bytes(
+                    c.result_ref.clone().try_into().unwrap(),
+                ))
+            }
+            _ => None,
+        })
+        .expect("coordinator serves the root's committed result_ref");
+    assert_eq!(
+        store.get(&root_ref).unwrap().to_vec(),
+        result_bytes(&root),
+        "coordinator-visible result_ref resolves to the bytes A published"
     );
-    let record = svc
-        .registry()
-        .get(WorkerId(worker.worker_id()))
-        .expect("worker is registered");
-    assert!(
-        record.last_heartbeat_ms > 0,
-        "heartbeat recorded a wall-clock timestamp"
+
+    // (b) Readable by another worker: peer B folds the log + reads from the store.
+    let mut worker_b = Worker::register(
+        connect(&endpoint).await,
+        common::WORKER_CLASS,
+        "inproc://worker-b",
+        storing_executor(store.clone()), // unused by B; B only reads
+        LocalResourceManager::dev_defaults(),
+        store.clone(),
+        16,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        worker_b.peer_read(root.id).await.unwrap(),
+        result_bytes(&root),
+        "peer worker reads the exact bytes worker A produced"
+    );
+    assert_eq!(
+        worker_b.peer_read(child.id).await.unwrap(),
+        result_bytes(&child),
+    );
+}
+
+#[tokio::test]
+async fn phantom_result_ref_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let (svc, endpoint) = spawn_coordinator(store).await;
+
+    let mote = common::pure_mote(9, &[]);
+    let warrant = common::pure_warrant();
+    submit(&svc, &mote, &warrant).await;
+
+    // A registered worker proposes a result_ref whose bytes were never stored.
+    let mut client = connect(&endpoint).await;
+    let worker_id = client
+        .register_worker(common::WORKER_CLASS, "inproc://phantom")
+        .await
+        .unwrap();
+    let id = mote.id.as_bytes().to_vec();
+    let err = client
+        .report_commit(kx_coordinator::proto::ReportCommitRequest {
+            mote_id: id.clone(),
+            idempotency_key: id,
+            result_ref: vec![0xAB; 32], // never published to the store
+            warrant_ref: vec![4; 32],
+            mote_def_hash: vec![5; 32],
+            nd_class: kx_coordinator::proto::NdClass::Pure as i32,
+            parents: vec![],
+            worker_id,
+        })
+        .await
+        .map(|_| ())
+        .unwrap_err();
+    // ResultRefAbsent maps to INVALID_ARGUMENT (see kx-coordinator error.rs).
+    match err {
+        kx_worker::WorkerError::Rpc(status) => {
+            assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        }
+        other => panic!("expected an RPC status error, got {other:?}"),
+    }
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        0,
+        "the phantom commit was not recorded"
     );
 }


### PR DESCRIPTION
## Summary

Second of two PRs for **P2.4 (distributed journal access)**. Realizes the distributed-read **data plane** (D55): a result committed via one worker is now **readable by the coordinator and by other workers**, over a shared content-addressed store. **Stacked on #70** (the ReadEntries seam); review/merge #70 first.

The journal stays single-writer-coordinator (D13); content is the shared, immutable, content-addressed data plane (D17) — local-fs now, S3 at P5.5 via the same trait.

**kx-worker**
- `Worker` holds an `Arc<LocalFsContentStore>` (shared data plane) + a local `ReadModel` folded incrementally from `ReadEntries`. `peer_read(mote_id)` folds the committed-entry log until the commit is seen, resolves `result_ref` **locally**, and reads bytes from the store — reads stay off the coordinator's hot path (scalability).
- The executor **publishes** result bytes to the store: the e2e builds a storing executor via the existing `TestMoteExecutor::new` closure (no kx-executor change; PURE has no R-11 gate, so the executor is the correct producer, and content-addressing makes the committed ref == the stored object).
- `WorkerClient::read_entries`; new `read_model` module; `WorkerError::NotCommitted` / `ContentMissing`.

**kx-coordinator**
- `CoordinatorService::with_store` + an optional store threaded to the owner thread. `flush_commits` **verifies `store.contains(result_ref)`** before appending when a store is configured (D55 phantom-ref guard) — rejecting an absent ref per-proposal with `CoordinatorError::ResultRefAbsent` (`INVALID_ARGUMENT`) without blocking batch-mates. `new()`/`with_registry()` keep the unverified path (P2.2/P2.3 behavior).

### Exit gate (P2.4 DoD)
`tests/e2e.rs`:
- **`committed_result_is_readable_by_coordinator_and_peer`** — worker A stores + proposes a root→child DAG; the coordinator **verifies + commits**; the coordinator **serves** the `result_ref` (ReadEntries) and the bytes resolve from its store; peer worker B **folds the log + reads the exact bytes A produced**.
- **`phantom_result_ref_is_rejected`** — an unpublished ref is refused; nothing committed.

### Thesis test
`git diff main -- crates/kx-executor crates/kx-inference crates/kx-scheduler` is **empty**.

## Test plan
- [x] `cargo test -p kx-worker -p kx-coordinator -p kx-proto`
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [x] thesis diff empty for the three frozen crates
- [ ] `ffi-link` + `check-reproducible` (I1.c) + Linux CI — run by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)