### PR TITLE
feat(kx-coordinator): poison-invalidation cascade — repudiate + cascade (P3.5, D22)

### DIFF
--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -48,14 +48,17 @@ mod commit;
 mod error;
 mod placement;
 mod registry;
+mod repudiation;
 mod reschedule;
 mod service;
 mod state;
 
 pub use clock::{Clock, SystemClock};
 pub use error::CoordinatorError;
+pub use kx_journal::RepudiationReason;
 pub use registry::{
     is_live, InMemoryWorkerRegistry, RegistryError, WorkerRecord, WorkerRegistry, WorkerStatus,
     DEFAULT_LIVENESS_TIMEOUT,
 };
+pub use repudiation::{RepudiationError, RepudiationOutcome};
 pub use service::CoordinatorService;

--- a/crates/kx-coordinator/src/repudiation.rs
+++ b/crates/kx-coordinator/src/repudiation.rs
@@ -1,0 +1,249 @@
+//! Poison-invalidation cascade (P3.5 / P0.7, D22). When a committed Mote is repudiated,
+//! every committed Mote downstream of it (reachable via Data edges, and Control edges
+//! that did not opt out of cascade) is **also** repudiated — `committed = truth`, so a
+//! wrong commit's blast radius must be contained explicitly (the runtime cannot recompute
+//! its way out: committed results are facts, not functions).
+//!
+//! This module is the **walker + entry builder** — a pure function of a projection
+//! snapshot. The coordinator's sole-writer thread (D40) runs it and appends the resulting
+//! `Repudiated` batch atomically (mirroring the P3.2 reap-write). The BFS itself + the
+//! cascade edge rule live in `kx_projection::transitive_consumers`
+//! (`control-edge-cascade-default.md`); this code applies the **fail-not-recompute**
+//! policy (D22 §5: mark `Repudiated`, never auto-re-Propose) and the sanity ceiling.
+
+use kx_journal::{repudiation_idempotency_key, JournalEntry, RepudiationReason};
+use kx_mote::MoteId;
+use kx_projection::Projection;
+
+/// Sanity ceiling on a single cascade (target + downstream). A repudiation whose
+/// invalidation set exceeds this is refused (D22 — mass-repudiation needs an explicit
+/// operator override, deferred to the P4.5 ops UX); it bounds the worst-case write batch
+/// and surfaces a likely mistaken mass-repudiation instead of silently rewriting the run.
+pub(crate) const DEFAULT_CASCADE_CEILING: usize = 10_000;
+
+/// Reporter id stamped on a coordinator-written cascade `Repudiated` entry (D22 §5):
+/// the cascade is the coordinator's consequence of the operator's seed repudiation.
+const COORDINATOR_REPUDIATOR_ID: u128 = 0;
+
+/// Outcome of a repudiation: the seed target plus the number of downstream Motes the
+/// cascade newly repudiated (a re-repudiation of an already-repudiated set reports `0`
+/// newly-cascaded — the journal dedupes by key, D15).
+#[derive(Debug, Clone, Copy)]
+pub struct RepudiationOutcome {
+    /// The seed Mote that was repudiated.
+    pub target: MoteId,
+    /// How many downstream committed Motes the cascade repudiated this call.
+    pub cascade_size: usize,
+}
+
+/// Why a repudiation could not be performed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RepudiationError {
+    /// The target is not a committed Mote — only committed facts can be repudiated
+    /// (`repudiation.md` §1: in-flight attempts are not repudiable).
+    #[error("repudiation target {0:?} is not committed")]
+    TargetNotCommitted(MoteId),
+    /// The invalidation set (target + downstream) exceeds the sanity ceiling.
+    #[error(
+        "cascade of {size} exceeds the ceiling of {ceiling}; refusing (operator override is P4.5)"
+    )]
+    CascadeTooLarge {
+        /// The would-be invalidation-set size (target + downstream).
+        size: usize,
+        /// The configured ceiling.
+        ceiling: usize,
+    },
+    /// The journal append of the cascade batch failed (catastrophic — the batch is
+    /// atomic, so nothing was written).
+    #[error("repudiation journal write failed: {0}")]
+    Append(String),
+    /// The orchestration core is gone (channel closed on shutdown).
+    #[error("coordinator core unavailable")]
+    CoreUnavailable,
+}
+
+/// The minimal read surface the cascade walker needs — the downstream closure and each
+/// Mote's committed seq. Behind a trait so the walker is unit-testable without a full
+/// projection (and so the dependency is explicit).
+pub(crate) trait CascadeGraph {
+    /// Downstream consumers reachable via the cascade edge rule (Data always; Control
+    /// unless opted out). Excludes `target` itself. Cycle-safe.
+    fn transitive_consumers(&self, target: &MoteId) -> Vec<MoteId>;
+    /// The seq of `mote`'s `Committed` entry, or `None` if not committed.
+    fn committed_seq_of(&self, mote: &MoteId) -> Option<u64>;
+}
+
+impl CascadeGraph for Projection {
+    fn transitive_consumers(&self, target: &MoteId) -> Vec<MoteId> {
+        Projection::transitive_consumers(self, target)
+    }
+    fn committed_seq_of(&self, mote: &MoteId) -> Option<u64> {
+        Projection::committed_seq_of(self, mote)
+    }
+}
+
+/// Build the `Repudiated` batch for repudiating `target` with `reason` and cascading to
+/// its committed downstream consumers (each `UpstreamCascade`). Pure: it only reads the
+/// graph and constructs entries — the caller appends them through the sole writer. The
+/// target is entry 0 (its own `reason`); the rest are the cascade. A downstream Mote that
+/// is not committed is skipped (nothing to repudiate — `ready_set` already gates it on its
+/// repudiated parent). Idempotency keys are derived per D15, so re-repudiating dedupes.
+pub(crate) fn cascade_repudiation_entries<G: CascadeGraph>(
+    graph: &G,
+    target: MoteId,
+    reason: RepudiationReason,
+    repudiator_id: u128,
+    ceiling: usize,
+) -> Result<Vec<JournalEntry>, RepudiationError> {
+    let Some(target_seq) = graph.committed_seq_of(&target) else {
+        return Err(RepudiationError::TargetNotCommitted(target));
+    };
+    let downstream: Vec<(MoteId, u64)> = graph
+        .transitive_consumers(&target)
+        .into_iter()
+        .filter_map(|c| graph.committed_seq_of(&c).map(|seq| (c, seq)))
+        .collect();
+    let size = 1 + downstream.len();
+    if size > ceiling {
+        return Err(RepudiationError::CascadeTooLarge { size, ceiling });
+    }
+    let mut entries = Vec::with_capacity(size);
+    entries.push(repudiated_entry(target, target_seq, reason, repudiator_id));
+    for (consumer, seq) in downstream {
+        entries.push(repudiated_entry(
+            consumer,
+            seq,
+            RepudiationReason::UpstreamCascade,
+            COORDINATOR_REPUDIATOR_ID,
+        ));
+    }
+    Ok(entries)
+}
+
+/// A `Repudiated` entry (`seq` is journal-assigned on append; the idempotency key is
+/// derived per D15 so duplicate repudiations of the same `(target, committed_seq)` dedupe).
+fn repudiated_entry(
+    target_mote_id: MoteId,
+    target_committed_seq: u64,
+    reason_class: RepudiationReason,
+    repudiator_id: u128,
+) -> JournalEntry {
+    JournalEntry::Repudiated {
+        target_mote_id,
+        idempotency_key: repudiation_idempotency_key(&target_mote_id, target_committed_seq),
+        seq: 0,
+        target_committed_seq,
+        reason_class,
+        repudiator_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// A hand-built graph: `committed` maps Mote → committed_seq; `consumers` maps a
+    /// target → its (already cascade-filtered) downstream closure.
+    struct MockGraph {
+        committed: BTreeMap<MoteId, u64>,
+        consumers: BTreeMap<MoteId, Vec<MoteId>>,
+    }
+    impl CascadeGraph for MockGraph {
+        fn transitive_consumers(&self, target: &MoteId) -> Vec<MoteId> {
+            self.consumers.get(target).cloned().unwrap_or_default()
+        }
+        fn committed_seq_of(&self, mote: &MoteId) -> Option<u64> {
+            self.committed.get(mote).copied()
+        }
+    }
+
+    fn m(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    fn reason_of(e: &JournalEntry) -> RepudiationReason {
+        match e {
+            JournalEntry::Repudiated { reason_class, .. } => *reason_class,
+            _ => panic!("expected Repudiated"),
+        }
+    }
+    fn target_of(e: &JournalEntry) -> MoteId {
+        match e {
+            JournalEntry::Repudiated { target_mote_id, .. } => *target_mote_id,
+            _ => panic!("expected Repudiated"),
+        }
+    }
+
+    #[test]
+    fn cascades_to_committed_downstream_with_upstream_cascade_reason() {
+        let graph = MockGraph {
+            committed: [(m(1), 1), (m(2), 2), (m(3), 3)].into_iter().collect(),
+            consumers: [(m(1), vec![m(2), m(3)])].into_iter().collect(),
+        };
+        let entries =
+            cascade_repudiation_entries(&graph, m(1), RepudiationReason::OperatorAction, 7, 10_000)
+                .unwrap();
+        assert_eq!(entries.len(), 3, "target + 2 downstream");
+        assert_eq!(target_of(&entries[0]), m(1));
+        assert_eq!(reason_of(&entries[0]), RepudiationReason::OperatorAction);
+        // Both downstream carry UpstreamCascade.
+        for e in &entries[1..] {
+            assert_eq!(reason_of(e), RepudiationReason::UpstreamCascade);
+        }
+    }
+
+    #[test]
+    fn skips_uncommitted_downstream() {
+        // m(3) is downstream but NOT committed → not repudiated (nothing to invalidate).
+        let graph = MockGraph {
+            committed: [(m(1), 1), (m(2), 2)].into_iter().collect(),
+            consumers: [(m(1), vec![m(2), m(3)])].into_iter().collect(),
+        };
+        let entries =
+            cascade_repudiation_entries(&graph, m(1), RepudiationReason::OperatorAction, 7, 10_000)
+                .unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "target + only the committed downstream m(2)"
+        );
+        assert_eq!(target_of(&entries[1]), m(2));
+    }
+
+    #[test]
+    fn refuses_uncommitted_target() {
+        let graph = MockGraph {
+            committed: BTreeMap::new(),
+            consumers: BTreeMap::new(),
+        };
+        let err =
+            cascade_repudiation_entries(&graph, m(9), RepudiationReason::OperatorAction, 7, 10_000)
+                .unwrap_err();
+        assert_eq!(err, RepudiationError::TargetNotCommitted(m(9)));
+    }
+
+    #[test]
+    fn refuses_cascade_over_ceiling() {
+        let downstream: Vec<MoteId> = (10u8..20).map(m).collect();
+        let mut committed: BTreeMap<MoteId, u64> = [(m(1), 1)].into_iter().collect();
+        for (i, d) in downstream.iter().enumerate() {
+            committed.insert(*d, 100 + i as u64);
+        }
+        let graph = MockGraph {
+            committed,
+            consumers: [(m(1), downstream)].into_iter().collect(),
+        };
+        // ceiling = 5, but the set is 1 + 10 = 11 → refused.
+        let err =
+            cascade_repudiation_entries(&graph, m(1), RepudiationReason::OperatorAction, 7, 5)
+                .unwrap_err();
+        assert_eq!(
+            err,
+            RepudiationError::CascadeTooLarge {
+                size: 11,
+                ceiling: 5
+            }
+        );
+    }
+}

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -105,6 +105,21 @@ impl CoordinatorService {
     pub fn registry(&self) -> &dyn WorkerRegistry {
         self.registry.as_ref()
     }
+
+    /// Repudiate `target` and cascade the poison-invalidation to its committed downstream
+    /// consumers (D22 / P0.7): one `Repudiated` entry per Mote (the target with `reason`,
+    /// the cascade with `UpstreamCascade`), written atomically through the sole writer, so
+    /// the next `LeaseWork` no longer offers any of them. Returns how many downstream Motes
+    /// the cascade repudiated. The operator-facing RPC / CLI is P4.5; this is the in-process
+    /// mechanism (the "distributed cascade mechanics" P0.7 deferred to P3.5).
+    pub async fn repudiate(
+        &self,
+        target: MoteId,
+        reason: crate::RepudiationReason,
+        repudiator_id: u128,
+    ) -> Result<crate::RepudiationOutcome, crate::RepudiationError> {
+        self.core.repudiate(target, reason, repudiator_id).await
+    }
 }
 
 #[tonic::async_trait]

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
-use kx_journal::{FailureReason, Journal, JournalEntry};
+use kx_journal::{FailureReason, Journal, JournalEntry, RepudiationReason};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
@@ -31,6 +31,9 @@ use crate::commit::CommitProposal;
 use crate::error::CoordinatorError;
 use crate::placement::LoadAwarePlacement;
 use crate::registry::{WorkerRegistry, WorkerStatus};
+use crate::repudiation::{
+    cascade_repudiation_entries, RepudiationError, RepudiationOutcome, DEFAULT_CASCADE_CEILING,
+};
 use crate::reschedule::{LeaseTracker, PURE_RETRY_BUDGET};
 
 /// Reporter id stamped on a coordinator-written `Failed{WorkerCrashed}` entry (D57 §3
@@ -95,6 +98,12 @@ pub(crate) enum Command {
         since_seq: u64,
         max: usize,
         reply: oneshot::Sender<Result<(Vec<JournalEntry>, u64), CoordinatorError>>,
+    },
+    Repudiate {
+        target: MoteId,
+        reason: RepudiationReason,
+        repudiator_id: u128,
+        reply: oneshot::Sender<Result<RepudiationOutcome, RepudiationError>>,
     },
 }
 
