### PR TITLE
feat(kx-chaos): P3.7 seed-deterministic chaos harness — the P3 EXIT GATE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-chaos"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "kx-capability",
+ "kx-content",
+ "kx-coordinator",
+ "kx-journal",
+ "kx-mote",
+ "kx-runtime",
+ "kx-warrant",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "kx-content"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/kx-proto",
     "crates/kx-coordinator",
     "crates/kx-worker",
+    "crates/kx-chaos",
 ]
 exclude = [
     "kx-cloud",
@@ -88,6 +89,9 @@ kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.0.1"
 kx-proto             = { path = "crates/kx-proto",             version = "0.0.1" }
 kx-coordinator       = { path = "crates/kx-coordinator",       version = "0.0.1" }
 kx-worker            = { path = "crates/kx-worker",            version = "0.0.1" }
+# The single-node engine — kx-chaos reuses its topology helpers (`derive_child_motes`,
+# `demo_topology_decision`) to check child-identity determinism under a shaper death.
+kx-runtime           = { path = "crates/kx-runtime",           version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-chaos/Cargo.toml
+++ b/crates/kx-chaos/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name         = "kx-chaos"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx chaos / failure-injection harness (P3.7 — the P3 exit gate). A seed-deterministic worker-death engine that kills workers mid-Mote across a seed sweep and proves, every time: exactly-once world effects (no double mutation), no orphaned/duplicated topology children after a shaper death, and correct repudiation cascades."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The distributed orchestration core under test: CoordinatorService (hosts the frozen
+# kx-scheduler), the worker registry + injectable Clock (P3.1 liveness), reschedule +
+# the P3.6c re-dispatch oracle gate, and repudiate (P3.5 cascade).
+kx-coordinator = { workspace = true }
+# The domain types the workflows are built from + the real topology child derivation
+# (`derive_child_motes`) the shaper scenario checks for determinism under death.
+kx-mote     = { workspace = true }
+kx-warrant  = { workspace = true }
+kx-runtime  = { workspace = true }
+# The capability seam the world-mutating dispatch fires through (idempotency token +
+# EffectRequest); the chaos broker counts net effects at this boundary.
+kx-capability = { workspace = true }
+# The in-memory single-writer journal the per-seed coordinator runs over (no fs, no
+# phantom-ref guard — fully deterministic).
+kx-journal = { workspace = true }
+# `ContentRef` — the broker's staged-effect handle + the deterministic result refs the
+# harness commits (no content store is wired, so any deterministic 32-byte ref is fine).
+kx-content = { workspace = true }
+# The coordinator's `Coordinator` RPC trait takes `tonic::Request`; the harness calls it
+# in-process (no server, no transport) — same shape the coordinator's own tests use.
+tonic     = { workspace = true }
+smallvec  = { workspace = true }
+blake3    = { workspace = true }
+thiserror = { workspace = true }
+tracing   = { workspace = true }
+
+[dev-dependencies]
+# The exit-gate sweeps drive the async CoordinatorService RPCs; the macro runtime is
+# enough (the harness spawns no tasks of its own — determinism by construction).
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/kx-chaos/src/assertions.rs
+++ b/crates/kx-chaos/src/assertions.rs
@@ -1,0 +1,54 @@
+//! The harness's result types: [`ChaosOutcome`] (what a run observed) and
+//! [`ChaosFailure`] (a gate violation or infrastructure fault, carrying the exact
+//! seed + plan + reason so a failing sweep prints its own reproduction).
+
+use std::fmt;
+
+use crate::plan::ChaosPlan;
+
+/// The observable result of one seed's run — the numbers the gate asserts on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChaosOutcome {
+    /// Committed (non-repudiated) Motes in the coordinator's projection at convergence.
+    pub committed_count: usize,
+    /// Net world effects applied (distinct tool-boundary idempotency keys). The
+    /// exactly-once witness.
+    pub net_effects: usize,
+    /// Total broker dispatch calls (a re-fire after a death counts here, not in
+    /// `net_effects`).
+    pub dispatch_calls: usize,
+    /// Whether the run ended in the P3.6c *safe-stuck* terminal: a fired-but-unstaged
+    /// world effect the recovery oracle refused to re-dispatch (uncommitted, not re-fired).
+    pub safely_stuck: bool,
+    /// For the repudiation scenario: how many downstream Motes the cascade marked.
+    pub cascade_size: Option<usize>,
+    /// For the topology scenario: how many shaper children were derived + committed.
+    pub materialized_children: usize,
+}
+
+/// A gate failure: an exactly-once / no-orphan / cascade invariant was violated, or the
+/// coordinator returned an unexpected error. Carries everything needed to reproduce:
+/// `run_seed(seed)` replays the identical `plan`.
+#[derive(Debug, Clone)]
+pub struct ChaosFailure {
+    /// The seed that reproduces this exactly.
+    pub seed: u64,
+    /// The plan derived from `seed`.
+    pub plan: ChaosPlan,
+    /// Why the run failed (invariant text or `infra: …`).
+    pub reason: String,
+    /// The outcome observed before the failure, when one was reached.
+    pub outcome: Option<ChaosOutcome>,
+}
+
+impl fmt::Display for ChaosFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "P3 chaos gate FAILED at seed {}\n  reproduce: kx_chaos::run_seed({})\n  plan: {:?}\n  reason: {}\n  outcome: {:?}",
+            self.seed, self.seed, self.plan, self.reason, self.outcome
+        )
+    }
+}
+
+impl std::error::Error for ChaosFailure {}

