### PR TITLE
feat(kx-workflow): P4.1a Morphic engine — pure WorkflowDef→Mote DAG compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-workflow"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "kx-content",
+ "kx-mote",
+ "kx-warrant",
+ "proptest",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/kx-coordinator",
     "crates/kx-worker",
     "crates/kx-chaos",
+    "crates/kx-workflow",
 ]
 exclude = [
     "kx-cloud",
@@ -92,6 +93,9 @@ kx-worker            = { path = "crates/kx-worker",            version = "0.0.1"
 # The single-node engine — kx-chaos reuses its topology helpers (`derive_child_motes`,
 # `demo_topology_decision`) to check child-identity determinism under a shaper death.
 kx-runtime           = { path = "crates/kx-runtime",           version = "0.0.1" }
+# The workflow engine (codename Morphic, P4.1) — compiles a WorkflowDef to a
+# Mote DAG. Sits above the scheduler; emits kx-mote + kx-warrant types only.
+kx-workflow          = { path = "crates/kx-workflow",          version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-workflow/Cargo.toml
+++ b/crates/kx-workflow/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name         = "kx-workflow"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx workflow engine (codename Morphic) — P4.1. Compiles a declarative multi-agent workflow definition into a deterministic Mote DAG. Sits ABOVE the scheduler and only emits Motes (kx-mote) + warrants (kx-warrant); the execution graph morphs at runtime via topology shapers. Compilation is a pure/total function: the same WorkflowDef yields byte-identical MoteIds across runs, processes, and machines."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The identity substrate the engine emits: MoteDef / Mote / MoteId / NdClass /
+# EffectPattern / GraphPosition / InputDataId / MoteGraph / edges.
+kx-mote    = { workspace = true }
+# The capability layer carried through to submission (WarrantSpec) + the
+# permissive convenience warrant builder for getting started.
+kx-warrant = { workspace = true }
+# ContentRef — a WarrantSpec field type (syscall_profile_ref / environment_ref);
+# needed to construct the convenience warrant.
+kx-content = { workspace = true }
+# Parent-edge storage matches kx-mote's `SmallVec<[ParentRef; 4]>`.
+smallvec   = { workspace = true }
+# Deterministic compile-time InputDataId derivation (entrypoint seed / child lineage).
+blake3     = { workspace = true }
+thiserror  = { workspace = true }
+
+[dev-dependencies]
+# Property-based determinism sweep over random valid DAGs.
+proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-workflow/src/compile.rs
+++ b/crates/kx-workflow/src/compile.rs
@@ -1,0 +1,248 @@
+//! [`compile`] — the pure, total, deterministic pass that turns a
+//! [`WorkflowDef`] into a Mote DAG.
+//!
+//! **Determinism is the contract.** The same `WorkflowDef` produces
+//! byte-identical `MoteId`s across runs, processes, and machines. The pass
+//! touches no clock, host, PID, or allocation order: every map is a `BTreeMap`,
+//! every traversal order is explicit (a min-index frontier in the topological
+//! sort; parents canonically sorted by `MoteId`), and all identity bytes flow
+//! from the workflow definition alone. This is what lets a compiled workflow be
+//! a *reproducible program* — the basis of synthesis-by-recipe (D50).
+//!
+//! **Why a DAG.** A Mote's identity is `blake3(mote_def_hash ‖ input_data_id ‖
+//! graph_position)`, and `input_data_id` derives from its parents — so a cycle
+//! would make identity depend on its own output. Loops/branches/fan-out are not
+//! static cycles; they are expressed at runtime via topology shapers that
+//! materialize children deterministically (D23/D37).
+
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
+
+use kx_mote::{
+    EdgeMeta, GraphPosition, InputDataId, Mote, MoteDef, MoteGraph, MoteId, ParentRef,
+    MOTE_DEF_SCHEMA_VERSION,
+};
+use smallvec::SmallVec;
+
+use crate::def::{CompiledMote, CompiledWorkflow, StepDef, StepRole, WorkflowDef};
+use crate::error::CompileError;
+
+/// Validated adjacency derived from a [`WorkflowDef`]'s edges.
+struct Adjacency {
+    /// In-degree per step index.
+    indegree: Vec<usize>,
+    /// `children[p]` = the step indices that depend on step `p`.
+    children: Vec<Vec<usize>>,
+    /// `parents_of[c]` = each parent of step `c` with its edge metadata.
+    parents_of: Vec<Vec<(usize, EdgeMeta)>>,
+}
+
+/// Compile a [`WorkflowDef`] into a deterministic Mote DAG.
+///
+/// Returns the compiled motes in topological (submission) order plus a
+/// [`MoteGraph`] view. Compilation is pure: identical input yields byte-
+/// identical `MoteId`s.
+///
+/// # Errors
+///
+/// - [`CompileError::StepIndexOutOfRange`] — an edge or critic producer names a
+///   non-existent step.
+/// - [`CompileError::DuplicateEdge`] — the same `(parent, child)` edge twice.
+/// - [`CompileError::Cycle`] — the declared edges are not acyclic.
+/// - [`CompileError::InvalidCritic`] — a critic's producer does not precede it.
+pub fn compile(def: &WorkflowDef) -> Result<CompiledWorkflow, CompileError> {
+    let n = def.steps.len();
+    let adj = build_adjacency(def, n)?;
+    let order = topo_order(n, &adj)?;
+
+    let mut mote_ids: Vec<Option<MoteId>> = vec![None; n];
+    let mut motes: Vec<CompiledMote> = Vec::with_capacity(n);
+    let mut graph = MoteGraph::new();
+
+    for (rank, &step_idx) in order.iter().enumerate() {
+        let s = &def.steps[step_idx];
+        let critic_for = resolve_critic(s, step_idx, &mote_ids)?;
+        let parents = resolve_parents(step_idx, &adj.parents_of, &mote_ids)?;
+
+        // u64 is the fixed wire width for positions (usize would diverge across
+        // 32/64-bit targets); u64::try_from over a usize never truncates.
+        let rank_u64 = u64::try_from(rank).unwrap_or(u64::MAX);
+        let graph_position = GraphPosition(rank_u64.to_le_bytes().to_vec());
+        let input_data_id = if parents.is_empty() {
+            entrypoint_input_id(def.seed(), rank_u64)
+        } else {
+            child_input_id(&parents)
+        };
+
+        let mote = Mote::new(
+            mote_def_for(s, critic_for),
+            input_data_id,
+            graph_position,
+            parents,
+        );
+        mote_ids[step_idx] = Some(mote.id);
+        graph.insert(mote.clone());
+        motes.push(CompiledMote {
+            mote,
+            warrant: s.warrant.clone(),
+            capability: s.capability.clone(),
+        });
+    }
+
+    Ok(CompiledWorkflow { motes, graph })
+}
+
+/// Validate edges + critic producer ranges and build the adjacency.
+fn build_adjacency(def: &WorkflowDef, n: usize) -> Result<Adjacency, CompileError> {
+    let mut indegree = vec![0usize; n];
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut parents_of: Vec<Vec<(usize, EdgeMeta)>> = vec![Vec::new(); n];
+    let mut seen: BTreeSet<(usize, usize)> = BTreeSet::new();
+
+    for e in &def.edges {
+        let (p, c) = (e.parent.index(), e.child.index());
+        if p >= n {
+            return Err(CompileError::StepIndexOutOfRange(p));
+        }
+        if c >= n {
+            return Err(CompileError::StepIndexOutOfRange(c));
+        }
+        if !seen.insert((p, c)) {
+            return Err(CompileError::DuplicateEdge {
+                parent: p,
+                child: c,
+            });
+        }
+        children[p].push(c);
+        parents_of[c].push((p, e.edge));
+        indegree[c] += 1;
+    }
+
+    for s in &def.steps {
+        if let StepRole::Critic { producer } = s.role {
+            if producer.index() >= n {
+                return Err(CompileError::StepIndexOutOfRange(producer.index()));
+            }
+        }
+    }
+
+    Ok(Adjacency {
+        indegree,
+        children,
+        parents_of,
+    })
+}
+
+/// Kahn topological sort with a deterministic min-index frontier. Returns the
+/// step indices in dependency order, or [`CompileError::Cycle`].
+fn topo_order(n: usize, adj: &Adjacency) -> Result<Vec<usize>, CompileError> {
+    let mut indegree = adj.indegree.clone();
+    let mut frontier: BinaryHeap<Reverse<usize>> =
+        (0..n).filter(|&i| indegree[i] == 0).map(Reverse).collect();
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+
+    while let Some(Reverse(node)) = frontier.pop() {
+        order.push(node);
+        let mut cs = adj.children[node].clone();
+        cs.sort_unstable(); // children released in ascending index order
+        for c in cs {
+            indegree[c] -= 1;
+            if indegree[c] == 0 {
+                frontier.push(Reverse(c));
+            }
+        }
+    }
+
+    if order.len() == n {
+        Ok(order)
+    } else {
+        // Some node never reached in-degree zero → it sits on a cycle.
+        let stuck = (0..n).find(|&i| indegree[i] > 0).unwrap_or(0);
+        Err(CompileError::Cycle(stuck))
+    }
+}
+
+/// Resolve a step's `critic_for`: `Some(producer MoteId)` for a critic whose
+/// producer already compiled, else `None` for non-critics.
+fn resolve_critic(
+    s: &StepDef,
+    step_idx: usize,
+    mote_ids: &[Option<MoteId>],
+) -> Result<Option<MoteId>, CompileError> {
+    match s.role {
+        StepRole::Critic { producer } => match mote_ids[producer.index()] {
+            Some(id) => Ok(Some(id)),
+            None => Err(CompileError::InvalidCritic {
+                critic: step_idx,
+                producer: producer.index(),
+            }),
+        },
+        _ => Ok(None),
+    }
+}
+
+/// Build a step's parent edges, canonically ordered by `MoteId`. Every parent
+/// precedes the step in topological order, so its `MoteId` is already derived.
+fn resolve_parents(
+    step_idx: usize,
+    parents_of: &[Vec<(usize, EdgeMeta)>],
+    mote_ids: &[Option<MoteId>],
+) -> Result<SmallVec<[ParentRef; 4]>, CompileError> {
+    let mut parents: SmallVec<[ParentRef; 4]> = SmallVec::new();
+    for (p, edge) in &parents_of[step_idx] {
+        let Some(parent_id) = mote_ids[*p] else {
+            // Unreachable under a valid topological order; treated as a
+            // structural ordering defect.
+            return Err(CompileError::Cycle(step_idx));
+        };
+        parents.push(ParentRef {
+            parent_id,
+            edge: *edge,
+        });
+    }
+    parents.sort_unstable_by(|a, b| a.parent_id.0.cmp(&b.parent_id.0));
+    Ok(parents)
+}
+
+/// Assemble the step's [`MoteDef`] at the current schema version.
+fn mote_def_for(s: &StepDef, critic_for: Option<MoteId>) -> MoteDef {
+    MoteDef {
+        logic_ref: s.logic_ref,
+        model_id: s.model_id.clone(),
+        prompt_template_hash: s.prompt_template_hash,
+        tool_contract: s.tool_contract.clone(),
+        nd_class: s.nd_class,
+        config_subset: s.config_subset.clone(),
+        effect_pattern: s.effect_pattern,
+        critic_for,
+        is_topology_shaper: matches!(s.role, StepRole::TopologyShaper),
+        inference_params: s.inference_params.clone(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+/// Deterministic `input_data_id` for an entrypoint (zero-parent) step: the
+/// workflow seed folded with the step's topological rank. Per `kx-mote`, an
+/// entrypoint's input id IS the BLAKE3 of a workflow-input seed — the workflow
+/// SDK (this crate) is the blessed place to compute it.
+fn entrypoint_input_id(seed: u32, rank: u64) -> InputDataId {
+    let mut h = blake3::Hasher::new();
+    h.update(b"kx-workflow/input-data-id/entrypoint/v1");
+    h.update(&seed.to_le_bytes());
+    h.update(&rank.to_le_bytes());
+    InputDataId::from_bytes(*h.finalize().as_bytes())
+}
+
+/// Deterministic compile-time `input_data_id` for a step with parents, derived
+/// from its (canonically sorted) parent lineage. The runtime executor owns the
+/// authoritative derivation from committed parent `result_ref`s; this stable
+/// compile-time value gives the workflow a reproducible identity ahead of any run.
+fn child_input_id(parents: &[ParentRef]) -> InputDataId {
+    let mut h = blake3::Hasher::new();
+    h.update(b"kx-workflow/input-data-id/child/v1");
+    for p in parents {
+        h.update(p.parent_id.as_bytes());
+        h.update(&[p.edge.kind.as_u8(), u8::from(p.edge.non_cascade)]);
+    }
+    InputDataId::from_bytes(*h.finalize().as_bytes())
+}

--- a/crates/kx-workflow/src/def.rs
+++ b/crates/kx-workflow/src/def.rs
@@ -1,0 +1,224 @@
+//! The Morphic workflow-as-data types ([`WorkflowDef`], [`StepDef`],
+//! [`StepRole`], [`StepRef`], [`StepEdge`]) and the compile output
+//! ([`CompiledMote`], [`CompiledWorkflow`]).
+//!
+//! A workflow is authored as a graph of *steps* (agents) joined by typed
+//! *edges* — NOT as pre-derived Motes. [`crate::compile`] turns that graph into
+//! a Mote DAG. Authoring-as-data is what makes compilation a meaningful, pure
+//! function: identity is derived, never hand-assigned.
+
+use std::collections::BTreeMap;
+
+use kx_mote::{
+    ConfigKey, ConfigVal, EdgeMeta, EffectPattern, InferenceParams, LogicRef, ModelId, Mote,
+    MoteGraph, NdClass, PromptTemplateHash, ToolName, ToolVersion,
+};
+use kx_warrant::WarrantSpec;
+
+/// An opaque handle to a step within one [`WorkflowDef`].
+///
+/// Minted only by [`WorkflowDef::add_step`]; the inner index is private so a
+/// `StepRef` cannot be forged or dangle within the workflow that created it.
+/// (Mixing a `StepRef` across two different `WorkflowDef`s is the one misuse the
+/// type cannot prevent; [`crate::compile`] still range-checks every index.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StepRef(pub(crate) usize);
+
+impl StepRef {
+    /// The underlying step index (its insertion order in the [`WorkflowDef`]).
+    #[inline]
+    #[must_use]
+    pub const fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// The role a step plays in the workflow — the axis that drives `critic_for`
+/// and `is_topology_shaper` on the compiled [`kx_mote::MoteDef`].
+///
+/// Modelled as an enum so the critic/shaper mutual exclusion (executor refusal
+/// R-8: a Mote may not be both a critic and a topology shaper) is
+/// *unrepresentable* — a step is exactly one of these.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StepRole {
+    /// An ordinary producer step. `critic_for = None`, `is_topology_shaper = false`.
+    Plain,
+    /// A critic for `producer` (the `ValidateThenCommit` 3c pattern, D20). The
+    /// compiled `MoteDef.critic_for` is set to the producer's derived `MoteId`.
+    /// The producer MUST precede this step in the DAG (declare a dependency
+    /// edge from producer to critic), or compilation fails with
+    /// [`crate::CompileError::InvalidCritic`].
+    Critic {
+        /// The step this critic validates.
+        producer: StepRef,
+    },
+    /// A topology shaper (`is_topology_shaper = true`). Its children are NOT
+    /// static compile output — at runtime the shaper commits a
+    /// [`kx_mote::TopologyDecision`] and the projection materializes children
+    /// deterministically (D23/D37). Here the step is only marked as a shaper;
+    /// the dynamic unroll is exercised against the runtime materializer.
+    TopologyShaper,
+}
+
+/// One authored step (agent): everything needed to build its
+/// [`kx_mote::MoteDef`] EXCEPT the per-instance position (`graph_position`) and
+/// committed-input identity (`input_data_id`), which [`crate::compile`] derives
+/// from the DAG. Carries the `warrant` + `capability` through to submission.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StepDef {
+    /// Hash of the compiled artifact backing this step's logic.
+    pub logic_ref: LogicRef,
+    /// Pinned model identity (inclusive of version + quantization).
+    pub model_id: ModelId,
+    /// Hash of the system/prompt template the step uses.
+    pub prompt_template_hash: PromptTemplateHash,
+    /// The closed set of tools the step may call, each at its pinned version.
+    pub tool_contract: BTreeMap<ToolName, ToolVersion>,
+    /// The non-determinism class — recovery semantics + tiering derive from it.
+    pub nd_class: NdClass,
+    /// Behavior-affecting configuration allowlist (operational keys excluded).
+    pub config_subset: BTreeMap<ConfigKey, ConfigVal>,
+    /// Which effect/commit pattern this step uses.
+    pub effect_pattern: EffectPattern,
+    /// Decoding parameters (participate in identity, D50). Seed lives here.
+    pub inference_params: InferenceParams,
+    /// The step's role (plain / critic / topology shaper).
+    pub role: StepRole,
+    /// The warrant the step runs under, carried verbatim to submission.
+    pub warrant: WarrantSpec,
+    /// The capability a WORLD-MUTATING / READ-ONLY-NONDET dispatch routes
+    /// through (PURE steps ignore it), carried verbatim to submission.
+    pub capability: ToolName,
+}
+
+/// A declared directed dependency edge (`parent` → `child`) carrying
+/// [`kx_mote::EdgeMeta`] (Data / Control, cascade semantics).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StepEdge {
+    /// The upstream step.
+    pub parent: StepRef,
+    /// The downstream step that depends on `parent`.
+    pub child: StepRef,
+    /// The kind of dependency (Data / Control) + cascade metadata.
+    pub edge: EdgeMeta,
+}
+
+/// A Morphic workflow authored as plain, deterministically-ordered data.
+///
+/// Step insertion order and the `seed` are identity-bearing (they feed
+/// `graph_position` and entrypoint `input_data_id`). Build one with
+/// [`WorkflowDef::new`], [`WorkflowDef::add_step`], and [`WorkflowDef::add_edge`],
+/// then [`crate::compile`] it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowDef {
+    pub(crate) steps: Vec<StepDef>,
+    pub(crate) edges: Vec<StepEdge>,
+    pub(crate) seed: u32,
+}
+
+impl WorkflowDef {
+    /// Create an empty workflow with the given workflow-input `seed`. The seed
+    /// is folded into every entrypoint step's `input_data_id`, so two workflows
+    /// identical except for their seed produce different `MoteId`s — the basis
+    /// of reproducible-by-reference synthesis (D50).
+    #[inline]
+    #[must_use]
+    pub const fn new(seed: u32) -> Self {
+        Self {
+            steps: Vec::new(),
+            edges: Vec::new(),
+            seed,
+        }
+    }
+
+    /// Append a step, returning its [`StepRef`] handle.
+    pub fn add_step(&mut self, step: StepDef) -> StepRef {
+        let idx = self.steps.len();
+        self.steps.push(step);
+        StepRef(idx)
+    }
+
+    /// Declare a `parent` → `child` dependency edge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CompileError::StepIndexOutOfRange`] if either ref is not
+    /// a step in this workflow, or [`crate::CompileError::DuplicateEdge`] if the
+    /// same `(parent, child)` pair was already declared.
+    pub fn add_edge(
+        &mut self,
+        parent: StepRef,
+        child: StepRef,
+        edge: EdgeMeta,
+    ) -> Result<(), crate::CompileError> {
+        let n = self.steps.len();
+        if parent.0 >= n {
+            return Err(crate::CompileError::StepIndexOutOfRange(parent.0));
+        }
+        if child.0 >= n {
+            return Err(crate::CompileError::StepIndexOutOfRange(child.0));
+        }
+        if self
+            .edges
+            .iter()
+            .any(|e| e.parent == parent && e.child == child)
+        {
+            return Err(crate::CompileError::DuplicateEdge {
+                parent: parent.0,
+                child: child.0,
+            });
+        }
+        self.edges.push(StepEdge {
+            parent,
+            child,
+            edge,
+        });
+        Ok(())
+    }
+
+    /// The number of steps declared so far.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.steps.len()
+    }
+
+    /// `true` if no steps have been declared.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+
+    /// The workflow-input seed.
+    #[inline]
+    #[must_use]
+    pub const fn seed(&self) -> u32 {
+        self.seed
+    }
+}
+
+/// One compiled step ready to submit: a derived [`Mote`] plus the warrant and
+/// capability carried from its [`StepDef`].
+///
+/// Structurally mirrors `kx_runtime::WorkflowMote`, so a [`CompiledWorkflow`]'s
+/// motes drop directly into the scheduler's submission surface.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompiledMote {
+    /// The derived Mote (identity already computed by [`Mote::new`]).
+    pub mote: Mote,
+    /// The warrant the Mote runs under.
+    pub warrant: WarrantSpec,
+    /// The capability a WM/ROND dispatch routes through.
+    pub capability: ToolName,
+}
+
+/// The result of [`crate::compile`]: the compiled motes in topological
+/// (submission) order, plus a [`MoteGraph`] view for DAG queries and tests.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompiledWorkflow {
+    /// Compiled motes in topological order — also the order to submit them.
+    pub motes: Vec<CompiledMote>,
+    /// The same motes as a `kx-mote` graph container (nodes + parent edges).
+    pub graph: MoteGraph,
+}

