### PR TITLE
feat(kx-runtime): topology-decision replay on shaper recovery (P3.4, P0.6)

### DIFF
--- a/crates/kx-runtime/src/crash.rs
+++ b/crates/kx-runtime/src/crash.rs
@@ -22,6 +22,14 @@ pub enum CrashPoint {
     /// Recovery RE-READS the committed `result_ref` — the headline novel
     /// claim: a committed world-mutating step is a fact, never re-run.
     PostCommitVtc,
+    /// Abort when the topology shaper has committed its `TopologyDecision` and
+    /// every *declared* Mote has committed, but its **materialized children**
+    /// have not yet run (children are appended last). The hardest recovery path
+    /// (P0.6 / P3.4): a fresh process must **replay the committed decision** —
+    /// re-materialize the SAME children from the shaper's committed `result_ref`
+    /// and run them — never re-run the shaper to re-decide (which would orphan or
+    /// duplicate children).
+    ShaperChildrenPending,
 }
 
 impl CrashPoint {
@@ -31,6 +39,7 @@ impl CrashPoint {
         match self {
             CrashPoint::PreCommitStc => "pre-commit-stc",
             CrashPoint::PostCommitVtc => "post-commit-vtc",
+            CrashPoint::ShaperChildrenPending => "shaper-children-pending",
         }
     }
 
@@ -54,8 +63,9 @@ impl FromStr for CrashPoint {
         match s {
             "pre-commit-stc" => Ok(CrashPoint::PreCommitStc),
             "post-commit-vtc" => Ok(CrashPoint::PostCommitVtc),
+            "shaper-children-pending" => Ok(CrashPoint::ShaperChildrenPending),
             other => Err(format!(
-                "unknown crash point {other:?} (expected `pre-commit-stc` or `post-commit-vtc`)"
+                "unknown crash point {other:?} (expected `pre-commit-stc`, `post-commit-vtc`, or `shaper-children-pending`)"
             )),
         }
     }
@@ -67,7 +77,11 @@ mod tests {
 
     #[test]
     fn crash_point_roundtrips_through_str() {
-        for cp in [CrashPoint::PreCommitStc, CrashPoint::PostCommitVtc] {
+        for cp in [
+            CrashPoint::PreCommitStc,
+            CrashPoint::PostCommitVtc,
+            CrashPoint::ShaperChildrenPending,
+        ] {
             assert_eq!(CrashPoint::from_str(cp.as_str()), Ok(cp));
         }
     }

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -20,7 +20,7 @@ use kx_executor::{
     TestMoteExecutor,
 };
 use kx_journal::{Journal, SqliteJournal};
-use kx_mote::{MoteId, NdClass};
+use kx_mote::{MoteId, NdClass, TopologyDecision};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Scheduler};
 use kx_warrant::{FsScope, NetScope};
@@ -124,14 +124,33 @@ pub fn run(config: &RuntimeConfig) -> Result<RunOutcome, RuntimeError> {
     // engine re-derives into runnable Motes, identity-matched to the projection).
     let mut runnable: Vec<WorkflowMote> = workflow.motes.clone();
     let mut children_derived = false;
+    let mut child_ids: Vec<MoteId> = Vec::new();
 
     // The drive loop.
     loop {
+        // Re-derive the committed shaper's materialized children into the runnable
+        // set **before** deciding whether to stop (P0.6 / P3.4 — the hardest path):
+        // on recovery the shaper's `Committed` is already folded, so a fresh process
+        // re-materializes the SAME children and runs them, never re-running the shaper
+        // to re-decide. Doing this after `pick_next` would let a recovery where only
+        // the children remain break first, orphaning the shaper's decision.
+        if !children_derived {
+            children_derived = derive_shaper_children(
+                &workflow,
+                &shaper_wm,
+                &topology_decision,
+                &projection,
+                &mut runnable,
+                &mut child_ids,
+            );
+        }
+
         let Some(action) = pick_next(&runnable, &projection) else {
             break;
         };
         match action {
             Action::RunPure(w) => {
+                crash_if_children_pending(config, &child_ids, w.mote.id);
                 run_pure_mote(&w.mote, &w.warrant, &*journal, &rm, &executor)?;
             }
             Action::RunWm { wm, recover } => {
@@ -176,23 +195,6 @@ pub fn run(config: &RuntimeConfig) -> Result<RunOutcome, RuntimeError> {
             }
         }
         fold_new(&journal, &mut projection, &mut folded_through)?;
-
-        // Once the shaper commits, re-derive its children as runnable Motes
-        // (identity-matched to the materializer's registrations) so they
-        // actually execute rather than merely materialize.
-        if !children_derived && projection.state_of(&workflow.shaper_id) == MoteState::Committed {
-            if let Some(shaper_result_ref) = projection.result_ref_of(&workflow.shaper_id) {
-                let children = topology::derive_child_motes(
-                    &shaper_wm.mote,
-                    shaper_result_ref,
-                    &topology_decision,
-                    &shaper_wm.warrant,
-                    &shaper_wm.capability,
-                );
-                runnable.extend(children);
-                children_derived = true;
-            }
-        }
     }
 
     let outcome = outcome(&runnable, &projection);
@@ -230,6 +232,48 @@ fn fold_new(
 
 /// Choose the next Mote to act on, in submission order: a `Pending` Mote whose
 /// parents are committed (fresh run), or an in-flight Mote to recover.
+/// Scenario-3 crash injection (P0.6 / P3.4): a hard kill the instant the first
+/// materialized child is about to run — the shaper's decision + every declared Mote are
+/// committed, the children are pending. Recovery must REPLAY the committed decision
+/// (re-materialize + run the same children), never re-run the shaper to re-decide.
+/// No-op unless that crash point is configured.
+fn crash_if_children_pending(config: &RuntimeConfig, child_ids: &[MoteId], mote_id: MoteId) {
+    if config.crash_at == Some(CrashPoint::ShaperChildrenPending) && child_ids.contains(&mote_id) {
+        CrashPoint::ShaperChildrenPending.abort_now();
+    }
+}
+
+/// If the shaper has committed, re-derive its materialized children (D49 — identity
+/// from journal facts only) into `runnable` + `child_ids`, returning `true`. Pure
+/// function of the committed shaper entry: a fresh recovery process derives the SAME
+/// children (P0.6 / P3.4 — replay the decision, never re-decide). Returns `false` while
+/// the shaper is uncommitted.
+fn derive_shaper_children(
+    workflow: &DemoWorkflow,
+    shaper_wm: &WorkflowMote,
+    topology_decision: &TopologyDecision,
+    projection: &Projection,
+    runnable: &mut Vec<WorkflowMote>,
+    child_ids: &mut Vec<MoteId>,
+) -> bool {
+    if projection.state_of(&workflow.shaper_id) != MoteState::Committed {
+        return false;
+    }
+    let Some(shaper_result_ref) = projection.result_ref_of(&workflow.shaper_id) else {
+        return false;
+    };
+    let children = topology::derive_child_motes(
+        &shaper_wm.mote,
+        shaper_result_ref,
+        topology_decision,
+        &shaper_wm.warrant,
+        &shaper_wm.capability,
+    );
+    child_ids.extend(children.iter().map(|c| c.mote.id));
+    runnable.extend(children);
+    true
+}
+
 fn pick_next(runnable: &[WorkflowMote], projection: &Projection) -> Option<Action> {
     let ready = projection.ready_set();
     for w in runnable {

--- a/crates/kx-runtime/tests/kill_and_replay.rs
+++ b/crates/kx-runtime/tests/kill_and_replay.rs
@@ -87,10 +87,16 @@ fn clean_reference_digest() -> String {
 }
 
 /// Count `Committed` entries per Mote in the on-disk journal — assertion (b).
+///
+/// The range end is `current_seq + 1`, NOT `u64::MAX`: SQLite binds `u64::MAX` to `-1`
+/// (i64), which silently returns **zero rows** (the bind quirk recorded in HANDOFF
+/// §2.55). Reading the real watermark makes every caller's count meaningful — without
+/// this, `assert_exactly_once` would pass vacuously over an empty map.
 fn committed_counts(journal_path: &Path) -> BTreeMap<MoteId, usize> {
     let journal = SqliteJournal::open(journal_path).unwrap();
+    let end = journal.current_seq().unwrap().saturating_add(1);
     let mut counts: BTreeMap<MoteId, usize> = BTreeMap::new();
-    for entry in journal.read_entries_by_seq(0..u64::MAX).unwrap() {
+    for entry in journal.read_entries_by_seq(0..end).unwrap() {
         if let JournalEntry::Committed { mote_id, .. } = entry {
             *counts.entry(mote_id).or_insert(0) += 1;
         }
@@ -180,6 +186,63 @@ fn scenario_2_validate_then_commit_post_commit_crash_rereads_not_reruns() {
     assert_exactly_once(&p.journal);
     let fresh = digest_of(&invoke("digest", &p, None));
     assert_eq!(fresh, reference, "(c) cross-process replay digest");
+}
+
+/// Scenario 3 — `shaper-children-pending` (P0.6 / P3.4, the hardest path): crash the
+/// instant the topology shaper has committed its `TopologyDecision` and every *declared*
+/// Mote is committed, but the **materialized children** have not yet run. Recovery must
+/// REPLAY the committed decision — re-materialize the SAME children (D49, identity from
+/// journal facts) and run them — NEVER re-run the shaper to re-decide (which would orphan
+/// or duplicate children). Without re-deriving the committed shaper's children before the
+/// drive loop can stop, a fresh process would break with the children orphaned.
+#[test]
+fn scenario_3_shaper_commits_then_crash_replays_decision_not_re_decided() {
+    let reference = clean_reference_digest();
+    let p = paths();
+
+    // Crash after the shaper + every declared Mote committed, before the children run.
+    let crashed = invoke("run", &p, Some("shaper-children-pending"));
+    assert_aborted(&crashed);
+
+    // At crash time: only the declared Motes are committed (exactly once each); the two
+    // materialized children have NOT committed yet.
+    let mid = committed_counts(&p.journal);
+    assert!(
+        mid.values().all(|&c| c == 1),
+        "every committed Mote appears exactly once at crash time"
+    );
+    let committed_at_crash = mid.len();
+    assert_eq!(
+        committed_at_crash, 6,
+        "the 6 declared Motes (incl. the shaper) committed; the 2 children are pending"
+    );
+
+    // Restart: recovery re-folds the committed shaper, re-materializes the SAME children,
+    // and runs them — the shaper is never re-run (its committed decision is a fact).
+    let replay = invoke("replay", &p, None);
+    let replay_digest = digest_of(&replay);
+
+    // (a) bit-identical committed set: the replayed decision yields the same children +
+    //     the same final committed set as a clean run.
+    assert_eq!(
+        replay_digest, reference,
+        "(a) recovery replays the committed decision: bit-identical committed set"
+    );
+    // (b) no Mote (shaper or child) committed more than once — the shaper did not
+    //     re-decide, the children were not duplicated.
+    assert_exactly_once(&p.journal);
+    // (c) cross-process replay digest.
+    let fresh = digest_of(&invoke("digest", &p, None));
+    assert_eq!(fresh, reference, "(c) cross-process replay digest");
+
+    // The previously-pending children DID materialize + commit on recovery (8 total now,
+    // up from 6 at crash) — they were not orphaned.
+    let after = committed_counts(&p.journal);
+    assert_eq!(
+        after.len(),
+        8,
+        "recovery ran the 2 previously-pending materialized children (6 → 8 committed)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fourth step of **PHASE P3** — "the hardest runtime path." A topology shaper commits its `TopologyDecision` as its `result_ref`; the projection materializes child Motes from that committed decision (D48/D49, P1.11). **P0.6's rule:** recovery **replays** the committed decision (re-materializes the SAME children) and **never re-runs the shaper to re-decide** (which would orphan/duplicate children).

## The gap (a real recovery hazard)
The mechanism shipped (P1.11 deterministic re-fold + P3.3's P0.4 gate preventing a committed shaper from being re-run). But the engine's drive loop derived the materialized children at the **end** of a loop iteration, *after* `pick_next`. Children are appended last, so a crash after every declared Mote committed leaves recovery in a state where only the children remain → `pick_next` returns `None` → the loop **breaks before deriving them**, **orphaning the shaper's decision**.

## Fix
Derive a committed shaper's children at the **top** of the loop (before `pick_next`), extracted into `derive_shaper_children` — a pure function of the committed shaper entry, so a fresh recovery process derives the SAME children. New `CrashPoint::ShaperChildrenPending` aborts the instant the first materialized child is about to run (shaper + all declared committed; children pending) — the orphan-triggering state. Touches **`kx-runtime` only**; `kx-scheduler`/`kx-inference` stay frozen (the build-seq "kx-scheduler + kx-journal" estimate predated the hosted-engine split — the real locus is the engine drive loop). **No new D-number** (implements P0.6 + the P1.11 mechanism).

## Tests
`kill_and_replay` **scenario_3**: crash with children pending → replay re-materializes the SAME children (identical MoteIds via D49), **byte-identical digest**, exactly-once, no re-decide. **Also fixed a latent test-helper bug:** `committed_counts` read `read_entries_by_seq(0..u64::MAX)`, which binds to `-1` on SQLite → **0 rows** (HANDOFF §2.55), so scenario_1/2's `assert_exactly_once` had been passing **vacuously over an empty map**. Now it reads `current_seq + 1`, making the exactly-once checks across **all** scenarios real. Full gate green (**858 passed / 0 failed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)