### PR TITLE
feat: M1.2 resolved-version run metadata (D79) + run-scoped idempotency token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
 name = "kx-capability"
 version = "0.0.1"
 dependencies = [
+ "blake3",
  "kx-content",
  "kx-mote",
  "kx-warrant",
@@ -1093,6 +1094,7 @@ dependencies = [
  "kx-projection",
  "kx-proto",
  "kx-scheduler",
+ "kx-tool-registry",
  "kx-warrant",
  "kx-worker",
  "smallvec",

--- a/crates/kx-capability/Cargo.toml
+++ b/crates/kx-capability/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 kx-mote    = { workspace = true }
 kx-content = { workspace = true }
 kx-warrant = { workspace = true }
+blake3     = { workspace = true }
 serde      = { workspace = true }
 thiserror  = { workspace = true }
 tracing    = { workspace = true }

--- a/crates/kx-capability/src/lib.rs
+++ b/crates/kx-capability/src/lib.rs
@@ -101,7 +101,7 @@ pub use capability::Capability;
 pub use errors::{BrokerError, CapabilityFailureReason};
 pub use local::LocalCapabilityBroker;
 pub use request::{BrokerHandle, EffectRequest};
-pub use token::idempotency_token_for;
+pub use token::{idempotency_token_for, run_scoped_token, INSTANCE_ID_LEN};
 
 #[cfg(test)]
 mod tests;

--- a/crates/kx-capability/src/token.rs
+++ b/crates/kx-capability/src/token.rs
@@ -1,16 +1,57 @@
-//! D38 §1 — derive the 32-byte idempotency token from a [`Mote`]'s identity.
+//! D38 §1 — derive the 32-byte cross-boundary idempotency token.
+//!
+//! The token roots in the **registered run** (`instance_id`, D64/M1.1) via
+//! [`run_scoped_token`] (M1.2): the same Mote re-submitted as a *new* run gets a
+//! *different* token, so cross-boundary exactly-once is **per run** — a fresh
+//! run fires a fresh effect, while a recovery re-dispatch of the *same* run
+//! re-derives the *same* token (the remote API dedups). [`idempotency_token_for`]
+//! (MoteId-only) survives for callers with no run context.
 
 use kx_mote::Mote;
 
-/// Derive the 32-byte idempotency token from a [`Mote`]'s identity.
+/// Length of a run's `instance_id` (the registered run nonce). Kept as a local
+/// literal so this crate stays **independent of `kx-journal`** (recovery-state
+/// independence); it mirrors `kx_journal::INSTANCE_ID_LEN`.
+pub const INSTANCE_ID_LEN: usize = 16;
+
+/// Domain tag for run-scoped idempotency tokens — separates them from
+/// `run_root_id` (`"kx-run-root"`) and any bare MoteId, so a token can never
+/// collide with another 32-byte identity on a different derivation path.
+const RUN_SCOPED_TOKEN_DOMAIN: &[u8] = b"kx-run-scoped-token";
+
+/// Derive the 32-byte cross-boundary idempotency token for a [`Mote`] within a
+/// registered run (M1.2, D64).
 ///
-/// Per D38 §1, the broker passes this token through to a remote tool's
-/// idempotency header (e.g., `Idempotency-Key: <hex>`) so that a recovery
-/// re-dispatch of the same Mote produces the SAME token; the remote API
-/// then returns the cached response and no double-effect occurs. The
-/// 32-byte form is the raw [`MoteId`][kx_mote::MoteId] bytes; the caller
-/// is free to hex-encode them per the remote API's wire format (e.g.,
-/// `blake3::Hash::from_bytes(token).to_hex()`).
+/// `token = blake3("kx-run-scoped-token" ‖ instance_id ‖ mote.id)`. Pure,
+/// deterministic, and replay-stable: a recovery re-dispatch of the *same*
+/// `(instance_id, mote)` re-derives the *same* token (the remote idempotency
+/// header dedups → no double-effect), while the *same* Mote under a *different*
+/// registered run produces a *different* token (a re-submitted recipe is a fresh
+/// run that fires a fresh effect). The broker passes this through to the remote
+/// tool's idempotency header (e.g. `Idempotency-Key: <hex>`); hex-encode per the
+/// remote API's wire format (`blake3::Hash::from_bytes(token).to_hex()`).
+#[inline]
+#[must_use]
+pub fn run_scoped_token(instance_id: &[u8; INSTANCE_ID_LEN], mote: &Mote) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(RUN_SCOPED_TOKEN_DOMAIN);
+    hasher.update(instance_id);
+    hasher.update(mote.id.as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Derive the 32-byte idempotency token from a [`Mote`]'s identity alone.
+///
+/// **Prefer [`run_scoped_token`]** for any caller that has the run's
+/// `instance_id` (the distributed dispatch path does, M1.2): MoteId-only keying
+/// means the *same* Mote re-submitted as a *new* run would collide on the
+/// cross-boundary key. This MoteId-only form survives for callers with no run
+/// context. Per D38 §1, the broker passes the token through to a remote tool's
+/// idempotency header (e.g., `Idempotency-Key: <hex>`) so a recovery re-dispatch
+/// of the same Mote produces the SAME token and the remote API returns the
+/// cached response (no double-effect). The 32-byte form is the raw
+/// [`MoteId`][kx_mote::MoteId] bytes; hex-encode per the remote API's wire
+/// format (e.g., `blake3::Hash::from_bytes(token).to_hex()`).
 ///
 /// # Example
 ///
@@ -51,4 +92,83 @@ use kx_mote::Mote;
 #[must_use]
 pub fn idempotency_token_for(mote: &Mote) -> [u8; 32] {
     *mote.id.as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_mote::{
+        EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, NdClass,
+        PromptTemplateHash,
+    };
+    use smallvec::SmallVec;
+    use std::collections::BTreeMap;
+
+    fn sample_mote(pos: &str) -> Mote {
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([0u8; 32]),
+            model_id: ModelId("m".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([0u8; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::WorldMutating,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::StageThenCommit,
+            critic_for: None,
+            is_topology_shaper: false,
+            inference_params: kx_mote::InferenceParams::default(),
+            critic_check: None,
+            schema_version: kx_mote::MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([0u8; 32]),
+            GraphPosition(pos.into()),
+            SmallVec::new(),
+        )
+    }
+
+    #[test]
+    fn run_scoped_token_is_stable_within_a_run() {
+        let mote = sample_mote("/root");
+        let id = [0x11u8; INSTANCE_ID_LEN];
+        // A recovery re-dispatch of the SAME (instance, mote) re-derives the
+        // SAME token (the remote idempotency header dedups).
+        assert_eq!(run_scoped_token(&id, &mote), run_scoped_token(&id, &mote));
+    }
+
+    #[test]
+    fn run_scoped_token_differs_across_runs_for_same_mote() {
+        let mote = sample_mote("/root");
+        let run_a = [0x11u8; INSTANCE_ID_LEN];
+        let run_b = [0x22u8; INSTANCE_ID_LEN];
+        // The SAME Mote under a DIFFERENT registered run → DIFFERENT token, so a
+        // re-submitted recipe is a fresh run that fires a fresh effect (D64).
+        assert_ne!(
+            run_scoped_token(&run_a, &mote),
+            run_scoped_token(&run_b, &mote)
+        );
+    }
+
+    #[test]
+    fn run_scoped_token_is_domain_separated() {
+        let mote = sample_mote("/root");
+        let id = [0x33u8; INSTANCE_ID_LEN];
+        let token = run_scoped_token(&id, &mote);
+        // Never the bare MoteId (the old MoteId-only token).
+        assert_ne!(&token, mote.id.as_bytes());
+        // Never a bare blake3(instance_id ‖ mote_id) without the domain tag.
+        let mut bare = blake3::Hasher::new();
+        bare.update(&id);
+        bare.update(mote.id.as_bytes());
+        assert_ne!(&token, bare.finalize().as_bytes());
+    }
+
+    #[test]
+    fn run_scoped_token_distinguishes_distinct_motes() {
+        let id = [0x44u8; INSTANCE_ID_LEN];
+        assert_ne!(
+            run_scoped_token(&id, &sample_mote("/a")),
+            run_scoped_token(&id, &sample_mote("/b"))
+        );
+    }
 }

--- a/crates/kx-coordinator/Cargo.toml
+++ b/crates/kx-coordinator/Cargo.toml
@@ -25,6 +25,11 @@ kx-projection = { workspace = true }
 kx-mote = { workspace = true }
 kx-content = { workspace = true }
 kx-warrant = { workspace = true }
+# Resolve-at-submit (M1.2, D79): the coordinator resolves the warrant's
+# tool_grants and captures the resolved versions as off-DAG run metadata. This
+# is a NEW dep edge but does NOT touch the frozen trio
+# (kx-scheduler/kx-executor/kx-inference) — the P2 thesis test holds.
+kx-tool-registry = { workspace = true }
 # `sync` (mpsc + oneshot) is additive over the workspace tokio features: the async
 # RPC handlers funnel commands to a single orchestration thread that owns the
 # journal + projection + scheduler. The Projection holds a non-`Send` trait object

--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -39,7 +39,7 @@
 //! `ReportCommit`. Selection is trivial (ready ∩ PURE ∩ executor_class); placement
 //! v2 (locality / GPU-slot awareness) is P2.5, and worker provisioning is P3 (D47).
 
-pub use kx_projection::MoteState;
+pub use kx_projection::{MoteState, RunResolvedVersions};
 pub use kx_proto::proto;
 pub use kx_scheduler::WorkerId;
 

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -14,6 +14,7 @@ use kx_projection::MoteState;
 use kx_proto::proto;
 use kx_proto::proto::coordinator_server::Coordinator;
 use kx_scheduler::WorkerId;
+use kx_tool_registry::{InMemoryToolRegistry, ToolRegistry};
 use kx_warrant::WarrantSpec;
 use tonic::{Request, Response, Status};
 
@@ -86,8 +87,43 @@ impl CoordinatorService {
         clock: Arc<dyn Clock>,
         nonce: Arc<dyn RunNonceSource>,
     ) -> Self {
+        // Default tool registry = the OSS built-ins (M1.2 resolve-at-submit
+        // capture, D79). Use [`with_tool_registry_and_seams`] to inject a custom
+        // registry (e.g. a test that registers its own tools to assert capture).
+        Self::with_tool_registry_and_seams(
+            journal,
+            registry,
+            store,
+            clock,
+            nonce,
+            Arc::new(InMemoryToolRegistry::with_builtins()),
+        )
+    }
+
+    /// As [`with_seams`], but injects the [`ToolRegistry`] the coordinator
+    /// resolves the warrant's `tool_grants` against at submit (M1.2/D79). The
+    /// resolved versions are captured as off-DAG run metadata (a
+    /// `RunVersionsResolved` journal fact). Tests inject a custom registry to
+    /// assert the captured tuples; production uses the built-ins default.
+    ///
+    /// [`with_seams`]: CoordinatorService::with_seams
+    pub fn with_tool_registry_and_seams<J: Journal + Send + 'static>(
+        journal: J,
+        registry: Arc<dyn WorkerRegistry>,
+        store: Option<Arc<LocalFsContentStore>>,
+        clock: Arc<dyn Clock>,
+        nonce: Arc<dyn RunNonceSource>,
+        tool_registry: Arc<dyn ToolRegistry>,
+    ) -> Self {
         Self {
-            core: CoreHandle::spawn(journal, store, registry.clone(), clock, nonce),
+            core: CoreHandle::spawn(
+                journal,
+                store,
+                registry.clone(),
+                clock,
+                nonce,
+                tool_registry,
+            ),
             registry,
         }
     }
@@ -135,6 +171,18 @@ impl CoordinatorService {
     /// journaled fact, never a recomputed value (the run-resume handle M2 builds on).
     pub async fn run_registration(&self) -> Result<Option<([u8; 16], [u8; 32])>, CoordinatorError> {
         self.core.run_registration().await
+    }
+
+    /// Read-side accessor: the resolved-version run metadata captured at submit
+    /// (M1.2, D79) — one [`RunResolvedVersions`] record per resolved capability
+    /// (a zero-grant warrant contributes one with no capability). Audit/lineage
+    /// only; off the truth path. (The observability query M11 builds on this.)
+    ///
+    /// [`RunResolvedVersions`]: kx_projection::RunResolvedVersions
+    pub async fn run_resolved_versions(
+        &self,
+    ) -> Result<Vec<kx_projection::RunResolvedVersions>, CoordinatorError> {
+        self.core.run_resolved_versions().await
     }
 
     /// Repudiate `target` and cascade the poison-invalidation to its committed downstream
@@ -216,6 +264,13 @@ impl Coordinator for CoordinatorService {
             mote_id: outcome.mote_id.as_bytes().to_vec(),
             status: status as i32,
             detail: String::new(),
+            // M1.2/D64: the registered run this Mote was admitted under (the
+            // resume key). Empty for an unregistered run (registration before
+            // submit is enforced in M1.3).
+            instance_id: outcome
+                .instance_id
+                .map(|id| id.to_vec())
+                .unwrap_or_default(),
         }))
     }
 
@@ -299,7 +354,7 @@ impl Coordinator for CoordinatorService {
         let executor_class =
             kx_warrant::ExecutorClass::try_from(proto_class).map_err(CoordinatorError::from)?;
         let max = usize::try_from(req.max_motes).unwrap_or(usize::MAX);
-        let work = self.core.lease_work(worker, executor_class, max).await?;
+        let (work, instance_id) = self.core.lease_work(worker, executor_class, max).await?;
         let items = work
             .into_iter()
             .map(|(mote, warrant)| proto::WorkItem {
@@ -307,7 +362,12 @@ impl Coordinator for CoordinatorService {
                 warrant: Some(warrant.into()),
             })
             .collect();
-        Ok(Response::new(proto::LeaseWorkResponse { items }))
+        Ok(Response::new(proto::LeaseWorkResponse {
+            items,
+            // M1.2/D64: the run the leased work belongs to, so the worker derives
+            // the run-scoped idempotency token. Empty for an unregistered run.
+            instance_id: instance_id.map(|id| id.to_vec()).unwrap_or_default(),
+        }))
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -20,11 +20,15 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
-use kx_journal::{FailureReason, Journal, JournalEntry, RepudiationReason, INSTANCE_ID_LEN};
+use kx_journal::{
+    FailureReason, Journal, JournalEntry, RepudiationReason, ResolvedCapabilityRecord,
+    ResolvedKindTag, INSTANCE_ID_LEN,
+};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
-use kx_warrant::{ExecutorClass, WarrantSpec};
+use kx_tool_registry::{resolve_run_versions, ToolKind, ToolRegistry};
+use kx_warrant::{warrant_ref_of, ExecutorClass, WarrantSpec};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::clock::Clock;
@@ -53,13 +57,22 @@ const COMMAND_BUFFER: usize = 1024;
 /// that transaction.
 const MAX_DRAIN: usize = 256;
 
-/// Outcome of a `SubmitMote`: the canonically re-derived id and whether it was a
-/// duplicate (idempotent re-submit before commit).
+/// Outcome of a `SubmitMote`: the canonically re-derived id, whether it was a
+/// duplicate (idempotent re-submit before commit), and the registered run's
+/// `instance_id` if the run was registered (M1.2/D64 — the resume key surfaced
+/// on the wire; `None` for an unregistered run, where M1.2 captures no metadata
+/// and the worker falls back to the MoteId-only token).
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SubmitOutcome {
     pub(crate) mote_id: MoteId,
     pub(crate) duplicate: bool,
+    pub(crate) instance_id: Option<[u8; INSTANCE_ID_LEN]>,
 }
+
+/// Leased work plus the run's `instance_id` (if registered) — the `LeaseWork`
+/// reply shape (M1.2): the worker derives the run-scoped idempotency token from
+/// the `instance_id`.
+type LeasedWork = (Vec<(Mote, WarrantSpec)>, Option<[u8; INSTANCE_ID_LEN]>);
 
 /// Outcome of a `ReportCommit`: the journal-assigned seq and whether the commit
 /// was newly appended or a dedup-by-key hit (first-wins).
@@ -94,7 +107,9 @@ pub(crate) enum Command {
         worker: WorkerId,
         executor_class: ExecutorClass,
         max: usize,
-        reply: oneshot::Sender<Vec<(Mote, WarrantSpec)>>,
+        // M1.2: the leased work PLUS the run's `instance_id` (if registered), so
+        // the worker can derive the run-scoped cross-boundary idempotency token.
+        reply: oneshot::Sender<LeasedWork>,
     },
     ReadEntries {
         since_seq: u64,
@@ -119,6 +134,9 @@ pub(crate) enum Command {
     RunRegistration {
         reply: oneshot::Sender<Option<([u8; INSTANCE_ID_LEN], [u8; 32])>>,
     },
+    RunResolvedVersions {
+        reply: oneshot::Sender<Vec<kx_projection::RunResolvedVersions>>,
+    },
 }
 
 /// Handle to the orchestration core. Cloneable + `Send + Sync` (it is just the
@@ -140,6 +158,7 @@ impl CoreHandle {
         registry: Arc<dyn WorkerRegistry>,
         clock: Arc<dyn Clock>,
         nonce: Arc<dyn RunNonceSource>,
+        tool_registry: Arc<dyn ToolRegistry>,
     ) -> Self {
         let (commands, inbox) = mpsc::channel(COMMAND_BUFFER);
         std::thread::spawn(move || {
@@ -149,6 +168,7 @@ impl CoreHandle {
                 &*registry,
                 &*clock,
                 &*nonce,
+                &*tool_registry,
                 inbox,
             );
         });
@@ -222,7 +242,7 @@ impl CoreHandle {
         worker: WorkerId,
         executor_class: ExecutorClass,
         max: usize,
-    ) -> Result<Vec<(Mote, WarrantSpec)>, CoordinatorError> {
+    ) -> Result<LeasedWork, CoordinatorError> {
         let (reply, response) = oneshot::channel();
         self.dispatch(Command::LeaseWork {
             worker,
@@ -334,6 +354,20 @@ impl CoreHandle {
             .map_err(|_| CoordinatorError::CoreUnavailable)
     }
 
+    /// The resolved-version run metadata captured so far (M1.2, D79) — one record
+    /// per resolved capability. Read from the folded projection; off the truth
+    /// path (never gates anything).
+    pub(crate) async fn run_resolved_versions(
+        &self,
+    ) -> Result<Vec<kx_projection::RunResolvedVersions>, CoordinatorError> {
+        let (reply, response) = oneshot::channel();
+        self.dispatch(Command::RunResolvedVersions { reply })
+            .await?;
+        response
+            .await
+            .map_err(|_| CoordinatorError::CoreUnavailable)
+    }
+
     async fn dispatch(&self, command: Command) -> Result<(), CoordinatorError> {
         self.commands
             .send(command)
@@ -381,6 +415,8 @@ struct LeaseReq {
 /// Serve one `LeaseWork` poll (D57): reap dead workers first so their in-flight Motes
 /// re-enter the candidate set for *this* poll, select up to `req.max` runnable Motes
 /// (ready ∪ rescheduleable), and record the new lease assignments for the next reap.
+/// Returns the leased work plus the run's `instance_id` (M1.2: the worker derives
+/// the run-scoped idempotency token from it; `None` for an unregistered run).
 fn serve_lease<J: Journal>(
     journal: &J,
     projection: &mut Projection,
@@ -388,7 +424,7 @@ fn serve_lease<J: Journal>(
     registry: &dyn WorkerRegistry,
     dispatch: &mut Dispatch,
     req: &LeaseReq,
-) -> Vec<(Mote, WarrantSpec)> {
+) -> LeasedWork {
     reap_dead_workers(
         journal,
         projection,
@@ -408,7 +444,9 @@ fn serve_lease<J: Journal>(
     dispatch
         .tracker
         .record_lease(req.worker, items.iter().map(|(mote, _)| mote.id));
-    items
+    // M1.2 (O(1) off-DAG read): the run the leased work belongs to.
+    let instance_id = projection.run_registration().map(|(id, _)| id);
+    (items, instance_id)
 }
 
 /// Select up to `max` ready Motes for `worker` to run. Candidates are ready
@@ -658,6 +696,7 @@ fn core_loop<J: Journal>(
     registry: &dyn WorkerRegistry,
     clock: &dyn Clock,
     nonce: &dyn RunNonceSource,
+    tool_registry: &dyn ToolRegistry,
     mut inbox: mpsc::Receiver<Command>,
 ) {
     let Some((mut projection, mut folded_through, submitted)) = recover(journal) else {
@@ -712,6 +751,7 @@ fn core_loop<J: Journal>(
                 registry,
                 clock,
                 nonce,
+                tool_registry,
                 &mut dispatch,
                 &mut scheduler,
                 command,
@@ -731,7 +771,12 @@ fn core_loop<J: Journal>(
 /// Service one non-`Commit` command against the owner-thread state (Commits are
 /// coalesced into group commits before this is reached, so the `Commit` arm is
 /// unreachable). Each arm sends its `oneshot` reply; a dropped receiver is ignored.
-#[allow(clippy::too_many_arguments)]
+///
+/// `too_many_lines` is allowed: this is a flat one-arm-per-`Command` dispatch
+/// match (each arm a thin delegation to a named helper). The length is the
+/// command count, not cognitive complexity; splitting the match into
+/// sub-dispatchers would be artificial.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn handle_command<J: Journal>(
     journal: &J,
     projection: &mut Projection,
@@ -739,6 +784,7 @@ fn handle_command<J: Journal>(
     registry: &dyn WorkerRegistry,
     clock: &dyn Clock,
     nonce: &dyn RunNonceSource,
+    tool_registry: &dyn ToolRegistry,
     dispatch: &mut Dispatch,
     scheduler: &mut Scheduler<LocalPlacement>,
     command: Command,
@@ -750,7 +796,16 @@ fn handle_command<J: Journal>(
             warrant,
             reply,
         } => {
-            let outcome = handle_submit(scheduler, projection, dispatch, *mote, *warrant);
+            let outcome = submit_and_capture(
+                journal,
+                projection,
+                folded_through,
+                tool_registry,
+                dispatch,
+                scheduler,
+                *mote,
+                *warrant,
+            );
             let _ = reply.send(outcome);
         }
         Command::StateOf { mote_id, reply } => {
@@ -768,7 +823,7 @@ fn handle_command<J: Journal>(
             max,
             reply,
         } => {
-            let items = serve_lease(
+            let leased = serve_lease(
                 journal,
                 projection,
                 folded_through,
@@ -780,7 +835,7 @@ fn handle_command<J: Journal>(
                     max,
                 },
             );
-            let _ = reply.send(items);
+            let _ = reply.send(leased);
         }
         Command::ReadEntries {
             since_seq,
@@ -835,6 +890,9 @@ fn handle_command<J: Journal>(
         }
         Command::RunRegistration { reply } => {
             let _ = reply.send(projection.run_registration());
+        }
+        Command::RunResolvedVersions { reply } => {
+            let _ = reply.send(projection.run_resolved_versions().to_vec());
         }
     }
 }
@@ -914,6 +972,43 @@ fn register_run<J: Journal>(
     Ok(instance_id)
 }
 
+/// Submit a Mote and, on a fresh submit of a registered run, capture its
+/// resolved versions (M1.2). Extracted from `handle_command`'s Submit arm to
+/// keep that function within the line budget.
+#[allow(clippy::too_many_arguments)]
+fn submit_and_capture<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    tool_registry: &dyn ToolRegistry,
+    dispatch: &mut Dispatch,
+    scheduler: &mut Scheduler<LocalPlacement>,
+    mote: Mote,
+    warrant: WarrantSpec,
+) -> SubmitOutcome {
+    let warrant_for_capture = warrant.clone();
+    let mut outcome = handle_submit(scheduler, projection, dispatch, mote, warrant);
+    // M1.2 (D79): on a FRESH (non-duplicate) submit of a REGISTERED run, capture
+    // the resolved tool/model/warrant versions as off-DAG run metadata and
+    // surface the run's instance_id. An unregistered run captures nothing (no
+    // instance_id to attach to) and gets `None` — forcing registration before
+    // submit is M1.3.
+    if !outcome.duplicate {
+        if let Some((instance_id, _)) = projection.run_registration() {
+            outcome.instance_id = Some(instance_id);
+            capture_run_versions(
+                journal,
+                projection,
+                folded_through,
+                tool_registry,
+                instance_id,
+                &warrant_for_capture,
+            );
+        }
+    }
+    outcome
+}
+
 /// Register a submitted Mote through the hosted scheduler (verbatim, thesis test) and
 /// retain its def for `LeaseWork`. Returns the canonical id + whether it was an
 /// idempotent re-submit (already admitted before commit).
@@ -933,7 +1028,124 @@ fn handle_submit(
         }
         Err(SchedulerError::DuplicateSubmission(_)) => true,
     };
-    SubmitOutcome { mote_id, duplicate }
+    // `instance_id` is filled by the caller (the Submit arm) after this returns —
+    // only for a fresh submit of a registered run (M1.2).
+    SubmitOutcome {
+        mote_id,
+        duplicate,
+        instance_id: None,
+    }
+}
+
+/// Capture the resolved tool/model/warrant versions of a fresh submit as off-DAG
+/// run **metadata** (M1.2, D79): resolve the warrant's `tool_grants` and append
+/// one `RunVersionsResolved` fact per resolved capability (a zero-grant warrant
+/// gets one fact with no capability), each anchored to the run's `instance_id`.
+/// **Metadata, never identity** — never folded into `MoteId`. O(1) per append,
+/// off the Mote-DAG.
+///
+/// Fail-CLOSED on a resolution miss: if any grant does not resolve cleanly
+/// (`NotFound` / `CapabilityExceedsWarrant` / pending review), NOTHING is
+/// journaled — no partial or over-privileged tuple is ever recorded. The submit
+/// still succeeds (M1.2 only captures; refusing such a submit is M1.3).
+fn capture_run_versions<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    tool_registry: &dyn ToolRegistry,
+    instance_id: [u8; INSTANCE_ID_LEN],
+    warrant: &WarrantSpec,
+) {
+    let events = match resolve_run_versions(tool_registry, warrant) {
+        Ok(events) => events,
+        Err(reason) => {
+            tracing::warn!(
+                ?reason,
+                "M1.2 resolved-version capture skipped: a tool grant did not resolve (M1.3 will refuse the submit)"
+            );
+            return;
+        }
+    };
+    let warrant_ref = warrant_ref_of(warrant);
+    let model_id = warrant.model_route.model_id.0.clone();
+    if events.is_empty() {
+        // Zero-grant warrant: still capture model + warrant as one metadata fact.
+        append_run_versions(
+            journal,
+            projection,
+            folded_through,
+            instance_id,
+            warrant_ref,
+            &model_id,
+            None,
+        );
+        return;
+    }
+    for event in events {
+        let capability = ResolvedCapabilityRecord {
+            tool_id: event.tool_id.0,
+            tool_version: event.tool_version.0,
+            resolved_kind: tool_kind_tag(&event.resolved_kind),
+            resolved_def_hash: event.resolved_def_hash,
+        };
+        append_run_versions(
+            journal,
+            projection,
+            folded_through,
+            instance_id,
+            warrant_ref,
+            &model_id,
+            Some(capability),
+        );
+    }
+}
+
+/// Append one `RunVersionsResolved` metadata fact through the sole writer and
+/// fold it (O(1), off the Mote-DAG). A journal append failure is logged and
+/// swallowed — capture is best-effort metadata, never on the truth path.
+fn append_run_versions<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    instance_id: [u8; INSTANCE_ID_LEN],
+    warrant_ref: kx_content::ContentRef,
+    model_id: &str,
+    capability: Option<ResolvedCapabilityRecord>,
+) {
+    let entry = JournalEntry::RunVersionsResolved {
+        instance_id,
+        warrant_ref,
+        model_id: model_id.to_owned(),
+        capability,
+        seq: 0,
+    };
+    match journal.append(entry) {
+        Ok(durable) => {
+            let seq = durable.seq();
+            if seq > *folded_through {
+                if let Err(err) = projection.fold(&durable) {
+                    tracing::warn!(?err, "fold of RunVersionsResolved metadata failed");
+                } else {
+                    *folded_through = seq;
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!(?err, "append of RunVersionsResolved metadata failed");
+        }
+    }
+}
+
+/// Map a resolved [`ToolKind`] to its journal [`ResolvedKindTag`] (the closed
+/// mirror kept in `kx-journal` so the journal stays dependency-clean).
+fn tool_kind_tag(kind: &ToolKind) -> ResolvedKindTag {
+    match kind {
+        ToolKind::Builtin => ResolvedKindTag::Builtin,
+        ToolKind::LocalScript { .. } => ResolvedKindTag::LocalScript,
+        ToolKind::External { .. } => ResolvedKindTag::External,
+        ToolKind::Mcp { .. } => ResolvedKindTag::Mcp,
+        ToolKind::SelfGenerated { .. } => ResolvedKindTag::SelfGenerated,
+    }
 }
 
 /// One queued `ReportCommit`: its validated proposal + the reply channel.

--- a/crates/kx-coordinator/tests/run_versions.rs
+++ b/crates/kx-coordinator/tests/run_versions.rs
@@ -1,0 +1,400 @@
+//! Resolved-version run metadata (M1.2, D79): at submit, the coordinator resolves
+//! the warrant's `tool_grants` + reads `model_id` and captures them as an off-DAG
+//! `RunVersionsResolved` journal fact anchored to the run's `instance_id` —
+//! **metadata, never identity**. The run's `instance_id` is surfaced on the
+//! `SubmitMote` response (the resume key) and on `LeaseWork` (the worker derives
+//! the run-scoped idempotency token from it). These are the M1-exit-gate clauses
+//! "resolved versions appear as metadata" + "cross-boundary exactly-once under the
+//! new token" (the lease-side half; the token derivation itself is unit-tested in
+//! kx-capability).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, RunNonceSource, WorkerRegistry,
+};
+use kx_journal::{InMemoryJournal, Journal, ResolvedKindTag, SqliteJournal};
+use kx_mote::{ModelId, NdClass, ToolName, ToolVersion};
+use kx_tool_registry::{
+    IdempotencyClass, InMemoryToolRegistry, ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+};
+use kx_warrant::{
+    warrant_ref_of, ExecutorClass, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    ToolGrant, ToolRequirement, WarrantSpec,
+};
+use tempfile::tempdir;
+use tonic::Request;
+
+// --- seams (mirror run_registration.rs) ---------------------------------------
+
+#[derive(Debug)]
+struct FixedNonce([u8; 16]);
+impl RunNonceSource for FixedNonce {
+    fn fresh_instance_id(&self) -> [u8; 16] {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct FixedClock(u64);
+impl Clock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+fn registry() -> Arc<dyn WorkerRegistry> {
+    Arc::new(InMemoryWorkerRegistry::new())
+}
+
+/// Coordinator over the DEFAULT built-in tool registry (the production path),
+/// with a fixed nonce so the registered `instance_id` is deterministic.
+fn coordinator<J: Journal + Send + 'static>(
+    journal: J,
+    instance_id: [u8; 16],
+) -> CoordinatorService {
+    CoordinatorService::with_seams(
+        journal,
+        registry(),
+        None,
+        Arc::new(FixedClock(7)),
+        Arc::new(FixedNonce(instance_id)),
+    )
+}
+
+/// Coordinator with an INJECTED tool registry (for the capability-exceeds test).
+fn coordinator_with_tools<J: Journal + Send + 'static>(
+    journal: J,
+    instance_id: [u8; 16],
+    tool_registry: Arc<dyn ToolRegistry>,
+) -> CoordinatorService {
+    CoordinatorService::with_tool_registry_and_seams(
+        journal,
+        registry(),
+        None,
+        Arc::new(FixedClock(7)),
+        Arc::new(FixedNonce(instance_id)),
+        tool_registry,
+    )
+}
+
+async fn register_run(svc: &CoordinatorService, fingerprint: [u8; 32]) -> [u8; 16] {
+    svc.register_run(Request::new(proto::RegisterRunRequest {
+        recipe_fingerprint: fingerprint.to_vec(),
+    }))
+    .await
+    .unwrap()
+    .into_inner()
+    .instance_id
+    .as_slice()
+    .try_into()
+    .unwrap()
+}
+
+/// A warrant granting the named `(tool_id, tool_version)` builtins + a model id.
+/// Permissive scopes so any empty-requirement builtin resolves.
+fn warrant_granting(tools: &[(&str, &str)], model_id: &str) -> WarrantSpec {
+    let tool_grants: BTreeSet<ToolGrant> = tools
+        .iter()
+        .map(|(id, ver)| ToolGrant {
+            tool_id: ToolName((*id).into()),
+            tool_version: ToolVersion((*ver).into()),
+        })
+        .collect();
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), kx_warrant::FsMode::ReadOnly);
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(BTreeSet::from([Host("api.example.com:443".into())])),
+        // Matches the OSS built-ins' syscall_profile_ref (exact-match required by
+        // `check_tool_requirement`), so fs-read/fs-write/text-summarize resolve.
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0u8; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId(model_id.into()),
+            max_input_tokens: 4096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}
+
+// === EXIT GATE: resolved versions appear as metadata ==========================
+
+#[tokio::test]
+async fn submit_captures_resolved_versions_as_metadata() {
+    let instance_id = [0xa1u8; 16];
+    let svc = coordinator(InMemoryJournal::new(), instance_id);
+    register_run(&svc, [0xb2u8; 32]).await;
+
+    let mote = common::mote(1, NdClass::Pure, &[]);
+    // Two builtins (resolve under any warrant) + a known model id.
+    let warrant = warrant_granting(&[("fs-read", "1"), ("text-summarize", "1")], "qwen2.5-0.5b");
+    let resp = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(resp.status, proto::SubmitStatus::Accepted as i32);
+
+    let records = svc.run_resolved_versions().await.unwrap();
+    // One record per resolved capability (BTreeSet order: fs-read, text-summarize).
+    assert_eq!(
+        records.len(),
+        2,
+        "one metadata record per resolved capability"
+    );
+    let warrant_ref = warrant_ref_of(&warrant);
+    for rec in &records {
+        assert_eq!(
+            rec.instance_id, instance_id,
+            "anchored to the registered run"
+        );
+        assert_eq!(
+            rec.warrant_ref, warrant_ref,
+            "captures the resolved warrant_ref"
+        );
+        assert_eq!(
+            rec.model_id, "qwen2.5-0.5b",
+            "captures the resolved model_id"
+        );
+    }
+    let caps: Vec<&str> = records
+        .iter()
+        .map(|r| r.capability.as_ref().unwrap().tool_id.as_str())
+        .collect();
+    assert_eq!(
+        caps,
+        ["fs-read", "text-summarize"],
+        "ordered, both captured"
+    );
+    for rec in &records {
+        let cap = rec.capability.as_ref().unwrap();
+        assert_eq!(cap.tool_version, "1");
+        assert_eq!(cap.resolved_kind, ResolvedKindTag::Builtin);
+        // resolved_def_hash is a real content ref (not the zero sentinel).
+        assert_ne!(cap.resolved_def_hash.as_bytes(), &[0u8; 32]);
+    }
+}
+
+#[tokio::test]
+async fn submit_response_surfaces_instance_id() {
+    // The exit-gate resume key + server-derived identity (D53): the SubmitMote
+    // response carries exactly the run's registered instance_id.
+    let instance_id = [0xc3u8; 16];
+    let svc = coordinator(InMemoryJournal::new(), instance_id);
+    let registered = register_run(&svc, [0x44u8; 32]).await;
+    assert_eq!(registered, instance_id);
+
+    let mote = common::mote(2, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("fs-read", "1")], "m");
+    let resp = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(
+        resp.instance_id, instance_id,
+        "SubmitMote surfaces the registered run id (the M2 resume key)"
+    );
+}
+
+#[tokio::test]
+async fn unregistered_run_captures_nothing_and_no_instance_id() {
+    // Back-compat (M1.1 `submit_without_register_still_works`): submitting without
+    // a prior RegisterRun still succeeds; M1.2 captures no metadata (no instance_id
+    // to anchor to) and the response instance_id is empty. Forcing registration
+    // before submit is M1.3.
+    let svc = coordinator(InMemoryJournal::new(), [0xd4u8; 16]);
+    let mote = common::mote(3, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("fs-read", "1")], "m");
+    let resp = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(resp.status, proto::SubmitStatus::Accepted as i32);
+    assert!(
+        resp.instance_id.is_empty(),
+        "unregistered run → no instance_id"
+    );
+    assert!(
+        svc.run_resolved_versions().await.unwrap().is_empty(),
+        "no metadata captured for an unregistered run"
+    );
+}
+
+// === EXIT GATE: instance_id flows to the worker (token root) ==================
+
+#[tokio::test]
+async fn lease_surfaces_instance_id_for_the_run_scoped_token() {
+    let instance_id = [0xe5u8; 16];
+    let svc = coordinator(InMemoryJournal::new(), instance_id);
+    register_run(&svc, [0x66u8; 32]).await;
+    let worker = common::register(&svc, "http://w1").await;
+
+    // A PURE root Mote is ready immediately (no parents) → leasable.
+    let mote = common::mote(4, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("fs-read", "1")], "m");
+    common::submit(&svc, &mote, &warrant).await;
+
+    let resp = svc
+        .lease_work(Request::new(proto::LeaseWorkRequest {
+            worker_id: worker,
+            executor_class: proto::ExecutorClass::MacosSandbox as i32,
+            max_motes: 16,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.items.len(), 1, "the PURE Mote is leased");
+    assert_eq!(
+        resp.instance_id, instance_id,
+        "LeaseWork carries the run id → the worker derives the run-scoped token"
+    );
+}
+
+// === SECURITY: metadata is independent of identity ============================
+
+#[tokio::test]
+async fn resolved_model_version_is_independent_of_mote_identity() {
+    // The SAME Mote submitted under two runs with DIFFERENT resolved model
+    // versions yields the SAME MoteId (resolved versions are metadata, never an
+    // identity input — D64/D79/D70) while the captured model_id differs per run.
+    let mote = common::mote(5, NdClass::Pure, &[]);
+
+    let svc_a = coordinator(InMemoryJournal::new(), [0x0au8; 16]);
+    register_run(&svc_a, [0x01u8; 32]).await;
+    let resp_a = common::submit(
+        &svc_a,
+        &mote,
+        &warrant_granting(&[("fs-read", "1")], "model-A"),
+    )
+    .await;
+
+    let svc_b = coordinator(InMemoryJournal::new(), [0x0bu8; 16]);
+    register_run(&svc_b, [0x01u8; 32]).await;
+    let resp_b = common::submit(
+        &svc_b,
+        &mote,
+        &warrant_granting(&[("fs-read", "1")], "model-B"),
+    )
+    .await;
+
+    assert_eq!(
+        resp_a.mote_id, resp_b.mote_id,
+        "identity is stable across resolved-version changes"
+    );
+
+    let model_a = svc_a.run_resolved_versions().await.unwrap()[0]
+        .model_id
+        .clone();
+    let model_b = svc_b.run_resolved_versions().await.unwrap()[0]
+        .model_id
+        .clone();
+    assert_eq!(model_a, "model-A");
+    assert_eq!(model_b, "model-B");
+    assert_ne!(
+        model_a, model_b,
+        "metadata varies independently of identity"
+    );
+}
+
+// === SECURITY: a capability-exceeds-warrant grant journals NO metadata ========
+
+#[tokio::test]
+async fn capability_exceeds_warrant_skips_capture() {
+    // A tool whose required net egress is NOT in the warrant fails to resolve →
+    // resolve_run_versions errors → NOTHING is journaled (no over-privileged or
+    // partial tuple is ever recorded). The submit still succeeds (M1.2 captures
+    // only; refusing such a submit is M1.3).
+    let mut tools = InMemoryToolRegistry::new();
+    tools
+        .register(
+            ToolDef {
+                tool_id: ToolName("greedy".into()),
+                tool_version: ToolVersion("1".into()),
+                kind: ToolKind::Builtin,
+                required_capability: ToolRequirement {
+                    // Requires egress to a host the warrant below does NOT permit.
+                    net_scope_required: NetScope::EgressAllowlist(BTreeSet::from([Host(
+                        "evil.example.com:443".into(),
+                    )])),
+                    fs_scope_required: FsScope::empty(),
+                    syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                    min_resource_ceiling: ResourceCeiling {
+                        cpu_milli: 0,
+                        mem_bytes: 0,
+                        wall_clock_ms: 0,
+                        fd_count: 0,
+                        disk_bytes: 0,
+                    },
+                },
+                description: "needs egress the warrant lacks".into(),
+                idempotency_class: IdempotencyClass::Token,
+            },
+            ToolProvenance::HumanAuthored {
+                author: "ops".into(),
+            },
+        )
+        .unwrap();
+
+    let instance_id = [0xf6u8; 16];
+    let svc = coordinator_with_tools(InMemoryJournal::new(), instance_id, Arc::new(tools));
+    register_run(&svc, [0x77u8; 32]).await;
+
+    let mote = common::mote(6, NdClass::Pure, &[]);
+    // net_scope = None → the greedy tool's egress requirement is NOT a subset.
+    let mut warrant = warrant_granting(&[("greedy", "1")], "m");
+    warrant.net_scope = NetScope::None;
+    let resp = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(
+        resp.status,
+        proto::SubmitStatus::Accepted as i32,
+        "submit still succeeds in M1.2"
+    );
+    assert!(
+        svc.run_resolved_versions().await.unwrap().is_empty(),
+        "a capability-exceeds-warrant grant journals NO metadata (fail-closed capture)"
+    );
+}
+
+// === DURABILITY: replay reconstructs the metadata verbatim ====================
+
+#[tokio::test]
+async fn replay_reconstructs_run_versions_metadata() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let instance_id = [0xabu8; 16];
+    let warrant = warrant_granting(&[("fs-read", "1"), ("fs-write", "1")], "qwen");
+    let mote = common::mote(7, NdClass::Pure, &[]);
+
+    let before = {
+        let svc = coordinator(SqliteJournal::open(&path).unwrap(), instance_id);
+        register_run(&svc, [0xcdu8; 32]).await;
+        common::submit(&svc, &mote, &warrant).await;
+        svc.run_resolved_versions().await.unwrap()
+    }; // svc dropped → core thread exits → Sqlite handle closed
+
+    assert_eq!(before.len(), 2);
+
+    // Fresh coordinator over the SAME journal → folds from scratch.
+    let svc2 = coordinator(SqliteJournal::open(&path).unwrap(), [0x00u8; 16]);
+    let after = svc2.run_resolved_versions().await.unwrap();
+    assert_eq!(
+        after, before,
+        "the resolved-version metadata is reconstructed byte-identically on replay"
+    );
+    // The registered identity also survives (read, never recomputed).
+    assert_eq!(
+        svc2.run_registration().await.unwrap().unwrap().0,
+        instance_id
+    );
+}

--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -10,7 +10,8 @@
 //! ```text
 //! header (74 bytes, common to all kinds):
 //!     kind             u8     (Proposed=0, Committed=1, Repudiated=2, Failed=3,
-//!                              EffectStaged=4, RunRegistered=5)
+//!                              EffectStaged=4, RunRegistered=5,
+//!                              RunVersionsResolved=6)
 //!     mote_id          [u8;32]
 //!     idempotency_key  [u8;32]
 //!     seq              u64 LE
@@ -41,6 +42,21 @@
 //!     instance_id        [u8;16]
 //!     recipe_fingerprint [u8;32]
 //!     ts                 u64 LE   (audit-only; excluded from every hash)
+//!
+//!   RunVersionsResolved (variable) (v4, M1.2, D79): one entry per resolved
+//!   capability (append-many; a zero-grant warrant emits one with has_cap=0):
+//!     instance_id        [u8;16]
+//!     warrant_ref        [u8;32]
+//!     model_id_len       u16 LE
+//!     model_id           [u8; model_id_len]  (UTF-8)
+//!     has_cap            u8 (0 or 1)
+//!     -- if has_cap == 1:
+//!     tool_id_len        u16 LE
+//!     tool_id            [u8; tool_id_len]   (UTF-8)
+//!     tool_version_len   u16 LE
+//!     tool_version       [u8; tool_version_len] (UTF-8)
+//!     resolved_kind_tag  u8 (Builtin=0 .. SelfGenerated=4)
+//!     resolved_def_hash  [u8;32]
 //!
 //! ParentEntry (34 bytes):
 //!     parent_id        [u8;32]
@@ -77,7 +93,21 @@ use smallvec::SmallVec;
 ///
 /// v3 readers refuse v2 files loudly (no in-place evolution; no production v2
 /// journals are retained across the bump per the corpus, acceptable).
-pub const JOURNAL_SCHEMA_VERSION: u16 = 3;
+///
+/// **v4 (M1.2, D79) changes** vs v3:
+/// - New `RunVersionsResolved` entry kind (=6) — an append-only, off-DAG
+///   run-metadata fact capturing the resolved `(tool_id, tool_version,
+///   resolved_kind, resolved_def_hash)` of a capability plus the run's
+///   `warrant_ref` and resolved `model_id`. Audit/lineage **metadata, never
+///   identity** (never folded into `MoteId`/`input_data_id`/any digest).
+/// - One entry per resolved capability (append-many); a zero-grant warrant
+///   emits one entry with no capability. Does NOT participate in dedup-by-key
+///   (the dedup index stays `{1, 2, 4}`). Strictly additive; `MAX_ENTRY_LEN`
+///   is unchanged (a single-capability body is small).
+///
+/// v4 readers refuse v3 files loudly (no in-place evolution; no production v3
+/// journals are retained across the bump per the corpus, acceptable).
+pub const JOURNAL_SCHEMA_VERSION: u16 = 4;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).
 pub const HEADER_LEN: usize = 74;
@@ -133,11 +163,80 @@ pub const KIND_EFFECT_STAGED: u8 = 4;
 /// carries the synthetic [`run_root_id`].
 pub const KIND_RUN_REGISTERED: u8 = 5;
 
+/// `RunVersionsResolved` entry-kind byte (NEW in v4; M1.2, D79).
+///
+/// An append-only, **off-DAG run-metadata** fact: the resolved `(tool_id,
+/// tool_version, resolved_kind, resolved_def_hash)` of one capability plus the
+/// run's `warrant_ref` and resolved `model_id`. These are audit/lineage
+/// **metadata, never identity** (never folded into `MoteId`/`input_data_id`/any
+/// content-addressed digest, per D64/D79/D70). One entry per resolved
+/// capability (append-many); a zero-grant warrant emits a single entry with no
+/// capability. Does NOT participate in dedup-by-key (the dedup index stays
+/// `{1, 2, 4}`); the header `idempotency_key` slot is the all-zero sentinel and
+/// the `mote_id` slot carries the run's synthetic [`run_root_id`].
+pub const KIND_RUN_VERSIONS_RESOLVED: u8 = 6;
+
 /// Length in bytes of a run's `instance_id` (the registered run nonce).
 pub const INSTANCE_ID_LEN: usize = 16;
 
 /// `RunRegistered` body length: `instance_id(16) + recipe_fingerprint(32) + ts(8)`.
 const RUN_REGISTERED_BODY_LEN: usize = INSTANCE_ID_LEN + 32 + 8;
+
+/// The kind of tool a capability resolved as, mirrored as a closed `u8`-tagged
+/// enum so `kx-journal` need not depend on `kx-tool-registry` (the journal must
+/// stay dependency-clean). Tags MUST mirror `kx_tool_registry::ToolKind`'s
+/// variant order (Builtin=0, LocalScript=1, External=2, Mcp=3,
+/// SelfGenerated=4); the coordinator maps `ToolKind → ResolvedKindTag` when
+/// building the entry. Adding a variant is a `schema_version` bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum ResolvedKindTag {
+    /// A built-in OSS tool (`kx_tool_registry::ToolKind::Builtin`).
+    Builtin = 0,
+    /// A registered local script (`kx_tool_registry::ToolKind::LocalScript`).
+    LocalScript = 1,
+    /// An external/URL-sourced tool (`kx_tool_registry::ToolKind::External`).
+    External = 2,
+    /// An MCP-exposed tool (`kx_tool_registry::ToolKind::Mcp`).
+    Mcp = 3,
+    /// A self-generated tool (`kx_tool_registry::ToolKind::SelfGenerated`).
+    SelfGenerated = 4,
+}
+
+impl ResolvedKindTag {
+    /// The tag's discriminant byte.
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Parse a tag byte; `None` for an unknown discriminant (decoder rejects).
+    #[must_use]
+    pub fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            0 => Some(Self::Builtin),
+            1 => Some(Self::LocalScript),
+            2 => Some(Self::External),
+            3 => Some(Self::Mcp),
+            4 => Some(Self::SelfGenerated),
+            _ => None,
+        }
+    }
+}
+
+/// One resolved capability captured in a [`JournalEntry::RunVersionsResolved`]
+/// fact (M1.2, D79). Audit/lineage metadata — never an identity input.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ResolvedCapabilityRecord {
+    /// The resolved tool's name (opaque identifier).
+    pub tool_id: String,
+    /// The resolved tool's pinned version.
+    pub tool_version: String,
+    /// Which tier served the resolution.
+    pub resolved_kind: ResolvedKindTag,
+    /// `blake3(canonical_bincode(ToolDef))` — pins the exact resolved `ToolDef`.
+    pub resolved_def_hash: ContentRef,
+}
 
 // ---------------------------------------------------------------------------
 // Closed reason enums (D19; `journal-entry.md` §6.2 + §7.2)
@@ -504,6 +603,29 @@ pub enum JournalEntry {
         /// Journal-assigned sequence (0 until appended). `= 1` for a fresh run.
         seq: u64,
     },
+
+    /// An append-only, off-DAG **run-metadata** fact (v4, M1.2, D79): the
+    /// resolved versions of a capability invoked under a run, captured at
+    /// submit. **Metadata, never identity** — never folded into
+    /// `MoteId`/`input_data_id`/any content-addressed digest (D64/D79/D70).
+    ///
+    /// One entry per resolved capability (append-many); a zero-grant warrant
+    /// emits one entry with `capability == None`. Does NOT participate in
+    /// dedup-by-key (the dedup index stays `{1, 2, 4}`). The header `mote_id`
+    /// slot carries the run's synthetic [`run_root_id`]; the `idempotency_key`
+    /// slot is the all-zero sentinel (kind 6 is excluded from the dedup gate).
+    RunVersionsResolved {
+        /// The run this metadata is attached to (its registered identity).
+        instance_id: [u8; INSTANCE_ID_LEN],
+        /// `blake3(canonical_bincode(WarrantSpec))` of the warrant resolved under.
+        warrant_ref: ContentRef,
+        /// The resolved model id (opaque identifier; audit metadata).
+        model_id: String,
+        /// The resolved capability, or `None` for a zero-grant warrant.
+        capability: Option<ResolvedCapabilityRecord>,
+        /// Journal-assigned sequence (0 until appended).
+        seq: u64,
+    },
 }
 
 /// The all-zero sentinel returned as the dedupe key of a `RunRegistered` entry,
@@ -535,7 +657,8 @@ impl JournalEntry {
             | Self::Repudiated { seq, .. }
             | Self::Failed { seq, .. }
             | Self::EffectStaged { seq, .. }
-            | Self::RunRegistered { seq, .. } => *seq,
+            | Self::RunRegistered { seq, .. }
+            | Self::RunVersionsResolved { seq, .. } => *seq,
         }
     }
 
@@ -558,9 +681,9 @@ impl JournalEntry {
             | Self::EffectStaged {
                 idempotency_key, ..
             } => idempotency_key,
-            // RunRegistered does not dedup; return the all-zero sentinel (kind 5
-            // is excluded from the dedup gate).
-            Self::RunRegistered { .. } => &ZERO_IDEMPOTENCY_KEY,
+            // RunRegistered / RunVersionsResolved do not dedup; return the
+            // all-zero sentinel (kinds 5 and 6 are excluded from the dedup gate).
+            Self::RunRegistered { .. } | Self::RunVersionsResolved { .. } => &ZERO_IDEMPOTENCY_KEY,
         }
     }
 
@@ -576,7 +699,8 @@ impl JournalEntry {
             | Self::Failed { mote_id, .. }
             | Self::EffectStaged { mote_id, .. } => *mote_id,
             Self::Repudiated { target_mote_id, .. } => *target_mote_id,
-            Self::RunRegistered { instance_id, .. } => run_root_id(instance_id),
+            Self::RunRegistered { instance_id, .. }
+            | Self::RunVersionsResolved { instance_id, .. } => run_root_id(instance_id),
         }
     }
 
@@ -590,6 +714,7 @@ impl JournalEntry {
             Self::Failed { .. } => KIND_FAILED,
             Self::EffectStaged { .. } => KIND_EFFECT_STAGED,
             Self::RunRegistered { .. } => KIND_RUN_REGISTERED,
+            Self::RunVersionsResolved { .. } => KIND_RUN_VERSIONS_RESOLVED,
         }
     }
 }
@@ -624,7 +749,7 @@ pub enum DecodeError {
         got: usize,
     },
     /// The kind discriminant byte is not one of the known values
-    /// (Proposed=0 .. RunRegistered=5).
+    /// (Proposed=0 .. RunVersionsResolved=6).
     #[error("unknown kind discriminant: {0}")]
     UnknownKind(u8),
     /// The `nondeterminism` discriminant byte is not one of the three known values.
@@ -653,6 +778,21 @@ pub enum DecodeError {
     /// [`Self::RepudiatedHeaderMismatch`]).
     #[error("RunRegistered body-header run_root_id mismatch")]
     RunRegisteredHeaderMismatch,
+    /// A `RunVersionsResolved` entry's header `mote_id` slot does not equal
+    /// `run_root_id(instance_id)` (v4 body-header consistency; mirrors
+    /// [`Self::RunRegisteredHeaderMismatch`]).
+    #[error("RunVersionsResolved body-header run_root_id mismatch")]
+    RunVersionsHeaderMismatch,
+    /// A `RunVersionsResolved` entry's `resolved_kind_tag` byte is not one of the
+    /// five known [`ResolvedKindTag`] values.
+    #[error("unknown resolved_kind tag: {0}")]
+    UnknownResolvedKind(u8),
+    /// A `RunVersionsResolved` entry's `has_cap` flag is neither 0 nor 1.
+    #[error("has_cap flag is not boolean: {0}")]
+    NonBooleanHasCap(u8),
+    /// A `RunVersionsResolved` entry's UTF-8 string field is not valid UTF-8.
+    #[error("RunVersionsResolved string field is not valid UTF-8")]
+    RunVersionsInvalidUtf8,
     /// Trailing bytes after a complete entry (§2 no-trailing-data rule).
     #[error("trailing bytes after entry: {0} extra")]
     TrailingBytes(usize),
@@ -672,6 +812,23 @@ pub enum EncodeError {
     /// silently coercing (`journal-entry.md` §11).
     #[error("non_cascade flag set on Data edge (anti-pattern §11)")]
     DataEdgeNonCascade,
+    /// A `RunVersionsResolved` string field exceeds the `u16` length prefix
+    /// (65535 bytes) — far beyond any real tool/model id.
+    #[error("RunVersionsResolved field exceeds u16 length prefix: {got} bytes")]
+    RunVersionsFieldTooLong {
+        /// The over-long field's byte length.
+        got: usize,
+    },
+    /// A `RunVersionsResolved` entry would exceed the absolute size cap
+    /// ([`MAX_ENTRY_LEN`]) — a pathologically large model/tool id.
+    #[error(
+        "RunVersionsResolved entry exceeds size cap: {got} bytes > {} max",
+        MAX_ENTRY_LEN
+    )]
+    RunVersionsTooLarge {
+        /// The encoded entry's byte length.
+        got: usize,
+    },
 }
 
 /// Encode a `JournalEntry` to its canonical on-disk byte representation
