### PR TITLE
feat: M1.1 run registration — registered instance-id identity (D64, retires D59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,7 @@ name = "kx-coordinator"
 version = "0.0.1"
 dependencies = [
  "criterion",
+ "getrandom 0.3.4",
  "kx-content",
  "kx-journal",
  "kx-mote",

--- a/crates/kx-coordinator/Cargo.toml
+++ b/crates/kx-coordinator/Cargo.toml
@@ -36,6 +36,10 @@ tokio = { workspace = true, features = ["sync"] }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+# OS entropy for the registered run-id nonce (M1.1, D64): a run identity must be
+# unpredictable to serve as a cross-boundary idempotency-token root. Version 0.3
+# is already in the lock graph (no new major added); `getrandom::fill` only.
+getrandom = "0.3"
 
 [dev-dependencies]
 # `time` is additive over the workspace tokio features — the e2e tests use a short

--- a/crates/kx-coordinator/src/error.rs
+++ b/crates/kx-coordinator/src/error.rs
@@ -45,6 +45,13 @@ pub enum CoordinatorError {
     #[error("unknown mote {0:?} (never submitted)")]
     UnknownMote(MoteId),
 
+    /// `RegisterRun` was called on a run whose journal already has entries but no
+    /// `RunRegistered` fact at seq=1 (a run started without registration). Run
+    /// registration must be the FIRST journal fact (M1.1, D64); registering after
+    /// the run has begun would violate the seq=1 / once-per-run invariant.
+    #[error("run already started without registration; RegisterRun must be the first fact")]
+    RunAlreadyStarted,
+
     /// A `ReportCommit` proposed a `result_ref` whose bytes are not present in the
     /// shared content store (D55 phantom-ref guard). When the coordinator is built
     /// with a store handle, it verifies `store.contains(result_ref)` before
@@ -107,6 +114,9 @@ impl From<CoordinatorError> for tonic::Status {
             | CoordinatorError::TooManyParents { .. }
             | CoordinatorError::DataEdgeNonCascade
             | CoordinatorError::Scheduler(_) => Self::invalid_argument(message),
+            // The run is not in a state that allows registration (it already
+            // began) — the gRPC-canonical code for a state precondition failure.
+            CoordinatorError::RunAlreadyStarted => Self::failed_precondition(message),
             CoordinatorError::Journal(_)
             | CoordinatorError::Projection(_)
             | CoordinatorError::CommitFailed(_) => Self::internal(message),

--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -46,6 +46,7 @@ pub use kx_scheduler::WorkerId;
 mod clock;
 mod commit;
 mod error;
+mod nonce;
 mod placement;
 mod registry;
 mod repudiation;
@@ -56,6 +57,7 @@ mod state;
 pub use clock::{Clock, SystemClock};
 pub use error::CoordinatorError;
 pub use kx_journal::RepudiationReason;
+pub use nonce::{OsRandomNonce, RunNonceSource};
 pub use registry::{
     is_live, InMemoryWorkerRegistry, RegistryError, WorkerRecord, WorkerRegistry, WorkerStatus,
     DEFAULT_LIVENESS_TIMEOUT,

--- a/crates/kx-coordinator/src/nonce.rs
+++ b/crates/kx-coordinator/src/nonce.rs
@@ -1,0 +1,45 @@
+//! [`RunNonceSource`] — the coordinator's source of fresh run instance ids (M1.1, D64).
+//!
+//! A run's identity is a **registered, journaled, immutable** 16-byte nonce (D64):
+//! re-running the same recipe yields a NEW run with a NEW identity. The nonce is
+//! generated ONCE at run registration (`RegisterRun`), journaled in the seq=1
+//! `RunRegistered` entry, and thereafter **read on replay — never recomputed**.
+//!
+//! It is behind a trait so tests inject a deterministic nonce (keeping a
+//! reproducible test surface) while production draws OS entropy: a run identity
+//! must be unpredictable to serve as a cross-boundary idempotency-token root.
+//!
+//! SN-8 (reframed v2, D64): run identity is a registered nonce, NOT a content
+//! hash. The nonce never enters a content-addressed digest; it is identity by
+//! registration, not by derivation.
+
+use kx_journal::INSTANCE_ID_LEN;
+
+/// A source of fresh, unguessable run instance ids.
+///
+/// `Debug` is required so a service that owns a `dyn RunNonceSource` stays
+/// `Debug`.
+pub trait RunNonceSource: Send + Sync + std::fmt::Debug {
+    /// Return a fresh 16-byte run instance id. Production implementations MUST
+    /// return an unpredictable value (OS entropy); test doubles may return a
+    /// fixed nonce for determinism.
+    fn fresh_instance_id(&self) -> [u8; INSTANCE_ID_LEN];
+}
+
+/// The production nonce source — 16 bytes of OS entropy via `getrandom`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OsRandomNonce;
+
+impl RunNonceSource for OsRandomNonce {
+    // The OS entropy source (getrandom) is infallible on every supported target
+    // (Linux CI / Apple-Silicon local, SN-7); a failure means the host RNG is
+    // unavailable, which is not a recoverable runtime condition. We surface it
+    // loudly rather than fabricate a predictable nonce — a guessable run identity
+    // would defeat D64's unguessable-identity / idempotency-token-root guarantee.
+    #[allow(clippy::expect_used)]
+    fn fresh_instance_id(&self) -> [u8; INSTANCE_ID_LEN] {
+        let mut buf = [0u8; INSTANCE_ID_LEN];
+        getrandom::fill(&mut buf).expect("OS entropy source (getrandom) must be available");
+        buf
+    }
+}

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -17,8 +17,10 @@ use kx_scheduler::WorkerId;
 use kx_warrant::WarrantSpec;
 use tonic::{Request, Response, Status};
 
+use crate::clock::{Clock, SystemClock};
 use crate::commit;
 use crate::error::CoordinatorError;
+use crate::nonce::{OsRandomNonce, RunNonceSource};
 use crate::registry::{InMemoryWorkerRegistry, RegistryError, WorkerRegistry};
 use crate::state::CoreHandle;
 
@@ -72,15 +74,36 @@ impl CoordinatorService {
         Self::build(journal, registry, Some(store))
     }
 
+    /// Build a coordinator with **injected run-registration seams** (M1.1, D64):
+    /// the run-id nonce source + the wall clock that stamps the `RunRegistered`
+    /// timestamp. Tests inject a fixed nonce + clock so the registered run
+    /// identity is deterministic; production uses [`OsRandomNonce`] +
+    /// [`SystemClock`] via the other constructors.
+    pub fn with_seams<J: Journal + Send + 'static>(
+        journal: J,
+        registry: Arc<dyn WorkerRegistry>,
+        store: Option<Arc<LocalFsContentStore>>,
+        clock: Arc<dyn Clock>,
+        nonce: Arc<dyn RunNonceSource>,
+    ) -> Self {
+        Self {
+            core: CoreHandle::spawn(journal, store, registry.clone(), clock, nonce),
+            registry,
+        }
+    }
+
     fn build<J: Journal + Send + 'static>(
         journal: J,
         registry: Arc<dyn WorkerRegistry>,
         store: Option<Arc<LocalFsContentStore>>,
     ) -> Self {
-        Self {
-            core: CoreHandle::spawn(journal, store, registry.clone()),
+        Self::with_seams(
+            journal,
             registry,
-        }
+            store,
+            Arc::new(SystemClock),
+            Arc::new(OsRandomNonce),
+        )
     }
 
     /// Read-side accessor: the current [`MoteState`] of `mote_id` in the
@@ -104,6 +127,14 @@ impl CoordinatorService {
     #[must_use]
     pub fn registry(&self) -> &dyn WorkerRegistry {
         self.registry.as_ref()
+    }
+
+    /// Read-side accessor: the registered run identity (D64) as
+    /// `(instance_id, recipe_fingerprint)`, or `None` if the run has not been
+    /// registered. Read from the folded projection — on recovery this returns the
+    /// journaled fact, never a recomputed value (the run-resume handle M2 builds on).
+    pub async fn run_registration(&self) -> Result<Option<([u8; 16], [u8; 32])>, CoordinatorError> {
+        self.core.run_registration().await
     }
 
     /// Repudiate `target` and cascade the poison-invalidation to its committed downstream
@@ -296,6 +327,27 @@ impl Coordinator for CoordinatorService {
         Ok(Response::new(proto::ReadEntriesResponse {
             entries,
             next_seq,
+        }))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn register_run(
+        &self,
+        request: Request<proto::RegisterRunRequest>,
+    ) -> Result<Response<proto::RegisterRunResponse>, Status> {
+        let req = request.into_inner();
+        // The recipe_fingerprint is a client-supplied 32-byte hash (discovery/dedup
+        // only — never identity, so the client MAY compute it, unlike a MoteId).
+        let recipe_fingerprint: [u8; 32] = req
+            .recipe_fingerprint
+            .as_slice()
+            .try_into()
+            .map_err(|_| Status::invalid_argument("recipe_fingerprint must be 32 bytes"))?;
+        // The coordinator assigns the instance_id (D53: identity is server-side).
+        let instance_id = self.core.register_run(recipe_fingerprint).await?;
+        tracing::info!("run registered");
+        Ok(Response::new(proto::RegisterRunResponse {
+            instance_id: instance_id.to_vec(),
         }))
     }
 }

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -20,15 +20,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
-use kx_journal::{FailureReason, Journal, JournalEntry, RepudiationReason};
+use kx_journal::{FailureReason, Journal, JournalEntry, RepudiationReason, INSTANCE_ID_LEN};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
 use kx_warrant::{ExecutorClass, WarrantSpec};
 use tokio::sync::{mpsc, oneshot};
 
+use crate::clock::Clock;
 use crate::commit::CommitProposal;
 use crate::error::CoordinatorError;
+use crate::nonce::RunNonceSource;
 use crate::placement::LoadAwarePlacement;
 use crate::registry::{WorkerRegistry, WorkerStatus};
 use crate::repudiation::{
@@ -110,6 +112,13 @@ pub(crate) enum Command {
         idempotency_key: [u8; 32],
         reply: oneshot::Sender<Result<u64, CoordinatorError>>,
     },
+    RegisterRun {
+        recipe_fingerprint: [u8; 32],
+        reply: oneshot::Sender<Result<[u8; INSTANCE_ID_LEN], CoordinatorError>>,
+    },
+    RunRegistration {
+        reply: oneshot::Sender<Option<([u8; INSTANCE_ID_LEN], [u8; 32])>>,
+    },
 }
 
 /// Handle to the orchestration core. Cloneable + `Send + Sync` (it is just the
@@ -129,9 +138,20 @@ impl CoreHandle {
         journal: J,
         store: Option<Arc<LocalFsContentStore>>,
         registry: Arc<dyn WorkerRegistry>,
+        clock: Arc<dyn Clock>,
+        nonce: Arc<dyn RunNonceSource>,
     ) -> Self {
         let (commands, inbox) = mpsc::channel(COMMAND_BUFFER);
-        std::thread::spawn(move || core_loop(&journal, store.as_deref(), &*registry, inbox));
+        std::thread::spawn(move || {
+            core_loop(
+                &journal,
+                store.as_deref(),
+                &*registry,
+                &*clock,
+                &*nonce,
+                inbox,
+            );
+        });
         Self { commands }
     }
 
@@ -279,6 +299,39 @@ impl CoreHandle {
         response
             .await
             .map_err(|_| CoordinatorError::CoreUnavailable)?
+    }
+
+    /// Register the run (M1.1, D64): assign a fresh, journaled, immutable
+    /// `instance_id` and append the seq=1 `RunRegistered` fact. The client calls
+    /// this once before submitting any Mote. Idempotent — a second call on the
+    /// same run returns the existing `instance_id`. Errors with `RunAlreadyStarted`
+    /// if the run has already begun without registration.
+    pub(crate) async fn register_run(
+        &self,
+        recipe_fingerprint: [u8; 32],
+    ) -> Result<[u8; INSTANCE_ID_LEN], CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::RegisterRun {
+            recipe_fingerprint,
+            reply,
+        })
+        .await?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)?
+    }
+
+    /// The registered run identity (D64) as `(instance_id, recipe_fingerprint)`,
+    /// or `None` if the run has not been registered. Read from the folded
+    /// projection — on recovery this is the journaled fact, never recomputed.
+    pub(crate) async fn run_registration(
+        &self,
+    ) -> Result<Option<([u8; INSTANCE_ID_LEN], [u8; 32])>, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::RunRegistration { reply }).await?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
     }
 
     async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
