### PR TITLE
feat(kx-coordinator): worker-death detection — heartbeat-timeout liveness (P3.1)

### DIFF
--- a/crates/kx-coordinator/src/clock.rs
+++ b/crates/kx-coordinator/src/clock.rs
@@ -1,0 +1,44 @@
+//! [`Clock`] — the coordinator's liveness time source (P3.1).
+//!
+//! Worker-death detection measures the time elapsed since a worker's last
+//! heartbeat. That measurement must read the **coordinator's** clock, not the
+//! worker-supplied wire timestamp ([`HeartbeatRequest.timestamp_ms`]): a dead
+//! worker sends nothing, so only the coordinator can observe the silence, and
+//! stamping receipt time with a single clock makes liveness immune to cross-node
+//! clock skew.
+//!
+//! The value is **liveness only — never hashed, never on the journal / Mote-identity
+//! path** (SN-8). It is behind a trait so tests inject a deterministic clock and
+//! advance time without real sleeps.
+//!
+//! [`HeartbeatRequest.timestamp_ms`]: kx_proto::proto::HeartbeatRequest
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A wall-clock source in milliseconds since the Unix epoch.
+///
+/// Used only to time worker liveness; the value never enters a hash, a journal
+/// entry, or any deterministic decision (SN-8). `Debug` is required so the
+/// registry that owns a `dyn Clock` stays `Debug`.
+pub trait Clock: Send + Sync + std::fmt::Debug {
+    /// Milliseconds since the Unix epoch. Liveness only; never hashed.
+    fn now_ms(&self) -> u64;
+}
+
+/// The production clock — the host wall clock.
+///
+/// A pre-epoch or overflowing reading collapses to `0` (the same total,
+/// panic-free shape the worker's `now_ms` uses); `0` only ever makes a worker
+/// look *older*, never spuriously live, so the conservative direction is kept.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .and_then(|d| u64::try_from(d.as_millis()).ok())
+            .unwrap_or(0)
+    }
+}

--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -43,6 +43,7 @@ pub use kx_projection::MoteState;
 pub use kx_proto::proto;
 pub use kx_scheduler::WorkerId;
 
+mod clock;
 mod commit;
 mod error;
 mod placement;
@@ -50,6 +51,10 @@ mod registry;
 mod service;
 mod state;
 
+pub use clock::{Clock, SystemClock};
 pub use error::CoordinatorError;
-pub use registry::{InMemoryWorkerRegistry, RegistryError, WorkerRecord, WorkerRegistry};
+pub use registry::{
+    is_live, InMemoryWorkerRegistry, RegistryError, WorkerRecord, WorkerRegistry, WorkerStatus,
+    DEFAULT_LIVENESS_TIMEOUT,
+};
 pub use service::CoordinatorService;

--- a/crates/kx-coordinator/src/placement.rs
+++ b/crates/kx-coordinator/src/placement.rs
@@ -12,21 +12,25 @@ use crate::registry::WorkerRegistry;
 /// id. Implements the frozen [`kx_scheduler::Placement`] trait — the v2 policy swaps in
 /// with **zero scheduler-core changes** (the P2.5 exit-gate obligation).
 ///