@@ -221,6 +230,29 @@ impl CoreHandle {
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)?
+    }
+
+    /// Repudiate `target` and cascade the poison-invalidation to its committed downstream
+    /// consumers (D22 / P0.7). Runs on the sole-writer thread: it computes the cascade
+    /// against the live projection and appends the `Repudiated` batch atomically.
+    pub(crate) async fn repudiate(
+        &self,
+        target: MoteId,
+        reason: RepudiationReason,
+        repudiator_id: u128,
+    ) -> Result<RepudiationOutcome, RepudiationError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::Repudiate {
+            target,
+            reason,
+            repudiator_id,
+            reply,
+        })
+        .await
+        .map_err(|_| RepudiationError::CoreUnavailable)?;
+        response
+            .await
+            .map_err(|_| RepudiationError::CoreUnavailable)?
     }
 
     async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
@@ -396,6 +428,47 @@ fn reap_dead_workers<J: Journal>(
     }
 }
 
+/// Repudiate `target` and cascade to its committed downstream consumers (D22 / P0.7).
+/// Computes the `Repudiated` batch against the live projection, appends it atomically
+/// through the sole writer (group commit), and folds the new entries — so the very next
+/// `lease_ready` / `ready_set` excludes the repudiated set (the distributed cascade is
+/// observed by workers through the coordinator's lease gate; no off-journal facts).
+/// Re-repudiating an already-repudiated set dedupes (D15) and folds nothing new.
+fn repudiate_cascade<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    target: MoteId,
+    reason: RepudiationReason,
+    repudiator_id: u128,
+) -> Result<RepudiationOutcome, RepudiationError> {
+    let entries = cascade_repudiation_entries(
+        &*projection,
+        target,
+        reason,
+        repudiator_id,
+        DEFAULT_CASCADE_CEILING,
+    )?;
+    // entry 0 is the target; the remainder is the downstream cascade.
+    let cascade_size = entries.len().saturating_sub(1);
+    let durable = journal
+        .append_batch(entries)
+        .map_err(|e| RepudiationError::Append(e.to_string()))?;
+    for entry in &durable {
+        let seq = entry.seq();
+        if seq > *folded_through {
+            projection
+                .fold(entry)
+                .map_err(|e| RepudiationError::Append(e.to_string()))?;
+            *folded_through = seq;
+        }
+    }
+    Ok(RepudiationOutcome {
+        target,
+        cascade_size,
+    })
+}
+
 /// Build the `Failed{WorkerCrashed}` entry for a Mote whose leasing worker died. The
 /// `idempotency_key` is the Mote's identity (`idempotency.md`: key == derived `MoteId`).
 fn failed_worker_crashed_entry(mote_id: MoteId) -> JournalEntry {
@@ -512,59 +585,15 @@ fn core_loop<J: Journal>(
                 &mut dispatch,
                 &mut pending,
             );
-            match command {
-                Command::Commit { .. } => unreachable!("Commit is handled above"),
-                Command::Submit {
-                    mote,
-                    warrant,
-                    reply,
-                } => {
-                    let outcome = handle_submit(
-                        &mut scheduler,
-                        &mut projection,
-                        &mut dispatch,
-                        *mote,
-                        *warrant,
-                    );
-                    let _ = reply.send(outcome);
-                }
-                Command::StateOf { mote_id, reply } => {
-                    let _ = reply.send(projection.state_of(&mote_id));
-                }
-                Command::CommittedCount { reply } => {
-                    let _ = reply.send(projection.snapshot().committed_count());
-                }
-                Command::ReadySet { reply } => {
-                    let _ = reply.send(projection.ready_set());
-                }
-                Command::LeaseWork {
-                    worker,
-                    executor_class,
-                    max,
-                    reply,
-                } => {
-                    let items = serve_lease(
-                        journal,
-                        &mut projection,
-                        &mut folded_through,
-                        registry,
-                        &mut dispatch,
-                        &LeaseReq {
-                            worker,
-                            executor_class,
-                            max,
-                        },
-                    );
-                    let _ = reply.send(items);
-                }
-                Command::ReadEntries {
-                    since_seq,
-                    max,
-                    reply,
-                } => {
-                    let _ = reply.send(read_committed_since(journal, since_seq, max));
-                }
-            }
+            handle_command(
+                journal,
+                &mut projection,
+                &mut folded_through,
+                registry,
+                &mut dispatch,
+                &mut scheduler,
+                command,
+            );
         }
         flush_commits(
             journal,
@@ -574,6 +603,83 @@ fn core_loop<J: Journal>(
             &mut dispatch,
             &mut pending,
         );
+    }
+}
+
+/// Service one non-`Commit` command against the owner-thread state (Commits are
+/// coalesced into group commits before this is reached, so the `Commit` arm is
+/// unreachable). Each arm sends its `oneshot` reply; a dropped receiver is ignored.
+fn handle_command<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    registry: &dyn WorkerRegistry,
+    dispatch: &mut Dispatch,
+    scheduler: &mut Scheduler<LocalPlacement>,
+    command: Command,
+) {
+    match command {
+        Command::Commit { .. } => unreachable!("Commit is handled above"),
+        Command::Submit {
+            mote,
+            warrant,
+            reply,
+        } => {
+            let outcome = handle_submit(scheduler, projection, dispatch, *mote, *warrant);
+            let _ = reply.send(outcome);
+        }
+        Command::StateOf { mote_id, reply } => {
+            let _ = reply.send(projection.state_of(&mote_id));
+        }
+        Command::CommittedCount { reply } => {
+            let _ = reply.send(projection.snapshot().committed_count());
+        }
+        Command::ReadySet { reply } => {
+            let _ = reply.send(projection.ready_set());
+        }
+        Command::LeaseWork {
+            worker,
+            executor_class,
+            max,
+            reply,
+        } => {
+            let items = serve_lease(
+                journal,
+                projection,
+                folded_through,
+                registry,
+                dispatch,
+                &LeaseReq {
+                    worker,
+                    executor_class,
+                    max,
+                },
+            );
+            let _ = reply.send(items);
+        }
+        Command::ReadEntries {
+            since_seq,
+            max,
+            reply,
+        } => {
+            let _ = reply.send(read_committed_since(journal, since_seq, max));
+        }
+        Command::Repudiate {
+            target,
+            reason,
+            repudiator_id,
+            reply,
+        } => {
+            let outcome = repudiate_cascade(
+                journal,
+                projection,
+                folded_through,
+                target,
+                reason,
+                repudiator_id,
+            );
+            let _ = reply.send(outcome);
+        }
     }
 }
 

