### PR TITLE
docs: altitude pass — compress design-narrative headers to corpus pointers

### DIFF
--- a/crates/kx-memoizer/src/lib.rs
+++ b/crates/kx-memoizer/src/lib.rs
@@ -13,72 +13,28 @@
 // `expect_used`. Integration tests under tests/*.rs carry per-file allows.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-//! # kx-memoizer — pure lookup over projection state
+//! # kx-memoizer — pure cache-hit lookup over projection state
 //!
-//! The memoizer answers a single question, with cryptographic precision:
+//! [`lookup`] answers one question as a **pure, total, deterministic** function of a
+//! candidate [`Mote`] and a read-only [`Snapshot`]: *"is this exact `MoteId` already
+//! committed and safe to serve as a cache hit?"* Matching is **EXACT cryptographic
+//! equality only**, never similarity (SN-8) — two Motes match iff their derived
+//! `MoteId`s are bit-identical. [`kx_mote::derive_mote_id`] is the single identity
+//! truth; canonicalize fuzzy-similar inputs with the normalizer (P1.7.10) *before*
+//! fingerprinting.
 //!
-//! > "Have we already committed for this exact `MoteId`, and is the
-//! > commitment safe to serve as a cache hit?"
+//! It returns a [`CacheHit`] (variant mirroring the candidate's [`NdClass`]) iff the
+//! projection reports the Mote `Committed`, no **Data-edge** parent is `Repudiated`
+//! (a repudiated parent poisons the lineage; Control edges sequence-only, never
+//! taint), and a `result_ref` is present. Read-side only: it never dispatches,
+//! re-dispatches, runs inference, or mutates — the executor (P1.9) acts on the hit,
+//! and the journal-write side goes through the executor's commit protocol.
 //!
-//! [`lookup`] is a **pure, total, deterministic** function over a candidate
-//! [`Mote`] and a read-only [`Snapshot`]. It performs **EXACT cryptographic
-//! equality only** — there is no similarity operator anywhere on the identity
-//! path, by SN-8 mandate. Two Motes match iff their derived `MoteId`s match
-//! bit-for-bit (which implies their `MoteDef`, `input_data_id`, and
-//! `graph_position` all match by BLAKE3 collision resistance).
-//!
-//! ## What the memoizer does (and doesn't)
-//!
-//! - **Does**: cross-reference the candidate Mote against the projection
-//!   snapshot. If the projection reports the Mote as `Committed` AND no
-//!   Data-edge parent is `Repudiated` AND a `result_ref` is present, returns
-//!   a [`CacheHit`] variant whose discriminant mirrors the candidate's
-//!   declared [`NdClass`].
-//! - **Doesn't**: dispatch effects, re-dispatch effects, run inference, or
-//!   mutate state. The executor (P1.9) is what acts on the hit.
-//!
-//! ## Effect-once vs inference-once (per `validate-then-commit.md` §10.5)
-//!
-//! These are SEPARATE primitives. The memoizer is the inference-once
-//! primitive: it caches the model's decision. The broker (P1.8.5) is the
-//! effect-once primitive: it deduplicates side effects against the
-//! warrant-scoped world.
-//!
-//! On a [`CacheHit::WorldMutating`], the executor MUST re-dispatch the
-//! broker effect against the cached `result_ref` — the cache supplies the
-//! decision, but the effect goes through the broker per attempt. The
-//! `redispatch_effect: true` field exists to make this constraint loud at
-//! every match site.
-//!
-//! ## Repudiation cascade
-//!
-//! A `Repudiated` Data-edge parent poisons the cache: the upstream lineage
-//! is invalid, so any cached result downstream is stale. Control-edge
-//! parents are sync-only and do **not** taint cache eligibility (they carry
-//! no data semantics — they sequence, they do not feed).
-//!
-//! ## NO similarity, NO fuzzy match — by design
-//!
-//! If two Motes "look similar" but have different `MoteId`s, they are
-//! distinct facts. The runtime serves cache hits only on exact match. The
-//! [`kx_mote::derive_mote_id`] function is the single source of identity
-//! truth; the memoizer trusts it by construction. The escape hatch for
-//! fuzzy-similar-but-not-identical inputs is the normalizer (P1.7.10):
-//! deterministic canonicalization BEFORE fingerprinting. Fuzzy residue lives
-//! behind a model-as-Mote seam whose canonical output is committed as a
-//! durable fact.
-//!
-//! ## What lives here
-//!
-//! - [`CacheHit`] — the three-variant enum mirroring [`NdClass`].
-//! - [`lookup`] — the pure cross-reference function.
-//!
-//! ## What does NOT live here
-//!
-//! - The executor's dispatch decision tree (P1.9).
-//! - The broker's effect-once primitive (P1.8.5 / capability-broker).
-//! - The journal-write side of memoization (memoization is a READ-side
-//!   primitive; writes go through the executor's commit protocol).
+//! **Effect-once ≠ inference-once.** The memoizer is *inference*-once (it caches the
+//! model's decision); the broker (P1.8.5) is *effect*-once (it dedups side effects).
+//! So [`CacheHit::WorldMutating`] carries `redispatch_effect: true`: the cache
+//! supplies the decision, but the effect still goes through the broker per attempt.
+//! Rationale: design corpus `validate-then-commit.md` §10.5.
 
 use kx_content::ContentRef;
 use kx_mote::{EdgeKind, Mote, NdClass};