-/// Built once per lease from a single registry [`snapshot`](WorkerRegistry::snapshot),
-/// so it tracks **live load** (the worker reports `in_flight` via Heartbeat) without
-/// re-locking the registry per Mote. Load-awareness is the scalability core; GPU-slot +
-/// data-locality are forward seams behind the same `place` surface (they need
-/// worker-reported capacity / result→worker tracking — P3/P5).
+/// Built once per lease from a single registry
+/// [`live_snapshot`](WorkerRegistry::live_snapshot), so it tracks **live load** (the
+/// worker reports `in_flight` via Heartbeat) without re-locking the registry per Mote,
+/// and — from P3.1 — **excludes dead workers** (heartbeat-timeout): no new work is
+/// placed on a worker the coordinator can no longer hear. Load-awareness is the
+/// scalability core; GPU-slot + data-locality are forward seams behind the same
+/// `place` surface (they need worker-reported capacity / result→worker tracking — P3/P5).
 pub(crate) struct LoadAwarePlacement {
-    /// Capable workers (class-matched), sorted by id, with their last-known load.
+    /// Live, capable workers (class-matched), sorted by id, with their last-known load.
     candidates: Vec<(WorkerId, u32)>,
 }
 
 impl LoadAwarePlacement {
-    /// Snapshot the registry once and keep the workers that can run `class`.
+    /// Snapshot the **live** registry once and keep the workers that can run `class`.
+    /// Dead workers are already filtered out by `live_snapshot` (P3.1), so placement
+    /// never routes work to a worker past its heartbeat-timeout.
     pub(crate) fn new(registry: &dyn WorkerRegistry, class: ExecutorClass) -> Self {
         let mut candidates: Vec<(WorkerId, u32)> = registry
-            .snapshot()
+            .live_snapshot()
             .into_iter()
             .filter(|w| w.executor_class == class)
             .map(|w| (w.id, w.in_flight))
@@ -70,11 +74,33 @@ fn shard_index(mote_id: &MoteId, len: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use super::*;
+    use crate::clock::Clock;
     use crate::registry::InMemoryWorkerRegistry;
 
     const BWRAP: ExecutorClass = ExecutorClass::Bwrap;
     const MAC: ExecutorClass = ExecutorClass::MacOsSandbox;
+
+    /// A deterministic clock the test advances by hand.
+    #[derive(Debug)]
+    struct FakeClock(AtomicU64);
+    impl FakeClock {
+        fn new(ms: u64) -> Arc<Self> {
+            Arc::new(Self(AtomicU64::new(ms)))
+        }
+        fn set(&self, ms: u64) {
+            self.0.store(ms, Ordering::Relaxed);
+        }
+    }
+    impl Clock for FakeClock {
+        fn now_ms(&self) -> u64 {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
 
     fn mote(byte: u8) -> MoteId {
         MoteId::from_bytes([byte; 32])
@@ -156,5 +182,30 @@ mod tests {
         reg.register(BWRAP, "bwrap".into());
         let p = LoadAwarePlacement::new(&reg, MAC);
         let _ = p.place(&mote(3));
+    }
+
+    #[test]
+    fn dead_workers_are_evicted_from_placement() {
+        let clock = FakeClock::new(1_000);
+        let reg =
+            InMemoryWorkerRegistry::with_clock_and_timeout(clock.clone(), Duration::from_secs(6));
+        let w0 = reg.register(MAC, "w0".into());
+        let w1 = reg.register(MAC, "w1".into());
+
+        // Both heard from at t=1_000; advance just past the timeout with no
+        // heartbeat → both dead → placement has no candidates and stays total.
+        clock.set(1_000 + 6_001);
+        let p = LoadAwarePlacement::new(&reg, MAC);
+        let _ = p.place(&mote(3)); // does not panic
+
+        // Revive w1 only: every Mote now routes to the one live worker, never the
+        // dead one (no new work placed on a worker past its heartbeat-timeout).
+        reg.heartbeat(w1, 0, 0).unwrap();
+        let p = LoadAwarePlacement::new(&reg, MAC);
+        for b in 0..32u8 {
+            let placed = p.place(&mote(b));
+            assert_eq!(placed, w1, "byte {b} must route to the live worker");
+            assert_ne!(placed, w0, "the dead worker is never placed on");
+        }
     }
 }

--- a/crates/kx-coordinator/src/registry.rs
+++ b/crates/kx-coordinator/src/registry.rs
@@ -2,16 +2,50 @@
 //! trait** (P2.2 DoD item 2) so the in-memory default can be swapped for a
 //! distributed / persistent store later without touching the service.
 //!
-//! In P2.2 the coordinator never dispatches work (that is P2.3): the registry is
-//! liveness bookkeeping plus the **admission oracle** for `ReportCommit` — an
-//! unregistered worker cannot propose a commit.
+//! The registry is liveness bookkeeping plus the **admission oracle** for
+//! `ReportCommit` / `LeaseWork` (an unregistered worker cannot propose or pull),
+//! and — from P3.1 — the **worker-death detector**: it owns the coordinator's
+//! [`Clock`], stamps each heartbeat's *receipt* time, and derives liveness as a
+//! pure function of (last-seen, now, timeout). A worker that stops heartbeating
+//! ages out of [`live_snapshot`](WorkerRegistry::live_snapshot), so placement (D56)
+//! routes no new work to it. Detection only — rescheduling a dead worker's
+//! in-flight Motes is P3.2 (safe only under the journal's idempotency dedupe).
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, PoisonError};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
 
 use kx_scheduler::WorkerId;
 use kx_warrant::ExecutorClass;
+
+use crate::clock::{Clock, SystemClock};
+
+/// Default liveness window: a worker unheard-from for longer than this is `Dead`.
+///
+/// Chosen conservatively at ≥ 3× the recommended worker heartbeat cadence (2 s),
+/// so two dropped/late heartbeats do not trip a false death (the P0.9 stuck-vs-dead
+/// policy: never declare a slow-but-alive worker dead — the only consequence here
+/// is placement eviction, which self-heals on the next heartbeat).
+pub const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_secs(6);
+
+/// A registered worker's liveness as of a given instant — a derived view, not
+/// stored state (so it can never drift from the timestamps it summarizes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerStatus {
+    /// Heard from within the liveness window.
+    Live,
+    /// Silent past the liveness window (heartbeat-timeout death, P3.1).
+    Dead,
+}
+
+/// Whether a worker last seen at `last_seen_ms` is still live at `now_ms` under
+/// `timeout_ms`. Pure + total: a `last_seen` in the future (clock non-monotonicity)
+/// counts as live via the saturating subtraction — the conservative direction.
+#[must_use]
+pub fn is_live(last_seen_ms: u64, now_ms: u64, timeout_ms: u64) -> bool {
+    now_ms.saturating_sub(last_seen_ms) <= timeout_ms
+}
 
 /// One worker's registration plus its last-known liveness.
 #[derive(Debug, Clone)]
@@ -22,7 +56,12 @@ pub struct WorkerRecord {
     pub executor_class: ExecutorClass,
     /// How the coordinator reaches the worker (host:port / URL / socket path).
     pub endpoint: String,
-    /// Wall-clock ms of the most recent heartbeat (liveness only; never hashed).
+    /// **Coordinator-stamped** ms at which the most recent heartbeat (or the
+    /// registration) was received — the single-clock basis for liveness (P3.1),
+    /// immune to worker/coordinator clock skew. Liveness only; never hashed.
+    pub last_seen_ms: u64,
+    /// The worker-supplied wall-clock from its last heartbeat — advisory /
+    /// diagnostic (the worker's own clock); NOT used for liveness. Never hashed.
     pub last_heartbeat_ms: u64,
     /// Motes the worker reported executing at its last heartbeat.
     pub in_flight: u32,
@@ -67,24 +106,85 @@ pub trait WorkerRegistry: Send + Sync {
     fn snapshot(&self) -> Vec<WorkerRecord> {
         Vec::new()
     }
+
+    /// A snapshot of the workers that are **currently live** — the input placement
+    /// must rank over so a dead worker (heartbeat-timeout, P3.1) gets no new work.
+    /// The implementor reads its own [`Clock`] + timeout to decide; the default
+    /// (for registries that don't track liveness) treats every worker as live, so
+    /// existing implementors keep their pre-P3.1 behavior.
+    fn live_snapshot(&self) -> Vec<WorkerRecord> {
+        self.snapshot()
+    }
+
+    /// The liveness [`WorkerStatus`] of one worker, or `None` if never registered —
+    /// the operator/diagnostic query for worker-death detection. The default
+    /// reports any registered worker `Live`; a liveness-tracking registry overrides
+    /// it. This is also the seam P3.2 reads to trigger reschedule-on-death.
+    fn status(&self, worker: WorkerId) -> Option<WorkerStatus> {
+        self.get(worker).map(|_| WorkerStatus::Live)
+    }
 }
 
 /// In-memory [`WorkerRegistry`] — the OSS default.
 ///
 /// `BTreeMap` for deterministic iteration order; an [`AtomicU64`] hands out
 /// monotonic ids starting at `0`. A poisoned lock is recovered (not panicked):
-/// the registry's invariants survive a panicking critic elsewhere.
-#[derive(Debug, Default)]
+/// the registry's invariants survive a panicking critic elsewhere. It owns the
+/// coordinator's [`Clock`] (the single liveness time source) and the liveness
+/// timeout, so death detection (P3.1) is encapsulated here — callers ask for
+/// [`live_snapshot`](WorkerRegistry::live_snapshot) / [`status`](WorkerRegistry::status)
+/// without threading `now`/`timeout` around.
+#[derive(Debug)]
 pub struct InMemoryWorkerRegistry {
     next_id: AtomicU64,
     workers: Mutex<BTreeMap<WorkerId, WorkerRecord>>,
+    clock: Arc<dyn Clock>,
+    liveness_timeout: Duration,
+}
+
+impl Default for InMemoryWorkerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl InMemoryWorkerRegistry {
-    /// Construct an empty registry.
+    /// Construct an empty registry over the host wall clock ([`SystemClock`]) and
+    /// the [`DEFAULT_LIVENESS_TIMEOUT`].
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    /// Construct an empty registry over a caller-supplied [`Clock`] (tests inject a
+    /// deterministic clock to advance time without sleeping) and the
+    /// [`DEFAULT_LIVENESS_TIMEOUT`].
+    #[must_use]
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self::with_clock_and_timeout(clock, DEFAULT_LIVENESS_TIMEOUT)
+    }
+
+    /// Construct an empty registry over a caller-supplied [`Clock`] and liveness
+    /// timeout (tests that exercise the timeout boundary).
+    #[must_use]
+    pub fn with_clock_and_timeout(clock: Arc<dyn Clock>, liveness_timeout: Duration) -> Self {
+        Self {
+            next_id: AtomicU64::new(0),
+            workers: Mutex::new(BTreeMap::new()),
+            clock,
+            liveness_timeout,
+        }
+    }
+
+    /// The configured liveness window.
+    #[must_use]
+    pub fn liveness_timeout(&self) -> Duration {
+        self.liveness_timeout
+    }
+
+    /// Liveness timeout in ms (saturating), the unit `is_live` compares in.
+    fn timeout_ms(&self) -> u64 {
+        u64::try_from(self.liveness_timeout.as_millis()).unwrap_or(u64::MAX)
     }
 }
 
@@ -95,6 +195,9 @@ impl WorkerRegistry for InMemoryWorkerRegistry {
             id,
             executor_class,
             endpoint,
+            // A just-registered worker is live: stamp receipt time so it is not
+            // instantly aged out before its first heartbeat.
+            last_seen_ms: self.clock.now_ms(),
             last_heartbeat_ms: 0,
             in_flight: 0,
         };
@@ -111,10 +214,14 @@ impl WorkerRegistry for InMemoryWorkerRegistry {
         now_ms: u64,
         in_flight: u32,
     ) -> Result<(), RegistryError> {
+        // Stamp the coordinator's own receipt time for liveness (skew-immune);
+        // keep the worker-supplied `now_ms` only as an advisory diagnostic.
+        let seen = self.clock.now_ms();
         let mut guard = self.workers.lock().unwrap_or_else(PoisonError::into_inner);
         let record = guard
             .get_mut(&worker)
             .ok_or(RegistryError::UnknownWorker(worker))?;
+        record.last_seen_ms = seen;
         record.last_heartbeat_ms = now_ms;
         record.in_flight = in_flight;
         Ok(())
@@ -142,5 +249,127 @@ impl WorkerRegistry for InMemoryWorkerRegistry {
             .values()
             .cloned()
             .collect()
+    }
+
+    fn live_snapshot(&self) -> Vec<WorkerRecord> {
+        let now = self.clock.now_ms();
+        let timeout = self.timeout_ms();
+        self.workers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .values()
+            .filter(|w| is_live(w.last_seen_ms, now, timeout))
+            .cloned()
+            .collect()
+    }
+
+    fn status(&self, worker: WorkerId) -> Option<WorkerStatus> {
+        let now = self.clock.now_ms();
+        let timeout = self.timeout_ms();
+        self.workers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&worker)
+            .map(|w| {
+                if is_live(w.last_seen_ms, now, timeout) {
+                    WorkerStatus::Live
+                } else {
+                    WorkerStatus::Dead
+                }
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLASS: ExecutorClass = ExecutorClass::MacOsSandbox;
+    const TIMEOUT: Duration = Duration::from_secs(6);
+
+    /// A deterministic clock the test advances by hand — no real sleeps.
+    #[derive(Debug)]
+    struct FakeClock(AtomicU64);
+
+    impl FakeClock {
+        fn new(ms: u64) -> Arc<Self> {
+            Arc::new(Self(AtomicU64::new(ms)))
+        }
+        fn set(&self, ms: u64) {
+            self.0.store(ms, Ordering::Relaxed);
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now_ms(&self) -> u64 {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
+
+    fn registry(clock: Arc<FakeClock>) -> InMemoryWorkerRegistry {
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock, TIMEOUT)
+    }
+
+    #[test]
+    fn is_live_is_total_and_conservative() {
+        // Exactly at the window edge is still live; one ms past is dead.
+        assert!(is_live(0, 6_000, 6_000));
+        assert!(!is_live(0, 6_001, 6_000));
+        // A future last-seen (clock non-monotonicity) is treated as live.
+        assert!(is_live(100, 50, 6_000));
+    }
+
+    #[test]
+    fn a_freshly_registered_worker_is_live_before_any_heartbeat() {
+        let clock = FakeClock::new(1_000);
+        let reg = registry(clock);
+        let w = reg.register(CLASS, "w".into());
+        assert_eq!(reg.status(w), Some(WorkerStatus::Live));
+        assert_eq!(reg.live_snapshot().len(), 1);
+    }
+
+    #[test]
+    fn a_worker_goes_dead_after_the_timeout_and_revives_on_heartbeat() {
+        let clock = FakeClock::new(1_000);
+        let reg = registry(clock.clone());
+        let w = reg.register(CLASS, "w".into());
+
+        // Within the window: live.
+        clock.set(1_000 + 6_000);
+        assert_eq!(reg.status(w), Some(WorkerStatus::Live));
+
+        // One ms past the window with no heartbeat: dead, and evicted from the
+        // live snapshot (placement will route it no new work).
+        clock.set(1_000 + 6_001);
+        assert_eq!(reg.status(w), Some(WorkerStatus::Dead));
+        assert!(reg.live_snapshot().is_empty());
+
+        // A heartbeat re-stamps receipt time → live again (self-healing).
+        reg.heartbeat(w, 999_999, 0).unwrap();
+        assert_eq!(reg.status(w), Some(WorkerStatus::Live));
+        assert_eq!(reg.live_snapshot().len(), 1);
+    }
+
+    #[test]
+    fn heartbeat_stamps_coordinator_clock_not_worker_timestamp() {
+        let clock = FakeClock::new(5_000);
+        let reg = registry(clock);
+        let w = reg.register(CLASS, "w".into());
+        // Worker reports a wildly skewed timestamp; liveness uses the coordinator
+        // clock (last_seen_ms = 5_000), the worker value is advisory only.
+        reg.heartbeat(w, 42, 3).unwrap();
+        let rec = reg.get(w).unwrap();
+        assert_eq!(rec.last_seen_ms, 5_000, "coordinator-stamped receipt time");
+        assert_eq!(
+            rec.last_heartbeat_ms, 42,
+            "worker timestamp kept as advisory"
+        );
+        assert_eq!(rec.in_flight, 3);
+    }
+
+    #[test]
+    fn status_of_unknown_worker_is_none() {
+        let reg = registry(FakeClock::new(1));
+        assert_eq!(reg.status(WorkerId(999)), None);
     }
 }

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -60,6 +60,18 @@ impl CoordinatorService {
         )
     }
 
+    /// Build a coordinator with **both** a caller-supplied worker registry and the
+    /// shared content store (the `with_registry` + `with_store` combination). Used
+    /// where a test needs a clock-injected registry (worker-death detection, P3.1)
+    /// *and* the store's phantom-ref guard.
+    pub fn with_store_and_registry<J: Journal + Send + 'static>(
+        journal: J,
+        store: Arc<LocalFsContentStore>,
+        registry: Arc<dyn WorkerRegistry>,
+    ) -> Self {
+        Self::build(journal, registry, Some(store))
+    }
+
     fn build<J: Journal + Send + 'static>(
         journal: J,
         registry: Arc<dyn WorkerRegistry>,

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -193,6 +193,25 @@ pub async fn register(service: &CoordinatorService, endpoint: &str) -> u64 {
         .worker_id
 }
 
+/// Send a heartbeat for `worker_id` through the service (liveness tests).
+pub async fn heartbeat(
+    service: &CoordinatorService,
+    worker_id: u64,
+    timestamp_ms: u64,
+    in_flight: u32,
+) -> bool {
+    service
+        .heartbeat(Request::new(proto::HeartbeatRequest {
+            worker_id,
+            timestamp_ms,
+            in_flight,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .ack
+}
+
 /// Submit a Mote + warrant through the service.
 pub async fn submit(
     service: &CoordinatorService,

--- a/crates/kx-coordinator/tests/liveness.rs
+++ b/crates/kx-coordinator/tests/liveness.rs
@@ -1,0 +1,142 @@
+//! Worker-death detection (P3.1): a worker that stops heartbeating ages out of the
+//! coordinator's live view past the liveness timeout, so `LeaseWork` (placement v2,
+//! D56) routes no new work to it. Detection only — rescheduling the dead worker's
+//! in-flight Motes is P3.2.
+//!
+//! Time is driven by an injected [`kx_coordinator::Clock`] so the test advances past
+//! the timeout deterministically, with no real sleeps. The coordinator stamps each
+//! heartbeat's *receipt* time with this clock (skew-immune liveness).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_coordinator::proto::ExecutorClass;
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, WorkerId, WorkerRegistry, WorkerStatus,
+};
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+
+const TIMEOUT: Duration = Duration::from_secs(6);
+
+/// A deterministic clock the test advances by hand.
+#[derive(Debug)]
+struct FakeClock(AtomicU64);
+impl FakeClock {
+    fn new(ms: u64) -> Arc<Self> {
+        Arc::new(Self(AtomicU64::new(ms)))
+    }
+    fn set(&self, ms: u64) {
+        self.0.store(ms, Ordering::Relaxed);
+    }
+}
+impl Clock for FakeClock {
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+fn coordinator(clock: Arc<FakeClock>) -> CoordinatorService {
+    let registry: Arc<dyn WorkerRegistry> = Arc::new(
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock, TIMEOUT),
+    );
+    CoordinatorService::with_registry(InMemoryJournal::new(), registry)
+}
+
+#[tokio::test]
+async fn a_silent_worker_is_detected_dead_and_gets_no_new_work() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant(); // executor_class = MacOsSandbox
+
+    let dead = common::register(&svc, "dead").await;
+    let live = common::register(&svc, "live").await;
+
+    // Several independent ready PURE roots to place.
+    let motes: Vec<_> = (10u8..18)
+        .map(|s| common::mote(s, NdClass::Pure, &[]))
+        .collect();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    // Both fresh registrations are live.
+    assert_eq!(
+        svc.registry().status(WorkerId(dead)),
+        Some(WorkerStatus::Live)
+    );
+    assert_eq!(
+        svc.registry().status(WorkerId(live)),
+        Some(WorkerStatus::Live)
+    );
+
+    // Advance just past the timeout with no heartbeats: both have aged out.
+    clock.set(1_000 + 6_001);
+    assert_eq!(
+        svc.registry().status(WorkerId(dead)),
+        Some(WorkerStatus::Dead)
+    );
+    assert_eq!(
+        svc.registry().status(WorkerId(live)),
+        Some(WorkerStatus::Dead)
+    );
+
+    // The `live` worker heartbeats (re-stamping its receipt time); `dead` stays silent.
+    common::heartbeat(&svc, live, 0, 0).await;
+    assert_eq!(
+        svc.registry().status(WorkerId(live)),
+        Some(WorkerStatus::Live)
+    );
+    assert_eq!(
+        svc.registry().status(WorkerId(dead)),
+        Some(WorkerStatus::Dead)
+    );
+
+    // Every Mote the live worker leases is placement-preferred for it (the dead
+    // worker is not a candidate) — and it can drain the whole ready set.
+    let leased = common::lease_work(&svc, live, ExecutorClass::MacosSandbox, 64).await;
+    assert_eq!(
+        leased.len(),
+        motes.len(),
+        "the live worker can lease all ready work; the dead one is evicted from placement"
+    );
+
+    // Even if the dead worker *did* poll (e.g. a network partition that later heals),
+    // fill-to-max still hands it ready work rather than starving it — detection only
+    // stops *placement preference*, it does not refuse a registered worker (reschedule
+    // + eviction-on-poll is P3.2). The point P3.1 proves: no new work is *placed* on it.
+    let dead_leased = common::lease_work(&svc, dead, ExecutorClass::MacosSandbox, 64).await;
+    // Work was already leased to `live` above but never committed; both can see ready
+    // work (double-execution is harmless under journal dedupe, D54). The assertion that
+    // matters is liveness status, checked above.
+    let _ = dead_leased;
+}
+
+#[tokio::test]
+async fn a_heartbeat_keeps_a_worker_live_across_the_window() {
+    let clock = FakeClock::new(0);
+    let svc = coordinator(clock.clone());
+
+    let w = common::register(&svc, "w").await;
+
+    // Walk time forward in sub-timeout steps, heartbeating each step: the worker
+    // never crosses the death threshold.
+    for step in 1..=10u64 {
+        clock.set(step * 5_000); // 5 s < 6 s timeout
+        common::heartbeat(&svc, w, 0, 0).await;
+        assert_eq!(
+            svc.registry().status(WorkerId(w)),
+            Some(WorkerStatus::Live),
+            "a worker heartbeating inside the window is always live (step {step})"
+        );
+    }
+
+    // Stop heartbeating and cross the window once: now dead.
+    clock.set(10 * 5_000 + 6_001);
+    assert_eq!(svc.registry().status(WorkerId(w)), Some(WorkerStatus::Dead));
+}

--- a/crates/kx-worker/Cargo.toml
+++ b/crates/kx-worker/Cargo.toml
@@ -28,14 +28,15 @@ kx-content = { workspace = true }
 tonic = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+# The background liveness heartbeat (P3.1): a spawned task ticks on an interval so an
+# idle worker stays live in the coordinator's registry. `rt` (via the workspace
+# `rt-multi-thread`) + `time` are additive over the workspace tokio features.
+tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 # The e2e test hosts a real CoordinatorService over an in-process gRPC server and
 # drives the full register -> lease -> run -> propose-commit loop against it.
 kx-coordinator = { workspace = true }
-# `time` is additive over the workspace tokio features — the e2e uses a short
-# connect-retry sleep while the in-process server binds (the kx-proto pattern).
-tokio = { workspace = true, features = ["time"] }
 smallvec = { workspace = true }
 # Shared on-disk content_root for the cross-node read e2e (worker A writes, the
 # coordinator verifies, peer B reads — all against one LocalFsContentStore root).

--- a/crates/kx-worker/src/lib.rs
+++ b/crates/kx-worker/src/lib.rs
@@ -39,8 +39,12 @@
 //! PURE Motes only. A PURE Mote has no real-world effect, so running it on the
 //! worker and proposing its commit is sound. WORLD-MUTATING Motes need a durable
 //! staged-intent RPC (so the coordinator records the `EffectStaged` recovery hint
-//! before the effect fires) — deferred. Placement v2 (locality / GPU-slot) is P2.5;
-//! worker provisioning / liveness-driven scale is P3 (D47).
+//! before the effect fires) — deferred. Placement v2 (locality / GPU-slot) is P2.5.
+//!
+//! From **P3.1** the worker also runs a background **liveness heartbeat**
+//! ([`Worker::spawn_heartbeat`]) so an idle worker stays live in the coordinator's
+//! registry (worker-death detection is heartbeat-timeout based). Worker provisioning
+//! / liveness-driven scale-to-zero remains P3+ (D47).
 //!
 //! ## Thesis test
 //!
@@ -61,4 +65,4 @@ mod worker;
 
 pub use client::WorkerClient;
 pub use error::WorkerError;
-pub use worker::Worker;
+pub use worker::{Worker, DEFAULT_HEARTBEAT_CADENCE};

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -1,13 +1,15 @@
 //! [`Worker`] — registers with the coordinator, then leases / runs / proposes.
 
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_executor::{LocalResourceManager, MoteExecutor};
 use kx_mote::{Mote, MoteId};
 use kx_proto::proto;
 use kx_warrant::{ExecutorClass, WarrantSpec};
+use tokio::task::JoinHandle;
 
 use crate::client::WorkerClient;
 use crate::error::WorkerError;
@@ -16,6 +18,15 @@ use crate::{commit_builder, run};
 
 /// `ReadEntries` page size when folding the local read model.
 const READ_PAGE: u32 = 256;
+
+/// Default cadence for the background liveness heartbeat ([`Worker::spawn_heartbeat`]).
+///
+/// Kept well under the coordinator's liveness timeout
+/// (`kx_coordinator::DEFAULT_LIVENESS_TIMEOUT` = 6 s): the **invariant** is
+/// `coordinator_timeout >= 3 * cadence`, so two dropped/late heartbeats do not trip
+/// a false worker-death (the P0.9 stuck-vs-dead policy — never declare a
+/// slow-but-alive worker dead).
+pub const DEFAULT_HEARTBEAT_CADENCE: Duration = Duration::from_secs(2);
 
 /// A registered worker bound to one coordinator. Holds the hosted executor + a
 /// resource manager (the verbatim P1 execution stack), the shared content store it
@@ -30,6 +41,11 @@ pub struct Worker {
     store: Arc<LocalFsContentStore>,
     read_model: ReadModel,
     max_lease: u32,
+    /// The worker's live in-flight Mote count — the single source of truth for the
+    /// load it reports. [`run_once`](Self::run_once) updates it around execution; the
+    /// background heartbeat ([`spawn_heartbeat`](Self::spawn_heartbeat)) reads it, so
+    /// liveness *and* load (D56 placement) stay accurate even while idle.
+    in_flight: Arc<AtomicU32>,
 }
 
 impl Worker {
@@ -58,6 +74,7 @@ impl Worker {
             store,
             read_model: ReadModel::new(),
             max_lease,
+            in_flight: Arc::new(AtomicU32::new(0)),
         })
     }
 
@@ -102,8 +119,11 @@ impl Worker {
 
         // Report load so the coordinator's placement (D56) can balance across workers:
         // `in_flight` = the batch we're about to run, reset to 0 when it drains.
-        // Best-effort — a heartbeat hiccup must never abort real execution.
+        // Publish to the shared counter (the background heartbeat reads it too), then
+        // send an immediate heartbeat so placement sees the load without waiting for
+        // the next tick. Best-effort — a heartbeat hiccup must never abort execution.
         let in_flight = u32::try_from(items.len()).unwrap_or(u32::MAX);
+        self.in_flight.store(in_flight, Ordering::Relaxed);
         if in_flight > 0 {
             let _ = self.client.heartbeat(self.id, now_ms(), in_flight).await;
         }
@@ -138,6 +158,7 @@ impl Worker {
                 _ => return Err(WorkerError::CommitRejected(response.detail)),
             }
         }
+        self.in_flight.store(0, Ordering::Relaxed);
         if in_flight > 0 {
             let _ = self.client.heartbeat(self.id, now_ms(), 0).await;
         }
@@ -148,6 +169,44 @@ impl Worker {
     /// Returns the coordinator's ack.
     pub async fn heartbeat(&mut self, in_flight: u32) -> Result<bool, WorkerError> {
         self.client.heartbeat(self.id, now_ms(), in_flight).await
+    }
+
+    /// Spawn a background task that heartbeats every `cadence`, keeping this worker
+    /// **live** in the coordinator's registry even while idle — an idle worker leases
+    /// no work, so without this it would send nothing and be falsely declared dead
+    /// (worker-death detection, P3.1). The reported `in_flight` tracks the worker's
+    /// live batch via the shared counter [`run_once`](Self::run_once) maintains, so
+    /// load-aware placement (D56) stays accurate.
+    ///
+    /// Returns the task [`JoinHandle`]; the caller owns its lifetime (drop/abort to
+    /// stop, e.g. on shutdown). Best-effort: a failed heartbeat is logged and retried
+    /// on the next tick — a transient hiccup never tears the worker down. Missed ticks
+    /// are delayed (not bursted) so a stall cannot produce a thundering catch-up.
+    ///
+    /// INVARIANT: `cadence` must be well under the coordinator's liveness timeout —
+    /// `timeout >= 3 * cadence` (see [`DEFAULT_HEARTBEAT_CADENCE`]) — so a couple of
+    /// dropped heartbeats do not trip a false death (P0.9: never declare a
+    /// slow-but-alive worker dead).
+    #[must_use]
+    pub fn spawn_heartbeat(&self, cadence: Duration) -> JoinHandle<()> {
+        let mut client = self.client.clone();
+        let id = self.id;
+        let in_flight = Arc::clone(&self.in_flight);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(cadence);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let load = in_flight.load(Ordering::Relaxed);
+                if let Err(error) = client.heartbeat(id, now_ms(), load).await {
+                    tracing::debug!(
+                        worker_id = id,
+                        %error,
+                        "background heartbeat failed; retrying next tick"
+                    );
+                }
+            }
+        })
     }
 }
 

--- a/crates/kx-worker/tests/e2e.rs
+++ b/crates/kx-worker/tests/e2e.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_coordinator::proto::coordinator_server::{Coordinator, CoordinatorServer};
-use kx_coordinator::{CoordinatorService, MoteState, WorkerId};
+use kx_coordinator::{CoordinatorService, MoteState, WorkerId, WorkerStatus};
 use kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor};
 use kx_journal::InMemoryJournal;
 use kx_mote::Mote;
@@ -292,5 +292,55 @@ async fn two_workers_share_the_workload_via_placement() {
     assert_eq!(
         worker_b.peer_read(motes[0].id).await.unwrap(),
         result_bytes(&motes[0]),
+    );
+}
+
+/// P3.1: an **idle** worker (leasing no work) stays live in the coordinator's
+/// registry because its background heartbeat keeps reporting in. Without it, an idle
+/// worker would send nothing and be falsely declared dead.
+#[tokio::test]
+async fn background_heartbeat_keeps_an_idle_worker_live() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let (svc, endpoint) = spawn_coordinator(store.clone()).await;
+
+    // Register a worker but never lease/run anything — it is purely idle.
+    let worker = Worker::register(
+        connect(&endpoint).await,
+        common::WORKER_CLASS,
+        "inproc://idle",
+        storing_executor(store.clone()),
+        LocalResourceManager::dev_defaults(),
+        store.clone(),
+        16,
+    )
+    .await
+    .unwrap();
+    let id = worker.worker_id();
+
+    // At registration the worker has not heartbeated yet (advisory timestamp == 0).
+    assert_eq!(
+        svc.registry().get(WorkerId(id)).unwrap().last_heartbeat_ms,
+        0,
+        "no heartbeat before the background task starts"
+    );
+
+    // Start the background heartbeat at a short cadence; let it tick several times.
+    let hb = worker.spawn_heartbeat(Duration::from_millis(20));
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    hb.abort();
+
+    // The idle worker reached the coordinator on its own (advisory timestamp now set
+    // by the background loop — the only heartbeat source, since nothing was leased)
+    // and is still live.
+    let rec = svc.registry().get(WorkerId(id)).unwrap();
+    assert!(
+        rec.last_heartbeat_ms > 0,
+        "the background heartbeat reached the coordinator while idle"
+    );
+    assert_eq!(
+        svc.registry().status(WorkerId(id)),
+        Some(WorkerStatus::Live),
+        "the idle worker is kept live by its background heartbeat"
     );
 }


### PR DESCRIPTION
First step of **PHASE P3 (fault tolerance)**. The coordinator now detects a worker that has stopped heartbeating and stops placing new work on it. **DETECTION ONLY** — rescheduling a dead worker's in-flight Motes is P3.2 (safe only under the journal's idempotency dedupe), so nothing destructive happens here.

