### PR TITLE
feat(kx-workflow): P4.1d graph-RAG as a ReadOnlyNondet retrieval Mote (SN-8-safe)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ version = "0.0.1"
 dependencies = [
  "blake3",
  "kx-content",
+ "kx-dataset",
  "kx-executor",
  "kx-journal",
  "kx-mote",

--- a/crates/kx-workflow/Cargo.toml
+++ b/crates/kx-workflow/Cargo.toml
@@ -21,6 +21,9 @@ kx-warrant = { workspace = true }
 # ContentRef — a WarrantSpec field type (syscall_profile_ref / environment_ref);
 # needed to construct the convenience warrant.
 kx-content = { workspace = true }
+# The data-management seam: the graph-RAG retrieval Mote consumes
+# `kx_dataset::RetrievalIndex` + commits a content-addressed result over `Hit`s.
+kx-dataset = { workspace = true }
 # Parent-edge storage matches kx-mote's `SmallVec<[ParentRef; 4]>`.
 smallvec   = { workspace = true }
 # Deterministic compile-time InputDataId derivation (entrypoint seed / child lineage).

--- a/crates/kx-workflow/src/lib.rs
+++ b/crates/kx-workflow/src/lib.rs
@@ -52,11 +52,13 @@
 mod compile;
 mod def;
 mod error;
+mod retrieval;
 mod synthesis;
 
 pub use compile::compile;
 pub use def::{CompiledMote, CompiledWorkflow, StepDef, StepEdge, StepRef, StepRole, WorkflowDef};
 pub use error::CompileError;
+pub use retrieval::{encode_retrieval_fact, retrieval, retrieval_result_ref};
 pub use synthesis::{
     critic, generator, permissive_warrant, synthesis_pipeline, topology_shaper, transform,
 };

--- a/crates/kx-workflow/src/retrieval.rs
+++ b/crates/kx-workflow/src/retrieval.rs
@@ -1,0 +1,68 @@
+//! Graph-RAG / vector retrieval as a **`ReadOnlyNondet` Mote** — the SN-8-safe
+//! way to bring similarity search into a Morphic workflow.
+//!
+//! A retrieval step reads a [`kx_dataset::RetrievalIndex`] (a nondeterministic,
+//! similarity-based read of the world) and commits its result as a
+//! **content-addressed fact**; everything downstream consumes that fact by
+//! **exact** hash. The similarity lives entirely inside the Mote body — it is
+//! NEVER an operator on the identity / commit / memoization path (the runtime
+//! matches by exact cryptographic equality only, SN-8).
+//!
+//! The committed fact is the ORDERED set of retrieved content refs — **scores
+//! are deliberately excluded** ([`encode_retrieval_fact`]). Two index states
+//! that return the same neighbours produce the same fact regardless of the
+//! float similarity scores, so similarity cannot leak into a `MoteId`.
+
+use kx_content::ContentRef;
+use kx_dataset::Hit;
+use kx_mote::{EffectPattern, LogicRef, ModelId, NdClass, ToolName};
+use kx_warrant::WarrantSpec;
+
+use crate::def::{StepDef, StepRole};
+use crate::synthesis::step;
+
+/// A retrieval step: a graph-RAG / vector lookup modelled as a `ReadOnlyNondet`
+/// Mote whose committed `result_ref` is the retrieved set. ROND because which
+/// neighbours come back depends on the (mutable) index state — a nondet read;
+/// `StageThenCommit` because the retrieved set is staged then committed as the
+/// Mote's fact. The similarity search itself is the Mote's runtime logic
+/// (`logic_ref`), confined behind the SN-8 boundary.
+#[must_use]
+pub fn retrieval(
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    step(
+        logic_ref,
+        model_id,
+        NdClass::ReadOnlyNondet,
+        EffectPattern::StageThenCommit,
+        StepRole::Plain,
+        warrant,
+        capability,
+    )
+}
+
+/// Canonical bytes of a retrieval RESULT — the ordered content refs only.
+///
+/// **Scores are excluded by design.** Similarity stays inside the retrieval
+/// Mote; the committed fact is the neighbour *set*, matched downstream by exact
+/// hash (SN-8). This is the one place the "similarity in, exact fact out"
+/// boundary is enforced in code.
+#[must_use]
+pub fn encode_retrieval_fact(hits: &[Hit]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(hits.len().saturating_mul(32));
+    for hit in hits {
+        out.extend_from_slice(hit.id.as_bytes());
+    }
+    out
+}
+
+/// The content-addressed identity of a retrieval result — what downstream Motes
+/// consume by exact hash. Pure over the retrieved ref set (scores excluded).
+#[must_use]
+pub fn retrieval_result_ref(hits: &[Hit]) -> ContentRef {
+    ContentRef::of(&encode_retrieval_fact(hits))
+}

--- a/crates/kx-workflow/src/synthesis.rs
+++ b/crates/kx-workflow/src/synthesis.rs
@@ -59,7 +59,7 @@ pub fn permissive_warrant(model_id: ModelId) -> WarrantSpec {
 /// Build a [`StepDef`] for the given role with sensible defaults (zeroed prompt
 /// template, empty tool contract + config, greedy inference params). Callers
 /// override any public field on the result as needed.
-fn step(
+pub(crate) fn step(
     logic_ref: LogicRef,
     model_id: ModelId,
     nd_class: NdClass,

--- a/crates/kx-workflow/tests/retrieval_mote.rs
+++ b/crates/kx-workflow/tests/retrieval_mote.rs
@@ -1,0 +1,98 @@
+//! Graph-RAG as a `ReadOnlyNondet` retrieval Mote, and the SN-8 boundary: the
+//! committed retrieval fact is the neighbour SET (exact content refs), with
+//! similarity scores excluded — so similarity never reaches a `MoteId`.
+#![allow(clippy::unwrap_used)]
+
+use kx_content::ContentRef;
+use kx_dataset::{Hit, InMemoryRetrievalIndex, RetrievalIndex};
+use kx_mote::{LogicRef, ModelId, NdClass, ToolName};
+use kx_workflow::{
+    compile, encode_retrieval_fact, permissive_warrant, retrieval, retrieval_result_ref,
+    WorkflowDef,
+};
+
+fn model() -> ModelId {
+    ModelId("local".into())
+}
+
+#[test]
+fn retrieval_step_compiles_to_read_only_nondet_mote() {
+    let warrant = permissive_warrant(model());
+    let mut wf = WorkflowDef::new(0);
+    wf.add_step(retrieval(
+        LogicRef::from_bytes([7; 32]),
+        model(),
+        warrant,
+        ToolName("rag".into()),
+    ));
+    let compiled = compile(&wf).unwrap();
+    let mote = &compiled.motes[0].mote;
+    assert_eq!(
+        mote.nd_class(),
+        NdClass::ReadOnlyNondet,
+        "retrieval is a nondeterministic read — similarity stays inside the Mote body"
+    );
+    assert!(!mote.def.is_topology_shaper);
+}
+
+#[test]
+fn end_to_end_retrieval_produces_a_content_addressed_fact() {
+    // A real similarity query (inside the would-be Mote body) ...
+    let mut index = InMemoryRetrievalIndex::new();
+    let a = ContentRef::of(b"doc-a");
+    let b = ContentRef::of(b"doc-b");
+    index.insert(a, vec![1.0, 0.0]);
+    index.insert(b, vec![0.0, 1.0]);
+    let hits = index.query(&[1.0, 0.0], 2);
+
+    // ... yields an EXACT content-addressed fact downstream consumes by hash.
+    let fact_ref = retrieval_result_ref(&hits);
+    assert_eq!(fact_ref, ContentRef::of(&encode_retrieval_fact(&hits)));
+    // Deterministic: same hits → same fact.
+    assert_eq!(retrieval_result_ref(&hits), fact_ref);
+}
+
+#[test]
+fn similarity_scores_do_not_leak_into_the_committed_fact() {
+    // Two retrieval results with the SAME neighbour ids but DIFFERENT scores
+    // must produce the SAME committed fact — proof that similarity (the float
+    // score) never reaches the content-addressed identity (SN-8).
+    let id1 = ContentRef::of(b"n1");
+    let id2 = ContentRef::of(b"n2");
+    let high = [
+        Hit {
+            id: id1,
+            score: 0.99,
+        },
+        Hit {
+            id: id2,
+            score: 0.50,
+        },
+    ];
+    let low = [
+        Hit {
+            id: id1,
+            score: 0.11,
+        },
+        Hit {
+            id: id2,
+            score: 0.02,
+        },
+    ];
+    assert_eq!(
+        encode_retrieval_fact(&high),
+        encode_retrieval_fact(&low),
+        "scores must be excluded from the committed fact"
+    );
+    assert_eq!(retrieval_result_ref(&high), retrieval_result_ref(&low));
+
+    // A different neighbour SET, however, IS a different fact.
+    let different = [Hit {
+        id: ContentRef::of(b"n3"),
+        score: 0.99,
+    }];
+    assert_ne!(
+        retrieval_result_ref(&high),
+        retrieval_result_ref(&different)
+    );
+}


### PR DESCRIPTION
## P4.1d — graph-RAG as a ReadOnlyNondet retrieval Mote

Fourth step of the P4.1 foundation. Brings vector / graph-RAG retrieval into a Morphic workflow **without violating SN-8** (the runtime matches by exact cryptographic equality, never similarity).

### The SN-8-safe pattern
A retrieval step reads a `kx_dataset::RetrievalIndex` — a nondeterministic, similarity-based read of the world — and commits its result as a **content-addressed fact**; everything downstream consumes that fact by **exact** hash. Similarity lives entirely inside the Mote body; it is **never** an operator on the identity / commit / memoization path.

### `src/retrieval.rs`
- **`retrieval(...)`** — builds a `ReadOnlyNondet` + `StageThenCommit` step (ROND because returned neighbours depend on mutable index state; the similarity search is the Mote's runtime logic, behind the boundary).
- **`encode_retrieval_fact(hits)`** — canonical bytes of the retrieved set = **ordered content refs only**; similarity **scores are deliberately excluded**, so two index states returning the same neighbours produce the same committed fact regardless of float scores. This is where "similarity in, exact fact out" is enforced in code.
- **`retrieval_result_ref(hits)`** — the content-addressed identity downstream consumes by exact hash.

### Tested (3)
- retrieval step compiles to a **ROND** mote;
- end-to-end: a real index query → a content-addressed fact;
- **scores don't leak**: same neighbour ids + different scores → identical committed fact; different neighbour set → different fact.

### Notes
- kx-workflow gains a **production** dep on `kx-dataset` (a clean leaf — verified via `cargo tree` that production deps still contain no scheduler/executor/inference/projection/runtime; **thesis test holds**).
- Full gate green: fmt · clippy `--all-targets -D warnings` · test (18 total).

Last of the P4.1 foundation: PR5 (P4.1e) — Delta-style sharing manifest over `Dataset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)