--- a/crates/kx-chaos/src/broker.rs
+++ b/crates/kx-chaos/src/broker.rs
@@ -1,0 +1,94 @@
+//! The chaos broker — the instrument that proves exactly-once at the world boundary.
+//!
+//! It implements [`CapabilityBroker`] but performs no real I/O: it returns a
+//! deterministic staged ref (content-addressed on the Mote id) and, crucially,
+//! **counts net world effects** by the tool-boundary idempotency key (the Mote id,
+//! per [`idempotency_token_for`](kx_capability::idempotency_token_for)). A
+//! re-dispatch of an already-applied key is a no-op at the world — exactly what a
+//! `Token`-class tool guarantees — so it bumps `dispatch_calls` but not
+//! `net_effects`. "Killed mid-effect, replacement re-fires, still ≤1 net effect" is
+//! read straight off these two counters.
+//!
+//! One broker is shared (cloned `Arc`s) across every simulated worker in a run, so the
+//! applied-key set spans the dying worker's fire and the replacement's re-fire.
+
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::ContentRef;
+use kx_mote::{Mote, ToolName, ToolVersion};
+use kx_warrant::WarrantSpec;
+
+/// A counting, side-effect-free [`CapabilityBroker`]. Clones share the counters.
+#[derive(Clone)]
+pub(crate) struct ChaosBroker {
+    dispatch_calls: Arc<AtomicUsize>,
+    net_effects: Arc<AtomicUsize>,
+    applied_keys: Arc<Mutex<BTreeSet<[u8; 32]>>>,
+}
+
+impl ChaosBroker {
+    /// A fresh broker with zeroed counters.
+    pub(crate) fn new() -> Self {
+        Self {
+            dispatch_calls: Arc::new(AtomicUsize::new(0)),
+            net_effects: Arc::new(AtomicUsize::new(0)),
+            applied_keys: Arc::new(Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    /// Total dispatch calls seen (a re-fire after a death counts here).
+    pub(crate) fn dispatch_calls(&self) -> usize {
+        self.dispatch_calls.load(Ordering::SeqCst)
+    }
+
+    /// Net world effects = count of distinct idempotency keys applied. This is the
+    /// exactly-once witness: it must never exceed the number of WM Motes that fired.
+    pub(crate) fn net_effects(&self) -> usize {
+        self.net_effects.load(Ordering::SeqCst)
+    }
+
+    /// The deterministic staged ref for `mote` — content-addressed on its id, so a
+    /// re-stage yields the identical ref (mirrors a real content-addressed store).
+    pub(crate) fn staged_ref(mote: &Mote) -> ContentRef {
+        ContentRef::from_bytes(*blake3::hash(mote.id.as_bytes()).as_bytes())
+    }
+}
+
+impl CapabilityBroker for ChaosBroker {
+    fn dispatch(
+        &self,
+        mote: &Mote,
+        _warrant: &WarrantSpec,
+        capability: &ToolName,
+        request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        self.dispatch_calls.fetch_add(1, Ordering::SeqCst);
+        // The tool-boundary idempotency key dedupes a re-fire: only a never-before-seen
+        // key is a real world effect. A WM dispatch always carries it (the executor sets
+        // it via `idempotency_token_for`); absent (a misuse) we conservatively count it.
+        let key = request.idempotency_key.unwrap_or(*mote.id.as_bytes());
+        if let Ok(mut applied) = self.applied_keys.lock() {
+            if applied.insert(key) {
+                self.net_effects.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        Ok(BrokerHandle {
+            staged_ref: Self::staged_ref(mote),
+            capability: capability.clone(),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+}

--- a/crates/kx-chaos/src/cluster.rs
+++ b/crates/kx-chaos/src/cluster.rs
@@ -1,0 +1,237 @@
+//! The deterministic cluster driver.
+//!
+//! Wraps one [`CoordinatorService`] (per seed) and drives it through **direct,
+//! sequenced RPC-trait calls** — no gRPC transport, no autonomous worker tasks. A
+//! single injected [`FakeClock`] is the only time source; the driver advances it by
+//! hand to make a worker cross the liveness timeout (the W-3 death pattern), so a
+//! reap + reschedule is triggered by the very next `LeaseWork`. Because each call is
+//! awaited before the next is issued, the coordinator's owner thread sees commands in
+//! exactly the driver's order — the run is a pure function of the plan.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_capability::{idempotency_token_for, CapabilityBroker, EffectRequest};
+use kx_content::ContentRef;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::{
+    proto, Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, RepudiationReason,
+    WorkerRegistry,
+};
+use kx_journal::InMemoryJournal;
+use kx_mote::{Mote, MoteId};
+use kx_warrant::{warrant_ref_of, FsScope, NetScope, WarrantSpec};
+use tonic::Request;
+
+use crate::broker::ChaosBroker;
+
+/// Logical start time (ms). Arbitrary; the clock only ever moves forward by hand.
+const START_MS: u64 = 1_000;
+/// The liveness timeout the registry uses; the driver jumps past it to kill a worker.
+const TIMEOUT: Duration = Duration::from_secs(6);
+/// Lease cap per poll — comfortably above any one scenario's ready set.
+const LEASE_MAX: u32 = 64;
+
+/// A hand-advanced clock shared by the registry and the driver.
+#[derive(Debug)]
+struct FakeClock(AtomicU64);
+
+impl FakeClock {
+    fn new(ms: u64) -> Arc<Self> {
+        Arc::new(Self(AtomicU64::new(ms)))
+    }
+    fn set(&self, ms: u64) {
+        self.0.store(ms, Ordering::Relaxed);
+    }
+}
+
+impl Clock for FakeClock {
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// A step error — an unexpected coordinator/RPC fault. Gate-invariant violations are
+/// reported separately (in `scenario`); this is only for "the infrastructure misbehaved".
+pub(crate) type StepResult<T> = Result<T, String>;
+
+/// One per-seed cluster: coordinator + clock + the shared counting broker.
+pub(crate) struct Cluster {
+    svc: CoordinatorService,
+    clock: Arc<FakeClock>,
+    broker: ChaosBroker,
+    now: u64,
+    timeout_ms: u64,
+    worker_seq: u64,
+}
+
+impl Cluster {
+    /// A fresh in-memory cluster (no content store ⇒ no phantom-ref guard ⇒ fully
+    /// deterministic, no filesystem). The registry shares the driver's clock.
+    pub(crate) fn new() -> Self {
+        let clock = FakeClock::new(START_MS);
+        let registry: Arc<dyn WorkerRegistry> = Arc::new(
+            InMemoryWorkerRegistry::with_clock_and_timeout(clock.clone(), TIMEOUT),
+        );
+        let svc = CoordinatorService::with_registry(InMemoryJournal::new(), registry);
+        let timeout_ms = u64::try_from(TIMEOUT.as_millis()).unwrap_or(6_000);
+        Self {
+            svc,
+            clock,
+            broker: ChaosBroker::new(),
+            now: START_MS,
+            timeout_ms,
+            worker_seq: 0,
+        }
+    }
+
+    /// The shared broker (read its net-effect / dispatch counters after a run).
+    pub(crate) fn broker(&self) -> &ChaosBroker {
+        &self.broker
+    }
+
+    /// Register a worker at the current clock time; returns its assigned id.
+    pub(crate) async fn register(&mut self) -> StepResult<u64> {
+        self.worker_seq += 1;
+        let endpoint = format!("chaos://w{}", self.worker_seq);
+        let resp = self
+            .svc
+            .register_worker(Request::new(proto::RegisterWorkerRequest {
+                executor_class: proto::ExecutorClass::MacosSandbox as i32,
+                endpoint,
+            }))
+            .await
+            .map_err(|s| format!("register_worker: {s}"))?;
+        Ok(resp.into_inner().worker_id)
+    }
+
+    /// Submit a Mote + warrant (registers it with the hosted scheduler).
+    pub(crate) async fn submit(&self, mote: &Mote, warrant: &WarrantSpec) -> StepResult<()> {
+        self.svc
+            .submit_mote(Request::new(proto::SubmitMoteRequest {
+                mote: Some(mote.clone().into()),
+                warrant: Some(warrant.clone().into()),
+            }))
+            .await
+            .map_err(|s| format!("submit_mote: {s}"))?;
+        Ok(())
+    }
+
+    /// Lease ready work for `worker`, returning the leased Motes (decoded from the
+    /// `WorkItem`s). Reaps dead workers first (D57), so this is also what triggers a
+    /// reschedule after a death.
+    pub(crate) async fn lease(&self, worker: u64) -> StepResult<Vec<Mote>> {
+        let resp = self
+            .svc
+            .lease_work(Request::new(proto::LeaseWorkRequest {
+                worker_id: worker,
+                executor_class: proto::ExecutorClass::MacosSandbox as i32,
+                max_motes: LEASE_MAX,
+            }))
+            .await
+            .map_err(|s| format!("lease_work: {s}"))?;
+        let mut motes = Vec::new();
+        for item in resp.into_inner().items {
+            let pm = item
+                .mote
+                .ok_or_else(|| "workitem missing mote".to_string())?;
+            let mote: Mote = pm
+                .try_into()
+                .map_err(|_| "workitem mote failed to decode".to_string())?;
+            motes.push(mote);
+        }
+        Ok(motes)
+    }
+
+    /// Record a WORLD-MUTATING Mote's staged intent (`EffectStaged` hint) for `worker`.
+    pub(crate) async fn stage(&self, worker: u64, mote: &Mote) -> StepResult<()> {
+        let id = mote.id.as_bytes().to_vec();
+        self.svc
+            .report_effect_staged(Request::new(proto::ReportEffectStagedRequest {
+                mote_id: id.clone(),
+                idempotency_key: id,
+                worker_id: worker,
+            }))
+            .await
+            .map_err(|s| format!("report_effect_staged: {s}"))?;
+        Ok(())
+    }
+
+    /// Fire the effect through the shared broker (counts a dispatch; bumps net effects
+    /// only for a never-before-seen idempotency key). Returns the staged ref to commit.
+    pub(crate) fn fire(&self, mote: &Mote, warrant: &WarrantSpec) -> StepResult<ContentRef> {
+        let request = EffectRequest {
+            payload: Vec::new(),
+            pattern: mote.def.effect_pattern,
+            idempotency_key: Some(idempotency_token_for(mote)),
+            net_scope: NetScope::None,
+            fs_scope: FsScope::empty(),
+        };
+        let handle = self
+            .broker
+            .dispatch(mote, warrant, &crate::workflow::world_tool(), request)
+            .map_err(|e| format!("broker dispatch: {e:?}"))?;
+        Ok(handle.staged_ref)
+    }
+
+    /// Propose a commit for `mote` by `worker` with the given `result_ref`. Returns the
+    /// commit outcome (`Committed` / `AlreadyCommitted` — the latter is the dedup path).
+    pub(crate) async fn commit(
+        &self,
+        worker: u64,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+        result_ref: ContentRef,
+    ) -> StepResult<proto::CommitOutcome> {
+        let id = mote.id.as_bytes().to_vec();
+        let resp = self
+            .svc
+            .report_commit(Request::new(proto::ReportCommitRequest {
+                mote_id: id.clone(),
+                idempotency_key: id,
+                result_ref: result_ref.as_bytes().to_vec(),
+                warrant_ref: warrant_ref_of(warrant).as_bytes().to_vec(),
+                mote_def_hash: mote.def.hash().as_bytes().to_vec(),
+                nd_class: proto::NdClass::from(mote.def.nd_class) as i32,
+                parents: mote.parents.iter().copied().map(Into::into).collect(),
+                worker_id: worker,
+            }))
+            .await
+            .map_err(|s| format!("report_commit: {s}"))?;
+        proto::CommitOutcome::try_from(resp.into_inner().outcome)
+            .map_err(|e| format!("unknown commit outcome: {e}"))
+    }
+
+    /// Jump the clock past the liveness timeout so any worker last seen at the current
+    /// time is now `Dead` — the next `lease`/reap re-offers its in-flight Motes.
+    pub(crate) fn advance_past_timeout(&mut self) {
+        self.now += self.timeout_ms + 1;
+        self.clock.set(self.now);
+    }
+
+    /// The committed (non-repudiated) Mote count in the coordinator's projection.
+    pub(crate) async fn committed_count(&self) -> StepResult<usize> {
+        self.svc
+            .committed_count()
+            .await
+            .map_err(|e| format!("committed_count: {e}"))
+    }
+
+    /// The current [`MoteState`] of `id`.
+    pub(crate) async fn state_of(&self, id: MoteId) -> StepResult<MoteState> {
+        self.svc
+            .state_of(id)
+            .await
+            .map_err(|e| format!("state_of: {e}"))
+    }
+
+    /// Repudiate `target` and cascade; returns the cascade size (downstream count).
+    pub(crate) async fn repudiate(&self, target: MoteId) -> StepResult<usize> {
+        self.svc
+            .repudiate(target, RepudiationReason::OperatorAction, 0xC0)
+            .await
+            .map(|o| o.cascade_size)
+            .map_err(|e| format!("repudiate: {e}"))
+    }
+}

--- a/crates/kx-chaos/src/lib.rs
+++ b/crates/kx-chaos/src/lib.rs
@@ -1,0 +1,55 @@
+//! # kx-chaos — the P3 exit-gate failure-injection harness (P3.7)
+//!
+//! This crate is kortecx's **product core proof**: a *seed-deterministic* engine
+//! that kills workers mid-Mote across a sweep of seeds and proves, for **every**
+//! seed, the three guarantees the P3 exit gate names:
+//!
+//! 1. **Exactly-once** — a worker killed mid-WORLD-MUTATING Mote never produces a
+//!    double world effect. The replacement either re-fires an *idempotent* effect
+//!    (≤1 net effect, dedup at the tool boundary) or — when the recovery oracle
+//!    cannot prove safety (P3.6c) — refuses to re-dispatch and leaves the Mote
+//!    *safely stuck* rather than risk a double mutation.
+//! 2. **No orphaned / duplicated children** — a topology shaper killed before it
+//!    commits its decision commits *exactly once* (dedup, first-wins), and the
+//!    children re-derived from that one committed decision are byte-identical to a
+//!    clean run (child identity is a pure function of the committed decision).
+//! 3. **Repudiation cascades correctly under chaos** — repudiating a root marks
+//!    its entire committed downstream lineage, even when that lineage was assembled
+//!    by a *replacement* worker after a death.
+//!
+//! ## Why deterministic, not autonomous
+//!
+//! The testing doctrine requires a *recorded, reproducible* seed: a failing run
+//! must replay identically. Autonomous workers racing on the wall clock cannot give
+//! that. So the harness derives a [`ChaosPlan`] purely from a `u64` seed (one
+//! [`SplitMix64`] stream, consumed entirely at plan construction) and drives the
+//! cluster through **direct, sequenced [`kx_coordinator::CoordinatorService`]
+//! calls** on a single task, advancing an injected [`Clock`](kx_coordinator::Clock)
+//! by hand. No `tokio::spawn` of competing workers, no real `sleep`, no gRPC. A
+//! seed maps to one action+death sequence maps to one [`ChaosOutcome`].
+//!
+//! The frozen engine crates (`kx-scheduler` / `kx-executor` / `kx-inference`) are
+//! never touched: the harness exercises the runtime only through the coordinator's
+//! public surface and the real [`kx_runtime::topology::derive_child_motes`].
+//!
+//! ## Entry point
+//!
+//! [`run_seed`] is the whole API: build it a seed, get back `Ok(ChaosOutcome)` or an
+//! [`ChaosFailure`] carrying the exact seed + plan + reason to reproduce.
+
+// Unit tests inside `src/` are exempt from the safety lints (the workspace denies
+// unwrap/expect/panic in library code); `tests/*.rs` carry their own per-file allows.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+mod assertions;
+mod broker;
+mod cluster;
+mod plan;
+mod prng;
+mod scenario;
+mod workflow;
+
+pub use assertions::{ChaosFailure, ChaosOutcome};
+pub use plan::{ChaosPlan, FaultPoint, ScenarioKind};
+pub use prng::SplitMix64;
+pub use scenario::run_seed;

--- a/crates/kx-chaos/src/plan.rs
+++ b/crates/kx-chaos/src/plan.rs
@@ -1,0 +1,149 @@
+//! The chaos plan: everything a seed deterministically decides, derived once.
+//!
+//! [`ChaosPlan::from_seed`] is total and pure — it consumes a single
+//! [`SplitMix64`](crate::SplitMix64) stream and returns the scenario, fault, and
+//! shape for that seed. Nothing downstream draws further randomness, so a seed maps
+//! to exactly one driven sequence and one outcome.
+
+use crate::prng::SplitMix64;
+
+/// Which P3 exit-gate guarantee a run exercises.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScenarioKind {
+    /// World-mutating exactly-once under worker death (and the P3.6c safe-stuck case).
+    ExactlyOnce,
+    /// A topology shaper death: exactly-one committed decision, deterministic children.
+    TopologyShaper,
+    /// Repudiation cascade correctness after a death during lineage assembly.
+    RepudiationCascade,
+}
+
+/// Where/whether the holder of the fault-target Mote fails. The cluster interprets
+/// each variant against the target's `nd_class` + effect pattern (e.g. a death before
+/// commit re-dispatches a PURE/staged Mote but leaves an unstaged world effect safely
+/// stuck — the P3.6c oracle refusal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultPoint {
+    /// No fault — a single worker drives the target to commit (control arm).
+    Clean,
+    /// Two live workers both lease and execute the target concurrently (no lease lock);
+    /// the journal's dedup-by-key must collapse it to one committed fact.
+    RacingDuplicate,
+    /// The holder dies after acting but before committing; a live worker reaps and
+    /// recovers it (or the oracle refuses re-dispatch and it stays safely stuck).
+    DeathBeforeCommit,
+}
+
+/// The effect pattern of the world-mutating target in an [`ScenarioKind::ExactlyOnce`]
+/// run. `StageThenCommit` records a durable `EffectStaged` hint (re-dispatch admissible
+/// after death); the other two dispatch *without* staging, so the P3.6c oracle refuses
+/// to re-dispatch a crash-failed one — the safe-stuck path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WmPattern {
+    /// Stage the intent before firing — recoverable after death.
+    StageThenCommit,
+    /// Critic-validated; fires without staging.
+    ValidateThenCommit,
+    /// Idempotent by design; fires without staging.
+    IdempotentByConstruction,
+}
+
+/// The fully-resolved decision for one seed. Constructed only via
+/// [`ChaosPlan::from_seed`]; every field is a pure function of `seed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChaosPlan {
+    /// The seed this plan was derived from (the reproduction handle).
+    pub seed: u64,
+    /// Which guarantee this run proves.
+    pub scenario: ScenarioKind,
+    /// How the fault-target's holder fails.
+    pub fault: FaultPoint,
+    /// The world-mutating target's effect pattern (relevant to `ExactlyOnce`).
+    pub wm_pattern: WmPattern,
+    /// How many workers the run registers (2..=4) — enough for a reap + a racer.
+    pub worker_count: u8,
+    /// A per-seed identity salt, so distinct seeds build visibly-distinct Motes
+    /// (aids debugging; each seed already has its own coordinator + journal).
+    pub salt: u8,
+}
+
+impl ChaosPlan {
+    /// Derive the plan for `seed`. Pure and total: equal seeds give equal plans.
+    #[must_use]
+    pub fn from_seed(seed: u64) -> Self {
+        let mut r = SplitMix64::new(seed);
+        let scenario = *r
+            .choose(&[
+                ScenarioKind::ExactlyOnce,
+                ScenarioKind::TopologyShaper,
+                ScenarioKind::RepudiationCascade,
+            ])
+            .unwrap_or(&ScenarioKind::ExactlyOnce);
+        let fault = *r
+            .choose(&[
+                FaultPoint::Clean,
+                FaultPoint::RacingDuplicate,
+                FaultPoint::DeathBeforeCommit,
+            ])
+            .unwrap_or(&FaultPoint::Clean);
+        let wm_pattern = *r
+            .choose(&[
+                WmPattern::StageThenCommit,
+                WmPattern::ValidateThenCommit,
+                WmPattern::IdempotentByConstruction,
+            ])
+            .unwrap_or(&WmPattern::StageThenCommit);
+        let worker_count = 2 + u8::try_from(r.below(3)).unwrap_or(0);
+        let salt = u8::try_from(r.below(251)).unwrap_or(0);
+        Self {
+            seed,
+            scenario,
+            fault,
+            wm_pattern,
+            worker_count,
+            salt,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChaosPlan;
+
+    #[test]
+    fn from_seed_is_deterministic() {
+        for seed in 0..5_000u64 {
+            assert_eq!(ChaosPlan::from_seed(seed), ChaosPlan::from_seed(seed));
+        }
+    }
+
+    #[test]
+    fn worker_count_in_range() {
+        for seed in 0..5_000u64 {
+            let p = ChaosPlan::from_seed(seed);
+            assert!((2..=4).contains(&p.worker_count), "seed {seed}: {p:?}");
+        }
+    }
+
+    #[test]
+    fn all_scenarios_and_faults_appear() {
+        use super::{FaultPoint, ScenarioKind};
+        let mut scen = [false; 3];
+        let mut fault = [false; 3];
+        for seed in 0..512u64 {
+            let p = ChaosPlan::from_seed(seed);
+            scen[match p.scenario {
+                ScenarioKind::ExactlyOnce => 0,
+                ScenarioKind::TopologyShaper => 1,
+                ScenarioKind::RepudiationCascade => 2,
+            }] = true;
+            fault[match p.fault {
+                FaultPoint::Clean => 0,
+                FaultPoint::RacingDuplicate => 1,
+                FaultPoint::DeathBeforeCommit => 2,
+            }] = true;
+        }
+        assert!(scen.iter().all(|&b| b), "every scenario is exercised");
+        assert!(fault.iter().all(|&b| b), "every fault is exercised");
+    }
+}

--- a/crates/kx-chaos/src/prng.rs
+++ b/crates/kx-chaos/src/prng.rs
@@ -1,0 +1,96 @@
+//! A tiny, dependency-free deterministic PRNG.
+//!
+//! The harness needs *reproducibility*, not cryptographic quality or perfect
+//! uniformity: a recorded seed must replay the exact same plan. `SplitMix64`
+//! (Steele/Lea/Flood, the seeding RNG behind `java.util.SplitableRandom`) is a
+//! well-known ~10-line generator that gives that with zero hidden global state and
+//! no external crate (so nothing new passes through `cargo-deny`). It is consumed
+//! entirely while building a [`crate::ChaosPlan`]; nothing else in the harness draws
+//! randomness, so the cluster driver is a pure function of the plan.
+
+/// A deterministic `SplitMix64` stream. Construct from a seed; pull values with
+/// [`SplitMix64::next_u64`] / [`SplitMix64::below`] / [`SplitMix64::choose`].
+#[derive(Debug, Clone)]
+pub struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    /// Start a fresh stream from `seed`. Equal seeds yield identical streams.
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    /// The next 64-bit value in the stream.
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// A value in `0..n`. For the small `n` the harness uses (≤ a few dozen) the
+    /// modulo bias is negligible *and deterministic* — reproducibility, not
+    /// uniformity, is the contract here. Returns `0` if `n == 0`.
+    pub fn below(&mut self, n: u64) -> u64 {
+        if n == 0 {
+            return 0;
+        }
+        self.next_u64() % n
+    }
+
+    /// Pick one element of `xs` deterministically. Returns `None` only for an empty
+    /// slice (the caller passes a non-empty fixed table).
+    pub fn choose<'a, T>(&mut self, xs: &'a [T]) -> Option<&'a T> {
+        let len = u64::try_from(xs.len()).ok()?;
+        if len == 0 {
+            return None;
+        }
+        let i = usize::try_from(self.below(len)).ok()?;
+        xs.get(i)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SplitMix64;
+
+    #[test]
+    fn same_seed_same_stream() {
+        let mut a = SplitMix64::new(42);
+        let mut b = SplitMix64::new(42);
+        for _ in 0..1_000 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn distinct_seeds_diverge() {
+        let mut a = SplitMix64::new(1);
+        let mut b = SplitMix64::new(2);
+        // Not a statistical claim — just that the streams are not trivially equal.
+        assert_ne!(a.next_u64(), b.next_u64());
+    }
+
+    #[test]
+    fn below_is_in_range() {
+        let mut r = SplitMix64::new(7);
+        for _ in 0..10_000 {
+            assert!(r.below(5) < 5);
+        }
+        assert_eq!(r.below(0), 0);
+    }
+
+    #[test]
+    fn choose_picks_from_slice() {
+        let mut r = SplitMix64::new(9);
+        let xs = [10, 20, 30];
+        for _ in 0..100 {
+            assert!(xs.contains(r.choose(&xs).unwrap()));
+        }
+        let empty: [u8; 0] = [];
+        assert!(r.choose(&empty).is_none());
+    }
+}

--- a/crates/kx-chaos/src/scenario.rs
+++ b/crates/kx-chaos/src/scenario.rs
@@ -1,0 +1,551 @@
+//! The three exit-gate scenarios and the [`run_seed`] entry point.
+//!
+//! Each scenario builds a tiny workflow, drives it through the [`Cluster`] with the
+//! plan's fault injected, then asserts the guarantee. A violated invariant (or an
+//! infrastructure fault) becomes a [`ChaosFailure`] carrying the reproducing seed.
+
+use std::collections::BTreeSet;
+
+use kx_coordinator::MoteState;
+use kx_mote::{Mote, MoteId, TopologyDecision};
+use kx_runtime::topology::DEMO_WORKER_COUNT;
+use kx_warrant::WarrantSpec;
+
+use crate::assertions::{ChaosFailure, ChaosOutcome};
+use crate::cluster::Cluster;
+use crate::plan::{ChaosPlan, FaultPoint, ScenarioKind, WmPattern};
+use crate::workflow;
+
+/// A failure reason paired with the outcome observed (when one was reached).
+type Failure = (String, Option<ChaosOutcome>);
+/// A scenario either proves its guarantee (returning the outcome) or fails.
+type ScenarioResult = Result<ChaosOutcome, Failure>;
+
+/// Wrap an infrastructure (RPC/coordinator) fault — no outcome was reached.
+fn infra(mut e: String) -> Failure {
+    e.insert_str(0, "infra: ");
+    (e, None)
+}
+
+/// A gate-invariant violation carrying the observed outcome.
+fn bad(reason: impl Into<String>, outcome: ChaosOutcome) -> Failure {
+    (reason.into(), Some(outcome))
+}
+
+/// Run the chaos scenario the seed selects and check its exit-gate invariant.
+///
+/// Pure and deterministic: equal seeds replay the identical run. On success the
+/// observed [`ChaosOutcome`] is returned; on any violation an [`ChaosFailure`] carries
+/// the seed + plan + reason so the failing seed reproduces exactly via `run_seed(seed)`.
+///
+/// # Errors
+/// Returns [`ChaosFailure`] when an exit-gate invariant is violated (double world
+/// effect, orphaned/duplicated children, an incorrect cascade) or the coordinator
+/// returns an unexpected error.
+pub async fn run_seed(seed: u64) -> Result<ChaosOutcome, ChaosFailure> {
+    let plan = ChaosPlan::from_seed(seed);
+    let result = match plan.scenario {
+        ScenarioKind::ExactlyOnce => exactly_once(&plan).await,
+        ScenarioKind::TopologyShaper => topology_shaper(&plan).await,
+        ScenarioKind::RepudiationCascade => repudiation_cascade(&plan).await,
+    };
+    result.map_err(|(reason, outcome)| ChaosFailure {
+        seed,
+        plan,
+        reason,
+        outcome,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A — exactly-once world effect under worker death
+// ---------------------------------------------------------------------------
+
+/// Whether the post-death re-lease re-offered the WM Mote (`None` off the death path)
+/// and whether it was leasable on first dispatch.
+struct WmDrive {
+    re_offered: Option<bool>,
+    leased_first: bool,
+}
+
+/// Drive the single WM Mote to its terminal state under the plan's fault.
+async fn drive_wm(
+    c: &mut Cluster,
+    plan: &ChaosPlan,
+    wm: &Mote,
+    warrant: &WarrantSpec,
+    staged: bool,
+) -> Result<WmDrive, Failure> {
+    let mut drive = WmDrive {
+        re_offered: None,
+        leased_first: true,
+    };
+    match plan.fault {
+        FaultPoint::Clean => {
+            let w = c.register().await.map_err(infra)?;
+            c.lease(w).await.map_err(infra)?;
+            if staged {
+                c.stage(w, wm).await.map_err(infra)?;
+            }
+            let r = c.fire(wm, warrant).map_err(infra)?;
+            c.commit(w, wm, warrant, r).await.map_err(infra)?;
+        }
+        FaultPoint::RacingDuplicate => {
+            let a = c.register().await.map_err(infra)?;
+            let b = c.register().await.map_err(infra)?;
+            c.lease(a).await.map_err(infra)?;
+            c.lease(b).await.map_err(infra)?;
+            // Both live workers execute the same ready Mote (no lease lock); fire + commit
+            // dedup to one net effect / one committed fact.
+            for w in [a, b] {
+                if staged {
+                    c.stage(w, wm).await.map_err(infra)?;
+                }
+                let r = c.fire(wm, warrant).map_err(infra)?;
+                c.commit(w, wm, warrant, r).await.map_err(infra)?;
+            }
+        }
+        FaultPoint::DeathBeforeCommit => {
+            let a = c.register().await.map_err(infra)?;
+            let leased = c.lease(a).await.map_err(infra)?;
+            drive.leased_first = leased.iter().any(|m| m.id == wm.id);
+            if staged {
+                c.stage(a, wm).await.map_err(infra)?;
+            }
+            // `a` FIRES the effect (net effect #1), then dies before committing — the exact
+            // stage→fire→{die} window the EffectStaged hint exists to make recoverable.
+            c.fire(wm, warrant).map_err(infra)?;
+            c.advance_past_timeout();
+            let b = c.register().await.map_err(infra)?;
+            let leased_b = c.lease(b).await.map_err(infra)?; // reaps `a`
+            let offered = leased_b.iter().any(|m| m.id == wm.id);
+            drive.re_offered = Some(offered);
+            if offered {
+                // Staged ⇒ oracle admits re-dispatch: re-stage (dedup) + re-fire (idempotent,
+                // net stays 1) + commit.
+                if staged {
+                    c.stage(b, wm).await.map_err(infra)?;
+                }
+                let r = c.fire(wm, warrant).map_err(infra)?;
+                c.commit(b, wm, warrant, r).await.map_err(infra)?;
+            }
+            // else: the P3.6c oracle refused re-dispatch (no staged hint) ⇒ safely stuck.
+        }
+    }
+    Ok(drive)
+}
+
+async fn exactly_once(plan: &ChaosPlan) -> ScenarioResult {
+    let mut c = Cluster::new();
+    let pattern = workflow::effect_pattern_of(plan.wm_pattern);
+    let staged = matches!(plan.wm_pattern, WmPattern::StageThenCommit);
+    let wm = workflow::wm_mote(plan.salt, 1, pattern);
+    let warrant = workflow::wm_warrant();
+    c.submit(&wm, &warrant).await.map_err(infra)?;
+
+    let WmDrive {
+        re_offered,
+        leased_first,
+    } = drive_wm(&mut c, plan, &wm, &warrant, staged).await?;
+
+    let committed = c.committed_count().await.map_err(infra)?;
+    let state = c.state_of(wm.id).await.map_err(infra)?;
+    let net = c.broker().net_effects();
+    let dispatches = c.broker().dispatch_calls();
+    let is_committed = matches!(state, MoteState::Committed);
+    let safely_stuck = matches!(plan.fault, FaultPoint::DeathBeforeCommit)
+        && re_offered == Some(false)
+        && !is_committed;
+    let outcome = ChaosOutcome {
+        committed_count: committed,
+        net_effects: net,
+        dispatch_calls: dispatches,
+        safely_stuck,
+        cascade_size: None,
+        materialized_children: 0,
+    };
+
+    assert_exactly_once(plan, staged, leased_first, is_committed, outcome)
+}
+
+/// Check the exactly-once invariants over an observed `outcome` (kept separate so the
+/// driver stays readable and within the line budget).
+fn assert_exactly_once(
+    plan: &ChaosPlan,
+    staged: bool,
+    leased_first: bool,
+    is_committed: bool,
+    outcome: ChaosOutcome,
+) -> ScenarioResult {
+    if matches!(plan.fault, FaultPoint::DeathBeforeCommit) && !leased_first {
+        return Err(bad(
+            "exactly-once: the WM Mote was not leasable on first dispatch",
+            outcome,
+        ));
+    }
+    // INVARIANT 1 (load-bearing): never more than one NET world effect for one WM Mote.
+    if outcome.net_effects != 1 {
+        return Err(bad(
+            format!(
+                "exactly-once: expected exactly 1 net world effect, got {}",
+                outcome.net_effects
+            ),
+            outcome,
+        ));
+    }
+    // INVARIANT 2: committed iff recovery was admissible; otherwise the only legitimate
+    // terminal is the P3.6c safe-stuck (death + unstaged + oracle refusal).
+    match (is_committed, plan.fault, staged) {
+        (true, _, _) => {
+            if outcome.committed_count != 1 {
+                return Err(bad(
+                    format!(
+                        "exactly-once: committed WM Mote but committed_count={}",
+                        outcome.committed_count
+                    ),
+                    outcome,
+                ));
+            }
+        }
+        (false, FaultPoint::DeathBeforeCommit, false) => {
+            if !outcome.safely_stuck {
+                return Err(bad(
+                    "exactly-once: unstaged WM Mote uncommitted but not classified safe-stuck",
+                    outcome,
+                ));
+            }
+            if outcome.committed_count != 0 {
+                return Err(bad(
+                    format!(
+                        "exactly-once: safe-stuck but committed_count={}",
+                        outcome.committed_count
+                    ),
+                    outcome,
+                ));
+            }
+        }
+        _ => {
+            return Err(bad(
+                format!(
+                    "exactly-once: WM Mote uncommitted in a path that must commit ({:?}, staged={staged})",
+                    plan.fault
+                ),
+                outcome,
+            ));
+        }
+    }
+    // INVARIANT 3: a staged death that recovered proves it via a re-dispatch (≥2 dispatches),
+    // so dedup — not luck — is what bounded the net effect to one.
+    if matches!(plan.fault, FaultPoint::DeathBeforeCommit)
+        && staged
+        && is_committed
+        && outcome.dispatch_calls < 2
+    {
+        return Err(bad(
+            format!(
+                "exactly-once: staged re-dispatch expected ≥2 dispatches, got {}",
+                outcome.dispatch_calls
+            ),
+            outcome,
+        ));
+    }
+    Ok(outcome)
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B — no orphaned / duplicated children after a shaper death
+// ---------------------------------------------------------------------------
+
+/// Drive the shaper to its terminal state under the plan's fault; return whether it ended
+/// in the P3.6c safe-stuck terminal (death + no staged hint + oracle refusal).
+async fn drive_shaper(
+    c: &mut Cluster,
+    plan: &ChaosPlan,
+    shaper: &Mote,
+    sw: &WarrantSpec,
+    td: &TopologyDecision,
+) -> Result<bool, Failure> {
+    match plan.fault {
+        FaultPoint::Clean => {
+            let w = c.register().await.map_err(infra)?;
+            c.lease(w).await.map_err(infra)?;
+            c.commit(w, shaper, sw, workflow::shaper_result_ref(td))
+                .await
+                .map_err(infra)?;
+            Ok(false)
+        }
+        FaultPoint::RacingDuplicate => {
+            let a = c.register().await.map_err(infra)?;
+            let b = c.register().await.map_err(infra)?;
+            c.lease(a).await.map_err(infra)?;
+            c.lease(b).await.map_err(infra)?;
+            // Both commit the SAME decision bytes ⇒ identical result_ref ⇒ dedup to one fact.
+            c.commit(a, shaper, sw, workflow::shaper_result_ref(td))
+                .await
+                .map_err(infra)?;
+            c.commit(b, shaper, sw, workflow::shaper_result_ref(td))
+                .await
+                .map_err(infra)?;
+            Ok(false)
+        }
+        FaultPoint::DeathBeforeCommit => {
+            let a = c.register().await.map_err(infra)?;
+            c.lease(a).await.map_err(infra)?; // a holds the shaper, never commits
+            c.advance_past_timeout();
+            let b = c.register().await.map_err(infra)?;
+            let leased_b = c.lease(b).await.map_err(infra)?; // reaps a
+            let offered = leased_b.iter().any(|m| m.id == shaper.id);
+            let st = c.state_of(shaper.id).await.map_err(infra)?;
+            // A READ-ONLY-NONDET shaper records no EffectStaged hint, so the oracle refuses to
+            // re-dispatch a crash-failed one (P3.6c) — it is safely stuck, decisionless.
+            Ok(!offered && !matches!(st, MoteState::Committed))
+        }
+    }
+}
+
+/// Derive the shaper's children (production `derive_child_motes`), assert the set is
+/// deterministic + distinct, then submit + commit them. Returns the child count.
+async fn materialize_children(
+    c: &mut Cluster,
+    shaper: &Mote,
+    td: &TopologyDecision,
+    safely_stuck: bool,
+) -> Result<usize, Failure> {
+    let children = workflow::derive_children(shaper, td);
+    let again = workflow::derive_children(shaper, td);
+    let ids: Vec<MoteId> = children.iter().map(|m| m.id).collect();
+    let ids_again: Vec<MoteId> = again.iter().map(|m| m.id).collect();
+    if ids != ids_again {
+        let o = topo_outcome(c, 0, safely_stuck).await?;
+        return Err(bad("topology: child derivation is non-deterministic", o));
+    }
+    let distinct: BTreeSet<MoteId> = ids.iter().copied().collect();
+    if distinct.len() != ids.len() {
+        let o = topo_outcome(c, 0, safely_stuck).await?;
+        return Err(bad("topology: duplicate child ids derived", o));
+    }
+    let cw = workflow::pure_warrant();
+    for child in &children {
+        c.submit(child, &cw).await.map_err(infra)?;
+    }
+    let w = c.register().await.map_err(infra)?;
+    c.lease(w).await.map_err(infra)?;
+    for child in &children {
+        c.commit(w, child, &cw, workflow::pure_result_ref(child))
+            .await
+            .map_err(infra)?;
+    }
+    Ok(children.len())
+}
+
+async fn topology_shaper(plan: &ChaosPlan) -> ScenarioResult {
+    let mut c = Cluster::new();
+    let shaper = workflow::shaper_mote(plan.salt);
+    let sw = workflow::pure_warrant();
+    let td = workflow::topology_decision();
+    c.submit(&shaper, &sw).await.map_err(infra)?;
+
+    let safely_stuck = drive_shaper(&mut c, plan, &shaper, &sw, &td).await?;
+    let shaper_committed = matches!(
+        c.state_of(shaper.id).await.map_err(infra)?,
+        MoteState::Committed
+    );
+    let materialized = if shaper_committed {
+        materialize_children(&mut c, &shaper, &td, safely_stuck).await?
+    } else {
+        0
+    };
+
+    let o = topo_outcome(&c, materialized, safely_stuck).await?;
+    if o.net_effects != 0 {
+        return Err(bad(
+            "topology: a non-world-mutating workflow produced a world effect",
+            o,
+        ));
+    }
+    if shaper_committed {
+        if materialized != DEMO_WORKER_COUNT {
+            return Err(bad(
+                format!("topology: expected {DEMO_WORKER_COUNT} children, got {materialized}"),
+                o,
+            ));
+        }
+        let expected = 1 + DEMO_WORKER_COUNT;
+        if o.committed_count != expected {
+            return Err(bad(
+                format!(
+                    "topology: expected committed_count {expected} (shaper + children), got {}",
+                    o.committed_count
+                ),
+                o,
+            ));
+        }
+    } else {
+        if !safely_stuck {
+            return Err(bad(
+                "topology: shaper uncommitted but not classified safe-stuck",
+                o,
+            ));
+        }
+        if materialized != 0 {
+            return Err(bad(
+                "topology: children materialized without a committed shaper (orphans!)",
+                o,
+            ));
+        }
+        if o.committed_count != 0 {
+            return Err(bad(
+                format!(
+                    "topology: nothing should be committed, got {}",
+                    o.committed_count
+                ),
+                o,
+            ));
+        }
+    }
+    Ok(o)
+}
+
+async fn topo_outcome(
+    c: &Cluster,
+    materialized: usize,
+    safely_stuck: bool,
+) -> Result<ChaosOutcome, Failure> {
+    Ok(ChaosOutcome {
+        committed_count: c.committed_count().await.map_err(infra)?,
+        net_effects: c.broker().net_effects(),
+        dispatch_calls: c.broker().dispatch_calls(),
+        safely_stuck,
+        cascade_size: None,
+        materialized_children: materialized,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Scenario C — repudiation cascade correctness under chaos
+// ---------------------------------------------------------------------------
+
+/// Commit the `root → mid → leaf` lineage under the plan's fault.
+async fn drive_lineage(
+    c: &mut Cluster,
+    plan: &ChaosPlan,
+    root: &Mote,
+    mid: &Mote,
+    leaf: &Mote,
+    wt: &WarrantSpec,
+) -> Result<(), Failure> {
+    match plan.fault {
+        FaultPoint::Clean => {
+            let w = c.register().await.map_err(infra)?;
+            for m in [root, mid, leaf] {
+                c.commit(w, m, wt, workflow::pure_result_ref(m))
+                    .await
+                    .map_err(infra)?;
+            }
+        }
+        FaultPoint::RacingDuplicate => {
+            let a = c.register().await.map_err(infra)?;
+            let b = c.register().await.map_err(infra)?;
+            for m in [root, mid, leaf] {
+                c.commit(a, m, wt, workflow::pure_result_ref(m))
+                    .await
+                    .map_err(infra)?;
+                c.commit(b, m, wt, workflow::pure_result_ref(m))
+                    .await
+                    .map_err(infra)?; // dedup
+            }
+        }
+        FaultPoint::DeathBeforeCommit => {
+            // `a` commits the root, then leases `mid` and dies before committing it; a
+            // replacement reaps and finishes the lineage (PURE reschedule, D57).
+            let a = c.register().await.map_err(infra)?;
+            c.commit(a, root, wt, workflow::pure_result_ref(root))
+                .await
+                .map_err(infra)?;
+            c.lease(a).await.map_err(infra)?; // a holds `mid`
+            c.advance_past_timeout();
+            let b = c.register().await.map_err(infra)?;
+            c.lease(b).await.map_err(infra)?; // reaps a → mid (PURE) re-offered
+            c.commit(b, mid, wt, workflow::pure_result_ref(mid))
+                .await
+                .map_err(infra)?;
+            c.commit(b, leaf, wt, workflow::pure_result_ref(leaf))
+                .await
+                .map_err(infra)?;
+        }
+    }
+    Ok(())
+}
+
+async fn repudiation_cascade(plan: &ChaosPlan) -> ScenarioResult {
+    let mut c = Cluster::new();
+    let root = workflow::pure_mote(plan.salt, 1, &[]);
+    let mid = workflow::pure_mote(plan.salt, 2, &[root.id]);
+    let leaf = workflow::pure_mote(plan.salt, 3, &[mid.id]);
+    let wt = workflow::pure_warrant();
+    for m in [&root, &mid, &leaf] {
+        c.submit(m, &wt).await.map_err(infra)?;
+    }
+    drive_lineage(&mut c, plan, &root, &mid, &leaf, &wt).await?;
+
+    let committed_before = c.committed_count().await.map_err(infra)?;
+    let cascade = c.repudiate(root.id).await.map_err(infra)?;
+    let r_state = c.state_of(root.id).await.map_err(infra)?;
+    let m_state = c.state_of(mid.id).await.map_err(infra)?;
+    let l_state = c.state_of(leaf.id).await.map_err(infra)?;
+    let cascade_again = c.repudiate(root.id).await.map_err(infra)?; // idempotent (D15)
+    let committed_after = c.committed_count().await.map_err(infra)?;
+
+    let outcome = ChaosOutcome {
+        committed_count: committed_after,
+        net_effects: c.broker().net_effects(),
+        dispatch_calls: c.broker().dispatch_calls(),
+        safely_stuck: false,
+        cascade_size: Some(cascade),
+        materialized_children: 0,
+    };
+
+    if committed_before != 3 {
+        return Err(bad(
+            format!("cascade: lineage not fully committed before repudiation (committed_count={committed_before})"),
+            outcome,
+        ));
+    }
+    if cascade != 2 {
+        return Err(bad(
+            format!("cascade: expected 2 downstream consumers, got {cascade}"),
+            outcome,
+        ));
+    }
+    for (name, st) in [("root", r_state), ("mid", m_state), ("leaf", l_state)] {
+        if !matches!(st, MoteState::Repudiated) {
+            return Err(bad(
+                format!("cascade: {name} not Repudiated after cascade (state {st:?})"),
+                outcome,
+            ));
+        }
+    }
+    // Idempotent (D15): the journal dedupes by key, so re-repudiating changes no facts.
+    // `cascade_size` is the *structural* cascade (so it repeats); state must stay put.
+    if cascade_again != cascade {
+        return Err(bad(
+            format!(
+                "cascade: re-repudiation not idempotent (first={cascade}, again={cascade_again})"
+            ),
+            outcome,
+        ));
+    }
+    if committed_after != 0 {
+        return Err(bad(
+            format!("cascade: committed_count should be 0 after full repudiation, got {committed_after}"),
+            outcome,
+        ));
+    }
+    if outcome.net_effects != 0 {
+        return Err(bad(
+            "cascade: a non-world-mutating workflow produced a world effect",
+            outcome,
+        ));
+    }
+    Ok(outcome)
+}

--- a/crates/kx-chaos/src/workflow.rs
+++ b/crates/kx-chaos/src/workflow.rs
@@ -1,0 +1,206 @@
+//! Workflow fixtures the scenarios submit: parameterized PURE / WORLD-MUTATING /
+//! topology-shaper Motes and the warrants that admit them, built from the real
+//! `kx-mote` / `kx-warrant` types. Identities are seed-salted so a run's Motes are
+//! visibly distinct; each seed has its own coordinator + journal, so cross-seed id
+//! reuse is harmless.
+//!
+//! The topology helpers wrap `kx-runtime`'s real `derive_child_motes`, so the shaper
+//! scenario checks the *production* child-identity derivation for determinism under a
+//! shaper death — not a re-implementation.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_mote::{
+    EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
+    MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, ToolName, ToolVersion,
+    TopologyDecision, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_runtime::topology::{demo_topology_decision, derive_child_motes, encode_topology_decision};
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    WarrantSpec,
+};
+use smallvec::SmallVec;
+
+use crate::plan::WmPattern;
+
+/// The executor backend the harness's workers register as and the warrants require.
+pub(crate) const WORKER_CLASS: ExecutorClass = ExecutorClass::MacOsSandbox;
+
+/// The capability a WORLD-MUTATING Mote names in its `tool_contract`. The chaos broker
+/// ignores the contract (it is not the real `LocalCapabilityBroker`), and the
+/// coordinator's `SubmitMote` runs no refusal predicates, so no warrant grant is needed.
+pub(crate) fn world_tool() -> ToolName {
+    ToolName("kx-chaos-effect".into())
+}
+
+/// The version pinned beside [`world_tool`].
+pub(crate) fn world_tool_version() -> ToolVersion {
+    ToolVersion("0.1.0".into())
+}
+
+/// Map the plan's [`WmPattern`] onto the domain effect pattern.
+pub(crate) fn effect_pattern_of(p: WmPattern) -> EffectPattern {
+    match p {
+        WmPattern::StageThenCommit => EffectPattern::StageThenCommit,
+        WmPattern::ValidateThenCommit => EffectPattern::ValidateThenCommit,
+        WmPattern::IdempotentByConstruction => EffectPattern::IdempotentByConstruction,
+    }
+}
+
+/// A distinct 32-byte identity base from `(salt, index)`.
+fn id_bytes(salt: u8, index: u8) -> [u8; 32] {
+    let mut b = [0u8; 32];
+    b[0] = salt;
+    b[1] = index;
+    b
+}
+
+fn parents_of(parent_ids: &[MoteId]) -> SmallVec<[ParentRef; 4]> {
+    parent_ids
+        .iter()
+        .map(|id| ParentRef {
+            parent_id: *id,
+            edge: EdgeMeta::data(),
+        })
+        .collect()
+}
+
+fn base_def(nd_class: NdClass, effect_pattern: EffectPattern) -> MoteDef {
+    MoteDef {
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class,
+        config_subset: BTreeMap::new(),
+        effect_pattern,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+/// A PURE Mote, made unique by `(salt, index)`, with optional data-edge parents.
+pub(crate) fn pure_mote(salt: u8, index: u8, parent_ids: &[MoteId]) -> Mote {
+    Mote::new(
+        base_def(NdClass::Pure, EffectPattern::IdempotentByConstruction),
+        InputDataId::from_bytes(id_bytes(salt, index)),
+        GraphPosition(vec![salt, index]),
+        parents_of(parent_ids),
+    )
+}
+
+/// A WORLD-MUTATING Mote with the given effect pattern, made unique by `(salt, index)`.
+/// Its `tool_contract` names [`world_tool`] (faithful shape; the broker ignores it).
+pub(crate) fn wm_mote(salt: u8, index: u8, pattern: EffectPattern) -> Mote {
+    let mut def = base_def(NdClass::WorldMutating, pattern);
+    def.tool_contract.insert(world_tool(), world_tool_version());
+    Mote::new(
+        def,
+        InputDataId::from_bytes(id_bytes(salt, index)),
+        GraphPosition(vec![salt, index]),
+        SmallVec::new(),
+    )
+}
+
+/// The topology shaper: READ-ONLY-NONDET, `is_topology_shaper`, made unique by `salt`.
+/// Its committed decision spawns `DEMO_WORKER_COUNT` PURE children.
+pub(crate) fn shaper_mote(salt: u8) -> Mote {
+    let mut def = base_def(
+        NdClass::ReadOnlyNondet,
+        EffectPattern::IdempotentByConstruction,
+    );
+    def.is_topology_shaper = true;
+    Mote::new(
+        def,
+        InputDataId::from_bytes(id_bytes(salt, 0xF0)),
+        GraphPosition(vec![salt, 0xF0]),
+        SmallVec::new(),
+    )
+}
+
+/// The shaper's topology decision (`DEMO_WORKER_COUNT` PURE workers).
+pub(crate) fn topology_decision() -> TopologyDecision {
+    demo_topology_decision()
+}
+
+/// The deterministic `result_ref` the shaper commits — content-addressed on the encoded
+/// decision, so any worker (the original or a post-death replacement) commits the *same*
+/// ref. Falls back to a fixed ref if encoding ever fails (it cannot for this decision).
+pub(crate) fn shaper_result_ref(td: &TopologyDecision) -> ContentRef {
+    match encode_topology_decision(td) {
+        Ok(bytes) => ContentRef::from_bytes(*blake3::hash(&bytes).as_bytes()),
+        Err(_) => ContentRef::from_bytes([0xEE; 32]),
+    }
+}
+
+/// Re-derive the shaper's child Motes from its committed `result_ref` + decision via the
+/// **production** `kx_runtime::topology::derive_child_motes`. A pure function of the
+/// committed decision: a death-and-replay of the shaper cannot fork this set.
+pub(crate) fn derive_children(shaper: &Mote, td: &TopologyDecision) -> Vec<Mote> {
+    let child_warrant = pure_warrant();
+    let capability = world_tool();
+    derive_child_motes(
+        shaper,
+        shaper_result_ref(td),
+        td,
+        &child_warrant,
+        &capability,
+    )
+    .into_iter()
+    .map(|wm| wm.mote)
+    .collect()
+}
+
+/// A deterministic `result_ref` for a non-world-mutating Mote — content-addressed on
+/// its id, so any worker (original or replacement) proposes the identical ref and the
+/// journal's dedup-by-key collapses a racing double-commit to one fact.
+pub(crate) fn pure_result_ref(mote: &Mote) -> ContentRef {
+    let mut tagged = b"kx-chaos-result:".to_vec();
+    tagged.extend_from_slice(mote.id.as_bytes());
+    ContentRef::from_bytes(*blake3::hash(&tagged).as_bytes())
+}
+
+/// A warrant a [`WORKER_CLASS`] worker can run a PURE Mote under.
+pub(crate) fn pure_warrant() -> WarrantSpec {
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+    let mut hosts = BTreeSet::new();
+    hosts.insert(Host("api.example.com:443".into()));
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(hosts),
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: WORKER_CLASS,
+    }
+}
+
+/// A warrant a [`WORKER_CLASS`] worker can run a WORLD-MUTATING Mote under.
+pub(crate) fn wm_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        ..pure_warrant()
+    }
+}

--- a/crates/kx-chaos/tests/exit_gate.rs
+++ b/crates/kx-chaos/tests/exit_gate.rs
@@ -1,0 +1,84 @@
+//! The P3 EXIT GATE — the product's core proof.
+//!
+//! Sweeps a fixed band of seeds; for **every** seed the harness kills a worker
+//! mid-Mote (or races two) and proves the run upheld its exit-gate invariant:
+//! exactly-once world effects, no orphaned/duplicated children after a shaper death,
+//! and a correct repudiation cascade. A single failing seed fails the gate and prints
+//! its own reproduction (`kx_chaos::run_seed(<seed>)`).
+//!
+//! This sweep runs inside `just ci` / `cargo test --workspace`. It is deterministic
+//! and uses no wall-clock or filesystem, so it is fast and reproducible. The deeper
+//! (millions-of-seeds) sweep lives in `seed_sweep.rs` behind `#[ignore]`.
+//!
+//! ## Test-plan (DoD) — every exit-gate requirement is covered by the sweep
+//!
+//! | Exit-gate requirement                         | Scenario                      | Asserted by                                   |
+//! |-----------------------------------------------|-------------------------------|-----------------------------------------------|
+//! | exactly-once (no double world mutation)       | `ExactlyOnce`                 | `net_effects == 1` across every fault + the safe-stuck refusal |
+//! | recovery via re-dispatch (dedup bounds it)    | `ExactlyOnce`/`DeathBeforeCommit`/staged | committed + `dispatch_calls ≥ 2`     |
+//! | P3.6c oracle refusal (no phantom re-fire)     | `ExactlyOnce`/`DeathBeforeCommit`/unstaged | `safely_stuck` + uncommitted + `net_effects == 1` |
+//! | no orphaned / duplicated children             | `TopologyShaper`              | deterministic child set, `materialized == DEMO_WORKER_COUNT`, exactly-once commit |
+//! | repudiation cascades correctly under chaos    | `RepudiationCascade`          | `cascade_size == 2`, all `Repudiated`, idempotent re-repudiate |
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    clippy::panic
+)]
+
+/// The always-on band. 2048 seeds saturates the 3 scenarios × 3 faults × 3 WM patterns
+/// grid many times over while staying sub-second (in-process, no real time).
+const GATE_SEEDS: u64 = 2_048;
+
+#[tokio::test(flavor = "current_thread")]
+async fn p3_exit_gate_seed_sweep() {
+    let mut proven = 0u64;
+    for seed in 0..GATE_SEEDS {
+        match kx_chaos::run_seed(seed).await {
+            Ok(_) => proven += 1,
+            Err(failure) => panic!("\n{failure}\n"),
+        }
+    }
+    assert_eq!(proven, GATE_SEEDS, "every seed must prove its invariant");
+}
+
+/// Spot-reproduction: a handful of explicit seeds run individually, so a regression on
+/// one prints in isolation (not buried in the sweep).
+#[tokio::test(flavor = "current_thread")]
+async fn reproduces_individual_seeds() {
+    for seed in [0u64, 1, 2, 3, 7, 42, 99, 255, 1_000, 2_047] {
+        kx_chaos::run_seed(seed)
+            .await
+            .unwrap_or_else(|f| panic!("\n{f}\n"));
+    }
+}
+
+/// Non-vacuity guard: a passing sweep must actually witness each distinctive terminal
+/// shape, or the gate would be green by doing nothing. Across the band we must see a
+/// real re-dispatch after a death (`dispatch_calls ≥ 2`), the P3.6c safe-stuck refusal,
+/// a materialized-children run, and a repudiation cascade. If a refactor ever made
+/// worker death a silent no-op, this fails even though the invariants "hold".
+#[tokio::test(flavor = "current_thread")]
+async fn gate_exercises_every_terminal_shape() {
+    let mut saw_redispatch = false;
+    let mut saw_safe_stuck = false;
+    let mut saw_children = false;
+    let mut saw_cascade = false;
+    for seed in 0..GATE_SEEDS {
+        let o = kx_chaos::run_seed(seed)
+            .await
+            .unwrap_or_else(|f| panic!("\n{f}\n"));
+        saw_redispatch |= o.dispatch_calls >= 2;
+        saw_safe_stuck |= o.safely_stuck;
+        saw_children |= o.materialized_children > 0;
+        saw_cascade |= o.cascade_size == Some(2);
+    }
+    assert!(
+        saw_redispatch,
+        "no run re-dispatched after a death (death path not exercised)"
+    );
+    assert!(saw_safe_stuck, "no run hit the P3.6c safe-stuck refusal");
+    assert!(saw_children, "no run materialized shaper children");
+    assert!(saw_cascade, "no run exercised a repudiation cascade");
+}

--- a/crates/kx-chaos/tests/seed_sweep.rs
+++ b/crates/kx-chaos/tests/seed_sweep.rs
@@ -1,0 +1,48 @@
+//! The deep seed sweep — explicit, `#[ignore]`d (not run in `just ci`).
+//!
+//! Run it before a P3 sign-off / during a validation campaign to push the chaos gate
+//! across millions of seeds:
+//!
+//! ```text
+//! cargo test -p kx-chaos --test seed_sweep -- --ignored --nocapture
+//! KX_CHAOS_SEEDS=5000000 cargo test -p kx-chaos --test seed_sweep -- --ignored --nocapture
+//! ```
+//!
+//! It reuses the same deterministic `run_seed`, so any failure prints the exact seed to
+//! drop into `kx_chaos::run_seed(<seed>)` for a one-shot reproduction.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    clippy::panic
+)]
+
+/// Default depth when `KX_CHAOS_SEEDS` is unset. Overridable for a longer campaign.
+const DEFAULT_DEEP_SEEDS: u64 = 1_000_000;
+
+fn deep_seed_count() -> u64 {
+    std::env::var("KX_CHAOS_SEEDS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_DEEP_SEEDS)
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "deep sweep — run explicitly before a P3 sign-off"]
+async fn deep_seed_sweep() {
+    let total = deep_seed_count();
+    let mut proven = 0u64;
+    for seed in 0..total {
+        if let Err(failure) = kx_chaos::run_seed(seed).await {
+            panic!("\n{failure}\n");
+        }
+        proven += 1;
+        if proven.is_multiple_of(100_000) {
+            eprintln!("kx-chaos deep sweep: {proven}/{total} seeds proven");
+        }
+    }
+    eprintln!("kx-chaos deep sweep: {proven}/{total} seeds proven — all exactly-once");
+    assert_eq!(proven, total);
+}

--- a/crates/kx-coordinator/tests/stress_campaign.rs
+++ b/crates/kx-coordinator/tests/stress_campaign.rs
@@ -1,0 +1,257 @@
+//! Clean-slate stress / load harnesses (validation campaign, 2026-05-29).
+//!
+//! These are **additive** and gated behind `#[ignore]` so the default
+//! `cargo test` and CI gates keep their existing semantics. Run explicitly:
+//!
+//! ```text
+//! cargo test -p kx-coordinator --test stress_campaign -- --ignored --nocapture
+//! ```
+//!
+//! They push the in-process coordinator harder than the existing `load.rs`:
+//! a multi-thousand-Mote layered DAG, concurrent distinct+duplicate commits at
+//! scale (exactly-once under contention), a wide poison-cascade blast radius, and
+//! a repeated drop/reopen recovery storm over a durable journal. The point is to
+//! surface pathological regressions and ordering bugs, not to benchmark.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::time::Instant;
+
+use kx_coordinator::proto::CommitOutcome;
+use kx_coordinator::{CoordinatorService, MoteState, RepudiationReason};
+use kx_journal::{InMemoryJournal, SqliteJournal};
+use kx_mote::{EdgeMeta, GraphPosition, InputDataId, Mote, MoteId, NdClass, ParentRef};
+use smallvec::SmallVec;
+use tempfile::tempdir;
+
+/// A uniquely-identified Mote at `index` (u64, beyond the 256 `common::mote`
+/// supports) with explicit data-edge `parents`. Identity is derived by
+/// `Mote::new` from `def + input_data_id + graph_position`.
+fn dag_mote(index: u64, nd: NdClass, parents: &[MoteId]) -> Mote {
+    let mut input = [0u8; 32];
+    input[..8].copy_from_slice(&index.to_le_bytes());
+    let prefs: SmallVec<[ParentRef; 4]> = parents
+        .iter()
+        .map(|id| ParentRef {
+            parent_id: *id,
+            edge: EdgeMeta::data(),
+        })
+        .collect();
+    Mote::new(
+        common::mote_def(nd),
+        InputDataId::from_bytes(input),
+        GraphPosition(index.to_le_bytes().to_vec()),
+        prefs,
+    )
+}
+
+/// SCALE — a ~3,000-Mote layered DAG. Each non-root node depends on two nodes in
+/// the previous layer (a fan-in/diamond lattice). Submit the whole graph, then
+/// commit layer by layer in dependency order, asserting the ready-set advances
+/// monotonically and every distinct Mote commits exactly once.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "stress: run with --ignored"]
+async fn stress_large_layered_dag_commits_exactly_once() {
+    const WIDTH: u64 = 50;
+    const DEPTH: u64 = 60; // 3,000 Motes
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    // Build layers: layer 0 is parentless; layer L node j depends on layer L-1
+    // nodes j and (j+1)%WIDTH.
+    let mut layers: Vec<Vec<Mote>> = Vec::with_capacity(DEPTH as usize);
+    for l in 0..DEPTH {
+        let mut layer = Vec::with_capacity(WIDTH as usize);
+        for j in 0..WIDTH {
+            let index = l * WIDTH + j;
+            let parents: Vec<MoteId> = if l == 0 {
+                vec![]
+            } else {
+                let prev = &layers[(l - 1) as usize];
+                vec![prev[j as usize].id, prev[((j + 1) % WIDTH) as usize].id]
+            };
+            layer.push(dag_mote(index, NdClass::Pure, &parents));
+        }
+        layers.push(layer);
+    }
+    let total = (WIDTH * DEPTH) as usize;
+
+    let start = Instant::now();
+    for layer in &layers {
+        for m in layer {
+            let r = common::submit(&svc, m, &warrant).await;
+            assert_eq!(
+                r.status,
+                kx_coordinator::proto::SubmitStatus::Accepted as i32
+            );
+        }
+    }
+    let submit_elapsed = start.elapsed();
+
+    // Only layer 0 is ready initially.
+    assert_eq!(svc.ready_set().await.unwrap().len(), WIDTH as usize);
+
+    let commit_start = Instant::now();
+    for layer in &layers {
+        for m in layer {
+            assert_eq!(
+                common::commit(&svc, m, worker).await.outcome,
+                CommitOutcome::Committed as i32
+            );
+        }
+    }
+    let commit_elapsed = commit_start.elapsed();
+
+    assert_eq!(svc.committed_count().await.unwrap(), total);
+    assert!(
+        svc.ready_set().await.unwrap().is_empty(),
+        "all work drained"
+    );
+    eprintln!("large-dag: {total} Motes — submit {submit_elapsed:?}, commit {commit_elapsed:?}");
+    // Generous machine-independent ceiling: catches an O(n^2) fold regression.
+    assert!(
+        commit_elapsed.as_secs() < 60,
+        "committing {total} Motes layer-by-layer should stay linear; took {commit_elapsed:?}"
+    );
+}
+
+/// PARALLEL SATURATION — N distinct Motes, each committed by TWO concurrent
+/// tasks (a duplicate race). Exactly-once must hold: every Mote ends Committed,
+/// the journal dedupes the duplicate by idempotency key, and `committed_count`
+/// equals N exactly (no double-write).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "stress: run with --ignored"]
+async fn stress_concurrent_distinct_and_duplicate_is_exactly_once() {
+    const N: u64 = 1_500;
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let motes: Vec<Mote> = (0..N).map(|i| dag_mote(i, NdClass::Pure, &[])).collect();
+    for m in &motes {
+        common::submit(&svc, m, &warrant).await;
+    }
+
+    // Two racing committers per Mote.
+    let mut handles = Vec::with_capacity((2 * N) as usize);
+    for m in &motes {
+        for _ in 0..2 {
+            let s = svc.clone();
+            let m = m.clone();
+            handles.push(tokio::spawn(async move {
+                common::commit(&s, &m, worker).await.outcome
+            }));
+        }
+    }
+    for h in handles {
+        let outcome = h.await.unwrap();
+        assert!(
+            outcome == CommitOutcome::Committed as i32
+                || outcome == CommitOutcome::AlreadyCommitted as i32,
+            "each racing commit is either the winner or a dedup hit"
+        );
+    }
+
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        N as usize,
+        "every distinct Mote committed exactly once despite duplicate races"
+    );
+}
+
+/// BLAST RADIUS — a root with a wide fan-out of direct children (one layer).
+/// Commit the whole star, repudiate the root, and assert the poison cascade
+/// invalidates exactly the children and nothing remains committed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "stress: run with --ignored"]
+async fn stress_repudiation_blast_radius() {
+    const FANOUT: u64 = 2_000;
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let warrant = common::sample_warrant();
+    let worker = common::register(&svc, "w").await;
+
+    let root = dag_mote(0, NdClass::Pure, &[]);
+    common::submit(&svc, &root, &warrant).await;
+    common::commit(&svc, &root, worker).await;
+
+    let children: Vec<Mote> = (1..=FANOUT)
+        .map(|i| dag_mote(i, NdClass::Pure, &[root.id]))
+        .collect();
+    for c in &children {
+        common::submit(&svc, c, &warrant).await;
+        common::commit(&svc, c, worker).await;
+    }
+    assert_eq!(svc.committed_count().await.unwrap(), (FANOUT + 1) as usize);
+
+    let start = Instant::now();
+    let outcome = svc
+        .repudiate(root.id, RepudiationReason::OperatorAction, 1)
+        .await
+        .unwrap();
+    eprintln!(
+        "repudiation: cascade of {} in {:?}",
+        outcome.cascade_size,
+        start.elapsed()
+    );
+    assert_eq!(
+        outcome.cascade_size, FANOUT as usize,
+        "all children cascaded"
+    );
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        0,
+        "the entire poisoned lineage is repudiated"
+    );
+    assert_eq!(svc.state_of(root.id).await.unwrap(), MoteState::Repudiated);
+}
+
+/// RECOVERY STORM — over a durable Sqlite journal, repeatedly commit a batch,
+/// drop the coordinator (simulating a crash), and reopen a fresh one over the
+/// same file. The recovered `committed_count` must equal the cumulative total
+/// every round — the journal, not the process, is the source of truth.
+#[tokio::test]
+#[ignore = "stress: run with --ignored"]
+async fn stress_recovery_storm_converges() {
+    const ROUNDS: u64 = 20;
+    const BATCH: u64 = 100;
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("storm.db");
+    let warrant = common::sample_warrant();
+
+    let mut committed_so_far = 0u64;
+    for round in 0..ROUNDS {
+        let svc = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+        // Recovery is implicit in `new`: the prior rounds' commits must be present.
+        assert_eq!(
+            svc.committed_count().await.unwrap(),
+            committed_so_far as usize,
+            "round {round}: recovered the cumulative committed state"
+        );
+        let worker = common::register(&svc, "w").await;
+        for j in 0..BATCH {
+            let m = dag_mote(round * BATCH + j, NdClass::Pure, &[]);
+            common::submit(&svc, &m, &warrant).await;
+            assert_eq!(
+                common::commit(&svc, &m, worker).await.outcome,
+                CommitOutcome::Committed as i32
+            );
+        }
+        committed_so_far += BATCH;
+        assert_eq!(
+            svc.committed_count().await.unwrap(),
+            committed_so_far as usize
+        );
+        // svc dropped here → owner thread exits → Sqlite connection closed.
+    }
+
+    // Final reopen confirms durable convergence.
+    let svc = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        (ROUNDS * BATCH) as usize,
+        "every committed Mote survived {ROUNDS} crash/recover cycles"
+    );
+}


### PR DESCRIPTION
## P3.7 — `kx-chaos`, the P3 EXIT GATE (the product's core proof)

A new `kx-chaos` workspace member: a **seed-deterministic** failure-injection engine that kills workers mid-Mote across a seed sweep and proves, for **every** seed, the three guarantees the P3 exit gate names.

### What it proves (per seed, deterministically)
- **Exactly-once world effects** — ≤1 net effect across a worker death + re-dispatch (dedup at the tool boundary), and the **P3.6c safe-stuck refusal** for a fired-but-unstaged effect (uncommitted, never re-fired).
- **No orphaned / duplicated topology children after a shaper death** — child identity derived from the *one* committed decision via the production `kx_runtime::topology::derive_child_motes`, committed exactly once.
- **Repudiation cascades correctly under chaos** — the full committed downstream lineage is marked, idempotent re-repudiation, even when the lineage was assembled by a *replacement* worker after a death.

### Determinism by construction
A `u64` seed → one `ChaosPlan` (hand-written `SplitMix64`, no rng dep) → one driven sequence over a single `CoordinatorService` via direct, sequenced RPC-trait calls with a hand-advanced `FakeClock`. **No gRPC, no autonomous tasks, no wall-clock.** A failing seed reproduces identically via `kx_chaos::run_seed(seed)` — the panic prints the seed + plan + reason.

### Layout
- `crates/kx-chaos/src/` — thin lib: `prng` · `plan` · `broker` (the `CountingBroker` net-effect instrument) · `workflow` · `cluster` (the deterministic driver) · `scenario` (the 3 runners + `run_seed`) · `assertions`.
- `crates/kx-chaos/tests/exit_gate.rs` — **always-on 2048-seed sweep** (runs in `just ci`, <1s), plus a **non-vacuity guard** asserting every terminal shape (re-dispatch, safe-stuck, children, cascade) is actually witnessed.
- `crates/kx-chaos/tests/seed_sweep.rs` — `#[ignore]` deep sweep (`KX_CHAOS_SEEDS`, default 1M), for pre-sign-off campaigns.
- `crates/kx-coordinator/tests/stress_campaign.rs` — committed as the companion **scale** suite (3k-Mote DAG, 1500×2 racing commits, 2k-child cascade, 20× recovery storm; all `#[ignore]`).

### Guarantees / gates
- **Thesis diff over `kx-scheduler` / `kx-executor` / `kx-inference` is EMPTY.**
- **No new external dependency** (the PRNG is hand-written; `cargo-deny` surface unchanged).
- 2048-seed gate green in <1s; **200k-seed deep sweep green**; full gate green (`fmt`, `clippy --workspace --all-targets -D warnings`, workspace `test`, `doc -D warnings`).

**P3 EXIT GATE — human sign-off owed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