@@ -739,6 +896,11 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
         // the `idempotency_key` slot is the all-zero sentinel (kind 5 does not
         // dedup); `nondeterminism` is the 0 sentinel (a run is not a Mote).
         JournalEntry::RunRegistered {
+            instance_id, seq, ..
+        } => (run_root_id(instance_id), ZERO_IDEMPOTENCY_KEY, *seq, 0),
+        // v4 (M1.2): same anchoring as RunRegistered — run-root id in the
+        // mote_id slot, all-zero idempotency key (kind 6 does not dedup), 0 nd.
+        JournalEntry::RunVersionsResolved {
             instance_id, seq, ..
         } => (run_root_id(instance_id), ZERO_IDEMPOTENCY_KEY, *seq, 0),
     };
@@ -821,6 +983,35 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             out.extend_from_slice(instance_id);
             out.extend_from_slice(recipe_fingerprint);
             out.extend_from_slice(&ts.to_le_bytes());
+        }
+        JournalEntry::RunVersionsResolved {
+            instance_id,
+            warrant_ref,
+            model_id,
+            capability,
+            ..
+        } => {
+            // v4 (M1.2): body = instance_id(16) ‖ warrant_ref(32) ‖
+            // u16-prefixed model_id ‖ has_cap(u8) ‖ [if has_cap: u16-prefixed
+            // tool_id ‖ u16-prefixed tool_version ‖ kind_tag(u8) ‖ def_hash(32)].
+            out.extend_from_slice(instance_id);
+            out.extend_from_slice(warrant_ref.as_bytes());
+            push_len_prefixed_str(&mut out, model_id)?;
+            match capability {
+                None => out.push(0u8),
+                Some(cap) => {
+                    out.push(1u8);
+                    push_len_prefixed_str(&mut out, &cap.tool_id)?;
+                    push_len_prefixed_str(&mut out, &cap.tool_version)?;
+                    out.push(cap.resolved_kind.as_u8());
+                    out.extend_from_slice(cap.resolved_def_hash.as_bytes());
+                }
+            }
+            // Pathological-id guard (real-id bodies are ~100 B). Mirrors the
+            // Committed TooManyParents bound — refuse rather than over-cap.
+            if out.len() > MAX_ENTRY_LEN {
+                return Err(EncodeError::RunVersionsTooLarge { got: out.len() });
+            }
         }
     }
 