--- a/crates/kx-model-validator/src/lib.rs
+++ b/crates/kx-model-validator/src/lib.rs
@@ -20,58 +20,28 @@
 
 //! # kx-model-validator — static bind-time fitness type check
 //!
-//! Model fitness as a **type check over capability sets**.
+//! Model fitness as a **type check over capability sets**: a task declares
+//! [`RequiredCapabilities`] (the signature it expects), a model exposes
+//! [`ProvidedCapabilities`] (its actual type), and [`check`] performs structural
+//! subtyping — the model binds iff `provided ⊇ required`. Runs at **bind time**
+//! (model load / before scheduling a Mote that needs it), never as a mid-execution
+//! discovery: find the wrong model at load time, not three Motes into a workflow.
 //!
-//! - A task declares a [`RequiredCapabilities`] — the type signature it expects.
-//! - A model exposes a [`ProvidedCapabilities`] — its actual type.
-//! - [`check`] performs structural subtyping: the model is a valid binding iff
-//!   its provided capabilities satisfy (are a superset of) the task's required
-//!   ones.
+//! Three outcomes ([`ValidatorOutcome`]): `TypeOk` (`provided ⊇ required`, clean
+//! bind), `DegradedSubtype` (binds, but a soft capability is missing or emulated —
+//! e.g. tool-calling via prompting — recorded so the formatter adapter compensates),
+//! and `TypeError` (a REQUIRED capability is missing — refuses to bind, names the gap).
 //!
-//! Runs at **bind time** — when a model is loaded, or before a Mote needing
-//! that model is scheduled. It is a **static** check, never a mid-execution
-//! discovery. The whole value: find the wrong model at load time, not three
-//! Motes into a workflow.
-//!
-//! ## Three outcomes ([`ValidatorOutcome`])
-//!
-//! - [`ValidatorOutcome::TypeOk`] — `provided ⊇ required` — clean bind.
-//! - [`ValidatorOutcome::DegradedSubtype`] — binds, but an optional/soft
-//!   capability is missing or emulated (e.g. tool-calling done via prompting
-//!   instead of native). Records the degraded mode for downstream callers
-//!   (the formatter adapter compensates).
-//! - [`ValidatorOutcome::TypeError`] — a REQUIRED capability is missing —
-//!   refuses to bind, names the missing member and why.
-//!
-//! ## Hard boundary: interface, NOT quality
-//!
-//! The validator type-checks the model's **interface (signature)**, never its
-//! output **quality (behavior)**. Capability is statically checkable; quality
-//! is not — that's the workflow / eval / critic layer's job (orchestration vs
-//! semantic correctness).
-//!
-//! The validator's smaller, honest claim ("I prove your model HAS the required
-//! capabilities; I do not claim it'll be GOOD at them") is the source of its
-//! credibility. Do not let it drift into a quality oracle.
-//!
-//! ## Soundness boundary: v1 → v2
-//!
-//! - **v1 (this crate)** — the validator type-checks against the model's
-//!   **declared** [`ProvidedCapabilities`]. Declarations can lie. v1's guarantee
-//!   is *"the model CLAIMS to satisfy the signature."* All v1 language uses
-//!   "declared." `TypeOk` is more precisely "TypeOk-as-declared."
-//! - **v2 (deferred)** — a capability probe will verify each declaration via a
-//!   one-time deterministic test, result cached. v2 language will use "verified"
-//!   and "guaranteed."
-//! - In v1, the capability broker (P1.8.5) remains the runtime backstop that
-//!   catches false declarations at execution.
-//!
-//! ## House model competes on equal merit
-//!
-//! The validator does **not** know which model is the house model. There is
-//! no field, no flag, no boost. The type-theoretic framing makes the
-//! no-favoritism property structural rather than aspirational. See
-//! [`Recommender`] for the ranking discipline.
+//! **Interface, not quality.** It type-checks the model's *signature*, never its
+//! output *behavior* — quality is the workflow / eval / critic layer's job. The
+//! honest, smaller claim ("the model HAS the required capabilities; not that it'll be
+//! GOOD at them") is the source of its credibility; do not let it drift into a quality
+//! oracle. **v1 checks the model's *declared* capabilities** (declarations can lie, so
+//! `TypeOk` is precisely "TypeOk-as-declared"; the capability broker P1.8.5 is the
+//! runtime backstop that catches false declarations at execution). **v2 (deferred)**
+//! verifies each declaration via a cached one-time deterministic probe ("declared" →
+//! "verified"). The validator has no notion of a house model — no field, no boost; the
+//! type-theoretic framing makes no-favoritism structural (see [`Recommender`]).
 
 mod capabilities;
 mod check;