--- a/crates/kx-workflow/src/error.rs
+++ b/crates/kx-workflow/src/error.rs
@@ -1,0 +1,46 @@
+//! [`CompileError`] — the closed vocabulary of ways a [`crate::WorkflowDef`]
+//! can fail to compile into a Mote DAG.
+//!
+//! Every variant names a *structural* defect detected by the pure
+//! [`crate::compile`] pass — never an I/O or runtime failure (compilation does
+//! neither). The variants are exhaustive: a `WorkflowDef` that triggers none of
+//! them compiles to a well-formed, acyclic DAG.
+
+use thiserror::Error;
+
+/// A structural defect that prevents a [`crate::WorkflowDef`] from compiling
+/// into a valid Mote DAG.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CompileError {
+    /// An edge (or a critic's producer reference) names a step index that does
+    /// not exist in the workflow. Carries the offending index.
+    #[error("step index {0} is out of range for this workflow")]
+    StepIndexOutOfRange(usize),
+
+    /// The declared edges form a cycle. A Mote's identity derives from its
+    /// committed inputs, so the execution graph MUST be acyclic — loops are
+    /// expressed at runtime via topology shapers, not as static cycles.
+    /// Carries one step index that participates in the unresolved cycle.
+    #[error("workflow DAG contains a cycle involving step {0}")]
+    Cycle(usize),
+
+    /// A critic step references a producer that is not a (transitive)
+    /// predecessor — the producer's `MoteId` is not yet known when the critic
+    /// is compiled. Add a dependency edge from the producer to the critic.
+    #[error("critic step {critic} references producer step {producer}, which does not precede it")]
+    InvalidCritic {
+        /// The critic step's index.
+        critic: usize,
+        /// The referenced producer step's index.
+        producer: usize,
+    },
+
+    /// The same `(parent, child)` edge was declared more than once.
+    #[error("duplicate edge from step {parent} to step {child}")]
+    DuplicateEdge {
+        /// The parent step's index.
+        parent: usize,
+        /// The child step's index.
+        child: usize,
+    },
+}

