### PR TITLE
feat(kx-coordinator): WM-distributed-dispatch seam — ReportEffectStaged + WM lease (P3.6a, D58)

### DIFF
--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -219,6 +219,39 @@ impl Coordinator for CoordinatorService {
     }
 
     #[tracing::instrument(skip_all)]
+    async fn report_effect_staged(
+        &self,
+        request: Request<proto::ReportEffectStagedRequest>,
+    ) -> Result<Response<proto::ReportEffectStagedResponse>, Status> {
+        let req = request.into_inner();
+        // D40 admission: only a registered worker may stage an effect (mirrors report_commit).
+        let worker = WorkerId(req.worker_id);
+        if self.registry.get(worker).is_none() {
+            return Err(CoordinatorError::UnknownWorker(worker).into());
+        }
+        let mote_id_bytes: [u8; 32] = req
+            .mote_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| Status::invalid_argument("mote_id must be 32 bytes"))?;
+        let idempotency_key: [u8; 32] = req
+            .idempotency_key
+            .as_slice()
+            .try_into()
+            .map_err(|_| Status::invalid_argument("idempotency_key must be 32 bytes"))?;
+        let mote_id = MoteId::from_bytes(mote_id_bytes);
+        let staged_seq = self
+            .core
+            .report_effect_staged(mote_id, idempotency_key)
+            .await?;
+        tracing::info!(seq = staged_seq, ?mote_id, "effect staged");
+        Ok(Response::new(proto::ReportEffectStagedResponse {
+            staged_seq,
+            ack: true,
+        }))
+    }
+
+    #[tracing::instrument(skip_all)]
     async fn lease_work(
         &self,
         request: Request<proto::LeaseWorkRequest>,

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_journal::{FailureReason, Journal, JournalEntry, RepudiationReason};
-use kx_mote::{Mote, MoteId, NdClass};
+use kx_mote::{Mote, MoteId};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
 use kx_warrant::{ExecutorClass, WarrantSpec};
@@ -104,6 +104,11 @@ pub(crate) enum Command {
         reason: RepudiationReason,
         repudiator_id: u128,
         reply: oneshot::Sender<Result<RepudiationOutcome, RepudiationError>>,
+    },
+    ReportEffectStaged {
+        mote_id: MoteId,
+        idempotency_key: [u8; 32],
+        reply: oneshot::Sender<Result<u64, CoordinatorError>>,
     },
 }
 
@@ -255,6 +260,27 @@ impl CoreHandle {
             .map_err(|_| RepudiationError::CoreUnavailable)?
     }
 
+    /// Record a WORLD-MUTATING Mote's staged-intent (D58): append an `EffectStaged`
+    /// entry through the sole writer and return its seq. The worker calls this BEFORE
+    /// firing the effect, so on worker death the coordinator's projection has the
+    /// recovery hint. Dedupes by key (D15) — a re-stage on recovery returns the seq.
+    pub(crate) async fn report_effect_staged(
+        &self,
+        mote_id: MoteId,
+        idempotency_key: [u8; 32],
+    ) -> Result<u64, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::ReportEffectStaged {
+            mote_id,
+            idempotency_key,
+            reply,
+        })
+        .await?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)?
+    }
+
     async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
         self.commands
             .send(command)
@@ -332,12 +358,14 @@ fn serve_lease<J: Journal>(
     items
 }
 