--- a/crates/kx-normalizer/src/lib.rs
+++ b/crates/kx-normalizer/src/lib.rs
@@ -15,75 +15,32 @@
 
 //! # kx-normalizer — deterministic canonicalization BEFORE fingerprinting
 //!
-//! The normalizer is the controlled escape hatch for "two inputs that mean
-//! the same thing but aren't bit-identical" — exactly the situation where a
-//! lesser system would reach for fuzzy matching. **The fix is NOT fuzzy
-//! matching.** Per SN-8 ("model proposes, runtime enforces") and D33, the
-//! runtime serves cache hits only on EXACT cryptographic equality. Two
-//! Motes match iff their derived `MoteId`s match bit-for-bit. There is NO
-//! similarity operator anywhere on the identity path.
+//! The controlled escape hatch for "two inputs that mean the same thing but aren't
+//! bit-identical" — the situation a lesser system answers with fuzzy matching. The
+//! fix is NOT fuzzy matching: per SN-8 and D33 the runtime serves cache hits only on
+//! EXACT cryptographic `MoteId` equality, with no similarity operator on the identity
+//! path. Instead [`normalize_deterministic`] canonicalizes inputs **before** they feed
+//! `MoteId` derivation, so equivalent inputs (`"ls   -la"` vs `"ls -la"`) become
+//! bit-identical and the memoizer's exact-equality hit fires for free; the fingerprint
+//! is computed over the canonical form. (The fingerprint itself is
+//! [`kx_mote::derive_mote_id`], not this crate.)
 //!
-//! The normalizer reconciles this with the workflow author's reasonable
-//! expectation that `"ls   -la"` and `"ls -la"` should refer to the same
-//! command. It does so by **canonicalizing inputs BEFORE they feed into
-//! `MoteId` derivation** — the two inputs become bit-identical after the
-//! rule applies, and the memoizer's exact-equality hit then fires for
-//! free. The fingerprint is computed over the canonical form.
+//! Two kinds (D33):
+//! - [`NormalizerKind::DeterministicRule`] — a versioned [`RuleSet`] applied purely,
+//!   bit-identical across machines + replays per `(rule_set, version)`. v0.1 ships one:
+//!   [`RuleSet::CommandLineIntent`] v1 (trim + collapse internal whitespace runs only —
+//!   no flag-reorder, path, or quoting normalization).
+//! - [`NormalizerKind::ModelAsMote`] — the model-as-Mote seam for fuzzy residue a rule
+//!   can't encode; the model's canonicalization is committed as a durable fact (the
+//!   journal-write side is the executor's, P1.9).
 //!