--- a/crates/kx-workflow/src/lib.rs
+++ b/crates/kx-workflow/src/lib.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-workflow` — the kortecx workflow engine, codename **Morphic** (P4.1).
+//!
+//! Morphic sits *above* the scheduler. It takes a declarative multi-agent
+//! workflow — authored as data ([`WorkflowDef`]: steps joined by typed edges) —
+//! and [`compile`]s it into a **Mote DAG** the runtime can execute. It only
+//! *emits* `kx-mote` + `kx-warrant` types; it never reaches into the scheduler,
+//! projection, or executor (the P2 thesis test: distribution is wiring, not a
+//! rewrite, and the engine that builds work is layered above the engine that
+//! runs it).
+//!
+//! # Why "Morphic"
+//!
+//! The *executed* graph physically changes shape as it runs. Agentic loops,
+//! conditional branches, and runtime-decided fan-out are NOT static cycles —
+//! they are expressed via **topology shapers** (`kx_mote::TopologyDecision`,
+//! D23/D37): a `ReadOnlyNondet` Mote commits a declarative decision and the
+//! projection materializes children deterministically. Each iteration is a
+//! fresh Mote with a distinct `graph_position`, so the executed graph is always
+//! an unrolled, replay-deterministic DAG. The graph *morphs* — hence Morphic.
+//!
+//! # Determinism is the contract
+//!
+//! [`compile`] is pure and total: the same [`WorkflowDef`] yields byte-identical
+//! `MoteId`s across runs, processes, and machines. That makes a compiled
+//! workflow a *reproducible program* — pin the seed + model + inference params
+//! and a synthetic corpus regenerates bit-for-bit (D50). Identity is always
+//! derived, never hand-assigned, and matched by exact cryptographic equality
+//! (SN-8) — never similarity.
+//!
+//! # Shape
+//!
+//! - [`WorkflowDef`] / [`StepDef`] / [`StepRole`] / [`StepEdge`] / [`StepRef`] —
+//!   the authoring surface (workflow as data).
+//! - [`compile`] → [`CompiledWorkflow`] of [`CompiledMote`]s (mote + warrant +
+//!   capability), in topological submission order.
+//! - [`synthesis_pipeline`] + the [`generator`] / [`transform`] / [`critic`] /
+//!   [`topology_shaper`] builders — the concrete data-synthesis recipe.
+
+#![forbid(unsafe_code)]
+// Pedantic lints kept as warnings workspace-wide; these few are noise for this
+// crate's shape (mirrors the allow-set used by `kx-warrant`).
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate
+)]
+// Inline test modules are exempt from the workspace deny on unwrap/expect.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod compile;
+mod def;
+mod error;
+mod synthesis;
+
+pub use compile::compile;
+pub use def::{CompiledMote, CompiledWorkflow, StepDef, StepEdge, StepRef, StepRole, WorkflowDef};
+pub use error::CompileError;
+pub use synthesis::{
+    critic, generator, permissive_warrant, synthesis_pipeline, topology_shaper, transform,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/kx-workflow/src/synthesis.rs
+++ b/crates/kx-workflow/src/synthesis.rs
@@ -1,0 +1,215 @@
+//! Ergonomic builders for the common Morphic step kinds, plus the concrete
+//! **data-synthesis recipe** ([`synthesis_pipeline`]) the P4.1 spec calls out:
+//! generator → transform → deterministic critic → content-addressed corpus.
+//!
+//! The builders pick the `nd_class` / `effect_pattern` combination that the
+//! executor's refusal predicates accept for each role, so authors don't have to
+//! memorize them (e.g. R-14 forbids a WORLD-MUTATING topology shaper — the
+//! shaper builder is READ-ONLY-NONDET). Returned [`StepDef`]s have public
+//! fields, so anything the builder defaults can be overridden afterwards.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_content::ContentRef;
+use kx_mote::{
+    EdgeMeta, EffectPattern, InferenceParams, LogicRef, ModelId, NdClass, PromptTemplateHash,
+    ToolName,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+use crate::def::{StepDef, StepRef, StepRole, WorkflowDef};
+use crate::error::CompileError;
+
+/// A permissive warrant suitable for local, single-process development and
+/// tests — every axis is wide open. The broker/executor seams still enforce
+/// structurally; this warrant simply narrows nothing.
+///
+/// Model-route limits are deliberately positive: the topology materializer
+/// narrows a shaper's warrant against each child role via `kx_warrant::intersect`,
+/// which rejects a zeroed model route as invalid.
+#[must_use]
+pub fn permissive_warrant(model_id: ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 4096,
+            max_output_tokens: 4096,
+            max_calls: 16,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// Build a [`StepDef`] for the given role with sensible defaults (zeroed prompt
+/// template, empty tool contract + config, greedy inference params). Callers
+/// override any public field on the result as needed.
+fn step(
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    nd_class: NdClass,
+    effect_pattern: EffectPattern,
+    role: StepRole,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    StepDef {
+        logic_ref,
+        model_id,
+        prompt_template_hash: PromptTemplateHash::from_bytes([0; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class,
+        config_subset: BTreeMap::new(),
+        effect_pattern,
+        inference_params: InferenceParams::default(),
+        role,
+        warrant,
+        capability,
+    }
+}
+
+/// A generator step: samples new content (READ-ONLY-NONDET, `StageThenCommit`).
+/// Its committed `result_ref` IS the generated payload.
+#[must_use]
+pub fn generator(
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    step(
+        logic_ref,
+        model_id,
+        NdClass::ReadOnlyNondet,
+        EffectPattern::StageThenCommit,
+        StepRole::Plain,
+        warrant,
+        capability,
+    )
+}
+
+/// A transform step: a deterministic function of its inputs (PURE,
+/// `IdempotentByConstruction`).
+#[must_use]
+pub fn transform(
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    step(
+        logic_ref,
+        model_id,
+        NdClass::Pure,
+        EffectPattern::IdempotentByConstruction,
+        StepRole::Plain,
+        warrant,
+        capability,
+    )
+}
+
+/// A critic step validating `producer`: a deterministic check (PURE,
+/// `IdempotentByConstruction`) — schema / dedup / stat-bounds / PII-leakage.
+/// Declare a dependency edge from `producer` to this step so the producer
+/// precedes it in the DAG.
+#[must_use]
+pub fn critic(
+    producer: StepRef,
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    step(
+        logic_ref,
+        model_id,
+        NdClass::Pure,
+        EffectPattern::IdempotentByConstruction,
+        StepRole::Critic { producer },
+        warrant,
+        capability,
+    )
+}
+
+/// A topology shaper (READ-ONLY-NONDET; R-14 forbids WORLD-MUTATING shapers).
+/// At runtime it commits a `TopologyDecision` from which the projection
+/// materializes children deterministically — its dynamic fan-out is not static
+/// compile output.
+#[must_use]
+pub fn topology_shaper(
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    step(
+        logic_ref,
+        model_id,
+        NdClass::ReadOnlyNondet,
+        EffectPattern::IdempotentByConstruction,
+        StepRole::TopologyShaper,
+        warrant,
+        capability,
+    )
+}
+
+/// The canonical data-synthesis recipe wired as a [`WorkflowDef`]:
+///
+/// ```text
+/// generator (ROND) ──data──> transform (PURE) ──data──> critic (PURE)
+/// ```
+///
+/// Reproducible by construction: pin the workflow `seed` (folded into the
+/// generator's entrypoint `input_data_id`) plus each step's model + inference
+/// params (folded into its `mote_def_hash`, D50) and the whole corpus
+/// regenerates byte-identically. The three `logic_ref`s name the generator,
+/// transform, and critic logic respectively.
+///
+/// # Errors
+///
+/// Propagates [`CompileError`] from edge declaration (it never fails for this
+/// fixed three-step shape, but the signature keeps edge wiring honest).
+pub fn synthesis_pipeline(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    gen_logic: LogicRef,
+    transform_logic: LogicRef,
+    critic_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    let warrant = permissive_warrant(model_id.clone());
+    let mut wf = WorkflowDef::new(seed);
+
+    let g = wf.add_step(generator(
+        gen_logic,
+        model_id.clone(),
+        warrant.clone(),
+        capability.clone(),
+    ));
+    let t = wf.add_step(transform(
+        transform_logic,
+        model_id.clone(),
+        warrant.clone(),
+        capability.clone(),
+    ));
+    let c = wf.add_step(critic(t, critic_logic, model_id, warrant, capability));
+
+    wf.add_edge(g, t, EdgeMeta::data())?;
+    wf.add_edge(t, c, EdgeMeta::data())?;
+    Ok(wf)
+}