@@ -603,6 +656,8 @@ fn core_loop<J: Journal>(
     journal: &J,
     store: Option<&LocalFsContentStore>,
     registry: &dyn WorkerRegistry,
+    clock: &dyn Clock,
+    nonce: &dyn RunNonceSource,
     mut inbox: mpsc::Receiver<Command>,
 ) {
     let Some((mut projection, mut folded_through, submitted)) = recover(journal) else {
@@ -655,6 +710,8 @@ fn core_loop<J: Journal>(
                 &mut projection,
                 &mut folded_through,
                 registry,
+                clock,
+                nonce,
                 &mut dispatch,
                 &mut scheduler,
                 command,
@@ -674,11 +731,14 @@ fn core_loop<J: Journal>(
 /// Service one non-`Commit` command against the owner-thread state (Commits are
 /// coalesced into group commits before this is reached, so the `Commit` arm is
 /// unreachable). Each arm sends its `oneshot` reply; a dropped receiver is ignored.
+#[allow(clippy::too_many_arguments)]
 fn handle_command<J: Journal>(
     journal: &J,
     projection: &mut Projection,
     folded_through: &mut u64,
     registry: &dyn WorkerRegistry,
+    clock: &dyn Clock,
+    nonce: &dyn RunNonceSource,
     dispatch: &mut Dispatch,
     scheduler: &mut Scheduler<LocalPlacement>,
     command: Command,
@@ -759,6 +819,23 @@ fn handle_command<J: Journal>(
             );
             let _ = reply.send(seq);
         }
+        Command::RegisterRun {
+            recipe_fingerprint,
+            reply,
+        } => {
+            let result = register_run(
+                journal,
+                projection,
+                folded_through,
+                clock,
+                nonce,
+                recipe_fingerprint,
+            );
+            let _ = reply.send(result);
+        }
+        Command::RunRegistration { reply } => {
+            let _ = reply.send(projection.run_registration());
+        }
     }
 }
 
@@ -787,6 +864,54 @@ fn stage_effect<J: Journal>(
         *folded_through = seq;
     }
     Ok(seq)
+}
+
+/// Register the run (M1.1, D63/D64): append the seq=1 `RunRegistered` fact —
+/// the run's registered, journaled, immutable `instance_id` (a fresh OS-entropy
+/// nonce) plus the client's `recipe_fingerprint` (discovery/dedup only) and an
+/// audit timestamp — then fold it (O(1), off the Mote-DAG) and return the id.
+///
+/// **Idempotent:** if the run is already registered (its seq=1 fact folded into
+/// the projection), the existing `instance_id` is returned and nothing is written
+/// — `instance_id` is read on replay, never recomputed. **Once-per-run, seq=1:**
+/// if the journal already has entries but no registration (a run that began
+/// without it), registration is refused (`RunAlreadyStarted`) so the fact can
+/// never land mid-run.
+fn register_run<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    clock: &dyn Clock,
+    nonce: &dyn RunNonceSource,
+    recipe_fingerprint: [u8; 32],
+) -> Result<[u8; INSTANCE_ID_LEN], CoordinatorError> {
+    // Idempotent: a registered run returns its existing identity (read on replay,
+    // never recomputed). The fingerprint argument is ignored on re-registration —
+    // the journaled fact is immutable.
+    if let Some((instance_id, _)) = projection.run_registration() {
+        return Ok(instance_id);
+    }
+    // Registration must be the FIRST journal fact (seq=1). A non-empty journal with
+    // no registration means the run already began without it — refuse rather than
+    // append a registration fact in the middle of a run.
+    if *folded_through != 0 {
+        return Err(CoordinatorError::RunAlreadyStarted);
+    }
+    let instance_id = nonce.fresh_instance_id();
+    let entry = JournalEntry::RunRegistered {
+        instance_id,
+        recipe_fingerprint,
+        // Audit-only; never hashed, never on the identity/scheduling path (SN-8).
+        ts: clock.now_ms(),
+        seq: 0,
+    };
+    let durable = journal.append(entry)?;
+    let seq = durable.seq();
+    if seq > *folded_through {
+        projection.fold(&durable)?;
+        *folded_through = seq;
+    }
+    Ok(instance_id)
 }
 
 /// Register a submitted Mote through the hosted scheduler (verbatim, thesis test) and

