### PR TITLE
P2.5: placement v2 — load-aware + shard distribution (P2 EXIT GATE)

### DIFF
--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -45,6 +45,7 @@ pub use kx_scheduler::WorkerId;
 
 mod commit;
 mod error;
+mod placement;
 mod registry;
 mod service;
 mod state;

--- a/crates/kx-coordinator/src/placement.rs
+++ b/crates/kx-coordinator/src/placement.rs
@@ -1,0 +1,160 @@
+//! [`LoadAwarePlacement`] — the P2.5 placement-v2 policy (D56).
+
+use kx_mote::MoteId;
+use kx_scheduler::{Placement, WorkerId};
+use kx_warrant::ExecutorClass;
+
+use crate::registry::WorkerRegistry;
+
+/// Placement v2: route a ready Mote to the **least-loaded** registered worker that can
+/// run it (matching `executor_class`), breaking equal-load ties by a **stable shard of
+/// the `mote_id`** so idle workers split work evenly instead of piling onto the lowest
+/// id. Implements the frozen [`kx_scheduler::Placement`] trait — the v2 policy swaps in
+/// with **zero scheduler-core changes** (the P2.5 exit-gate obligation).
+///
+/// Built once per lease from a single registry [`snapshot`](WorkerRegistry::snapshot),
+/// so it tracks **live load** (the worker reports `in_flight` via Heartbeat) without
+/// re-locking the registry per Mote. Load-awareness is the scalability core; GPU-slot +
+/// data-locality are forward seams behind the same `place` surface (they need
+/// worker-reported capacity / result→worker tracking — P3/P5).
+pub(crate) struct LoadAwarePlacement {
+    /// Capable workers (class-matched), sorted by id, with their last-known load.
+    candidates: Vec<(WorkerId, u32)>,
+}
+
+impl LoadAwarePlacement {
+    /// Snapshot the registry once and keep the workers that can run `class`.
+    pub(crate) fn new(registry: &dyn WorkerRegistry, class: ExecutorClass) -> Self {
+        let mut candidates: Vec<(WorkerId, u32)> = registry
+            .snapshot()
+            .into_iter()
+            .filter(|w| w.executor_class == class)
+            .map(|w| (w.id, w.in_flight))
+            .collect();
+        candidates.sort_by_key(|(id, _)| id.0);
+        Self { candidates }
+    }
+}
+
+impl Placement for LoadAwarePlacement {
+    fn place(&self, mote_id: &MoteId) -> WorkerId {
+        // The polling worker is always capable (it registered with this class), so the
+        // candidate set is non-empty in practice; the guard keeps `place` total.
+        if self.candidates.is_empty() {
+            return WorkerId(0);
+        }
+        let min_load = self
+            .candidates
+            .iter()
+            .map(|(_, load)| *load)
+            .min()
+            .unwrap_or(0);
+        let least_loaded: Vec<WorkerId> = self
+            .candidates
+            .iter()
+            .filter(|(_, load)| *load == min_load)
+            .map(|(id, _)| *id)
+            .collect();
+        least_loaded[shard_index(mote_id, least_loaded.len())]
+    }
+}
+
+/// A stable index in `0..len` derived from the Mote's identity. `mote_id` is a BLAKE3
+/// hash, so its leading bytes are uniformly distributed — an even shard.
+fn shard_index(mote_id: &MoteId, len: usize) -> usize {
+    let b = mote_id.as_bytes();
+    let head = u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]);
+    let len_u64 = u64::try_from(len).unwrap_or(u64::MAX);
+    usize::try_from(head % len_u64).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::InMemoryWorkerRegistry;
+
+    const BWRAP: ExecutorClass = ExecutorClass::Bwrap;
+    const MAC: ExecutorClass = ExecutorClass::MacOsSandbox;
+
+    fn mote(byte: u8) -> MoteId {
+        MoteId::from_bytes([byte; 32])
+    }
+
+    #[test]
+    fn single_worker_gets_everything() {
+        let reg = InMemoryWorkerRegistry::new();
+        let w = reg.register(MAC, "a".into());
+        let p = LoadAwarePlacement::new(&reg, MAC);
+        assert_eq!(p.place(&mote(0)), w);
+        assert_eq!(p.place(&mote(7)), w);
+        assert_eq!(p.place(&mote(255)), w);
+    }
+
+    #[test]
+    fn least_loaded_wins() {
+        let reg = InMemoryWorkerRegistry::new();
+        let busy = reg.register(MAC, "busy".into());
+        let idle = reg.register(MAC, "idle".into());
+        reg.heartbeat(busy, 1, 5).unwrap(); // busy: in_flight = 5
+        reg.heartbeat(idle, 1, 0).unwrap(); // idle: in_flight = 0
+        let p = LoadAwarePlacement::new(&reg, MAC);
+        // Every Mote routes to the idle worker regardless of its shard.
+        for b in 0..32u8 {
+            assert_eq!(
+                p.place(&mote(b)),
+                idle,
+                "byte {b} should route to the idle worker"
+            );
+        }
+        assert_ne!(idle, busy);
+    }
+
+    #[test]
+    fn equal_load_shards_across_workers() {
+        let reg = InMemoryWorkerRegistry::new();
+        let w0 = reg.register(MAC, "w0".into());
+        let w1 = reg.register(MAC, "w1".into());
+        // Both idle (in_flight defaults to 0) → ties broken by mote shard.
+        let p = LoadAwarePlacement::new(&reg, MAC);
+        // head([0;32]) = 0 (even) → w0; head([1;32]) is odd → w1.
+        assert_eq!(p.place(&mote(0)), w0);
+        assert_eq!(p.place(&mote(1)), w1);
+        // Over many Motes, both workers are used (even split, not all-lowest-id).
+        let mut seen_w0 = false;
+        let mut seen_w1 = false;
+        for b in 0..64u8 {
+            match p.place(&mote(b)) {
+                w if w == w0 => seen_w0 = true,
+                w if w == w1 => seen_w1 = true,
+                _ => unreachable!(),
+            }
+        }
+        assert!(
+            seen_w0 && seen_w1,
+            "equal load must spread across both workers"
+        );
+    }
+
+    #[test]
+    fn only_class_matching_workers_are_candidates() {
+        let reg = InMemoryWorkerRegistry::new();
+        let bwrap = reg.register(BWRAP, "bwrap".into());
+        let mac = reg.register(MAC, "mac".into());
+        // A MacOsSandbox lease never routes to the Bwrap worker, and vice-versa.
+        let p_mac = LoadAwarePlacement::new(&reg, MAC);
+        let p_bwrap = LoadAwarePlacement::new(&reg, BWRAP);
+        for b in 0..32u8 {
+            assert_eq!(p_mac.place(&mote(b)), mac);
+            assert_eq!(p_bwrap.place(&mote(b)), bwrap);
+        }
+    }
+
+    #[test]
+    fn no_capable_worker_is_total() {
+        // No worker of the requested class → `place` stays total (never panics).
+        let reg = InMemoryWorkerRegistry::new();
+        reg.register(BWRAP, "bwrap".into());
+        let p = LoadAwarePlacement::new(&reg, MAC);
+        let _ = p.place(&mote(3));
+    }
+}