@@ -1058,8 +1249,126 @@ pub fn decode_entry_with_def_hash(
                 seq,
             })
         }
+        KIND_RUN_VERSIONS_RESOLVED => {
+            // v4 (M1.2): variable-length body. Cursor-based parse with strict
+            // bounds at every read; reject trailing bytes at the end.
+            const PREFIX_LEN: usize = INSTANCE_ID_LEN + 32; // instance_id ‖ warrant_ref
+            if body.len() < PREFIX_LEN + 2 + 1 {
+                // PREFIX + model_id_len(u16) + has_cap(u8)
+                return Err(DecodeError::BodyTooShort {
+                    kind,
+                    got: body.len(),
+                    expected: PREFIX_LEN + 2 + 1,
+                });
+            }
+            let mut instance_id = [0u8; INSTANCE_ID_LEN];
+            instance_id.copy_from_slice(&body[..INSTANCE_ID_LEN]);
+            // Body-header consistency (mirrors RunRegistered).
+            if mote_id != run_root_id(&instance_id) {
+                return Err(DecodeError::RunVersionsHeaderMismatch);
+            }
+            let mut warrant_ref_bytes = [0u8; 32];
+            warrant_ref_bytes.copy_from_slice(&body[INSTANCE_ID_LEN..PREFIX_LEN]);
+            let warrant_ref = ContentRef::from_bytes(warrant_ref_bytes);
+
+            let mut cursor = PREFIX_LEN;
+            let model_id = read_len_prefixed_str(body, &mut cursor, kind)?;
+            let has_cap = read_u8(body, &mut cursor, kind)?;
+            let capability = match has_cap {
+                0 => None,
+                1 => {
+                    let tool_id = read_len_prefixed_str(body, &mut cursor, kind)?;
+                    let tool_version = read_len_prefixed_str(body, &mut cursor, kind)?;
+                    let tag_byte = read_u8(body, &mut cursor, kind)?;
+                    let resolved_kind = ResolvedKindTag::from_u8(tag_byte)
+                        .ok_or(DecodeError::UnknownResolvedKind(tag_byte))?;
+                    let def_hash_bytes = read_array32(body, &mut cursor, kind)?;
+                    Some(ResolvedCapabilityRecord {
+                        tool_id,
+                        tool_version,
+                        resolved_kind,
+                        resolved_def_hash: ContentRef::from_bytes(def_hash_bytes),
+                    })
+                }
+                other => return Err(DecodeError::NonBooleanHasCap(other)),
+            };
+            if cursor != body.len() {
+                return Err(DecodeError::TrailingBytes(body.len() - cursor));
+            }
+            Ok(JournalEntry::RunVersionsResolved {
+                instance_id,
+                warrant_ref,
+                model_id,
+                capability,
+                seq,
+            })
+        }
         other => Err(DecodeError::UnknownKind(other)),
     }