--- a/crates/kx-coordinator/tests/run_registration.rs
+++ b/crates/kx-coordinator/tests/run_registration.rs
@@ -1,0 +1,262 @@
+//! Run registration (M1.1, D63/D64): the coordinator assigns a fresh, journaled,
+//! immutable `instance_id` at `RegisterRun` (the seq=1 `RunRegistered` fact) and
+//! returns it. Identity is a *registered nonce*, not a content hash — re-running
+//! the same recipe yields a NEW run with a NEW identity (the recipe fingerprint is
+//! retained only for discovery/dedup). The nonce + clock are injected as seams so
+//! these assertions are deterministic.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::sync::Arc;
+
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, RunNonceSource, WorkerRegistry,
+};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry, SqliteJournal};
+use tempfile::tempdir;
+use tonic::{Code, Request};
+
+/// A deterministic nonce source — every run gets the same injected `instance_id`
+/// (production uses `OsRandomNonce`).
+#[derive(Debug)]
+struct FixedNonce([u8; 16]);
+
+impl RunNonceSource for FixedNonce {
+    fn fresh_instance_id(&self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// A fixed wall clock so the journaled `ts` is deterministic (it is audit-only;
+/// never on the identity path).
+#[derive(Debug)]
+struct FixedClock(u64);
+
+impl Clock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+fn registry() -> Arc<dyn WorkerRegistry> {
+    Arc::new(InMemoryWorkerRegistry::new())
+}
+
+fn coordinator_with_nonce<J: Journal + Send + 'static>(
+    journal: J,
+    instance_id: [u8; 16],
+    ts: u64,
+) -> CoordinatorService {
+    CoordinatorService::with_seams(
+        journal,
+        registry(),
+        None,
+        Arc::new(FixedClock(ts)),
+        Arc::new(FixedNonce(instance_id)),
+    )
+}
+
+/// Call the `RegisterRun` RPC and return the assigned 16-byte instance_id.
+async fn register_run(svc: &CoordinatorService, recipe_fingerprint: [u8; 32]) -> [u8; 16] {
+    let resp = svc
+        .register_run(Request::new(proto::RegisterRunRequest {
+            recipe_fingerprint: recipe_fingerprint.to_vec(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    resp.instance_id
+        .as_slice()
+        .try_into()
+        .expect("instance_id is 16 bytes")
+}
+
+#[tokio::test]
+async fn register_run_appends_run_registered_at_seq_1() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let instance_id = [0xa1u8; 16];
+    let fingerprint = [0xb2u8; 32];
+
+    {
+        let svc = coordinator_with_nonce(SqliteJournal::open(&path).unwrap(), instance_id, 42);
+        let returned = register_run(&svc, fingerprint).await;
+        assert_eq!(returned, instance_id, "RegisterRun returns the assigned id");
+        assert_eq!(
+            svc.run_registration().await.unwrap(),
+            Some((instance_id, fingerprint)),
+            "the projection surfaces the registered identity + fingerprint"
+        );
+    } // svc dropped → core thread exits → Sqlite handle closed
+
+    // The seq=1 entry is the RunRegistered fact (read via an independent handle —
+    // exercises encode → SQLite → decode round-trip).
+    let journal = SqliteJournal::open(&path).unwrap();
+    assert_eq!(
+        journal.current_seq().unwrap(),
+        1,
+        "registration is the only fact"
+    );
+    let entries: Vec<JournalEntry> = journal.read_entries_by_seq(1..2).unwrap().collect();
+    assert_eq!(entries.len(), 1);
+    match &entries[0] {
+        JournalEntry::RunRegistered {
+            instance_id: got_id,
+            recipe_fingerprint: got_fp,
+            ts,
+            seq,
+        } => {
+            assert_eq!(*got_id, instance_id);
+            assert_eq!(*got_fp, fingerprint);
+            assert_eq!(*ts, 42, "audit timestamp came from the injected clock");
+            assert_eq!(*seq, 1, "RunRegistered is the FIRST entry of the run");
+        }
+        other => panic!("seq=1 entry must be RunRegistered, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn register_run_is_idempotent() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let instance_id = [0x5au8; 16];
+    let fingerprint = [0x6bu8; 32];
+
+    let svc = coordinator_with_nonce(SqliteJournal::open(&path).unwrap(), instance_id, 7);
+    let first = register_run(&svc, fingerprint).await;
+    // A second RegisterRun on the same run returns the SAME id, writes nothing new
+    // (even if the client passes a different fingerprint — the fact is immutable).
+    let second = register_run(&svc, [0xffu8; 32]).await;
+    assert_eq!(first, second, "re-registration returns the existing id");
+    drop(svc);
+
+    // Exactly one RunRegistered entry exists (no second fact appended).
+    let journal = SqliteJournal::open(&path).unwrap();
+    let current = journal.current_seq().unwrap();
+    let run_registered = journal
+        .read_entries_by_seq(1..(current + 1))
+        .unwrap()
+        .filter(|e| matches!(e, JournalEntry::RunRegistered { .. }))
+        .count();
+    assert_eq!(run_registered, 1, "exactly one registration fact");
+}
+
+#[tokio::test]
+async fn two_runs_same_recipe_get_distinct_instance_ids() {
+    // The roadmap exit-gate assertion (D64): re-submitting an identical recipe (same
+    // recipe_fingerprint) is a NEW run with a NEW, distinct registered identity.
+    let fingerprint = [0x11u8; 32];
+    let id_a = [0xaau8; 16];
+    let id_b = [0xbbu8; 16];
+
+    let svc_a = coordinator_with_nonce(InMemoryJournal::new(), id_a, 1);
+    let svc_b = coordinator_with_nonce(InMemoryJournal::new(), id_b, 1);
+
+    let run_a = register_run(&svc_a, fingerprint).await;
+    let run_b = register_run(&svc_b, fingerprint).await;
+
+    assert_ne!(
+        run_a, run_b,
+        "two runs of the same recipe → distinct identities"
+    );
+    assert_eq!(run_a, id_a);
+    assert_eq!(run_b, id_b);
+    // Same recipe → same fingerprint on both runs (discovery/dedup key).
+    let (_, fp_a) = svc_a.run_registration().await.unwrap().unwrap();
+    let (_, fp_b) = svc_b.run_registration().await.unwrap().unwrap();
+    assert_eq!(fp_a, fingerprint);
+    assert_eq!(fp_b, fingerprint);
+}
+
+#[tokio::test]
+async fn recover_reads_instance_id_not_recomputed() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let fingerprint = [0x33u8; 32];
+    let original_id = [0xa0u8; 16];
+    let different_id = [0xb0u8; 16];
+
+    // Run A registers with `original_id`.
+    {
+        let svc_a = coordinator_with_nonce(SqliteJournal::open(&path).unwrap(), original_id, 1);
+        assert_eq!(register_run(&svc_a, fingerprint).await, original_id);
+    }
+
+    // A fresh coordinator over the SAME journal — with a DIFFERENT nonce source —
+    // recovers the registered identity from the log; the nonce is NEVER recomputed.
+    let svc_b = coordinator_with_nonce(SqliteJournal::open(&path).unwrap(), different_id, 999);
+    assert_eq!(
+        svc_b.run_registration().await.unwrap(),
+        Some((original_id, fingerprint)),
+        "recovery reads the journaled instance_id, not the new nonce"
+    );
+    // Re-registering on the recovered run is idempotent — returns the ORIGINAL id,
+    // not the fresh nonce, and appends nothing.
+    assert_eq!(register_run(&svc_b, fingerprint).await, original_id);
+    drop(svc_b);
+    let journal = SqliteJournal::open(&path).unwrap();
+    assert_eq!(
+        journal.current_seq().unwrap(),
+        1,
+        "recovery + re-register wrote no second fact"
+    );
+}
+
+#[tokio::test]
+async fn submit_without_register_still_works() {
+    // Back-compat (M1.1 is additive): a run that never calls RegisterRun submits +
+    // commits exactly as before; run_registration() is simply None.
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let warrant = common::sample_warrant();
+    let mote = common::pure_root_mote();
+
+    let worker = common::register(&svc, "w").await;
+    common::submit(&svc, &mote, &warrant).await;
+    common::commit(&svc, &mote, worker).await;
+
+    assert_eq!(svc.committed_count().await.unwrap(), 1);
+    assert_eq!(svc.state_of(mote.id).await.unwrap(), MoteState::Committed);
+    assert_eq!(
+        svc.run_registration().await.unwrap(),
+        None,
+        "no registration → no run identity (submit path unaffected)"
+    );
+}
+
+#[tokio::test]
+async fn register_run_refused_after_run_started() {
+    // Registration must be the FIRST fact (seq=1). If a run begins without it,
+    // RegisterRun is refused (FAILED_PRECONDITION) — the fact can never land mid-run.
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let warrant = common::sample_warrant();
+    let mote = common::pure_root_mote();
+
+    let worker = common::register(&svc, "w").await;
+    common::submit(&svc, &mote, &warrant).await;
+    common::commit(&svc, &mote, worker).await;
+
+    let err = svc
+        .register_run(Request::new(proto::RegisterRunRequest {
+            recipe_fingerprint: vec![0x44u8; 32],
+        }))
+        .await
+        .expect_err("registration after the run started must be refused");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert_eq!(svc.run_registration().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn register_run_rejects_bad_fingerprint_length() {
+    let svc = CoordinatorService::new(InMemoryJournal::new());
+    let err = svc
+        .register_run(Request::new(proto::RegisterRunRequest {
+            recipe_fingerprint: vec![0u8; 31], // not 32
+        }))
+        .await
+        .expect_err("a non-32-byte fingerprint is rejected at the boundary");
+    assert_eq!(err.code(), Code::InvalidArgument);
+}

--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -9,7 +9,8 @@
 //!
 //! ```text
 //! header (74 bytes, common to all kinds):
-//!     kind             u8     (Proposed=0, Committed=1, Repudiated=2, Failed=3)
+//!     kind             u8     (Proposed=0, Committed=1, Repudiated=2, Failed=3,
+//!                              EffectStaged=4, RunRegistered=5)
 //!     mote_id          [u8;32]
 //!     idempotency_key  [u8;32]
 //!     seq              u64 LE
@@ -34,6 +35,13 @@
 //!     reason_class     u8
 //!     reporter_id      u128 LE
 //!
+//!   EffectStaged (0 bytes): header-only (v2, D38 §2b)
+//!
+//!   RunRegistered (56 bytes) (v3, M1.1, D63/D64):
+//!     instance_id        [u8;16]
+//!     recipe_fingerprint [u8;32]
+//!     ts                 u64 LE   (audit-only; excluded from every hash)
+//!
 //! ParentEntry (34 bytes):
 //!     parent_id        [u8;32]
 //!     edge_kind        u8 (Data=0, Control=1)
@@ -56,7 +64,20 @@ use smallvec::SmallVec;
 ///
 /// v2 readers refuse v1 files loudly (no in-place evolution; no production v1
 /// journals exist per the corpus, acceptable).
-pub const JOURNAL_SCHEMA_VERSION: u16 = 2;
+///
+/// **v3 (M1.1, D63/D64) changes** vs v2:
+/// - New `RunRegistered` entry kind (=5) — the append-only, immutable
+///   run-registration fact (the first entry of a run). Establishes the run's
+///   identity root: a journaled `instance_id` (the cross-boundary
+///   idempotency-token root) plus a `recipe_fingerprint` retained for
+///   discovery/dedup only (NOT identity).
+/// - `RunRegistered` does NOT participate in dedup-by-key (one run registers
+///   exactly once by construction — one journal per run), so the dedup index
+///   stays `{1, 2, 4}`. Strictly additive; `MAX_ENTRY_LEN` is unchanged.
+///
+/// v3 readers refuse v2 files loudly (no in-place evolution; no production v2
+/// journals are retained across the bump per the corpus, acceptable).
+pub const JOURNAL_SCHEMA_VERSION: u16 = 3;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).
 pub const HEADER_LEN: usize = 74;
@@ -100,6 +121,23 @@ pub const KIND_FAILED: u8 = 3;
 /// **header-only** (no payload bytes); dedup-by-key participates per the
 /// expanded `{1, 2, 4}` index.
 pub const KIND_EFFECT_STAGED: u8 = 4;
+/// `RunRegistered` entry-kind byte (NEW in v3; M1.1, D63/D64).
+///
+/// `RunRegistered` is the append-only, immutable run-registration fact — the
+/// FIRST entry of every run (`seq = 1` for a fresh run). It establishes the
+/// run's identity root (`instance_id`, read on replay and never recomputed) and
+/// carries the `recipe_fingerprint` for discovery/dedup only. Body layout:
+/// `instance_id(16) ‖ recipe_fingerprint(32) ‖ ts(u64 LE)` = 56 bytes. Does NOT
+/// participate in dedup-by-key (the dedup index stays `{1, 2, 4}`); the header
+/// `idempotency_key` slot is the all-zero sentinel and the `mote_id` slot
+/// carries the synthetic [`run_root_id`].
+pub const KIND_RUN_REGISTERED: u8 = 5;
+
+/// Length in bytes of a run's `instance_id` (the registered run nonce).
+pub const INSTANCE_ID_LEN: usize = 16;
+
+/// `RunRegistered` body length: `instance_id(16) + recipe_fingerprint(32) + ts(8)`.
+const RUN_REGISTERED_BODY_LEN: usize = INSTANCE_ID_LEN + 32 + 8;
 
 // ---------------------------------------------------------------------------
 // Closed reason enums (D19; `journal-entry.md` §6.2 + §7.2)
@@ -439,6 +477,52 @@ pub enum JournalEntry {
         /// Per-run monotonic sequence number assigned by the journal at append time.
         seq: u64,
     },
+
+    /// The append-only, immutable run-registration fact (v3, M1.1, D63/D64) —
+    /// the FIRST entry of every run (`seq = 1` for a fresh run). Establishes the
+    /// run's identity root.
+    ///
+    /// `instance_id` is the run's registered identity and the cross-boundary
+    /// idempotency-token **root** (token derivation is wired in M1.2 — no
+    /// `run_scoped_token` exists yet); it is **read on replay, never
+    /// recomputed**. `recipe_fingerprint` is the
+    /// content/def hash of the run's recipe, retained for **discovery/dedup
+    /// only** — never an identity input. `ts` is audit-only and excluded from
+    /// every hash.
+    ///
+    /// Does NOT participate in dedup-by-key: each run registers exactly once by
+    /// construction (one journal per run). The header `mote_id` slot carries the
+    /// synthetic [`run_root_id`]; the header `idempotency_key` slot is the
+    /// all-zero sentinel (kind 5 is excluded from the dedup gate).
+    RunRegistered {
+        /// The per-run nonce — the registered run identity (and token root).
+        instance_id: [u8; INSTANCE_ID_LEN],
+        /// The recipe fingerprint (discovery/dedup only; never identity).
+        recipe_fingerprint: [u8; 32],
+        /// Wall-clock submission time (ms). Audit-only; excluded from every hash.
+        ts: u64,
+        /// Journal-assigned sequence (0 until appended). `= 1` for a fresh run.
+        seq: u64,
+    },
+}
+
+/// The all-zero sentinel returned as the dedupe key of a `RunRegistered` entry,
+/// which does not participate in dedup-by-key. A `static` so
+/// [`JournalEntry::idempotency_key`] can hand back a `&[u8; 32]` uniformly.
+static ZERO_IDEMPOTENCY_KEY: [u8; 32] = [0u8; 32];
+
+/// Derive the synthetic 32-byte "run root" id that occupies a `RunRegistered`
+/// entry's header `mote_id` slot, from the run's `instance_id`.
+///
+/// Domain-separated (`"kx-run-root"`) from real Mote ids so it can never collide
+/// with one. Derived locally in `kx-journal` (no `kx-executor` dependency — the
+/// journal must not depend on the executor).
+#[must_use]
+pub fn run_root_id(instance_id: &[u8; INSTANCE_ID_LEN]) -> MoteId {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"kx-run-root");
+    hasher.update(instance_id);
+    MoteId::from_bytes(*hasher.finalize().as_bytes())
 }
 
 impl JournalEntry {
@@ -450,7 +534,8 @@ impl JournalEntry {
             | Self::Committed { seq, .. }
             | Self::Repudiated { seq, .. }
             | Self::Failed { seq, .. }
-            | Self::EffectStaged { seq, .. } => *seq,
+            | Self::EffectStaged { seq, .. }
+            | Self::RunRegistered { seq, .. } => *seq,
         }
     }
 
@@ -473,11 +558,16 @@ impl JournalEntry {
             | Self::EffectStaged {
                 idempotency_key, ..
             } => idempotency_key,
+            // RunRegistered does not dedup; return the all-zero sentinel (kind 5
+            // is excluded from the dedup gate).
+            Self::RunRegistered { .. } => &ZERO_IDEMPOTENCY_KEY,
         }
     }
 
     /// The entry's primary `mote_id`. For `Repudiated` entries this is the
-    /// `target_mote_id` (matches the header's `mote_id` per `journal-entry.md` §6).
+    /// `target_mote_id` (matches the header's `mote_id` per `journal-entry.md` §6);
+    /// for `RunRegistered` (which names no Mote) this is the synthetic
+    /// [`run_root_id`] derived from the run's `instance_id`.
     #[must_use]
     pub fn mote_id(&self) -> MoteId {
         match self {
@@ -486,6 +576,7 @@ impl JournalEntry {
             | Self::Failed { mote_id, .. }
             | Self::EffectStaged { mote_id, .. } => *mote_id,
             Self::Repudiated { target_mote_id, .. } => *target_mote_id,
+            Self::RunRegistered { instance_id, .. } => run_root_id(instance_id),
         }
     }
 
@@ -498,6 +589,7 @@ impl JournalEntry {
             Self::Repudiated { .. } => KIND_REPUDIATED,
             Self::Failed { .. } => KIND_FAILED,
             Self::EffectStaged { .. } => KIND_EFFECT_STAGED,
+            Self::RunRegistered { .. } => KIND_RUN_REGISTERED,
         }
     }
 }
@@ -531,7 +623,8 @@ pub enum DecodeError {
         /// Bytes actually present.
         got: usize,
     },
-    /// The kind discriminant byte is not one of the four known values.
+    /// The kind discriminant byte is not one of the known values
+    /// (Proposed=0 .. RunRegistered=5).
     #[error("unknown kind discriminant: {0}")]
     UnknownKind(u8),
     /// The `nondeterminism` discriminant byte is not one of the three known values.
@@ -555,6 +648,11 @@ pub enum DecodeError {
     /// (`journal-entry.md` §6 + test #17).
     #[error("Repudiated body-header mote_id mismatch")]
     RepudiatedHeaderMismatch,
+    /// A `RunRegistered` entry's header `mote_id` slot does not equal
+    /// `run_root_id(instance_id)` (v3 body-header consistency; mirrors
+    /// [`Self::RepudiatedHeaderMismatch`]).
+    #[error("RunRegistered body-header run_root_id mismatch")]
+    RunRegisteredHeaderMismatch,
     /// Trailing bytes after a complete entry (§2 no-trailing-data rule).
     #[error("trailing bytes after entry: {0} extra")]
     TrailingBytes(usize),
@@ -637,6 +735,12 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             idempotency_key,
             seq,
         } => (*mote_id, *idempotency_key, *seq, 0),
+        // v3 (M1.1): the header `mote_id` slot carries the synthetic run-root id;
+        // the `idempotency_key` slot is the all-zero sentinel (kind 5 does not
+        // dedup); `nondeterminism` is the 0 sentinel (a run is not a Mote).
+        JournalEntry::RunRegistered {
+            instance_id, seq, ..
+        } => (run_root_id(instance_id), ZERO_IDEMPOTENCY_KEY, *seq, 0),
     };
     out.extend_from_slice(mote_id_for_header.as_bytes());
     out.extend_from_slice(&idempotency_key);
@@ -706,6 +810,17 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             // The full carrying information (mote_id + idempotency_key + seq)
             // is in the 74-byte header; the recovery fold reads presence to
             // set `effect_staged_observed` on `MoteInfo`.
+        }
+        JournalEntry::RunRegistered {
+            instance_id,
+            recipe_fingerprint,
+            ts,
+            ..
+        } => {
+            // v3 (M1.1): body = instance_id(16) ‖ recipe_fingerprint(32) ‖ ts(u64 LE).
+            out.extend_from_slice(instance_id);
+            out.extend_from_slice(recipe_fingerprint);
+            out.extend_from_slice(&ts.to_le_bytes());
         }
     }
 
