### PR TITLE
feat(kx-critic): P4.2 deterministic-critic foundation (CriticVerdict + 4 checks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ kx-cloud/
 /06-*.md
 /07-*.md
 /CLAUDE.md
+# Local Claude Code agent state (plans, transcripts, settings) — never committed.
+/.claude/
 /docs/design/*.md
 /docs/suggestions/*.md
 # Plan files are private-only (SN-5: plans NEVER land in the public OSS repo).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-critic"
+version = "0.0.1"
+dependencies = [
+ "criterion",
+ "kx-critic-types",
+ "kx-dataset",
+ "proptest",
+ "regex",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
+name = "kx-critic-types"
+version = "0.0.1"
+dependencies = [
+ "bincode",
+ "blake3",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "kx-dataset"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ members = [
     "crates/kx-chaos",
     "crates/kx-workflow",
     "crates/kx-dataset",
+    "crates/kx-critic-types",
+    "crates/kx-critic",
 ]
 exclude = [
     "kx-cloud",
@@ -58,6 +60,12 @@ blake3             = "1"
 bytes              = { version = "1", features = ["serde"] }
 smallvec           = { version = "1", features = ["serde"] }
 serde              = { version = "1", features = ["derive"] }
+# JSON well-formedness for the kx-critic `Json` schema check (validation-only —
+# values are never decoded to floats, so no NaN/float-ordering on any path).
+serde_json         = "1"
+# Deterministic PII-class scanners (kx-critic). The regex engine is leftmost-first
+# and fully deterministic; patterns are compiled once via LazyLock.
+regex              = "1"
 proptest           = "1"
 tempfile           = "3"
 # Benchmark harness (dev-only). default-features off drops the html_reports
@@ -100,6 +108,13 @@ kx-workflow          = { path = "crates/kx-workflow",          version = "0.0.1"
 # The data-management seam (P4.1c) — typed (tensor/vector/blob/multi-modal)
 # DataStore/Dataset/RetrievalIndex over committed content; journal-authoritative.
 kx-dataset           = { path = "crates/kx-dataset",           version = "0.0.1" }
+# Deterministic-critic vocabulary (P4.2) — CriticVerdict / CriticReason / CheckSpec.
+# Parser-free + dataset-free so kx-mote can embed a CheckSpec in MoteDef without a
+# dependency cycle or inheriting regex/serde_json.
+kx-critic-types      = { path = "crates/kx-critic-types",      version = "0.0.1" }
+# Deterministic-critic evaluator (P4.2) — the pure/total evaluate(spec, bytes) ->
+# CriticVerdict over the four checks (schema / dedup / stat-bounds / PII-leakage).
+kx-critic            = { path = "crates/kx-critic",            version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-critic-types/Cargo.toml
+++ b/crates/kx-critic-types/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name         = "kx-critic-types"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx deterministic-critic VOCABULARY (P4.2) — the pure, parser-free type surface a critic Mote commits: CriticVerdict (the content-addressed trust FACT, SN-8: exact crypto-equality only), CriticReason (closed failure vocabulary, integer-scaled evidence — no floats on the identity/commit path), and CheckSpec (the four declarative deterministic checks: schema / dedup / stat-bounds / PII-leakage). Held separate from the kx-critic evaluator so kx-mote can carry a CheckSpec in MoteDef without inheriting parser deps (regex/serde_json) — and dataset-free (a self-contained SchemaTag mirror) so it sits below kx-dataset without a dependency cycle."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Canonical content-addressed encoding of the committed verdict (frozen
+# bincode v2, little-endian + fixed-int — byte-identical to
+# `kx_mote::canonical_config`, replicated here to keep this crate kx-mote-free).
+bincode   = { workspace = true }
+# CriticVerdict::content_ref_bytes — the verdict's content-addressed identity.
+blake3    = { workspace = true }
+# CheckSpec::hash_into stack-inline tensor shape (mirrors kx_dataset shape storage).
+smallvec  = { workspace = true }
+# Persistence-friendly derives on the spec / verdict / reason types.
+serde     = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-critic-types/src/lib.rs
+++ b/crates/kx-critic-types/src/lib.rs
@@ -1,0 +1,71 @@
+//! # kx-critic-types — the deterministic-critic vocabulary (P4.2)
+//!
+//! A **critic** is a Mote that reads an upstream producer's committed output and
+//! commits a *verdict*. P4.2 makes the common case — a **deterministic check** —
+//! a first-class, declarative, reproducible primitive. This crate is the pure
+//! **type surface** of that primitive; the evaluator that actually runs the
+//! checks lives in the sibling `kx-critic` crate.
+//!
+//! ## Why a separate types crate
+//!
+//! `kx-mote` (the core identity crate the whole workspace depends on) carries a
+//! [`CheckSpec`] inside `MoteDef` so a critic's check folds into its `MoteId`
+//! (reproducible by construction). `kx-mote` must NOT inherit the evaluator's
+//! parser dependencies (`regex` / `serde_json`), so the *types* are split out
+//! here. This crate depends only on `serde` / `bincode` / `blake3` / `smallvec`
+//! / `thiserror`.
+//!
+//! It is also deliberately **`kx-dataset`-free**: the schema check validates
+//! against a self-contained [`SchemaTag`] mirror of `kx_dataset::ContentSchema`,
+//! so this crate sits *below* `kx-dataset` (which itself depends on `kx-mote`)
+//! with no dependency cycle.
+//!
+//! ## SN-8 — model proposes, runtime enforces
+//!
+//! A [`CriticVerdict`] is a **content-addressed fact**: produced by exact
+//! deterministic evaluation and compared downstream by **byte-equality only**
+//! (never a similarity score). All evidence carried in [`CriticReason`] is
+//! integer-scaled — no floats ever touch the identity / commit / memoization
+//! path, preserving the no-float precondition of the canonical bincode hash.
+//!
+//! ## Determinism contract
+//!
+//! Every encoding here is a **pure, total** function of its input: the same
+//! value yields byte-identical [`CriticVerdict::encode`] output across runs,
+//! processes, and machines (no clock / host / PID / RNG / float-NaN ordering).
+//! [`CheckSpec::hash_into`] folds a spec into a `blake3::Hasher` with stable u8
+//! tags, little-endian integers, and canonical (`BTreeSet`-ordered) set
+//! iteration.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation
+)]
+// `.expect()` on canonical-bincode encode of a type WITHOUT floats and WITHOUT
+// non-encodable variants IS infallible. The single site (CriticVerdict::encode)
+// carries an inline message naming the precondition; this crate-level allow
+// suppresses the workspace `clippy::expect_used = "deny"` policy for that one
+// legitimate documented use (mirrors kx-mote's MoteDef::hash treatment).
+#![allow(clippy::expect_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+mod spec;
+mod verdict;
+
+#[cfg(test)]
+mod tests;
+
+pub use spec::{
+    CheckSpec, DedupSpec, PiiSpec, RecordFraming, SchemaSpec, SchemaTag, StatBoundsSpec,
+    TensorDTypeTag,
+};
+pub use verdict::{
+    canonical_config, CheckKind, CriticReason, CriticVerdict, PiiClass, SchemaFault, StatKind,
+    VerdictDecodeError, CRITIC_SCHEMA_VERSION,
+};

--- a/crates/kx-critic-types/src/spec.rs
+++ b/crates/kx-critic-types/src/spec.rs
@@ -1,0 +1,301 @@
+//! [`CheckSpec`] — a deterministic check declared as DATA. A critic Mote carries
+//! its `CheckSpec` so the check folds into the Mote's identity (reproducible by
+//! construction) and the runtime evaluates it in-process — no opaque binary.
+//!
+//! Illegal states unrepresentable: a [`CheckSpec`] is exactly one of the four
+//! kinds; every set field is a `BTreeSet` (canonical iteration order) and every
+//! numeric field is an integer (no floats on the identity path).
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+use crate::verdict::{CheckKind, PiiClass, StatKind};
+
+/// One deterministic check. The runtime evaluates exactly one of these against a
+/// producer's committed output bytes (see `kx_critic::evaluate`).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CheckSpec {
+    /// Validate that the output conforms to a declared [`SchemaTag`].
+    Schema(SchemaSpec),
+    /// Reject duplicate records under a declared framing + key.
+    Dedup(DedupSpec),
+    /// Reject when a declared aggregate leaves an inclusive integer bound.
+    StatBounds(StatBoundsSpec),
+    /// Reject when a forbidden PII pattern class matches.
+    PiiLeak(PiiSpec),
+}
+
+/// The element type of a tensor payload. Self-contained mirror of
+/// `kx_dataset::TensorDType` (this crate is deliberately `kx-dataset`-free; see
+/// the crate docs). Stable `as_u8` tag for canonical folding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TensorDTypeTag {
+    /// 32-bit IEEE float.
+    F32,
+    /// 16-bit IEEE float.
+    F16,
+    /// bfloat16.
+    BF16,
+    /// 64-bit signed integer.
+    I64,
+    /// 32-bit signed integer.
+    I32,
+    /// unsigned byte.
+    U8,
+    /// boolean (one byte per element).
+    Bool,
+}
+
+impl TensorDTypeTag {
+    /// Stable u8 tag for content-addressed folding. MUST NOT change without a
+    /// `CRITIC_SCHEMA_VERSION` bump. Matches `kx_dataset::TensorDType::as_u8`.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        match self {
+            TensorDTypeTag::F32 => 0,
+            TensorDTypeTag::F16 => 1,
+            TensorDTypeTag::BF16 => 2,
+            TensorDTypeTag::I64 => 3,
+            TensorDTypeTag::I32 => 4,
+            TensorDTypeTag::U8 => 5,
+            TensorDTypeTag::Bool => 6,
+        }
+    }
+
+    /// The on-disk byte width of one element of this dtype. Used by the schema
+    /// check to validate a tensor/vector payload's total length.
+    #[must_use]
+    pub const fn byte_width(self) -> u64 {
+        match self {
+            TensorDTypeTag::F32 | TensorDTypeTag::I32 => 4,
+            TensorDTypeTag::F16 | TensorDTypeTag::BF16 => 2,
+            TensorDTypeTag::I64 => 8,
+            TensorDTypeTag::U8 | TensorDTypeTag::Bool => 1,
+        }
+    }
+}
+
+/// The declared type a schema check validates against. Self-contained mirror of
+/// `kx_dataset::ContentSchema` (`kx-critic` offers a `From<&ContentSchema>`
+/// conversion). The stable per-variant u8 tags match `ContentSchema::hash_into`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SchemaTag {
+    /// Untyped bytes — always conforms.
+    Blob,
+    /// UTF-8 text.
+    Text,
+    /// A well-formed JSON document.
+    Json,
+    /// A dense tensor of `dtype` with the given row-major `shape`.
+    Tensor {
+        /// Element type.
+        dtype: TensorDTypeTag,
+        /// Dimensions, row-major. Empty = scalar.
+        shape: SmallVec<[u64; 4]>,
+    },
+    /// An embedding vector of `dim` `f32`s.
+    Vector {
+        /// Dimensionality.
+        dim: u32,
+    },
+    /// An image payload (forward stub; no structural constraint yet).
+    Image,
+    /// An audio payload (forward stub; no structural constraint yet).
+    Audio,
+}
+
+impl SchemaTag {
+    /// Fold the schema tag into a hasher canonically (stable tag + parameters).
+    /// Byte-identical to `kx_dataset::ContentSchema::hash_into`.
+    pub(crate) fn hash_into(&self, h: &mut blake3::Hasher) {
+        match self {
+            SchemaTag::Blob => {
+                h.update(&[0]);
+            }
+            SchemaTag::Text => {
+                h.update(&[1]);
+            }
+            SchemaTag::Json => {
+                h.update(&[2]);
+            }
+            SchemaTag::Tensor { dtype, shape } => {
+                h.update(&[3, dtype.as_u8()]);
+                h.update(&(shape.len() as u64).to_le_bytes());
+                for dim in shape {
+                    h.update(&dim.to_le_bytes());
+                }
+            }
+            SchemaTag::Vector { dim } => {
+                h.update(&[4]);
+                h.update(&dim.to_le_bytes());
+            }
+            SchemaTag::Image => {
+                h.update(&[5]);
+            }
+            SchemaTag::Audio => {
+                h.update(&[6]);
+            }
+        }
+    }
+}
+
+/// Spec for the schema check.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaSpec {
+    /// The schema the output bytes must satisfy.
+    pub expected: SchemaTag,
+}
+
+/// How records are framed within the producer's output bytes. Closed enum so the
+/// dedup / stat parsers are total and declarative (no opaque callback).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RecordFraming {
+    /// One record per LF-delimited line (a trailing newline is optional and does
+    /// NOT produce a final empty record).
+    LinesLf,
+    /// Length-prefixed records: `u32`-LE byte length followed by that many bytes,
+    /// repeated to end of input.
+    LengthPrefixedU32,
+    /// Fixed-width records of exactly `width` bytes each.
+    FixedWidth {
+        /// Record width in bytes (must be non-zero; a zero width is treated as
+        /// an `Unparseable` framing error at evaluation, never a panic).
+        width: u32,
+    },
+}
+
+impl RecordFraming {
+    fn hash_into(self, h: &mut blake3::Hasher) {
+        match self {
+            RecordFraming::LinesLf => h.update(&[0]),
+            RecordFraming::LengthPrefixedU32 => h.update(&[1]),
+            RecordFraming::FixedWidth { width } => {
+                h.update(&[2]);
+                h.update(&width.to_le_bytes())
+            }
+        };
+    }
+}
+
+/// Spec for the dedup check.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DedupSpec {
+    /// How to split the output into records.
+    pub framing: RecordFraming,
+    /// Dedup on the whole record (`None`) or on a `[start, end)` byte sub-range
+    /// of each record (`Some`). An out-of-range key range yields `Unparseable`.
+    pub key_range: Option<(u32, u32)>,
+}
+
+/// Spec for the stat-bounds check.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatBoundsSpec {
+    /// How to split the output into records.
+    pub framing: RecordFraming,
+    /// Which statistic to bound.
+    pub stat: StatKind,
+    /// Fixed-point scale of the numeric field + bounds (e.g. `1000` = three
+    /// decimal places). Numeric fields are parsed as scaled integers; means use
+    /// integer division (documented truncation toward zero).
+    pub scale: u32,
+    /// Inclusive lower bound, in scaled-integer space.
+    pub lo_scaled: i64,
+    /// Inclusive upper bound, in scaled-integer space.
+    pub hi_scaled: i64,
+    /// For `MeanScaled` / `MinScaled` / `MaxScaled`: the `[start, end)` byte
+    /// sub-range of each record holding the scaled-integer numeric field
+    /// (ASCII decimal). Ignored for `RecordCount`. `None` parses the whole
+    /// record as the field.
+    pub numeric_field_range: Option<(u32, u32)>,
+}
+
+/// Spec for the PII-leakage check.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PiiSpec {
+    /// The detector classes to forbid. `BTreeSet` gives canonical iteration
+    /// order, which is the deterministic priority when several classes match.
+    pub forbidden: BTreeSet<PiiClass>,
+}
+
+impl CheckSpec {
+    /// Which check kind this is.
+    #[must_use]
+    pub const fn kind(&self) -> CheckKind {
+        match self {
+            CheckSpec::Schema(_) => CheckKind::Schema,
+            CheckSpec::Dedup(_) => CheckKind::Dedup,
+            CheckSpec::StatBounds(_) => CheckKind::StatBounds,
+            CheckSpec::PiiLeak(_) => CheckKind::PiiLeak,
+        }
+    }
+
+    /// Fold this spec into a hasher canonically. Stable per-variant u8 tag,
+    /// little-endian integers, `BTreeSet` iterated in `Ord` order. Two equal
+    /// specs fold identically; two differing specs fold differently (the
+    /// identity-discrimination guarantee that makes a critic's check part of its
+    /// `MoteId`).
+    ///
+    /// This is the secondary / test surface. PR-2's `MoteDef::hash` carries the
+    /// spec via canonical bincode over the embedded `CheckSpec`; this method
+    /// freezes the same byte intent independently.
+    pub fn hash_into(&self, h: &mut blake3::Hasher) {
+        match self {
+            CheckSpec::Schema(s) => {
+                h.update(&[0]);
+                s.expected.hash_into(h);
+            }
+            CheckSpec::Dedup(s) => {
+                h.update(&[1]);
+                s.framing.hash_into(h);
+                hash_key_range(h, s.key_range);
+            }
+            CheckSpec::StatBounds(s) => {
+                h.update(&[2]);
+                s.framing.hash_into(h);
+                h.update(&[stat_tag(s.stat)]);
+                h.update(&s.scale.to_le_bytes());
+                h.update(&s.lo_scaled.to_le_bytes());
+                h.update(&s.hi_scaled.to_le_bytes());
+                hash_key_range(h, s.numeric_field_range);
+            }
+            CheckSpec::PiiLeak(s) => {
+                h.update(&[3]);
+                h.update(&(s.forbidden.len() as u64).to_le_bytes());
+                for class in &s.forbidden {
+                    h.update(&[pii_tag(*class)]);
+                }
+            }
+        }
+    }
+}
+
+fn hash_key_range(h: &mut blake3::Hasher, range: Option<(u32, u32)>) {
+    match range {
+        None => h.update(&[0]),
+        Some((start, end)) => {
+            h.update(&[1]);
+            h.update(&start.to_le_bytes());
+            h.update(&end.to_le_bytes())
+        }
+    };
+}
+
+const fn stat_tag(stat: StatKind) -> u8 {
+    match stat {
+        StatKind::RecordCount => 0,
+        StatKind::MeanScaled => 1,
+        StatKind::MinScaled => 2,
+        StatKind::MaxScaled => 3,
+    }
+}
+
+const fn pii_tag(class: PiiClass) -> u8 {
+    match class {
+        PiiClass::Email => 0,
+        PiiClass::IpV4 => 1,
+        PiiClass::CreditCardLuhn => 2,
+        PiiClass::UsSsn => 3,
+    }
+}

--- a/crates/kx-critic-types/src/tests.rs
+++ b/crates/kx-critic-types/src/tests.rs
@@ -1,0 +1,275 @@
+//! Unit + property tests for the deterministic-critic vocabulary: canonical
+//! verdict encode/decode round-trips and `CheckSpec::hash_into`
+//! determinism + identity-discrimination.
+
+use std::collections::BTreeSet;
+
+use proptest::prelude::*;
+use smallvec::smallvec;
+
+use crate::{
+    CheckSpec, CriticReason, CriticVerdict, DedupSpec, PiiClass, PiiSpec, RecordFraming,
+    SchemaFault, SchemaSpec, SchemaTag, StatBoundsSpec, StatKind, TensorDTypeTag,
+    VerdictDecodeError, CRITIC_SCHEMA_VERSION,
+};
+
+fn all_reason_samples() -> Vec<CriticReason> {
+    vec![
+        CriticReason::SchemaMismatch {
+            expected: SchemaTag::Json,
+            detail: SchemaFault::TagMismatch,
+        },
+        CriticReason::SchemaMismatch {
+            expected: SchemaTag::Tensor {
+                dtype: TensorDTypeTag::F32,
+                shape: smallvec![2, 3],
+            },
+            detail: SchemaFault::ShapeMismatch {
+                expected_elems: 6,
+                actual_bytes: 20,
+            },
+        },
+        CriticReason::SchemaMismatch {
+            expected: SchemaTag::Text,
+            detail: SchemaFault::NotUtf8 { at_offset: 7 },
+        },
+        CriticReason::SchemaMismatch {
+            expected: SchemaTag::Json,
+            detail: SchemaFault::NotJson { at_offset: 3 },
+        },
+        CriticReason::DuplicateDetected {
+            duplicate_count: 4,
+            first_duplicate_index: 9,
+        },
+        CriticReason::StatOutOfBounds {
+            stat: StatKind::MeanScaled,
+            observed_scaled: -12,
+            lo_scaled: 0,
+            hi_scaled: 100,
+        },
+        CriticReason::PiiLeak {
+            class: PiiClass::CreditCardLuhn,
+            match_offset: 42,
+            match_len: 16,
+        },
+        CriticReason::Unparseable {
+            check: crate::CheckKind::Dedup,
+            at_offset: 11,
+        },
+    ]
+}
+
+#[test]
+fn verdict_encode_carries_version_prefix() {
+    let bytes = CriticVerdict::Valid.encode();
+    assert_eq!(&bytes[0..2], &CRITIC_SCHEMA_VERSION.to_le_bytes());
+}
+
+#[test]
+fn verdict_round_trip_all_variants() {
+    let mut verdicts = vec![CriticVerdict::Valid];
+    for reason in all_reason_samples() {
+        verdicts.push(CriticVerdict::Invalid { reason });
+    }
+    for v in verdicts {
+        let bytes = v.encode();
+        let back = CriticVerdict::decode(&bytes).expect("decode");
+        assert_eq!(v, back);
+    }
+}
+
+#[test]
+fn verdict_encode_is_deterministic() {
+    let v = CriticVerdict::Invalid {
+        reason: CriticReason::DuplicateDetected {
+            duplicate_count: 1,
+            first_duplicate_index: 0,
+        },
+    };
+    assert_eq!(v.encode(), v.encode());
+    // An independently constructed equal value encodes identically.
+    let v2 = CriticVerdict::Invalid {
+        reason: CriticReason::DuplicateDetected {
+            duplicate_count: 1,
+            first_duplicate_index: 0,
+        },
+    };
+    assert_eq!(v.encode(), v2.encode());
+    assert_eq!(v.content_ref_bytes(), v2.content_ref_bytes());
+}
+
+#[test]
+fn decode_rejects_unknown_version() {
+    let mut bytes = CriticVerdict::Valid.encode();
+    bytes[0] = 0xFF;
+    bytes[1] = 0xFF;
+    assert_eq!(
+        CriticVerdict::decode(&bytes),
+        Err(VerdictDecodeError::UnknownSchemaVersion(0xFFFF))
+    );
+}
+
+#[test]
+fn decode_rejects_short_and_trailing_garbage() {
+    assert_eq!(
+        CriticVerdict::decode(&[]),
+        Err(VerdictDecodeError::Malformed)
+    );
+    assert_eq!(
+        CriticVerdict::decode(&[0]),
+        Err(VerdictDecodeError::Malformed)
+    );
+    let mut bytes = CriticVerdict::Valid.encode();
+    bytes.push(0xAB); // trailing garbage
+    assert_eq!(
+        CriticVerdict::decode(&bytes),
+        Err(VerdictDecodeError::Malformed)
+    );
+}
+
+#[test]
+fn valid_distinct_from_invalid_ref() {
+    let valid = CriticVerdict::Valid;
+    let invalid = CriticVerdict::Invalid {
+        reason: CriticReason::Unparseable {
+            check: crate::CheckKind::Schema,
+            at_offset: 0,
+        },
+    };
+    assert_ne!(valid.content_ref_bytes(), invalid.content_ref_bytes());
+    assert!(valid.is_valid());
+    assert!(!invalid.is_valid());
+}
+
+fn digest(spec: &CheckSpec) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    spec.hash_into(&mut h);
+    *h.finalize().as_bytes()
+}
+
+#[test]
+fn hash_into_is_deterministic() {
+    let spec = CheckSpec::StatBounds(StatBoundsSpec {
+        framing: RecordFraming::LinesLf,
+        stat: StatKind::MeanScaled,
+        scale: 1000,
+        lo_scaled: -5,
+        hi_scaled: 5,
+        numeric_field_range: Some((0, 4)),
+    });
+    assert_eq!(digest(&spec), digest(&spec));
+}
+
+#[test]
+fn hash_into_discriminates_specs() {
+    let base = CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LinesLf,
+        key_range: None,
+    });
+    let other_framing = CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LengthPrefixedU32,
+        key_range: None,
+    });
+    let other_key = CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LinesLf,
+        key_range: Some((0, 4)),
+    });
+    let other_kind = CheckSpec::Schema(SchemaSpec {
+        expected: SchemaTag::Blob,
+    });
+    assert_ne!(digest(&base), digest(&other_framing));
+    assert_ne!(digest(&base), digest(&other_key));
+    assert_ne!(digest(&base), digest(&other_kind));
+}
+
+#[test]
+fn pii_set_order_is_canonical() {
+    // BTreeSet ordering means the digest is independent of insertion order.
+    let mut a = BTreeSet::new();
+    a.insert(PiiClass::UsSsn);
+    a.insert(PiiClass::Email);
+    let mut b = BTreeSet::new();
+    b.insert(PiiClass::Email);
+    b.insert(PiiClass::UsSsn);
+    let sa = CheckSpec::PiiLeak(PiiSpec { forbidden: a });
+    let sb = CheckSpec::PiiLeak(PiiSpec { forbidden: b });
+    assert_eq!(digest(&sa), digest(&sb));
+}
+
+// --- proptest -------------------------------------------------------------
+
+prop_compose! {
+    fn arb_schema_tag()(
+        tag in 0u8..7,
+        dim in 0u32..512,
+        d0 in 0u64..8, d1 in 0u64..8,
+    ) -> SchemaTag {
+        match tag {
+            0 => SchemaTag::Blob,
+            1 => SchemaTag::Text,
+            2 => SchemaTag::Json,
+            3 => SchemaTag::Tensor { dtype: TensorDTypeTag::F32, shape: smallvec![d0, d1] },
+            4 => SchemaTag::Vector { dim },
+            5 => SchemaTag::Image,
+            _ => SchemaTag::Audio,
+        }
+    }
+}
+
+fn arb_reason() -> impl Strategy<Value = CriticReason> {
+    prop_oneof![
+        (arb_schema_tag()).prop_map(|expected| CriticReason::SchemaMismatch {
+            expected,
+            detail: SchemaFault::TagMismatch
+        }),
+        (any::<u64>(), any::<u64>()).prop_map(|(duplicate_count, first_duplicate_index)| {
+            CriticReason::DuplicateDetected {
+                duplicate_count,
+                first_duplicate_index,
+            }
+        }),
+        (any::<i64>(), any::<i64>(), any::<i64>()).prop_map(
+            |(observed_scaled, lo_scaled, hi_scaled)| CriticReason::StatOutOfBounds {
+                stat: StatKind::MeanScaled,
+                observed_scaled,
+                lo_scaled,
+                hi_scaled,
+            }
+        ),
+        (any::<u64>(), any::<u64>()).prop_map(|(match_offset, match_len)| {
+            CriticReason::PiiLeak {
+                class: PiiClass::Email,
+                match_offset,
+                match_len,
+            }
+        }),
+    ]
+}
+
+fn arb_verdict() -> impl Strategy<Value = CriticVerdict> {
+    prop_oneof![
+        Just(CriticVerdict::Valid),
+        arb_reason().prop_map(|reason| CriticVerdict::Invalid { reason }),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn prop_verdict_round_trip(v in arb_verdict()) {
+        let bytes = v.encode();
+        let back = CriticVerdict::decode(&bytes).expect("decode");
+        prop_assert_eq!(v, back);
+    }
+
+    #[test]
+    fn prop_verdict_encode_deterministic(v in arb_verdict()) {
+        prop_assert_eq!(v.encode(), v.encode());
+        prop_assert_eq!(v.content_ref_bytes(), v.content_ref_bytes());
+    }
+
+    #[test]
+    fn prop_decode_never_panics(bytes in proptest::collection::vec(any::<u8>(), 0..256)) {
+        // Total: decode returns a Result for ALL inputs — never panics.
+        let _ = CriticVerdict::decode(&bytes);
+    }
+}

--- a/crates/kx-critic-types/src/verdict.rs
+++ b/crates/kx-critic-types/src/verdict.rs
@@ -1,0 +1,244 @@
+//! [`CriticVerdict`] — the content-addressed fact a deterministic critic Mote
+//! commits — plus its closed [`CriticReason`] failure vocabulary and the frozen
+//! canonical encoding used to content-address it.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::spec::SchemaTag;
+
+/// Schema version of the [`CriticVerdict`] / `CheckSpec` wire encodings. Bumped
+/// on ANY change to the canonical bytes of either (the verdict bytes are a
+/// committed content-addressed fact; the spec bytes fold into a critic Mote's
+/// `MoteId`). Encoded as the first two bytes of [`CriticVerdict::encode`].
+pub const CRITIC_SCHEMA_VERSION: u16 = 1;
+
+/// A critic's committed verdict — the value a critic Mote's `result_ref` payload
+/// decodes to.
+///
+/// **SN-8:** produced by EXACT deterministic evaluation; compared downstream by
+/// byte-equality only (the projection's promotion gate reads `Valid` vs
+/// `Invalid`, never a score). Two runs over identical producer output produce a
+/// byte-identical verdict and therefore an identical content ref — the journal
+/// dedups it to a single fact.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CriticVerdict {
+    /// The producer output passed the deterministic check.
+    Valid,
+    /// The producer output failed; `reason` names the closed failure kind.
+    Invalid {
+        /// Why the check rejected the output.
+        reason: CriticReason,
+    },
+}
+
+/// The closed failure vocabulary — one variant family per deterministic check
+/// kind, plus the total-input `Unparseable` escape hatch.
+///
+/// Illegal states unrepresentable: a reason is exactly one kind, and each
+/// carries only **deterministic, reproducible, integer-scaled** evidence
+/// (indices / counts / byte offsets) — never floats, never host-derived data.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CriticReason {
+    /// The schema check failed: the output did not conform to the declared tag.
+    SchemaMismatch {
+        /// The schema the spec required.
+        expected: SchemaTag,
+        /// The first failing structural fact.
+        detail: SchemaFault,
+    },
+    /// The dedup check failed: duplicate records were detected.
+    DuplicateDetected {
+        /// Count of records that duplicated an earlier one (occurrences beyond
+        /// the first).
+        duplicate_count: u64,
+        /// Zero-based index of the FIRST record that duplicated an earlier one.
+        first_duplicate_index: u64,
+    },
+    /// The stat-bounds check failed: an aggregate left its declared inclusive
+    /// integer bound.
+    StatOutOfBounds {
+        /// Which statistic was out of bounds.
+        stat: StatKind,
+        /// The integer-encoded observed value (see `StatBoundsSpec::scale`).
+        observed_scaled: i64,
+        /// The inclusive lower bound the spec declared (scaled).
+        lo_scaled: i64,
+        /// The inclusive upper bound the spec declared (scaled).
+        hi_scaled: i64,
+    },
+    /// The PII-leakage check failed: a forbidden pattern class matched.
+    PiiLeak {
+        /// Which detector class matched.
+        class: PiiClass,
+        /// Byte offset of the first match in the input.
+        match_offset: u64,
+        /// Byte length of the matched span.
+        match_len: u64,
+    },
+    /// The input bytes could not be parsed into the structure the check needs
+    /// (e.g. a dedup/stat over a malformed record framing). Total-on-adversarial
+    /// input: evaluation NEVER panics — a parse failure is a deterministic
+    /// `Invalid`, not a crash.
+    Unparseable {
+        /// Which check raised it.
+        check: CheckKind,
+        /// Byte offset where parsing failed.
+        at_offset: u64,
+    },
+}
+
+/// Stable, u8-tagged discriminant naming a deterministic check kind. Carried by
+/// [`CriticReason::Unparseable`] and produced by `CheckSpec::kind`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum CheckKind {
+    /// The schema check.
+    Schema,
+    /// The dedup check.
+    Dedup,
+    /// The stat-bounds check.
+    StatBounds,
+    /// The PII-leakage check.
+    PiiLeak,
+}
+
+/// The first structural fact that failed a schema check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SchemaFault {
+    /// The top-level schema tag did not match (e.g. expected `Json`, got bytes
+    /// that are not a well-formed JSON document).
+    TagMismatch,
+    /// A `Tensor` / `Vector` payload's byte length did not match the declared
+    /// element count.
+    ShapeMismatch {
+        /// Element count the schema declared.
+        expected_elems: u64,
+        /// Actual byte length of the payload.
+        actual_bytes: u64,
+    },
+    /// `Text` / `Json` required UTF-8 and the bytes were not valid UTF-8.
+    NotUtf8 {
+        /// Byte offset of the first invalid UTF-8 sequence.
+        at_offset: u64,
+    },
+    /// `Json` required a well-formed JSON document and parsing failed.
+    NotJson {
+        /// Byte offset where JSON parsing failed (0 if not localizable).
+        at_offset: u64,
+    },
+}
+
+/// Which aggregate statistic a stat-bounds check computes over the records.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum StatKind {
+    /// The number of records.
+    RecordCount,
+    /// The arithmetic mean of each record's numeric field (scaled integer,
+    /// integer division — see `StatBoundsSpec`).
+    MeanScaled,
+    /// The minimum of each record's numeric field (scaled integer).
+    MinScaled,
+    /// The maximum of each record's numeric field (scaled integer).
+    MaxScaled,
+}
+
+/// A forbidden PII detector class. Iteration order over a `BTreeSet<PiiClass>`
+/// (canonical, `Ord`-derived below) is the deterministic multi-match priority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum PiiClass {
+    /// An email address.
+    Email,
+    /// An IPv4 address in dotted-quad form.
+    IpV4,
+    /// A credit-card number passing the Luhn checksum.
+    CreditCardLuhn,
+    /// A US Social Security Number (NNN-NN-NNNN).
+    UsSsn,
+}
+
+impl CriticVerdict {
+    /// `true` iff this is [`CriticVerdict::Valid`].
+    #[must_use]
+    pub const fn is_valid(&self) -> bool {
+        matches!(self, Self::Valid)
+    }
+
+    /// Canonical content-addressable bytes:
+    /// `[CRITIC_SCHEMA_VERSION as u16 LE] ‖ bincode(self, canonical_config())`.
+    ///
+    /// Infallible: there are no floats and no non-encodable variants, so the
+    /// bincode encode cannot fail (same precondition as `kx_mote::MoteDef::hash`).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        // SAFETY (expect): CriticVerdict has no floats and no non-encodable
+        // types, so canonical bincode encoding is infallible — mirrors the
+        // documented-infallible `kx_mote::MoteDef::hash` encode site.
+        let body = bincode::serde::encode_to_vec(self, canonical_config()).expect(
+            "CriticVerdict canonical encoding is infallible (no floats, no non-encodable types)",
+        );
+        let mut out = Vec::with_capacity(2 + body.len());
+        out.extend_from_slice(&CRITIC_SCHEMA_VERSION.to_le_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    /// Decode canonical bytes produced by [`CriticVerdict::encode`].
+    ///
+    /// # Errors
+    ///
+    /// [`VerdictDecodeError::UnknownSchemaVersion`] if the two-byte version
+    /// prefix is not [`CRITIC_SCHEMA_VERSION`]; [`VerdictDecodeError::Malformed`]
+    /// if the prefix is missing or the body fails to decode.
+    pub fn decode(bytes: &[u8]) -> Result<Self, VerdictDecodeError> {
+        let Some((prefix, body)) = bytes.split_first_chunk::<2>() else {
+            return Err(VerdictDecodeError::Malformed);
+        };
+        let version = u16::from_le_bytes(*prefix);
+        if version != CRITIC_SCHEMA_VERSION {
+            return Err(VerdictDecodeError::UnknownSchemaVersion(version));
+        }
+        let (verdict, consumed) =
+            bincode::serde::decode_from_slice::<Self, _>(body, canonical_config())
+                .map_err(|_| VerdictDecodeError::Malformed)?;
+        // Reject trailing garbage — canonical bytes are exact.
+        if consumed != body.len() {
+            return Err(VerdictDecodeError::Malformed);
+        }
+        Ok(verdict)
+    }
+
+    /// The content-addressed identity of this verdict: `blake3(self.encode())`.
+    ///
+    /// The executor commits the encoded verdict to the content store; this is
+    /// the 32-byte ref both the executor and the projection compute, so they
+    /// agree byte-for-byte (SN-8 exact equality).
+    #[must_use]
+    pub fn content_ref_bytes(&self) -> [u8; 32] {
+        *blake3::hash(&self.encode()).as_bytes()
+    }
+}
+
+/// The canonical bincode configuration for [`CriticVerdict`] / `CheckSpec`
+/// encodings: bincode v2, little-endian, fixed-int. **Byte-identical to
+/// `kx_mote::canonical_config`** — replicated here so this crate stays
+/// `kx-mote`-free. Any change to these flags is a [`CRITIC_SCHEMA_VERSION`] bump.
+#[must_use]
+pub fn canonical_config(
+) -> bincode::config::Configuration<bincode::config::LittleEndian, bincode::config::Fixint> {
+    bincode::config::standard()
+        .with_little_endian()
+        .with_fixed_int_encoding()
+}
+
+/// Failure decoding a [`CriticVerdict`] from canonical bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum VerdictDecodeError {
+    /// The version prefix named a `CRITIC_SCHEMA_VERSION` this build does not
+    /// understand.
+    #[error("unknown CriticVerdict schema_version {0}")]
+    UnknownSchemaVersion(u16),
+    /// The bytes were missing the version prefix, failed to decode, or carried
+    /// trailing garbage.
+    #[error("malformed CriticVerdict body")]
+    Malformed,
+}

--- a/crates/kx-critic/Cargo.toml
+++ b/crates/kx-critic/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name         = "kx-critic"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx deterministic-critic EVALUATOR (P4.2) — the pure, total, deterministic evaluate(&CheckSpec, &[u8]) -> CriticVerdict over the four checks the corpus calls out: schema (ContentSchema conformance), dedup (duplicate records under a declared framing+key), stat-bounds (an aggregate within inclusive integer bounds), and PII-leakage (forbidden detector classes). Returns a verdict for ALL inputs — adversarial, truncated, empty, non-UTF-8 — and NEVER panics; identical (spec, input) yields a byte-identical verdict on every run / process / machine. SN-8: a verdict is a content-addressed FACT compared by exact equality, never similarity. The verdict + spec TYPES live in kx-critic-types (parser-free, so kx-mote can embed a CheckSpec without inheriting regex/serde_json); this crate adds the evaluation logic."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The verdict / spec vocabulary this crate evaluates over.
+kx-critic-types = { workspace = true }
+# Typed ContentSchema -> SchemaTag ergonomic conversion (authoring convenience).
+# kx-critic sits ABOVE kx-dataset (which depends on kx-mote), so this is cycle-free.
+kx-dataset      = { workspace = true }
+# JSON well-formedness for the `Json` schema check (validation-only; no float decode).
+serde_json      = { workspace = true }
+# serde::de::IgnoredAny — validates JSON structure WITHOUT materializing numbers
+# (so no f64/NaN is ever constructed on any path).
+serde           = { workspace = true }
+# Deterministic PII-class scanners; patterns compiled once via std LazyLock.
+regex           = { workspace = true }
+# Stack-inline scratch in the record framers.
+smallvec        = { workspace = true }
+
+[dev-dependencies]
+proptest        = { workspace = true }
+criterion       = { workspace = true }
+
+[[bench]]
+name    = "evaluate"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/kx-critic/benches/evaluate.rs
+++ b/crates/kx-critic/benches/evaluate.rs
@@ -1,0 +1,94 @@
+//! Throughput benchmark for `kx_critic::evaluate` across the four checks at
+//! input sizes {1 KiB, 64 KiB, 1 MiB, 16 MiB}. Reports ns/iter with
+//! `Throughput::Bytes` so the per-byte cost (and its ~linear scaling) is visible.
+//!
+//! Run: `cargo bench -p kx-critic`.
+
+// criterion_group!/criterion_main! generate undocumented items + a `main`.
+#![allow(missing_docs)]
+
+use std::collections::BTreeSet;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kx_critic::{
+    evaluate, CheckSpec, DedupSpec, PiiClass, PiiSpec, RecordFraming, SchemaSpec, SchemaTag,
+    StatBoundsSpec, StatKind,
+};
+
+const SIZES: &[usize] = &[1 << 10, 1 << 16, 1 << 20, 1 << 24];
+
+/// A deterministic LCG buffer of ASCII-decimal LF-delimited records, reused so
+/// every check sees realistic record-shaped bytes. No RNG crate (determinism).
+fn record_buffer(target_len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(target_len + 16);
+    let mut x: u64 = 0x1234_5678_9ABC_DEF0;
+    while out.len() < target_len {
+        x = x
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let v = (x >> 33) % 100_000;
+        out.extend_from_slice(v.to_string().as_bytes());
+        out.push(b'\n');
+    }
+    out.truncate(target_len);
+    out
+}
+
+fn specs() -> Vec<(&'static str, CheckSpec)> {
+    vec![
+        (
+            "schema_text",
+            CheckSpec::Schema(SchemaSpec {
+                expected: SchemaTag::Text,
+            }),
+        ),
+        (
+            "dedup_lines",
+            CheckSpec::Dedup(DedupSpec {
+                framing: RecordFraming::LinesLf,
+                key_range: None,
+            }),
+        ),
+        (
+            "statbounds_mean",
+            CheckSpec::StatBounds(StatBoundsSpec {
+                framing: RecordFraming::LinesLf,
+                stat: StatKind::MeanScaled,
+                scale: 1,
+                lo_scaled: i64::MIN,
+                hi_scaled: i64::MAX,
+                numeric_field_range: None,
+            }),
+        ),
+        (
+            "pii_all",
+            CheckSpec::PiiLeak(PiiSpec {
+                forbidden: [
+                    PiiClass::Email,
+                    PiiClass::IpV4,
+                    PiiClass::CreditCardLuhn,
+                    PiiClass::UsSsn,
+                ]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            }),
+        ),
+    ]
+}
+
+fn bench_evaluate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("evaluate");
+    for &size in SIZES {
+        let input = record_buffer(size);
+        group.throughput(Throughput::Bytes(size as u64));
+        for (name, spec) in specs() {
+            group.bench_with_input(BenchmarkId::new(name, size), &input, |b, input| {
+                b.iter(|| evaluate(&spec, std::hint::black_box(input)));
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_evaluate);
+criterion_main!(benches);

--- a/crates/kx-critic/src/checks/dedup.rs
+++ b/crates/kx-critic/src/checks/dedup.rs
@@ -1,0 +1,58 @@
+//! The **dedup** check: are there duplicate records under a declared framing +
+//! key? Frame the input, extract each record's key (whole record or a byte
+//! sub-range), and reject on the first key that repeats an earlier one.
+
+use std::collections::BTreeSet;
+
+use kx_critic_types::{CheckKind, CriticReason, CriticVerdict, DedupSpec};
+
+use crate::framing::{frame, key_of};
+
+/// Evaluate the dedup check. Total + deterministic.
+#[must_use]
+pub fn eval(spec: &DedupSpec, input: &[u8]) -> CriticVerdict {
+    let records = match frame(spec.framing, input) {
+        Ok(r) => r,
+        Err(e) => return unparseable(e.at_offset),
+    };
+
+    let mut seen: BTreeSet<&[u8]> = BTreeSet::new();
+    let mut first_duplicate_index: Option<u64> = None;
+    let mut duplicate_count: u64 = 0;
+
+    for (idx, record) in records.iter().enumerate() {
+        let Some(key) = key_of(record, spec.key_range) else {
+            // Key range out of bounds for this record → deterministic Unparseable.
+            // Offset points at the record's place in the stream by index; we use
+            // the index as a stable locator (byte offset is framing-dependent).
+            return unparseable(idx as u64);
+        };
+        if seen.contains(key) {
+            duplicate_count += 1;
+            if first_duplicate_index.is_none() {
+                first_duplicate_index = Some(idx as u64);
+            }
+        } else {
+            seen.insert(key);
+        }
+    }
+
+    match first_duplicate_index {
+        None => CriticVerdict::Valid,
+        Some(first_duplicate_index) => CriticVerdict::Invalid {
+            reason: CriticReason::DuplicateDetected {
+                duplicate_count,
+                first_duplicate_index,
+            },
+        },
+    }
+}
+
+fn unparseable(at_offset: u64) -> CriticVerdict {
+    CriticVerdict::Invalid {
+        reason: CriticReason::Unparseable {
+            check: CheckKind::Dedup,
+            at_offset,
+        },
+    }
+}

--- a/crates/kx-critic/src/checks/mod.rs
+++ b/crates/kx-critic/src/checks/mod.rs
@@ -1,0 +1,7 @@
+//! The four deterministic checks. Each `eval(&Spec, &[u8]) -> CriticVerdict` is
+//! pure, total, and deterministic (see the crate-level contract).
+
+pub mod dedup;
+pub mod pii;
+pub mod schema;
+pub mod stat_bounds;

--- a/crates/kx-critic/src/checks/pii.rs
+++ b/crates/kx-critic/src/checks/pii.rs
@@ -1,0 +1,103 @@
+//! The **PII-leakage** check: does a forbidden detector class match the output?
+//!
+//! Each class is a deterministic byte scanner (`regex::bytes`, leftmost-first,
+//! compiled once via `LazyLock`). When several forbidden classes match, the one
+//! whose first match has the smallest byte offset wins; ties break by the
+//! `BTreeSet<PiiClass>` iteration order (canonical priority). The detectors run
+//! over raw bytes, so non-UTF-8 input is handled without a panic.
+
+use std::sync::LazyLock;
+
+use kx_critic_types::{CriticReason, CriticVerdict, PiiClass, PiiSpec};
+use regex::bytes::Regex;
+
+/// Evaluate the PII-leakage check. Total + deterministic.
+#[must_use]
+pub fn eval(spec: &PiiSpec, input: &[u8]) -> CriticVerdict {
+    // Iterate forbidden classes in BTreeSet (canonical) order; keep the match
+    // with the smallest byte offset, ties resolved by this iteration order.
+    let mut best: Option<(PiiClass, usize, usize)> = None;
+    for &class in &spec.forbidden {
+        if let Some((start, len)) = find_first(class, input) {
+            let take = match best {
+                Some((_, best_start, _)) => start < best_start,
+                None => true,
+            };
+            if take {
+                best = Some((class, start, len));
+            }
+        }
+    }
+
+    match best {
+        None => CriticVerdict::Valid,
+        Some((class, start, len)) => CriticVerdict::Invalid {
+            reason: CriticReason::PiiLeak {
+                class,
+                match_offset: start as u64,
+                match_len: len as u64,
+            },
+        },
+    }
+}
+
+fn find_first(class: PiiClass, input: &[u8]) -> Option<(usize, usize)> {
+    match class {
+        PiiClass::Email => first_match(&EMAIL, input),
+        PiiClass::IpV4 => first_match(&IPV4, input),
+        PiiClass::UsSsn => first_match(&US_SSN, input),
+        PiiClass::CreditCardLuhn => {
+            // A candidate digit run that ALSO passes the Luhn checksum. Take the
+            // earliest such run (find_iter yields matches left-to-right).
+            for m in CC_CANDIDATE.find_iter(input) {
+                if luhn_ok(m.as_bytes()) {
+                    return Some((m.start(), m.end() - m.start()));
+                }
+            }
+            None
+        }
+    }
+}
+
+fn first_match(re: &Regex, input: &[u8]) -> Option<(usize, usize)> {
+    re.find(input).map(|m| (m.start(), m.end() - m.start()))
+}
+
+/// Luhn checksum over an ASCII digit string. `digits` is assumed to be all
+/// `b'0'..=b'9'` (the candidate regex guarantees this).
+fn luhn_ok(digits: &[u8]) -> bool {
+    let mut sum: u32 = 0;
+    // Walk right-to-left, doubling every second digit.
+    for (i, &b) in digits.iter().rev().enumerate() {
+        let mut d = u32::from(b - b'0');
+        if i % 2 == 1 {
+            d *= 2;
+            if d > 9 {
+                d -= 9;
+            }
+        }
+        sum += d;
+    }
+    sum.is_multiple_of(10)
+}
+
+// Patterns compiled once. `expect` is on a frozen literal pattern, so it cannot
+// fail at runtime — a malformed pattern is a compile-time-detectable test
+// failure, not a production path.
+#[allow(clippy::expect_used)]
+fn compile(pattern: &str) -> Regex {
+    Regex::new(pattern).expect("frozen PII pattern is a valid regex")
+}
+
+static EMAIL: LazyLock<Regex> =
+    LazyLock::new(|| compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"));
+
+static IPV4: LazyLock<Regex> = LazyLock::new(|| {
+    compile(
+        r"\b(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b",
+    )
+});
+
+static US_SSN: LazyLock<Regex> = LazyLock::new(|| compile(r"\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b"));
+
+static CC_CANDIDATE: LazyLock<Regex> = LazyLock::new(|| compile(r"\b[0-9]{13,19}\b"));

--- a/crates/kx-critic/src/checks/schema.rs
+++ b/crates/kx-critic/src/checks/schema.rs
@@ -1,0 +1,109 @@
+//! The **schema** check: does the payload conform to a declared [`SchemaTag`]?
+//!
+//! - `Blob` / `Image` / `Audio` — no structural constraint; always `Valid`.
+//! - `Text` — must be valid UTF-8.
+//! - `Json` — must be valid UTF-8 AND a well-formed JSON document
+//!   (`serde_json` validation only; values are never materialized to floats, so
+//!   no NaN/float-ordering touches any path).
+//! - `Tensor { dtype, shape }` — byte length must equal `product(shape) *
+//!   dtype.byte_width()`.
+//! - `Vector { dim }` — byte length must equal `dim * 4` (f32 elements).
+
+use kx_critic_types::{CriticReason, CriticVerdict, SchemaFault, SchemaSpec, SchemaTag};
+
+/// Evaluate the schema check. Total + deterministic.
+#[must_use]
+pub fn eval(spec: &SchemaSpec, input: &[u8]) -> CriticVerdict {
+    match &spec.expected {
+        SchemaTag::Blob | SchemaTag::Image | SchemaTag::Audio => CriticVerdict::Valid,
+        SchemaTag::Text => match utf8_fault(input) {
+            None => CriticVerdict::Valid,
+            Some(detail) => invalid(SchemaTag::Text, detail),
+        },
+        SchemaTag::Json => {
+            if let Some(detail) = utf8_fault(input) {
+                return invalid(SchemaTag::Json, detail);
+            }
+            // UTF-8 already established; validate well-formedness without
+            // materializing numbers (IgnoredAny visits structure only).
+            match serde_json::from_slice::<serde::de::IgnoredAny>(input) {
+                Ok(_) => CriticVerdict::Valid,
+                Err(e) => invalid(
+                    SchemaTag::Json,
+                    SchemaFault::NotJson {
+                        at_offset: json_error_offset(&e, input.len()),
+                    },
+                ),
+            }
+        }
+        SchemaTag::Tensor { dtype, shape } => {
+            let elems = shape.iter().copied().fold(1u64, u64::saturating_mul);
+            let expected_bytes = elems.saturating_mul(dtype.byte_width());
+            check_len(
+                expected_bytes,
+                input.len() as u64,
+                elems,
+                SchemaTag::Tensor {
+                    dtype: *dtype,
+                    shape: shape.clone(),
+                },
+            )
+        }
+        SchemaTag::Vector { dim } => {
+            let elems = u64::from(*dim);
+            let expected_bytes = elems.saturating_mul(4); // f32
+            check_len(
+                expected_bytes,
+                input.len() as u64,
+                elems,
+                SchemaTag::Vector { dim: *dim },
+            )
+        }
+    }
+}
+
+fn check_len(
+    expected_bytes: u64,
+    actual_bytes: u64,
+    expected_elems: u64,
+    expected: SchemaTag,
+) -> CriticVerdict {
+    if expected_bytes == actual_bytes {
+        CriticVerdict::Valid
+    } else {
+        invalid(
+            expected,
+            SchemaFault::ShapeMismatch {
+                expected_elems,
+                actual_bytes,
+            },
+        )
+    }
+}
+
+fn invalid(expected: SchemaTag, detail: SchemaFault) -> CriticVerdict {
+    CriticVerdict::Invalid {
+        reason: CriticReason::SchemaMismatch { expected, detail },
+    }
+}
+
+/// Returns `Some(NotUtf8 { at_offset })` if `input` is not valid UTF-8, else
+/// `None`. `std::str::from_utf8`'s error reports the first invalid byte offset.
+fn utf8_fault(input: &[u8]) -> Option<SchemaFault> {
+    match std::str::from_utf8(input) {
+        Ok(_) => None,
+        Err(e) => Some(SchemaFault::NotUtf8 {
+            at_offset: e.valid_up_to() as u64,
+        }),
+    }
+}
+
+/// Best-effort byte offset of a serde_json parse failure. serde_json reports a
+/// 1-based column on the failing line; we clamp to the input length so the
+/// offset is always in range (the value is diagnostic, not identity-bearing
+/// beyond being deterministic for identical input).
+fn json_error_offset(e: &serde_json::Error, len: usize) -> u64 {
+    let col = e.column();
+    let off = col.saturating_sub(1);
+    off.min(len) as u64
+}

--- a/crates/kx-critic/src/checks/stat_bounds.rs
+++ b/crates/kx-critic/src/checks/stat_bounds.rs
@@ -1,0 +1,92 @@
+//! The **stat-bounds** check: is a declared aggregate within an inclusive integer
+//! bound? Frame the input, parse each record's numeric field as a scaled integer
+//! (ASCII decimal — never a float), compute the statistic in scaled-integer
+//! space, and reject if it leaves `[lo_scaled, hi_scaled]`.
+//!
+//! Aggregates over an empty record set are defined (not a panic): `RecordCount`
+//! is `0`; `MeanScaled` / `MinScaled` / `MaxScaled` are `0`. `MeanScaled` uses
+//! integer division (truncation toward zero).
+
+use kx_critic_types::{CheckKind, CriticReason, CriticVerdict, StatBoundsSpec, StatKind};
+
+use crate::framing::{frame, key_of};
+
+/// Evaluate the stat-bounds check. Total + deterministic.
+#[must_use]
+pub fn eval(spec: &StatBoundsSpec, input: &[u8]) -> CriticVerdict {
+    let records = match frame(spec.framing, input) {
+        Ok(r) => r,
+        Err(e) => return unparseable(e.at_offset),
+    };
+
+    let observed_scaled = match spec.stat {
+        StatKind::RecordCount => i64::try_from(records.len()).unwrap_or(i64::MAX),
+        StatKind::MeanScaled | StatKind::MinScaled | StatKind::MaxScaled => {
+            let mut sum: i128 = 0;
+            let mut min: Option<i64> = None;
+            let mut max: Option<i64> = None;
+            for (idx, record) in records.iter().enumerate() {
+                let Some(field) = key_of(record, spec.numeric_field_range) else {
+                    return unparseable(idx as u64);
+                };
+                let Some(value) = parse_scaled_int(field) else {
+                    return unparseable(idx as u64);
+                };
+                sum += i128::from(value);
+                min = Some(min.map_or(value, |m| m.min(value)));
+                max = Some(max.map_or(value, |m| m.max(value)));
+            }
+            match spec.stat {
+                StatKind::MeanScaled => {
+                    let count = records.len() as i128;
+                    if count == 0 {
+                        0
+                    } else {
+                        // Integer division truncates toward zero (documented).
+                        i64::try_from(sum / count).unwrap_or_else(|_| {
+                            if sum.is_negative() {
+                                i64::MIN
+                            } else {
+                                i64::MAX
+                            }
+                        })
+                    }
+                }
+                StatKind::MinScaled => min.unwrap_or(0),
+                StatKind::MaxScaled => max.unwrap_or(0),
+                StatKind::RecordCount => unreachable!("handled in the outer match"),
+            }
+        }
+    };
+
+    if observed_scaled >= spec.lo_scaled && observed_scaled <= spec.hi_scaled {
+        CriticVerdict::Valid
+    } else {
+        CriticVerdict::Invalid {
+            reason: CriticReason::StatOutOfBounds {
+                stat: spec.stat,
+                observed_scaled,
+                lo_scaled: spec.lo_scaled,
+                hi_scaled: spec.hi_scaled,
+            },
+        }
+    }
+}
+
+/// Parse an ASCII decimal scaled integer (optionally signed). Returns `None` on
+/// any non-numeric byte, empty field, or overflow — the caller maps that to a
+/// deterministic `Unparseable`. No float, no locale, no whitespace trimming
+/// (strict so the parse is reproducible).
+fn parse_scaled_int(field: &[u8]) -> Option<i64> {
+    let s = std::str::from_utf8(field).ok()?;
+    s.parse::<i64>().ok()
+}
+
+fn unparseable(at_offset: u64) -> CriticVerdict {
+    CriticVerdict::Invalid {
+        reason: CriticReason::Unparseable {
+            check: CheckKind::StatBounds,
+            at_offset,
+        },
+    }
+}

--- a/crates/kx-critic/src/convert.rs
+++ b/crates/kx-critic/src/convert.rs
@@ -1,0 +1,40 @@
+//! Ergonomic conversion from the data-plane's `kx_dataset::ContentSchema` to the
+//! parser-free [`SchemaTag`] a `SchemaSpec` validates against. Lets an author
+//! holding a `TypedRef` derive a schema critic without restating the tag.
+//!
+//! A free function (not a `From` impl): both `SchemaTag` and `ContentSchema` are
+//! foreign to this crate, so the orphan rule forbids the trait impl.
+//!
+//! [`SchemaTag`]: kx_critic_types::SchemaTag
+
+use kx_critic_types::{SchemaTag, TensorDTypeTag};
+use kx_dataset::{ContentSchema, TensorDType};
+
+/// Convert a `kx_dataset::ContentSchema` into the parser-free [`SchemaTag`].
+#[must_use]
+pub fn schema_tag_of(schema: &ContentSchema) -> SchemaTag {
+    match schema {
+        ContentSchema::Blob => SchemaTag::Blob,
+        ContentSchema::Text => SchemaTag::Text,
+        ContentSchema::Json => SchemaTag::Json,
+        ContentSchema::Tensor { dtype, shape } => SchemaTag::Tensor {
+            dtype: dtype_tag(*dtype),
+            shape: shape.clone(),
+        },
+        ContentSchema::Vector { dim } => SchemaTag::Vector { dim: *dim },
+        ContentSchema::Image => SchemaTag::Image,
+        ContentSchema::Audio => SchemaTag::Audio,
+    }
+}
+
+const fn dtype_tag(dtype: TensorDType) -> TensorDTypeTag {
+    match dtype {
+        TensorDType::F32 => TensorDTypeTag::F32,
+        TensorDType::F16 => TensorDTypeTag::F16,
+        TensorDType::BF16 => TensorDTypeTag::BF16,
+        TensorDType::I64 => TensorDTypeTag::I64,
+        TensorDType::I32 => TensorDTypeTag::I32,
+        TensorDType::U8 => TensorDTypeTag::U8,
+        TensorDType::Bool => TensorDTypeTag::Bool,
+    }
+}

--- a/crates/kx-critic/src/evaluate.rs
+++ b/crates/kx-critic/src/evaluate.rs
@@ -1,0 +1,20 @@
+//! [`evaluate`] — the single entry point dispatching a [`CheckSpec`] to its check.
+
+use kx_critic_types::{CheckSpec, CriticVerdict};
+
+use crate::checks;
+
+/// Evaluate one deterministic check against a producer's committed output bytes.
+///
+/// **Pure, total, deterministic** (see the crate-level contract): returns a
+/// [`CriticVerdict`] for every input, never panics, and yields byte-identical
+/// verdicts for identical `(spec, input)` across runs / processes / machines.
+#[must_use]
+pub fn evaluate(spec: &CheckSpec, input: &[u8]) -> CriticVerdict {
+    match spec {
+        CheckSpec::Schema(s) => checks::schema::eval(s, input),
+        CheckSpec::Dedup(s) => checks::dedup::eval(s, input),
+        CheckSpec::StatBounds(s) => checks::stat_bounds::eval(s, input),
+        CheckSpec::PiiLeak(s) => checks::pii::eval(s, input),
+    }
+}

--- a/crates/kx-critic/src/framing.rs
+++ b/crates/kx-critic/src/framing.rs
@@ -1,0 +1,100 @@
+//! Total record framing shared by the dedup and stat-bounds checks.
+//!
+//! [`frame`] splits raw bytes into records per a [`RecordFraming`]. It is a TOTAL
+//! parser: every malformed framing (truncated length prefix, non-divisible
+//! fixed-width input, zero width) yields a [`FramingError`] carrying the byte
+//! offset — never a panic. Records borrow from the input (zero-copy).
+
+use kx_critic_types::RecordFraming;
+use smallvec::SmallVec;
+
+/// A framing parse failure, localized to a byte offset.
+pub(crate) struct FramingError {
+    pub(crate) at_offset: u64,
+}
+
+/// Split `input` into records per `framing`. Records borrow from `input`.
+///
+/// # Errors
+///
+/// Returns [`FramingError`] (with the failing byte offset) for a truncated
+/// length-prefix, a fixed-width input whose length is not a multiple of `width`,
+/// or a zero `width`.
+pub(crate) fn frame<'a>(
+    framing: RecordFraming,
+    input: &'a [u8],
+) -> Result<SmallVec<[&'a [u8]; 16]>, FramingError> {
+    let mut out: SmallVec<[&'a [u8]; 16]> = SmallVec::new();
+    match framing {
+        RecordFraming::LinesLf => {
+            // LF-delimited; a trailing newline does NOT yield a final empty
+            // record. An empty input yields zero records.
+            let mut start = 0usize;
+            for (i, &b) in input.iter().enumerate() {
+                if b == b'\n' {
+                    out.push(&input[start..i]);
+                    start = i + 1;
+                }
+            }
+            if start < input.len() {
+                out.push(&input[start..]);
+            }
+        }
+        RecordFraming::LengthPrefixedU32 => {
+            let mut pos = 0usize;
+            while pos < input.len() {
+                let Some(len_bytes) = input.get(pos..pos + 4) else {
+                    return Err(FramingError {
+                        at_offset: pos as u64,
+                    });
+                };
+                let len =
+                    u32::from_le_bytes([len_bytes[0], len_bytes[1], len_bytes[2], len_bytes[3]])
+                        as usize;
+                let body_start = pos + 4;
+                let Some(body) = input.get(body_start..body_start + len) else {
+                    return Err(FramingError {
+                        at_offset: body_start as u64,
+                    });
+                };
+                out.push(body);
+                pos = body_start + len;
+            }
+        }
+        RecordFraming::FixedWidth { width } => {
+            let width = width as usize;
+            if width == 0 {
+                return Err(FramingError { at_offset: 0 });
+            }
+            if !input.len().is_multiple_of(width) {
+                // The first incomplete record starts at the last whole boundary.
+                let at = (input.len() / width) * width;
+                return Err(FramingError {
+                    at_offset: at as u64,
+                });
+            }
+            let mut pos = 0usize;
+            while pos < input.len() {
+                out.push(&input[pos..pos + width]);
+                pos += width;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Extract a `[start, end)` byte sub-range key from a record. Returns `None` if
+/// the range is out of bounds or inverted (the caller maps that to
+/// `Unparseable`). `None` range selects the whole record.
+pub(crate) fn key_of(record: &[u8], range: Option<(u32, u32)>) -> Option<&[u8]> {
+    match range {
+        None => Some(record),
+        Some((start, end)) => {
+            let (start, end) = (start as usize, end as usize);
+            if start > end {
+                return None;
+            }
+            record.get(start..end)
+        }
+    }
+}

--- a/crates/kx-critic/src/lib.rs
+++ b/crates/kx-critic/src/lib.rs
@@ -1,0 +1,68 @@
+//! # kx-critic — the deterministic-critic evaluator (P4.2)
+//!
+//! [`evaluate`] runs one declarative [`CheckSpec`] against a producer's committed
+//! output bytes and returns a [`CriticVerdict`]. The four checks the corpus calls
+//! out are implemented here:
+//!
+//! - **schema** ([`checks::schema`]) — does the payload conform to a
+//!   [`SchemaTag`] (UTF-8 / JSON well-formedness / tensor·vector byte-length)?
+//! - **dedup** ([`checks::dedup`]) — are there duplicate records under a declared
+//!   framing + key?
+//! - **stat-bounds** ([`checks::stat_bounds`]) — is an aggregate within an
+//!   inclusive integer bound?
+//! - **PII-leakage** ([`checks::pii`]) — does a forbidden detector class match?
+//!
+//! ## Contract (load-bearing)
+//!
+//! [`evaluate`] is **pure, total, and deterministic**:
+//! - *Total* — it returns a [`CriticVerdict`] for EVERY input (adversarial,
+//!   truncated, empty, non-UTF-8, gigabytes). It never panics; a parse failure is
+//!   a deterministic [`CriticReason::Unparseable`], not a crash.
+//! - *Pure / deterministic* — the same `(spec, input)` yields a byte-identical
+//!   verdict on every run, process, and machine: no clock, host, PID, RNG, or
+//!   float-NaN ordering participates. (Floats never appear in a verdict — all
+//!   evidence is integer-scaled — so the canonical verdict bytes are stable.)
+//! - *Bounded* — O(input) work and O(input) peak memory.
+//!
+//! ## SN-8
+//!
+//! A verdict is a content-addressed FACT. The runtime commits
+//! `verdict.encode()` to the content store and the projection compares verdicts
+//! by byte-equality only (`Valid` vs `Invalid`) — never a similarity score.
+//!
+//! [`CheckSpec`]: kx_critic_types::CheckSpec
+//! [`CriticVerdict`]: kx_critic_types::CriticVerdict
+//! [`SchemaTag`]: kx_critic_types::SchemaTag
+//! [`CriticReason::Unparseable`]: kx_critic_types::CriticReason::Unparseable
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod checks;
+mod convert;
+mod evaluate;
+mod framing;
+
+#[cfg(test)]
+mod tests;
+
+pub use convert::schema_tag_of;
+pub use evaluate::evaluate;
+
+// Re-export the full vocabulary so downstream crates depend on `kx-critic` alone.
+pub use kx_critic_types::{
+    canonical_config, CheckKind, CheckSpec, CriticReason, CriticVerdict, DedupSpec, PiiClass,
+    PiiSpec, RecordFraming, SchemaFault, SchemaSpec, SchemaTag, StatBoundsSpec, StatKind,
+    TensorDTypeTag, VerdictDecodeError, CRITIC_SCHEMA_VERSION,
+};

--- a/crates/kx-critic/src/tests.rs
+++ b/crates/kx-critic/src/tests.rs
@@ -1,0 +1,534 @@
+//! Unit + property tests for the four deterministic checks: correctness,
+//! determinism, and total-on-adversarial-input (no panic) coverage.
+
+use std::collections::BTreeSet;
+
+use proptest::prelude::*;
+use smallvec::smallvec;
+
+use kx_critic_types::{
+    CheckSpec, CriticReason, CriticVerdict, DedupSpec, PiiClass, PiiSpec, RecordFraming,
+    SchemaFault, SchemaSpec, SchemaTag, StatBoundsSpec, StatKind, TensorDTypeTag,
+};
+
+use crate::evaluate;
+
+fn schema(tag: SchemaTag) -> CheckSpec {
+    CheckSpec::Schema(SchemaSpec { expected: tag })
+}
+
+// --- schema check ---------------------------------------------------------
+
+#[test]
+fn schema_blob_always_valid() {
+    assert_eq!(
+        evaluate(&schema(SchemaTag::Blob), &[0xFF, 0x00, 0x13]),
+        CriticVerdict::Valid
+    );
+    assert_eq!(
+        evaluate(&schema(SchemaTag::Blob), &[]),
+        CriticVerdict::Valid
+    );
+}
+
+#[test]
+fn schema_text_rejects_non_utf8() {
+    assert_eq!(
+        evaluate(&schema(SchemaTag::Text), b"hello"),
+        CriticVerdict::Valid
+    );
+    let v = evaluate(&schema(SchemaTag::Text), &[0x68, 0xFF, 0x69]);
+    match v {
+        CriticVerdict::Invalid {
+            reason:
+                CriticReason::SchemaMismatch {
+                    detail: SchemaFault::NotUtf8 { at_offset },
+                    ..
+                },
+        } => assert_eq!(at_offset, 1),
+        other => panic!("expected NotUtf8, got {other:?}"),
+    }
+}
+
+#[test]
+fn schema_json_valid_and_invalid() {
+    assert_eq!(
+        evaluate(&schema(SchemaTag::Json), br#"{"a":1,"b":[2,3]}"#),
+        CriticVerdict::Valid
+    );
+    let v = evaluate(&schema(SchemaTag::Json), b"{not json");
+    assert!(matches!(
+        v,
+        CriticVerdict::Invalid {
+            reason: CriticReason::SchemaMismatch {
+                detail: SchemaFault::NotJson { .. },
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn schema_tensor_shape_mismatch() {
+    // 2x3 f32 = 24 bytes expected.
+    let tag = SchemaTag::Tensor {
+        dtype: TensorDTypeTag::F32,
+        shape: smallvec![2, 3],
+    };
+    assert_eq!(
+        evaluate(&schema(tag.clone()), &[0u8; 24]),
+        CriticVerdict::Valid
+    );
+    let v = evaluate(&schema(tag), &[0u8; 20]);
+    match v {
+        CriticVerdict::Invalid {
+            reason:
+                CriticReason::SchemaMismatch {
+                    detail:
+                        SchemaFault::ShapeMismatch {
+                            expected_elems,
+                            actual_bytes,
+                        },
+                    ..
+                },
+        } => {
+            assert_eq!(expected_elems, 6);
+            assert_eq!(actual_bytes, 20);
+        }
+        other => panic!("expected ShapeMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn schema_vector_dim_bytes() {
+    let tag = SchemaTag::Vector { dim: 4 }; // 4 * 4 = 16 bytes
+    assert_eq!(
+        evaluate(&schema(tag.clone()), &[0u8; 16]),
+        CriticVerdict::Valid
+    );
+    assert!(matches!(
+        evaluate(&schema(tag), &[0u8; 12]),
+        CriticVerdict::Invalid { .. }
+    ));
+}
+
+// --- dedup check ----------------------------------------------------------
+
+fn dedup_lines(key_range: Option<(u32, u32)>) -> CheckSpec {
+    CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LinesLf,
+        key_range,
+    })
+}
+
+#[test]
+fn dedup_no_duplicates_valid() {
+    assert_eq!(
+        evaluate(&dedup_lines(None), b"a\nb\nc\n"),
+        CriticVerdict::Valid
+    );
+    assert_eq!(evaluate(&dedup_lines(None), b""), CriticVerdict::Valid);
+}
+
+#[test]
+fn dedup_detects_first_duplicate_index() {
+    // records: a(0) b(1) a(2) b(3) — first dup at index 2, count 2.
+    let v = evaluate(&dedup_lines(None), b"a\nb\na\nb");
+    match v {
+        CriticVerdict::Invalid {
+            reason:
+                CriticReason::DuplicateDetected {
+                    duplicate_count,
+                    first_duplicate_index,
+                },
+        } => {
+            assert_eq!(first_duplicate_index, 2);
+            assert_eq!(duplicate_count, 2);
+        }
+        other => panic!("expected DuplicateDetected, got {other:?}"),
+    }
+}
+
+#[test]
+fn dedup_key_subrange() {
+    // Key on bytes [0,2): "ab" rows collide on prefix even with distinct suffix.
+    let v = evaluate(&dedup_lines(Some((0, 2))), b"abXX\nabYY\n");
+    assert!(matches!(
+        v,
+        CriticVerdict::Invalid {
+            reason: CriticReason::DuplicateDetected {
+                first_duplicate_index: 1,
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn dedup_length_prefixed_framing() {
+    // Two length-prefixed records "aa","aa" → duplicate.
+    let mut bytes = Vec::new();
+    for _ in 0..2 {
+        bytes.extend_from_slice(&2u32.to_le_bytes());
+        bytes.extend_from_slice(b"aa");
+    }
+    let spec = CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LengthPrefixedU32,
+        key_range: None,
+    });
+    assert!(matches!(
+        evaluate(&spec, &bytes),
+        CriticVerdict::Invalid {
+            reason: CriticReason::DuplicateDetected { .. }
+        }
+    ));
+}
+
+#[test]
+fn dedup_malformed_framing_is_unparseable_not_panic() {
+    // Truncated length prefix (only 2 bytes where 4 are needed).
+    let spec = CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LengthPrefixedU32,
+        key_range: None,
+    });
+    let v = evaluate(&spec, &[0x05, 0x00]);
+    assert!(matches!(
+        v,
+        CriticVerdict::Invalid {
+            reason: CriticReason::Unparseable {
+                check: kx_critic_types::CheckKind::Dedup,
+                ..
+            }
+        }
+    ));
+}
+
+// --- stat-bounds check ----------------------------------------------------
+
+fn stat(stat: StatKind, lo: i64, hi: i64, field: Option<(u32, u32)>) -> CheckSpec {
+    CheckSpec::StatBounds(StatBoundsSpec {
+        framing: RecordFraming::LinesLf,
+        stat,
+        scale: 1,
+        lo_scaled: lo,
+        hi_scaled: hi,
+        numeric_field_range: field,
+    })
+}
+
+#[test]
+fn statbounds_record_count_in_range() {
+    assert_eq!(
+        evaluate(&stat(StatKind::RecordCount, 1, 3, None), b"x\ny\n"),
+        CriticVerdict::Valid
+    );
+    assert!(matches!(
+        evaluate(&stat(StatKind::RecordCount, 0, 1, None), b"x\ny\nz\n"),
+        CriticVerdict::Invalid {
+            reason: CriticReason::StatOutOfBounds {
+                observed_scaled: 3,
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn statbounds_empty_input_count_zero() {
+    assert_eq!(
+        evaluate(&stat(StatKind::RecordCount, 0, 0, None), b""),
+        CriticVerdict::Valid
+    );
+    // Mean of empty is defined as 0.
+    assert_eq!(
+        evaluate(&stat(StatKind::MeanScaled, 0, 0, None), b""),
+        CriticVerdict::Valid
+    );
+}
+
+#[test]
+fn statbounds_mean_integer_truncation() {
+    // values 1,2 → mean = 3/2 = 1 (truncated). In [1,1] → Valid.
+    assert_eq!(
+        evaluate(&stat(StatKind::MeanScaled, 1, 1, None), b"1\n2\n"),
+        CriticVerdict::Valid
+    );
+    // values 1,2,3 → mean 2; bound [3,9] → Invalid observed 2.
+    assert!(matches!(
+        evaluate(&stat(StatKind::MeanScaled, 3, 9, None), b"1\n2\n3\n"),
+        CriticVerdict::Invalid {
+            reason: CriticReason::StatOutOfBounds {
+                observed_scaled: 2,
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn statbounds_min_max_and_negatives() {
+    assert!(matches!(
+        evaluate(&stat(StatKind::MinScaled, 0, 100, None), b"5\n-3\n10\n"),
+        CriticVerdict::Invalid {
+            reason: CriticReason::StatOutOfBounds {
+                observed_scaled: -3,
+                ..
+            }
+        }
+    ));
+    assert_eq!(
+        evaluate(&stat(StatKind::MaxScaled, 0, 10, None), b"5\n-3\n10\n"),
+        CriticVerdict::Valid
+    );
+}
+
+#[test]
+fn statbounds_non_numeric_is_unparseable() {
+    let v = evaluate(&stat(StatKind::MeanScaled, 0, 10, None), b"1\nNaN\n");
+    assert!(matches!(
+        v,
+        CriticVerdict::Invalid {
+            reason: CriticReason::Unparseable {
+                check: kx_critic_types::CheckKind::StatBounds,
+                at_offset: 1
+            }
+        }
+    ));
+}
+
+// --- PII check ------------------------------------------------------------
+
+fn pii(classes: &[PiiClass]) -> CheckSpec {
+    CheckSpec::PiiLeak(PiiSpec {
+        forbidden: classes.iter().copied().collect::<BTreeSet<_>>(),
+    })
+}
+
+#[test]
+fn pii_email_match_offset() {
+    let v = evaluate(&pii(&[PiiClass::Email]), b"contact me at a@b.com please");
+    match v {
+        CriticVerdict::Invalid {
+            reason:
+                CriticReason::PiiLeak {
+                    class: PiiClass::Email,
+                    match_offset,
+                    ..
+                },
+        } => assert_eq!(match_offset, 14),
+        other => panic!("expected Email leak, got {other:?}"),
+    }
+}
+
+#[test]
+fn pii_ipv4() {
+    assert!(matches!(
+        evaluate(&pii(&[PiiClass::IpV4]), b"host 192.168.0.1 down"),
+        CriticVerdict::Invalid {
+            reason: CriticReason::PiiLeak {
+                class: PiiClass::IpV4,
+                ..
+            }
+        }
+    ));
+    // 999.x is not a valid octet → no match.
+    assert_eq!(
+        evaluate(&pii(&[PiiClass::IpV4]), b"999.1.1.1"),
+        CriticVerdict::Valid
+    );
+}
+
+#[test]
+fn pii_credit_card_luhn_true_and_false() {
+    // 4111111111111111 is a canonical Luhn-valid test PAN.
+    assert!(matches!(
+        evaluate(
+            &pii(&[PiiClass::CreditCardLuhn]),
+            b"card 4111111111111111 end"
+        ),
+        CriticVerdict::Invalid {
+            reason: CriticReason::PiiLeak {
+                class: PiiClass::CreditCardLuhn,
+                ..
+            }
+        }
+    ));
+    // Same length, fails Luhn.
+    assert_eq!(
+        evaluate(&pii(&[PiiClass::CreditCardLuhn]), b"4111111111111112"),
+        CriticVerdict::Valid
+    );
+}
+
+#[test]
+fn pii_ssn() {
+    assert!(matches!(
+        evaluate(&pii(&[PiiClass::UsSsn]), b"ssn 123-45-6789"),
+        CriticVerdict::Invalid {
+            reason: CriticReason::PiiLeak {
+                class: PiiClass::UsSsn,
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn pii_no_match_valid() {
+    assert_eq!(
+        evaluate(
+            &pii(&[PiiClass::Email, PiiClass::IpV4]),
+            b"nothing sensitive here"
+        ),
+        CriticVerdict::Valid
+    );
+}
+
+#[test]
+fn pii_earliest_offset_wins_across_classes() {
+    // SSN at offset 0, email later — SSN (earlier offset) wins.
+    let input = b"123-45-6789 then a@b.com";
+    let v = evaluate(&pii(&[PiiClass::Email, PiiClass::UsSsn]), input);
+    assert!(matches!(
+        v,
+        CriticVerdict::Invalid {
+            reason: CriticReason::PiiLeak {
+                class: PiiClass::UsSsn,
+                match_offset: 0,
+                ..
+            }
+        }
+    ));
+}
+
+// --- determinism + totality (adversarial sweep) ---------------------------
+
+fn all_specs() -> Vec<CheckSpec> {
+    vec![
+        schema(SchemaTag::Json),
+        schema(SchemaTag::Text),
+        schema(SchemaTag::Tensor {
+            dtype: TensorDTypeTag::F32,
+            shape: smallvec![2, 2],
+        }),
+        dedup_lines(None),
+        dedup_lines(Some((0, 3))),
+        CheckSpec::Dedup(DedupSpec {
+            framing: RecordFraming::LengthPrefixedU32,
+            key_range: None,
+        }),
+        CheckSpec::Dedup(DedupSpec {
+            framing: RecordFraming::FixedWidth { width: 4 },
+            key_range: None,
+        }),
+        stat(StatKind::RecordCount, 0, 5, None),
+        stat(StatKind::MeanScaled, -10, 10, None),
+        pii(&[
+            PiiClass::Email,
+            PiiClass::IpV4,
+            PiiClass::CreditCardLuhn,
+            PiiClass::UsSsn,
+        ]),
+    ]
+}
+
+#[test]
+fn adversarial_inputs_never_panic_and_are_deterministic() {
+    let mut inputs: Vec<Vec<u8>> = vec![
+        vec![],
+        vec![0xFF; 64 * 1024],
+        b"\n\n\n".to_vec(),
+        vec![0x00, 0x00, 0x00], // truncated length prefix
+        b"\xff\xfe non utf8 \x00".to_vec(),
+        b"123".to_vec(),
+    ];
+    // A fixed pseudo-random buffer (no RNG — a deterministic LCG) to stress
+    // the byte scanners without nondeterminism.
+    let mut x: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut buf = Vec::with_capacity(4096);
+    for _ in 0..4096 {
+        x = x
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        buf.push((x >> 33) as u8);
+    }
+    inputs.push(buf);
+
+    for spec in all_specs() {
+        for input in &inputs {
+            let a = evaluate(&spec, input);
+            let b = evaluate(&spec, input);
+            // Determinism: identical (spec, input) → byte-identical verdict.
+            assert_eq!(
+                a.encode(),
+                b.encode(),
+                "nondeterministic verdict for {spec:?}"
+            );
+        }
+    }
+}
+
+// --- proptest -------------------------------------------------------------
+
+fn arb_spec() -> impl Strategy<Value = CheckSpec> {
+    prop_oneof![
+        Just(schema(SchemaTag::Json)),
+        Just(schema(SchemaTag::Text)),
+        Just(schema(SchemaTag::Blob)),
+        Just(dedup_lines(None)),
+        Just(CheckSpec::Dedup(DedupSpec {
+            framing: RecordFraming::LengthPrefixedU32,
+            key_range: None,
+        })),
+        Just(CheckSpec::Dedup(DedupSpec {
+            framing: RecordFraming::FixedWidth { width: 3 },
+            key_range: Some((0, 2)),
+        })),
+        Just(stat(StatKind::RecordCount, 0, 4, None)),
+        Just(stat(StatKind::MeanScaled, -5, 5, None)),
+        Just(pii(&[PiiClass::Email, PiiClass::UsSsn])),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn prop_evaluate_total_no_panic(
+        spec in arb_spec(),
+        input in proptest::collection::vec(any::<u8>(), 0..1024),
+    ) {
+        // Total: returns a verdict for ALL inputs, never panics.
+        let _ = evaluate(&spec, &input);
+    }
+
+    #[test]
+    fn prop_evaluate_deterministic(
+        spec in arb_spec(),
+        input in proptest::collection::vec(any::<u8>(), 0..1024),
+    ) {
+        let a = evaluate(&spec, &input);
+        let b = evaluate(&spec, &input);
+        prop_assert_eq!(a.encode(), b.encode());
+    }
+}
+
+// --- conversion -----------------------------------------------------------
+
+#[test]
+fn content_schema_converts_to_tag() {
+    use kx_dataset::{ContentSchema, TensorDType};
+    assert_eq!(crate::schema_tag_of(&ContentSchema::Json), SchemaTag::Json);
+    assert_eq!(
+        crate::schema_tag_of(&ContentSchema::Vector { dim: 8 }),
+        SchemaTag::Vector { dim: 8 }
+    );
+    assert_eq!(
+        crate::schema_tag_of(&ContentSchema::Tensor {
+            dtype: TensorDType::I64,
+            shape: smallvec![3],
+        }),
+        SchemaTag::Tensor {
+            dtype: TensorDTypeTag::I64,
+            shape: smallvec![3],
+        }
+    );
+}

--- a/crates/kx-critic/tests/stress.rs
+++ b/crates/kx-critic/tests/stress.rs
@@ -1,0 +1,107 @@
+//! Scale + reproducibility stress for `kx_critic::evaluate`.
+//!
+//! `#[ignore]` (release-mode, opt-in like the kx-workflow stress suite): run via
+//! `cargo test -p kx-critic --release -- --ignored`. Asserts the two properties
+//! that matter at scale: (1) the evaluator stays total + fast as record counts
+//! grow across a scaling table, and (2) verdicts are byte-identical across two
+//! independent evaluations of the same input (the SN-8 reproducibility guarantee
+//! the runtime relies on — identical input ⇒ identical committed verdict ref).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::BTreeSet;
+
+use kx_critic::{
+    evaluate, CheckSpec, CriticVerdict, DedupSpec, PiiClass, PiiSpec, RecordFraming, SchemaSpec,
+    SchemaTag, StatBoundsSpec, StatKind,
+};
+
+/// Record counts to scale through (mirrors the kx-workflow stress `POINTS` table).
+const POINTS: &[usize] = &[1_000, 10_000, 100_000, 1_000_000];
+
+/// Build `n` LF-delimited ASCII-decimal records deterministically (no RNG).
+fn records(n: usize, unique: bool) -> Vec<u8> {
+    let mut out = Vec::with_capacity(n * 8);
+    let mut x: u64 = 0xDEAD_BEEF_CAFE_F00D;
+    for i in 0..n {
+        let v = if unique {
+            i as u64
+        } else {
+            // Force collisions: a small value domain so duplicates appear early.
+            x = x.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            (x >> 40) % 16
+        };
+        out.extend_from_slice(v.to_string().as_bytes());
+        out.push(b'\n');
+    }
+    out
+}
+
+fn specs() -> Vec<CheckSpec> {
+    vec![
+        CheckSpec::Schema(SchemaSpec {
+            expected: SchemaTag::Text,
+        }),
+        CheckSpec::Dedup(DedupSpec {
+            framing: RecordFraming::LinesLf,
+            key_range: None,
+        }),
+        CheckSpec::StatBounds(StatBoundsSpec {
+            framing: RecordFraming::LinesLf,
+            stat: StatKind::MeanScaled,
+            scale: 1,
+            lo_scaled: i64::MIN,
+            hi_scaled: i64::MAX,
+            numeric_field_range: None,
+        }),
+        CheckSpec::PiiLeak(PiiSpec {
+            forbidden: [PiiClass::Email, PiiClass::UsSsn]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+        }),
+    ]
+}
+
+#[test]
+#[ignore = "scale stress; run with --release -- --ignored"]
+fn evaluate_scales_and_is_reproducible() {
+    for &n in POINTS {
+        let unique_input = records(n, true);
+        let dup_input = records(n, false);
+        for spec in specs() {
+            for input in [&unique_input, &dup_input] {
+                // Reproducibility: two independent evaluations agree byte-for-byte.
+                let v1 = evaluate(&spec, input);
+                let v2 = evaluate(&spec, input);
+                assert_eq!(
+                    v1.content_ref_bytes(),
+                    v2.content_ref_bytes(),
+                    "verdict ref drifted at n={n} for {spec:?}"
+                );
+                // Totality at scale: a verdict is always produced.
+                let _ = matches!(v1, CriticVerdict::Valid | CriticVerdict::Invalid { .. });
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "scale stress; run with --release -- --ignored"]
+fn dedup_detects_collision_at_scale() {
+    // A duplicate-heavy 1M-record stream must be rejected, deterministically.
+    let input = records(1_000_000, false);
+    let spec = CheckSpec::Dedup(DedupSpec {
+        framing: RecordFraming::LinesLf,
+        key_range: None,
+    });
+    let v = evaluate(&spec, &input);
+    assert!(
+        matches!(
+            v,
+            CriticVerdict::Invalid {
+                reason: kx_critic::CriticReason::DuplicateDetected { .. }
+            }
+        ),
+        "expected a duplicate detection on a 16-value-domain 1M stream"
+    );
+}


### PR DESCRIPTION
## P4.2 — deterministic critic Motes, foundation PR (1 of 3)

Step 4.2 makes a **deterministic critic** a first-class, declarative, reproducible, SN-8-safe primitive — "a critic is itself a Mote reading upstream committed output." This is the **first gated PR**: two pure leaf crates with full test + perf coverage. **No existing crate consumes them yet** — that is deliberate (foundation-first). The runtime wiring lands in follow-ons:

- **PR 4.2-2** — `MoteDef.critic_check: Option<CheckSpec>` (schema 4→5) + `kx-workflow` `deterministic_critic(...)` builder + `kx-executor` native-check path (evaluate → commit a `CriticVerdict`, no execvp) + R-15 refusal.
- **PR 4.2-3** — projection promotion-gating (un-stub `promotion_state_impl`): a deterministic critic gates a world-mutating step (the P4 exit-gate proof).

### New crates (24 → 26)

**`kx-critic-types`** — the parser-free vocabulary. Kept separate so `kx-mote` can embed a `CheckSpec` in `MoteDef` (PR 4.2-2) **without** inheriting `regex`/`serde_json`, and **`kx-dataset`-free** (self-contained `SchemaTag` mirror) so it sits *below* `kx-dataset` with no dependency cycle.
- `CriticVerdict { Valid | Invalid { reason } }` — the content-addressed trust **FACT**. Frozen canonical encoding (`[version u16 LE] ‖ bincode v2 LE+fixint`, byte-identical to `kx_mote::canonical_config`) + blake3 `content_ref_bytes`. **SN-8: compared by exact byte-equality only, never a similarity score.**
- `CriticReason` — closed failure vocabulary; **all evidence integer-scaled** (no floats touch the identity/commit path, preserving the canonical-hash no-float precondition).
- `CheckSpec { Schema | Dedup | StatBounds | PiiLeak }` — checks declared as **data**; `CheckSpec::hash_into` folds a spec into a critic Mote's identity (stable u8 tags, LE ints, `BTreeSet`-canonical order).

**`kx-critic`** — the pure / **total** / deterministic `evaluate(&CheckSpec, &[u8]) -> CriticVerdict` over the four checks (schema / dedup / stat-bounds / PII-leakage). Returns a verdict for **all** inputs (adversarial, truncated, empty, non-UTF-8) and **never panics**; identical `(spec, input)` yields a byte-identical verdict on every run/process/machine. `serde_json` validates JSON structure via `IgnoredAny` (no float materialized); `regex` drives deterministic PII scanners compiled once via `LazyLock`.

### Testing + performance
- **37** unit/proptest: per-check correctness, determinism, total-on-adversarial sweep (64 KiB random + truncated framings + non-UTF-8), verdict encode/decode round-trip over all variants, `hash_into` determinism + identity-discrimination.
- **criterion bench** across {1 KiB, 64 KiB, 1 MiB, 16 MiB} per check (`cargo bench -p kx-critic`).
- **`#[ignore]` release stress**: 1M-record reproducibility (byte-identical verdict refs) + collision detection (`cargo test -p kx-critic --release -- --ignored`).

### Gate
`fmt` ✓ · `clippy --workspace --all-targets -D warnings` ✓ · `test --workspace` ✓ (no regressions) · `deny` ✓ (serde_json + regex: advisories/bans/licenses/sources ok) · `doc -D warnings` ✓ · targeted byte-determinism on new rlibs: bit-identical ✓. (`ffi-link` + full `check-reproducible` enforced by CI — unaffected by pure additive leaf crates.)

Also gitignores `/.claude/` (local agent state).

Refs: P4.2 (`01-build-sequence` §4.2). Golden rules 3 (born module-split) + 5.2 (illegal states unrepresentable; integer-only identity path). SN-8 (model proposes, runtime enforces — exact crypto-equality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)