### PR TITLE
feat(kx-executor): P0.4 hard gate — never re-run a committed Mote (P3.3)

### DIFF
--- a/crates/kx-executor/src/lifecycle.rs
+++ b/crates/kx-executor/src/lifecycle.rs
@@ -110,6 +110,32 @@ pub struct WmLifecycleCommit {
     pub critic_proposed_seq: Option<u64>,
 }
 
+/// The **P0.4 hard gate** (P3.3): if `mote_id` is already `Committed` in the journal,
+/// return its committed `(seq, result_ref)` so the caller serves the committed fact and
+/// **never re-runs the Mote's logic**. For a non-deterministic Mote (ReadOnlyNondet /
+/// WorldMutating) this is a *correctness* invariant — re-running would re-sample a
+/// different observation or fire a second world effect, breaking exactly-once; for PURE
+/// it is a harmless-but-wasteful re-run avoided. The committed entry is the source of
+/// truth (`vision §`: "a non-deterministic step is never recomputed once committed;
+/// recovery reads what it did"). Repudiation supersession of a committed result is the
+/// cascade's concern (P3.5); the single-node engine already excludes committed +
+/// repudiated Motes from dispatch, so this gate is the executor-level defense-in-depth
+/// that makes the guarantee hold for *any* caller (engine, worker, future SDK).
+fn serve_if_committed<J: Journal + ?Sized>(
+    journal: &J,
+    mote_id: &MoteId,
+) -> Result<Option<(u64, ContentRef)>, LifecycleError> {
+    match journal
+        .read_committed(mote_id)
+        .map_err(|e| LifecycleError::JournalAppend(format!("read Committed (P0.4 gate): {e:?}")))?
+    {
+        Some(JournalEntry::Committed {
+            seq, result_ref, ..
+        }) => Ok(Some((seq, result_ref))),
+        _ => Ok(None),
+    }
+}
+
 /// Run a single PURE Mote end-to-end. PR 9a's contract:
 /// - The Mote MUST have `nd_class = Pure`. Non-PURE Motes return
 ///   `LifecycleError::Internal` because the broker / commit-protocol path
@@ -125,6 +151,11 @@ pub struct WmLifecycleCommit {
 ///
 /// See [`LifecycleError`] variants. The caller must write a `Failed` journal
 /// entry when `LifecycleError::Refused` is returned (this module does not).
+///
+/// **P0.4 hard gate (P3.3):** before running, if `mote` is already `Committed` in the
+/// journal, recovery READS the committed `result_ref` and the Mote's logic is **never
+/// re-run**. For PURE this is a free optimization; the gate is shared with
+/// [`run_wm_mote`], where it is a correctness invariant.
 pub fn run_pure_mote<J, R, E>(
     mote: &Mote,
     warrant: &WarrantSpec,
@@ -142,6 +173,16 @@ where
             "PR 9a lifecycle handles PURE Motes only; got {:?}",
             mote.nd_class()
         )));
+    }
+
+    // P0.4 hard gate (P3.3): already committed → serve the committed result, never re-run.
+    if let Some((committed_seq, result_ref)) = serve_if_committed(journal, &mote.id)? {
+        tracing::debug!(mote = ?mote.id, committed_seq, "P0.4 gate: already committed — serving result, not re-running");
+        return Ok(LifecycleCommit {
+            committed_seq,
+            result_ref,
+            mote_id: mote.id,
+        });
     }
 
     // Step 2: acquire resource slot.
@@ -441,6 +482,22 @@ where
             "run_wm_mote handles WM/ReadOnlyNondet only; got Pure mote {:?}; caller must use run_pure_mote",
             mote.id
         )));
+    }
+
+    // P0.4 hard gate (P3.3): a committed non-deterministic Mote is NEVER re-run — serve
+    // the committed result. Re-running would re-sample a different ReadOnlyNondet
+    // observation, or fire a SECOND world effect for a WorldMutating Mote whose effect is
+    // already done + recorded (exactly-once). No Proposed is appended, the broker /
+    // commit-protocol is not invoked. (The EffectStaged-but-not-committed recovery path is
+    // `redispatch_wm_mote`, gated by the oracle; here the Mote is already Committed.)
+    if let Some((committed_seq, result_ref)) = serve_if_committed(journal, &mote.id)? {
+        tracing::debug!(mote = ?mote.id, committed_seq, "P0.4 gate: committed nondet Mote — serving result, not re-dispatching");
+        return Ok(WmLifecycleCommit {
+            committed_seq,
+            result_ref,
+            mote_id: mote.id,
+            critic_proposed_seq: None,
+        });
     }
 
     // Step 2: acquire resource slot.