+}
+
+/// Push a `u16`-length-prefixed UTF-8 string (v4 `RunVersionsResolved` bodies).
+fn push_len_prefixed_str(out: &mut Vec<u8>, s: &str) -> Result<(), EncodeError> {
+    let len = u16::try_from(s.len())
+        .map_err(|_| EncodeError::RunVersionsFieldTooLong { got: s.len() })?;
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(s.as_bytes());
+    Ok(())
+}
+
+/// Read a `u16`-length-prefixed UTF-8 string at `*cursor`, advancing it. Strict
+/// bounds + UTF-8 validation; total (never panics).
+fn read_len_prefixed_str(body: &[u8], cursor: &mut usize, kind: u8) -> Result<String, DecodeError> {
+    if body.len() < *cursor + 2 {
+        return Err(DecodeError::BodyTooShort {
+            kind,
+            got: body.len(),
+            expected: *cursor + 2,
+        });
+    }
+    let len = u16::from_le_bytes(body[*cursor..*cursor + 2].try_into().expect("2 bytes")) as usize;
+    *cursor += 2;
+    if body.len() < *cursor + len {
+        return Err(DecodeError::BodyTooShort {
+            kind,
+            got: body.len(),
+            expected: *cursor + len,
+        });
+    }
+    let s = std::str::from_utf8(&body[*cursor..*cursor + len])
+        .map_err(|_| DecodeError::RunVersionsInvalidUtf8)?
+        .to_owned();
+    *cursor += len;
+    Ok(s)
+}
+
+/// Read a single byte at `*cursor`, advancing it.
+fn read_u8(body: &[u8], cursor: &mut usize, kind: u8) -> Result<u8, DecodeError> {
+    if body.len() < *cursor + 1 {
+        return Err(DecodeError::BodyTooShort {
+            kind,
+            got: body.len(),
+            expected: *cursor + 1,
+        });
+    }
+    let b = body[*cursor];
+    *cursor += 1;
+    Ok(b)
+}
+
+/// Read a 32-byte array at `*cursor`, advancing it.
+fn read_array32(body: &[u8], cursor: &mut usize, kind: u8) -> Result<[u8; 32], DecodeError> {
+    if body.len() < *cursor + 32 {
+        return Err(DecodeError::BodyTooShort {
+            kind,
+            got: body.len(),
+            expected: *cursor + 32,
+        });
+    }
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&body[*cursor..*cursor + 32]);
+    *cursor += 32;
+    Ok(buf)
 }
 
 fn nd_class_from_byte(b: u8) -> Result<NdClass, DecodeError> {
@@ -1484,6 +1793,130 @@ mod tests {
         // blake3-of-16-bytes identity.
         let bare = MoteId::from_bytes(*blake3::hash(&a).as_bytes());
         assert_ne!(run_root_id(&a), bare);
+    }
+
+    // -------------------- v4 (M1.2): RunVersionsResolved --------------------
+
+    fn sample_run_versions(capability: Option<ResolvedCapabilityRecord>) -> JournalEntry {
+        JournalEntry::RunVersionsResolved {
+            instance_id: [0x55u8; INSTANCE_ID_LEN],
+            warrant_ref: ContentRef::from_bytes([0x66; 32]),
+            model_id: "qwen2.5-0.5b".to_owned(),
+            capability,
+            seq: 7,
+        }
+    }
+
+    fn sample_capability() -> ResolvedCapabilityRecord {
+        ResolvedCapabilityRecord {
+            tool_id: "fs-read".to_owned(),
+            tool_version: "1.0.0".to_owned(),
+            resolved_kind: ResolvedKindTag::Builtin,
+            resolved_def_hash: ContentRef::from_bytes([0x77; 32]),
+        }
+    }
+
+    #[test]
+    fn run_versions_round_trips_with_and_without_capability() {
+        for cap in [None, Some(sample_capability())] {
+            let e = sample_run_versions(cap);
+            let bytes = encode_entry(&e).unwrap();
+            assert_eq!(decode_entry(&bytes).unwrap(), e);
+        }
+    }
+
+    #[test]
+    fn run_versions_header_carries_run_root_id_and_zero_idempotency_key() {
+        let e = sample_run_versions(Some(sample_capability()));
+        let instance_id = match &e {
+            JournalEntry::RunVersionsResolved { instance_id, .. } => *instance_id,
+            _ => unreachable!(),
+        };
+        let bytes = encode_entry(&e).unwrap();
+        assert_eq!(&bytes[1..33], run_root_id(&instance_id).as_bytes());
+        assert_eq!(&bytes[33..65], &[0u8; 32]);
+        assert_eq!(e.idempotency_key(), &[0u8; 32]);
+        assert_eq!(e.mote_id(), run_root_id(&instance_id));
+        assert_eq!(e.kind(), KIND_RUN_VERSIONS_RESOLVED);
+    }
+
+    #[test]
+    fn decode_rejects_run_versions_header_body_mismatch() {
+        let e = sample_run_versions(Some(sample_capability()));
+        let mut bytes = encode_entry(&e).unwrap();
+        bytes[1] ^= 0xff; // corrupt the run-root id in the header
+        assert_eq!(
+            decode_entry(&bytes).unwrap_err(),
+            DecodeError::RunVersionsHeaderMismatch
+        );
+    }
+
+    #[test]
+    fn decode_rejects_run_versions_trailing_bytes() {
+        let e = sample_run_versions(Some(sample_capability()));
+        let mut bytes = encode_entry(&e).unwrap();
+        bytes.push(0xff);
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::TrailingBytes(1))
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_run_versions_body_too_short() {
+        let e = sample_run_versions(Some(sample_capability()));
+        let mut bytes = encode_entry(&e).unwrap();
+        bytes.pop(); // truncate the def_hash
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::BodyTooShort {
+                kind: KIND_RUN_VERSIONS_RESOLVED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_run_versions_unknown_kind_tag() {
+        let e = sample_run_versions(Some(sample_capability()));
+        let bytes = encode_entry(&e).unwrap();
+        // The kind tag byte sits just before the trailing 32-byte def_hash.
+        let tag_idx = bytes.len() - 33;
+        let mut corrupted = bytes.clone();
+        corrupted[tag_idx] = 0xff;
+        assert_eq!(
+            decode_entry(&corrupted).unwrap_err(),
+            DecodeError::UnknownResolvedKind(0xff)
+        );
+    }
+
+    #[test]
+    fn decode_rejects_run_versions_non_boolean_has_cap() {
+        // has_cap sits right after instance_id(16) ‖ warrant_ref(32) ‖
+        // u16-prefixed model_id, all inside the body (after the 74-byte header).
+        let e = sample_run_versions(None);
+        let bytes = encode_entry(&e).unwrap();
+        let has_cap_idx = bytes.len() - 1; // None body ends at has_cap
+        let mut corrupted = bytes.clone();
+        corrupted[has_cap_idx] = 2;
+        assert_eq!(
+            decode_entry(&corrupted).unwrap_err(),
+            DecodeError::NonBooleanHasCap(2)
+        );
+    }
+
+    #[test]
+    fn resolved_kind_tag_round_trips_and_rejects_unknown() {
+        for tag in [
+            ResolvedKindTag::Builtin,
+            ResolvedKindTag::LocalScript,
+            ResolvedKindTag::External,
+            ResolvedKindTag::Mcp,
+            ResolvedKindTag::SelfGenerated,
+        ] {
+            assert_eq!(ResolvedKindTag::from_u8(tag.as_u8()), Some(tag));
+        }
+        assert_eq!(ResolvedKindTag::from_u8(5), None);
     }
 
     #[test]

--- a/crates/kx-journal/src/in_memory.rs
+++ b/crates/kx-journal/src/in_memory.rs
@@ -230,6 +230,7 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Repudiated { seq, .. }
         | JournalEntry::Failed { seq, .. }
         | JournalEntry::EffectStaged { seq, .. }
-        | JournalEntry::RunRegistered { seq, .. } => *seq = new_seq,
+        | JournalEntry::RunRegistered { seq, .. }
+        | JournalEntry::RunVersionsResolved { seq, .. } => *seq = new_seq,
     }
 }

--- a/crates/kx-journal/src/lib.rs
+++ b/crates/kx-journal/src/lib.rs
@@ -90,9 +90,10 @@
 pub use crate::entry::{
     decode_entry, decode_entry_with_def_hash, encode_entry, is_pre_commit_crash,
     repudiation_idempotency_key, run_root_id, DecodeError, EncodeError, FailureReason,
-    JournalEntry, ParentEntry, RepudiationReason, HEADER_LEN, INSTANCE_ID_LEN,
-    JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED,
-    KIND_REPUDIATED, KIND_RUN_REGISTERED, MAX_ENTRY_LEN, MAX_PARENTS,
+    JournalEntry, ParentEntry, RepudiationReason, ResolvedCapabilityRecord, ResolvedKindTag,
+    HEADER_LEN, INSTANCE_ID_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_EFFECT_STAGED,
+    KIND_FAILED, KIND_PROPOSED, KIND_REPUDIATED, KIND_RUN_REGISTERED, KIND_RUN_VERSIONS_RESOLVED,
+    MAX_ENTRY_LEN, MAX_PARENTS,
 };
 pub use crate::in_memory::InMemoryJournal;
 pub use crate::sqlite::SqliteJournal;

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -11,7 +11,7 @@
 //!
 //! CREATE TABLE entries (
 //!     seq             INTEGER  PRIMARY KEY,   -- per-run monotonic u64
-//!     kind            INTEGER  NOT NULL,      -- u8 (Proposed=0, Committed=1, Repudiated=2, Failed=3, EffectStaged=4, RunRegistered=5)
+//!     kind            INTEGER  NOT NULL,      -- u8 (Proposed=0, Committed=1, Repudiated=2, Failed=3, EffectStaged=4, RunRegistered=5, RunVersionsResolved=6)
 //!     mote_id         BLOB     NOT NULL,      -- 32 bytes
 //!     idempotency_key BLOB     NOT NULL,      -- 32 bytes
 //!     nondeterminism  INTEGER  NOT NULL DEFAULT 0,
@@ -21,7 +21,7 @@
 //!
 //! CREATE INDEX idx_entries_mote_id ON entries (mote_id);
 //! CREATE UNIQUE INDEX idx_entries_dedupe ON entries (idempotency_key, kind) WHERE kind IN (1, 2, 4);
-//! -- RunRegistered (kind 5) is NOT in the dedupe set: one run registers exactly once by construction.
+//! -- RunRegistered (kind 5) + RunVersionsResolved (kind 6) are NOT in the dedupe set: run-metadata facts, append-only (one run registers once; resolved-versions are append-many).
 //! CREATE INDEX idx_entries_def_hash ON entries (mote_def_hash) WHERE kind = 1;
 //! ```
 //!
@@ -467,7 +467,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Repudiated { seq, .. }
         | JournalEntry::Failed { seq, .. }
         | JournalEntry::EffectStaged { seq, .. }
-        | JournalEntry::RunRegistered { seq, .. } => *seq = new_seq,
+        | JournalEntry::RunRegistered { seq, .. }
+        | JournalEntry::RunVersionsResolved { seq, .. } => *seq = new_seq,
     }
 }
 