@@ -910,6 +1025,39 @@ pub fn decode_entry_with_def_hash(
                 seq,
             })
         }
+        KIND_RUN_REGISTERED => {
+            // v3 (M1.1): body = instance_id(16) ‖ recipe_fingerprint(32) ‖ ts(u64 LE).
+            // Exact-length (mirrors Repudiated's `!= 57`): over-length surfaces as
+            // BodyTooShort rather than a separate TrailingBytes path.
+            if body.len() != RUN_REGISTERED_BODY_LEN {
+                return Err(DecodeError::BodyTooShort {
+                    kind,
+                    got: body.len(),
+                    expected: RUN_REGISTERED_BODY_LEN,
+                });
+            }
+            let mut instance_id = [0u8; INSTANCE_ID_LEN];
+            instance_id.copy_from_slice(&body[..INSTANCE_ID_LEN]);
+            // Body-header consistency: the header `mote_id` slot MUST be the
+            // synthetic run-root id derived from this `instance_id` (mirrors the
+            // Repudiated body-vs-header check).
+            if mote_id != run_root_id(&instance_id) {
+                return Err(DecodeError::RunRegisteredHeaderMismatch);
+            }
+            let mut recipe_fingerprint = [0u8; 32];
+            recipe_fingerprint.copy_from_slice(&body[INSTANCE_ID_LEN..INSTANCE_ID_LEN + 32]);
+            let ts = u64::from_le_bytes(
+                body[INSTANCE_ID_LEN + 32..RUN_REGISTERED_BODY_LEN]
+                    .try_into()
+                    .expect("8 bytes"),
+            );
+            Ok(JournalEntry::RunRegistered {
+                instance_id,
+                recipe_fingerprint,
+                ts,
+                seq,
+            })
+        }
         other => Err(DecodeError::UnknownKind(other)),
     }
 }