--- a/crates/kx-executor/tests/integration_p04_gate.rs
+++ b/crates/kx-executor/tests/integration_p04_gate.rs
@@ -1,0 +1,254 @@
+//! P0.4 hard gate (P3.3): the executor never re-runs a Mote that is already
+//! `Committed` — it serves the committed `result_ref`. For a non-deterministic Mote
+//! (ReadOnlyNondet / WorldMutating) this is a correctness invariant (re-running would
+//! re-sample a different observation, or fire a second world effect); for PURE it is a
+//! wasted-compute optimization. The proof is a **counting** executor / broker: after
+//! two `run_*` calls on the same Mote, the body / broker was invoked exactly once — the
+//! second call was served from the committed journal entry, not re-run.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{
+    run_pure_mote, run_wm_mote, LocalResourceManager, StandardCommitProtocol, TestMoteExecutor,
+};
+use kx_journal::InMemoryJournal;
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
+    PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+fn warrant(class: MoteClass) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: class,
+        nd_class: class,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn mote(seed: u8, nd: NdClass) -> Mote {
+    let def = MoteDef {
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: nd,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::IdempotentByConstruction,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+/// A broker that counts `dispatch` invocations — the witness that a committed
+/// non-deterministic Mote is NOT re-dispatched on a second run (no second world effect).
+struct CountingBroker {
+    store: Arc<InMemoryContentStore>,
+    dispatches: Arc<AtomicU32>,
+}
+impl std::fmt::Debug for CountingBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CountingBroker").finish()
+    }
+}
+impl CapabilityBroker for CountingBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        // A fresh ref per dispatch — so a re-dispatch would produce a *different* ref,
+        // making "served the committed ref" distinguishable from "re-ran".
+        let n = self.dispatches.fetch_add(1, Ordering::Relaxed);
+        let staged_ref = self.store.put(&[n as u8 + 1; 8]).expect("put");
+        Ok(BrokerHandle {
+            staged_ref,
+            capability: ToolName("counting".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+#[test]
+fn committed_pure_mote_is_served_not_rerun() {
+    let journal = InMemoryJournal::new();
+    let rm = LocalResourceManager::dev_defaults();
+    let runs = Arc::new(AtomicU32::new(0));
+    let r = runs.clone();
+    // Each run returns a DIFFERENT ref, so re-running would be observable.
+    let executor = TestMoteExecutor::new(move |_m, _w| {
+        let n = r.fetch_add(1, Ordering::Relaxed);
+        ContentRef::from_bytes([n as u8 + 1; 32])
+    });
+    let w = warrant(MoteClass::Pure);
+    let m = mote(0x11, NdClass::Pure);
+
+    let first = run_pure_mote(&m, &w, &journal, &rm, &executor).unwrap();
+    let second = run_pure_mote(&m, &w, &journal, &rm, &executor).unwrap();
+
+    assert_eq!(
+        runs.load(Ordering::Relaxed),
+        1,
+        "P0.4 gate: body run exactly once; the second call served the committed result"
+    );
+    assert_eq!(
+        first.result_ref, second.result_ref,
+        "served the same committed result_ref"
+    );
+    assert_eq!(first.committed_seq, second.committed_seq);
+}
+
+#[test]
+fn committed_world_mutating_mote_is_not_re_dispatched() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let dispatches = Arc::new(AtomicU32::new(0));
+    let broker = Arc::new(CountingBroker {
+        store: store.clone(),
+        dispatches: dispatches.clone(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let w = warrant(MoteClass::WorldMutating);
+    let m = mote(0x22, NdClass::WorldMutating);
+    let submission: BTreeMap<MoteId, Mote> = std::iter::once((m.id, m.clone())).collect();
+
+    let first = run_wm_mote(
+        &m,
+        &w,
+        ToolName("c".into()),
+        empty_request(),
+        &submission,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .unwrap();
+    let second = run_wm_mote(
+        &m,
+        &w,
+        ToolName("c".into()),
+        empty_request(),
+        &submission,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .unwrap();
+
+    assert_eq!(
+        dispatches.load(Ordering::Relaxed),
+        1,
+        "P0.4 gate: a committed WORLD-MUTATING Mote is served, NEVER re-dispatched (no second world effect)"
+    );
+    assert_eq!(
+        first.result_ref, second.result_ref,
+        "served the committed effect result"
+    );
+    assert_eq!(first.committed_seq, second.committed_seq);
+}
+
+#[test]
+fn committed_read_only_nondet_observation_is_not_resampled() {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let dispatches = Arc::new(AtomicU32::new(0));
+    let broker = Arc::new(CountingBroker {
+        store: store.clone(),
+        dispatches: dispatches.clone(),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let w = warrant(MoteClass::ReadOnlyNondet);
+    let m = mote(0x33, NdClass::ReadOnlyNondet);
+    let submission: BTreeMap<MoteId, Mote> = std::iter::once((m.id, m.clone())).collect();
+
+    let first = run_wm_mote(
+        &m,
+        &w,
+        ToolName("c".into()),
+        empty_request(),
+        &submission,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .unwrap();
+    let second = run_wm_mote(
+        &m,
+        &w,
+        ToolName("c".into()),
+        empty_request(),
+        &submission,
+        &*journal,
+        &rm,
+        &protocol,
+    )
+    .unwrap();
+
+    assert_eq!(
+        dispatches.load(Ordering::Relaxed),
+        1,
+        "P0.4 gate: a committed READ-ONLY-NONDET observation is served, NEVER re-sampled"
+    );
+    assert_eq!(
+        first.result_ref, second.result_ref,
+        "the durable observation is stable across recovery (not a fresh sample)"
+    );
+}


### PR DESCRIPTION
Third step of **PHASE P3 (fault tolerance)**. The executor now enforces the **P0.4** rule structurally: before running, `run_pure_mote` / `run_wm_mote` check the journal — if the Mote is already `Committed`, they **serve the committed `result_ref` and never re-run** the Mote's logic.

- **ReadOnlyNondet** — re-running would re-sample a *different* observation → serving the committed one preserves exactly-once for the observed value.
- **WorldMutating** — re-running would fire a *second* world effect → serving the committed result (no `Proposed` appended, broker/commit-protocol not invoked) preserves exactly-once. (The `EffectStaged`-but-not-committed recovery path is the separate oracle-gated `redispatch_wm_mote`; here the Mote is already `Committed`.)
- **PURE** — re-running is harmless but wasteful → a free optimization.

Defense in depth: makes the guarantee hold for **any** caller (single-node engine, distributed worker, future SDK), not just the engine's `pick_next` which already skips committed Motes. Mechanism: a shared `serve_if_committed` helper over `Journal::read_committed` — **no signature change** (the verbatim thesis-witness stays valid), matching the "kx-executor + kx-journal" mapping. Implements existing **P0.4** (vision §: *"a non-deterministic step is never recomputed once committed; recovery reads what it did"*); **no new D-number**. Repudiation supersession of a committed result is the cascade's concern (P3.5).

**Thesis note:** this is the **first legitimate P3 change to `kx-executor`** — the frozen-diff was the *P2 distribution* thesis; P3 fault tolerance evolves the engine, per the build sequence. `kx-scheduler` + `kx-inference` remain unchanged (thesis diff over those two still empty); the verbatim-hosting tests still pass.

## Tests (+3, deep)
A **counting** executor / broker proves the body / broker is invoked **exactly once** across two `run_*` calls on the same Mote (a re-run would be observable): `committed_pure_mote_is_served_not_rerun`, `committed_world_mutating_mote_is_not_re_dispatched`, `committed_read_only_nondet_observation_is_not_resampled`. Full gate green (**857 passed / 0 failed**); all existing recovery suites (`cross_product_recovery`, `redispatch_wm_mote`, `kill_and_replay`) unchanged + passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)