--- a/crates/kx-journal/tests/dod.rs
+++ b/crates/kx-journal/tests/dod.rs
@@ -256,7 +256,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Repudiated { seq, .. }
         | JournalEntry::Failed { seq, .. }
         | JournalEntry::EffectStaged { seq, .. }
-        | JournalEntry::RunRegistered { seq, .. } => *seq = new_seq,
+        | JournalEntry::RunRegistered { seq, .. }
+        | JournalEntry::RunVersionsResolved { seq, .. } => *seq = new_seq,
     }
 }
 
@@ -296,6 +297,14 @@ fn obligation_13_schema_version_mismatch_loud_refusal() {
         }
         other => panic!("expected SchemaVersionMismatch, got {other:?}"),
     }
+}
+
+/// M1.2 (D79): pin the schema version so the v3→v4 bump (the new
+/// `RunVersionsResolved` kind) is an intentional, reviewable change — a future
+/// edit that touches the entry encoding must bump this in lock-step.
+#[test]
+fn schema_version_is_v4() {
+    assert_eq!(JOURNAL_SCHEMA_VERSION, 4);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kx-journal/tests/proptest_entry.rs
+++ b/crates/kx-journal/tests/proptest_entry.rs
@@ -184,6 +184,55 @@ fn arb_run_registered() -> impl Strategy<Value = JournalEntry> {
         })
 }
 