@@ -994,6 +1142,13 @@ mod tests {
             JournalEntry::EffectStaged {
                 mote_id: MoteId::from_bytes([1u8; 32]),
                 idempotency_key: [2u8; 32],
+                seq: 0,
+            },
+            // v3 (M1.1): RunRegistered. Header carries the synthetic run-root id.
+            JournalEntry::RunRegistered {
+                instance_id: [3u8; INSTANCE_ID_LEN],
+                recipe_fingerprint: [4u8; 32],
+                ts: 0,
                 seq: 0,
             },
         ];
@@ -1215,6 +1370,120 @@ mod tests {
             seq: 200,
         };
         assert_eq!(decode_entry(&encode_entry(&es).unwrap()).unwrap(), es);
+
+        // v3 (M1.1): RunRegistered
+        let rr = JournalEntry::RunRegistered {
+            instance_id: [0x5a; INSTANCE_ID_LEN],
+            recipe_fingerprint: [0x6b; 32],
+            ts: 0x0123_4567_89ab_cdef,
+            seq: 300,
+        };
+        assert_eq!(decode_entry(&encode_entry(&rr).unwrap()).unwrap(), rr);
+    }
+
+    #[test]
+    fn run_registered_total_length_is_130() {
+        // v3 (M1.1): 74 header + 56 body (16 instance_id + 32 recipe_fingerprint
+        // + 8 ts) = 130 bytes.
+        let e = JournalEntry::RunRegistered {
+            instance_id: [9u8; INSTANCE_ID_LEN],
+            recipe_fingerprint: [8u8; 32],
+            ts: 42,
+            seq: 1,
+        };
+        assert_eq!(encode_entry(&e).unwrap().len(), 130);
+    }
+
+    #[test]
+    fn run_registered_header_carries_run_root_id_and_zero_idempotency_key() {
+        let instance_id = [0x11u8; INSTANCE_ID_LEN];
+        let e = JournalEntry::RunRegistered {
+            instance_id,
+            recipe_fingerprint: [0x22; 32],
+            ts: 7,
+            seq: 1,
+        };
+        let bytes = encode_entry(&e).unwrap();
+        // Header mote_id slot = run_root_id(instance_id).
+        assert_eq!(&bytes[1..33], run_root_id(&instance_id).as_bytes());
+        // Header idempotency_key slot = the all-zero sentinel (kind 5 doesn't dedup).
+        assert_eq!(&bytes[33..65], &[0u8; 32]);
+        // The accessor agrees.
+        assert_eq!(e.idempotency_key(), &[0u8; 32]);
+        assert_eq!(e.mote_id(), run_root_id(&instance_id));
+        assert_eq!(e.kind(), KIND_RUN_REGISTERED);
+    }
+
+    #[test]
+    fn decode_rejects_run_registered_body_too_short() {
+        let e = JournalEntry::RunRegistered {
+            instance_id: [1u8; INSTANCE_ID_LEN],
+            recipe_fingerprint: [2u8; 32],
+            ts: 3,
+            seq: 1,
+        };
+        let mut bytes = encode_entry(&e).unwrap();
+        bytes.pop(); // drop one body byte
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::BodyTooShort {
+                kind: KIND_RUN_REGISTERED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_run_registered_trailing_bytes() {
+        let e = JournalEntry::RunRegistered {
+            instance_id: [1u8; INSTANCE_ID_LEN],
+            recipe_fingerprint: [2u8; 32],
+            ts: 3,
+            seq: 1,
+        };
+        let mut bytes = encode_entry(&e).unwrap();
+        bytes.push(0xff); // over-length body
+                          // Exact-length check (mirrors Repudiated `!= 57`) surfaces as BodyTooShort.
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::BodyTooShort {
+                kind: KIND_RUN_REGISTERED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_run_registered_header_body_mismatch() {
+        let e = JournalEntry::RunRegistered {
+            instance_id: [0x33u8; INSTANCE_ID_LEN],
+            recipe_fingerprint: [0x44; 32],
+            ts: 5,
+            seq: 1,
+        };
+        let mut bytes = encode_entry(&e).unwrap();
+        // Corrupt the header mote_id slot so it no longer equals
+        // run_root_id(instance_id).
+        bytes[1] ^= 0xff;
+        assert_eq!(
+            decode_entry(&bytes).unwrap_err(),
+            DecodeError::RunRegisteredHeaderMismatch
+        );
+    }
+
+    #[test]
+    fn run_root_id_is_deterministic_and_domain_separated() {
+        let a = [0xaau8; INSTANCE_ID_LEN];
+        let b = [0xbbu8; INSTANCE_ID_LEN];
+        // Deterministic.
+        assert_eq!(run_root_id(&a), run_root_id(&a));
+        // Distinct instances → distinct roots.
+        assert_ne!(run_root_id(&a), run_root_id(&b));
+        // Domain-separated: NOT a bare blake3 of the instance_id (the "kx-run-root"
+        // tag must participate), so a run-root id can never collide with any other
+        // blake3-of-16-bytes identity.
+        let bare = MoteId::from_bytes(*blake3::hash(&a).as_bytes());
+        assert_ne!(run_root_id(&a), bare);
     }
 
     #[test]

--- a/crates/kx-journal/src/in_memory.rs
+++ b/crates/kx-journal/src/in_memory.rs
@@ -229,6 +229,7 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Committed { seq, .. }
         | JournalEntry::Repudiated { seq, .. }
         | JournalEntry::Failed { seq, .. }
-        | JournalEntry::EffectStaged { seq, .. } => *seq = new_seq,
+        | JournalEntry::EffectStaged { seq, .. }
+        | JournalEntry::RunRegistered { seq, .. } => *seq = new_seq,
     }
 }

--- a/crates/kx-journal/src/lib.rs
+++ b/crates/kx-journal/src/lib.rs
@@ -66,9 +66,10 @@
 //!
 //! ## What lives here
 //!
-//! - [`JournalEntry`] — the four-kind union (Proposed / Committed / Repudiated / Failed)
-//!   with hand-rolled canonical byte encoding matching `journal-entry.md` §3-7
-//!   byte-for-byte (no bincode varint surprises; the `parents` length is u16 per spec).
+//! - [`JournalEntry`] — the kind union (Proposed / Committed / Repudiated / Failed /
+//!   EffectStaged / RunRegistered) with hand-rolled canonical byte encoding matching
+//!   `journal-entry.md` §3-7 byte-for-byte (no bincode varint surprises; the `parents`
+//!   length is u16 per spec).
 //! - [`Journal`] — the backend-agnostic trait.
 //! - [`SqliteJournal`] — the OSS local backend using `rusqlite` with `BEGIN IMMEDIATE`
 //!   txns, a single `entries` table with a partial unique index for dedupe-by-key on
@@ -88,9 +89,10 @@
 
 pub use crate::entry::{
     decode_entry, decode_entry_with_def_hash, encode_entry, is_pre_commit_crash,
-    repudiation_idempotency_key, DecodeError, EncodeError, FailureReason, JournalEntry,
-    ParentEntry, RepudiationReason, HEADER_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED,
-    KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED, KIND_REPUDIATED, MAX_ENTRY_LEN, MAX_PARENTS,
+    repudiation_idempotency_key, run_root_id, DecodeError, EncodeError, FailureReason,
+    JournalEntry, ParentEntry, RepudiationReason, HEADER_LEN, INSTANCE_ID_LEN,
+    JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED,
+    KIND_REPUDIATED, KIND_RUN_REGISTERED, MAX_ENTRY_LEN, MAX_PARENTS,
 };
 pub use crate::in_memory::InMemoryJournal;
 pub use crate::sqlite::SqliteJournal;

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -11,7 +11,7 @@
 //!
 //! CREATE TABLE entries (
 //!     seq             INTEGER  PRIMARY KEY,   -- per-run monotonic u64
-//!     kind            INTEGER  NOT NULL,      -- u8 (Proposed=0, Committed=1, Repudiated=2, Failed=3)
+//!     kind            INTEGER  NOT NULL,      -- u8 (Proposed=0, Committed=1, Repudiated=2, Failed=3, EffectStaged=4, RunRegistered=5)
 //!     mote_id         BLOB     NOT NULL,      -- 32 bytes
 //!     idempotency_key BLOB     NOT NULL,      -- 32 bytes
 //!     nondeterminism  INTEGER  NOT NULL DEFAULT 0,
@@ -20,7 +20,8 @@
 //! );
 //!
 //! CREATE INDEX idx_entries_mote_id ON entries (mote_id);
-//! CREATE UNIQUE INDEX idx_entries_dedupe ON entries (idempotency_key, kind) WHERE kind IN (1, 2);
+//! CREATE UNIQUE INDEX idx_entries_dedupe ON entries (idempotency_key, kind) WHERE kind IN (1, 2, 4);
+//! -- RunRegistered (kind 5) is NOT in the dedupe set: one run registers exactly once by construction.
 //! CREATE INDEX idx_entries_def_hash ON entries (mote_def_hash) WHERE kind = 1;
 //! ```
 //!
@@ -465,7 +466,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Committed { seq, .. }
         | JournalEntry::Repudiated { seq, .. }
         | JournalEntry::Failed { seq, .. }
-        | JournalEntry::EffectStaged { seq, .. } => *seq = new_seq,
+        | JournalEntry::EffectStaged { seq, .. }
+        | JournalEntry::RunRegistered { seq, .. } => *seq = new_seq,
     }
 }
 

