### PR TITLE
feat(kx-dataset): P4.1c journal-authoritative data-management seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-dataset"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "kx-content",
+ "kx-mote",
+ "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "kx-executor"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/kx-worker",
     "crates/kx-chaos",
     "crates/kx-workflow",
+    "crates/kx-dataset",
 ]
 exclude = [
     "kx-cloud",
@@ -96,6 +97,9 @@ kx-runtime           = { path = "crates/kx-runtime",           version = "0.0.1"
 # The workflow engine (codename Morphic, P4.1) — compiles a WorkflowDef to a
 # Mote DAG. Sits above the scheduler; emits kx-mote + kx-warrant types only.
 kx-workflow          = { path = "crates/kx-workflow",          version = "0.0.1" }
+# The data-management seam (P4.1c) — typed (tensor/vector/blob/multi-modal)
+# DataStore/Dataset/RetrievalIndex over committed content; journal-authoritative.
+kx-dataset           = { path = "crates/kx-dataset",           version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-dataset/Cargo.toml
+++ b/crates/kx-dataset/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name         = "kx-dataset"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx data-management seam (P4.1c) — a pluggable, JOURNAL-AUTHORITATIVE data layer for the Morphic engine. Types committed content (tensor / vector / blob / multi-modal) behind a DataStore/Dataset/RetrievalIndex trait surface; the layer is a reconstructible, queryable projection/cache of committed content — never a second source of truth (lose it → rebuild by replay). Similarity (RetrievalIndex) is confined to the ReadOnlyNondet retrieval boundary (SN-8: never on the identity/commit path). In-memory impls ship now; a Lance backend (vectors+tensors+blobs+Delta versioning) is a later gated step behind the same traits."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Content-addressed identity the typed records + datasets are keyed by.
+kx-content = { workspace = true }
+# MoteId — dataset lineage (which Motes produced the corpus).
+kx-mote    = { workspace = true }
+# Tensor shape / dataset rows stack-inline storage.
+smallvec   = { workspace = true }
+# Content-addressed Dataset identity + typed-ref hashing.
+blake3     = { workspace = true }
+# Persistence-friendly derives on the schema / typed-ref / dataset types.
+serde      = { workspace = true }
+thiserror  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-dataset/src/error.rs
+++ b/crates/kx-dataset/src/error.rs
@@ -1,0 +1,17 @@
+//! [`DataError`] — the data-layer error vocabulary.
+
+use thiserror::Error;
+
+/// An error from a [`crate::DataStore`] operation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum DataError {
+    /// No payload is stored at the requested [`kx_content::ContentRef`]. Because
+    /// the data layer is journal-authoritative (a cache/projection of committed
+    /// content), a miss is recoverable by re-folding committed content.
+    #[error("no payload stored at the requested content ref")]
+    NotFound,
+
+    /// The store's lock was poisoned by a panic in another thread.
+    #[error("data store lock poisoned")]
+    Poisoned,
+}

--- a/crates/kx-dataset/src/index.rs
+++ b/crates/kx-dataset/src/index.rs
@@ -1,0 +1,115 @@
+//! [`RetrievalIndex`] — the vector / graph-RAG similarity seam.
+//!
+//! **SN-8 boundary (load-bearing).** Similarity search lives here, and it MUST
+//! stay *inside* the ReadOnlyNondet retrieval boundary: a retrieval Mote queries
+//! an index as an input-gathering act, then commits its result as a
+//! content-addressed fact that everything downstream consumes by **exact** hash.
+//! Similarity is NEVER an operator on the identity / commit / memoization path
+//! (the runtime matches by exact cryptographic equality only). An approximate
+//! (ANN) backend is non-deterministic by nature — another reason it is confined
+//! behind this trait and never folded into a `MoteId`.
+//!
+//! [`InMemoryRetrievalIndex`] is an exact brute-force scan (deterministic,
+//! suitable for tests + small corpora); a real ANN/Lance backend implements the
+//! same trait in a later gated step.
+
+use kx_content::ContentRef;
+
+/// One retrieval result: a content ref and its similarity score (higher = closer).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Hit {
+    /// The retrieved payload's content-addressed identity.
+    pub id: ContentRef,
+    /// Cosine similarity in `[-1, 1]` (exact backend) or an approximate score.
+    pub score: f32,
+}
+
+/// A similarity index over embedding vectors, keyed by content ref. Used ONLY
+/// inside ReadOnlyNondet retrieval Motes (see the module note / SN-8).
+pub trait RetrievalIndex {
+    /// Add (or overwrite) the vector for `id`.
+    fn insert(&mut self, id: ContentRef, vector: Vec<f32>);
+
+    /// Return the `k` nearest entries to `query`, highest score first.
+    /// Dimension-mismatched entries are skipped.
+    fn query(&self, query: &[f32], k: usize) -> Vec<Hit>;
+
+    /// Number of indexed vectors.
+    fn len(&self) -> usize;
+
+    /// `true` if the index is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An exact brute-force cosine-similarity index. Deterministic: ties break by
+/// ascending content ref, so identical inputs yield an identical result order.
+#[derive(Default)]
+pub struct InMemoryRetrievalIndex {
+    items: Vec<(ContentRef, Vec<f32>)>,
+}
+
+impl InMemoryRetrievalIndex {
+    /// Create an empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Cosine similarity; `0.0` if either vector has zero norm or the dimensions
+/// differ.
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom == 0.0 {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+impl RetrievalIndex for InMemoryRetrievalIndex {
+    fn insert(&mut self, id: ContentRef, vector: Vec<f32>) {
+        if let Some(slot) = self.items.iter_mut().find(|(existing, _)| *existing == id) {
+            slot.1 = vector;
+        } else {
+            self.items.push((id, vector));
+        }
+    }
+
+    fn query(&self, query: &[f32], k: usize) -> Vec<Hit> {
+        let mut scored: Vec<Hit> = self
+            .items
+            .iter()
+            .map(|(id, v)| Hit {
+                id: *id,
+                score: cosine(query, v),
+            })
+            .collect();
+        // Deterministic order: score descending (total_cmp handles NaN/ties
+        // totally), then ascending content ref as the stable tiebreak.
+        scored.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.id.as_bytes().cmp(b.id.as_bytes()))
+        });
+        scored.truncate(k);
+        scored
+    }
+
+    fn len(&self) -> usize {
+        self.items.len()
+    }
+}

--- a/crates/kx-dataset/src/lib.rs
+++ b/crates/kx-dataset/src/lib.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-dataset` — the kortecx data-management seam (P4.1c).
+//!
+//! A pluggable, **journal-authoritative** data layer for the Morphic engine
+//! (`kx-workflow`). It types committed content — tensors, vectors, blobs, text,
+//! and forward-stubbed multi-modal payloads — behind a small trait surface, and
+//! it is always a *reconstructible projection/cache* of committed content, never
+//! a second source of truth. Lose the store and it rebuilds by re-folding
+//! committed content; correctness lives in the journal (D40) + content
+//! addressing (D17), not here.
+//!
+//! # Shape
+//!
+//! - [`ContentSchema`] / [`TypedRef`] / [`TensorDType`] — the typed-ref hook that
+//!   lets transforms + critics reason over multi-modal content (the multi-modal
+//!   layer, P10, extends the enum).
+//! - [`DataStore`] + [`InMemoryDataStore`] — store/read typed payloads by content
+//!   ref. A Lance backend (vectors + tensors + blobs + Delta versioning) is a
+//!   later gated step behind the same trait.
+//! - [`Dataset`] / [`DatasetId`] — a content-addressed corpus of typed rows + the
+//!   Motes that produced it; its identity is a **pure function** of rows +
+//!   lineage (reproducible-by-reference — the recipe-as-product / Delta-sharing
+//!   basis, P4.1e).
+//! - [`RetrievalIndex`] + [`InMemoryRetrievalIndex`] — the vector / graph-RAG
+//!   similarity seam. **Used ONLY inside ReadOnlyNondet retrieval Motes** — the
+//!   runtime matches by exact cryptographic equality (SN-8); similarity never
+//!   touches the identity / commit / memoization path.
+
+#![forbid(unsafe_code)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod error;
+mod index;
+mod schema;
+mod store;
+
+pub use error::DataError;
+pub use index::{Hit, InMemoryRetrievalIndex, RetrievalIndex};
+pub use schema::{ContentSchema, TensorDType, TypedRef};
+pub use store::{DataStore, Dataset, DatasetId, InMemoryDataStore};
+
+#[cfg(test)]
+mod tests;

--- a/crates/kx-dataset/src/schema.rs
+++ b/crates/kx-dataset/src/schema.rs
@@ -1,0 +1,121 @@
+//! [`ContentSchema`] — the typed-ref hook that lets the Morphic engine reason
+//! over multi-modal committed content (tensors, vectors, blobs, text, and
+//! forward-stubbed image/audio) without parsing the bytes.
+//!
+//! A [`TypedRef`] pairs a content-addressed [`ContentRef`] with its schema, so
+//! transforms and critics can type-check over a corpus. The enum is extensible:
+//! a new data type is one variant — the forward seam the data-platform threads
+//! (multi-modal, P10) and the Lance backend (P9) build on.
+
+use kx_content::ContentRef;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+/// The element type of a tensor payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TensorDType {
+    /// 32-bit IEEE float.
+    F32,
+    /// 16-bit IEEE float.
+    F16,
+    /// bfloat16.
+    BF16,
+    /// 64-bit signed integer.
+    I64,
+    /// 32-bit signed integer.
+    I32,
+    /// unsigned byte.
+    U8,
+    /// boolean (one byte per element).
+    Bool,
+}
+
+impl TensorDType {
+    /// Stable u8 tag for content-addressed hashing. MUST NOT change without a
+    /// schema-version bump.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        match self {
+            TensorDType::F32 => 0,
+            TensorDType::F16 => 1,
+            TensorDType::BF16 => 2,
+            TensorDType::I64 => 3,
+            TensorDType::I32 => 4,
+            TensorDType::U8 => 5,
+            TensorDType::Bool => 6,
+        }
+    }
+}
+
+/// The declared type of a content-addressed payload. Opaque to the byte store;
+/// the data layer uses it to type-check and to route retrieval.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContentSchema {
+    /// Untyped bytes.
+    Blob,
+    /// UTF-8 text.
+    Text,
+    /// A JSON document.
+    Json,
+    /// A dense tensor of `dtype` with the given row-major `shape`.
+    Tensor {
+        /// Element type.
+        dtype: TensorDType,
+        /// Dimensions, row-major. Empty = scalar.
+        shape: SmallVec<[u64; 4]>,
+    },
+    /// An embedding vector of `dim` `f32`s (the retrieval/RAG payload).
+    Vector {
+        /// Dimensionality.
+        dim: u32,
+    },
+    /// An image payload (forward stub for the multi-modal layer, P10).
+    Image,
+    /// An audio payload (forward stub for the multi-modal layer, P10).
+    Audio,
+}
+
+impl ContentSchema {
+    /// Fold the schema into a hasher canonically (stable tag + parameters).
+    /// Used by [`crate::Dataset::id`] so a dataset's identity is a pure function
+    /// of its rows.
+    pub(crate) fn hash_into(&self, h: &mut blake3::Hasher) {
+        match self {
+            ContentSchema::Blob => {
+                h.update(&[0]);
+            }
+            ContentSchema::Text => {
+                h.update(&[1]);
+            }
+            ContentSchema::Json => {
+                h.update(&[2]);
+            }
+            ContentSchema::Tensor { dtype, shape } => {
+                h.update(&[3, dtype.as_u8()]);
+                h.update(&(shape.len() as u64).to_le_bytes());
+                for dim in shape {
+                    h.update(&dim.to_le_bytes());
+                }
+            }
+            ContentSchema::Vector { dim } => {
+                h.update(&[4]);
+                h.update(&dim.to_le_bytes());
+            }
+            ContentSchema::Image => {
+                h.update(&[5]);
+            }
+            ContentSchema::Audio => {
+                h.update(&[6]);
+            }
+        }
+    }
+}
+
+/// A content-addressed payload tagged with its [`ContentSchema`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TypedRef {
+    /// The content-addressed identity of the payload bytes.
+    pub content_ref: ContentRef,
+    /// The declared type of those bytes.
+    pub schema: ContentSchema,
+}

--- a/crates/kx-dataset/src/store.rs
+++ b/crates/kx-dataset/src/store.rs
@@ -1,0 +1,164 @@
+//! [`DataStore`] — the pluggable, journal-authoritative data-management seam —
+//! and [`Dataset`] — a content-addressed corpus of typed rows with lineage.
+//!
+//! **Journal-authoritative.** A `DataStore` is a reconstructible, queryable
+//! projection/cache of *committed* content — never a second source of truth.
+//! Lose the store and it rebuilds by re-folding committed content; correctness
+//! lives in the journal (D40) + content-addressing (D17), not here. Accordingly
+//! a [`Dataset`]'s identity ([`Dataset::id`]) is a **pure function of its content
+//! refs + lineage** — independent of any store instance — so a corpus
+//! regenerated on another machine has the same `DatasetId`.
+//!
+//! [`InMemoryDataStore`] is the OSS-default backend; a Lance backend
+//! (vectors + tensors + blobs + Delta versioning) is a later gated step behind
+//! this same trait.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use kx_content::ContentRef;
+use kx_mote::MoteId;
+
+use crate::error::DataError;
+use crate::schema::{ContentSchema, TypedRef};
+
+/// A pluggable typed store over content-addressed payloads. Methods take `&self`
+/// (interior mutability) so a store can be shared (`Arc<dyn DataStore>`) by, e.g.,
+/// a retrieval Mote — without granting it write authority over the journal.
+pub trait DataStore {
+    /// Store `bytes` tagged with `schema`, returning the content-addressed
+    /// [`TypedRef`]. Idempotent on the bytes (same bytes → same ref).
+    ///
+    /// # Errors
+    /// [`DataError::Poisoned`] if the store's lock was poisoned.
+    fn put_typed(&self, bytes: &[u8], schema: ContentSchema) -> Result<TypedRef, DataError>;
+
+    /// Read the payload + schema at `r`.
+    ///
+    /// # Errors
+    /// [`DataError::NotFound`] if absent; [`DataError::Poisoned`] on a poisoned lock.
+    fn get(&self, r: &ContentRef) -> Result<(Vec<u8>, ContentSchema), DataError>;
+
+    /// The schema declared for `r`, if present.
+    fn schema_of(&self, r: &ContentRef) -> Option<ContentSchema>;
+
+    /// `true` if a payload is stored at `r`.
+    fn contains(&self, r: &ContentRef) -> bool;
+}
+
+/// A 32-byte content-addressed identity of a [`Dataset`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DatasetId(pub [u8; 32]);
+
+impl DatasetId {
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for DatasetId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DatasetId({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+/// A content-addressed corpus: an ordered set of typed rows plus the Motes that
+/// produced it (lineage/provenance). Its [`Dataset::id`] is pure over the rows +
+/// lineage, so the corpus is reproducible-by-reference (the recipe-as-product /
+/// Delta-sharing basis, P4.1e).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Dataset {
+    /// The typed rows, in their canonical (identity-bearing) order.
+    pub rows: Vec<TypedRef>,
+    /// The Motes whose committed output produced this corpus (provenance).
+    pub lineage: Vec<MoteId>,
+}
+
+impl Dataset {
+    /// Build a dataset from its rows + lineage.
+    #[must_use]
+    pub fn new(rows: Vec<TypedRef>, lineage: Vec<MoteId>) -> Self {
+        Self { rows, lineage }
+    }
+
+    /// The content-addressed identity — a **pure** function of rows + lineage.
+    /// Two byte-identical corpora (anywhere, any machine) share a `DatasetId`.
+    #[must_use]
+    pub fn id(&self) -> DatasetId {
+        let mut h = blake3::Hasher::new();
+        h.update(b"kx-dataset/dataset-id/v1");
+        h.update(&(self.rows.len() as u64).to_le_bytes());
+        for row in &self.rows {
+            h.update(row.content_ref.as_bytes());
+            row.schema.hash_into(&mut h);
+        }
+        h.update(&(self.lineage.len() as u64).to_le_bytes());
+        for mote in &self.lineage {
+            h.update(mote.as_bytes());
+        }
+        DatasetId(*h.finalize().as_bytes())
+    }
+
+    /// Number of rows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// `true` if the corpus has no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+/// The OSS-default in-memory [`DataStore`]. A `BTreeMap` keyed by content ref;
+/// suitable for tests and single-process runs. Drop it and rebuild from
+/// committed content — nothing authoritative lives here.
+#[derive(Default)]
+pub struct InMemoryDataStore {
+    inner: Mutex<BTreeMap<ContentRef, (Vec<u8>, ContentSchema)>>,
+}
+
+impl InMemoryDataStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl DataStore for InMemoryDataStore {
+    fn put_typed(&self, bytes: &[u8], schema: ContentSchema) -> Result<TypedRef, DataError> {
+        let content_ref = ContentRef::of(bytes);
+        let mut guard = self.inner.lock().map_err(|_| DataError::Poisoned)?;
+        guard.insert(content_ref, (bytes.to_vec(), schema.clone()));
+        Ok(TypedRef {
+            content_ref,
+            schema,
+        })
+    }
+
+    fn get(&self, r: &ContentRef) -> Result<(Vec<u8>, ContentSchema), DataError> {
+        let guard = self.inner.lock().map_err(|_| DataError::Poisoned)?;
+        guard.get(r).cloned().ok_or(DataError::NotFound)
+    }
+
+    fn schema_of(&self, r: &ContentRef) -> Option<ContentSchema> {
+        let guard = self.inner.lock().ok()?;
+        guard.get(r).map(|(_, schema)| schema.clone())
+    }
+
+    fn contains(&self, r: &ContentRef) -> bool {
+        self.inner
+            .lock()
+            .map(|g| g.contains_key(r))
+            .unwrap_or(false)
+    }
+}

--- a/crates/kx-dataset/src/tests.rs
+++ b/crates/kx-dataset/src/tests.rs
@@ -1,0 +1,148 @@
+//! Unit tests: typed store roundtrip + schema typing, dataset identity purity +
+//! journal-authoritative reconstruction, and deterministic retrieval ordering.
+
+use kx_content::ContentRef;
+use kx_mote::MoteId;
+use smallvec::smallvec;
+
+use crate::{
+    ContentSchema, DataStore, Dataset, InMemoryDataStore, InMemoryRetrievalIndex, RetrievalIndex,
+    TensorDType, TypedRef,
+};
+
+#[test]
+fn datastore_roundtrip_and_schema_typing() {
+    let store = InMemoryDataStore::new();
+    let schema = ContentSchema::Tensor {
+        dtype: TensorDType::F32,
+        shape: smallvec![2, 3],
+    };
+    let bytes = b"\x00\x01\x02\x03payload";
+
+    let typed = store.put_typed(bytes, schema.clone()).unwrap();
+    assert_eq!(typed.content_ref, ContentRef::of(bytes));
+    assert_eq!(typed.schema, schema);
+    assert!(store.contains(&typed.content_ref));
+    assert_eq!(store.schema_of(&typed.content_ref), Some(schema.clone()));
+
+    let (got_bytes, got_schema) = store.get(&typed.content_ref).unwrap();
+    assert_eq!(got_bytes, bytes);
+    assert_eq!(got_schema, schema);
+
+    // Idempotent on the bytes.
+    let again = store.put_typed(bytes, schema).unwrap();
+    assert_eq!(again.content_ref, typed.content_ref);
+}
+
+#[test]
+fn missing_ref_is_not_found() {
+    let store = InMemoryDataStore::new();
+    let missing = ContentRef::from_bytes([9; 32]);
+    assert!(!store.contains(&missing));
+    assert!(store.get(&missing).is_err());
+    assert_eq!(store.schema_of(&missing), None);
+}
+
+/// A dataset's identity is a PURE function of its rows + lineage — independent
+/// of any store. Rebuilding the store from the same committed content
+/// reconstructs the same DatasetId (journal-authoritative: the store is a
+/// cache, the corpus identity is durable-by-reference).
+#[test]
+fn dataset_id_is_pure_and_reconstructible() {
+    let schema = ContentSchema::Vector { dim: 3 };
+    let mk = |store: &InMemoryDataStore| -> Dataset {
+        let a = store.put_typed(b"row-a", schema.clone()).unwrap();
+        let b = store.put_typed(b"row-b", schema.clone()).unwrap();
+        Dataset::new(vec![a, b], vec![MoteId::from_bytes([7; 32])])
+    };
+
+    // Two independent stores fed the same committed content → same DatasetId.
+    let id1 = mk(&InMemoryDataStore::new()).id();
+    let id2 = mk(&InMemoryDataStore::new()).id();
+    assert_eq!(
+        id1, id2,
+        "DatasetId must be reproducible across store instances"
+    );
+
+    // And id() does not depend on a store at all — pure over rows + lineage.
+    let rows = vec![
+        TypedRef {
+            content_ref: ContentRef::of(b"row-a"),
+            schema: schema.clone(),
+        },
+        TypedRef {
+            content_ref: ContentRef::of(b"row-b"),
+            schema,
+        },
+    ];
+    let storeless = Dataset::new(rows, vec![MoteId::from_bytes([7; 32])]).id();
+    assert_eq!(id1, storeless);
+}
+
+#[test]
+fn dataset_id_is_sensitive_to_rows_and_lineage() {
+    let s = ContentSchema::Blob;
+    let base = Dataset::new(
+        vec![TypedRef {
+            content_ref: ContentRef::of(b"x"),
+            schema: s.clone(),
+        }],
+        vec![MoteId::from_bytes([1; 32])],
+    );
+    let diff_row = Dataset::new(
+        vec![TypedRef {
+            content_ref: ContentRef::of(b"y"),
+            schema: s.clone(),
+        }],
+        vec![MoteId::from_bytes([1; 32])],
+    );
+    let diff_lineage = Dataset::new(
+        vec![TypedRef {
+            content_ref: ContentRef::of(b"x"),
+            schema: s,
+        }],
+        vec![MoteId::from_bytes([2; 32])],
+    );
+    assert_ne!(base.id(), diff_row.id());
+    assert_ne!(base.id(), diff_lineage.id());
+}
+
+#[test]
+fn retrieval_is_deterministic_and_orders_by_similarity() {
+    let mut index = InMemoryRetrievalIndex::new();
+    let near = ContentRef::of(b"near");
+    let mid = ContentRef::of(b"mid");
+    let far = ContentRef::of(b"far");
+    index.insert(near, vec![1.0, 0.0, 0.0]);
+    index.insert(mid, vec![0.7, 0.7, 0.0]);
+    index.insert(far, vec![0.0, 0.0, 1.0]);
+
+    let q = [1.0, 0.0, 0.0];
+    let hits = index.query(&q, 3);
+    assert_eq!(hits.len(), 3);
+    assert_eq!(hits[0].id, near, "closest vector ranks first");
+    assert_eq!(hits[1].id, mid);
+    assert_eq!(hits[2].id, far);
+
+    // Deterministic across calls.
+    assert_eq!(index.query(&q, 3), hits);
+
+    // top-k truncation.
+    assert_eq!(index.query(&q, 1).len(), 1);
+    assert_eq!(index.query(&q, 1)[0].id, near);
+}
+
+#[test]
+fn retrieval_skips_dimension_mismatch() {
+    let mut index = InMemoryRetrievalIndex::new();
+    let ok = ContentRef::of(b"ok");
+    let wrong = ContentRef::of(b"wrong");
+    index.insert(ok, vec![1.0, 0.0]);
+    index.insert(wrong, vec![1.0, 0.0, 0.0]); // different dim → cosine 0.0
+
+    let hits = index.query(&[1.0, 0.0], 2);
+    assert_eq!(hits[0].id, ok);
+    // The mismatched entry scores 0.0 and ranks last.
+    assert_eq!(hits[1].id, wrong);
+    assert!(hits[0].score > hits[1].score);
+}


### PR DESCRIPTION
## P4.1c — `kx-dataset` (data-management seam)

Third step of the P4.1 foundation. A new born-compliant crate: the pluggable **data layer** for the Morphic engine, designed so the tensor/vector/multi-modal data-platform threads (synthesis, graph-RAG, Delta-sharing, Lance) all hang off one trait surface.

### Journal-authoritative
A `DataStore` is a **reconstructible projection/cache of committed content — never a second source of truth.** Lose it → rebuild by re-folding committed content; correctness lives in the journal (D40) + content-addressing (D17), not here. Accordingly a `Dataset`'s identity (`DatasetId`) is a **pure function of its rows + lineage**, independent of any store instance — so a corpus regenerated on another machine has the same `DatasetId` (the recipe-as-product / Delta-sharing basis, P4.1e).

### Modules
- **`schema.rs`** — `ContentSchema` (`Blob`/`Text`/`Json`/`Tensor{dtype,shape}`/`Vector{dim}`/`Image`/`Audio` — extensible; `Image`/`Audio` are forward stubs for the multi-modal layer, P10) + `TensorDType` + `TypedRef`.
- **`store.rs`** — `DataStore` trait (`&self` interior mutability → composes as `Arc<dyn DataStore>` without journal write authority) + `InMemoryDataStore`; `Dataset` + `DatasetId`.
- **`index.rs`** — `RetrievalIndex` trait (the vector / graph-RAG seam) + a deterministic exact brute-force `InMemoryRetrievalIndex`.

### SN-8 boundary (load-bearing)
`RetrievalIndex` similarity is used **ONLY inside ReadOnlyNondet retrieval Motes** — its output becomes a content-addressed fact consumed downstream by exact hash. Similarity **never** touches the identity / commit / memoization path. An ANN/Lance backend (non-deterministic by nature) is confined behind this trait in a later gated step (PR9).

### Tested (6)
Typed roundtrip + schema typing · not-found · **`DatasetId` purity + cross-store reconstruction** (journal-authoritative) · `DatasetId` sensitivity to rows/lineage · deterministic similarity ordering · dimension-mismatch skip. Full gate green: fmt · clippy `--all-targets -D warnings` · test · doc `-D warnings` · cargo-deny.

Forward seams consumed by: PR4 (graph-RAG nondet Mote → `RetrievalIndex`), PR5 (sharing manifest → `Dataset`), PR9 (Lance backend), PR10 (multi-modal schemas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)