+/// **v4 (M1.2): ResolvedKindTag strategy** — one of the five closed variants.
+fn arb_resolved_kind() -> impl Strategy<Value = kx_journal::ResolvedKindTag> {
+    use kx_journal::ResolvedKindTag::{Builtin, External, LocalScript, Mcp, SelfGenerated};
+    prop_oneof![
+        Just(Builtin),
+        Just(LocalScript),
+        Just(External),
+        Just(Mcp),
+        Just(SelfGenerated),
+    ]
+}
+
+/// **v4 (M1.2): RunVersionsResolved strategy.** `instance_id` is the 16-byte run
+/// nonce; `model_id`/`tool_id`/`tool_version` are bounded UTF-8 ids; the
+/// capability is present or absent (zero-grant warrant).
+fn arb_run_versions_resolved() -> impl Strategy<Value = JournalEntry> {
+    let arb_cap = (
+        "[a-z0-9._-]{0,40}",
+        "[a-z0-9._-]{0,16}",
+        arb_resolved_kind(),
+        arb_byte_array_32(),
+    )
+        .prop_map(|(tool_id, tool_version, resolved_kind, def_hash)| {
+            kx_journal::ResolvedCapabilityRecord {
+                tool_id,
+                tool_version,
+                resolved_kind,
+                resolved_def_hash: ContentRef::from_bytes(def_hash),
+            }
+        });
+    (
+        proptest::array::uniform16(any::<u8>()),
+        arb_byte_array_32(),
+        "[a-z0-9._-]{0,40}",
+        proptest::option::of(arb_cap),
+        any::<u64>(),
+    )
+        .prop_map(|(instance_id, warrant_ref, model_id, capability, seq)| {
+            let _: [u8; INSTANCE_ID_LEN] = instance_id;
+            JournalEntry::RunVersionsResolved {
+                instance_id,
+                warrant_ref: ContentRef::from_bytes(warrant_ref),
+                model_id,
+                capability,
+                seq,
+            }
+        })
+}
+
 /// **v2 (PR 7): EffectStaged strategy.** Header-only; no body fields.
 fn arb_effect_staged() -> impl Strategy<Value = JournalEntry> {
     (arb_mote_id(), arb_byte_array_32(), any::<u64>()).prop_map(
@@ -325,6 +374,24 @@ proptest! {
             bytes.len(),
             MAX_ENTRY_LEN
         );
+    }
+
+    // **v4 (M1.2)** — encode/decode round-trip for RunVersionsResolved entries
+    // (variable-length body; capability present or absent).
+    #[test]
+    fn prop_run_versions_round_trip(entry in arb_run_versions_resolved()) {
+        let bytes = encode_entry(&entry).expect("encode");
+        let decoded = decode_entry(&bytes).expect("decode");
+        prop_assert_eq!(decoded, entry);
+    }
+
+    // **v4 (M1.2)** — encoding determinism + size cap for RunVersionsResolved.
+    #[test]
+    fn prop_run_versions_deterministic_and_capped(entry in arb_run_versions_resolved()) {
+        let a = encode_entry(&entry).expect("encode a");
+        let b = encode_entry(&entry).expect("encode b");
+        prop_assert_eq!(&a, &b);
+        prop_assert!(a.len() <= MAX_ENTRY_LEN);
     }
 
     // Property 1 — encode/decode round-trip for Committed entries via

--- a/crates/kx-projection/src/lib.rs
+++ b/crates/kx-projection/src/lib.rs
@@ -107,6 +107,7 @@ pub use projection::Projection;
 pub use promotion::{ContentStoreVerdicts, VerdictLookup};
 pub use register::RegisterMote;
 pub use snapshot::Snapshot;
+pub use state::RunResolvedVersions;
 
 #[cfg(test)]
 mod tests;

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -307,27 +307,60 @@ impl Projection {
                 info.effect_staged_observed = true;
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
+            // Off-DAG run-metadata facts (extracted to keep `fold` under the
+            // line budget): both record an O(1) field and NEVER touch
+            // `rebuild_children_index` (the per-mutation O(n²) D92 path).
+            JournalEntry::RunRegistered { .. } | JournalEntry::RunVersionsResolved { .. } => {
+                self.fold_run_metadata(entry);
+            }
+        }
+        Ok(prev)
+    }
+
+    /// Fold an off-DAG run-metadata fact (`RunRegistered` / `RunVersionsResolved`).
+    ///
+    /// Both name no Mote, so this registers NO `MoteInfo` and does NOT call
+    /// `rebuild_children_index` — O(1), off the Mote-DAG. The data is **metadata,
+    /// never identity**: no scheduling/identity/digest decision reads it.
+    fn fold_run_metadata(&mut self, entry: &JournalEntry) {
+        match entry {
             JournalEntry::RunRegistered {
                 instance_id,
                 recipe_fingerprint,
                 seq,
                 ..
             } => {
-                // **v3 (M1.1, D63/D64): run registration.** Off the Mote-DAG —
-                // names no Mote, so this fold registers NO MoteInfo and does NOT
-                // call `rebuild_children_index` (the per-mutation O(n²) path).
-                // It records the run's identity root as an O(1) field. Idempotent
-                // on replay: the seq=1 entry replays the same bytes, so re-folding
-                // sets the same `RunRegistration`. `ts` is audit-only and ignored
-                // here (never an input to any scheduling/identity decision).
+                // v3 (M1.1, D63/D64). Idempotent on replay: the seq=1 entry
+                // replays the same bytes, so re-folding sets the same value.
+                // `ts` is audit-only and ignored here.
                 self.state.run_registration = Some(crate::state::RunRegistration {
                     instance_id: *instance_id,
                     recipe_fingerprint: *recipe_fingerprint,
                 });
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
+            JournalEntry::RunVersionsResolved {
+                instance_id,
+                warrant_ref,
+                model_id,
+                capability,
+                seq,
+            } => {
+                // v4 (M1.2, D79). Append-many: a run accrues one record per
+                // resolved capability. Replay rebuilds the same Vec from scratch
+                // (each journaled entry folds exactly once).
+                self.state
+                    .run_resolved_versions
+                    .push(crate::state::RunResolvedVersions {
+                        instance_id: *instance_id,
+                        warrant_ref: *warrant_ref,
+                        model_id: model_id.clone(),
+                        capability: capability.clone(),
+                    });
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
+            _ => unreachable!("fold_run_metadata called with a non-run-metadata kind"),
         }
-        Ok(prev)
     }
 
     /// The largest `seq` applied so far. `0` for an empty projection.
@@ -603,6 +636,18 @@ impl Projection {
         self.state
             .run_registration
             .map(|r| (r.instance_id, r.recipe_fingerprint))
+    }
+
+    /// The resolved-version run metadata (D79) folded so far — one record per
+    /// `RunVersionsResolved` entry (one per resolved capability; a zero-grant
+    /// warrant contributes one with `capability == None`).
+    ///
+    /// **Audit/lineage metadata, never identity.** Off the Mote-DAG: no
+    /// scheduling/identity/digest decision reads it, so it can never move the
+    /// projection digest. Reconstructed verbatim on replay.
+    #[must_use]
+    pub fn run_resolved_versions(&self) -> &[crate::state::RunResolvedVersions] {
+        &self.state.run_resolved_versions
     }
 
     /// Count of Motes currently in `MoteState::Repudiated`.

--- a/crates/kx-projection/src/snapshot.rs
+++ b/crates/kx-projection/src/snapshot.rs
@@ -97,6 +97,13 @@ impl Snapshot {
             .map(|r| (r.instance_id, r.recipe_fingerprint))
     }
 
+    /// Resolved-version run metadata (D79). See
+    /// [`crate::Projection::run_resolved_versions`].
+    #[must_use]
+    pub fn run_resolved_versions(&self) -> &[crate::state::RunResolvedVersions] {
+        &self.state.run_resolved_versions
+    }
+
     /// Direct parents. See [`crate::Projection::parents_of`].
     #[must_use]
     pub fn parents_of(&self, mote_id: &MoteId) -> SmallVec<[(MoteId, EdgeMeta); 4]> {

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -105,6 +105,22 @@ pub(crate) struct RunRegistration {
     pub(crate) recipe_fingerprint: [u8; 32],
 }
 
+/// One resolved-version run-metadata record (v4, M1.2, D79), folded from a
+/// `RunVersionsResolved` entry. **Audit/lineage metadata, never identity** — no
+/// scheduling/identity/digest decision reads it. Off the Mote-DAG. Surfaced by
+/// [`crate::Projection::run_resolved_versions`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunResolvedVersions {
+    /// The run this metadata is attached to.
+    pub instance_id: [u8; kx_journal::INSTANCE_ID_LEN],
+    /// The warrant resolved under (`blake3(canonical_bincode(WarrantSpec))`).
+    pub warrant_ref: ContentRef,
+    /// The resolved model id (opaque audit identifier).
+    pub model_id: String,
+    /// The resolved capability, or `None` for a zero-grant warrant.
+    pub capability: Option<kx_journal::ResolvedCapabilityRecord>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct State {
     /// Per-MoteId info — declared, committed, and any in-flight state.
@@ -118,6 +134,10 @@ pub(crate) struct State {
     /// The registered run identity (D64), or `None` until a `RunRegistered`
     /// entry is folded. Off-DAG; O(1) to set and read.
     pub(crate) run_registration: Option<RunRegistration>,
+    /// Resolved-version run metadata (D79), appended as each `RunVersionsResolved`
+    /// entry folds (one per resolved capability). Off-DAG; O(1) per append.
+    /// Audit/lineage only — never an identity/scheduling/digest input.
+    pub(crate) run_resolved_versions: Vec<RunResolvedVersions>,
 }
 
 impl State {

--- a/crates/kx-projection/tests/proptest_fold.rs
+++ b/crates/kx-projection/tests/proptest_fold.rs
@@ -530,6 +530,111 @@ fn run_registered_before_motes_does_not_change_committed_set() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// **v4 (M1.2, D79) — RunVersionsResolved fold is off the Mote-DAG (O(1)).**
+//
+// Like RunRegistered, it names no Mote: folding registers no MoteInfo, leaves
+// the children index empty, advances current_seq, and appends a metadata record
+// the runtime digest (committed Motes only) can never see.
+// ---------------------------------------------------------------------------
+
+fn run_versions_resolved(
+    instance_seed: u8,
+    model_id: &str,
+    capability: Option<kx_journal::ResolvedCapabilityRecord>,
+    seq: u64,
+) -> JournalEntry {
+    JournalEntry::RunVersionsResolved {
+        instance_id: [instance_seed; kx_journal::INSTANCE_ID_LEN],
+        warrant_ref: ContentRef::from_bytes([0xcd; 32]),
+        model_id: model_id.to_owned(),
+        capability,
+        seq,
+    }
+}
+
+fn sample_cap_record() -> kx_journal::ResolvedCapabilityRecord {
+    kx_journal::ResolvedCapabilityRecord {
+        tool_id: "fs-read".to_owned(),
+        tool_version: "1.0.0".to_owned(),
+        resolved_kind: kx_journal::ResolvedKindTag::Builtin,
+        resolved_def_hash: ContentRef::from_bytes([0x42; 32]),
+    }
+}
+
+#[test]
+fn run_versions_resolved_fold_is_off_dag_and_appends_metadata() {
+    let mut p = Projection::new();
+    p.fold(&run_registered(0xa1, 0xb2, 1)).unwrap();
+    p.fold(&run_versions_resolved(
+        0xa1,
+        "qwen",
+        Some(sample_cap_record()),
+        2,
+    ))
+    .unwrap();
+    p.fold(&run_versions_resolved(0xa1, "qwen", None, 3))
+        .unwrap();
+    // No Mote registered; current_seq advanced; both records appended in order.
+    assert_eq!(p.len(), 0);
+    assert_eq!(p.committed_count(), 0);
+    assert_eq!(p.current_seq(), 3);
+    let recs = p.run_resolved_versions();
+    assert_eq!(recs.len(), 2);
+    assert_eq!(recs[0].model_id, "qwen");
+    assert_eq!(recs[0].capability.as_ref().unwrap().tool_id, "fs-read");
+    assert!(recs[1].capability.is_none());
+}
+
+/// **Scale (D95):** folding a large run-metadata log stays O(1) **off the
+/// Mote-DAG** — N `RunVersionsResolved` entries register NO Mote and never
+/// rebuild the children index (the D92 O(n²) wall), so the committed digest the
+/// runtime hashes (over committed Motes only) is untouched at any N. Run with
+/// `cargo test -p kx-projection --release -- --ignored run_versions_fold_scale`.
+#[test]
+#[ignore = "scale: run with --release --ignored"]
+fn run_versions_fold_scale_is_off_dag() {
+    const N: u64 = 10_000;
+    let mut p = Projection::new();
+    p.fold(&run_registered(0x01, 0x02, 1)).unwrap();
+    for seq in 2..=(N + 1) {
+        let cap = if seq % 3 == 0 {
+            Some(sample_cap_record())
+        } else {
+            None
+        };
+        p.fold(&run_versions_resolved(0x01, "model", cap, seq))
+            .unwrap();
+    }
+    // Off-DAG: NO Mote registered, NO committed fact → the digest is unmoved.
+    assert_eq!(p.len(), 0, "no Mote registered at any N");
+    assert_eq!(p.committed_count(), 0);
+    assert_eq!(p.iter_motes().count(), 0);
+    // All N metadata records accrued; current_seq tracks the log.
+    assert_eq!(p.run_resolved_versions().len() as u64, N);
+    assert_eq!(p.current_seq(), N + 1);
+}
+
+#[test]
+fn run_versions_resolved_replays_identically_from_scratch() {
+    // Each journaled entry folds exactly once on replay → the accrued metadata
+    // Vec is byte-identical when a fresh projection re-folds the same trace.
+    let entries = vec![
+        run_registered(0x5a, 0x6b, 1),
+        run_versions_resolved(0x5a, "m1", Some(sample_cap_record()), 2),
+        run_versions_resolved(0x5a, "m1", None, 3),
+    ];
+    let mut a = Projection::new();
+    let mut b = Projection::new();
+    for e in &entries {
+        a.fold(e).unwrap();
+    }
+    for e in &entries {
+        b.fold(e).unwrap();
+    }
+    assert_eq!(a.run_resolved_versions(), b.run_resolved_versions());
+}
+
 #[test]
 fn fold_many_stops_on_first_error_and_state_reflects_applied_entries() {
     let mut p = Projection::new();

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -213,6 +213,7 @@ message SubmitMoteResponse {
   bytes mote_id = 1;                    // 32B — coordinator-derived identity
   SubmitStatus status = 2;
   string detail = 3;                    // human-readable; empty on accept
+  bytes instance_id = 4;                // 16B — the registered run this Mote was admitted under (M1.2/D64; the resume key clients hand back to M2)
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +317,7 @@ message WorkItem {
 
 message LeaseWorkResponse {
   repeated WorkItem items = 1;          // empty when no ready work matches
+  bytes instance_id = 2;                // 16B — the registered run; the worker derives the cross-boundary idempotency token from it (M1.2/D64). Empty if the run is unregistered.
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kx-proto/tests/dod.rs
+++ b/crates/kx-proto/tests/dod.rs
@@ -48,6 +48,7 @@ fn obligation_1_submit_mote_response_round_trips() {
         mote_id: vec![0xAB; 32],
         status: proto::SubmitStatus::Accepted as i32,
         detail: String::new(),
+        instance_id: vec![0xCD; 16],
     });
 }
 
@@ -114,13 +115,17 @@ fn obligation_1_lease_work_response_round_trips() {
             mote: Some(sample_mote().into()),
             warrant: Some(sample_warrant().into()),
         }],
+        instance_id: vec![0xEF; 16],
     };
     roundtrip(&resp);
 }
 
 #[test]
 fn obligation_1_lease_work_response_empty_round_trips() {
-    roundtrip(&proto::LeaseWorkResponse { items: vec![] });
+    roundtrip(&proto::LeaseWorkResponse {
+        items: vec![],
+        instance_id: vec![],
+    });
 }
 
 #[test]
@@ -258,6 +263,7 @@ fn obligation_3_work_item_preserves_identity() {
             mote: Some(mote.clone().into()),
             warrant: Some(warrant.clone().into()),
         }],
+        instance_id: vec![0x01; 16],
     };
 
     let bytes = resp.encode_to_vec();

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -54,6 +54,7 @@ impl Coordinator for NoopCoordinator {
             mote_id,
             status: SubmitStatus::Accepted as i32,
             detail: String::new(),
+            instance_id: vec![0u8; 16],
         }))
     }
 