--- a/crates/kx-journal/tests/dod.rs
+++ b/crates/kx-journal/tests/dod.rs
@@ -255,7 +255,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Committed { seq, .. }
         | JournalEntry::Repudiated { seq, .. }
         | JournalEntry::Failed { seq, .. }
-        | JournalEntry::EffectStaged { seq, .. } => *seq = new_seq,
+        | JournalEntry::EffectStaged { seq, .. }
+        | JournalEntry::RunRegistered { seq, .. } => *seq = new_seq,
     }
 }
 

--- a/crates/kx-journal/tests/proptest_entry.rs
+++ b/crates/kx-journal/tests/proptest_entry.rs
@@ -29,8 +29,8 @@
 use kx_content::ContentRef;
 use kx_journal::{
     decode_entry, decode_entry_with_def_hash, encode_entry, FailureReason, InMemoryJournal,
-    Journal, JournalEntry, ParentEntry, RepudiationReason, SqliteJournal, MAX_ENTRY_LEN,
-    MAX_PARENTS,
+    Journal, JournalEntry, ParentEntry, RepudiationReason, SqliteJournal, INSTANCE_ID_LEN,
+    MAX_ENTRY_LEN, MAX_PARENTS,
 };
 use kx_mote::{MoteDefHash, MoteId, NdClass};
 use proptest::prelude::*;
@@ -162,6 +162,28 @@ fn arb_committed() -> impl Strategy<Value = JournalEntry> {
         )
 }
 