## Design — liveness is a derived property, not stored state
- **New `Clock` trait (+ `SystemClock`)** is the coordinator's liveness time source. A dead worker sends nothing, so the *coordinator* must read its own clock; it now stamps each heartbeat's **receipt** time (`WorkerRecord.last_seen_ms`), making liveness single-clock and immune to worker/coordinator skew. The worker-supplied `timestamp_ms` is kept only as an advisory diagnostic (`last_heartbeat_ms`). Liveness is **never hashed / never on the journal path** (SN-8).
- **`is_live(last_seen, now, timeout)`** is a pure, total function (saturating-sub → a future last-seen counts as live, the conservative direction). **`WorkerStatus {Live, Dead}`** is derived, so it can never drift from the timestamps it summarizes.
- The **`InMemoryWorkerRegistry` owns the clock + timeout** and exposes `live_snapshot()` / `status()`; **`LoadAwarePlacement` ranks over `live_snapshot()`** instead of `snapshot()`, so a dead worker is evicted from placement with **no signature churn** in the core loop or service. No background reaper, no timer in the owner thread (request-driven core + **D40 sole-writer** preserved). New trait methods are default-implemented (back-compat).
- Honors **P0.9 (stuck-vs-dead)**: default timeout 6 s ≥ 3× the worker heartbeat cadence (2 s), so a couple of dropped/late heartbeats never trip a false death; the only consequence is placement eviction, which **self-heals** on the next beat.

## kx-worker
An idle worker leases no work and so would send nothing → falsely declared dead. Added **`Worker::spawn_heartbeat(cadence)`** — a background task (interval, missed-tick = Delay, best-effort) that reports the live in-flight count via a shared `AtomicU32` `run_once` maintains, so liveness **and** load (D56 placement) stay accurate while idle. `tokio` promoted to a real dependency.

## D47
P3.1 is the named trigger: D47 lifts DEFERRED → ACTIVE for the **liveness half only**. **No front-door listener, no scale-to-zero, no provisioning branch** — detection only; the §B design stays deferred.

## Thesis test
`kx-scheduler` / `kx-executor` / `kx-inference` source **unchanged** (diff-proven empty). Distribution + fault-tolerance is wiring, not a rewrite.

## Tests (+9) & gate
Registry liveness (FakeClock boundary / revival / skew), placement dead-worker eviction, coordinator detection integration (`tests/liveness.rs`), idle-worker-stays-live e2e. Full local gate green: fmt, clippy `-D warnings`, `cargo test --workspace` (**846 passed / 0 failed / 8 ignored**), deny, doc `-D warnings`, ffi-link, **I1.c byte-determinism** (21 artifacts bit-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)