--- a/crates/kx-workflow/src/tests.rs
+++ b/crates/kx-workflow/src/tests.rs
@@ -1,0 +1,173 @@
+//! Unit tests for the Morphic compile pass: determinism, seed sensitivity,
+//! topological soundness, cycle/critic validation, and role flags.
+
+use kx_mote::{EdgeMeta, LogicRef, ModelId, NdClass, ToolName};
+
+use crate::def::StepRef;
+use crate::{
+    compile, critic, permissive_warrant, synthesis_pipeline, topology_shaper, transform,
+    CompileError, WorkflowDef,
+};
+
+fn model() -> ModelId {
+    ModelId("local".into())
+}
+fn cap() -> ToolName {
+    ToolName("demo".into())
+}
+fn warrant() -> kx_warrant::WarrantSpec {
+    permissive_warrant(model())
+}
+fn logic(seed: u8) -> LogicRef {
+    LogicRef::from_bytes([seed; 32])
+}
+
+#[test]
+fn empty_workflow_compiles_to_empty() {
+    let wf = WorkflowDef::new(0);
+    let out = compile(&wf).unwrap();
+    assert!(out.motes.is_empty());
+    assert!(out.graph.is_empty());
+}
+
+#[test]
+fn compile_is_deterministic() {
+    let wf = synthesis_pipeline(7, model(), cap(), logic(1), logic(2), logic(3)).unwrap();
+    let a = compile(&wf).unwrap();
+    let b = compile(&wf).unwrap();
+    let ids_a: Vec<_> = a.motes.iter().map(|m| m.mote.id).collect();
+    let ids_b: Vec<_> = b.motes.iter().map(|m| m.mote.id).collect();
+    assert_eq!(ids_a, ids_b);
+    assert_eq!(a.motes.len(), 3);
+}
+
+#[test]
+fn seed_changes_identity() {
+    let wf1 = synthesis_pipeline(1, model(), cap(), logic(1), logic(2), logic(3)).unwrap();
+    let wf2 = synthesis_pipeline(2, model(), cap(), logic(1), logic(2), logic(3)).unwrap();
+    let a = compile(&wf1).unwrap();
+    let b = compile(&wf2).unwrap();
+    // The entrypoint generator's identity folds the workflow seed, and the
+    // change propagates down the lineage to every descendant.
+    for (x, y) in a.motes.iter().zip(b.motes.iter()) {
+        assert_ne!(
+            x.mote.id, y.mote.id,
+            "every MoteId must shift with the seed"
+        );
+    }
+}
+
+#[test]
+fn topo_order_places_parents_before_children() {
+    let wf = synthesis_pipeline(0, model(), cap(), logic(1), logic(2), logic(3)).unwrap();
+    let out = compile(&wf).unwrap();
+    let pos: std::collections::BTreeMap<_, _> = out
+        .motes
+        .iter()
+        .enumerate()
+        .map(|(i, m)| (m.mote.id, i))
+        .collect();
+    for (i, m) in out.motes.iter().enumerate() {
+        for parent in &m.mote.parents {
+            let pi = pos[&parent.parent_id];
+            assert!(pi < i, "parent must be submitted before its child");
+        }
+    }
+}
+
+#[test]
+fn parents_all_exist_in_graph() {
+    let wf = synthesis_pipeline(0, model(), cap(), logic(1), logic(2), logic(3)).unwrap();
+    let out = compile(&wf).unwrap();
+    for m in &out.motes {
+        for parent in &m.mote.parents {
+            assert!(
+                out.graph.get(&parent.parent_id).is_some(),
+                "every declared parent must be a node in the graph"
+            );
+        }
+    }
+}
+
+#[test]
+fn critic_resolves_to_producer_mote_id() {
+    let wf = synthesis_pipeline(0, model(), cap(), logic(1), logic(2), logic(3)).unwrap();
+    let out = compile(&wf).unwrap();
+    // The transform carries logic_ref [2; 32]; the critic validates it.
+    let transform_id = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(2))
+        .map(|m| m.mote.id)
+        .unwrap();
+    let critic = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.critic_for.is_some())
+        .unwrap();
+    assert_eq!(critic.mote.def.critic_for, Some(transform_id));
+}
+
+#[test]
+fn topology_shaper_is_flagged_and_read_only_nondet() {
+    let mut wf = WorkflowDef::new(0);
+    wf.add_step(topology_shaper(logic(9), model(), warrant(), cap()));
+    let out = compile(&wf).unwrap();
+    let shaper = &out.motes[0].mote;
+    assert!(shaper.def.is_topology_shaper);
+    assert_eq!(shaper.nd_class(), NdClass::ReadOnlyNondet);
+}
+
+#[test]
+fn cycle_is_rejected() {
+    let mut wf = WorkflowDef::new(0);
+    let a = wf.add_step(transform(logic(1), model(), warrant(), cap()));
+    let b = wf.add_step(transform(logic(2), model(), warrant(), cap()));
+    wf.add_edge(a, b, EdgeMeta::data()).unwrap();
+    wf.add_edge(b, a, EdgeMeta::data()).unwrap();
+    assert!(matches!(compile(&wf), Err(CompileError::Cycle(_))));
+}
+
+#[test]
+fn duplicate_edge_is_rejected_at_declaration() {
+    let mut wf = WorkflowDef::new(0);
+    let a = wf.add_step(transform(logic(1), model(), warrant(), cap()));
+    let b = wf.add_step(transform(logic(2), model(), warrant(), cap()));
+    wf.add_edge(a, b, EdgeMeta::data()).unwrap();
+    assert_eq!(
+        wf.add_edge(a, b, EdgeMeta::data()),
+        Err(CompileError::DuplicateEdge {
+            parent: 0,
+            child: 1
+        })
+    );
+}
+
+#[test]
+fn out_of_range_edge_is_rejected() {
+    let mut wf = WorkflowDef::new(0);
+    let a = wf.add_step(transform(logic(1), model(), warrant(), cap()));
+    // StepRef(5) does not exist.
+    assert_eq!(
+        wf.add_edge(a, StepRef(5), EdgeMeta::data()),
+        Err(CompileError::StepIndexOutOfRange(5))
+    );
+}
+
+#[test]
+fn critic_whose_producer_does_not_precede_is_rejected() {
+    // Critic at index 0 references a producer at index 1 with NO ordering edge.
+    // The min-index frontier processes the critic first, before the producer's
+    // MoteId is known → InvalidCritic.
+    let mut wf = WorkflowDef::new(0);
+    let producer_ref = StepRef(1);
+    wf.add_step(critic(producer_ref, logic(3), model(), warrant(), cap()));
+    wf.add_step(transform(logic(2), model(), warrant(), cap()));
+    assert_eq!(
+        compile(&wf),
+        Err(CompileError::InvalidCritic {
+            critic: 0,
+            producer: 1
+        })
+    );
+}