-/// Select up to `max` ready PURE Motes for `worker` to run. Candidates are
-/// ready (parents-all-committed) ∩ PURE (the only class executed-then-proposed in
-/// P2.x; WM is deferred) ∩ matching the worker's backend (`executor_class`). Placement
-/// v2 (D56) then orders them: Motes the load-aware policy routes to `worker` come
-/// **first**, the rest **fill to `max`** — so work balances across workers by load
-/// (shard-by-mote on ties) while a live poller never idles when ready work exists
+/// Select up to `max` ready Motes for `worker` to run. Candidates are ready
+/// (parents-all-committed) ∩ matching the worker's backend (`executor_class`). **D58
+/// (P3.6) lifts the PURE-only restriction**: WORLD-MUTATING + READ-ONLY-NONDET Motes are
+/// now leasable (the worker stages its intent via `ReportEffectStaged` before firing,
+/// then proposes the commit). Submission-time refusals (R-1/R-2/R-10, P0.8) already gated
+/// admissibility at `SubmitMote`; the executor's R-11/R-13 + the coordinator's D55
+/// phantom-ref guard backstop the dispatch. Placement v2 (D56) then orders them:
+/// `worker`'s placement-preferred Motes come **first**, the rest **fill to `max`**
 /// (starvation-free; double execution stays harmless under dedup, D54).
 fn lease_ready(
     projection: &Projection,
@@ -368,8 +396,8 @@ fn lease_ready(
         if projection.state_of(&mote_id) == MoteState::Committed {
             continue;
         }
-        if let Some((mote, warrant)) = submitted_defs.get(&mote_id) {
-            if mote.nd_class() == NdClass::Pure && warrant.executor_class == executor_class {
+        if let Some((_mote, warrant)) = submitted_defs.get(&mote_id) {
+            if warrant.executor_class == executor_class {
                 if placement.place(&mote_id) == worker {
                     preferred.push(mote_id);
                 } else {
@@ -680,7 +708,48 @@ fn handle_command<J: Journal>(
             );
             let _ = reply.send(outcome);
         }
+        Command::ReportEffectStaged {
+            mote_id,
+            idempotency_key,
+            reply,
+        } => {
+            let seq = stage_effect(
+                journal,
+                projection,
+                folded_through,
+                mote_id,
+                idempotency_key,
+            );
+            let _ = reply.send(seq);
+        }
     }
+}
+
+/// Append a WORLD-MUTATING Mote's `EffectStaged` entry through the sole writer (D58 —
+/// the durable staged-intent the worker records before firing) and fold it, returning
+/// the assigned seq. Dedupes by key (D15): a re-stage on recovery returns the existing
+/// seq and folds nothing new. This is what gives the coordinator's projection the
+/// `effect_staged_observed` recovery hint, so a worker death between stage and commit is
+/// safely re-dispatchable (the oracle permits it; the tool's idempotency dedupes the effect).
+fn stage_effect<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    mote_id: MoteId,
+    idempotency_key: [u8; 32],
+) -> Result<u64, CoordinatorError> {
+    let entry = JournalEntry::EffectStaged {
+        mote_id,
+        idempotency_key,
+        seq: 0,
+    };
+    let durable = journal.append(entry)?;
+    let seq = durable.seq();
+    if seq > *folded_through {
+        projection.fold(&durable)?;
+        *folded_through = seq;
+    }
+    Ok(seq)
 }
 
 /// Register a submitted Mote through the hosted scheduler (verbatim, thesis test) and

--- a/crates/kx-coordinator/tests/lease_work.rs
+++ b/crates/kx-coordinator/tests/lease_work.rs
@@ -72,22 +72,25 @@ async fn leases_the_ready_root_then_advances_as_parents_commit() {
 }
 
 #[tokio::test]
-async fn does_not_lease_non_pure_motes() {
+async fn leases_world_mutating_motes_since_p3_6() {
     let svc = coordinator();
     let warrant = common::sample_warrant();
     let worker = common::register(&svc, "w").await;
 
-    // A ready (parentless) WORLD-MUTATING Mote: in the ready-set, but the PURE
-    // gate must keep it out of the lease.
+    // A ready (parentless) WORLD-MUTATING Mote. P2.3 kept it out of the lease (PURE-only);
+    // D58 (P3.6) lifts that — WM is now leasable (the worker stages its intent via
+    // ReportEffectStaged before firing). It still respects executor_class.
     let wm = common::mote(7, NdClass::WorldMutating, &[]);
     common::submit(&svc, &wm, &warrant).await;
 
-    assert!(
-        common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16)
-            .await
-            .is_empty(),
-        "WORLD-MUTATING Motes are not leased in P2.3"
+    let leased = common::lease_work(&svc, worker, ExecutorClass::MacosSandbox, 16).await;
+    assert_eq!(
+        leased.len(),
+        1,
+        "WORLD-MUTATING Motes are leasable since P3.6 (D58)"
     );
+    let leased_mote: kx_mote::Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(leased_mote.id, wm.id);
 }
 
 #[tokio::test]

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -244,6 +244,27 @@ message ReportCommitResponse {
 }
 
 // ---------------------------------------------------------------------------
+// RPC (7) — report effect staged (D58, P3.6). For a WORLD-MUTATING Mote, the
+// worker durably records its INTENT to fire BEFORE calling the broker: the
+// coordinator (sole writer, D40) appends an EffectStaged entry and acks. The
+// worker MUST NOT fire the effect until the ack — so on worker death the
+// coordinator's projection has the staged hint and recovery may re-dispatch
+// (the tool's idempotency closes the double-effect window). EffectStaged dedupes
+// by key (D15), so a re-stage on recovery is a no-op success.
+// ---------------------------------------------------------------------------
+
+message ReportEffectStagedRequest {
+  bytes mote_id = 1;                    // 32B — the WM Mote about to fire
+  bytes idempotency_key = 2;            // 32B — == mote_id (idempotency.md)
+  uint64 worker_id = 3;                 // the staging worker (admission gate)
+}
+
+message ReportEffectStagedResponse {
+  uint64 staged_seq = 1;                // journal seq of the EffectStaged entry (or dedup hit)
+  bool ack = 2;                         // true once durable — the worker fires only after this
+}
+
+// ---------------------------------------------------------------------------
 // RPC (3) — heartbeat (worker liveness)
 // ---------------------------------------------------------------------------
 
@@ -351,4 +372,5 @@ service Coordinator {
   rpc ReportCommit(ReportCommitRequest) returns (ReportCommitResponse);
   rpc LeaseWork(LeaseWorkRequest) returns (LeaseWorkResponse);
   rpc ReadEntries(ReadEntriesRequest) returns (ReadEntriesResponse);
+  rpc ReportEffectStaged(ReportEffectStagedRequest) returns (ReportEffectStagedResponse);
 }

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -17,8 +17,8 @@ use kx_proto::proto::{
     journal_entry, CommitOutcome, CommittedEntry, ExecutorClass, HeartbeatRequest,
     HeartbeatResponse, JournalEntry, LeaseWorkRequest, LeaseWorkResponse, NdClass,
     ReadEntriesRequest, ReadEntriesResponse, RegisterWorkerRequest, RegisterWorkerResponse,
-    ReportCommitRequest, ReportCommitResponse, SubmitMoteRequest, SubmitMoteResponse, SubmitStatus,
-    WorkItem,
+    ReportCommitRequest, ReportCommitResponse, ReportEffectStagedRequest,
+    ReportEffectStagedResponse, SubmitMoteRequest, SubmitMoteResponse, SubmitStatus, WorkItem,
 };
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
@@ -64,6 +64,17 @@ impl Coordinator for NoopCoordinator {
             committed_seq: 1,
             outcome: CommitOutcome::Committed as i32,
             detail: String::new(),
+        }))
+    }
+
+    async fn report_effect_staged(
+        &self,
+        req: Request<ReportEffectStagedRequest>,
+    ) -> Result<Response<ReportEffectStagedResponse>, Status> {
+        let _ = req.into_inner();
+        Ok(Response::new(ReportEffectStagedResponse {
+            staged_seq: 1,
+            ack: true,
         }))
     }
 


### PR DESCRIPTION
First half of **P3.6** (the deferred WORLD-MUTATING distributed-dispatch foundation, **new D58**). This is the **coordinator-side seam**; the worker-side stage→fire→commit dispatch is **P3.6b**.

- **kx-proto:** new `ReportEffectStaged` RPC (7th Coordinator RPC). The worker durably records its **intent-to-fire BEFORE calling the broker**: request `(mote_id, idempotency_key, worker_id)` → response `(staged_seq, ack)`. The worker fires only after the ack — so on worker death the coordinator's projection has the `EffectStaged` recovery hint (D38) and the Mote is safely re-dispatchable (the oracle permits it; the tool's idempotency dedupes the effect).
- **kx-coordinator:** `Command::ReportEffectStaged` + `CoordinatorService::report_effect_staged` — the owner thread (**sole writer, D40**) appends the `EffectStaged` entry + folds, returning the seq; dedupes by key (D15). Admission mirrors `ReportCommit` (registered worker only).
- **kx-coordinator:** `lease_ready` lifts the PURE-only filter (D54) → **WM + ReadOnlyNondet Motes are now leasable** (executor_class still gates the backend). Submission-time refusals (P0.8) + executor R-11/R-13 + the D55 phantom-ref guard backstop dispatch. Reschedule (D57) + cascade (D22) are nd_class-agnostic and already apply.

**Safe/inert for existing flows:** no path submits WM distributed yet, and no worker calls `ReportEffectStaged` until P3.6b. **Coordinator-only** — `kx-scheduler`/`kx-executor`/`kx-inference` source unchanged (thesis preserved; the worker drives the protocol via RPCs in P3.6b, not by forking the engine). Design-freeze: `docs/design/wm-distributed-dispatch.md` (D58). **866 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)