--- a/crates/kx-coordinator/tests/repudiation.rs
+++ b/crates/kx-coordinator/tests/repudiation.rs
@@ -1,0 +1,148 @@
+//! Poison-invalidation cascade (P3.5 / P0.7, D22): repudiating a committed Mote cascades
+//! to its committed downstream consumers (one `Repudiated{UpstreamCascade}` each), the
+//! coordinator writes the batch through its sole-writer thread, and the next `LeaseWork`
+//! offers none of them. Idempotent (re-repudiation dedupes); only committed Motes are
+//! repudiable.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use kx_coordinator::proto::ExecutorClass;
+use kx_coordinator::{CoordinatorService, MoteState, RepudiationError, RepudiationReason};
+use kx_journal::InMemoryJournal;
+use kx_mote::NdClass;
+
+const MAC: ExecutorClass = ExecutorClass::MacosSandbox;
+
+fn coordinator() -> CoordinatorService {
+    CoordinatorService::new(InMemoryJournal::new())
+}
+
+/// a → b → c (data edges). Repudiating `a` cascades to `b` and `c`.
+#[tokio::test]
+async fn repudiating_a_root_cascades_to_committed_downstream() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    let c = common::mote(3, NdClass::Pure, &[b.id]);
+    for m in [&a, &b, &c] {
+        common::submit(&svc, m, &warrant).await;
+    }
+    // Commit the whole chain (in dependency order).
+    common::commit(&svc, &a, worker).await;
+    common::commit(&svc, &b, worker).await;
+    common::commit(&svc, &c, worker).await;
+    for m in [&a, &b, &c] {
+        assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
+    }
+
+    // Repudiate the root → cascade marks b and c.
+    let outcome = svc
+        .repudiate(a.id, RepudiationReason::OperatorAction, 42)
+        .await
+        .unwrap();
+    assert_eq!(outcome.target, a.id);
+    assert_eq!(outcome.cascade_size, 2, "b and c are downstream of a");
+
+    for m in [&a, &b, &c] {
+        assert_eq!(
+            svc.state_of(m.id).await.unwrap(),
+            MoteState::Repudiated,
+            "the whole poisoned lineage is repudiated"
+        );
+    }
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        0,
+        "no Mote remains committed after the cascade"
+    );
+
+    // Re-repudiating is idempotent: the journal dedupes by key, state is unchanged.
+    let again = svc
+        .repudiate(a.id, RepudiationReason::OperatorAction, 42)
+        .await
+        .unwrap();
+    assert_eq!(
+        again.cascade_size, 2,
+        "the cascade set is recomputed identically"
+    );
+    for m in [&a, &b, &c] {
+        assert_eq!(svc.state_of(m.id).await.unwrap(), MoteState::Repudiated);
+    }
+}
+
+/// Repudiating a leaf invalidates only it — the cascade is downstream-only.
+#[tokio::test]
+async fn repudiating_a_leaf_does_not_touch_its_ancestors() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    common::submit(&svc, &a, &warrant).await;
+    common::submit(&svc, &b, &warrant).await;
+    common::commit(&svc, &a, worker).await;
+    common::commit(&svc, &b, worker).await;
+
+    let outcome = svc
+        .repudiate(b.id, RepudiationReason::OperatorAction, 1)
+        .await
+        .unwrap();
+    assert_eq!(outcome.cascade_size, 0, "b is a leaf — no downstream");
+    assert_eq!(svc.state_of(b.id).await.unwrap(), MoteState::Repudiated);
+    assert_eq!(
+        svc.state_of(a.id).await.unwrap(),
+        MoteState::Committed,
+        "the ancestor is untouched — cascade flows downstream only"
+    );
+}
+
+/// After a cascade, the coordinator's `LeaseWork` offers none of the repudiated Motes —
+/// the distributed cascade is observed by workers through the lease gate.
+#[tokio::test]
+async fn repudiated_motes_are_not_leasable() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // a committed; b (child of a) submitted-but-not-committed → b is ready to lease.
+    let a = common::mote(1, NdClass::Pure, &[]);
+    let b = common::mote(2, NdClass::Pure, &[a.id]);
+    common::submit(&svc, &a, &warrant).await;
+    common::submit(&svc, &b, &warrant).await;
+    common::commit(&svc, &a, worker).await;
+    assert_eq!(
+        common::lease_work(&svc, worker, MAC, 16).await.len(),
+        1,
+        "b is leasable while its parent a is committed"
+    );
+
+    // Repudiate a → b's parent is now repudiated → b is no longer leasable.
+    svc.repudiate(a.id, RepudiationReason::OperatorAction, 1)
+        .await
+        .unwrap();
+    assert!(
+        common::lease_work(&svc, worker, MAC, 16).await.is_empty(),
+        "no Mote with a repudiated parent is leased"
+    );
+}
+
+#[tokio::test]
+async fn repudiating_an_uncommitted_mote_is_refused() {
+    let svc = coordinator();
+    let warrant = common::sample_warrant();
+    let _ = common::register(&svc, "w").await;
+    let a = common::mote(1, NdClass::Pure, &[]);
+    common::submit(&svc, &a, &warrant).await; // submitted, NOT committed
+
+    let err = svc
+        .repudiate(a.id, RepudiationReason::OperatorAction, 1)
+        .await
+        .unwrap_err();
+    assert_eq!(err, RepudiationError::TargetNotCommitted(a.id));
+}