--- a/crates/kx-workflow/tests/compile_determinism.rs
+++ b/crates/kx-workflow/tests/compile_determinism.rs
@@ -1,0 +1,70 @@
+//! Property test: random valid DAGs compile deterministically (identical
+//! `MoteId`s across two compiles) and always to a well-formed DAG (every parent
+//! precedes its child and exists in the graph).
+//!
+//! Integration tests compile as their own crate, so this file carries its own
+//! lint exemptions (the workspace deny on unwrap/expect applies to library code).
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use kx_mote::{EdgeMeta, LogicRef, ModelId, ToolName};
+use kx_workflow::{compile, permissive_warrant, transform, StepRef, WorkflowDef};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+fn build(seed: u32, n: usize, edges: &[(usize, usize)]) -> WorkflowDef {
+    let model = ModelId("local".into());
+    let cap = ToolName("demo".into());
+    let warrant = permissive_warrant(model.clone());
+    let mut wf = WorkflowDef::new(seed);
+    let mut refs: Vec<StepRef> = Vec::with_capacity(n);
+    for i in 0..n {
+        refs.push(wf.add_step(transform(
+            LogicRef::from_bytes([i as u8; 32]),
+            model.clone(),
+            warrant.clone(),
+            cap.clone(),
+        )));
+    }
+    for &(a, b) in edges {
+        // Only parent<child edges → guaranteed acyclic. Duplicate edges are
+        // rejected at declaration; ignore those so the property still holds.
+        if a < n && b < n && a < b {
+            let _ = wf.add_edge(refs[a], refs[b], EdgeMeta::data());
+        }
+    }
+    wf
+}
+
+proptest! {
+    #[test]
+    fn random_dags_compile_deterministically(
+        seed in any::<u32>(),
+        n in 1usize..8,
+        raw_edges in proptest::collection::vec((0usize..8, 0usize..8), 0..24),
+    ) {
+        let wf = build(seed, n, &raw_edges);
+
+        let a = compile(&wf).unwrap();
+        let b = compile(&wf).unwrap();
+
+        // Determinism: byte-identical MoteId sequences.
+        let ids_a: Vec<_> = a.motes.iter().map(|m| m.mote.id).collect();
+        let ids_b: Vec<_> = b.motes.iter().map(|m| m.mote.id).collect();
+        prop_assert_eq!(ids_a, ids_b);
+        prop_assert_eq!(a.motes.len(), n);
+
+        // Well-formed: parents precede children and exist in the graph.
+        let pos: BTreeMap<_, _> = a
+            .motes
+            .iter()
+            .enumerate()
+            .map(|(i, m)| (m.mote.id, i))
+            .collect();
+        for (i, m) in a.motes.iter().enumerate() {
+            for parent in &m.mote.parents {
+                prop_assert!(a.graph.get(&parent.parent_id).is_some());
+                prop_assert!(pos[&parent.parent_id] < i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## P4.1a — `kx-workflow` (codename **Morphic**)

First step of **Phase P4** (platform layer). Introduces the workflow engine that sits *above* the scheduler and compiles a declarative multi-agent workflow into a deterministic **Mote DAG**.

### What
- **New crate `kx-workflow`** — emits `kx-mote` + `kx-warrant` types only; **no production dep on `kx-scheduler`/`kx-projection`/`kx-executor`** (P2 thesis test holds).
- **`compile(&WorkflowDef) -> Result<CompiledWorkflow, CompileError>`** — pure / total / deterministic. Same `WorkflowDef` → **byte-identical `MoteId`s** across runs/processes/machines (`BTreeMap` throughout, explicit min-index Kahn topo order, parents canonically sorted by `MoteId`, identity bytes from the definition alone). A compiled workflow is a *reproducible program* (basis of synthesis-by-recipe, D50).
- **Authoring as data:** `WorkflowDef` / `StepDef` / `StepRole` (`Plain` | `Critic{producer}` | `TopologyShaper` — critic/shaper mutual exclusion made *unrepresentable*) / `StepEdge` / `StepRef`.
- **Output:** `CompiledMote{mote, warrant, capability}` (mirrors `kx_runtime::WorkflowMote`, drops into `Scheduler::submit`) + `CompiledWorkflow{motes, graph: MoteGraph}`.
- **`synthesis.rs`** — the concrete data-synthesis recipe (generator → transform → deterministic critic) + ergonomic builders that pick the `nd_class`/`effect_pattern` each role's refusal predicates accept (e.g. R-14 → shapers are READ-ONLY-NONDET).

### Why a DAG (not arbitrary graphs)
`MoteId = blake3(mote_def_hash ‖ input_data_id ‖ graph_position)` and `input_data_id` derives from parents — a cycle would make identity depend on its own output. Loops / branches / fan-out are **not** static cycles; they unroll at runtime via **topology shapers** (D23/D37). A shaper step here is marked `is_topology_shaper`; its dynamic children are runtime-materialized (exercised in P4.1b).

### Tested
- 11 unit tests: determinism, seed-sensitivity, topo soundness (parents before children), parents-exist, critic→producer `MoteId` resolution, shaper flagged + ROND, and rejection of cycles / duplicate edges / out-of-range refs / critic-before-producer.
- Proptest sweeping random valid DAGs for compile determinism + DAG well-formedness.
- Local gate green: `fmt` · `clippy --all-targets -D warnings` · `test` · `doc -D warnings` · `cargo deny check`.

### Notes for review
- **Sign-off flag #1 (entrypoint `InputDataId`):** entrypoint input id = `blake3(workflow seed ‖ topo rank)`; per `kx-mote/src/id.rs` an entrypoint's input id IS the BLAKE3 of a workflow-input seed and "the workflow SDK (P4) is the blessed place to compute it." Child input ids are a stable compile-time value derived from parent lineage; the runtime executor owns the authoritative derivation from committed `result_ref`s.

Part of the P4 arc: P4.1b (e2e run + shaper unroll) · P4.1c (`kx-dataset` seam) · P4.1d (graph-RAG nondet Mote) · P4.1e (Delta-style sharing manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)