+/// **v3 (M1.1): RunRegistered strategy.** `instance_id` is the 16-byte run nonce;
+/// `recipe_fingerprint` is a 32-byte discovery/dedup hash; `ts` is audit-only.
+fn arb_run_registered() -> impl Strategy<Value = JournalEntry> {
+    (
+        proptest::array::uniform16(any::<u8>()),
+        arb_byte_array_32(),
+        any::<u64>(),
+        any::<u64>(),
+    )
+        .prop_map(|(instance_id, recipe_fingerprint, ts, seq)| {
+            // The strategy already produces a 16-byte array; pin it to
+            // INSTANCE_ID_LEN so a future length change fails to compile here.
+            let _: [u8; INSTANCE_ID_LEN] = instance_id;
+            JournalEntry::RunRegistered {
+                instance_id,
+                recipe_fingerprint,
+                ts,
+                seq,
+            }
+        })
+}
+
 /// **v2 (PR 7): EffectStaged strategy.** Header-only; no body fields.
 fn arb_effect_staged() -> impl Strategy<Value = JournalEntry> {
     (arb_mote_id(), arb_byte_array_32(), any::<u64>()).prop_map(
@@ -273,6 +295,36 @@ proptest! {
         let a = encode_entry(&entry).expect("encode a");
         let b = encode_entry(&entry).expect("encode b");
         prop_assert_eq!(a, b);
+    }
+
+    // **v3 (M1.1)** — encode/decode round-trip for RunRegistered entries.
+    // Fixed 130-byte size (74 header + 56 body).
+    #[test]
+    fn prop_run_registered_round_trip(entry in arb_run_registered()) {
+        let bytes = encode_entry(&entry).expect("encode");
+        prop_assert_eq!(bytes.len(), 130);
+        let decoded = decode_entry(&bytes).expect("decode");
+        prop_assert_eq!(decoded, entry);
+    }
+
+    // **v3 (M1.1)** — encoding determinism for RunRegistered.
+    #[test]
+    fn prop_encoding_is_deterministic_run_registered(entry in arb_run_registered()) {
+        let a = encode_entry(&entry).expect("encode a");
+        let b = encode_entry(&entry).expect("encode b");
+        prop_assert_eq!(a, b);
+    }
+
+    // **v3 (M1.1)** — size cap holds for RunRegistered.
+    #[test]
+    fn prop_size_cap_run_registered(entry in arb_run_registered()) {
+        let bytes = encode_entry(&entry).expect("encode");
+        prop_assert!(
+            bytes.len() <= MAX_ENTRY_LEN,
+            "RunRegistered encoded to {} bytes; cap is {}",
+            bytes.len(),
+            MAX_ENTRY_LEN
+        );
     }
 
     // Property 1 — encode/decode round-trip for Committed entries via

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -307,6 +307,25 @@ impl Projection {
                 info.effect_staged_observed = true;
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
+            JournalEntry::RunRegistered {
+                instance_id,
+                recipe_fingerprint,
+                seq,
+                ..
+            } => {
+                // **v3 (M1.1, D63/D64): run registration.** Off the Mote-DAG —
+                // names no Mote, so this fold registers NO MoteInfo and does NOT
+                // call `rebuild_children_index` (the per-mutation O(n²) path).
+                // It records the run's identity root as an O(1) field. Idempotent
+                // on replay: the seq=1 entry replays the same bytes, so re-folding
+                // sets the same `RunRegistration`. `ts` is audit-only and ignored
+                // here (never an input to any scheduling/identity decision).
+                self.state.run_registration = Some(crate::state::RunRegistration {
+                    instance_id: *instance_id,
+                    recipe_fingerprint: *recipe_fingerprint,
+                });
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
         }
         Ok(prev)
     }
@@ -570,6 +589,20 @@ impl Projection {
     #[must_use]
     pub fn committed_count(&self) -> usize {
         self.iter_motes_in_state(MoteState::Committed).count()
+    }
+
+    /// The registered run identity (D64) as `(instance_id, recipe_fingerprint)`,
+    /// or `None` if no `RunRegistered` entry has been folded.
+    ///
+    /// Set when the run's seq=1 `RunRegistered` entry is folded; read on replay,
+    /// never recomputed. Off the Mote-DAG (does not gate scheduling); for M1.1
+    /// it is a queryable run-identity marker (M1.2 metadata + the catalog build
+    /// on it).
+    #[must_use]
+    pub fn run_registration(&self) -> Option<([u8; kx_journal::INSTANCE_ID_LEN], [u8; 32])> {
+        self.state
+            .run_registration
+            .map(|r| (r.instance_id, r.recipe_fingerprint))
     }
 
     /// Count of Motes currently in `MoteState::Repudiated`.

--- a/crates/kx-projection/src/snapshot.rs
+++ b/crates/kx-projection/src/snapshot.rs
@@ -88,6 +88,15 @@ impl Snapshot {
         self.state.state_of_id(mote_id)
     }
 
+    /// The registered run identity (D64). See
+    /// [`crate::Projection::run_registration`].
+    #[must_use]
+    pub fn run_registration(&self) -> Option<([u8; kx_journal::INSTANCE_ID_LEN], [u8; 32])> {
+        self.state
+            .run_registration
+            .map(|r| (r.instance_id, r.recipe_fingerprint))
+    }
+
     /// Direct parents. See [`crate::Projection::parents_of`].
     #[must_use]
     pub fn parents_of(&self, mote_id: &MoteId) -> SmallVec<[(MoteId, EdgeMeta); 4]> {

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -93,6 +93,18 @@ pub(crate) struct DeclaredInfo {
     pub(crate) warrant_ref: ContentRef,
 }
 
+/// The registered, journaled run identity (v3, M1.1, D63/D64). Established when
+/// the `RunRegistered` entry (seq=1) is folded; **read on replay, never
+/// recomputed**. Off the Mote-DAG — folding it touches no Mote and never
+/// rebuilds the children index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RunRegistration {
+    /// The per-run nonce — the registered run identity (and token root).
+    pub(crate) instance_id: [u8; kx_journal::INSTANCE_ID_LEN],
+    /// The recipe fingerprint (discovery/dedup only; never identity).
+    pub(crate) recipe_fingerprint: [u8; 32],
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct State {
     /// Per-MoteId info — declared, committed, and any in-flight state.
@@ -103,6 +115,9 @@ pub(crate) struct State {
     pub(crate) children: BTreeMap<MoteId, Vec<(MoteId, EdgeMeta)>>,
     /// The largest `seq` value applied so far.
     pub(crate) last_seq: u64,
+    /// The registered run identity (D64), or `None` until a `RunRegistered`
+    /// entry is folded. Off-DAG; O(1) to set and read.
+    pub(crate) run_registration: Option<RunRegistration>,
 }
 
 impl State {

--- a/crates/kx-projection/tests/proptest_fold.rs
+++ b/crates/kx-projection/tests/proptest_fold.rs
@@ -210,6 +210,37 @@ proptest! {
         }
     }
 
+    // **v3 (M1.1)** — prepending a RunRegistered entry to any trace leaves the
+    // committed-set signature unchanged (it registers no Mote) and sets the run
+    // identity. Folding it never touches the Mote-DAG; the committed digest the
+    // runtime hashes is therefore invariant under run registration.
+    #[test]
+    fn prop_run_registered_is_off_dag_for_any_trace(trace in arb_trace()) {
+        let entries = materialize(&trace);
+
+        let mut without_reg = Projection::new();
+        for e in &entries {
+            without_reg.fold(e).expect("fold without reg");
+        }
+
+        let mut with_reg = Projection::new();
+        with_reg.fold(&run_registered(0x99, 0xee, 0)).expect("fold reg");
+        for e in &entries {
+            with_reg.fold(e).expect("fold with reg");
+        }
+
+        // RunRegistered adds no Mote → identical Mote set + per-state counts.
+        prop_assert_eq!(with_reg.len(), without_reg.len());
+        prop_assert_eq!(with_reg.committed_count(), without_reg.committed_count());
+        prop_assert_eq!(with_reg.repudiated_count(), without_reg.repudiated_count());
+        prop_assert_eq!(with_reg.failed_count(), without_reg.failed_count());
+        prop_assert!(with_reg.run_registration().is_some());
+        prop_assert!(without_reg.run_registration().is_none());
+        for (id, state) in without_reg.iter_motes() {
+            prop_assert_eq!(with_reg.state_of(&id), state);
+        }
+    }
+
     // Property 2 — `fold_many` matches a `fold` loop.
     #[test]
     fn prop_fold_many_matches_fold_loop(trace in arb_trace()) {
@@ -418,6 +449,85 @@ fn per_state_counts_sum_to_len() {
     assert_eq!(p.committed_count(), 2);
     assert_eq!(p.failed_count(), 1);
     assert_eq!(p.scheduled_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// **v3 (M1.1, D63/D64) — RunRegistered fold is off the Mote-DAG (O(1)).**
+//
+// RunRegistered names no Mote: folding it MUST register no MoteInfo, leave the
+// children index empty, advance current_seq, set run_registration(), and never
+// touch any Mote's per-state classification. These pin that the run-registration
+// fact is a pure off-DAG marker — the scalability guarantee (no O(n²) index
+// rebuild, no phantom Mote) and the determinism guarantee (the digest, computed
+// over committed Motes only, is unaffected).
+// ---------------------------------------------------------------------------
+
+fn run_registered(instance_seed: u8, recipe_seed: u8, seq: u64) -> JournalEntry {
+    JournalEntry::RunRegistered {
+        instance_id: [instance_seed; kx_journal::INSTANCE_ID_LEN],
+        recipe_fingerprint: [recipe_seed; 32],
+        ts: 0,
+        seq,
+    }
+}
+
+#[test]
+fn run_registered_fold_is_off_dag() {
+    let mut p = Projection::new();
+    p.fold(&run_registered(0xa1, 0xb2, 1)).unwrap();
+    // No Mote registered, all per-state counts zero.
+    assert_eq!(p.len(), 0);
+    assert!(p.is_empty());
+    assert_eq!(p.committed_count(), 0);
+    assert_eq!(p.iter_motes().count(), 0);
+    // current_seq advanced; run identity is queryable.
+    assert_eq!(p.current_seq(), 1);
+    assert_eq!(
+        p.run_registration(),
+        Some(([0xa1; kx_journal::INSTANCE_ID_LEN], [0xb2; 32]))
+    );
+}
+
+#[test]
+fn run_registered_fold_is_idempotent_on_replay() {
+    // Replaying the seq=1 RunRegistered (recovery re-folds the same bytes) sets
+    // the same run identity and adds no Mote — instance_id read, never recomputed.
+    let mut p = Projection::new();
+    p.fold(&run_registered(0x5a, 0x6b, 1)).unwrap();
+    let first = p.run_registration();
+    p.fold(&run_registered(0x5a, 0x6b, 1)).unwrap();
+    assert_eq!(p.run_registration(), first);
+    assert_eq!(p.len(), 0);
+}
+
+#[test]
+fn run_registered_before_motes_does_not_change_committed_set() {
+    // Run with registration prepended (seq=1), then Motes.
+    let mut with_reg = Projection::new();
+    with_reg.fold(&run_registered(0x11, 0x22, 1)).unwrap();
+    with_reg.fold(&arb_committed(1, 2, NdClass::Pure)).unwrap();
+    with_reg
+        .fold(&arb_committed(2, 3, NdClass::WorldMutating))
+        .unwrap();
+
+    // Same Motes, no registration.
+    let mut without_reg = Projection::new();
+    without_reg
+        .fold(&arb_committed(1, 1, NdClass::Pure))
+        .unwrap();
+    without_reg
+        .fold(&arb_committed(2, 2, NdClass::WorldMutating))
+        .unwrap();
+
+    // The committed SET is identical (RunRegistered adds no Mote) — this is what
+    // the runtime digest (committed Motes only) hashes, so it is unchanged.
+    assert_eq!(with_reg.committed_count(), without_reg.committed_count());
+    assert_eq!(with_reg.len(), without_reg.len());
+    assert!(with_reg.run_registration().is_some());
+    assert_eq!(without_reg.run_registration(), None);
+    for (id, state) in without_reg.iter_motes() {
+        assert_eq!(with_reg.state_of(&id), state);
+    }
 }
 
 #[test]

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -363,6 +363,25 @@ message ReadEntriesResponse {
 }
 
 // ---------------------------------------------------------------------------
+// RPC (8) — register a run (M1.1, D63/D64). The client establishes a run BEFORE
+// submitting any Mote: the coordinator assigns a fresh, journaled, immutable
+// `instance_id` (the registered run identity + cross-boundary idempotency-token
+// root, D64) and appends a `RunRegistered` entry at seq=1. The client supplies a
+// `recipe_fingerprint` (the recipe's def/content hash, e.g. a ManifestId) for
+// discovery/dedup — it is NEVER the run identity. Calling twice on the same run
+// returns the existing `instance_id` (idempotent retry). The instance_id is
+// coordinator-assigned; clients NEVER compute it (D53 identity invariant).
+// ---------------------------------------------------------------------------
+
+message RegisterRunRequest {
+  bytes recipe_fingerprint = 1;         // 32B — recipe def/content hash (discovery/dedup only)
+}
+
+message RegisterRunResponse {
+  bytes instance_id = 1;                // 16B — coordinator-assigned registered run identity
+}
+
+// ---------------------------------------------------------------------------
 // Service — hosted by the coordinator; workers are clients.
 // ---------------------------------------------------------------------------
 
@@ -374,4 +393,5 @@ service Coordinator {
   rpc LeaseWork(LeaseWorkRequest) returns (LeaseWorkResponse);
   rpc ReadEntries(ReadEntriesRequest) returns (ReadEntriesResponse);
   rpc ReportEffectStaged(ReportEffectStagedRequest) returns (ReportEffectStagedResponse);
+  rpc RegisterRun(RegisterRunRequest) returns (RegisterRunResponse);
 }

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -16,9 +16,10 @@ use kx_proto::proto::coordinator_server::{Coordinator, CoordinatorServer};
 use kx_proto::proto::{
     journal_entry, CommitOutcome, CommittedEntry, ExecutorClass, HeartbeatRequest,
     HeartbeatResponse, JournalEntry, LeaseWorkRequest, LeaseWorkResponse, NdClass,
-    ReadEntriesRequest, ReadEntriesResponse, RegisterWorkerRequest, RegisterWorkerResponse,
-    ReportCommitRequest, ReportCommitResponse, ReportEffectStagedRequest,
-    ReportEffectStagedResponse, SubmitMoteRequest, SubmitMoteResponse, SubmitStatus, WorkItem,
+    ReadEntriesRequest, ReadEntriesResponse, RegisterRunRequest, RegisterRunResponse,
+    RegisterWorkerRequest, RegisterWorkerResponse, ReportCommitRequest, ReportCommitResponse,
+    ReportEffectStagedRequest, ReportEffectStagedResponse, SubmitMoteRequest, SubmitMoteResponse,
+    SubmitStatus, WorkItem,
 };
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
@@ -91,6 +92,19 @@ impl Coordinator for NoopCoordinator {
                 mote: Some(sample_mote().into()),
                 warrant: Some(sample_warrant().into()),
             }],
+        }))
+    }
+
+    async fn register_run(
+        &self,
+        req: Request<RegisterRunRequest>,
+    ) -> Result<Response<RegisterRunResponse>, Status> {
+        // Echo back a fixed 16-byte instance_id so the test confirms the RPC
+        // round-trips. (Real nonce generation + journaling is coordinator-side
+        // in M1.1; not here.)
+        let _ = req.into_inner();
+        Ok(Response::new(RegisterRunResponse {
+            instance_id: vec![9; 16],
         }))
     }
 
@@ -241,4 +255,18 @@ async fn coordinator_skeleton_serves_all_rpcs() {
             assert_eq!(c.result_ref.len(), 32, "committed result_ref round-tripped");
         }
     }
+
+    // (8) register run — recipe_fingerprint goes up, instance_id comes back.
+    let run = client
+        .register_run(RegisterRunRequest {
+            recipe_fingerprint: vec![7; 32],
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        run.instance_id.len(),
+        16,
+        "instance_id round-tripped over the wire"
+    );
 }

--- a/crates/kx-worker/tests/wm_dispatch.rs
+++ b/crates/kx-worker/tests/wm_dispatch.rs
@@ -376,6 +376,12 @@ impl Coordinator for RecordingCoordinator {
     ) -> Result<Response<kx_coordinator::proto::ReadEntriesResponse>, Status> {
         self.inner.read_entries(request).await
     }
+    async fn register_run(
+        &self,
+        request: Request<kx_coordinator::proto::RegisterRunRequest>,
+    ) -> Result<Response<kx_coordinator::proto::RegisterRunResponse>, Status> {
+        self.inner.register_run(request).await
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What & why

Implements **M1.1** of the v2 durable-agentic-execution roadmap: a run's identity becomes a **registered, journaled, immutable `instance_id`** (a per-run nonce), **not** a content hash (**D64**, retires **D59**). The recipe def/content hash survives only as a **recipe fingerprint** for discovery/dedup. Purely additive (Golden Rule 1) — the frozen trio (`kx-scheduler` / `kx-executor` / `kx-inference`) is untouched (**thesis diff empty**).

## What was implemented
- **kx-journal** — completes the v3 `RunRegistered` entry (KIND=5): decoder arm with exact-length + body-header `run_root_id` consistency check (new `DecodeError::RunRegisteredHeaderMismatch`), `set_seq` arms in both backends, doc honesty fixes (stale dedup index `(1,2)`→`(1,2,4)`; `run_scoped_token` marked a forward seam; layout summary). Consumes the previously-dead `RUN_REGISTERED_BODY_LEN`.
- **kx-projection** — O(1) **off-DAG** fold arm: sets a single `run_registration` field, **never** calls `rebuild_children_index` (the >10k-mote O(n²) wall) and registers no phantom Mote; `run_registration()` accessor on `Projection`/`Snapshot`.
- **kx-proto** — `RegisterRun` RPC (8th) + `RegisterRunRequest`/`Response`, length-validated at the boundary; skeleton no-op + test-double ripple.
- **kx-coordinator** — `RunNonceSource` seam (`OsRandomNonce` via `getrandom` 0.3, already in the lock graph) + `Clock` threaded through the core; `RegisterRun` handler appends the seq=1 fact, **idempotent** on re-call, **`RunAlreadyStarted`** if a run began without it; the coordinator assigns the `instance_id` (D53 — clients never compute identity). `with_seams` test constructor + `run_registration()` read accessor.

## What was tested (seven-kind D95 contract)
- **unit + proptest**: entry round-trip, `run_root_id` determinism/domain-separation, body-too-short / header-mismatch rejection.
- **projection proptests**: folding `RunRegistered` leaves the committed set + children index unchanged.
- **7 coordinator integration tests** incl. the **roadmap exit gate** (re-running the same recipe → distinct `instance_id`, same `recipe_fingerprint`), recover-reads-not-recomputed, idempotency, seq=1/SQLite round-trip, and submit-without-register back-compat.

## Determinism / scalability / performance
- `a0_guard` canonical demo digest `a6b5c679…` **UNCHANGED** (registration is coordinator-only; the single-process demo path is untouched). `digest_projection` hashes only committed Motes, so `RunRegistered` cannot move it.
- `RunRegistered` append is **O(1)**; dedup index unchanged (`{1,2,4}`); fold is **O(1)** and off the O(n²) children-index path.

## Local gate (mirrors `just ci`, Apple Silicon)
fmt-check ✓ · clippy `--workspace --all-targets -D warnings` ✓ · `cargo test --workspace` ✓ **1006/0** · cargo-deny ✓ · doc `-D warnings` ✓ · ffi-link ✓ · **I1.c byte-determinism ✓ (28 artifacts bit-identical)** · thesis-diff **empty**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)