--- a/crates/kx-coordinator/src/registry.rs
+++ b/crates/kx-coordinator/src/registry.rs
@@ -59,6 +59,14 @@ pub trait WorkerRegistry: Send + Sync {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// A point-in-time copy of every registered worker's record — the input a
+    /// placement policy ranks over (P2.5, D56). Default returns empty so existing
+    /// implementors stay valid; the in-memory registry overrides it. Implementors
+    /// MUST clone-and-release (never hold an internal lock across the returned data).
+    fn snapshot(&self) -> Vec<WorkerRecord> {
+        Vec::new()
+    }
 }
 
 /// In-memory [`WorkerRegistry`] — the OSS default.
@@ -125,5 +133,14 @@ impl WorkerRegistry for InMemoryWorkerRegistry {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .len()
+    }
+
+    fn snapshot(&self) -> Vec<WorkerRecord> {
+        self.workers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect()
     }
 }

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -66,7 +66,7 @@ impl CoordinatorService {
         store: Option<Arc<LocalFsContentStore>>,
     ) -> Self {
         Self {
-            core: CoreHandle::spawn(journal, store),
+            core: CoreHandle::spawn(journal, store, registry.clone()),
             registry,
         }
     }
@@ -208,7 +208,7 @@ impl Coordinator for CoordinatorService {
         let executor_class =
             kx_warrant::ExecutorClass::try_from(proto_class).map_err(CoordinatorError::from)?;
         let max = usize::try_from(req.max_motes).unwrap_or(usize::MAX);
-        let work = self.core.lease_work(executor_class, max).await?;
+        let work = self.core.lease_work(worker, executor_class, max).await?;
         let items = work
             .into_iter()
             .map(|(mote, warrant)| proto::WorkItem {

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -23,12 +23,14 @@ use kx_content::{ContentStore, LocalFsContentStore};
 use kx_journal::{Journal, JournalEntry};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
-use kx_scheduler::{LocalPlacement, Scheduler, SchedulerError};
+use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
 use kx_warrant::{ExecutorClass, WarrantSpec};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::commit::CommitProposal;
 use crate::error::CoordinatorError;
+use crate::placement::LoadAwarePlacement;
+use crate::registry::WorkerRegistry;
 
 /// Bound on in-flight commands queued to the orchestration core. A bounded
 /// channel applies backpressure: when the core is saturated, `dispatch` awaits
@@ -78,6 +80,7 @@ pub(crate) enum Command {
         reply: oneshot::Sender<Vec<MoteId>>,
     },
     LeaseWork {
+        worker: WorkerId,
         executor_class: ExecutorClass,
         max: usize,
         reply: oneshot::Sender<Vec<(Mote, WarrantSpec)>>,
@@ -100,13 +103,15 @@ impl CoreHandle {
     /// Spawn the owner thread, taking sole ownership of `journal`. When `store` is
     /// `Some`, the core verifies `store.contains(result_ref)` before committing a
     /// proposal (D55 phantom-ref guard); when `None`, commits are not content-checked
-    /// (the P2.2/P2.3 behavior).
+    /// (the P2.2/P2.3 behavior). `registry` is the live worker view the lease-time
+    /// placement policy ranks over (D56).
     pub(crate) fn spawn<J: Journal + Send + 'static>(
         journal: J,
         store: Option<Arc<LocalFsContentStore>>,
+        registry: Arc<dyn WorkerRegistry>,
     ) -> Self {
         let (commands, inbox) = mpsc::channel(COMMAND_BUFFER);
-        std::thread::spawn(move || core_loop(&journal, store.as_deref(), inbox));
+        std::thread::spawn(move || core_loop(&journal, store.as_deref(), &*registry, inbox));
         Self { commands }
     }
 
@@ -167,16 +172,20 @@ impl CoreHandle {
     }
 
     /// Lease up to `max` ready PURE Motes runnable on `executor_class`, returning
-    /// each with the warrant it was submitted under (the dispatch surface the
-    /// worker pulls). No lease/lock is held: double execution is harmless under
-    /// the journal's dedupe-by-key, and provisioning is reserved for P3 (D47).
+    /// each with the warrant it was submitted under (the dispatch surface the worker
+    /// pulls). Placement v2 (D56) prefers Motes the load-aware policy routes to
+    /// `worker`, then fills to `max` with the rest so a live poller never idles while
+    /// ready work exists. No lease/lock is held: double execution is harmless under
+    /// the journal's dedupe-by-key, and worker-death reschedule is reserved for P3.
     pub(crate) async fn lease_work(
         &self,
+        worker: WorkerId,
         executor_class: ExecutorClass,
         max: usize,
     ) -> Result<Vec<(Mote, WarrantSpec)>, CoordinatorError> {
         let (reply, response) = oneshot::channel();
         self.dispatch(Command::LeaseWork {
+            worker,
             executor_class,
             max,
             reply,
@@ -244,29 +253,41 @@ fn recover<J: Journal>(journal: &J) -> Option<(Projection, u64, BTreeSet<MoteId>
     Some((projection, folded_through, submitted))
 }
 
-/// Select up to `max` ready PURE Motes runnable on `executor_class`, each paired
-/// with the warrant it was submitted under (the dispatch surface a worker pulls).
-/// Ready = parents-all-committed (the dispatch precondition); PURE is the only
-/// class the worker executes-then-proposes in P2.3 (WM needs a durable staged-intent
-/// RPC, deferred); the warrant's executor_class must match the worker's backend.
+/// Select up to `max` ready PURE Motes for `worker` to run. Candidates are
+/// ready (parents-all-committed) ∩ PURE (the only class executed-then-proposed in
+/// P2.x; WM is deferred) ∩ matching the worker's backend (`executor_class`). Placement
+/// v2 (D56) then orders them: Motes the load-aware policy routes to `worker` come
+/// **first**, the rest **fill to `max`** — so work balances across workers by load
+/// (shard-by-mote on ties) while a live poller never idles when ready work exists
+/// (starvation-free; double execution stays harmless under dedup, D54).
 fn lease_ready(
     projection: &Projection,
     submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    registry: &dyn WorkerRegistry,
+    worker: WorkerId,
     executor_class: ExecutorClass,
     max: usize,
 ) -> Vec<(Mote, WarrantSpec)> {
-    let mut items = Vec::new();
+    let placement = LoadAwarePlacement::new(registry, executor_class);
+    let mut preferred: Vec<MoteId> = Vec::new();
+    let mut rest: Vec<MoteId> = Vec::new();
     for mote_id in projection.ready_set() {
-        if items.len() >= max {
-            break;
-        }
         if let Some((mote, warrant)) = submitted_defs.get(&mote_id) {
             if mote.nd_class() == NdClass::Pure && warrant.executor_class == executor_class {
-                items.push((mote.clone(), warrant.clone()));
+                if placement.place(&mote_id) == worker {
+                    preferred.push(mote_id);
+                } else {
+                    rest.push(mote_id);
+                }
             }
         }
     }
-    items
+    preferred
+        .into_iter()
+        .chain(rest)
+        .take(max)
+        .filter_map(|id| submitted_defs.get(&id).cloned())
+        .collect()
 }
 
 /// Read up to `max` `Committed` entries with seq in `(since_seq, current_seq]`, in
@@ -306,6 +327,7 @@ fn read_committed_since<J: Journal>(
 fn core_loop<J: Journal>(
     journal: &J,
     store: Option<&LocalFsContentStore>,
+    registry: &dyn WorkerRegistry,
     mut inbox: mpsc::Receiver<Command>,
 ) {
     let Some((mut projection, mut folded_through, mut submitted)) = recover(journal) else {
@@ -387,11 +409,19 @@ fn core_loop<J: Journal>(
                     let _ = reply.send(projection.ready_set());
                 }
                 Command::LeaseWork {
+                    worker,
                     executor_class,
                     max,
                     reply,
                 } => {
-                    let items = lease_ready(&projection, &submitted_defs, executor_class, max);
+                    let items = lease_ready(
+                        &projection,
+                        &submitted_defs,
+                        registry,
+                        worker,
+                        executor_class,
+                        max,
+                    );
                     let _ = reply.send(items);
                 }
                 Command::ReadEntries {

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -100,6 +100,14 @@ impl Worker {
             .lease_work(self.id, self.executor_class, self.max_lease)
             .await?;
 
+        // Report load so the coordinator's placement (D56) can balance across workers:
+        // `in_flight` = the batch we're about to run, reset to 0 when it drains.
+        // Best-effort — a heartbeat hiccup must never abort real execution.
+        let in_flight = u32::try_from(items.len()).unwrap_or(u32::MAX);
+        if in_flight > 0 {
+            let _ = self.client.heartbeat(self.id, now_ms(), in_flight).await;
+        }
+
         let mut committed = 0usize;
         for item in items {
             let mote: Mote = item
@@ -129,6 +137,9 @@ impl Worker {
                 }
                 _ => return Err(WorkerError::CommitRejected(response.detail)),
             }
+        }
+        if in_flight > 0 {
+            let _ = self.client.heartbeat(self.id, now_ms(), 0).await;
         }
         Ok(committed)
     }

--- a/crates/kx-worker/tests/e2e.rs
+++ b/crates/kx-worker/tests/e2e.rs
@@ -1,13 +1,17 @@
-//! End-to-end P2.4 exit-gate witness: a result committed via one worker is
-//! **readable by the coordinator and by another worker**, over real gRPC + a
-//! shared content-addressed store.
+//! End-to-end distributed witnesses over real gRPC + a shared content-addressed store.
 //!
-//! Topology: one in-process `CoordinatorService` built `with_store` (so it
-//! VERIFIES each committed `result_ref` against the shared store — D55) on
-//! loopback; worker A runs PURE Motes through a **storing** executor (real bytes
-//! land in the shared store before it proposes); worker B is a peer that only
-//! reads. The store is one `LocalFsContentStore` root all three share (single
-//! host now; the S3 backend is the cross-host impl at P5.5).
+//! - **P2.4** (`committed_result_is_readable_by_coordinator_and_peer`): a result
+//!   committed via one worker is readable by the coordinator and by another worker;
+//!   plus `phantom_result_ref_is_rejected` (D55 store verification).
+//! - **P2.5 / P2 EXIT GATE** (`two_workers_share_the_workload_via_placement`): two
+//!   workers of the same class run a workflow distributed, placement v2 (D56) balances
+//!   the Motes across them, all commit exactly once.
+//!
+//! Topology: one in-process `CoordinatorService` built `with_store` (so it VERIFIES each
+//! committed `result_ref` against the shared store — D55) on loopback; workers run PURE
+//! Motes through a **storing** executor (real bytes land in the shared store before they
+//! propose). The store is one `LocalFsContentStore` root all nodes share (single host
+//! now; the S3 backend is the cross-host impl at P5.5).
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
 
@@ -18,7 +22,7 @@ use std::time::Duration;
 
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_coordinator::proto::coordinator_server::{Coordinator, CoordinatorServer};
-use kx_coordinator::{CoordinatorService, MoteState};
+use kx_coordinator::{CoordinatorService, MoteState, WorkerId};
 use kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor};
 use kx_journal::InMemoryJournal;
 use kx_mote::Mote;
@@ -208,5 +212,85 @@ async fn phantom_result_ref_is_rejected() {
         svc.committed_count().await.unwrap(),
         0,
         "the phantom commit was not recorded"
+    );
+}
+
+/// P2 EXIT GATE: a two-node (coordinator + ≥2 worker) setup runs the workflow
+/// distributed — placement v2 (D56) balances ready Motes across workers of the same
+/// class, all commit exactly once, and the executor/inference/scheduler crates are
+/// unchanged (thesis test, asserted by the CI diff job, not here).
+#[tokio::test]
+async fn two_workers_share_the_workload_via_placement() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let (svc, endpoint) = spawn_coordinator(store.clone()).await;
+
+    // Eight independent ready PURE Motes.
+    let warrant = common::pure_warrant();
+    let motes: Vec<Mote> = (10u8..18).map(|s| common::pure_mote(s, &[])).collect();
+    for m in &motes {
+        submit(&svc, m, &warrant).await;
+    }
+
+    // Two workers of the same class, each leasing small batches.
+    let register = |ep: String, tag: &'static str| {
+        let store = store.clone();
+        async move {
+            Worker::register(
+                connect(&ep).await,
+                common::WORKER_CLASS,
+                tag,
+                storing_executor(store.clone()),
+                LocalResourceManager::dev_defaults(),
+                store,
+                2,
+            )
+            .await
+            .unwrap()
+        }
+    };
+    let mut worker_a = register(endpoint.clone(), "inproc://a").await;
+    let mut worker_b = register(endpoint.clone(), "inproc://b").await;
+
+    // Interleave bounded polls until the DAG drains. Placement routes each worker its
+    // sharded Motes first; fill-to-max keeps a poller busy if its shard is empty, so
+    // neither starves and both make progress.
+    let mut a_total = 0usize;
+    let mut b_total = 0usize;
+    for _ in 0..16 {
+        a_total += worker_a.run_once().await.unwrap();
+        b_total += worker_b.run_once().await.unwrap();
+        if svc.committed_count().await.unwrap() >= motes.len() {
+            break;
+        }
+    }
+
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        motes.len(),
+        "every Mote committed exactly once across the two workers"
+    );
+    assert!(
+        a_total > 0 && b_total > 0,
+        "placement shared work across both workers (a={a_total}, b={b_total})"
+    );
+    assert_eq!(
+        a_total + b_total,
+        motes.len(),
+        "no Mote double-committed (dedup holds)"
+    );
+
+    // Load reporting reached the coordinator (run_once heartbeats in_flight).
+    let rec_a = svc.registry().get(WorkerId(worker_a.worker_id())).unwrap();
+    let rec_b = svc.registry().get(WorkerId(worker_b.worker_id())).unwrap();
+    assert!(
+        rec_a.last_heartbeat_ms > 0 || rec_b.last_heartbeat_ms > 0,
+        "at least one worker reported load via heartbeat during run"
+    );
+
+    // Cross-worker read still holds (P2.4): B reads a result regardless of who ran it.
+    assert_eq!(
+        worker_b.peer_read(motes[0].id).await.unwrap(),
+        result_bytes(&motes[0]),
     );
 }


### PR DESCRIPTION
## Summary

The final P2 step + the **P2 EXIT GATE**: a real placement policy that balances ready Motes across multiple workers, swapped in **via the frozen `kx_scheduler::Placement` trait with zero scheduler-core changes**. Single PR (no proto change, no kx-scheduler change).

- **kx-coordinator** — new `LoadAwarePlacement` (impls `kx_scheduler::Placement`): routes a ready Mote to the **least-loaded** registered worker that can run it (`executor_class` match), breaking equal-load ties by a **stable shard of the `mote_id`** (idle workers split evenly instead of piling onto the lowest id). Built once per lease from a single `WorkerRegistry::snapshot()` (new trait method with a **default impl** so existing implementors + the `dod.rs` mock stay valid). `lease_ready` returns a worker's **preferred** (placement-routed) Motes first, then **fills to `max`** with the rest — so a live poller never idles while ready work exists (**starvation-free**; double execution stays harmless under dedup, D54). The hosted `Scheduler`'s own placement is untouched (its `tick` path is unused on the coordinator — dispatch is `lease_ready`).
- **kx-worker** — `run_once` reports `in_flight` via the existing `Heartbeat` RPC (batch size before running, 0 after) so the registry carries a **live load signal**. Best-effort — a heartbeat hiccup never aborts execution.

### Design note (corrected during planning)
A naive "lease iff `place==W`, least-loaded" would have broken: `in_flight` wasn't reported on the pull path (least-loaded → "lowest id" → all work to one worker), and hard assignment **starves** under poll-only (no liveness eviction). Fixed by **wiring load reporting** + **shard tiebreak** + **preferred-first/fill-to-max** (never withhold).

### Scope
Load-awareness is the scalability core. **GPU-slot awareness** (needs worker-reported capacity → a `RegisterWorker` field) + **data/model locality** (needs result→worker tracking) + **worker-death eviction** remain documented forward seams behind the same `place()` surface (P3/P5).

### Thesis test / exit gate
`git diff main -- crates/kx-executor crates/kx-inference crates/kx-scheduler` is **empty**. The multi-worker e2e is the P2 exit-gate witness.

## Test plan
- [x] placement unit tests (least-loaded; equal-load shard spread; class filter; single worker; total-on-no-candidate)
- [x] `two_workers_share_the_workload_via_placement` — 2 workers run 8 Motes distributed, both commit ≥1, all commit exactly once, load reported, cross-worker read holds
- [x] existing single-worker behavior preserved (lease_work/read_entries/e2e suites)
- [x] `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [ ] `ffi-link` + `check-reproducible` (I1.c) + Linux CI — run by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)