### PR TITLE
feat(kx-worker): worker WM-dispatch + validate-then-commit under distribution (P3.6b, D58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,7 @@ dependencies = [
 name = "kx-worker"
 version = "0.0.1"
 dependencies = [
+ "kx-capability",
  "kx-content",
  "kx-coordinator",
  "kx-executor",

--- a/crates/kx-worker/Cargo.toml
+++ b/crates/kx-worker/Cargo.toml
@@ -25,6 +25,12 @@ kx-journal = { workspace = true }
 kx-mote = { workspace = true }
 kx-warrant = { workspace = true }
 kx-content = { workspace = true }
+# The capability broker (P3.6b WORLD-MUTATING dispatch): the worker holds an
+# `Arc<dyn CapabilityBroker>` and FIRES the effect itself (staging the response bytes
+# into the shared content store), driving stage->fire->commit via RPCs since it is not
+# the journal writer (D40). The broker NEVER writes the journal (D14) — so this is glue,
+# not an engine fork (the P2 thesis test holds).
+kx-capability = { workspace = true }
 tonic = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/kx-worker/src/client.rs
+++ b/crates/kx-worker/src/client.rs
@@ -9,8 +9,8 @@ use tonic::transport::Channel;
 
 use crate::error::WorkerError;
 
-/// A worker's connection to the coordinator (the four worker-facing RPCs:
-/// register / heartbeat / lease / report-commit).
+/// A worker's connection to the coordinator (the worker-facing RPCs:
+/// register / heartbeat / lease / report-effect-staged / report-commit / read-entries).
 #[derive(Clone)]
 pub struct WorkerClient {
     inner: CoordinatorClient<Channel>,
@@ -87,6 +87,37 @@ impl WorkerClient {
             .await?
             .into_inner();
         Ok(resp.items)
+    }
+
+    /// Record the **intent to fire** a WORLD-MUTATING effect, durably, before the
+    /// effect fires (D58 §2). The worker is not the journal writer (D40), so it asks
+    /// the coordinator (sole writer) to append the `EffectStaged` recovery hint; only
+    /// after the ack may the worker call `broker.dispatch`. `idempotency_key == mote_id`
+    /// (identity invariant) so a re-stage on recovery dedupes (D15) to the same seq.
+    /// Returns the `EffectStaged` seq; errors with [`WorkerError::EffectStagedRejected`]
+    /// if the coordinator declines to ack (the worker MUST NOT then fire).
+    pub async fn report_effect_staged(
+        &mut self,
+        mote_id: [u8; 32],
+        idempotency_key: [u8; 32],
+        worker_id: u64,
+    ) -> Result<u64, WorkerError> {
+        let resp = self
+            .inner
+            .report_effect_staged(proto::ReportEffectStagedRequest {
+                mote_id: mote_id.to_vec(),
+                idempotency_key: idempotency_key.to_vec(),
+                worker_id,
+            })
+            .await?
+            .into_inner();
+        if resp.ack {
+            Ok(resp.staged_seq)
+        } else {
+            Err(WorkerError::EffectStagedRejected(
+                kx_mote::MoteId::from_bytes(mote_id),
+            ))
+        }
     }
 
     /// Propose a commit. The coordinator validates + appends (sole writer, D40) and

--- a/crates/kx-worker/src/error.rs
+++ b/crates/kx-worker/src/error.rs
@@ -42,6 +42,29 @@ pub enum WorkerError {
     /// A committed result's bytes are absent from the shared content store.
     #[error("content {0:?} is missing from the shared store")]
     ContentMissing(kx_content::ContentRef),
+
+    /// The coordinator did NOT ack a `ReportEffectStaged` (`ack == false`). The
+    /// worker MUST NOT fire the effect without the durable staged-intent record
+    /// (D58 §2) — firing first would re-fire on recovery with no staged hint (the
+    /// double-effect hazard). The dispatch is aborted; the Mote stays leasable.
+    #[error("coordinator did not ack EffectStaged for mote {0:?}")]
+    EffectStagedRejected(kx_mote::MoteId),
+
+    /// Firing a WORLD-MUTATING effect through the capability broker failed (boxed:
+    /// `BrokerError` is large, and an un-boxed variant would bloat every `Result`).
+    #[error("broker dispatch failed: {0}")]
+    Dispatch(Box<kx_capability::BrokerError>),
+
+    /// A non-PURE Mote's `tool_contract` named no capability to dispatch under, so
+    /// the worker cannot resolve which effect to fire.
+    #[error("cannot resolve a capability from the tool_contract of mote {0:?}")]
+    CapabilityResolution(kx_mote::MoteId),
+}
+
+impl From<kx_capability::BrokerError> for WorkerError {
+    fn from(error: kx_capability::BrokerError) -> Self {
+        Self::Dispatch(Box::new(error))
+    }
 }
 
 impl From<tonic::transport::Error> for WorkerError {

--- a/crates/kx-worker/src/lib.rs
+++ b/crates/kx-worker/src/lib.rs
@@ -11,16 +11,18 @@
 )]
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-//! # kx-worker — the kortecx P2.3 worker (the `CoordinatorClient`)
+//! # kx-worker — the kortecx worker (the `CoordinatorClient`)
 //!
 //! A worker is a gRPC **client** of the coordinator. It:
 //!
 //! 1. **registers** with the coordinator ([`Worker::register`] → `RegisterWorker`),
 //!    declaring the executor backend it can run;
 //! 2. **pulls** ready work ([`Worker::run_once`] → `LeaseWork`) — the coordinator
-//!    returns ready PURE Motes runnable on this backend, each with its warrant;
-//! 3. **runs** each Mote through the **hosted P1 executor** ([`kx_executor`],
-//!    verbatim — which transitively hosts `kx-inference`);
+//!    returns ready Motes runnable on this backend, each with its warrant;
+//! 3. **dispatches** each Mote: PURE recomputes through the **hosted P1 executor**
+//!    ([`kx_executor`], verbatim — which transitively hosts `kx-inference`);
+//!    WORLD-MUTATING / READ-ONLY-NONDET stages-then-fires through the capability
+//!    broker (P3.6b, D58 — see `run_wm`);
 //! 4. **proposes** the result back (`ReportCommit`); the coordinator is the SOLE
 //!    journal writer (D13 / D40) and assigns the committed seq.
 //!
@@ -34,12 +36,17 @@
 //! uses) — not read back from the throwaway journal, which would lose the Mote's
 //! parents and flatten its nd_class.
 //!
-//! ## Scope (P2.3)
+//! ## Scope
 //!
-//! PURE Motes only. A PURE Mote has no real-world effect, so running it on the
-//! worker and proposing its commit is sound. WORLD-MUTATING Motes need a durable
-//! staged-intent RPC (so the coordinator records the `EffectStaged` recovery hint
-//! before the effect fires) — deferred. Placement v2 (locality / GPU-slot) is P2.5.
+//! PURE recomputes locally and proposes its commit (sound: no real-world effect).
+//! **P3.6b (D58)** adds WORLD-MUTATING / READ-ONLY-NONDET dispatch: the worker holds
+//! an `Arc<dyn CapabilityBroker>` and drives **stage→fire→commit** — for
+//! `StageThenCommit`, `ReportEffectStaged` records the `EffectStaged` recovery hint
+//! through the sole writer (D40) before the broker fires, then `ReportCommit` proposes
+//! the staged ref. Worker-death after stage re-leases (D57) and the tool-boundary
+//! idempotency key makes the re-dispatch a no-op (exactly-once, D58 §7). The VTC
+//! critic is an ordinary DAG Mote the coordinator leases once the producer commits —
+//! the worker does not schedule it (§6). Placement v2 (locality / GPU-slot) is P2.5.
 //!
 //! From **P3.1** the worker also runs a background **liveness heartbeat**
 //! ([`Worker::spawn_heartbeat`]) so an idle worker stays live in the coordinator's
@@ -50,7 +57,10 @@
 //!
 //! `kx-scheduler` / `kx-executor` / `kx-inference` source is **unchanged** —
 //! distribution is wiring. kx-worker is a new leaf crate; it adds the client and
-//! the propose-don't-write glue, nothing more.
+//! the propose-don't-write glue, nothing more. The P3.6b WORLD-MUTATING path holds an
+//! `Arc<dyn CapabilityBroker>` and re-implements the stage→fire→commit ORDERING via
+//! RPCs, but never calls `run_wm_mote` / `StandardCommitProtocol` (those write a
+//! journal the worker doesn't own) — so the engine is still not forked.
 
 /// The gRPC schema + generated client (re-exported for callers that build wire
 /// types directly, e.g. tests).
@@ -61,6 +71,7 @@ mod commit_builder;
 mod error;
 mod read_model;
 mod run;
+mod run_wm;
 mod worker;
 
 pub use client::WorkerClient;

--- a/crates/kx-worker/src/run_wm.rs
+++ b/crates/kx-worker/src/run_wm.rs
@@ -1,0 +1,100 @@
+//! Dispatching a leased WORLD-MUTATING / READ-ONLY-NONDET Mote (P3.6b, D58).
+//!
+//! The worker is **not** the journal writer (D40), so it cannot use the
+//! single-node lifecycle ([`kx_executor::run_wm_mote`] / `StandardCommitProtocol`),
+//! which appends `EffectStaged` + `Committed` to a journal it owns. Instead the
+//! worker drives the **same stage→fire→commit ordering** with the journal appends
+//! replaced by RPCs (D58 §4):
+//!
+//! 1. resolve the capability + build the [`EffectRequest`] (mirroring the
+//!    single-node `engine::effect_request_for`);
+//! 2. for `StageThenCommit`: `ReportEffectStaged` → **await the ack BEFORE firing**
+//!    (the coordinator records the durable intent; firing first is the double-effect
+//!    hazard, D58 §2). `IdempotentByConstruction` + `ValidateThenCommit` dispatch
+//!    directly — mirroring the frozen `StandardCommitProtocol` per-pattern (VTC's
+//!    safety is the sibling critic, not an `EffectStaged` hint);
+//! 3. `broker.dispatch` fires the effect and stages its response bytes into the
+//!    **shared** content store (D55 data plane), returning `staged_ref`;
+//! 4. the caller PROPOSES `staged_ref` as the `result_ref` via `ReportCommit`
+//!    (the coordinator's D55 phantom-ref guard verifies it is in the store).
+//!
+//! The worker does **not** schedule the VTC critic (D58 §6): distributed, the critic
+//! is an ordinary DAG Mote that becomes ready once the producer commits, and the
+//! coordinator's `ready_set` leases it — the worker has no scheduler authority. This
+//! is glue over the broker trait, not an engine fork: `kx-executor` source is
+//! untouched (the P2 thesis test holds).
+
+use kx_capability::{idempotency_token_for, CapabilityBroker, EffectRequest};
+use kx_content::ContentRef;
+use kx_mote::{EffectPattern, Mote, ToolName};
+use kx_warrant::{FsScope, NetScope, WarrantSpec};
+
+use crate::client::WorkerClient;
+use crate::error::WorkerError;
+
+/// Drive stage→fire for a non-PURE Mote and return the staged `result_ref` to
+/// PROPOSE via `ReportCommit`. Async because `ReportEffectStaged` is an RPC; the
+/// broker's `dispatch` is the trait's synchronous method.
+pub(crate) async fn run_wm(
+    client: &mut WorkerClient,
+    broker: &dyn CapabilityBroker,
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    worker_id: u64,
+) -> Result<ContentRef, WorkerError> {
+    let capability = resolve_capability(mote)?;
+    let request = effect_request_for(mote);
+
+    // Stage the intent durably BEFORE firing (StageThenCommit only). Await the ack:
+    // `report_effect_staged` returns `Err(EffectStagedRejected)` if the coordinator
+    // declines, and `?` aborts before any `broker.dispatch` — never fire unstaged.
+    if effect_staged_required(mote.effect_pattern()) {
+        let id = *mote.id.as_bytes();
+        client.report_effect_staged(id, id, worker_id).await?;
+    }
+
+    let handle = broker.dispatch(mote, warrant, &capability, request)?;
+    Ok(handle.staged_ref)
+}
+
+/// Resolve the single capability a non-PURE Mote dispatches under, from its
+/// `tool_contract`. v0.1 expects exactly one entry and picks the first (a
+/// `BTreeMap` iterates in a deterministic key order). The broker's own `precheck`
+/// re-verifies the pick against `tool_contract` + `warrant.tool_grants`, so a wrong
+/// pick fails loud at `dispatch` (mapped to [`WorkerError::Dispatch`]).
+fn resolve_capability(mote: &Mote) -> Result<ToolName, WorkerError> {
+    mote.def
+        .tool_contract
+        .keys()
+        .next()
+        .cloned()
+        .ok_or(WorkerError::CapabilityResolution(mote.id))
+}
+
+/// Build the [`EffectRequest`] for a non-PURE Mote — mirrors the single-node
+/// `engine::effect_request_for` (empty payload, pattern from the def, empty scopes).
+///
+/// Unlike the demo driver, the worker sets `idempotency_key =
+/// Some(idempotency_token_for(mote))`: it is the 32-byte tool-boundary key (D38 §1)
+/// that makes a re-dispatch after worker death a no-op at the world boundary
+/// (exactly-once, D58 §7), and it is required for token-class WM tools (executor
+/// predicate R-10). It is harmless for non-token capabilities.
+fn effect_request_for(mote: &Mote) -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: mote.effect_pattern(),
+        idempotency_key: Some(idempotency_token_for(mote)),
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+/// Whether this pattern requires the `ReportEffectStaged` RPC before firing — the
+/// single decision point for the per-pattern split (D58 §4 vs the frozen
+/// `StandardCommitProtocol`). `StageThenCommit` pre-records the dispatch intent;
+/// `IdempotentByConstruction` (remote-API dedupe) and `ValidateThenCommit` (gated by
+/// the sibling critic) dispatch directly, matching `commit_validate_then_commit` /
+/// `commit_idempotent`. Flip this one line if D58 is amended to stage VTC too.
+fn effect_staged_required(pattern: EffectPattern) -> bool {
+    matches!(pattern, EffectPattern::StageThenCommit)
+}

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -4,9 +4,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use kx_capability::CapabilityBroker;
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_executor::{LocalResourceManager, MoteExecutor};
-use kx_mote::{Mote, MoteId};
+use kx_mote::{Mote, MoteId, NdClass};
 use kx_proto::proto;
 use kx_warrant::{ExecutorClass, WarrantSpec};
 use tokio::task::JoinHandle;
@@ -14,7 +15,7 @@ use tokio::task::JoinHandle;
 use crate::client::WorkerClient;
 use crate::error::WorkerError;
 use crate::read_model::ReadModel;
-use crate::{commit_builder, run};
+use crate::{commit_builder, run, run_wm};
 
 /// `ReadEntries` page size when folding the local read model.
 const READ_PAGE: u32 = 256;
@@ -39,6 +40,11 @@ pub struct Worker {
     executor: Arc<dyn MoteExecutor>,
     resource_manager: LocalResourceManager,
     store: Arc<LocalFsContentStore>,
+    /// Fires WORLD-MUTATING / READ-ONLY-NONDET effects (P3.6b, D58): staging the
+    /// response bytes into the shared `store` (data plane). PURE Motes never touch it.
+    /// One worker can run both classes, so the field is always present even on a
+    /// PURE-only worker (it simply has no capabilities registered).
+    broker: Arc<dyn CapabilityBroker>,
     read_model: ReadModel,
     max_lease: u32,
     /// The worker's live in-flight Mote count — the single source of truth for the
@@ -53,8 +59,14 @@ impl Worker {
     /// reachable at `endpoint`, and return a ready worker. `executor` +
     /// `resource_manager` host the P1 execution stack verbatim; `store` is the shared
     /// content-addressed store (the worker's executor publishes results to it and the
-    /// worker reads peer results from it); `max_lease` bounds how many Motes a single
-    /// [`run_once`](Self::run_once) pulls.
+    /// worker reads peer results from it); `broker` fires WORLD-MUTATING effects,
+    /// staging their bytes into that same `store` (P3.6b, D58); `max_lease` bounds how
+    /// many Motes a single [`run_once`](Self::run_once) pulls.
+    // A wide constructor that injects the worker's full dependency set in one place
+    // (transport, backend, resources, data plane, effect surface). Bundling these into a
+    // config struct would be churn for no clarity gain (Rule 1) — the args are distinct,
+    // named, and set exactly once at registration.
+    #[allow(clippy::too_many_arguments)]
     pub async fn register(
         mut client: WorkerClient,
         executor_class: ExecutorClass,
@@ -62,6 +74,7 @@ impl Worker {
         executor: Arc<dyn MoteExecutor>,
         resource_manager: LocalResourceManager,
         store: Arc<LocalFsContentStore>,
+        broker: Arc<dyn CapabilityBroker>,
         max_lease: u32,
     ) -> Result<Self, WorkerError> {
         let id = client.register_worker(executor_class, endpoint).await?;
@@ -72,6 +85,7 @@ impl Worker {
             executor,
             resource_manager,
             store,
+            broker,
             read_model: ReadModel::new(),
             max_lease,
             in_flight: Arc::new(AtomicU32::new(0)),
@@ -108,9 +122,10 @@ impl Worker {
         }
     }
 
-    /// Lease one batch of ready PURE Motes, run each through the hosted executor,
-    /// and propose its commit. Returns the number of commits the coordinator
-    /// accepted this round (0 when no ready work matches).
+    /// Lease one batch of ready Motes, dispatch each (PURE recomputes through the
+    /// hosted executor; non-PURE stages-then-fires via the broker, P3.6b/D58), and
+    /// propose its commit. Returns the number of commits the coordinator accepted
+    /// this round (0 when no ready work matches).
     pub async fn run_once(&mut self) -> Result<usize, WorkerError> {
         let items = self
             .client
@@ -139,8 +154,16 @@ impl Worker {
                 .ok_or(WorkerError::MissingField("warrant"))?
                 .try_into()?;
 
-            let result_ref =
-                run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)?;
+            // PURE recomputes locally through the hosted executor (verbatim, D40 — a
+            // throwaway journal). Non-PURE (WORLD-MUTATING / READ-ONLY-NONDET) drives
+            // stage→fire→commit via RPCs + the broker (P3.6b, D58 §4): the worker is not
+            // the journal writer, so it cannot run `run_wm_mote`. Either path yields the
+            // `result_ref` (= the broker's `staged_ref` for non-PURE) the worker PROPOSES.
+            let result_ref = if mote.nd_class() == NdClass::Pure {
+                run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)?
+            } else {
+                run_wm::run_wm(&mut self.client, &*self.broker, &mote, &warrant, self.id).await?
+            };
             let request =
                 commit_builder::report_commit_request(&mote, &warrant, result_ref, self.id);
             let response = self.client.report_commit(request).await?;

--- a/crates/kx-worker/tests/common/mod.rs
+++ b/crates/kx-worker/tests/common/mod.rs
@@ -12,11 +12,14 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
 use kx_content::ContentRef;
 use kx_mote::{
     EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
-    MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, ToolName, ToolVersion,
+    MOTE_DEF_SCHEMA_VERSION,
 };
 use kx_warrant::{
     ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
@@ -26,6 +29,20 @@ use smallvec::SmallVec;
 
 /// The executor backend the worker registers as and the warrant requires.
 pub const WORKER_CLASS: ExecutorClass = ExecutorClass::MacOsSandbox;
+
+/// The capability a WORLD-MUTATING test Mote declares in its `tool_contract` (so the
+/// worker's `resolve_capability` finds it). The custom test brokers below ignore the
+/// per-call contract (they are not the `LocalCapabilityBroker`), so no warrant grant is
+/// needed — the coordinator's `SubmitMote` runs no refusal predicates (it hosts the
+/// scheduler, which only registers the Mote).
+pub fn world_tool() -> ToolName {
+    ToolName("kx-test-effect".into())
+}
+
+/// The version pinned alongside [`world_tool`] in a WM Mote's `tool_contract`.
+pub fn world_tool_version() -> ToolVersion {
+    ToolVersion("0.1.0".into())
+}
 
 fn pure_def() -> MoteDef {
     MoteDef {
@@ -94,4 +111,113 @@ pub fn pure_warrant() -> WarrantSpec {
         environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
         executor_class: WORKER_CLASS,
     }
+}
+
+fn wm_def(pattern: EffectPattern, critic_for: Option<MoteId>) -> MoteDef {
+    let mut tool_contract = BTreeMap::new();
+    // A critic is non-WM (R-7) and dispatches nothing; only the WM producer needs a
+    // capability in its contract for `resolve_capability` to pick.
+    let nd_class = if critic_for.is_some() {
+        NdClass::Pure
+    } else {
+        tool_contract.insert(world_tool(), world_tool_version());
+        NdClass::WorldMutating
+    };
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract,
+        nd_class,
+        config_subset: BTreeMap::new(),
+        effect_pattern: pattern,
+        critic_for,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+/// A WORLD-MUTATING Mote with the given effect pattern, made unique by `seed`, with
+/// optional data-edge parents. Its `tool_contract` names [`world_tool`] so the worker's
+/// `resolve_capability` succeeds.
+#[must_use]
+pub fn wm_mote(seed: u8, pattern: EffectPattern, parent_ids: &[MoteId]) -> Mote {
+    Mote::new(
+        wm_def(pattern, None),
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        parents(parent_ids),
+    )
+}
+
+/// A `ValidateThenCommit` WORLD-MUTATING producer (D58 §6) — its sibling critic gates
+/// promotion; distributed, the critic is an ordinary ready DAG Mote (see [`critic`]).
+#[must_use]
+pub fn vtc_producer(seed: u8, parent_ids: &[MoteId]) -> Mote {
+    wm_mote(seed, EffectPattern::ValidateThenCommit, parent_ids)
+}
+
+/// The PURE critic for `producer` (R-7: a critic is non-WM). It carries `producer` as a
+/// data-edge parent so the projection's `ready_set` only offers it once the producer is
+/// `Committed` — distributed, the coordinator schedules it by dependency (the worker has
+/// no scheduler authority, D58 §6).
+#[must_use]
+pub fn critic(seed: u8, producer: MoteId) -> Mote {
+    Mote::new(
+        wm_def(EffectPattern::IdempotentByConstruction, Some(producer)),
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        parents(&[producer]),
+    )
+}
+
+fn parents(parent_ids: &[MoteId]) -> SmallVec<[ParentRef; 4]> {
+    parent_ids
+        .iter()
+        .map(|id| ParentRef {
+            parent_id: *id,
+            edge: EdgeMeta::data(),
+        })
+        .collect()
+}
+
+/// A warrant a [`WORKER_CLASS`] worker can run a WORLD-MUTATING Mote under. Same as
+/// [`pure_warrant`] but with a WORLD-MUTATING class (the custom test brokers skip the
+/// per-call grant check, so `tool_grants` stays empty).
+#[must_use]
+pub fn wm_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        ..pure_warrant()
+    }
+}
+
+/// A broker that never dispatches — for PURE-only workers (the WM path is never taken,
+/// so this is never invoked). Panics if it ever is, surfacing a wiring mistake.
+#[must_use]
+pub fn noop_broker() -> Arc<dyn CapabilityBroker> {
+    struct NoopBroker;
+    impl CapabilityBroker for NoopBroker {
+        fn dispatch(
+            &self,
+            _mote: &Mote,
+            _warrant: &WarrantSpec,
+            _capability: &ToolName,
+            _request: EffectRequest,
+        ) -> Result<BrokerHandle, BrokerError> {
+            panic!("a PURE-only worker must never dispatch through the broker");
+        }
+        fn probe_readback(
+            &self,
+            _mote: &Mote,
+            _warrant: &WarrantSpec,
+            _capability: &ToolName,
+            _probe: EffectRequest,
+        ) -> Result<Option<BrokerHandle>, BrokerError> {
+            panic!("a PURE-only worker must never probe through the broker");
+        }
+    }
+    Arc::new(NoopBroker)
 }

--- a/crates/kx-worker/tests/e2e.rs
+++ b/crates/kx-worker/tests/e2e.rs
@@ -109,6 +109,7 @@ async fn committed_result_is_readable_by_coordinator_and_peer() {
         storing_executor(store.clone()),
         LocalResourceManager::dev_defaults(),
         store.clone(),
+        common::noop_broker(),
         16,
     )
     .await
@@ -155,6 +156,7 @@ async fn committed_result_is_readable_by_coordinator_and_peer() {
         storing_executor(store.clone()), // unused by B; B only reads
         LocalResourceManager::dev_defaults(),
         store.clone(),
+        common::noop_broker(),
         16,
     )
     .await
@@ -243,6 +245,7 @@ async fn two_workers_share_the_workload_via_placement() {
                 storing_executor(store.clone()),
                 LocalResourceManager::dev_defaults(),
                 store,
+                common::noop_broker(),
                 2,
             )
             .await
@@ -312,6 +315,7 @@ async fn background_heartbeat_keeps_an_idle_worker_live() {
         storing_executor(store.clone()),
         LocalResourceManager::dev_defaults(),
         store.clone(),
+        common::noop_broker(),
         16,
     )
     .await

--- a/crates/kx-worker/tests/thesis_verbatim.rs
+++ b/crates/kx-worker/tests/thesis_verbatim.rs
@@ -7,6 +7,11 @@
 //! source is unchanged is the PR diff (`git diff <merge-base> -- crates/kx-scheduler
 //! crates/kx-executor crates/kx-inference` is empty) — this test just pins the
 //! dependency direction so the hosting cannot silently drift.
+//!
+//! P3.6b note: the worker now also holds an `Arc<dyn CapabilityBroker>` and drives the
+//! WORLD-MUTATING stage→fire→commit ORDERING via RPCs (see `run_wm`), but it never calls
+//! `run_wm_mote` / `StandardCommitProtocol` — those write a journal the worker does not
+//! own (D40). So the engine is still hosted, not forked.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
 

--- a/crates/kx-worker/tests/wm_dispatch.rs
+++ b/crates/kx-worker/tests/wm_dispatch.rs
@@ -1,0 +1,639 @@
+//! P3.6b — WORLD-MUTATING distributed dispatch (D58 §8, the W-1…W-5 obligations).
+//!
+//! A worker stages its intent (`ReportEffectStaged`) through the coordinator (sole
+//! writer, D40) BEFORE firing the effect through its `CapabilityBroker`, then PROPOSES
+//! the staged ref (`ReportCommit`). Exactly-once holds across worker death by composing
+//! the staged-intent recovery hint (D58 §2) with reschedule (D57) and the tool-boundary
+//! idempotency key (D38 §1).
+//!
+//! - **W-1** happy stage→fire→commit.
+//! - **W-2** ordering: the worker does not fire before the stage ack.
+//! - **W-3** worker-death-after-stage → exactly-once (≤1 net world effect despite a
+//!   re-dispatch, proven by a counting idempotent broker).
+//! - **W-4** validate-then-commit distributed (plumbing + repudiation cascade; the
+//!   promote/unpromote gate is a P1-default stub, activation deferred — see the test).
+//! - **W-5** dedupe-on-late-commit (the dead worker's late commit → `AlreadyCommitted`).
+//!
+//! Determinism: an injected `Clock` drives death (W-3/W-5); the test brokers are
+//! deterministic (fixed bytes → stable `ContentRef`). No wall-clock in the gating path.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use kx_capability::{
+    idempotency_token_for, BrokerError, BrokerHandle, CapabilityBroker, EffectRequest,
+};
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
+use kx_coordinator::proto::coordinator_server::{Coordinator, CoordinatorServer};
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, RepudiationReason, WorkerRegistry,
+};
+use kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor};
+use kx_journal::InMemoryJournal;
+use kx_mote::{EffectPattern, Mote, ToolName};
+use kx_warrant::WarrantSpec;
+use kx_worker::{Worker, WorkerClient};
+use tempfile::TempDir;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+const TIMEOUT: Duration = Duration::from_secs(6);
+
+/// The deterministic effect bytes a test broker stages for a Mote.
+fn wm_bytes(mote: &Mote) -> Vec<u8> {
+    let mut v = b"wm-effect:".to_vec();
+    v.extend_from_slice(mote.id.as_bytes());
+    v
+}
+
+/// A `MoteExecutor` for the (unused) PURE path on a WM worker — and the real PURE path
+/// for W-4's critic. Publishes bytes to the shared store, returning the ref.
+fn storing_executor(store: Arc<LocalFsContentStore>) -> Arc<dyn MoteExecutor> {
+    Arc::new(TestMoteExecutor::new(move |mote, _warrant| {
+        let mut v = b"kx-result:".to_vec();
+        v.extend_from_slice(mote.id.as_bytes());
+        store.put(&v).expect("publish result bytes")
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Test brokers
+// ---------------------------------------------------------------------------
+
+/// Stages deterministic effect bytes into the shared store and returns the ref —
+/// the minimal faithful WM dispatch (the executor's own WM integration tests use the
+/// same shape). Content-addressed, so re-staging the same Mote yields the same ref.
+struct StagingBroker {
+    store: Arc<LocalFsContentStore>,
+}
+impl CapabilityBroker for StagingBroker {
+    fn dispatch(
+        &self,
+        mote: &Mote,
+        _warrant: &WarrantSpec,
+        capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        let staged_ref = self.store.put(&wm_bytes(mote)).expect("stage effect bytes");
+        Ok(BrokerHandle {
+            staged_ref,
+            capability: capability.clone(),
+            capability_version: common::world_tool_version(),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+/// Counts dispatches and **net** world effects: a dispatch with an already-seen
+/// idempotency key (D38 §1 token) is a no-op at the world boundary (the tool dedupes),
+/// so it does NOT bump `net_effects`. Proves "≤1 net effect despite a re-dispatch" (W-3).
+#[derive(Clone)]
+struct CountingBroker {
+    store: Arc<LocalFsContentStore>,
+    dispatch_calls: Arc<AtomicUsize>,
+    net_effects: Arc<AtomicUsize>,
+    applied_keys: Arc<Mutex<std::collections::BTreeSet<[u8; 32]>>>,
+}
+impl CountingBroker {
+    fn new(store: Arc<LocalFsContentStore>) -> Self {
+        Self {
+            store,
+            dispatch_calls: Arc::new(AtomicUsize::new(0)),
+            net_effects: Arc::new(AtomicUsize::new(0)),
+            applied_keys: Arc::new(Mutex::new(std::collections::BTreeSet::new())),
+        }
+    }
+}
+impl CapabilityBroker for CountingBroker {
+    fn dispatch(
+        &self,
+        mote: &Mote,
+        _warrant: &WarrantSpec,
+        capability: &ToolName,
+        request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        self.dispatch_calls.fetch_add(1, Ordering::SeqCst);
+        // The tool-boundary idempotency key (== mote_id) makes a re-dispatch a no-op:
+        // only a never-before-seen key is a real world effect.
+        let key = request
+            .idempotency_key
+            .expect("WM dispatch carries a token");
+        if self.applied_keys.lock().unwrap().insert(key) {
+            self.net_effects.fetch_add(1, Ordering::SeqCst);
+        }
+        let staged_ref = self.store.put(&wm_bytes(mote)).expect("stage effect bytes");
+        Ok(BrokerHandle {
+            staged_ref,
+            capability: capability.clone(),
+            capability_version: common::world_tool_version(),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+/// Records `"dispatched"` into a shared ordering log when it fires (W-2). Paired with
+/// [`RecordingCoordinator`], which records `"staged"` — the log proves the worker stages
+/// before it fires.
+struct RecordingBroker {
+    store: Arc<LocalFsContentStore>,
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+impl CapabilityBroker for RecordingBroker {
+    fn dispatch(
+        &self,
+        mote: &Mote,
+        _warrant: &WarrantSpec,
+        capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        self.log.lock().unwrap().push("dispatched");
+        let staged_ref = self.store.put(&wm_bytes(mote)).expect("stage effect bytes");
+        Ok(BrokerHandle {
+            staged_ref,
+            capability: capability.clone(),
+            capability_version: common::world_tool_version(),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Coordinator harness
+// ---------------------------------------------------------------------------
+
+/// A deterministic clock the test advances by hand (mirrors `tests/reschedule.rs`).
+#[derive(Debug)]
+struct FakeClock(AtomicU64);
+impl FakeClock {
+    fn new(ms: u64) -> Arc<Self> {
+        Arc::new(Self(AtomicU64::new(ms)))
+    }
+    fn set(&self, ms: u64) {
+        self.0.store(ms, Ordering::Relaxed);
+    }
+}
+impl Clock for FakeClock {
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+async fn connect(endpoint: &str) -> WorkerClient {
+    for _ in 0..100 {
+        if let Ok(c) = WorkerClient::connect(endpoint.to_string()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("worker connects to the coordinator");
+}
+
+async fn submit(svc: &CoordinatorService, mote: &Mote, warrant: &WarrantSpec) {
+    svc.submit_mote(Request::new(kx_coordinator::proto::SubmitMoteRequest {
+        mote: Some(mote.clone().into()),
+        warrant: Some(warrant.clone().into()),
+    }))
+    .await
+    .unwrap();
+}
+
+/// Serve `svc` over loopback gRPC; return the endpoint URL (the retrying [`connect`]
+/// tolerates the brief bind→serve gap, mirroring the e2e harness).
+fn serve<S>(svc: S) -> String
+where
+    S: Coordinator,
+{
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(CoordinatorServer::new(svc))
+            .serve(addr)
+            .await
+            .unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Register a worker whose WM path uses `broker` (PURE path is the unused storing
+/// executor). One round of `run_once` drives lease → stage → fire → propose.
+async fn register_worker(
+    endpoint: &str,
+    store: Arc<LocalFsContentStore>,
+    broker: Arc<dyn CapabilityBroker>,
+    tag: &str,
+) -> Worker {
+    Worker::register(
+        connect(endpoint).await,
+        common::WORKER_CLASS,
+        tag.to_string(),
+        storing_executor(store.clone()),
+        LocalResourceManager::dev_defaults(),
+        store,
+        broker,
+        16,
+    )
+    .await
+    .unwrap()
+}
+
+/// The committed `result_ref` of `mote` as the coordinator serves it over `ReadEntries`.
+async fn committed_ref(client: &mut WorkerClient, mote: &Mote) -> ContentRef {
+    let (entries, _next) = client.read_entries(0, 256).await.unwrap();
+    entries
+        .iter()
+        .find_map(|e| match e.kind.as_ref().unwrap() {
+            kx_coordinator::proto::journal_entry::Kind::Committed(c)
+                if c.mote_id == mote.id.as_bytes().to_vec() =>
+            {
+                Some(ContentRef::from_bytes(
+                    c.result_ref.clone().try_into().unwrap(),
+                ))
+            }
+            _ => None,
+        })
+        .expect("coordinator serves the committed result_ref")
+}
+
+// ---------------------------------------------------------------------------
+// W-1 — happy stage→fire→commit
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn w1_stage_then_commit_happy_path() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let svc = CoordinatorService::with_store(InMemoryJournal::new(), store.clone());
+    let endpoint = serve(svc.clone());
+
+    let wm = common::wm_mote(7, EffectPattern::StageThenCommit, &[]);
+    submit(&svc, &wm, &common::wm_warrant()).await;
+
+    let broker = Arc::new(StagingBroker {
+        store: store.clone(),
+    });
+    let mut worker = register_worker(&endpoint, store.clone(), broker, "w1").await;
+
+    assert_eq!(worker.run_once().await.unwrap(), 1, "the WM Mote committed");
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+    assert_eq!(svc.state_of(wm.id).await.unwrap(), MoteState::Committed);
+
+    // The effect bytes the broker staged are in the shared store under the committed
+    // result_ref (D55 data plane; the coordinator's phantom-ref guard accepted them).
+    let mut observer = connect(&endpoint).await;
+    let r = committed_ref(&mut observer, &wm).await;
+    assert_eq!(store.get(&r).unwrap().to_vec(), wm_bytes(&wm));
+}
+
+// ---------------------------------------------------------------------------
+// W-2 — ordering: stage ack BEFORE fire
+// ---------------------------------------------------------------------------
+
+/// Delegates every RPC to an inner [`CoordinatorService`], recording `"staged"` into a
+/// shared log once a `ReportEffectStaged` is durably recorded. Paired with
+/// [`RecordingBroker`] (records `"dispatched"`), the log order proves the worker awaits
+/// the stage ack before firing.
+#[derive(Clone)]
+struct RecordingCoordinator {
+    inner: CoordinatorService,
+    log: Arc<Mutex<Vec<&'static str>>>,
+}
+
+#[tonic::async_trait]
+impl Coordinator for RecordingCoordinator {
+    async fn register_worker(
+        &self,
+        request: Request<kx_coordinator::proto::RegisterWorkerRequest>,
+    ) -> Result<Response<kx_coordinator::proto::RegisterWorkerResponse>, Status> {
+        self.inner.register_worker(request).await
+    }
+    async fn heartbeat(
+        &self,
+        request: Request<kx_coordinator::proto::HeartbeatRequest>,
+    ) -> Result<Response<kx_coordinator::proto::HeartbeatResponse>, Status> {
+        self.inner.heartbeat(request).await
+    }
+    async fn submit_mote(
+        &self,
+        request: Request<kx_coordinator::proto::SubmitMoteRequest>,
+    ) -> Result<Response<kx_coordinator::proto::SubmitMoteResponse>, Status> {
+        self.inner.submit_mote(request).await
+    }
+    async fn report_commit(
+        &self,
+        request: Request<kx_coordinator::proto::ReportCommitRequest>,
+    ) -> Result<Response<kx_coordinator::proto::ReportCommitResponse>, Status> {
+        self.inner.report_commit(request).await
+    }
+    async fn report_effect_staged(
+        &self,
+        request: Request<kx_coordinator::proto::ReportEffectStagedRequest>,
+    ) -> Result<Response<kx_coordinator::proto::ReportEffectStagedResponse>, Status> {
+        let resp = self.inner.report_effect_staged(request).await?;
+        // Recorded only after the inner sole writer durably appended the EffectStaged.
+        self.log.lock().unwrap().push("staged");
+        Ok(resp)
+    }
+    async fn lease_work(
+        &self,
+        request: Request<kx_coordinator::proto::LeaseWorkRequest>,
+    ) -> Result<Response<kx_coordinator::proto::LeaseWorkResponse>, Status> {
+        self.inner.lease_work(request).await
+    }
+    async fn read_entries(
+        &self,
+        request: Request<kx_coordinator::proto::ReadEntriesRequest>,
+    ) -> Result<Response<kx_coordinator::proto::ReadEntriesResponse>, Status> {
+        self.inner.read_entries(request).await
+    }
+}
+
+#[tokio::test]
+async fn w2_does_not_fire_before_stage_ack() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let svc = CoordinatorService::with_store(InMemoryJournal::new(), store.clone());
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let endpoint = serve(RecordingCoordinator {
+        inner: svc.clone(),
+        log: log.clone(),
+    });
+
+    let wm = common::wm_mote(8, EffectPattern::StageThenCommit, &[]);
+    submit(&svc, &wm, &common::wm_warrant()).await;
+
+    let broker = Arc::new(RecordingBroker {
+        store: store.clone(),
+        log: log.clone(),
+    });
+    let mut worker = register_worker(&endpoint, store.clone(), broker, "w2").await;
+
+    assert_eq!(worker.run_once().await.unwrap(), 1);
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        ["staged", "dispatched"],
+        "the worker recorded the durable EffectStaged BEFORE firing the effect (D58 §2)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// W-3 — worker-death-after-stage → exactly-once
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn w3_worker_death_after_stage_is_exactly_once() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let clock = FakeClock::new(1_000);
+    let registry: Arc<dyn WorkerRegistry> = Arc::new(
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock.clone(), TIMEOUT),
+    );
+    let svc = CoordinatorService::with_store_and_registry(
+        InMemoryJournal::new(),
+        store.clone(),
+        registry,
+    );
+    let endpoint = serve(svc.clone());
+
+    let wm = common::wm_mote(11, EffectPattern::StageThenCommit, &[]);
+    let warrant = common::wm_warrant();
+    submit(&svc, &wm, &warrant).await;
+
+    // One counting broker shared by the dying-worker simulation and the live worker, so
+    // the applied-key set (tool-boundary idempotency) spans both dispatches.
+    let broker = CountingBroker::new(store.clone());
+
+    // --- The dying worker: register, lease, STAGE, FIRE once, then die (no commit). ---
+    let mut dying = connect(&endpoint).await;
+    let dying_id = dying
+        .register_worker(common::WORKER_CLASS, "dying")
+        .await
+        .unwrap();
+    let leased = dying
+        .lease_work(dying_id, common::WORKER_CLASS, 16)
+        .await
+        .unwrap();
+    assert_eq!(leased.len(), 1, "dying worker leased the WM Mote");
+    let id = *wm.id.as_bytes();
+    dying.report_effect_staged(id, id, dying_id).await.unwrap();
+    // It fired the effect (net effect #1) before crashing — the exact stage→fire→{die}
+    // window the EffectStaged hint exists to make recoverable.
+    let cap = common::world_tool();
+    let req = EffectRequest {
+        payload: Vec::new(),
+        pattern: wm.effect_pattern(),
+        idempotency_key: Some(idempotency_token_for(&wm)),
+        net_scope: kx_warrant::NetScope::None,
+        fs_scope: kx_warrant::FsScope::empty(),
+    };
+    broker.dispatch(&wm, &warrant, &cap, req).unwrap();
+    assert_eq!(broker.net_effects.load(Ordering::SeqCst), 1);
+    // dying worker is now silent forever.
+
+    // --- Time advances past the liveness timeout; a live worker recovers it. ---
+    clock.set(1_000 + 6_001);
+    let mut worker =
+        register_worker(&endpoint, store.clone(), Arc::new(broker.clone()), "live").await;
+    // run_once: reap the dead lease → re-lease (D57) → re-stage (dedupe) → re-fire
+    // (idempotent: key already applied) → commit.
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        1,
+        "the replacement committed"
+    );
+
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        1,
+        "exactly one commit"
+    );
+    assert_eq!(svc.state_of(wm.id).await.unwrap(), MoteState::Committed);
+    assert_eq!(
+        broker.dispatch_calls.load(Ordering::SeqCst),
+        2,
+        "the effect was re-dispatched after the death (so dedupe is what bounds it)"
+    );
+    assert_eq!(
+        broker.net_effects.load(Ordering::SeqCst),
+        1,
+        "≤1 NET world effect despite two dispatches — exactly-once at the world boundary"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// W-4 — validate-then-commit distributed (plumbing + cascade)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn w4_validate_then_commit_distributed_and_cascade() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let svc = CoordinatorService::with_store(InMemoryJournal::new(), store.clone());
+    let endpoint = serve(svc.clone());
+
+    // A VTC producer + its sibling critic (a PURE child gated on the producer).
+    let producer = common::vtc_producer(20, &[]);
+    let critic = common::critic(21, producer.id);
+    submit(&svc, &producer, &common::wm_warrant()).await;
+    submit(&svc, &critic, &common::pure_warrant()).await;
+
+    let broker = Arc::new(StagingBroker {
+        store: store.clone(),
+    });
+    let mut worker = register_worker(&endpoint, store.clone(), broker, "w4").await;
+
+    // Round 1: the producer (WM) is ready → staged+fired+committed via the broker.
+    assert_eq!(worker.run_once().await.unwrap(), 1, "producer committed");
+    assert_eq!(
+        svc.state_of(producer.id).await.unwrap(),
+        MoteState::Committed
+    );
+
+    // Round 2: the critic is now ready (producer committed) → runs the PURE path
+    // (run_pure through the executor) and commits its verdict. The worker did NOT
+    // schedule it — the coordinator's ready_set did (D58 §6).
+    assert_eq!(worker.run_once().await.unwrap(), 1, "critic committed");
+    assert_eq!(svc.state_of(critic.id).await.unwrap(), MoteState::Committed);
+
+    // The producer is NOT auto-failed by the verdict (P0.8): it stays Committed. The
+    // promote/unpromote GATE (`promotion_state`) is a P1-default stub (always
+    // NotApplicable) — its verdict-reading activation is a kx-projection change deferred
+    // to its own ticket; here we assert the distributed plumbing + that no auto-fail
+    // occurs.
+    assert_eq!(
+        svc.state_of(producer.id).await.unwrap(),
+        MoteState::Committed
+    );
+
+    // Repudiating the producer cascades the poison-invalidation to its committed
+    // downstream lineage (D22 / P3.5) — the critic, a committed consumer.
+    let outcome = svc
+        .repudiate(producer.id, RepudiationReason::OperatorAction, 42)
+        .await
+        .unwrap();
+    assert_eq!(outcome.target, producer.id);
+    assert_eq!(
+        outcome.cascade_size, 1,
+        "the critic is downstream of the producer"
+    );
+    assert_eq!(
+        svc.state_of(producer.id).await.unwrap(),
+        MoteState::Repudiated
+    );
+    assert_eq!(
+        svc.state_of(critic.id).await.unwrap(),
+        MoteState::Repudiated,
+        "the cascade reaches the committed consumer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// W-5 — dedupe-on-late-commit
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn w5_dead_workers_late_commit_dedupes() {
+    let dir = TempDir::new().unwrap();
+    let store = Arc::new(LocalFsContentStore::open(dir.path()).unwrap());
+    let clock = FakeClock::new(1_000);
+    let registry: Arc<dyn WorkerRegistry> = Arc::new(
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock.clone(), TIMEOUT),
+    );
+    let svc = CoordinatorService::with_store_and_registry(
+        InMemoryJournal::new(),
+        store.clone(),
+        registry,
+    );
+    let endpoint = serve(svc.clone());
+
+    let wm = common::wm_mote(13, EffectPattern::StageThenCommit, &[]);
+    let warrant = common::wm_warrant();
+    submit(&svc, &wm, &warrant).await;
+    let broker = CountingBroker::new(store.clone());
+
+    // The dying worker stages + fires, then dies.
+    let mut dying = connect(&endpoint).await;
+    let dying_id = dying
+        .register_worker(common::WORKER_CLASS, "dying")
+        .await
+        .unwrap();
+    dying
+        .lease_work(dying_id, common::WORKER_CLASS, 16)
+        .await
+        .unwrap();
+    let id = *wm.id.as_bytes();
+    dying.report_effect_staged(id, id, dying_id).await.unwrap();
+    let staged = broker
+        .dispatch(
+            &wm,
+            &warrant,
+            &common::world_tool(),
+            EffectRequest {
+                payload: Vec::new(),
+                pattern: wm.effect_pattern(),
+                idempotency_key: Some(idempotency_token_for(&wm)),
+                net_scope: kx_warrant::NetScope::None,
+                fs_scope: kx_warrant::FsScope::empty(),
+            },
+        )
+        .unwrap();
+
+    // The live worker recovers and commits.
+    clock.set(1_000 + 6_001);
+    let mut worker =
+        register_worker(&endpoint, store.clone(), Arc::new(broker.clone()), "live").await;
+    assert_eq!(worker.run_once().await.unwrap(), 1);
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+
+    // The "dead" worker was only slow: its late ReportCommit for the same Mote dedupes
+    // (first-wins, D54) → AlreadyCommitted, committed count unchanged.
+    let late = dying
+        .report_commit(kx_coordinator::proto::ReportCommitRequest {
+            mote_id: id.to_vec(),
+            idempotency_key: id.to_vec(),
+            result_ref: staged.staged_ref.as_bytes().to_vec(),
+            warrant_ref: kx_warrant::warrant_ref_of(&warrant).as_bytes().to_vec(),
+            mote_def_hash: wm.def.hash().as_bytes().to_vec(),
+            nd_class: kx_coordinator::proto::NdClass::from(wm.nd_class()) as i32,
+            parents: vec![],
+            worker_id: dying_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        late.outcome,
+        kx_coordinator::proto::CommitOutcome::AlreadyCommitted as i32,
+        "the dead worker's late commit dedupes to the first"
+    );
+    assert_eq!(svc.committed_count().await.unwrap(), 1, "no double commit");
+}


### PR DESCRIPTION
## P3.6b — worker WM-dispatch + validate-then-commit under distribution

The **worker half** of P3.6 (P3.6a shipped the coordinator seam in #79). A leased non-PURE Mote is now dispatched via **stage → fire → commit**, driven by RPCs:

1. resolve the capability from the Mote's `tool_contract` + build the `EffectRequest` (with `idempotency_token_for(mote)` as the tool-boundary key);
2. for `StageThenCommit`: call `ReportEffectStaged` and **await the ack BEFORE firing** (D58 §2). `IdempotentByConstruction` + `ValidateThenCommit` dispatch directly — mirroring the frozen `StandardCommitProtocol` per-pattern;
3. fire through an injected `Arc<dyn CapabilityBroker>` (stages response bytes into the shared content store, D55 data plane);
4. PROPOSE the staged ref via the existing `ReportCommit` (the coordinator's D55 phantom-ref guard verifies it).

### Thesis test holds
The worker **never** calls `run_wm_mote` / `StandardCommitProtocol` (those write a journal it does not own — D40); it re-implements only the RPC ordering. `kx-scheduler` / `kx-executor` / `kx-inference` source is **unchanged** (diff empty).

### Exactly-once under worker death
`ReportEffectStaged` records the recovery hint through the sole writer; reschedule (D57) re-leases; the tool-boundary idempotency key makes the re-dispatch a no-op at the world boundary.

### VTC distributed
The critic is an ordinary ready DAG Mote the coordinator leases once the producer commits (the worker has no scheduler authority, D58 §6); repudiating the producer cascades (D22). The promote/unpromote gate (`promotion_state`) is the P1-default stub — its activation is a `kx-projection` change deferred to its own ticket.

> Note: distributed, a WM Mote's journal is `EffectStaged → Committed` (no `Proposed` — that was the single-node executor's job). The recovery oracle + reschedule handle this (verified by W-3).

## Tests (W-1…W-5, `crates/kx-worker/tests/wm_dispatch.rs`)
- **W-1** happy stage-then-commit
- **W-2** fire-only-after-ack ordering (recorder proves `["staged","dispatched"]`)
- **W-3** worker-death-after-stage **exactly-once** (counting idempotent broker: 2 dispatches, ≤1 net effect)
- **W-4** VTC plumbing + repudiation cascade
- **W-5** dedupe-on-late-commit (`AlreadyCommitted`)

## Gate
fmt · clippy `--workspace --all-targets -D warnings` · `cargo test --workspace` **871 passed / 0 failed / 8 ignored** (+5) · cargo-deny · doc `-D warnings` · ffi-link · **I1.c byte-determinism PASS** · thesis diff empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)