@@ -92,6 +93,7 @@ impl Coordinator for NoopCoordinator {
                 mote: Some(sample_mote().into()),
                 warrant: Some(sample_warrant().into()),
             }],
+            instance_id: vec![0u8; 16],
         }))
     }
 

--- a/crates/kx-tool-registry/src/lib.rs
+++ b/crates/kx-tool-registry/src/lib.rs
@@ -16,9 +16,14 @@
 //! # Resolution path (D32 §5)
 //!
 //! `local → registry → MCP`. Invisible to the capability model — the warrant
-//! sees only the `(ToolName, ToolVersion)` reference. BUT the resolved tier is
-//! **journaled** via a content-addressed [`ToolResolutionEvent`] so replay
-//! resolves identically. At resolution time, [`check_tool_requirement`]
+//! sees only the `(ToolName, ToolVersion)` reference. The resolved tier is
+//! **content-addressed** by a [`ToolResolutionEvent`] (the event struct is a
+//! pure resolution artifact — NOT itself a journal entry). In M1.2 (D79) the
+//! coordinator captures the resolved `(tool_id, tool_version, resolved_kind,
+//! resolved_def_hash)` of every grant — via [`resolve_run_versions`] — as
+//! off-DAG run **metadata** (a journaled `RunVersionsResolved` fact attached to
+//! the run's `instance_id`); these versions are audit/lineage metadata, never
+//! folded into identity. At resolution time, [`check_tool_requirement`]
 //! enforces `tool.required_capability ⊆ warrant`; the broker (P1.8.5) never
 //! sees a tool whose capability exceeds the warrant.
 //!
@@ -97,7 +102,7 @@ pub use errors::{RegistrationError, ResolutionError};
 pub use idempotency_class::IdempotencyClass;
 pub use ids::{McpEndpointId, RegistrationToken, ReviewerId};
 pub use provenance::{RegistrationStatus, ToolProvenance};
-pub use registry::{InMemoryToolRegistry, ToolRegistry};
+pub use registry::{resolve_run_versions, InMemoryToolRegistry, ToolRegistry};
 pub use token::registration_token_of;
 pub use tool_def::{ResolvedTool, ToolDef, ToolResolutionEvent};
 pub use tool_kind::ToolKind;

--- a/crates/kx-tool-registry/src/registry.rs
+++ b/crates/kx-tool-registry/src/registry.rs
@@ -191,6 +191,35 @@ pub trait ToolRegistry: Send + Sync {
     ) -> Result<(), RegistrationError>;
 }
 
+/// Resolve every tool a warrant grants, in canonical `(tool_id, tool_version)`
+/// order, returning the content-addressed [`ToolResolutionEvent`] for each
+/// (M1.2, D79). Pure over the registry state — reuses [`ToolRegistry::resolve`]
+/// per grant (so the same subset checks + content-addressing apply).
+///
+/// The caller (the coordinator, at submit) captures these events as off-DAG
+/// run **metadata** (a journaled `RunVersionsResolved` fact) — never identity.
+/// A zero-grant warrant yields an empty `Vec`.
+///
+/// # Errors
+///
+/// Propagates the first [`ResolutionError`] (`NotFound`,
+/// `CapabilityExceedsWarrant`, `PendingHumanReview`) — so a tool that does not
+/// resolve cleanly is surfaced before any metadata is journaled (fail-closed on
+/// the capture path; no over-privileged or phantom tuple is ever recorded).
+pub fn resolve_run_versions(
+    registry: &dyn ToolRegistry,
+    warrant: &WarrantSpec,
+) -> Result<Vec<ToolResolutionEvent>, ResolutionError> {
+    // `tool_grants` is a `BTreeSet<ToolGrant>` — iteration is already in
+    // canonical (tool_id, tool_version) order, so the captured order is
+    // deterministic across runs.
+    warrant
+        .tool_grants
+        .iter()
+        .map(|grant| registry.resolve(grant, warrant).map(|r| r.event))
+        .collect()
+}
+
 /// Internal per-registration record.
 #[derive(Debug, Clone)]
 struct RegistrationRecord {

--- a/crates/kx-tool-registry/src/tests.rs
+++ b/crates/kx-tool-registry/src/tests.rs
@@ -166,6 +166,61 @@ fn resolve_event_is_deterministic() {
 }
 
 // -----------------------------------------------------------------
+// resolve_run_versions (M1.2, D79)
+// -----------------------------------------------------------------
+
+#[test]
+fn resolve_run_versions_orders_by_grant_and_is_empty_for_zero_grants() {
+    let mut reg = InMemoryToolRegistry::new();
+    for id in ["beta", "alpha"] {
+        reg.register(
+            sample_def(id, "1", ToolKind::Builtin, permissive_req()),
+            ToolProvenance::HumanAuthored {
+                author: "ops".into(),
+            },
+        )
+        .unwrap();
+    }
+    let mut warrant = permissive_warrant();
+    warrant.tool_grants = BTreeSet::from([
+        ToolGrant {
+            tool_id: ToolName("beta".into()),
+            tool_version: ToolVersion("1".into()),
+        },
+        ToolGrant {
+            tool_id: ToolName("alpha".into()),
+            tool_version: ToolVersion("1".into()),
+        },
+    ]);
+    let events = resolve_run_versions(&reg, &warrant).unwrap();
+    // BTreeSet iteration is canonical (tool_id, tool_version) order → alpha, beta.
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].tool_id.0, "alpha");
+    assert_eq!(events[1].tool_id.0, "beta");
+
+    // Zero-grant warrant → empty Vec (no metadata to capture).
+    let mut empty = permissive_warrant();
+    empty.tool_grants = BTreeSet::new();
+    assert!(resolve_run_versions(&reg, &empty).unwrap().is_empty());
+}
+
+#[test]
+fn resolve_run_versions_propagates_resolution_error() {
+    // A grant for a tool that does not resolve cleanly fails the whole capture
+    // (fail-closed: no partial/over-privileged metadata is ever journaled).
+    let reg = InMemoryToolRegistry::new();
+    let mut warrant = permissive_warrant();
+    warrant.tool_grants = BTreeSet::from([ToolGrant {
+        tool_id: ToolName("missing".into()),
+        tool_version: ToolVersion("1".into()),
+    }]);
+    assert!(matches!(
+        resolve_run_versions(&reg, &warrant),
+        Err(ResolutionError::NotFound { .. })
+    ));
+}
+
+// -----------------------------------------------------------------
 // resolve — refusals
 // -----------------------------------------------------------------
 

