### PR TITLE
feat(kx-coordinator): reschedule dead workers' in-flight PURE Motes (P3.2, D57)

### DIFF
--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -48,6 +48,7 @@ mod commit;
 mod error;
 mod placement;
 mod registry;
+mod reschedule;
 mod service;
 mod state;
 

--- a/crates/kx-coordinator/src/reschedule.rs
+++ b/crates/kx-coordinator/src/reschedule.rs
@@ -1,0 +1,184 @@
+//! [`LeaseTracker`] — coordinator-side reschedule bookkeeping (D57).
+//!
+//! When a worker dies (P3.1 [`WorkerStatus::Dead`](crate::WorkerStatus)) the coordinator
+//! must re-lease its in-flight PURE Motes and record each death as a journal fact, bounded
+//! by a retry budget. This type holds the owner-thread state that makes that possible —
+//! who currently holds an unresolved lease on what, which crash-failed Motes remain
+//! rescheduleable, and how many times each has crash-failed. It is **pure bookkeeping**:
+//! it writes no journal (the owner thread does) and reads no clock. Design: D57
+//! (`distributed-reschedule.md`); recovery action it serves: D21 (`stuck-vs-dead.md`) §6/§7.
+//!
+//! A forward index (`worker → leased Motes`) plus a reverse index (`Mote → holding
+//! workers`) keep every operation sub-linear in the worker fleet: resolving a commit
+//! touches only the Motes' actual holders, not every worker — so reschedule bookkeeping
+//! scales with in-flight work, not fleet size.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_mote::MoteId;
+use kx_scheduler::WorkerId;
+
+/// Default PURE retry budget — the sanity ceiling from D21 §7 (D57 §4). A Mote whose
+/// successive leasing workers all crash accumulates this many `Failed{WorkerCrashed}`
+/// entries and is then terminal (no further replacement); workflow likely has a
+/// structural problem.
+pub(crate) const PURE_RETRY_BUDGET: u32 = 100;
+
+/// Owner-thread reschedule bookkeeping (D57). See the module docs.
+#[derive(Debug, Default)]
+pub(crate) struct LeaseTracker {
+    /// Forward: each worker's currently-outstanding (unresolved) leases.
+    leases: BTreeMap<WorkerId, BTreeSet<MoteId>>,
+    /// Reverse: each Mote's currently-holding workers (so `resolve_committed` is
+    /// O(holders), not O(fleet)). An entry is dropped when its set empties.
+    holders: BTreeMap<MoteId, BTreeSet<WorkerId>>,
+    /// Crash-failed-but-still-rescheduleable Motes — the extra lease candidates
+    /// `lease_ready` unions with the projection's ready-set (D57 §2).
+    crash_failed: BTreeSet<MoteId>,
+    /// Per-Mote count of worker-crash failures (the retry-budget counter, D57 §4).
+    attempt_failures: BTreeMap<MoteId, u32>,
+}
+
+impl LeaseTracker {
+    /// Record that `worker` now holds an outstanding lease on each of `motes`.
+    pub(crate) fn record_lease(
+        &mut self,
+        worker: WorkerId,
+        motes: impl IntoIterator<Item = MoteId>,
+    ) {
+        let forward = self.leases.entry(worker).or_default();
+        for mote in motes {
+            forward.insert(mote);
+            self.holders.entry(mote).or_default().insert(worker);
+        }
+    }
+
+    /// The crash-failed Motes that remain rescheduleable — unioned into the lease
+    /// candidate set by `lease_ready`.
+    pub(crate) fn rescheduleable(&self) -> &BTreeSet<MoteId> {
+        &self.crash_failed
+    }
+
+    /// Workers that currently hold ≥1 outstanding lease (the reap scan set).
+    pub(crate) fn leasing_workers(&self) -> Vec<WorkerId> {
+        self.leases.keys().copied().collect()
+    }
+
+    /// Remove and return `worker`'s outstanding leases (used when reaping a dead
+    /// worker), keeping the reverse index consistent.
+    pub(crate) fn take_leases(&mut self, worker: WorkerId) -> BTreeSet<MoteId> {
+        let leased = self.leases.remove(&worker).unwrap_or_default();
+        for mote in &leased {
+            if let Some(holders) = self.holders.get_mut(mote) {
+                holders.remove(&worker);
+                if holders.is_empty() {
+                    self.holders.remove(mote);
+                }
+            }
+        }
+        leased
+    }
+
+    /// Record a worker-crash failure of `mote` against `budget`. Returns `true` iff
+    /// `mote` remains rescheduleable (failures still `< budget`), `false` iff the
+    /// budget is now exhausted (terminal — caller stops re-leasing it). The caller
+    /// writes the `Failed{WorkerCrashed}` journal entry regardless (the death is a
+    /// fact either way, D21 §11).
+    pub(crate) fn record_crash(&mut self, mote: MoteId, budget: u32) -> bool {
+        let failures = self.attempt_failures.entry(mote).or_insert(0);
+        *failures += 1;
+        if *failures < budget {
+            self.crash_failed.insert(mote);
+            true
+        } else {
+            // Terminal: never lease it again; drop it from the candidate set.
+            self.crash_failed.remove(&mote);
+            false
+        }
+    }
+
+    /// Resolve `mote` — a commit (first-wins) clears it from **all** tracking. O(holders
+    /// of `mote`) via the reverse index, not O(fleet).
+    pub(crate) fn resolve_committed(&mut self, mote: MoteId) {
+        if let Some(holders) = self.holders.remove(&mote) {
+            for worker in holders {
+                if let Some(forward) = self.leases.get_mut(&worker) {
+                    forward.remove(&mote);
+                    if forward.is_empty() {
+                        self.leases.remove(&worker);
+                    }
+                }
+            }
+        }
+        self.crash_failed.remove(&mote);
+        self.attempt_failures.remove(&mote);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mote(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    #[test]
+    fn lease_then_resolve_clears_all_tracking() {
+        let mut t = LeaseTracker::default();
+        t.record_lease(WorkerId(1), [mote(1), mote(2)]);
+        t.record_lease(WorkerId(2), [mote(2)]); // mote(2) double-leased (poll-only)
+        assert_eq!(t.leasing_workers(), vec![WorkerId(1), WorkerId(2)]);
+
+        // Committing mote(2) clears it from BOTH holders; worker 2 had only it → gone.
+        t.resolve_committed(mote(2));
+        assert_eq!(
+            t.leasing_workers(),
+            vec![WorkerId(1)],
+            "worker with no remaining leases is dropped"
+        );
+        // worker 1 still holds mote(1).
+        let w1 = t.take_leases(WorkerId(1));
+        assert_eq!(w1.into_iter().collect::<Vec<_>>(), vec![mote(1)]);
+        assert!(t.leasing_workers().is_empty());
+    }
+
+    #[test]
+    fn crash_makes_rescheduleable_until_budget_exhausted() {
+        let mut t = LeaseTracker::default();
+        let m = mote(7);
+        // budget = 3 → first two crashes stay rescheduleable, the third is terminal.
+        assert!(t.record_crash(m, 3));
+        assert!(t.rescheduleable().contains(&m));
+        assert!(t.record_crash(m, 3));
+        assert!(t.rescheduleable().contains(&m));
+        assert!(!t.record_crash(m, 3), "third crash exhausts budget=3");
+        assert!(
+            !t.rescheduleable().contains(&m),
+            "terminal Mote is no longer rescheduleable"
+        );
+    }
+
+    #[test]
+    fn commit_after_crash_clears_the_retry_counter() {
+        let mut t = LeaseTracker::default();
+        let m = mote(9);
+        assert!(t.record_crash(m, 100));
+        assert!(t.rescheduleable().contains(&m));
+        t.resolve_committed(m);
+        assert!(
+            !t.rescheduleable().contains(&m),
+            "a commit resolves the crash-failed Mote"
+        );
+        // A fresh crash after a commit starts the count over (counter was cleared).
+        for _ in 0..50 {
+            assert!(t.record_crash(m, 100));
+        }
+    }
+
+    #[test]
+    fn take_leases_of_unknown_worker_is_empty() {
+        let mut t = LeaseTracker::default();
+        assert!(t.take_leases(WorkerId(42)).is_empty());
+    }
+}

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
-use kx_journal::{Journal, JournalEntry};
+use kx_journal::{FailureReason, Journal, JournalEntry};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
@@ -30,7 +30,13 @@ use tokio::sync::{mpsc, oneshot};
 use crate::commit::CommitProposal;
 use crate::error::CoordinatorError;
 use crate::placement::LoadAwarePlacement;
-use crate::registry::WorkerRegistry;
+use crate::registry::{WorkerRegistry, WorkerStatus};
+use crate::reschedule::{LeaseTracker, PURE_RETRY_BUDGET};
+
+/// Reporter id stamped on a coordinator-written `Failed{WorkerCrashed}` entry (D57 §3
+/// / D21 §6). The coordinator is the reporter when it observes a worker's death, as
+/// distinct from a worker self-reporting; `0` is the reserved coordinator id.
+const COORDINATOR_REPORTER_ID: u128 = 0;
 
 /// Bound on in-flight commands queued to the orchestration core. A bounded
 /// channel applies backpressure: when the core is saturated, `dispatch` awaits
@@ -253,6 +259,47 @@ fn recover<J: Journal>(journal: &J) -> Option<(Projection, u64, BTreeSet<MoteId>
     Some((projection, folded_through, submitted))
 }
 
+/// A `LeaseWork` request's parameters, bundled so [`serve_lease`] stays within the
+/// argument-count budget.
+struct LeaseReq {
+    worker: WorkerId,
+    executor_class: ExecutorClass,
+    max: usize,
+}
+
+/// Serve one `LeaseWork` poll (D57): reap dead workers first so their in-flight Motes
+/// re-enter the candidate set for *this* poll, select up to `req.max` runnable Motes
+/// (ready ∪ rescheduleable), and record the new lease assignments for the next reap.
+fn serve_lease<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    registry: &dyn WorkerRegistry,
+    dispatch: &mut Dispatch,
+    req: &LeaseReq,
+) -> Vec<(Mote, WarrantSpec)> {
+    reap_dead_workers(
+        journal,
+        projection,
+        folded_through,
+        registry,
+        &mut dispatch.tracker,
+    );
+    let items = lease_ready(
+        projection,
+        &dispatch.defs,
+        registry,
+        dispatch.tracker.rescheduleable(),
+        req.worker,
+        req.executor_class,
+        req.max,
+    );
+    dispatch
+        .tracker
+        .record_lease(req.worker, items.iter().map(|(mote, _)| mote.id));
+    items
+}
+
 /// Select up to `max` ready PURE Motes for `worker` to run. Candidates are
 /// ready (parents-all-committed) ∩ PURE (the only class executed-then-proposed in
 /// P2.x; WM is deferred) ∩ matching the worker's backend (`executor_class`). Placement
@@ -264,6 +311,7 @@ fn lease_ready(
     projection: &Projection,
     submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
     registry: &dyn WorkerRegistry,
+    rescheduleable: &BTreeSet<MoteId>,
     worker: WorkerId,
     executor_class: ExecutorClass,
     max: usize,
@@ -271,7 +319,23 @@ fn lease_ready(
     let placement = LoadAwarePlacement::new(registry, executor_class);
     let mut preferred: Vec<MoteId> = Vec::new();
     let mut rest: Vec<MoteId> = Vec::new();
-    for mote_id in projection.ready_set() {
+    let mut seen: BTreeSet<MoteId> = BTreeSet::new();
+    // Candidates = the projection's ready-set (Pending, parents committed) ∪ the
+    // crash-failed-but-rescheduleable set (D57 §2): a crash-failed Mote is `Failed` in
+    // the projection so it left the ready-set, but its parents are still committed
+    // (commits are permanent) so it is genuinely re-runnable. A Mote already committed
+    // since being crash-failed is skipped (first-wins resolved it).
+    for mote_id in projection
+        .ready_set()
+        .into_iter()
+        .chain(rescheduleable.iter().copied())
+    {
+        if !seen.insert(mote_id) {
+            continue;
+        }
+        if projection.state_of(&mote_id) == MoteState::Committed {
+            continue;
+        }
         if let Some((mote, warrant)) = submitted_defs.get(&mote_id) {
             if mote.nd_class() == NdClass::Pure && warrant.executor_class == executor_class {
                 if placement.place(&mote_id) == worker {
@@ -288,6 +352,60 @@ fn lease_ready(
         .take(max)
         .filter_map(|id| submitted_defs.get(&id).cloned())
         .collect()
+}
+
+/// Reap dead workers (D57 §3). For each registered worker the registry now reports
+/// [`WorkerStatus::Dead`] that still holds outstanding leases, write a
+/// `Failed{WorkerCrashed}` for each of its unresolved Motes (the mandated death fact —
+/// D21 §11, *no off-journal facts*), fold it, and — if the Mote is still under its retry
+/// budget — re-add it to the rescheduleable set so the next poller picks it up. A Mote
+/// that committed before the reap (raced ahead) is simply resolved, never crash-failed.
+///
+/// Runs at the head of every `LeaseWork`, so reschedule is driven by the same poll that
+/// will service it — no background reaper, no owner-thread timer (matching P3.1's derived
+/// liveness). Writes go through the owner thread, preserving the D40 sole-writer invariant.
+fn reap_dead_workers<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    registry: &dyn WorkerRegistry,
+    tracker: &mut LeaseTracker,
+) {
+    for worker in tracker.leasing_workers() {
+        if registry.status(worker) != Some(WorkerStatus::Dead) {
+            continue;
+        }
+        for mote_id in tracker.take_leases(worker) {
+            if projection.state_of(&mote_id) == MoteState::Committed {
+                tracker.resolve_committed(mote_id);
+                continue;
+            }
+            match journal.append(failed_worker_crashed_entry(mote_id)) {
+                Ok(durable) => {
+                    let seq = durable.seq();
+                    if seq > *folded_through && projection.fold(&durable).is_ok() {
+                        *folded_through = seq;
+                    }
+                    tracker.record_crash(mote_id, PURE_RETRY_BUDGET);
+                }
+                Err(error) => {
+                    tracing::error!(%error, ?mote_id, "failed to record worker-crash death");
+                }
+            }
+        }
+    }
+}
+
+/// Build the `Failed{WorkerCrashed}` entry for a Mote whose leasing worker died. The
+/// `idempotency_key` is the Mote's identity (`idempotency.md`: key == derived `MoteId`).
+fn failed_worker_crashed_entry(mote_id: MoteId) -> JournalEntry {
+    JournalEntry::Failed {
+        mote_id,
+        idempotency_key: *mote_id.as_bytes(),
+        seq: 0,
+        reason_class: FailureReason::WorkerCrashed,
+        reporter_id: COORDINATOR_REPORTER_ID,
+    }
 }
 
 /// Read up to `max` `Committed` entries with seq in `(since_seq, current_seq]`, in
@@ -322,6 +440,25 @@ fn read_committed_since<J: Journal>(
     Ok((entries, next_seq))
 }
 
+/// The coordinator's dispatch bookkeeping, grouped so the lease/commit helpers take one
+/// `&mut` rather than a long argument list:
+/// - `submitted` — every admitted Mote id (commit admission: only a submitted Mote may
+///   commit; recovery seeds it from the already-committed set);
+/// - `defs` — admitted-but-not-yet-committed Motes, kept so `LeaseWork` can hand a worker
+///   the Mote + warrant to run (kx-scheduler consumes the Mote on submit, exposes no
+///   get-by-id accessor, and is frozen by the thesis test — so the coordinator retains
+///   its own copy); freed on commit, so the map is bounded by in-flight work;
+/// - `tracker` — the D57 reschedule bookkeeping (leases, crash-failed, retry counts).
+///
+/// Recovery does not repopulate `defs`/`tracker`: committed Motes are never ready, and a
+/// leased-but-uncommitted Mote lost to a coordinator restart is re-leased afresh (still
+/// `Pending`), the journal dedupe keeping any double-commit first-wins.
+struct Dispatch {
+    submitted: BTreeSet<MoteId>,
+    defs: BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    tracker: LeaseTracker,
+}
+
 /// The owner-thread loop. Recovers the projection from the journal, then services
 /// commands until every sender drops (the channel closes on coordinator shutdown).
 fn core_loop<J: Journal>(
@@ -330,17 +467,15 @@ fn core_loop<J: Journal>(
     registry: &dyn WorkerRegistry,
     mut inbox: mpsc::Receiver<Command>,
 ) {
-    let Some((mut projection, mut folded_through, mut submitted)) = recover(journal) else {
+    let Some((mut projection, mut folded_through, submitted)) = recover(journal) else {
         return;
     };
     let mut scheduler = Scheduler::new(LocalPlacement);
-    // Definitions of admitted-but-not-yet-committed Motes, kept so `LeaseWork` can
-    // hand a worker the Mote + warrant to run. (kx-scheduler consumes the Mote on
-    // submit and exposes no get-by-id accessor — and is frozen by the thesis test —
-    // so the coordinator retains its own copy.) Recovery does not repopulate this:
-    // committed Motes are never ready, and pending work lost to a crash is a P3
-    // concern.
-    let mut submitted_defs: BTreeMap<MoteId, (Mote, WarrantSpec)> = BTreeMap::new();
+    let mut dispatch = Dispatch {
+        submitted,
+        defs: BTreeMap::new(),
+        tracker: LeaseTracker::default(),
+    };
 
     while let Some(first) = inbox.blocking_recv() {
         // Drain everything immediately available (up to MAX_DRAIN) so consecutive
@@ -374,8 +509,7 @@ fn core_loop<J: Journal>(
                 store,
                 &mut projection,
                 &mut folded_through,
-                &submitted,
-                &mut submitted_defs,
+                &mut dispatch,
                 &mut pending,
             );
             match command {
@@ -385,19 +519,14 @@ fn core_loop<J: Journal>(
                     warrant,
                     reply,
                 } => {
-                    let mote_id = mote.id;
-                    let mote = *mote;
-                    let warrant = *warrant;
-                    let duplicate =
-                        match scheduler.submit(mote.clone(), warrant.clone(), &mut projection) {
-                            Ok(()) => {
-                                submitted.insert(mote_id);
-                                submitted_defs.insert(mote_id, (mote, warrant));
-                                false
-                            }
-                            Err(SchedulerError::DuplicateSubmission(_)) => true,
-                        };
-                    let _ = reply.send(SubmitOutcome { mote_id, duplicate });
+                    let outcome = handle_submit(
+                        &mut scheduler,
+                        &mut projection,
+                        &mut dispatch,
+                        *mote,
+                        *warrant,
+                    );
+                    let _ = reply.send(outcome);
                 }
                 Command::StateOf { mote_id, reply } => {
                     let _ = reply.send(projection.state_of(&mote_id));
@@ -414,13 +543,17 @@ fn core_loop<J: Journal>(
                     max,
                     reply,
                 } => {
-                    let items = lease_ready(
-                        &projection,
-                        &submitted_defs,
+                    let items = serve_lease(
+                        journal,
+                        &mut projection,
+                        &mut folded_through,
                         registry,
-                        worker,
-                        executor_class,
-                        max,
+                        &mut dispatch,
+                        &LeaseReq {
+                            worker,
+                            executor_class,
+                            max,
+                        },
                     );
                     let _ = reply.send(items);
                 }
@@ -438,11 +571,32 @@ fn core_loop<J: Journal>(
             store,
             &mut projection,
             &mut folded_through,
-            &submitted,
-            &mut submitted_defs,
+            &mut dispatch,
             &mut pending,
         );
     }
+}
+
+/// Register a submitted Mote through the hosted scheduler (verbatim, thesis test) and
+/// retain its def for `LeaseWork`. Returns the canonical id + whether it was an
+/// idempotent re-submit (already admitted before commit).
+fn handle_submit(
+    scheduler: &mut Scheduler<LocalPlacement>,
+    projection: &mut Projection,
+    dispatch: &mut Dispatch,
+    mote: Mote,
+    warrant: WarrantSpec,
+) -> SubmitOutcome {
+    let mote_id = mote.id;
+    let duplicate = match scheduler.submit(mote.clone(), warrant.clone(), projection) {
+        Ok(()) => {
+            dispatch.submitted.insert(mote_id);
+            dispatch.defs.insert(mote_id, (mote, warrant));
+            false
+        }
+        Err(SchedulerError::DuplicateSubmission(_)) => true,
+    };
+    SubmitOutcome { mote_id, duplicate }
 }
 
 /// One queued `ReportCommit`: its validated proposal + the reply channel.
@@ -477,8 +631,7 @@ fn flush_commits<J: Journal>(
     store: Option<&LocalFsContentStore>,
     projection: &mut Projection,
     folded_through: &mut u64,
-    submitted: &BTreeSet<MoteId>,
-    submitted_defs: &mut BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    dispatch: &mut Dispatch,
     pending: &mut Vec<PendingCommit>,
 ) {
     if pending.is_empty() {
@@ -494,7 +647,7 @@ fn flush_commits<J: Journal>(
         Vec::with_capacity(batch.len());
     let mut committed_ids: Vec<MoteId> = Vec::with_capacity(batch.len());
     for (proposal, reply) in batch {
-        if !submitted.contains(&proposal.mote_id) {
+        if !dispatch.submitted.contains(&proposal.mote_id) {
             let _ = reply.send(Err(CoordinatorError::UnknownMote(proposal.mote_id)));
         } else if store.is_some_and(|s| !s.contains(&proposal.result_ref)) {
             let _ = reply.send(Err(CoordinatorError::ResultRefAbsent(proposal.mote_id)));
@@ -512,9 +665,12 @@ fn flush_commits<J: Journal>(
         Ok(applied) => {
             // The defs are no longer leasable once committed (a committed Mote is
             // never in the ready-set); free them to keep the map bounded by
-            // in-flight work, not total submissions.
+            // in-flight work, not total submissions. Resolving the commit in the
+            // reschedule tracker (D57) clears every outstanding lease + crash-failed
+            // entry for the Mote — first-wins resolves all concurrent attempts at once.
             for id in &committed_ids {
-                submitted_defs.remove(id);
+                dispatch.defs.remove(id);
+                dispatch.tracker.resolve_committed(*id);
             }
             for (reply, applied) in replies.into_iter().zip(applied) {
                 let _ = reply.send(Ok(applied));

--- a/crates/kx-coordinator/tests/reschedule.rs
+++ b/crates/kx-coordinator/tests/reschedule.rs
@@ -1,0 +1,233 @@
+//! Reschedule-on-failure (P3.2 / D57): when a worker dies (P3.1), its in-flight PURE
+//! Motes are re-leased to a live worker, the death is recorded as a journal fact, and
+//! exactly-once holds (the dead worker's late commit dedupes — first-wins).
+//!
+//! Time is driven by an injected [`kx_coordinator::Clock`] so a worker is declared dead
+//! deterministically, with no sleeps. Death is asserted *via the service*: a reaped Mote
+//! shows `state_of == Failed` (the projection is a pure fold of the log, so a `Failed`
+//! state proves a `Failed{WorkerCrashed}` journal entry exists — D21 §11, no off-journal
+//! facts) before its replacement commits.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_coordinator::proto::{CommitOutcome, ExecutorClass};
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, WorkerRegistry,
+};
+use kx_journal::InMemoryJournal;
+use kx_mote::{Mote, NdClass};
+
+const TIMEOUT: Duration = Duration::from_secs(6);
+
+/// A deterministic clock the test advances by hand.
+#[derive(Debug)]
+struct FakeClock(AtomicU64);
+impl FakeClock {
+    fn new(ms: u64) -> Arc<Self> {
+        Arc::new(Self(AtomicU64::new(ms)))
+    }
+    fn set(&self, ms: u64) {
+        self.0.store(ms, Ordering::Relaxed);
+    }
+}
+impl Clock for FakeClock {
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+fn coordinator(clock: Arc<FakeClock>) -> CoordinatorService {
+    let registry: Arc<dyn WorkerRegistry> = Arc::new(
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock, TIMEOUT),
+    );
+    CoordinatorService::with_registry(InMemoryJournal::new(), registry)
+}
+
+const MAC: ExecutorClass = ExecutorClass::MacosSandbox;
+
+/// R-1 (reschedule) + R-3 (death is a journal fact) + R-2 (dedupe on late commit).
+#[tokio::test]
+async fn dead_workers_in_flight_mote_is_rescheduled_and_commits_exactly_once() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant();
+
+    let dying = common::register(&svc, "dying").await;
+    let m = common::mote(7, NdClass::Pure, &[]);
+    common::submit(&svc, &m, &warrant).await;
+
+    // The dying worker leases the Mote (now tracked as its in-flight lease) but never
+    // commits it.
+    let leased = common::lease_work(&svc, dying, MAC, 16).await;
+    assert_eq!(leased.len(), 1, "dying worker leased the ready Mote");
+
+    // Time advances past the liveness timeout; a fresh live worker registers and polls.
+    clock.set(1_000 + 6_001);
+    let live = common::register(&svc, "live").await;
+    let released = common::lease_work(&svc, live, MAC, 16).await;
+    let released_mote: Mote = released[0].mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(
+        released_mote.id, m.id,
+        "the dead worker's Mote was re-leased to the live worker"
+    );
+
+    // R-3: the death is a journal fact — the reap folded a Failed{WorkerCrashed}, so the
+    // projection now reports the Mote `Failed` (until the replacement commits).
+    assert_eq!(
+        svc.state_of(m.id).await.unwrap(),
+        MoteState::Failed,
+        "worker-crash death is recorded as a journal fact (Failed state)"
+    );
+
+    // R-1: the live worker completes the replacement → exactly one commit.
+    let out = common::commit(&svc, &m, live).await;
+    assert_eq!(out.outcome, CommitOutcome::Committed as i32);
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+    assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
+
+    // R-2: the dead worker was not actually dead and commits late → dedupes (first-wins),
+    // committed count unchanged.
+    let late = common::commit(&svc, &m, dying).await;
+    assert_eq!(
+        late.outcome,
+        CommitOutcome::AlreadyCommitted as i32,
+        "the dead worker's late commit dedupes to the first"
+    );
+    assert_eq!(svc.committed_count().await.unwrap(), 1, "no double commit");
+}
+
+/// R-6 (command ordering: commit-then-reap). A worker that committed *before* being
+/// declared dead is reaped as a no-op — no spurious Failed, no double commit.
+#[tokio::test]
+async fn reap_after_commit_is_a_noop() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant();
+
+    let worker = common::register(&svc, "w").await;
+    let m = common::mote(3, NdClass::Pure, &[]);
+    common::submit(&svc, &m, &warrant).await;
+
+    // Lease then commit — the Mote is done before any death is declared.
+    let _ = common::lease_work(&svc, worker, MAC, 16).await;
+    common::commit(&svc, &m, worker).await;
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+
+    // Now the worker times out; a fresh worker polls, triggering the reap. The committed
+    // Mote is resolved (not crash-failed) — it stays Committed, nothing is re-leased.
+    clock.set(1_000 + 6_001);
+    let other = common::register(&svc, "other").await;
+    let leased = common::lease_work(&svc, other, MAC, 16).await;
+    assert!(
+        leased.is_empty(),
+        "a committed Mote is not re-leased after reap"
+    );
+    assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        1,
+        "no spurious second commit"
+    );
+}
+
+/// R-5 (no spurious reschedule). A *live* worker's lease is never crash-failed when a
+/// peer polls and the reap runs.
+#[tokio::test]
+async fn a_live_workers_lease_is_not_reaped() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant();
+
+    let holder = common::register(&svc, "holder").await;
+    let m = common::mote(5, NdClass::Pure, &[]);
+    common::submit(&svc, &m, &warrant).await;
+    let _ = common::lease_work(&svc, holder, MAC, 16).await;
+
+    // Time advances, but the holder heartbeats (stays live); a peer polls → reap runs.
+    clock.set(1_000 + 5_000);
+    common::heartbeat(&svc, holder, 0, 0).await;
+    let peer = common::register(&svc, "peer").await;
+    let _ = common::lease_work(&svc, peer, MAC, 16).await;
+
+    // The holder's Mote was NOT crash-failed (no Failed entry) — it is still leasable
+    // (Pending), not Failed.
+    assert_eq!(
+        svc.state_of(m.id).await.unwrap(),
+        MoteState::Pending,
+        "a live worker's in-flight Mote is never reaped"
+    );
+}
+
+/// Scalability / fault-tolerance under fan-out: a fleet runs many Motes distributed;
+/// one worker dies mid-run holding a batch; every Mote still commits **exactly once**.
+#[tokio::test]
+async fn fleet_survives_one_worker_death_exactly_once() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant();
+
+    // A fleet of 4 workers and 24 independent ready PURE Motes.
+    let fleet: Vec<u64> = {
+        let mut ids = Vec::new();
+        for tag in ["a", "b", "c", "d"] {
+            ids.push(common::register(&svc, tag).await);
+        }
+        ids
+    };
+    let motes: Vec<Mote> = (0u8..24)
+        .map(|s| common::mote(s, NdClass::Pure, &[]))
+        .collect();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    // The doomed worker leases a batch and then "dies" (never commits, never heartbeats).
+    let doomed = fleet[0];
+    let stranded = common::lease_work(&svc, doomed, MAC, 6).await;
+    assert!(!stranded.is_empty(), "doomed worker stranded a batch");
+
+    // Time passes the timeout; the survivors keep heartbeating and drain everything.
+    clock.set(1_000 + 6_001);
+    let survivors = &fleet[1..];
+    let mut committed_by: std::collections::BTreeMap<u64, usize> =
+        std::collections::BTreeMap::new();
+    for _round in 0..64 {
+        for &w in survivors {
+            common::heartbeat(&svc, w, clock.now_ms(), 0).await;
+            let batch = common::lease_work(&svc, w, MAC, 4).await;
+            for item in batch {
+                let mote: Mote = item.mote.clone().unwrap().try_into().unwrap();
+                let out = common::commit(&svc, &mote, w).await;
+                if out.outcome == CommitOutcome::Committed as i32 {
+                    *committed_by.entry(w).or_default() += 1;
+                }
+            }
+        }
+        if svc.committed_count().await.unwrap() >= motes.len() {
+            break;
+        }
+    }
+
+    // Every Mote committed exactly once — including the doomed worker's stranded batch,
+    // which the survivors reaped + re-ran. No Mote was double-counted (dedupe holds).
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        motes.len(),
+        "every Mote committed despite the worker death"
+    );
+    let total_new: usize = committed_by.values().sum();
+    assert_eq!(
+        total_new,
+        motes.len(),
+        "exactly-once: new commits sum to the Mote count (no double commit)"
+    );
+    for m in &motes {
+        assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
+    }
+}


### PR DESCRIPTION
Second step of **PHASE P3 (fault tolerance)**. When a worker dies (P3.1 detection), the coordinator now re-leases its in-flight **PURE** Motes to a live worker, records each death as a **journal fact**, and preserves **exactly-once** — the dead worker's late commit dedupes (first-wins). Implements D21 §6/§7 in the distributed pull-coordinator; recorded as **new D57**. **Detection-only scope from P3.1 → now reschedule; PURE-only (P2.x dispatch scope).**

## The pull-model subtlety (D57 §2)
A leased Mote is `Pending`→`Committed` with no `Proposed`, so a `Failed{WorkerCrashed}` entry would terminalize a recoverable PURE Mote and **stop** re-lease. Resolution: the `Failed` entry is still written (D21 §11 — death is a journal fact) and the projection honestly shows `Failed`, but reschedule eligibility lives in the **coordinator's lease layer** — `lease_ready` draws from `ready_set() ∪ crash_failed`. The projection's pure-fold state machine is untouched.

## Thesis bonus
P3.2 touches **only `kx-coordinator`** — `kx-scheduler` stays hosted-verbatim, `kx-journal`'s `Failed` kind already exists. Distribution *and* fault-tolerance reschedule are both coordinator-layer wiring. **Thesis diff over `kx-scheduler`/`kx-executor`/`kx-inference` is still empty.**

## Mechanism
- `reschedule.rs` — `LeaseTracker`: forward (`worker→leases`) + reverse (`mote→holders`) indexes so `resolve_committed` is **O(holders), not O(fleet)** (scalability); `crash_failed` re-lease set; per-Mote retry counter (PURE budget 100, D21 §7).
- `state.rs` — `reap_dead_workers` runs at the head of every `LeaseWork` (reschedule driven by the same poll that services it — no background reaper/timer, matching P3.1's derived liveness; **D40 sole-writer intact**); `lease_ready` unions `ready_set ∪ crash_failed`; `flush_commits` resolves committed Motes. Owner state grouped into `Dispatch`; submit/lease extracted to stay within clippy's complexity budget.

## Tests (+8), deterministic via injected `Clock`
LeaseTracker unit (lease/resolve, budget exhaustion, reverse-index, commit-clears-counter) + integration **R-1…R-6**: reschedule + dedupe + **death-is-a-journal-fact** (asserted via `state_of == Failed`, since the projection is a pure fold of the log), commit-then-reap no-op, no-spurious-reschedule, and a **4-worker / 24-Mote fleet that survives one worker's mid-run death with every Mote committed exactly once** (the scalability/fault proof). Full gate green (**854 passed / 0 failed**). loom intentionally not used — the owner thread serializes all commands (actor model), so command-ordering tests, not shared-memory race models, are the right tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)