-//! ## Two normalizer kinds (D33)
-//!
-//! - [`NormalizerKind::DeterministicRule`] — a versioned rule set, applied
-//!   purely. Bit-identical across machines + replays per `(rule_set,
-//!   version)`. **v0.1 ships ONE rule set**: [`RuleSet::CommandLineIntent`]
-//!   v1, which canonicalizes whitespace (trim + collapse internal
-//!   whitespace runs to a single ASCII space). Conservative — does NOT
-//!   reorder flags, does NOT resolve paths, does NOT canonicalize
-//!   quoting. **When the rule is unsure, it keeps inputs distinct.**
-//!
-//! - [`NormalizerKind::ModelAsMote`] — the model-as-Mote seam for fuzzy
-//!   residue. The normalizer IS itself a Mote whose canonical output is
-//!   content-addressed and replayed. This is the escape hatch when a
-//!   deterministic rule cannot encode the intent; the model's
-//!   canonicalization is frozen as a durable fact.
-//!
-//! ## Why "conservative" matters
-//!
-//! A normalizer that merges things it shouldn't is far worse than one that
-//! keeps too many things distinct. Merging silently routes cache hits to
-//! the wrong upstream — a correctness bug that surfaces only under
-//! workflow author surprise. Keeping things distinct surfaces as "the
-//! cache didn't fire" — diagnosable, addressable, never silently wrong.
-//!
-//! v0.1's `CommandLineIntent` v1 is intentionally tiny: trim + whitespace
-//! collapse only. No flag-reordering (would silently change `cp src dst`
-//! into `cp dst src` if applied naively). No path normalization (changes
-//! semantics under symlinks). No quoting normalization (requires shell
-//! parser). Each of these is a **deliberate future-rule slot** — when
-//! added, they bump the rule version, never silently change v1's
-//! behavior.
-//!
-//! ## Versioning
-//!
-//! `(rule_set, version)` is the dispatch key. Two callers with the same
-//! `(rule_set, version)` get bit-identical canonical bytes; replay
-//! reproduces verbatim. **Future rule additions MUST bump the version**
-//! — silently changing v1's canonical output would break replay for
-//! every MoteId derived from a v1-normalized input.
-//!
-//! ## What lives here
-//!
-//! - [`RuleSet`] — the versioned rule-set identifier enum.
-//! - [`NormalizerKind`] — the per-call dispatch discriminant.
-//! - [`NormalizerError`] — typed failures.
-//! - [`normalize_deterministic`] — apply a rule set + version to raw bytes.
-//!
-//! ## What does NOT live here
-//!
-//! - The fingerprint computation itself (that's `kx_mote::derive_mote_id`).
-//! - The journal-write side of "ModelAsMote" normalizers (the executor at
-//!   P1.9 commits the model's canonical output as a Mote).
-//! - Any similarity operator. **Forbidden by SN-8** anywhere on the
-//!   identity path.
+//! **Conservative by mandate:** when a rule is unsure it keeps inputs *distinct*.
+//! Merging things it shouldn't silently routes a cache hit to the wrong upstream (a
+//! correctness bug surfacing only under author surprise); keeping them distinct merely
+//! misses a hit (diagnosable, never silently wrong). **Adding or changing a rule MUST
+//! bump the version** — silently changing v1's canonical bytes would break replay for
+//! every MoteId derived from a v1-normalized input. Rationale + the deliberate
+//! future-rule slots (flag-reorder, path, quoting): corpus `decisions.md` D33.
 
 use bytes::Bytes;
 use kx_mote::MoteId;


### PR DESCRIPTION
**Doc-only PR.** Applies the *documentation-altitude* convention: keep the interface **contract** inline (what / guarantees / invariants / which decision is enforced), move cross-cutting design **narrative** to a short corpus pointer. No logic change; no public API change.

### Why
Some crate headers had grown into design essays that duplicate the private corpus (decisions / specs). The contract belongs next to the code; the narrative belongs in the corpus with a pointer — readable when you open the file, with the deep "why" one hop away and kept honest by `cargo doc -D warnings` link-checking.

### What changed (3 crates with genuine bloat)
| Crate | Header | Kept (contract) | Moved (narrative) |
|---|---|---|---|
| `kx-memoizer` | 66 → 20 | pure/total/deterministic lookup, exact crypto-equality (SN-8), CacheHit/repudiation/`redispatch_effect` | effect-once-vs-inference-once + no-fuzzy essays → `validate-then-commit.md` §10.5 |
| `kx-normalizer` | 71 → 26 | canonicalize-before-fingerprint, the two D33 kinds, version-bump-or-break-replay, conservative-by-mandate | "why conservative" + future-rule slots → `decisions.md` D33 |
| `kx-model-validator` | 54 → 23 | structural-subtyping check, three outcomes, interface-not-quality, v1-declared/v2-verified, no-favoritism | per-section essays collapsed to tight prose |

Net **−117 doc lines**, every contract preserved.

### What was deliberately left intact
Assessed **all** non-frozen crates. Only the three above had real narrative bloat. Left as-is (Golden Rule 1 — no churn for marginal gains):
- **Trait-seam cores** (`kx-mote`/`kx-journal`/`kx-content`/`kx-warrant`/`kx-tool-registry`/`kx-capability`) — deep contract docs are a *feature* on the seams.
- **FFI safety audit trail** (`kx-llamacpp`) — layering/lifetime/safety-invariant docs are load-bearing.
- **Determinism contracts** (`kx-context-assembler`, `kx-projection`, `kx-tiering`) — already well-calibrated, with corpus pointers present.

### Excluded
`kx-scheduler` / `kx-executor` / `kx-inference` — under the just-signed-off P2 thesis-diff-empty freeze; editing even their doc comments would break the proof for a cosmetic reason. They get the altitude treatment when a P3 step touches them functionally.

### Verified
fmt · clippy `-D warnings` · doc `-D warnings` (intra-doc links intact) · tests pass for all three crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)