--- a/crates/kx-tool-registry/src/tool_def.rs
+++ b/crates/kx-tool-registry/src/tool_def.rs
@@ -1,6 +1,8 @@
 //! [`ToolDef`] — the spec the registry stores. Plus the resolution-side
-//! [`ToolResolutionEvent`] (journaled at resolution time) and [`ResolvedTool`]
-//! (the rich return shape from [`crate::ToolRegistry::resolve`]).
+//! [`ToolResolutionEvent`] (content-addressed at resolution time; the resolved
+//! versions are captured into run metadata by the coordinator in M1.2, D79 —
+//! the event struct is not itself a journal entry) and [`ResolvedTool`] (the
+//! rich return shape from [`crate::ToolRegistry::resolve`]).
 
 use kx_content::ContentRef;
 use kx_mote::{canonical_config, ToolName, ToolVersion};
@@ -22,7 +24,7 @@ use crate::tool_kind::ToolKind;
 ///
 /// PR 4.6 added the required `idempotency_class` field. **This is a
 /// canonical-bytes-shifting change**: `RegistrationToken` (the dedup primary
-/// key) and `ToolResolutionEvent.resolved_def_hash` (the journaled
+/// key) and `ToolResolutionEvent.resolved_def_hash` (the content-addressed
 /// resolution event) for any given `ToolDef` now differ from what the
 /// pre-PR-4.6 `ToolDef` would have produced. No production state exists at
 /// either pin site at the time of the shift, so the canonical-bytes change
@@ -59,11 +61,15 @@ pub struct ToolDef {
 /// The content-addressed fact that "tool X version Y was resolved as kind Z
 /// from this registry at the resolution event corresponding to this `ContentRef`."
 ///
-/// Journaled by the executor at the registry-resolution event so replay
-/// resolves identically. **Identity excludes wall-clock time** — including time
-/// would break content-addressing (two runs would produce different refs for
-/// the same resolution). Time, if needed for audit, lives in the journal
-/// entry's header.
+/// A pure resolution artifact — **not itself a journal entry**. The coordinator
+/// captures the resolved `(tool_id, tool_version, resolved_kind,
+/// resolved_def_hash)` as off-DAG run **metadata** (a `RunVersionsResolved`
+/// journal fact, M1.2/D79); these versions are audit/lineage metadata, never an
+/// identity input, and the executor never journals this struct (the coordinator
+/// is the sole writer, D40). **Identity excludes wall-clock time** — including
+/// time would break content-addressing (two runs would produce different refs
+/// for the same resolution). Time, if needed for audit, lives in the
+/// `RunVersionsResolved` entry's header.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ToolResolutionEvent {
     /// The tool that was resolved.

--- a/crates/kx-worker/src/client.rs
+++ b/crates/kx-worker/src/client.rs
@@ -70,13 +70,16 @@ impl WorkerClient {
         Ok(resp.ack)
     }
 
-    /// Pull up to `max_motes` ready PURE Motes runnable on `executor_class`.
+    /// Pull up to `max_motes` ready Motes runnable on `executor_class`, plus the
+    /// registered run's `instance_id` (M1.2/D64) — the worker derives the
+    /// run-scoped cross-boundary idempotency token from it. The `instance_id` is
+    /// empty for an unregistered run (the worker then falls back to MoteId-only).
     pub async fn lease_work(
         &mut self,
         worker_id: u64,
         executor_class: ExecutorClass,
         max_motes: u32,
-    ) -> Result<Vec<proto::WorkItem>, WorkerError> {
+    ) -> Result<(Vec<proto::WorkItem>, Vec<u8>), WorkerError> {
         let resp = self
             .inner
             .lease_work(proto::LeaseWorkRequest {
@@ -86,7 +89,7 @@ impl WorkerClient {
             })
             .await?
             .into_inner();
-        Ok(resp.items)
+        Ok((resp.items, resp.instance_id))
     }
 
     /// Record the **intent to fire** a WORLD-MUTATING effect, durably, before the

--- a/crates/kx-worker/src/run_wm.rs
+++ b/crates/kx-worker/src/run_wm.rs
@@ -24,7 +24,9 @@
 //! is glue over the broker trait, not an engine fork: `kx-executor` source is
 //! untouched (the P2 thesis test holds).
 
-use kx_capability::{idempotency_token_for, CapabilityBroker, EffectRequest};
+use kx_capability::{
+    idempotency_token_for, run_scoped_token, CapabilityBroker, EffectRequest, INSTANCE_ID_LEN,
+};
 use kx_content::ContentRef;
 use kx_mote::{EffectPattern, Mote, ToolName};
 use kx_warrant::{FsScope, NetScope, WarrantSpec};
@@ -35,15 +37,21 @@ use crate::error::WorkerError;
 /// Drive stage→fire for a non-PURE Mote and return the staged `result_ref` to
 /// PROPOSE via `ReportCommit`. Async because `ReportEffectStaged` is an RPC; the
 /// broker's `dispatch` is the trait's synchronous method.
+///
+/// `instance_id` is the registered run (M1.2/D64): when `Some`, the cross-boundary
+/// idempotency token is run-scoped (`run_scoped_token`), so the same Mote in a
+/// different run fires a distinct effect; when `None` (unregistered run), it falls
+/// back to the MoteId-only token.
 pub(crate) async fn run_wm(
     client: &mut WorkerClient,
     broker: &dyn CapabilityBroker,
     mote: &Mote,
     warrant: &WarrantSpec,
     worker_id: u64,
+    instance_id: Option<[u8; INSTANCE_ID_LEN]>,
 ) -> Result<ContentRef, WorkerError> {
     let capability = resolve_capability(mote)?;
-    let request = effect_request_for(mote);
+    let request = effect_request_for(mote, instance_id);
 
     // Stage the intent durably BEFORE firing (StageThenCommit only). Await the ack:
     // `report_effect_staged` returns `Err(EffectStagedRejected)` if the coordinator
@@ -74,16 +82,22 @@ fn resolve_capability(mote: &Mote) -> Result<ToolName, WorkerError> {
 /// Build the [`EffectRequest`] for a non-PURE Mote — mirrors the single-node
 /// `engine::effect_request_for` (empty payload, pattern from the def, empty scopes).
 ///
-/// Unlike the demo driver, the worker sets `idempotency_key =
-/// Some(idempotency_token_for(mote))`: it is the 32-byte tool-boundary key (D38 §1)
-/// that makes a re-dispatch after worker death a no-op at the world boundary
-/// (exactly-once, D58 §7), and it is required for token-class WM tools (executor
-/// predicate R-10). It is harmless for non-token capabilities.
-fn effect_request_for(mote: &Mote) -> EffectRequest {
+/// The worker sets the 32-byte tool-boundary key (D38 §1) that makes a re-dispatch
+/// after worker death a no-op at the world boundary (exactly-once, D58 §7), and
+/// that token-class WM tools require (executor predicate R-10). M1.2/D64: when the
+/// run is registered (`instance_id = Some`), the key is **run-scoped**
+/// (`run_scoped_token`) so the same Mote in a *fresh* run fires a *distinct*
+/// effect; an unregistered run falls back to the MoteId-only token. Harmless for
+/// non-token capabilities.
+fn effect_request_for(mote: &Mote, instance_id: Option<[u8; INSTANCE_ID_LEN]>) -> EffectRequest {
+    let idempotency_key = match instance_id {
+        Some(id) => run_scoped_token(&id, mote),
+        None => idempotency_token_for(mote),
+    };
     EffectRequest {
         payload: Vec::new(),
         pattern: mote.effect_pattern(),
-        idempotency_key: Some(idempotency_token_for(mote)),
+        idempotency_key: Some(idempotency_key),
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
     }

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use kx_capability::CapabilityBroker;
+use kx_capability::{CapabilityBroker, INSTANCE_ID_LEN};
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_executor::{LocalResourceManager, MoteExecutor};
 use kx_mote::{Mote, MoteId, NdClass};
@@ -127,10 +127,14 @@ impl Worker {
     /// propose its commit. Returns the number of commits the coordinator accepted
     /// this round (0 when no ready work matches).
     pub async fn run_once(&mut self) -> Result<usize, WorkerError> {
-        let items = self
+        let (items, instance_id_bytes) = self
             .client
             .lease_work(self.id, self.executor_class, self.max_lease)
             .await?;
+        // M1.2/D64: the registered run this batch belongs to. A 16-byte id ⇒ the
+        // worker derives a run-scoped cross-boundary token; empty (unregistered
+        // run) ⇒ fall back to the MoteId-only token.
+        let instance_id: Option<[u8; INSTANCE_ID_LEN]> = instance_id_bytes.try_into().ok();
 
         // Report load so the coordinator's placement (D56) can balance across workers:
         // `in_flight` = the batch we're about to run, reset to 0 when it drains.
@@ -162,7 +166,15 @@ impl Worker {
             let result_ref = if mote.nd_class() == NdClass::Pure {
                 run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)?
             } else {
-                run_wm::run_wm(&mut self.client, &*self.broker, &mote, &warrant, self.id).await?
+                run_wm::run_wm(
+                    &mut self.client,
+                    &*self.broker,
+                    &mote,
+                    &warrant,
+                    self.id,
+                    instance_id,
+                )
+                .await?
             };
             let request =
                 commit_builder::report_commit_request(&mote, &warrant, result_ref, self.id);

--- a/crates/kx-worker/tests/wm_dispatch.rs
+++ b/crates/kx-worker/tests/wm_dispatch.rs
@@ -445,7 +445,7 @@ async fn w3_worker_death_after_stage_is_exactly_once() {
         .register_worker(common::WORKER_CLASS, "dying")
         .await
         .unwrap();
-    let leased = dying
+    let (leased, _instance_id) = dying
         .lease_work(dying_id, common::WORKER_CLASS, 16)
         .await
         .unwrap();


### PR DESCRIPTION
## M1.2 — Resolved-Version Run Metadata (D79) + Run-Scoped Idempotency Token

Closes M1.2's share of the M1 exit gate (v2 durable-agentic pivot). **Additive** (Golden Rule 1); the **thesis diff over `kx-scheduler`/`kx-executor`/`kx-inference` is EMPTY**; the canonical demo digest `a6b5c679…` is **unchanged** (the new fact is off the Mote-DAG, and `digest_projection` hashes only committed Motes).

### What & why
- **Capture resolved versions as run metadata (D79).** When a Mote is submitted, the coordinator (sole writer, D40) resolves the warrant's `tool_grants` + reads `model_id` and journals a `RunVersionsResolved` fact — the resolved `(tool_id, tool_version, resolved_kind, resolved_def_hash)` per capability + `warrant_ref` + `model_id` — anchored to the run's `instance_id`. **Audit/lineage metadata, never identity** (never folded into `MoteId`/`input_data_id`/any digest — D64/D79/D70).
- **Run-scoped idempotency token (D64).** `run_scoped_token(instance_id, mote)` roots the cross-boundary token in the registered run, so the same Mote re-submitted as a *fresh* run fires a *fresh* effect, while a recovery re-dispatch of the *same* run re-derives the *same* token. Threaded `LeaseWork → worker → EffectRequest`.
- **Doc honesty.** Corrected the four `kx-tool-registry` comments that falsely claimed `ToolResolutionEvent` was journaled (no such variant existed).

### Design decision (the retired-D59 re-price): resolve-at-submit
Because `ToolRegistry::resolve()` is reached only via the still-unwired `assemble()` (dispatch-time resolution is **M5.1/D78**), resolve-at-submit is the only path that captures a real, testable metadata fact now. M5.1 will later verify dispatch-time resolution against this captured fact (forward seam). Adds a `kx-coordinator → kx-tool-registry` dep edge — does **not** touch the frozen trio.

### Crates
`kx-journal` (kind 6, schema v3→v4; `ResolvedKindTag` closed mirror keeps the journal dependency-clean) · `kx-projection` (O(1) off-DAG fold, never touches `rebuild_children_index`/D92 + accessor) · `kx-tool-registry` (`resolve_run_versions` + doc fix) · `kx-capability` (`run_scoped_token`) · `kx-coordinator` (capture + `instance_id` on `SubmitMote`/`LeaseWork` + read accessor; unregistered runs capture nothing — forcing registration is M1.3) · `kx-proto` · `kx-worker`.

### Tests — seven-kind D95 contract
- **unit** — journal (round-trip 0/1/N caps, header-anchor + bounds rejects, schema v4), capability (token stable/differs-across-runs/domain-separated/distinct), registry (`resolve_run_versions` order + fail-closed), projection (off-DAG fold + accessor).
- **integration** (`kx-coordinator/tests/run_versions.rs`, 7 tests) — **exit-gate "resolved versions appear as metadata"**; `SubmitMote`/`LeaseWork` surface `instance_id` (**exit-gate token flow, lease side**); metadata ≠ identity; capability-exceeds-warrant ⇒ no tuple journaled; unregistered-run back-compat.
- **property** — journal encode/decode round-trip + determinism.
- **durability / kill-replay** — SQLite drop+reopen reconstructs the metadata byte-identically.
- **scale** — `#[ignore]` 10k-entry fold stays O(1) off-DAG (no children-index rebuild).
- **security** — metadata-not-identity; fail-closed capture; server-derived `instance_id` (D53).
- **digest** — `a0_guard` canonical digest `a6b5c679…` unchanged.

Full local gate green: fmt · clippy `--workspace --all-targets -D warnings` · `test --workspace` (incl. smoke-with-model) · doc `-D warnings` · cargo-deny. `I1.c` byte-determinism + `ffi-link` run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)