### PR TITLE
fix(kx-coordinator): gate distributed WM re-dispatch on the recovery oracle (R-13, P3.6c)

### DIFF
--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_journal::{FailureReason, Journal, JournalEntry, RepudiationReason};
-use kx_mote::{Mote, MoteId};
+use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
 use kx_warrant::{ExecutorClass, WarrantSpec};
@@ -362,9 +362,13 @@ fn serve_lease<J: Journal>(
 /// (parents-all-committed) ∩ matching the worker's backend (`executor_class`). **D58
 /// (P3.6) lifts the PURE-only restriction**: WORLD-MUTATING + READ-ONLY-NONDET Motes are
 /// now leasable (the worker stages its intent via `ReportEffectStaged` before firing,
-/// then proposes the commit). Submission-time refusals (R-1/R-2/R-10, P0.8) already gated
-/// admissibility at `SubmitMote`; the executor's R-11/R-13 + the coordinator's D55
-/// phantom-ref guard backstop the dispatch. Placement v2 (D56) then orders them:
+/// then proposes the commit). **R-13 under distribution (P3.6c):** a crash-failed *re-offer*
+/// of a non-PURE Mote is gated on the recovery oracle (`redispatch_admissible`) — without a
+/// durable `EffectStaged` hint the coordinator refuses to re-lease it (the effect may have
+/// fired; re-dispatch would double it), exactly as single-node `pick_next` / the executor's
+/// R-13 refuse. The executor's R-13 is single-node only, so the coordinator MUST enforce it
+/// itself on the distributed re-dispatch path. Fresh `ready_set` Motes (first dispatch) are
+/// ungated. The D55 phantom-ref guard backstops the commit. Placement v2 (D56) then orders them:
 /// `worker`'s placement-preferred Motes come **first**, the rest **fill to `max`**
 /// (starvation-free; double execution stays harmless under dedup, D54).
 fn lease_ready(
@@ -385,11 +389,19 @@ fn lease_ready(
     // the projection so it left the ready-set, but its parents are still committed
     // (commits are permanent) so it is genuinely re-runnable. A Mote already committed
     // since being crash-failed is skipped (first-wins resolved it).
-    for mote_id in projection
-        .ready_set()
-        .into_iter()
-        .chain(rescheduleable.iter().copied())
-    {
+    //
+    // The rescheduleable (re-offer) half is gated by `redispatch_admissible` (R-13, P3.6c):
+    // a non-PURE Mote with no `EffectStaged` hint may have fired its effect before crashing,
+    // so re-dispatch would risk a double effect — it is left stuck (operator-recoverable),
+    // never re-leased. The ready-set half is NOT gated (those are first dispatches; a
+    // StageThenCommit Mote that staged-then-crashed is `Pending`/in the ready-set with the
+    // hint present, so it is still offered there).
+    for mote_id in projection.ready_set().into_iter().chain(
+        rescheduleable
+            .iter()
+            .copied()
+            .filter(|id| redispatch_admissible(submitted_defs, projection, id)),
+    ) {
         if !seen.insert(mote_id) {
             continue;
         }
@@ -412,6 +424,31 @@ fn lease_ready(
         .take(max)
         .filter_map(|id| submitted_defs.get(&id).cloned())
         .collect()
+}
+
+/// R-13 under distribution (P3.6c): whether a **crash-failed** Mote is safe to *re-dispatch*.
+///
+/// PURE is always recomputable. A non-PURE (WORLD-MUTATING / READ-ONLY-NONDET) Mote is only
+/// re-dispatchable when the recovery oracle says so — i.e. a durable `EffectStaged` hint was
+/// recorded before the effect fired (`Projection::can_redispatch_world_effect`), so the broker's
+/// tool-boundary idempotency dedupes the re-fire. Without the hint the effect *may already have
+/// fired* (D58 lets `ValidateThenCommit` / `IdempotentByConstruction` dispatch without staging),
+/// and re-dispatch would risk a double world-effect — which is unrecoverable
+/// (`validate-then-commit.md`). So the coordinator refuses to re-lease it; the Mote is left
+/// stuck and operator-recoverable (repudiation), mirroring single-node `pick_next`
+/// (`kx-runtime`) + the executor R-13 gate (`kx-executor::redispatch_wm_mote`), whose checks are
+/// single-node only. Unknown defs are never re-offered.
+fn redispatch_admissible(
+    submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    projection: &Projection,
+    id: &MoteId,
+) -> bool {
+    match submitted_defs.get(id) {
+        Some((mote, _)) => {
+            mote.nd_class() == NdClass::Pure || projection.can_redispatch_world_effect(id)
+        }
+        None => false,
+    }
 }
 
 /// Reap dead workers (D57 §3). For each registered worker the registry now reports

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -92,6 +92,21 @@ pub fn mote(seed: u8, nd_class: NdClass, parent_ids: &[MoteId]) -> Mote {
     )
 }
 
+/// A parentless WORLD-MUTATING Mote with an explicit effect pattern (so a test can build a
+/// `ValidateThenCommit` / `IdempotentByConstruction` producer that — per D58 — never writes
+/// `EffectStaged`). Made unique by `seed`.
+#[must_use]
+pub fn wm_mote(seed: u8, effect_pattern: EffectPattern) -> Mote {
+    let mut def = mote_def(NdClass::WorldMutating);
+    def.effect_pattern = effect_pattern;
+    Mote::new(
+        def,
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
 /// The canonical parentless PURE root Mote.
 #[must_use]
 pub fn pure_root_mote() -> Mote {
@@ -239,6 +254,27 @@ pub async fn commit(
         .await
         .unwrap()
         .into_inner()
+}
+
+/// Record a WORLD-MUTATING Mote's staged-intent (`ReportEffectStaged`) for `worker_id` through
+/// the service — the durable `EffectStaged` hint the recovery oracle keys on. `idempotency_key
+/// == mote_id` (identity invariant). Returns the staged seq.
+pub async fn report_effect_staged(
+    service: &CoordinatorService,
+    mote: &Mote,
+    worker_id: u64,
+) -> u64 {
+    let id = mote.id.as_bytes().to_vec();
+    service
+        .report_effect_staged(Request::new(proto::ReportEffectStagedRequest {
+            mote_id: id.clone(),
+            idempotency_key: id,
+            worker_id,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .staged_seq
 }
 
 /// Lease ready PURE work for `worker_id` on `executor_class` through the service.

--- a/crates/kx-coordinator/tests/wm_reschedule.rs
+++ b/crates/kx-coordinator/tests/wm_reschedule.rs
@@ -1,0 +1,152 @@
+//! P3.6c — R-13 under distribution: the coordinator gates a crash-failed *re-dispatch* of a
+//! non-PURE Mote on the recovery oracle, so a WORLD-MUTATING effect that may have fired is
+//! never re-leased without a durable `EffectStaged` hint.
+//!
+//! Single-node, `pick_next` / the executor's R-13 refuse to re-dispatch a WM Mote whose
+//! `EffectStaged` was never recorded (the effect might already have fired — re-dispatch would
+//! double it, which is unrecoverable). Distributed, reschedule (D57) re-leases dead workers'
+//! in-flight Motes; without this gate it would re-offer a fired-but-unstaged VTC / IBC producer
+//! (D58 lets those patterns dispatch WITHOUT staging) and a second worker would re-fire the
+//! effect. The gate (`redispatch_admissible`) closes that window: PURE is always recomputable;
+//! a non-PURE crash-failed Mote is re-offered ONLY with the `EffectStaged` hint
+//! (`can_redispatch_world_effect`); otherwise it is left stuck (operator-recoverable).
+//!
+//! Time is driven by an injected [`kx_coordinator::Clock`] — death is deterministic, no sleeps.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_coordinator::proto::ExecutorClass;
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, WorkerRegistry,
+};
+use kx_journal::InMemoryJournal;
+use kx_mote::{EffectPattern, Mote, NdClass};
+
+const TIMEOUT: Duration = Duration::from_secs(6);
+const MAC: ExecutorClass = ExecutorClass::MacosSandbox;
+
+/// A deterministic clock the test advances by hand (mirrors `tests/reschedule.rs`).
+#[derive(Debug)]
+struct FakeClock(AtomicU64);
+impl FakeClock {
+    fn new(ms: u64) -> Arc<Self> {
+        Arc::new(Self(AtomicU64::new(ms)))
+    }
+    fn set(&self, ms: u64) {
+        self.0.store(ms, Ordering::Relaxed);
+    }
+}
+impl Clock for FakeClock {
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+fn coordinator(clock: Arc<FakeClock>) -> CoordinatorService {
+    let registry: Arc<dyn WorkerRegistry> = Arc::new(
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock, TIMEOUT),
+    );
+    CoordinatorService::with_registry(InMemoryJournal::new(), registry)
+}
+
+/// R-13: a non-PURE Mote that crashed WITHOUT a durable `EffectStaged` hint (the
+/// `ValidateThenCommit` / `IdempotentByConstruction` fire-then-crash window — those patterns
+/// never stage) is NOT re-offered. Re-dispatch would risk doubling a real-world effect.
+#[tokio::test]
+async fn crash_failed_world_mutating_without_effect_staged_is_not_re_offered() {
+    for pattern in [
+        EffectPattern::ValidateThenCommit,
+        EffectPattern::IdempotentByConstruction,
+    ] {
+        let clock = FakeClock::new(1_000);
+        let svc = coordinator(clock.clone());
+        let warrant = common::sample_warrant();
+
+        let dying = common::register(&svc, "dying").await;
+        let m = common::wm_mote(7, pattern);
+        common::submit(&svc, &m, &warrant).await;
+
+        // First dispatch is allowed (fresh ready Mote); the worker fires the effect then dies
+        // WITHOUT staging — for VTC/IBC there is no EffectStaged step (D58 §4).
+        let leased = common::lease_work(&svc, dying, MAC, 16).await;
+        assert_eq!(leased.len(), 1, "{pattern:?}: first dispatch is offered");
+
+        // Time advances past the timeout; a live worker polls → reap re-classifies the dead
+        // lease as crash-failed, but the oracle gate refuses to re-offer it.
+        clock.set(1_000 + 6_001);
+        let live = common::register(&svc, "live").await;
+        let offered = common::lease_work(&svc, live, MAC, 16).await;
+        assert!(
+            offered.is_empty(),
+            "{pattern:?}: a crash-failed non-PURE Mote with no EffectStaged is NOT re-offered \
+             (R-13 — re-dispatch could double the effect)"
+        );
+        assert_eq!(
+            svc.state_of(m.id).await.unwrap(),
+            MoteState::Failed,
+            "{pattern:?}: it is left stuck (operator-recoverable via repudiation), not re-leased"
+        );
+    }
+}
+
+/// R-13: a `StageThenCommit` Mote that DID record `EffectStaged` before crashing IS re-offered —
+/// the durable hint makes re-dispatch safe (the broker's tool-boundary idempotency dedupes the
+/// re-fire). This is the safe path P3.6b's W-3 exercises end-to-end.
+#[tokio::test]
+async fn crash_failed_world_mutating_with_effect_staged_is_re_offered() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant();
+
+    let dying = common::register(&svc, "dying").await;
+    let m = common::wm_mote(9, EffectPattern::StageThenCommit);
+    common::submit(&svc, &m, &warrant).await;
+
+    let leased = common::lease_work(&svc, dying, MAC, 16).await;
+    assert_eq!(leased.len(), 1, "first dispatch is offered");
+
+    // The worker stages its intent (EffectStaged recorded) then crashes before committing.
+    common::report_effect_staged(&svc, &m, dying).await;
+
+    clock.set(1_000 + 6_001);
+    let live = common::register(&svc, "live").await;
+    let offered = common::lease_work(&svc, live, MAC, 16).await;
+    assert_eq!(
+        offered.len(),
+        1,
+        "with the EffectStaged hint, re-dispatch is safe → the Mote is re-offered"
+    );
+    let offered_mote: Mote = offered[0].mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(offered_mote.id, m.id);
+}
+
+/// Regression guard: a crash-failed PURE Mote is always re-offered (recomputable — no
+/// world-effect hazard). The gate must not over-reach into the PURE reschedule path (D57).
+#[tokio::test]
+async fn crash_failed_pure_mote_is_still_re_offered() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator(clock.clone());
+    let warrant = common::sample_warrant();
+
+    let dying = common::register(&svc, "dying").await;
+    let m = common::mote(3, NdClass::Pure, &[]);
+    common::submit(&svc, &m, &warrant).await;
+
+    let leased = common::lease_work(&svc, dying, MAC, 16).await;
+    assert_eq!(leased.len(), 1);
+
+    clock.set(1_000 + 6_001);
+    let live = common::register(&svc, "live").await;
+    let offered = common::lease_work(&svc, live, MAC, 16).await;
+    assert_eq!(
+        offered.len(),
+        1,
+        "PURE is recomputable — a crash-failed PURE Mote is still re-leased (D57 unchanged)"
+    );
+}


### PR DESCRIPTION
## P3.6c — close the distributed WM exactly-once gap

A review of the P3.6b "no-`Proposed` distributed journal" note surfaced a real, verified exactly-once gap.

**Single-node**, before re-dispatching a WORLD-MUTATING effect on recovery, the engine/executor **must** consult `Projection::can_redispatch_world_effect` and refuse if false (**R-13 / D38 §2b**). Without an `EffectStaged` hint the effect may already have fired, so re-dispatch would double it — and "double-effected external mutations are not recoverable."

**Distributed**, reschedule (D57) re-leased **any** non-committed crash-failed Mote unconditionally — the oracle was **never consulted in `kx-coordinator`** (confirmed: its only two call sites are single-node). Because `ValidateThenCommit` / `IdempotentByConstruction` dispatch **without** staging (the P3.6b decision; `run_wm.rs::effect_staged_required` → true only for `StageThenCommit`) yet `broker.dispatch` fires the real effect, a worker that fired a VTC/IBC effect then died before `ReportCommit` would have its effect **re-fired** by the re-leased replacement. Single-node R-13 forbids exactly this.

> Latent today (no SDK/workflow layer until P4 → no real workflow submits VTC distributed; the W-tests use the safe StageThenCommit path), but a genuine hole in the core exactly-once promise that must close before P4 exercises WM and before P3.7's chaos gate can honestly certify exactly-once.

## Fix (coordinator-only, thesis-preserving)

`lease_ready` now gates the **crash-failed (`rescheduleable`)** candidates on a new `redispatch_admissible` helper: PURE is always recomputable; a non-PURE crash-failed Mote is re-offered **only** when `can_redispatch_world_effect` is true (a durable `EffectStaged` hint exists → the broker's tool-boundary idempotency dedupes the re-fire). Otherwise it is left **stuck** (operator-recoverable via repudiation), exactly as single-node refuses. Fresh `ready_set` Motes (first dispatch) are ungated; a `StageThenCommit` Mote that staged-then-crashed stays `Pending`/in `ready_set` and is still offered.

No engine change (thesis diff over `kx-scheduler`/`kx-executor`/`kx-inference` **empty**); **no new D-number** (implements R-13/D38 §2b under distribution, as P3.3 implemented P0.4).

| Mote at worker-death | re-offered after fix? | single-node |
|---|---|---|
| PURE | yes (recomputable) | re-run |
| StageThenCommit, staged then crashed | yes (`Pending`, hint present) | re-dispatch (R-13 permits) |
| VTC/IBC fired then crashed (no EffectStaged) | **no — stuck** | **refused (R-13) — stuck** |

## Tests (`crates/kx-coordinator/tests/wm_reschedule.rs`)
- fired-but-unstaged **VTC** and **IBC** Mote → **not** re-offered after death (`state Failed`, stuck).
- `StageThenCommit` that recorded `EffectStaged` → **is** re-offered (safe path; matches W-3 e2e).
- PURE crash-failed → still re-offered (D57 unchanged — no regression).

Workspace **874 passed / 0 failed / 8 ignored** (+3). Local gate green (fmt, clippy `-D warnings`, deny, doc, thesis-diff empty); CI runs ffi-link + I1.c byte-determinism + smoke.

## Follow-up (noted, out of scope)
The executor's submission refusals (R-1/R-10) aren't wired at the coordinator's `SubmitMote` (`scheduler.rs::submit` only registers). Defense-in-depth, not required to close this hole (the oracle gate alone makes re-dispatch safe). Recorded as a known gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)