### PR DESCRIPTION
Fifth step of **PHASE P3**. When a committed Mote is repudiated, every committed Mote downstream of it (Data edges always; Control edges unless they opted out of cascade) is **also** repudiated — `committed = truth`, so a wrong commit's blast radius must be contained explicitly (the runtime can't recompute its way out). Implements P0.6's deferred **distributed cascade mechanics** + the D22 walker/policy.

## What P1 shipped vs P3.5
The **contract pieces** were P1: `Repudiated` entry + `UpstreamCascade` reason + idempotency key + dedupe; `transitive_consumers` BFS with the cascade edge rule baked in; projection fold → `Repudiated` state; `ready_set` + memoizer already poison on a repudiated parent. **P3.5 builds the walker + write path:**
- `repudiation.rs`: `cascade_repudiation_entries` — a pure function over a `CascadeGraph` (impl'd for `Projection`) computing the invalidation set (`transitive_consumers ∩ committed`) and building one `Repudiated` per Mote (target with its `reason`, cascade with `UpstreamCascade`), bounded by a **sanity ceiling** (`DEFAULT_CASCADE_CEILING=10_000`; over → refused, operator override is P4.5). The trait makes it unit-testable.
- `Command::Repudiate` + `CoordinatorService::repudiate(...)`: the owner thread (**sole writer, D40**) runs the walker against the live projection and appends the `Repudiated` batch **atomically** (mirroring the P3.2 reap-write), then folds — so the next `LeaseWork`/`ready_set` excludes the repudiated set (workers observe via the lease gate; no off-journal facts). Re-repudiation **dedupes** (D15). **Fail-not-recompute** (D22 §5): no auto-re-Propose.

## Thesis / locus
**Coordinator-only** — like P3.2/P3.4 the build-seq "kx-scheduler + kx-journal" estimate predated the hosted split; the scheduler's `ready_set` already respects repudiation, so no scheduler change. `kx-scheduler`/`kx-inference` stay frozen-empty. **No new D-number** (implements D22/P0.7). Operator RPC/CLI stays P4.5.

## Tests (+8)
Walker unit (cascades to committed downstream w/ `UpstreamCascade`, skips uncommitted, refuses uncommitted target, refuses over-ceiling) + integration (root cascade + idempotent re-repudiation; leaf spares ancestors; repudiated Motes not leasable; uncommitted target refused). Full gate green (**866 passed / 0 failed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)