### PR TITLE
feat(kx-workflow): P4.1b e2e run through kx-runtime + deterministic shaper unroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,12 @@ version = "0.0.1"
 dependencies = [
  "blake3",
  "kx-content",
+ "kx-executor",
+ "kx-journal",
  "kx-mote",
+ "kx-projection",
+ "kx-runtime",
+ "kx-scheduler",
  "kx-warrant",
  "proptest",
  "smallvec",

--- a/crates/kx-workflow/Cargo.toml
+++ b/crates/kx-workflow/Cargo.toml
@@ -30,6 +30,16 @@ thiserror  = { workspace = true }
 [dev-dependencies]
 # Property-based determinism sweep over random valid DAGs.
 proptest = { workspace = true }
+# End-to-end: drive a compiled PURE workflow through the real single-node runtime
+# primitives to Committed, and reuse the production topology child derivation to
+# prove deterministic shaper unroll. DEV-ONLY — kx-workflow keeps NO production
+# dependency on the scheduler/executor/projection (the thesis test).
+kx-runtime    = { workspace = true }
+kx-scheduler  = { workspace = true }
+kx-projection = { workspace = true }
+kx-journal    = { workspace = true }
+kx-executor   = { workspace = true }
+kx-content    = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kx-workflow/tests/end_to_end_run.rs
+++ b/crates/kx-workflow/tests/end_to_end_run.rs
@@ -1,0 +1,109 @@
+//! End-to-end: a Morphic-compiled PURE workflow drives through the real
+//! single-node runtime primitives (`Scheduler::submit` → `run_pure_mote`) to
+//! `Committed`, and two independent runs produce a byte-identical journal
+//! digest. This closes the loop: workflow source → Mote DAG → run → reproducible
+//! committed state.
+//!
+//! Integration tests compile as their own crate; this file carries its own lint
+//! exemptions. `kx-runtime`/`kx-scheduler`/etc. are DEV-only deps — kx-workflow
+//! keeps no production dependency on them (the thesis test).
+#![allow(clippy::unwrap_used)]
+
+use kx_executor::{run_pure_mote, LocalResourceManager, TestMoteExecutor};
+use kx_journal::SqliteJournal;
+use kx_mote::{EdgeMeta, LogicRef, ModelId, ToolName};
+use kx_projection::Projection;
+use kx_runtime::digest_journal;
+use kx_scheduler::{LocalPlacement, Scheduler};
+use kx_workflow::{compile, permissive_warrant, transform, CompiledWorkflow, WorkflowDef};
+
+/// A 3-step all-PURE chain: A ──data──> B ──data──> C. PURE so no broker /
+/// capability wiring is needed and the committed journal is fully deterministic.
+fn pure_chain() -> WorkflowDef {
+    let model = ModelId("local".into());
+    let cap = ToolName("demo".into());
+    let warrant = permissive_warrant(model.clone());
+    let mut wf = WorkflowDef::new(42);
+    let a = wf.add_step(transform(
+        LogicRef::from_bytes([1; 32]),
+        model.clone(),
+        warrant.clone(),
+        cap.clone(),
+    ));
+    let b = wf.add_step(transform(
+        LogicRef::from_bytes([2; 32]),
+        model.clone(),
+        warrant.clone(),
+        cap.clone(),
+    ));
+    let c = wf.add_step(transform(
+        LogicRef::from_bytes([3; 32]),
+        model,
+        warrant,
+        cap,
+    ));
+    wf.add_edge(a, b, EdgeMeta::data()).unwrap();
+    wf.add_edge(b, c, EdgeMeta::data()).unwrap();
+    wf
+}
+
+/// Submit every compiled mote to a fresh scheduler+projection (exercising the
+/// real submission surface), run each PURE mote to commit, then digest the
+/// resulting journal. Returns `(digest_hex, committed_count)`.
+fn run_pure_workflow(compiled: &CompiledWorkflow) -> (String, usize) {
+    let journal = SqliteJournal::open_in_memory().unwrap();
+    let rm = LocalResourceManager::dev_defaults();
+    let executor = TestMoteExecutor::deterministic();
+
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    for cm in &compiled.motes {
+        scheduler
+            .submit(cm.mote.clone(), cm.warrant.clone(), &mut projection)
+            .unwrap();
+    }
+    // Compiled motes are in topological order, so running them in sequence
+    // respects dependencies.
+    for cm in &compiled.motes {
+        run_pure_mote(&cm.mote, &cm.warrant, &journal, &rm, &executor).unwrap();
+    }
+
+    let digest = digest_journal(&journal).unwrap();
+    let committed = Projection::from_journal(&journal)
+        .unwrap()
+        .committed_count();
+    (digest.to_hex(), committed)
+}
+
+#[test]
+fn compiled_pure_workflow_runs_and_is_reproducible() {
+    let wf = pure_chain();
+    let c1 = compile(&wf).unwrap();
+    let c2 = compile(&wf).unwrap();
+
+    let (digest_a, committed_a) = run_pure_workflow(&c1);
+    let (digest_b, committed_b) = run_pure_workflow(&c2);
+
+    assert_eq!(committed_a, 3, "all three PURE motes must commit");
+    assert_eq!(committed_b, 3);
+    assert_eq!(
+        digest_a, digest_b,
+        "two independent runs of the compiled workflow must yield a byte-identical committed digest"
+    );
+}
+
+#[test]
+fn compiled_motes_submit_in_dependency_order() {
+    // The scheduler accepts every compiled mote (parents already submitted
+    // earlier in topological order), confirming the output plugs into the
+    // submission surface without reordering.
+    let wf = pure_chain();
+    let compiled = compile(&wf).unwrap();
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    for cm in &compiled.motes {
+        assert!(scheduler
+            .submit(cm.mote.clone(), cm.warrant.clone(), &mut projection)
+            .is_ok());
+    }
+}

--- a/crates/kx-workflow/tests/shaper_unroll.rs
+++ b/crates/kx-workflow/tests/shaper_unroll.rs
@@ -1,0 +1,64 @@
+//! A Morphic-compiled topology shaper unrolls into deterministic children:
+//! given the shaper's committed `TopologyDecision`, the production
+//! `kx_runtime::topology::derive_child_motes` re-derives byte-identical child
+//! `MoteId`s across re-derivation (the replay guarantee), and the children fold
+//! in the shaper's committed `result_ref` (so a different decision → different
+//! children). This is how loops / branches / fan-out express as a runtime DAG.
+#![allow(clippy::unwrap_used)]
+
+use kx_content::ContentRef;
+use kx_mote::{LogicRef, ModelId, ToolName};
+use kx_runtime::topology::{demo_topology_decision, derive_child_motes, encode_topology_decision};
+use kx_workflow::{compile, permissive_warrant, topology_shaper, WorkflowDef};
+
+#[test]
+fn compiled_shaper_unrolls_deterministically() {
+    let model = ModelId("local".into());
+    let cap = ToolName("demo".into());
+    let warrant = permissive_warrant(model.clone());
+
+    // Compile a one-step workflow whose only step is a topology shaper.
+    let mut wf = WorkflowDef::new(0);
+    wf.add_step(topology_shaper(
+        LogicRef::from_bytes([9; 32]),
+        model,
+        warrant.clone(),
+        cap.clone(),
+    ));
+    let compiled = compile(&wf).unwrap();
+    let shaper = &compiled.motes[0].mote;
+    assert!(shaper.def.is_topology_shaper);
+
+    // The shaper's committed result IS a TopologyDecision; its content-ref is
+    // what child identity folds in.
+    let decision = demo_topology_decision();
+    let result_ref = ContentRef::of(&encode_topology_decision(&decision).unwrap());
+
+    let children_a = derive_child_motes(shaper, result_ref, &decision, &warrant, &cap);
+    let children_b = derive_child_motes(shaper, result_ref, &decision, &warrant, &cap);
+    let ids_a: Vec<_> = children_a.iter().map(|w| w.mote.id).collect();
+    let ids_b: Vec<_> = children_b.iter().map(|w| w.mote.id).collect();
+
+    assert_eq!(ids_a.len(), decision.children.len());
+    assert!(ids_a.len() >= 2, "the demo decision fans out to ≥2 workers");
+    assert_eq!(
+        ids_a, ids_b,
+        "re-derivation (replay) must produce byte-identical child MoteIds"
+    );
+
+    // Children are PURE workers parented on the shaper (control edge).
+    for w in &children_a {
+        assert_eq!(w.mote.parents.len(), 1);
+        assert_eq!(w.mote.parents[0].parent_id, shaper.id);
+    }
+
+    // Sensitivity: a different committed decision result_ref → different child
+    // identities (child MoteId folds in the shaper's committed result).
+    let other_ref = ContentRef::from_bytes([0xAB; 32]);
+    let children_c = derive_child_motes(shaper, other_ref, &decision, &warrant, &cap);
+    let ids_c: Vec<_> = children_c.iter().map(|w| w.mote.id).collect();
+    assert_ne!(
+        ids_a, ids_c,
+        "child identity must fold the shaper's committed result_ref"
+    );
+}


### PR DESCRIPTION
## P4.1b — Morphic e2e + shaper unroll

Second step of the P4.1 foundation. Proves a **Morphic-compiled workflow actually runs** on the real single-node runtime, and that its **dynamic shaper unroll is replay-deterministic** — closing the loop: workflow source → Mote DAG → run → reproducible committed state.

### `tests/end_to_end_run.rs`
- A 3-step all-PURE chain (A→B→C, data edges) is compiled, every `CompiledMote` submitted via the real **`Scheduler::submit`** (exercising the submission surface), then each PURE mote run via **`run_pure_mote`** to `Committed` over an in-memory journal.
- **Two independent runs → byte-identical `digest_journal` digest** (reproducibility) and all three motes commit.
- A second test asserts compiled motes submit cleanly in topological order.

### `tests/shaper_unroll.rs`
- A compiled **topology-shaper** step, fed a committed `TopologyDecision`, is unrolled by the production **`kx_runtime::topology::derive_child_motes`**.
- Re-derivation yields **byte-identical child `MoteId`s** (the replay guarantee); children are PURE workers parented on the shaper; a **different committed `result_ref` → different children** (child identity folds in the shaper's committed result). This is how loops / branches / fan-out express as a runtime DAG.

### Notes
- `kx-runtime`/`kx-scheduler`/`kx-projection`/`kx-journal`/`kx-executor`/`kx-content` are added as **DEV-only deps** — kx-workflow keeps **no production dependency** on them (thesis test holds).
- PURE-only by design (no broker/WM wiring); the journal is fully deterministic via `TestMoteExecutor::deterministic`.
- Local gate green: fmt · clippy `--all-targets -D warnings` · test (15 total: 11 unit + 1 proptest + 3 integration).

Next in the P4.1 arc: P4.1c (`kx-dataset` seam) · P4.1d (graph-RAG nondet Mote) · P4.1e (sharing manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)