### PR TITLE
feat: M1.3 — submission refusals + registration-before-submit (closes the M1 exit gate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "kx-mote",
  "kx-projection",
  "kx-proto",
+ "kx-refusal",
  "kx-scheduler",
  "kx-tool-registry",
  "kx-warrant",
@@ -1161,6 +1162,7 @@ dependencies = [
  "kx-model-validator",
  "kx-mote",
  "kx-projection",
+ "kx-refusal",
  "kx-tool-registry",
  "kx-warrant",
  "libc",
@@ -1359,6 +1361,19 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "kx-refusal"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-mote",
+ "kx-tool-registry",
+ "kx-warrant",
+ "proptest",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/kx-critic-types",
     "crates/kx-critic",
     "crates/kx-capture",
+    "crates/kx-refusal",
     "crates/kx-model-harness",
 ]
 exclude = [
@@ -120,6 +121,11 @@ kx-critic            = { path = "crates/kx-critic",            version = "0.0.1"
 # Step-capture projection (P4.2 pivot) — opt-in, off-truth-path per-Mote capture of
 # input/output/reasoning/thinking in blob storage; reuse the action, never the thinking.
 kx-capture           = { path = "crates/kx-capture",           version = "0.0.1" }
+# Submission-time refusal vocabulary + predicates (M1.3) — a dependency-light LEAF
+# (kx-mote / kx-tool-registry / kx-warrant only) so the control-plane kx-coordinator
+# can enforce R-1..R-15 + D66 at SubmitMote WITHOUT linking kx-executor's inference
+# stack. kx-executor re-exports it for back-compat.
+kx-refusal           = { path = "crates/kx-refusal",           version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-chaos/src/cluster.rs
+++ b/crates/kx-chaos/src/cluster.rs
@@ -106,12 +106,24 @@ impl Cluster {
         Ok(resp.into_inner().worker_id)
     }
 
-    /// Submit a Mote + warrant (registers it with the hosted scheduler).
+    /// Submit a Mote + warrant (registers it with the hosted scheduler). M1.3:
+    /// the run is registered first (idempotent) so the submit passes the
+    /// registration-before-submit gate; the chaos warrants carry empty
+    /// `tool_grants` (→ resolution `Resolved([])`, no D66/R-10) and the WM Mote's
+    /// `tool_contract` is non-empty (→ R-1 passes), so the gate admits every
+    /// chaos Mote.
     pub(crate) async fn submit(&self, mote: &Mote, warrant: &WarrantSpec) -> StepResult<()> {
+        self.svc
+            .register_run(Request::new(proto::RegisterRunRequest {
+                recipe_fingerprint: [0x5au8; 32].to_vec(),
+            }))
+            .await
+            .map_err(|s| format!("register_run: {s}"))?;
         self.svc
             .submit_mote(Request::new(proto::SubmitMoteRequest {
                 mote: Some(mote.clone().into()),
                 warrant: Some(warrant.clone().into()),
+                accept_at_least_once: false,
             }))
             .await
             .map_err(|s| format!("submit_mote: {s}"))?;

--- a/crates/kx-chaos/src/workflow.rs
+++ b/crates/kx-chaos/src/workflow.rs
@@ -30,8 +30,11 @@ use crate::plan::WmPattern;
 pub(crate) const WORKER_CLASS: ExecutorClass = ExecutorClass::MacOsSandbox;
 
 /// The capability a WORLD-MUTATING Mote names in its `tool_contract`. The chaos broker
-/// ignores the contract (it is not the real `LocalCapabilityBroker`), and the
-/// coordinator's `SubmitMote` runs no refusal predicates, so no warrant grant is needed.
+/// ignores the contract (it is not the real `LocalCapabilityBroker`). M1.3: the
+/// coordinator's `SubmitMote` now runs refusal predicates, but a non-empty
+/// `tool_contract` satisfies R-1, and the chaos warrants carry empty `tool_grants`
+/// (→ resolution `Resolved([])`, so neither D66 nor R-10 fires) — so the chaos Motes
+/// are admitted without granting this (broker-ignored) tool in the warrant.
 pub(crate) fn world_tool() -> ToolName {
     ToolName("kx-chaos-effect".into())
 }

--- a/crates/kx-coordinator/Cargo.toml
+++ b/crates/kx-coordinator/Cargo.toml
@@ -30,6 +30,12 @@ kx-warrant = { workspace = true }
 # is a NEW dep edge but does NOT touch the frozen trio
 # (kx-scheduler/kx-executor/kx-inference) — the P2 thesis test holds.
 kx-tool-registry = { workspace = true }
+# Submission-refusal predicates at SubmitMote (M1.3): R-1/R-7/R-8/R-14/R-15 +
+# R-10 + the D66 fail-closed-on-resolution-miss gate. A dependency-LIGHT leaf
+# (kx-mote/kx-tool-registry/kx-warrant only) — deliberately NOT kx-executor, so
+# the control-plane coordinator never links the inference/llama.cpp stack (the
+# seam discipline: distribution is wiring, not a rewrite).
+kx-refusal = { workspace = true }
 # `sync` (mpsc + oneshot) is additive over the workspace tokio features: the async
 # RPC handlers funnel commands to a single orchestration thread that owns the
 # journal + projection + scheduler. The Projection holds a non-`Send` trait object

--- a/crates/kx-coordinator/benches/commit_throughput.rs
+++ b/crates/kx-coordinator/benches/commit_throughput.rs
@@ -147,10 +147,17 @@ fn setup(
             .unwrap()
             .into_inner()
             .worker_id;
+        // M1.3: register the run before submitting (registration-before-submit gate).
+        svc.register_run(Request::new(proto::RegisterRunRequest {
+            recipe_fingerprint: vec![0x5au8; 32],
+        }))
+        .await
+        .unwrap();
         for m in &motes {
             svc.submit_mote(Request::new(proto::SubmitMoteRequest {
                 mote: Some(m.clone().into()),
                 warrant: Some(w.clone().into()),
+                accept_at_least_once: false,
             }))
             .await
             .unwrap();

--- a/crates/kx-coordinator/src/error.rs
+++ b/crates/kx-coordinator/src/error.rs
@@ -52,6 +52,25 @@ pub enum CoordinatorError {
     #[error("run already started without registration; RegisterRun must be the first fact")]
     RunAlreadyStarted,
 
+    /// `SubmitMote` was called before the run was registered (no seq=1
+    /// `RunRegistered` fact). M1.3 forces registration-before-submit (D64/D98:
+    /// run identity is the explicit `RegisterRun` RPC, never lazy-on-submit) so
+    /// every admitted Mote anchors to a real `instance_id` (the resume key + the
+    /// run-scoped idempotency-token root). An ordering precondition failure, not
+    /// a refusal of the construction.
+    #[error("run not registered; call RegisterRun before submitting any Mote (M1.3)")]
+    RunNotRegistered,
+
+    /// A `SubmitMote` was REFUSED by a submission-time predicate (M1.3): R-1 /
+    /// R-7 / R-8 / R-14 / R-15 / R-10, or the D66 fail-closed-on-tool-resolution
+    /// gate. The request was well-formed; the *construction* is unsafe. The
+    /// service maps this to a `SUBMIT_STATUS_REJECTED` response (carrying the
+    /// refusal detail), not a transport error — so it never reaches the `Status`
+    /// conversion on the success path; the defensive mapping below classifies it
+    /// as a precondition failure.
+    #[error("submission refused: {0}")]
+    SubmissionRefused(#[from] kx_refusal::SubmissionRefusal),
+
     /// A `ReportCommit` proposed a `result_ref` whose bytes are not present in the
     /// shared content store (D55 phantom-ref guard). When the coordinator is built
     /// with a store handle, it verifies `store.contains(result_ref)` before
@@ -116,7 +135,14 @@ impl From<CoordinatorError> for tonic::Status {
             | CoordinatorError::Scheduler(_) => Self::invalid_argument(message),
             // The run is not in a state that allows registration (it already
             // began) — the gRPC-canonical code for a state precondition failure.
-            CoordinatorError::RunAlreadyStarted => Self::failed_precondition(message),
+            // Submit-before-register is the same class of ordering violation.
+            CoordinatorError::RunAlreadyStarted | CoordinatorError::RunNotRegistered => {
+                Self::failed_precondition(message)
+            }
+            // A refusal is a precondition failure on the construction; on the
+            // success path the service consumes it into a REJECTED response
+            // before this conversion, so this arm is defensive.
+            CoordinatorError::SubmissionRefused(_) => Self::failed_precondition(message),
             CoordinatorError::Journal(_)
             | CoordinatorError::Projection(_)
             | CoordinatorError::CommitFailed(_) => Self::internal(message),

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -241,6 +241,8 @@ impl Coordinator for CoordinatorService {
         request: Request<proto::SubmitMoteRequest>,
     ) -> Result<Response<proto::SubmitMoteResponse>, Status> {
         let req = request.into_inner();
+        // M1.3/D38 §2c: per-Mote opt-in to dispatch an AtLeastOnce WM tool.
+        let accept_at_least_once = req.accept_at_least_once;
         // IDENTITY INVARIANT (D53): `TryFrom<proto::Mote>` re-derives the MoteId
         // Rust-side; the wire `mote_id` is advisory and never trusted.
         let mote: Mote = req
@@ -253,25 +255,47 @@ impl Coordinator for CoordinatorService {
             .ok_or_else(|| Status::invalid_argument("SubmitMote.warrant is required"))?
             .try_into()
             .map_err(CoordinatorError::from)?;
+        // The coordinator-derived identity (D53) — captured before the move so
+        // it can ride a REJECTED response when the submit is refused (M1.3).
+        let mote_id = mote.id.as_bytes().to_vec();
 
-        let outcome = self.core.submit(mote, warrant).await?;
-        let status = if outcome.duplicate {
-            proto::SubmitStatus::Duplicate
-        } else {
-            proto::SubmitStatus::Accepted
-        };
-        Ok(Response::new(proto::SubmitMoteResponse {
-            mote_id: outcome.mote_id.as_bytes().to_vec(),
-            status: status as i32,
-            detail: String::new(),
-            // M1.2/D64: the registered run this Mote was admitted under (the
-            // resume key). Empty for an unregistered run (registration before
-            // submit is enforced in M1.3).
-            instance_id: outcome
-                .instance_id
-                .map(|id| id.to_vec())
-                .unwrap_or_default(),
-        }))
+        match self.core.submit(mote, warrant, accept_at_least_once).await {
+            Ok(outcome) => {
+                let status = if outcome.duplicate {
+                    proto::SubmitStatus::Duplicate
+                } else {
+                    proto::SubmitStatus::Accepted
+                };
+                Ok(Response::new(proto::SubmitMoteResponse {
+                    mote_id: outcome.mote_id.as_bytes().to_vec(),
+                    status: status as i32,
+                    detail: String::new(),
+                    // M1.2/D64: the registered run this Mote was admitted under
+                    // (the resume key). M1.3 forces registration-before-submit,
+                    // so an accepted Mote always carries a real instance_id.
+                    instance_id: outcome
+                        .instance_id
+                        .map(|id| id.to_vec())
+                        .unwrap_or_default(),
+                }))
+            }
+            // M1.3: a submission-refusal predicate fired on a WELL-FORMED request
+            // (R-1/R-7/R-8/R-14/R-15/R-10/D66). The proto contract is a structured
+            // SUBMIT_STATUS_REJECTED response carrying the refusal detail — not a
+            // transport error. instance_id is empty (nothing was admitted/written).
+            Err(CoordinatorError::SubmissionRefused(refusal)) => {
+                Ok(Response::new(proto::SubmitMoteResponse {
+                    mote_id,
+                    status: proto::SubmitStatus::Rejected as i32,
+                    detail: refusal.to_string(),
+                    instance_id: Vec::new(),
+                }))
+            }
+            // RunNotRegistered → failed_precondition (an ordering violation, sibling
+            // of RunAlreadyStarted); CoreUnavailable → unavailable; durable faults →
+            // internal — all via the CoordinatorError → Status mapping.
+            Err(other) => Err(other.into()),
+        }
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -26,8 +26,9 @@ use kx_journal::{
 };
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
+use kx_refusal::{validate_mote_submission, ToolResolution};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
-use kx_tool_registry::{resolve_run_versions, ToolKind, ToolRegistry};
+use kx_tool_registry::{IdempotencyClass, ToolKind, ToolRegistry, ToolResolutionEvent};
 use kx_warrant::{warrant_ref_of, ExecutorClass, WarrantSpec};
 use tokio::sync::{mpsc, oneshot};
 
@@ -87,7 +88,11 @@ pub(crate) enum Command {
     Submit {
         mote: Box<Mote>,
         warrant: Box<WarrantSpec>,
-        reply: oneshot::Sender<SubmitOutcome>,
+        // M1.3/D38 §2c: the per-Mote opt-in to dispatch an AtLeastOnce WM tool.
+        accept_at_least_once: bool,
+        // M1.3: the submit is now fallible — registration-before-submit + the
+        // submission-refusal predicates can reject before anything is written.
+        reply: oneshot::Sender<Result<SubmitOutcome, CoordinatorError>>,
     },
     Commit {
         proposal: Box<CommitProposal>,
@@ -179,17 +184,19 @@ impl CoreHandle {
         &self,
         mote: Mote,
         warrant: WarrantSpec,
+        accept_at_least_once: bool,
     ) -> Result<SubmitOutcome, CoordinatorError> {
         let (reply, response) = oneshot::channel();
         self.dispatch(Command::Submit {
             mote: Box::new(mote),
             warrant: Box::new(warrant),
+            accept_at_least_once,
             reply,
         })
         .await?;
         response
             .await
-            .map_err(|_| CoordinatorError::CoreUnavailable)
+            .map_err(|_| CoordinatorError::CoreUnavailable)?
     }
 
     pub(crate) async fn commit(
@@ -794,6 +801,7 @@ fn handle_command<J: Journal>(
         Command::Submit {
             mote,
             warrant,
+            accept_at_least_once,
             reply,
         } => {
             let outcome = submit_and_capture(
@@ -805,6 +813,7 @@ fn handle_command<J: Journal>(
                 scheduler,
                 *mote,
                 *warrant,
+                accept_at_least_once,
             );
             let _ = reply.send(outcome);
         }
@@ -985,28 +994,79 @@ fn submit_and_capture<J: Journal>(
     scheduler: &mut Scheduler<LocalPlacement>,
     mote: Mote,
     warrant: WarrantSpec,
-) -> SubmitOutcome {
+    accept_at_least_once: bool,
+) -> Result<SubmitOutcome, CoordinatorError> {
+    // GATE 1 — registration-before-submit (M1.3, D64/D98). An unregistered run
+    // has no journaled identity to anchor capture (M1.2) or the run-scoped
+    // idempotency token, so submit is refused BEFORE the scheduler/journal is
+    // touched. The seq=1 RunRegistered fact is read on replay, never recomputed.
+    let Some((instance_id, _)) = projection.run_registration() else {
+        return Err(CoordinatorError::RunNotRegistered);
+    };
+
+    // GATE 2 — resolve the warrant's tool grants ONCE, then run the single-Mote
+    // submission-refusal predicate (M1.3). A WORLD-MUTATING Mote with
+    // unresolvable tools (D66 fail-closed) or an AtLeastOnce-without-accept tool
+    // (R-10) — or any sibling-independent unsafe construction (R-1/R-7/R-8/R-14/
+    // R-15) — is refused with NOTHING written. A PURE/READ-ONLY-NONDET Mote is
+    // never refused on resolution grounds (no double-fire hazard).
+    let (resolution, events) = resolve_for_submit(tool_registry, &warrant);
+    validate_mote_submission(&mote, accept_at_least_once, &resolution)
+        .map_err(CoordinatorError::SubmissionRefused)?;
+
+    // Admit through the hosted scheduler (verbatim — the P2 thesis test).
     let warrant_for_capture = warrant.clone();
     let mut outcome = handle_submit(scheduler, projection, dispatch, mote, warrant);
-    // M1.2 (D79): on a FRESH (non-duplicate) submit of a REGISTERED run, capture
-    // the resolved tool/model/warrant versions as off-DAG run metadata and
-    // surface the run's instance_id. An unregistered run captures nothing (no
-    // instance_id to attach to) and gets `None` — forcing registration before
-    // submit is M1.3.
+
+    // M1.2 (D79): on a FRESH (non-duplicate) submit, surface the run's
+    // instance_id and — when the tools resolved cleanly — capture the resolved
+    // tool/model/warrant versions as off-DAG run metadata. Registration is now
+    // guaranteed (Gate 1), so every fresh submit anchors to a real instance_id.
+    // A WM Unresolved submit never reaches here (refused at Gate 2); a PURE/ROND
+    // Unresolved submit reaches here and skips capture (the M1.2 behavior).
     if !outcome.duplicate {
-        if let Some((instance_id, _)) = projection.run_registration() {
-            outcome.instance_id = Some(instance_id);
+        outcome.instance_id = Some(instance_id);
+        if let ToolResolution::Resolved(_) = resolution {
             capture_run_versions(
                 journal,
                 projection,
                 folded_through,
-                tool_registry,
                 instance_id,
                 &warrant_for_capture,
+                events,
             );
         }
     }
-    outcome
+    Ok(outcome)
+}
+
+/// Resolve the warrant's tool grants ONCE per fresh submit (canonical
+/// `(tool_id, tool_version)` order) — feeding BOTH the M1.3 refusal predicate
+/// and the M1.2 metadata capture from a single pass over
+/// [`ToolRegistry::resolve`](kx_tool_registry::ToolRegistry::resolve).
+///
+/// Returns the per-submit [`ToolResolution`] (the resolved
+/// [`IdempotencyClass`]es, or `Unresolved` on a miss) plus the resolved
+/// [`ToolResolutionEvent`]s (for capture). On ANY resolution miss (`NotFound` /
+/// `CapabilityExceedsWarrant` / `PendingHumanReview` / `McpUnreachable`) returns
+/// `(Unresolved, vec![])`: a WM Mote is then refused fail-closed (D66), a
+/// PURE/ROND Mote is admitted with capture skipped.
+fn resolve_for_submit(
+    tool_registry: &dyn ToolRegistry,
+    warrant: &WarrantSpec,
+) -> (ToolResolution, Vec<ToolResolutionEvent>) {
+    let mut classes: Vec<IdempotencyClass> = Vec::with_capacity(warrant.tool_grants.len());
+    let mut events: Vec<ToolResolutionEvent> = Vec::with_capacity(warrant.tool_grants.len());
+    for grant in &warrant.tool_grants {
+        match tool_registry.resolve(grant, warrant) {
+            Ok(resolved) => {
+                classes.push(resolved.def.idempotency_class);
+                events.push(resolved.event);
+            }
+            Err(_) => return (ToolResolution::Unresolved, Vec::new()),
+        }
+    }
+    (ToolResolution::Resolved(classes), events)
 }
 
 /// Register a submitted Mote through the hosted scheduler (verbatim, thesis test) and
@@ -1038,34 +1098,25 @@ fn handle_submit(
 }
 
 /// Capture the resolved tool/model/warrant versions of a fresh submit as off-DAG
-/// run **metadata** (M1.2, D79): resolve the warrant's `tool_grants` and append
-/// one `RunVersionsResolved` fact per resolved capability (a zero-grant warrant
-/// gets one fact with no capability), each anchored to the run's `instance_id`.
-/// **Metadata, never identity** — never folded into `MoteId`. O(1) per append,
-/// off the Mote-DAG.
+/// run **metadata** (M1.2, D79): append one `RunVersionsResolved` fact per
+/// resolved capability (a zero-grant warrant gets one fact with no capability),
+/// each anchored to the run's `instance_id`. **Metadata, never identity** —
+/// never folded into `MoteId`. O(1) per append, off the Mote-DAG.
 ///
-/// Fail-CLOSED on a resolution miss: if any grant does not resolve cleanly
-/// (`NotFound` / `CapabilityExceedsWarrant` / pending review), NOTHING is
-/// journaled — no partial or over-privileged tuple is ever recorded. The submit
-/// still succeeds (M1.2 only captures; refusing such a submit is M1.3).
+/// `events` are the already-resolved [`ToolResolutionEvent`]s from
+/// [`resolve_for_submit`] (resolved once per submit, shared with the M1.3 refusal
+/// predicate). This is only called once resolution SUCCEEDED — a resolution miss
+/// is handled upstream in [`submit_and_capture`] (a WM Mote is refused, D66; a
+/// non-WM Mote is admitted and this capture is skipped), so no partial or
+/// over-privileged tuple is ever recorded.
 fn capture_run_versions<J: Journal>(
     journal: &J,
     projection: &mut Projection,
     folded_through: &mut u64,
-    tool_registry: &dyn ToolRegistry,
     instance_id: [u8; INSTANCE_ID_LEN],
     warrant: &WarrantSpec,
+    events: Vec<ToolResolutionEvent>,
 ) {
-    let events = match resolve_run_versions(tool_registry, warrant) {
-        Ok(events) => events,
-        Err(reason) => {
-            tracing::warn!(
-                ?reason,
-                "M1.2 resolved-version capture skipped: a tool grant did not resolve (M1.3 will refuse the submit)"
-            );
-            return;
-        }
-    };
     let warrant_ref = warrant_ref_of(warrant);
     let model_id = warrant.model_route.model_id.0.clone();
     if events.is_empty() {

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -19,7 +19,7 @@ use kx_content::ContentRef;
 use kx_coordinator::proto;
 use kx_coordinator::proto::coordinator_server::Coordinator;
 use kx_coordinator::CoordinatorService;
-use tonic::Request;
+use tonic::{Request, Status};
 
 use kx_mote::{
     ConfigKey, ConfigVal, EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId,
@@ -106,6 +106,13 @@ pub fn mote(seed: u8, nd_class: NdClass, parent_ids: &[MoteId]) -> Mote {
 pub fn wm_mote(seed: u8, effect_pattern: EffectPattern) -> Mote {
     let mut def = mote_def(NdClass::WorldMutating);
     def.effect_pattern = effect_pattern;
+    // M1.3 R-1: a WORLD-MUTATING `IdempotentByConstruction` Mote with an EMPTY
+    // tool_contract is refused at submit (no idempotency-supporting tool to dedup
+    // against). Declare the `fs-write` builtin so every `wm_mote` — regardless of
+    // pattern — passes the R-1 structural check. (R-10/D66 resolve the WARRANT's
+    // grants, not this contract, so this does not affect those predicates.)
+    def.tool_contract
+        .insert(ToolName("fs-write".into()), ToolVersion("1".into()));
     Mote::new(
         def,
         InputDataId::from_bytes([seed; 32]),
@@ -144,10 +151,15 @@ pub fn sample_warrant() -> WarrantSpec {
     let mut hosts = BTreeSet::new();
     hosts.insert(Host("api.example.com:443".into()));
 
+    // M1.3: the grant must RESOLVE against the OSS built-ins (`fs-read@1`,
+    // IdempotencyClass::Readback) so a WORLD-MUTATING Mote submitted under this
+    // warrant passes the D66 fail-closed gate (a resolvable, non-AtLeastOnce
+    // tool). `fs-read@1` requires `syscall_profile_ref == [0; 32]` (exact match),
+    // so the warrant carries that value.
     let mut tool_grants = BTreeSet::new();
     tool_grants.insert(ToolGrant {
         tool_id: ToolName("fs-read".into()),
-        tool_version: ToolVersion("1.2.0".into()),
+        tool_version: ToolVersion("1".into()),
     });
 
     WarrantSpec {
@@ -155,7 +167,7 @@ pub fn sample_warrant() -> WarrantSpec {
         nd_class: MoteClass::Pure,
         fs_scope: FsScope { mounts },
         net_scope: NetScope::EgressAllowlist(hosts),
-        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        syscall_profile_ref: ContentRef::from_bytes([0u8; 32]),
         tool_grants,
         model_route: ModelRoute {
             model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
@@ -234,20 +246,86 @@ pub async fn heartbeat(
         .ack
 }
 
-/// Submit a Mote + warrant through the service.
+/// A fixed recipe fingerprint for the test helpers' auto-registration. The
+/// fingerprint is discovery-only metadata (never identity, D64/D79), so a
+/// constant is fine — the per-run `instance_id` still comes from the service's
+/// nonce source (random under `new`, fixed under the seam constructors).
+pub const TEST_RECIPE_FINGERPRINT: [u8; 32] = [0x5au8; 32];
+
+/// Register the run through the service (M1.1/D64), returning its `instance_id`.
+/// Idempotent: the first call writes the seq=1 `RunRegistered` fact; a later call
+/// returns the existing id and writes nothing. Call once before submitting (the
+/// M1.3 registration-before-submit gate) — or rely on [`submit`], which does.
+pub async fn register_run(service: &CoordinatorService, fingerprint: [u8; 32]) -> Vec<u8> {
+    service
+        .register_run(Request::new(proto::RegisterRunRequest {
+            recipe_fingerprint: fingerprint.to_vec(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .instance_id
+}
+
+/// Submit a Mote + warrant through the service, **auto-registering the run first**
+/// (M1.3 forces registration-before-submit). The registration is idempotent, so a
+/// test that submits many Motes registers exactly once (seq=1). `accept_at_least_once`
+/// defaults `false` — an AtLeastOnce WM tool is fail-closed; use [`submit_accepting`]
+/// to opt in. Tests that exercise the un-registered path use [`submit_unregistered`].
 pub async fn submit(
     service: &CoordinatorService,
     mote: &Mote,
     warrant: &WarrantSpec,
 ) -> proto::SubmitMoteResponse {
+    let _ = register_run(service, TEST_RECIPE_FINGERPRINT).await;
     service
         .submit_mote(Request::new(proto::SubmitMoteRequest {
             mote: Some(mote.clone().into()),
             warrant: Some(warrant.clone().into()),
+            accept_at_least_once: false,
         }))
         .await
         .unwrap()
         .into_inner()
+}
+
+/// As [`submit`], but sets `accept_at_least_once = true` (M1.3/D38 §2c — the
+/// operator opt-in to dispatch a resolved `AtLeastOnce` WORLD-MUTATING tool).
+pub async fn submit_accepting(
+    service: &CoordinatorService,
+    mote: &Mote,
+    warrant: &WarrantSpec,
+) -> proto::SubmitMoteResponse {
+    let _ = register_run(service, TEST_RECIPE_FINGERPRINT).await;
+    service
+        .submit_mote(Request::new(proto::SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(warrant.clone().into()),
+            accept_at_least_once: true,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+/// Submit a Mote + warrant through the service WITHOUT registering the run first
+/// and WITHOUT unwrapping — for tests that exercise the M1.3
+/// registration-before-submit gate (an un-registered submit is refused with
+/// `failed_precondition`). Returns the raw `Result` so the caller asserts the
+/// `tonic::Status` (or the REJECTED response).
+pub async fn submit_unregistered(
+    service: &CoordinatorService,
+    mote: &Mote,
+    warrant: &WarrantSpec,
+) -> Result<proto::SubmitMoteResponse, Status> {
+    service
+        .submit_mote(Request::new(proto::SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(warrant.clone().into()),
+            accept_at_least_once: false,
+        }))
+        .await
+        .map(tonic::Response::into_inner)
 }
 
 /// Report a commit for `mote` by `worker_id` through the service.

--- a/crates/kx-coordinator/tests/dod.rs
+++ b/crates/kx-coordinator/tests/dod.rs
@@ -65,6 +65,17 @@ fn register_req(endpoint: &str) -> RegisterWorkerRequest {
     }
 }
 
+/// Register the run through the gRPC client so subsequent `submit_mote` calls
+/// pass the M1.3 registration-before-submit gate (idempotent — call once).
+async fn register_run(client: &mut CoordinatorClient<Channel>) {
+    client
+        .register_run(proto::RegisterRunRequest {
+            recipe_fingerprint: vec![0x5au8; 32],
+        })
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn o1_coordinator_is_sole_journal_writer() {
     let service = CoordinatorService::new(InMemoryJournal::new());
@@ -76,12 +87,14 @@ async fn o1_coordinator_is_sole_journal_writer() {
         .unwrap()
         .into_inner();
 
+    register_run(&mut client).await;
     let mote = common::pure_root_mote();
     let expected_id = mote.id;
     let submit = client
         .submit_mote(SubmitMoteRequest {
             mote: Some(mote.clone().into()),
             warrant: Some(common::sample_warrant().into()),
+            accept_at_least_once: false,
         })
         .await
         .unwrap()
@@ -217,6 +230,7 @@ async fn o3_mote_id_rederived_server_side() {
     let service = CoordinatorService::new(InMemoryJournal::new());
     let mut client = start(service).await;
 
+    register_run(&mut client).await;
     let mote = common::pure_root_mote();
     let expected_id = mote.id;
     let mut wire: proto::Mote = mote.into();
@@ -226,6 +240,7 @@ async fn o3_mote_id_rederived_server_side() {
         .submit_mote(SubmitMoteRequest {
             mote: Some(wire),
             warrant: Some(common::sample_warrant().into()),
+            accept_at_least_once: false,
         })
         .await
         .unwrap()
@@ -243,11 +258,13 @@ async fn o4_unknown_worker_rejected_no_write() {
     let mut client = start(service.clone()).await;
 
     // Mote is known (submitted) but no worker registered.
+    register_run(&mut client).await;
     let mote = common::pure_root_mote();
     client
         .submit_mote(SubmitMoteRequest {
             mote: Some(mote.clone().into()),
             warrant: Some(common::sample_warrant().into()),
+            accept_at_least_once: false,
         })
         .await
         .unwrap();
@@ -291,11 +308,13 @@ async fn o4_bad_hash_length_rejected_no_write() {
         .await
         .unwrap()
         .into_inner();
+    register_run(&mut client).await;
     let mote = common::pure_root_mote();
     client
         .submit_mote(SubmitMoteRequest {
             mote: Some(mote.clone().into()),
             warrant: Some(common::sample_warrant().into()),
+            accept_at_least_once: false,
         })
         .await
         .unwrap();
@@ -317,11 +336,13 @@ async fn o4_unspecified_nd_class_rejected_no_write() {
         .await
         .unwrap()
         .into_inner();
+    register_run(&mut client).await;
     let mote = common::pure_root_mote();
     client
         .submit_mote(SubmitMoteRequest {
             mote: Some(mote.clone().into()),
             warrant: Some(common::sample_warrant().into()),
+            accept_at_least_once: false,
         })
         .await
         .unwrap();

--- a/crates/kx-coordinator/tests/edge_cases.rs
+++ b/crates/kx-coordinator/tests/edge_cases.rs
@@ -113,6 +113,7 @@ async fn submit_missing_mote_or_warrant_is_rejected() {
         .submit_mote(Request::new(proto::SubmitMoteRequest {
             mote: None,
             warrant: Some(warrant.clone().into()),
+            accept_at_least_once: false,
         }))
         .await
         .unwrap_err();
@@ -122,6 +123,7 @@ async fn submit_missing_mote_or_warrant_is_rejected() {
         .submit_mote(Request::new(proto::SubmitMoteRequest {
             mote: Some(mote.into()),
             warrant: None,
+            accept_at_least_once: false,
         }))
         .await
         .unwrap_err();

--- a/crates/kx-coordinator/tests/m1_exit_gate.rs
+++ b/crates/kx-coordinator/tests/m1_exit_gate.rs
@@ -1,0 +1,241 @@
+//! The M1 EXIT GATE (v2 pivot, D63/D64/D66/D79): with M1.1 (run registration) +
+//! M1.2 (resolved-version metadata + run-scoped token) + M1.3 (submission refusals
+//! + registration-before-submit) all wired, the following hold end-to-end:
+//!
+//! 1. a re-submitted identical recipe produces a FRESH registered run (new id);
+//! 2. the recipe fingerprint round-trips as discovery metadata (≠ identity);
+//! 3. resolved versions appear as off-DAG metadata;
+//! 4. a tool-resolution miss is refused (D66 fail-closed);
+//! 5. cross-boundary exactly-once: the lease surfaces the run id (the run-scoped
+//!    token root), a double commit dedupes to one, and a distinct run of the same
+//!    recipe commits independently (per-run namespacing).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, RunNonceSource, WorkerRegistry,
+};
+use kx_journal::{InMemoryJournal, Journal};
+use kx_mote::{EffectPattern, ModelId, NdClass, ToolName, ToolVersion};
+use kx_warrant::{
+    ExecutorClass, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, ToolGrant,
+    WarrantSpec,
+};
+use tonic::Request;
+
+#[derive(Debug)]
+struct FixedNonce([u8; 16]);
+impl RunNonceSource for FixedNonce {
+    fn fresh_instance_id(&self) -> [u8; 16] {
+        self.0
+    }
+}
+#[derive(Debug)]
+struct FixedClock(u64);
+impl Clock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+fn coordinator<J: Journal + Send + 'static>(
+    journal: J,
+    instance_id: [u8; 16],
+) -> CoordinatorService {
+    let registry: Arc<dyn WorkerRegistry> = Arc::new(InMemoryWorkerRegistry::new());
+    CoordinatorService::with_seams(
+        journal,
+        registry,
+        None,
+        Arc::new(FixedClock(7)),
+        Arc::new(FixedNonce(instance_id)),
+    )
+}
+
+fn warrant_granting(tools: &[(&str, &str)], model_id: &str) -> WarrantSpec {
+    let tool_grants: BTreeSet<ToolGrant> = tools
+        .iter()
+        .map(|(id, ver)| ToolGrant {
+            tool_id: ToolName((*id).into()),
+            tool_version: ToolVersion((*ver).into()),
+        })
+        .collect();
+    let mut mounts = BTreeMap::new();
+    mounts.insert(
+        std::path::PathBuf::from("/tmp/in"),
+        kx_warrant::FsMode::ReadOnly,
+    );
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(BTreeSet::from([Host("api.example.com:443".into())])),
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0u8; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId(model_id.into()),
+            max_input_tokens: 4096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}
+
+async fn register(svc: &CoordinatorService, fp: [u8; 32]) -> Vec<u8> {
+    svc.register_run(Request::new(proto::RegisterRunRequest {
+        recipe_fingerprint: fp.to_vec(),
+    }))
+    .await
+    .unwrap()
+    .into_inner()
+    .instance_id
+}
+
+// === Clauses 1–3: re-submit → fresh run; fingerprint matches; metadata present =
+
+#[tokio::test]
+async fn resubmitting_a_recipe_starts_a_fresh_registered_run_with_metadata() {
+    let recipe = [0x9cu8; 32]; // the SAME recipe fingerprint for both runs
+    let mote = common::mote(1, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("fs-read", "1")], "qwen2.5-0.5b");
+
+    // Run A.
+    let id_a = [0xa1u8; 16];
+    let svc_a = coordinator(InMemoryJournal::new(), id_a);
+    let reg_a = register(&svc_a, recipe).await;
+    assert_eq!(reg_a, id_a.to_vec());
+    let resp_a = common::submit(&svc_a, &mote, &warrant).await;
+    assert_eq!(resp_a.status, proto::SubmitStatus::Accepted as i32);
+    assert_eq!(
+        resp_a.instance_id,
+        id_a.to_vec(),
+        "the response carries the run id"
+    );
+
+    // Clause 2 — fingerprint round-trips (discovery metadata, not identity).
+    assert_eq!(
+        svc_a.run_registration().await.unwrap(),
+        Some((id_a, recipe))
+    );
+    // Clause 3 — resolved versions captured as metadata.
+    let recs = svc_a.run_resolved_versions().await.unwrap();
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].instance_id, id_a, "metadata anchored to the run id");
+
+    // Run B — SAME recipe, fresh journal + fresh nonce.
+    let id_b = [0xb2u8; 16];
+    let svc_b = coordinator(InMemoryJournal::new(), id_b);
+    let reg_b = register(&svc_b, recipe).await;
+    let resp_b = common::submit(&svc_b, &mote, &warrant).await;
+    assert_eq!(resp_b.status, proto::SubmitStatus::Accepted as i32);
+
+    // Clause 1 — re-running the SAME recipe yields a DISTINCT registered identity.
+    assert_ne!(
+        reg_a, reg_b,
+        "a re-submitted recipe starts a fresh registered run"
+    );
+    assert_eq!(
+        svc_b.run_registration().await.unwrap(),
+        Some((id_b, recipe))
+    );
+}
+
+// === Clause 4: a tool-resolution miss is refused ==============================
+
+#[tokio::test]
+async fn world_mutating_resolution_miss_is_refused() {
+    let svc = coordinator(InMemoryJournal::new(), [0xc3u8; 16]);
+    register(&svc, [0x4cu8; 32]).await;
+    let wm = common::wm_mote(2, EffectPattern::StageThenCommit);
+    let warrant = warrant_granting(&[("ghost", "1")], "m"); // unresolvable
+
+    let resp = common::submit(&svc, &wm, &warrant).await;
+    assert_eq!(resp.status, proto::SubmitStatus::Rejected as i32);
+    assert_eq!(svc.committed_count().await.unwrap(), 0, "nothing committed");
+}
+
+// === Clause 5: cross-boundary exactly-once under the run-scoped token =========
+
+#[tokio::test]
+async fn cross_boundary_exactly_once_per_run() {
+    let id_a = [0xd4u8; 16];
+    let svc_a = coordinator(InMemoryJournal::new(), id_a);
+    register(&svc_a, [0x5du8; 32]).await;
+    let worker_a = common::register(&svc_a, "wa").await;
+
+    let wm = common::wm_mote(3, EffectPattern::StageThenCommit);
+    let warrant = warrant_granting(&[("fs-write", "1")], "m"); // fs-write (Staged) resolves
+    assert_eq!(
+        common::submit(&svc_a, &wm, &warrant).await.status,
+        proto::SubmitStatus::Accepted as i32
+    );
+
+    // The lease surfaces the run id → the worker derives the run-scoped token.
+    let lease = svc_a
+        .lease_work(Request::new(proto::LeaseWorkRequest {
+            worker_id: worker_a,
+            executor_class: proto::ExecutorClass::MacosSandbox as i32,
+            max_motes: 16,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(lease.items.len(), 1, "the WM Mote is leased");
+    assert_eq!(
+        lease.instance_id,
+        id_a.to_vec(),
+        "LeaseWork carries the run-scoped token root"
+    );
+
+    // A double commit dedupes to exactly one (journal first-wins by identity).
+    assert_eq!(
+        common::commit(&svc_a, &wm, worker_a).await.outcome,
+        proto::CommitOutcome::Committed as i32
+    );
+    assert_eq!(
+        common::commit(&svc_a, &wm, worker_a).await.outcome,
+        proto::CommitOutcome::AlreadyCommitted as i32
+    );
+    assert_eq!(
+        svc_a.committed_count().await.unwrap(),
+        1,
+        "exactly-once within the run"
+    );
+
+    // A DISTINCT run of the SAME Mote def commits independently (per-run namespacing:
+    // the run-scoped token root id_b ≠ id_a, so cross-boundary effects do not collide).
+    let id_b = [0xe5u8; 16];
+    let svc_b = coordinator(InMemoryJournal::new(), id_b);
+    register(&svc_b, [0x5du8; 32]).await;
+    let worker_b = common::register(&svc_b, "wb").await;
+    common::submit(&svc_b, &wm, &warrant).await;
+    assert_eq!(
+        common::commit(&svc_b, &wm, worker_b).await.outcome,
+        proto::CommitOutcome::Committed as i32
+    );
+    assert_eq!(
+        svc_b.committed_count().await.unwrap(),
+        1,
+        "the distinct run has its own commit"
+    );
+    assert_ne!(
+        id_a, id_b,
+        "the two runs have distinct run-scoped token roots"
+    );
+}

--- a/crates/kx-coordinator/tests/recovery.rs
+++ b/crates/kx-coordinator/tests/recovery.rs
@@ -8,9 +8,13 @@
 
 mod common;
 
-use kx_coordinator::proto::CommitOutcome;
+use std::collections::BTreeSet;
+
+use kx_coordinator::proto::{self, CommitOutcome};
 use kx_coordinator::{CoordinatorService, MoteState};
 use kx_journal::SqliteJournal;
+use kx_mote::{EffectPattern, ToolName, ToolVersion};
+use kx_warrant::ToolGrant;
 use tempfile::tempdir;
 
 #[tokio::test]
@@ -78,4 +82,69 @@ async fn multi_mote_state_recovered_after_restart() {
     // recovered projection has no record of it (uncommitted work is re-derivable
     // from the workflow, not the log).
     assert_eq!(svc2.state_of(c.id).await.unwrap(), MoteState::Pending);
+}
+
+/// M1.3 chaos/durability: a D66-refused WORLD-MUTATING submit leaves NO partial
+/// state. Across a drop/reopen the run is still registered (the durable seq=1
+/// `RunRegistered` fact) but nothing was committed; the SAME Mote, retried under a
+/// RESOLVABLE warrant after the reopen, commits. The gate reads the durable
+/// journal fact, not in-memory state.
+#[tokio::test]
+async fn refused_submit_writes_nothing_and_run_recovers() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("journal.db");
+    let wm = common::wm_mote(7, EffectPattern::StageThenCommit);
+
+    // A warrant granting a tool the registry cannot resolve → D66 for a WM Mote.
+    let bad_warrant = {
+        let mut w = common::sample_warrant();
+        w.tool_grants = BTreeSet::from([ToolGrant {
+            tool_id: ToolName("ghost-tool".into()),
+            tool_version: ToolVersion("9".into()),
+        }]);
+        w
+    };
+
+    {
+        let svc = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+        // `common::submit` auto-registers (seq=1) then submits → D66 REJECTED.
+        let resp = common::submit(&svc, &wm, &bad_warrant).await;
+        assert_eq!(resp.status, proto::SubmitStatus::Rejected as i32);
+        assert_eq!(
+            svc.committed_count().await.unwrap(),
+            0,
+            "the refused submit wrote nothing"
+        );
+        assert!(
+            svc.run_registration().await.unwrap().is_some(),
+            "the run is registered (the seq=1 fact)"
+        );
+    } // drop → core exits → Sqlite connection closed
+
+    // Reopen: the registration fact survived; no Mote / commit did.
+    let svc2 = CoordinatorService::new(SqliteJournal::open(&path).unwrap());
+    assert_eq!(
+        svc2.committed_count().await.unwrap(),
+        0,
+        "no committed state recovered from a refused submit"
+    );
+    assert!(
+        svc2.run_registration().await.unwrap().is_some(),
+        "the registration fact is durable across the reopen"
+    );
+
+    // Retry the SAME Mote under a RESOLVABLE warrant → accepted + committed.
+    let resp2 = common::submit(&svc2, &wm, &common::sample_warrant()).await;
+    assert_eq!(
+        resp2.status,
+        proto::SubmitStatus::Accepted as i32,
+        "the retry under a resolvable warrant succeeds post-reopen"
+    );
+    let worker = common::register(&svc2, "w").await;
+    common::commit(&svc2, &wm, worker).await;
+    assert_eq!(
+        svc2.committed_count().await.unwrap(),
+        1,
+        "the retried WM Mote commits"
+    );
 }

--- a/crates/kx-coordinator/tests/run_registration.rs
+++ b/crates/kx-coordinator/tests/run_registration.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use kx_coordinator::proto;
 use kx_coordinator::proto::coordinator_server::Coordinator;
 use kx_coordinator::{
-    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, RunNonceSource, WorkerRegistry,
+    Clock, CoordinatorService, InMemoryWorkerRegistry, RunNonceSource, WorkerRegistry,
 };
 use kx_journal::{InMemoryJournal, Journal, JournalEntry, SqliteJournal};
 use tempfile::tempdir;
@@ -207,37 +207,43 @@ async fn recover_reads_instance_id_not_recomputed() {
 }
 
 #[tokio::test]
-async fn submit_without_register_still_works() {
-    // Back-compat (M1.1 is additive): a run that never calls RegisterRun submits +
-    // commits exactly as before; run_registration() is simply None.
+async fn submit_without_register_is_refused() {
+    // M1.3 (was the M1.1 back-compat `submit_without_register_still_works`): a run
+    // that never calls RegisterRun is now REFUSED at submit (FAILED_PRECONDITION) —
+    // a run can never start un-registered (D64/D98: identity is the explicit
+    // RegisterRun, never lazy-on-submit). Nothing is committed; identity stays None.
     let svc = CoordinatorService::new(InMemoryJournal::new());
     let warrant = common::sample_warrant();
     let mote = common::pure_root_mote();
 
-    let worker = common::register(&svc, "w").await;
-    common::submit(&svc, &mote, &warrant).await;
-    common::commit(&svc, &mote, worker).await;
+    let _worker = common::register(&svc, "w").await;
+    let err = common::submit_unregistered(&svc, &mote, &warrant)
+        .await
+        .expect_err("submit before RegisterRun must be refused (M1.3)");
+    assert_eq!(err.code(), Code::FailedPrecondition);
 
-    assert_eq!(svc.committed_count().await.unwrap(), 1);
-    assert_eq!(svc.state_of(mote.id).await.unwrap(), MoteState::Committed);
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
     assert_eq!(
         svc.run_registration().await.unwrap(),
         None,
-        "no registration → no run identity (submit path unaffected)"
+        "no registration → no run identity (submit refused)"
     );
 }
 
 #[tokio::test]
 async fn register_run_refused_after_run_started() {
-    // Registration must be the FIRST fact (seq=1). If a run begins without it,
-    // RegisterRun is refused (FAILED_PRECONDITION) — the fact can never land mid-run.
+    // Registration must be the FIRST fact (seq=1). M1.3 forces registration before
+    // SUBMIT, so the normal path can no longer start a run un-registered — but a
+    // worker can still stage an effect (ReportEffectStaged), which appends a journal
+    // entry. If a run ever produces an entry without a RunRegistered fact, RegisterRun
+    // is refused (FAILED_PRECONDITION); the seq=1 fact can never land mid-run
+    // (defense-in-depth — the RunAlreadyStarted guard).
     let svc = CoordinatorService::new(InMemoryJournal::new());
-    let warrant = common::sample_warrant();
-    let mote = common::pure_root_mote();
-
     let worker = common::register(&svc, "w").await;
-    common::submit(&svc, &mote, &warrant).await;
-    common::commit(&svc, &mote, worker).await;
+
+    // Stage an effect → a journal entry at seq=1 with NO RunRegistered fact.
+    let mote = common::pure_root_mote();
+    common::report_effect_staged(&svc, &mote, worker).await;
 
     let err = svc
         .register_run(Request::new(proto::RegisterRunRequest {

--- a/crates/kx-coordinator/tests/run_versions.rs
+++ b/crates/kx-coordinator/tests/run_versions.rs
@@ -31,7 +31,7 @@ use kx_warrant::{
     ToolGrant, ToolRequirement, WarrantSpec,
 };
 use tempfile::tempdir;
-use tonic::Request;
+use tonic::{Code, Request};
 
 // --- seams (mirror run_registration.rs) ---------------------------------------
 
@@ -211,23 +211,32 @@ async fn submit_response_surfaces_instance_id() {
 }
 
 #[tokio::test]
-async fn unregistered_run_captures_nothing_and_no_instance_id() {
-    // Back-compat (M1.1 `submit_without_register_still_works`): submitting without
-    // a prior RegisterRun still succeeds; M1.2 captures no metadata (no instance_id
-    // to anchor to) and the response instance_id is empty. Forcing registration
-    // before submit is M1.3.
+async fn unregistered_submit_is_refused() {
+    // M1.3 (was M1.1/M1.2 `unregistered_run_captures_nothing`): submit-before-register
+    // is now REFUSED (failed_precondition). An unregistered run has no journaled
+    // identity to anchor capture or the run-scoped idempotency token (D64/D98 —
+    // identity is the explicit RegisterRun, never lazy-on-submit), so NOTHING is
+    // written: no Mote, no metadata, no registration.
     let svc = coordinator(InMemoryJournal::new(), [0xd4u8; 16]);
     let mote = common::mote(3, NdClass::Pure, &[]);
     let warrant = warrant_granting(&[("fs-read", "1")], "m");
-    let resp = common::submit(&svc, &mote, &warrant).await;
-    assert_eq!(resp.status, proto::SubmitStatus::Accepted as i32);
-    assert!(
-        resp.instance_id.is_empty(),
-        "unregistered run → no instance_id"
+    let err = common::submit_unregistered(&svc, &mote, &warrant)
+        .await
+        .expect_err("submit before RegisterRun must be refused (M1.3)");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert_eq!(
+        svc.committed_count().await.unwrap(),
+        0,
+        "a refused submit writes nothing"
     );
     assert!(
         svc.run_resolved_versions().await.unwrap().is_empty(),
-        "no metadata captured for an unregistered run"
+        "no metadata captured for a refused submit"
+    );
+    assert_eq!(
+        svc.run_registration().await.unwrap(),
+        None,
+        "the run is still unregistered"
     );
 }
 
@@ -312,9 +321,10 @@ async fn resolved_model_version_is_independent_of_mote_identity() {
 #[tokio::test]
 async fn capability_exceeds_warrant_skips_capture() {
     // A tool whose required net egress is NOT in the warrant fails to resolve →
-    // resolve_run_versions errors → NOTHING is journaled (no over-privileged or
-    // partial tuple is ever recorded). The submit still succeeds (M1.2 captures
-    // only; refusing such a submit is M1.3).
+    // resolution is Unresolved → NOTHING is journaled (no over-privileged or partial
+    // tuple is ever recorded). The mote here is PURE, so M1.3's D66 fail-closed
+    // refusal does NOT fire (D66 is WORLD-MUTATING-only — a non-mutating Mote has no
+    // double-fire hazard); the submit still succeeds and capture is skipped.
     let mut tools = InMemoryToolRegistry::new();
     tools
         .register(

--- a/crates/kx-coordinator/tests/stress_campaign.rs
+++ b/crates/kx-coordinator/tests/stress_campaign.rs
@@ -116,6 +116,16 @@ async fn stress_large_layered_dag_commits_exactly_once() {
         commit_elapsed.as_secs() < 60,
         "committing {total} Motes layer-by-layer should stay linear; took {commit_elapsed:?}"
     );
+    // M1.3 scale guard: the submit path now does, per FRESH submit, an idempotent
+    // run registration (O(1) after the first), an O(grants) warrant resolution, and
+    // the M1.2 off-DAG metadata capture (O(grants) append + O(1) fold). With the
+    // single-grant `sample_warrant`, that is O(1) per submit → O(total) overall.
+    // A super-linear blow-up (e.g. re-resolving or re-folding per submit) trips here.
+    assert!(
+        submit_elapsed.as_secs() < 60,
+        "submitting {total} Motes (register-once + per-submit O(grants) resolve + \
+         capture + admit) should stay linear; took {submit_elapsed:?}"
+    );
 }
 
 /// PARALLEL SATURATION — N distinct Motes, each committed by TWO concurrent

--- a/crates/kx-coordinator/tests/submission_refusal.rs
+++ b/crates/kx-coordinator/tests/submission_refusal.rs
@@ -1,0 +1,339 @@
+//! M1.3 — submission-refusal predicates wired at `SubmitMote`:
+//!
+//! - **Registration gate** (D64/D98): submit-before-register → `failed_precondition`,
+//!   nothing written.
+//! - **D66 fail-closed** (StageThenCommit is the #1 no-double-fire seam): a
+//!   WORLD-MUTATING Mote whose tools do not resolve (unregistered tool, or a tool
+//!   whose required capability exceeds the warrant) → `SUBMIT_STATUS_REJECTED`,
+//!   nothing journaled.
+//! - **R-10** (D38 §2c): a WM Mote resolving to an `AtLeastOnce` tool is refused
+//!   unless the submission sets `accept_at_least_once`.
+//! - **PURE/ROND are never refused on resolution grounds** (no double-fire hazard):
+//!   an unresolvable grant skips capture (M1.2) but the submit succeeds.
+//!
+//! All assertions go through the real gRPC service (`Coordinator` trait) with a
+//! fixed nonce/clock so the registered identity is deterministic.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::{
+    Clock, CoordinatorService, InMemoryWorkerRegistry, RunNonceSource, WorkerRegistry,
+};
+use kx_journal::{InMemoryJournal, Journal};
+use kx_mote::{EffectPattern, ModelId, NdClass, ToolName, ToolVersion};
+use kx_tool_registry::{
+    IdempotencyClass, InMemoryToolRegistry, ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, ToolGrant,
+    ToolRequirement, WarrantSpec,
+};
+use tonic::{Code, Request};
+
+#[derive(Debug)]
+struct FixedNonce([u8; 16]);
+impl RunNonceSource for FixedNonce {
+    fn fresh_instance_id(&self) -> [u8; 16] {
+        self.0
+    }
+}
+#[derive(Debug)]
+struct FixedClock(u64);
+impl Clock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+fn registry() -> Arc<dyn WorkerRegistry> {
+    Arc::new(InMemoryWorkerRegistry::new())
+}
+
+/// Coordinator over the default OSS built-in tool registry.
+fn coordinator<J: Journal + Send + 'static>(
+    journal: J,
+    instance_id: [u8; 16],
+) -> CoordinatorService {
+    CoordinatorService::with_seams(
+        journal,
+        registry(),
+        None,
+        Arc::new(FixedClock(7)),
+        Arc::new(FixedNonce(instance_id)),
+    )
+}
+
+/// Coordinator with an injected tool registry (for the AtLeastOnce / exceeds tests).
+fn coordinator_with_tools<J: Journal + Send + 'static>(
+    journal: J,
+    instance_id: [u8; 16],
+    tools: Arc<dyn ToolRegistry>,
+) -> CoordinatorService {
+    CoordinatorService::with_tool_registry_and_seams(
+        journal,
+        registry(),
+        None,
+        Arc::new(FixedClock(7)),
+        Arc::new(FixedNonce(instance_id)),
+        tools,
+    )
+}
+
+/// A warrant granting the named `(tool_id, tool_version)` pairs + a model id, with
+/// the syscall profile the OSS built-ins require (exact-match).
+fn warrant_granting(tools: &[(&str, &str)], model_id: &str) -> WarrantSpec {
+    let tool_grants: BTreeSet<ToolGrant> = tools
+        .iter()
+        .map(|(id, ver)| ToolGrant {
+            tool_id: ToolName((*id).into()),
+            tool_version: ToolVersion((*ver).into()),
+        })
+        .collect();
+    let mut mounts = BTreeMap::new();
+    mounts.insert(
+        std::path::PathBuf::from("/tmp/in"),
+        kx_warrant::FsMode::ReadOnly,
+    );
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(BTreeSet::from([Host("api.example.com:443".into())])),
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0u8; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId(model_id.into()),
+            max_input_tokens: 4096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::MacOsSandbox,
+    }
+}
+
+/// A registry with one `AtLeastOnce` builtin (`emailer@1`) — the R-10 trigger.
+fn registry_with_at_least_once() -> Arc<dyn ToolRegistry> {
+    let mut reg = InMemoryToolRegistry::with_builtins();
+    reg.register(
+        ToolDef {
+            tool_id: ToolName("emailer".into()),
+            tool_version: ToolVersion("1".into()),
+            kind: ToolKind::Builtin,
+            required_capability: ToolRequirement {
+                net_scope_required: NetScope::None,
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: "sends an email; no closing mechanism (at-least-once)".into(),
+            idempotency_class: IdempotencyClass::AtLeastOnce,
+        },
+        ToolProvenance::HumanAuthored {
+            author: "ops".into(),
+        },
+    )
+    .unwrap();
+    Arc::new(reg)
+}
+
+async fn register(svc: &CoordinatorService, fp: [u8; 32]) {
+    svc.register_run(Request::new(proto::RegisterRunRequest {
+        recipe_fingerprint: fp.to_vec(),
+    }))
+    .await
+    .unwrap();
+}
+
+// === Registration gate ========================================================
+
+#[tokio::test]
+async fn submit_before_register_is_refused_failed_precondition() {
+    let svc = coordinator(InMemoryJournal::new(), [0x11u8; 16]);
+    let mote = common::wm_mote(1, EffectPattern::StageThenCommit);
+    let warrant = warrant_granting(&[("fs-write", "1")], "m");
+
+    let err = common::submit_unregistered(&svc, &mote, &warrant)
+        .await
+        .expect_err("submit before RegisterRun must be refused");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert_eq!(svc.committed_count().await.unwrap(), 0, "nothing committed");
+    assert_eq!(
+        svc.run_registration().await.unwrap(),
+        None,
+        "still unregistered"
+    );
+}
+
+// === D66 — fail-closed on a tool-resolution miss ==============================
+
+#[tokio::test]
+async fn d66_refuses_world_mutating_with_unregistered_tool() {
+    let svc = coordinator(InMemoryJournal::new(), [0x22u8; 16]);
+    register(&svc, [0xb2u8; 32]).await;
+
+    let mote = common::wm_mote(2, EffectPattern::StageThenCommit);
+    // The warrant grants a tool that is NOT in the registry → resolution miss.
+    let warrant = warrant_granting(&[("ghost-tool", "9")], "m");
+    let resp = common::submit(&svc, &mote, &warrant).await;
+
+    assert_eq!(resp.status, proto::SubmitStatus::Rejected as i32);
+    assert!(
+        resp.detail.contains("D66"),
+        "detail names the D66 refusal: {}",
+        resp.detail
+    );
+    assert!(
+        resp.instance_id.is_empty(),
+        "a refused submit surfaces no instance_id"
+    );
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
+    assert!(
+        svc.run_resolved_versions().await.unwrap().is_empty(),
+        "a refused submit journals no metadata"
+    );
+}
+
+#[tokio::test]
+async fn d66_security_refuses_capability_exceeding_warrant() {
+    // A tool whose required net egress is NOT in the warrant fails to resolve
+    // (CapabilityExceedsWarrant) → for a WM Mote, D66 refuses (anti-privilege-
+    // laundering + anti-double-fire at the boundary).
+    let mut reg = InMemoryToolRegistry::with_builtins();
+    reg.register(
+        ToolDef {
+            tool_id: ToolName("greedy".into()),
+            tool_version: ToolVersion("1".into()),
+            kind: ToolKind::Builtin,
+            required_capability: ToolRequirement {
+                net_scope_required: NetScope::EgressAllowlist(BTreeSet::from([Host(
+                    "evil.example.com:443".into(),
+                )])),
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: "needs egress the warrant lacks".into(),
+            idempotency_class: IdempotencyClass::Token,
+        },
+        ToolProvenance::HumanAuthored {
+            author: "ops".into(),
+        },
+    )
+    .unwrap();
+
+    let svc = coordinator_with_tools(InMemoryJournal::new(), [0x33u8; 16], Arc::new(reg));
+    register(&svc, [0xb3u8; 32]).await;
+
+    let mote = common::wm_mote(3, EffectPattern::StageThenCommit);
+    let mut warrant = warrant_granting(&[("greedy", "1")], "m");
+    warrant.net_scope = NetScope::None; // greedy's egress requirement is NOT a subset
+    let resp = common::submit(&svc, &mote, &warrant).await;
+
+    assert_eq!(
+        resp.status,
+        proto::SubmitStatus::Rejected as i32,
+        "a WM Mote that grants a privilege-exceeding tool is refused (D66 fail-closed)"
+    );
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
+}
+
+// === R-10 — AtLeastOnce requires explicit accept ==============================
+
+#[tokio::test]
+async fn r10_refuses_at_least_once_without_accept_then_accepts() {
+    let svc = coordinator_with_tools(
+        InMemoryJournal::new(),
+        [0x44u8; 16],
+        registry_with_at_least_once(),
+    );
+    register(&svc, [0xb4u8; 32]).await;
+
+    let mote = common::wm_mote(4, EffectPattern::IdempotentByConstruction);
+    let warrant = warrant_granting(&[("emailer", "1")], "m");
+
+    // accept_at_least_once defaults false → R-10 refuses.
+    let refused = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(refused.status, proto::SubmitStatus::Rejected as i32);
+    assert!(
+        refused.detail.contains("R-10"),
+        "detail names R-10: {}",
+        refused.detail
+    );
+    assert_eq!(svc.committed_count().await.unwrap(), 0);
+
+    // The operator opts in → accepted.
+    let accepted = common::submit_accepting(&svc, &mote, &warrant).await;
+    assert_eq!(
+        accepted.status,
+        proto::SubmitStatus::Accepted as i32,
+        "accept_at_least_once=true admits the AtLeastOnce WM Mote"
+    );
+}
+
+// === PURE / ROND are never refused on resolution grounds ======================
+
+#[tokio::test]
+async fn pure_with_unresolvable_grant_is_accepted_capture_skipped() {
+    let svc = coordinator(InMemoryJournal::new(), [0x55u8; 16]);
+    register(&svc, [0xb5u8; 32]).await;
+
+    let mote = common::mote(5, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("ghost-tool", "9")], "m"); // unresolvable
+    let resp = common::submit(&svc, &mote, &warrant).await;
+
+    assert_eq!(
+        resp.status,
+        proto::SubmitStatus::Accepted as i32,
+        "a PURE Mote with an unresolvable grant is admitted (D66 is WM-only)"
+    );
+    assert!(
+        svc.run_resolved_versions().await.unwrap().is_empty(),
+        "capture is skipped on the resolution miss (M1.2 behavior preserved)"
+    );
+}
+
+#[tokio::test]
+async fn pure_with_resolvable_grant_is_accepted_and_captured() {
+    let svc = coordinator(InMemoryJournal::new(), [0x66u8; 16]);
+    register(&svc, [0xb6u8; 32]).await;
+
+    let mote = common::mote(6, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("fs-read", "1")], "qwen");
+    let resp = common::submit(&svc, &mote, &warrant).await;
+
+    assert_eq!(resp.status, proto::SubmitStatus::Accepted as i32);
+    let records = svc.run_resolved_versions().await.unwrap();
+    assert_eq!(
+        records.len(),
+        1,
+        "the resolvable grant is captured as metadata"
+    );
+    assert_eq!(records[0].capability.as_ref().unwrap().tool_id, "fs-read");
+}

--- a/crates/kx-executor/Cargo.toml
+++ b/crates/kx-executor/Cargo.toml
@@ -25,6 +25,11 @@ kx-capability        = { workspace = true }
 kx-model-validator   = { workspace = true }
 kx-critic-types      = { workspace = true }
 kx-critic            = { workspace = true }
+# Submission-time refusal vocabulary + predicates (M1.3) — extracted to a leaf
+# crate so the control-plane kx-coordinator can enforce refusals without linking
+# kx-executor's inference stack. Re-exported here for back-compat (lifecycle +
+# the existing refusal tests consume the same names).
+kx-refusal           = { workspace = true }
 bincode              = { workspace = true }
 blake3               = { workspace = true }
 bytes                = { workspace = true }

--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -281,7 +281,6 @@ pub mod fact_zero;
 pub mod factory;
 pub mod lifecycle;
 pub mod native_critic;
-pub mod refusal;
 pub mod resource_manager;
 pub mod verify;
 // The spawn module ships shared Unix primitives (fork + pipe + dup2 +
@@ -308,9 +307,14 @@ pub use lifecycle::{
     TestMoteExecutor, WmLifecycleCommit, WmRedispatchOracle,
 };
 pub use native_critic::run_native_critic_mote;
-pub use refusal::{
-    refusal_from_narrowing, validate_submission, validate_submission_with_idempotency,
-    SubmissionRefusal, WorkflowSubmission,
+// Submission-time refusal vocabulary + predicates. Extracted to the `kx-refusal`
+// leaf crate (M1.3) so the control-plane `kx-coordinator` can enforce refusals
+// without linking this crate's inference stack; re-exported here so existing
+// callers (`kx_executor::validate_submission`, etc.) and the lifecycle path are
+// unchanged.
+pub use kx_refusal::{
+    refusal_from_narrowing, validate_mote_submission, validate_submission,
+    validate_submission_with_idempotency, SubmissionRefusal, ToolResolution, WorkflowSubmission,
 };
 pub use resource_manager::{LocalResourceManager, ResourceError, ResourceManager, Slot};
 pub use verify::{verify_pure_rerun, VerifyError, VerifyOutcome};

--- a/crates/kx-executor/src/lifecycle.rs
+++ b/crates/kx-executor/src/lifecycle.rs
@@ -29,9 +29,10 @@ use kx_warrant::WarrantSpec;
 use smallvec::SmallVec;
 use thiserror::Error;
 
+use kx_refusal::SubmissionRefusal;
+
 use crate::commit_protocol::{CommitInput, CommitProtocol, CommitProtocolError};
 use crate::executor_trait::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
-use crate::refusal::SubmissionRefusal;
 use crate::resource_manager::{ResourceError, ResourceManager};
 
 /// Top-level lifecycle errors. The PURE-Mote happy path returns `Ok(commit)`;

--- a/crates/kx-executor/src/native_critic.rs
+++ b/crates/kx-executor/src/native_critic.rs
@@ -26,8 +26,8 @@ use crate::lifecycle::{LifecycleCommit, LifecycleError};
 /// Run a native deterministic-critic Mote to commit.
 ///
 /// Steps:
-/// 1. Run-time R-15 guard (defense-in-depth; the submission predicate
-///    `crate::refusal::check_r15` is the primary enforcement).
+/// 1. Run-time R-15 guard (defense-in-depth; the submission-time R-15 predicate
+///    in `kx_refusal` is the primary enforcement).
 /// 2. **P0.4 hard gate** — if this critic is already committed, serve the
 ///    committed verdict ref, never re-evaluate.
 /// 3. Read the producer's committed output bytes (the critic has a Data edge to

--- a/crates/kx-proto/proto/kortecx/v1/coordinator.proto
+++ b/crates/kx-proto/proto/kortecx/v1/coordinator.proto
@@ -200,6 +200,7 @@ message WarrantSpec {
 message SubmitMoteRequest {
   Mote mote = 1;
   WarrantSpec warrant = 2;
+  bool accept_at_least_once = 3;        // M1.3/D38 §2c: opt-in to dispatch an AtLeastOnce WM tool (default false = fail-closed under R-10)
 }
 
 enum SubmitStatus {

--- a/crates/kx-proto/tests/dod.rs
+++ b/crates/kx-proto/tests/dod.rs
@@ -38,6 +38,7 @@ fn obligation_1_submit_mote_request_round_trips() {
     let req = proto::SubmitMoteRequest {
         mote: Some(sample_mote().into()),
         warrant: Some(sample_warrant().into()),
+        accept_at_least_once: false,
     };
     roundtrip(&req);
 }
@@ -178,6 +179,7 @@ fn obligation_2_encoding_same_value_is_stable() {
     let req = proto::SubmitMoteRequest {
         mote: Some(sample_mote().into()),
         warrant: Some(sample_warrant().into()),
+        accept_at_least_once: false,
     };
     assert_eq!(req.encode_to_vec(), req.encode_to_vec());
 }
@@ -226,6 +228,7 @@ fn obligation_3_full_wire_pipeline_preserves_identity() {
     let req = proto::SubmitMoteRequest {
         mote: Some(mote.clone().into()),
         warrant: Some(warrant.clone().into()),
+        accept_at_least_once: false,
     };
 
     // Through the actual gRPC wire bytes and back.

--- a/crates/kx-proto/tests/skeleton_builds.rs
+++ b/crates/kx-proto/tests/skeleton_builds.rs
@@ -193,6 +193,7 @@ async fn coordinator_skeleton_serves_all_rpcs() {
         .submit_mote(SubmitMoteRequest {
             mote: Some(sample_mote().into()),
             warrant: Some(sample_warrant().into()),
+            accept_at_least_once: false,
         })
         .await
         .unwrap()

--- a/crates/kx-refusal/Cargo.toml
+++ b/crates/kx-refusal/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name         = "kx-refusal"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx submission-time refusal VOCABULARY + predicates (R-1..R-15 + D66) — the pure, total, dependency-light gate a Mote submission is checked against before any dispatch. SubmissionRefusal (the closed refusal vocabulary), WorkflowSubmission (the full-graph shape), ToolResolution (the per-submit tool-resolution outcome), validate_submission / validate_submission_with_idempotency (full-graph) + validate_mote_submission (the single-Mote SubmitMote-boundary subset). Held in a leaf crate so the control-plane kx-coordinator can enforce refusals WITHOUT depending on kx-executor's inference/llama.cpp stack (the seam discipline: distribution is wiring)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Mote / MoteDef / MoteId / NdClass — the submission shape the predicates reason over.
+kx-mote          = { workspace = true }
+# IdempotencyClass (R-10 / D66) + ToolDef (the dead-code lifecycle placeholders).
+kx-tool-registry = { workspace = true }
+# WarrantSpec (the master warrant) + NarrowingError (the AttemptedWiden mapping).
+kx-warrant       = { workspace = true }
+thiserror        = { workspace = true }
+
+[dev-dependencies]
+# ContentRef for building test warrants (syscall_profile_ref / environment_ref).
+kx-content = { workspace = true }
+# SmallVec parents when building test Motes via Mote::new.
+smallvec   = { workspace = true }
+# Property tests: validate_mote_submission is pure/total over arbitrary inputs.
+proptest   = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-refusal/src/lib.rs
+++ b/crates/kx-refusal/src/lib.rs
@@ -1,0 +1,42 @@
+//! # kx-refusal — submission-time refusal predicates (the safety gate)
+//!
+//! A Mote submission is checked against a closed vocabulary of **refusal
+//! predicates** before any dispatch, inference, or commit. This crate is the
+//! pure, total, dependency-light home of that gate: the [`SubmissionRefusal`]
+//! vocabulary, the [`WorkflowSubmission`] shape, the [`ToolResolution`] outcome,
+//! and the validators.
+//!
+//! ## Two validation surfaces
+//!
+//! - [`validate_submission`] / [`validate_submission_with_idempotency`] reason
+//!   over a **full** [`WorkflowSubmission`] (`BTreeMap<MoteId, Mote>`) — they run
+//!   the sibling-dependent predicates (R-2/R-4/R-5/R-6/R-9) that need the whole
+//!   critic/producer graph. This is the future SDK / workflow-submission path.
+//! - [`validate_mote_submission`] reasons over a **single** Mote at the
+//!   coordinator's `SubmitMote` boundary (M1.3) — it runs ONLY the
+//!   sibling-INDEPENDENT predicates (R-1, R-7-self, R-8, R-14, R-15) plus the
+//!   R-10 / D66 idempotency gate with a **fail-closed** [`ToolResolution`].
+//!
+//! ## Why a separate leaf crate
+//!
+//! The refusal vocabulary depends only on `kx-mote`, `kx-tool-registry`, and
+//! `kx-warrant`. Holding it here — below `kx-executor` — lets the control-plane
+//! `kx-coordinator` enforce refusals at `SubmitMote` WITHOUT pulling
+//! `kx-executor`'s inference / llama.cpp stack into the orchestration server.
+//! `kx-executor` re-exports this crate's surface for back-compat, so its own
+//! lifecycle / commit-protocol modules and tests see the same names.
+//!
+//! ## SN-8 — model proposes, runtime enforces
+//!
+//! Every predicate is a **pure, total** function of its inputs — same Mote, same
+//! resolution ⇒ same refusal (no clock / host / RNG / float). A refusal is a
+//! structural fact about an *unsafe construction*, never a similarity score.
+
+#![forbid(unsafe_code)]
+
+mod refusal;
+
+pub use refusal::{
+    refusal_from_narrowing, validate_mote_submission, validate_submission,
+    validate_submission_with_idempotency, SubmissionRefusal, ToolResolution, WorkflowSubmission,
+};

--- a/crates/kx-refusal/src/refusal.rs
+++ b/crates/kx-refusal/src/refusal.rs
@@ -1,10 +1,10 @@
-//! Submission-time refusal predicates (R-1..R-9 + R-8b + ValidatorTypeError +
-//! AttemptedWiden) per `docs/design/validate-then-commit.md` §7. **PR 9a
-//! scope**; R-10..R-13 reserved for PR 9b.
+//! Submission-time refusal predicates (R-1..R-9 + R-8b + R-10 + R-14 + R-15 +
+//! D66 + `ValidatorTypeError` + `AttemptedWiden`) per
+//! `docs/design/validate-then-commit.md` §7 + the D66 fail-closed gate (M1.3).
 //!
 //! Each refusal results in a single `Failed::UnsafeWorldMutatingConstruction`
 //! journal entry; no broker dispatch, no inference call, no commit beyond the
-//! `Failed` entry. The fact-zero protocol (`crate::fact_zero`) is the
+//! `Failed` entry. The fact-zero protocol (`kx_executor::write_fact_zero`) is the
 //! caller's responsibility to invoke before any Mote dispatch.
 
 use std::collections::BTreeMap;
@@ -64,7 +64,7 @@ pub enum SubmissionRefusal {
         mote_id: MoteId,
         /// The producer being critiqued.
         target: MoteId,
-        /// The producer's actual nd_class.
+        /// The producer's actual `nd_class`.
         target_class: NdClass,
     },
 
@@ -203,6 +203,26 @@ pub enum SubmissionRefusal {
         /// The offending Mote.
         mote_id: MoteId,
     },
+
+    /// **D66** (M1.3). A `WORLD_MUTATING` Mote whose tool grants could NOT be
+    /// resolved at the submit boundary (a `NotFound` / `CapabilityExceedsWarrant`
+    /// / `PendingHumanReview` miss). `StageThenCommit` is the #1 no-double-fire
+    /// seam (D66): the runtime cannot vouch for the exactly-once dispatch of a
+    /// tool it cannot resolve to an [`IdempotencyClass`], so a WM Mote with
+    /// unresolvable tools is refused **fail-closed**. PURE / READ-ONLY-NONDET
+    /// Motes are unaffected — they carry no double-fire hazard, so an
+    /// unresolvable grant on a non-WM Mote is not a refusal (it keeps M1.2's
+    /// capture-skip behavior).
+    ///
+    /// This closes the historical fail-OPEN: the full-graph `check_r10` returns
+    /// `Ok(())` for a Mote with no resolved-class entry (a legitimate no-tool
+    /// PURE Mote), which the single-Mote boundary path must NOT do for a WM Mote
+    /// whose tools simply failed to resolve.
+    #[error("D66: WORLD-MUTATING Mote {mote_id:?} has unresolvable tool grants; the runtime cannot guarantee exactly-once dispatch of a tool it cannot resolve (StageThenCommit fail-closed)")]
+    D66UnresolvableWorldMutatingTools {
+        /// The offending Mote.
+        mote_id: MoteId,
+    },
 }
 
 /// A workflow submission — the shape `validate_submission` reasons over.
@@ -227,6 +247,26 @@ pub struct WorkflowSubmission {
     pub accept_at_least_once: BTreeMap<MoteId, bool>,
 }
 
+/// The tool-resolution outcome for a single Mote at the coordinator's
+/// `SubmitMote` boundary (M1.3 / D66). The coordinator resolves the Mote's
+/// warrant grants against the [`ToolRegistry`](kx_tool_registry::ToolRegistry)
+/// once per fresh submit and hands the result to [`validate_mote_submission`].
+///
+/// - `Resolved(classes)` — every grant resolved cleanly; `classes` are the
+///   resolved [`IdempotencyClass`]es (canonical grant order). R-10 reasons over
+///   these.
+/// - `Unresolved` — at least one grant did not resolve (`NotFound` /
+///   `CapabilityExceedsWarrant` / `PendingHumanReview`). For a WORLD-MUTATING
+///   Mote this is a fail-closed refusal ([`SubmissionRefusal::D66UnresolvableWorldMutatingTools`]);
+///   for a PURE / READ-ONLY-NONDET Mote it is harmless (no double-fire hazard).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolResolution {
+    /// Every warrant grant resolved; the resolved idempotency classes.
+    Resolved(Vec<IdempotencyClass>),
+    /// At least one warrant grant did not resolve cleanly.
+    Unresolved,
+}
+
 /// Validate a workflow submission against R-1..R-9 + R-8b. Returns `Ok(())`
 /// on a safe submission; the first refusal hit returns `Err(refusal)`.
 ///
@@ -236,7 +276,7 @@ pub struct WorkflowSubmission {
 /// R-8b, R-9). PR 9b may expand the function to collect a `Vec<SubmissionRefusal>`
 /// if reviewer feedback wants all hits at once.
 ///
-/// ValidatorTypeError + AttemptedWiden are not surfaced by this function
+/// `ValidatorTypeError` + `AttemptedWiden` are not surfaced by this function
 /// — they ride the lifecycle path's `kx_model_validator::check` +
 /// `kx_warrant::intersect` calls. The caller maps those errors to
 /// `SubmissionRefusal::ValidatorTypeError` / `SubmissionRefusal::AttemptedWiden`
@@ -320,7 +360,7 @@ pub fn validate_submission(submission: &WorkflowSubmission) -> Result<(), Submis
 ///
 /// ```
 /// use std::collections::{BTreeMap, BTreeSet};
-/// use kx_executor::{validate_submission_with_idempotency, WorkflowSubmission};
+/// use kx_refusal::{validate_submission_with_idempotency, WorkflowSubmission};
 /// use kx_content::ContentRef;
 /// use kx_mote::{ModelId, MoteId};
 /// use kx_tool_registry::IdempotencyClass;
@@ -370,6 +410,50 @@ pub fn validate_submission_with_idempotency(
     for mote in submission.motes.values() {
         check_r10(mote, submission, resolved_idempotency_classes)?;
     }
+    Ok(())
+}
+
+/// Validate a SINGLE Mote at the coordinator's `SubmitMote` boundary (M1.3).
+///
+/// `SubmitMote` admits one Mote at a time, so the SIBLING-DEPENDENT predicates
+/// (R-2 needs a sibling critic; R-4 / R-5 need the target Mote; R-6 needs all
+/// critics; R-9 walks the critic chain) cannot run here without false-refusing a
+/// valid producer whose critic is submitted under a separate call. This function
+/// runs ONLY the sibling-INDEPENDENT predicates — R-1, R-7 (self), R-8, R-14,
+/// R-15 — plus R-10 with a **fail-closed** [`ToolResolution`] (the D66 miss). The
+/// sibling-graph predicates ride the future full-graph SDK path via
+/// [`validate_submission`], which is left untouched.
+///
+/// `accept_at_least_once` is the per-Mote opt-in from the `SubmitMote` request
+/// (`false` = fail-closed). `resolution` is the coordinator's per-submit
+/// resolution of the Mote's warrant grants.
+///
+/// # Errors
+///
+/// Returns the first applicable [`SubmissionRefusal`] (declared order: R-1, R-7,
+/// R-8, R-14, R-15, R-10/D66); `Ok(())` for a safe Mote.
+pub fn validate_mote_submission(
+    mote: &Mote,
+    accept_at_least_once: bool,
+    resolution: &ToolResolution,
+) -> Result<(), SubmissionRefusal> {
+    // R-3 is structurally unreachable (effect_pattern is a required field); the
+    // call documents the position in the predicate sequence (mirrors
+    // `validate_submission`).
+    check_r3(mote);
+    // R-1 — WORLD-MUTATING IdempotentByConstruction with no idempotent tool.
+    check_r1(mote)?;
+    // R-7 (self) — a critic Mote that is itself WORLD-MUTATING. The R-4 / R-5
+    // halves of `check_r4_r5_r7` need the critic's target sibling, so they are
+    // NOT run on the single-Mote path; `check_r7_self` is the self-only slice.
+    check_r7_self(mote)?;
+    // R-8 + R-8b + R-14 + R-15 — shaper + native-critic constructions (self-only).
+    check_r8(mote)?;
+    check_r8b(mote, &BTreeMap::new());
+    check_r14(mote)?;
+    check_r15(mote)?;
+    // R-10 + D66 — the idempotency gate over the resolved (or unresolved) tools.
+    check_r10_resolved(mote, accept_at_least_once, resolution)?;
     Ok(())
 }
 
@@ -603,6 +687,57 @@ fn check_r10(
         return Ok(());
     }
     Err(SubmissionRefusal::R10AtLeastOnceWithoutAccept { mote_id: mote.id })
+}
+
+/// **R-7 (self-only).** Refuse a critic Mote (`critic_for == Some(_)`) whose own
+/// `nd_class` is WORLD-MUTATING. This is the sibling-INDEPENDENT slice of
+/// `check_r4_r5_r7` — it consults only the Mote's own fields, so it is safe on
+/// the single-Mote [`validate_mote_submission`] path (R-4 / R-5, which need the
+/// critic's target sibling, are not run there).
+fn check_r7_self(mote: &Mote) -> Result<(), SubmissionRefusal> {
+    if mote.def.critic_for.is_some() && mote.def.nd_class == NdClass::WorldMutating {
+        return Err(SubmissionRefusal::R7WorldMutatingCritic { mote_id: mote.id });
+    }
+    Ok(())
+}
+
+/// **R-10 + D66 (fail-closed).** The single-Mote idempotency gate. Constrains
+/// WORLD-MUTATING Motes only (R-10 / D66 have no meaning for a non-mutating
+/// Mote): a non-WM Mote returns `Ok(())` regardless of `resolution`, preserving
+/// M1.2's capture-skip behavior for a PURE / READ-ONLY-NONDET Mote with an
+/// unresolvable grant.
+///
+/// For a WM Mote:
+/// - `ToolResolution::Unresolved` → fail-closed
+///   [`SubmissionRefusal::D66UnresolvableWorldMutatingTools`] (the runtime cannot
+///   vouch for exactly-once dispatch of a tool it cannot resolve).
+/// - `ToolResolution::Resolved(classes)` with any `AtLeastOnce` class and
+///   `accept_at_least_once == false` → [`SubmissionRefusal::R10AtLeastOnceWithoutAccept`].
+///
+/// Unlike the full-graph [`check_r10`] (which fail-OPENs on a missing resolved
+/// entry — correct there, since a no-tool PURE Mote legitimately has none), this
+/// boundary check fail-CLOSEs on an unresolved WM Mote.
+fn check_r10_resolved(
+    mote: &Mote,
+    accept_at_least_once: bool,
+    resolution: &ToolResolution,
+) -> Result<(), SubmissionRefusal> {
+    if mote.def.nd_class != NdClass::WorldMutating {
+        return Ok(());
+    }
+    let classes = match resolution {
+        ToolResolution::Unresolved => {
+            return Err(SubmissionRefusal::D66UnresolvableWorldMutatingTools { mote_id: mote.id });
+        }
+        ToolResolution::Resolved(classes) => classes,
+    };
+    let has_at_least_once = classes
+        .iter()
+        .any(|c| matches!(c, IdempotencyClass::AtLeastOnce));
+    if has_at_least_once && !accept_at_least_once {
+        return Err(SubmissionRefusal::R10AtLeastOnceWithoutAccept { mote_id: mote.id });
+    }
+    Ok(())
 }
 
 #[allow(dead_code)] // PR 9a placeholder for the R-1 lifecycle integration

--- a/crates/kx-refusal/tests/mote_submission.rs
+++ b/crates/kx-refusal/tests/mote_submission.rs
@@ -1,0 +1,285 @@
+//! M1.3 — `validate_mote_submission` (the single-Mote SubmitMote-boundary gate):
+//! the R-1/R-7/R-8/R-14/R-15 + R-10/D66 decision table, the D66 fail-closed
+//! property (WM-only), and the narrow-vs-full sibling contract. These are the
+//! UNIT + behavioral assertions for the predicate at its home crate; the
+//! coordinator wires it (see `kx-coordinator/tests/submission_refusal.rs`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
+    PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_refusal::{
+    validate_mote_submission, validate_submission, SubmissionRefusal, ToolResolution,
+    WorkflowSubmission,
+};
+use kx_tool_registry::IdempotencyClass;
+use smallvec::SmallVec;
+
+fn warrant() -> kx_warrant::WarrantSpec {
+    kx_warrant::WarrantSpec {
+        mote_class: kx_warrant::MoteClass::Pure,
+        nd_class: kx_warrant::MoteClass::Pure,
+        fs_scope: kx_warrant::FsScope::empty(),
+        net_scope: kx_warrant::NetScope::None,
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: kx_warrant::ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: kx_warrant::ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: kx_warrant::ExecutorClass::Bwrap,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_mote(
+    seed: u8,
+    nd_class: NdClass,
+    effect_pattern: EffectPattern,
+    critic_for: Option<MoteId>,
+    is_topology_shaper: bool,
+    tool_contract: BTreeMap<ToolName, ToolVersion>,
+) -> Mote {
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract,
+        nd_class,
+        config_subset: BTreeMap::new(),
+        effect_pattern,
+        critic_for,
+        is_topology_shaper,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+/// A WORLD-MUTATING producer with a non-empty tool_contract (so R-1 never fires),
+/// `StageThenCommit` (so R-2/R-9 are irrelevant), no critic role.
+fn wm_producer(seed: u8) -> Mote {
+    let mut tc = BTreeMap::new();
+    tc.insert(ToolName("fs-write".into()), ToolVersion("1".into()));
+    build_mote(
+        seed,
+        NdClass::WorldMutating,
+        EffectPattern::StageThenCommit,
+        None,
+        false,
+        tc,
+    )
+}
+
+// === D66 — fail-closed on a tool-resolution miss (WORLD-MUTATING only) ========
+
+#[test]
+fn d66_refuses_world_mutating_with_unresolved_tools() {
+    let err =
+        validate_mote_submission(&wm_producer(1), false, &ToolResolution::Unresolved).unwrap_err();
+    assert!(matches!(
+        err,
+        SubmissionRefusal::D66UnresolvableWorldMutatingTools { .. }
+    ));
+}
+
+#[test]
+fn d66_does_not_refuse_pure_with_unresolved_tools() {
+    // A PURE Mote carries no double-fire hazard — an unresolvable warrant grant is
+    // NOT a D66 refusal (it keeps M1.2's capture-skip behavior).
+    let pure = build_mote(
+        1,
+        NdClass::Pure,
+        EffectPattern::IdempotentByConstruction,
+        None,
+        false,
+        BTreeMap::new(),
+    );
+    assert!(validate_mote_submission(&pure, false, &ToolResolution::Unresolved).is_ok());
+}
+
+#[test]
+fn d66_does_not_refuse_read_only_nondet_with_unresolved_tools() {
+    let rond = build_mote(
+        1,
+        NdClass::ReadOnlyNondet,
+        EffectPattern::IdempotentByConstruction,
+        None,
+        false,
+        BTreeMap::new(),
+    );
+    assert!(validate_mote_submission(&rond, false, &ToolResolution::Unresolved).is_ok());
+}
+
+// === R-10 — resolved AtLeastOnce gate (with the accept opt-in) ================
+
+#[test]
+fn clean_world_mutating_with_resolved_non_at_least_once_is_ok() {
+    let resolution =
+        ToolResolution::Resolved(vec![IdempotencyClass::Token, IdempotencyClass::Staged]);
+    assert!(validate_mote_submission(&wm_producer(2), false, &resolution).is_ok());
+}
+
+#[test]
+fn r10_refuses_at_least_once_without_accept() {
+    let resolution = ToolResolution::Resolved(vec![IdempotencyClass::AtLeastOnce]);
+    let err = validate_mote_submission(&wm_producer(3), false, &resolution).unwrap_err();
+    assert!(matches!(
+        err,
+        SubmissionRefusal::R10AtLeastOnceWithoutAccept { .. }
+    ));
+}
+
+#[test]
+fn r10_accepts_at_least_once_with_explicit_accept() {
+    let resolution = ToolResolution::Resolved(vec![IdempotencyClass::AtLeastOnce]);
+    assert!(validate_mote_submission(&wm_producer(3), true, &resolution).is_ok());
+}
+
+// === R-1 precedence over D66 ==================================================
+
+#[test]
+fn r1_precedes_d66_for_empty_contract_idempotent_wm() {
+    // A WM IdempotentByConstruction Mote with an EMPTY tool_contract is an R-1
+    // refusal — checked BEFORE the D66 resolution miss.
+    let m = build_mote(
+        4,
+        NdClass::WorldMutating,
+        EffectPattern::IdempotentByConstruction,
+        None,
+        false,
+        BTreeMap::new(),
+    );
+    let err = validate_mote_submission(&m, false, &ToolResolution::Unresolved).unwrap_err();
+    assert!(
+        matches!(err, SubmissionRefusal::R1NoIdempotentTool { .. }),
+        "R-1 (not D66) fires first for an empty-contract IdempotentByConstruction WM Mote"
+    );
+}
+
+// === Other sibling-INDEPENDENT predicates fire on the narrow path =============
+
+#[test]
+fn r7_self_refuses_world_mutating_critic() {
+    let target = MoteId::from_bytes([0xEE; 32]);
+    let mut tc = BTreeMap::new();
+    tc.insert(ToolName("fs-write".into()), ToolVersion("1".into()));
+    let wm_critic = build_mote(
+        5,
+        NdClass::WorldMutating,
+        EffectPattern::StageThenCommit,
+        Some(target),
+        false,
+        tc,
+    );
+    let err = validate_mote_submission(
+        &wm_critic,
+        false,
+        &ToolResolution::Resolved(vec![IdempotencyClass::Staged]),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        SubmissionRefusal::R7WorldMutatingCritic { .. }
+    ));
+}
+
+#[test]
+fn r8_refuses_shaper_that_is_also_a_critic() {
+    let target = MoteId::from_bytes([0xEE; 32]);
+    let shaper_critic = build_mote(
+        6,
+        NdClass::Pure,
+        EffectPattern::IdempotentByConstruction,
+        Some(target),
+        true,
+        BTreeMap::new(),
+    );
+    let err = validate_mote_submission(&shaper_critic, false, &ToolResolution::Resolved(vec![]))
+        .unwrap_err();
+    assert!(matches!(err, SubmissionRefusal::R8ShaperAndCritic { .. }));
+}
+
+#[test]
+fn r14_refuses_world_mutating_shaper() {
+    let mut tc = BTreeMap::new();
+    tc.insert(ToolName("fs-write".into()), ToolVersion("1".into()));
+    let wm_shaper = build_mote(
+        7,
+        NdClass::WorldMutating,
+        EffectPattern::StageThenCommit,
+        None,
+        true,
+        tc,
+    );
+    let err = validate_mote_submission(
+        &wm_shaper,
+        false,
+        &ToolResolution::Resolved(vec![IdempotencyClass::Staged]),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        SubmissionRefusal::R14WorldMutatingShaper { .. }
+    ));
+}
+
+// === The narrow-vs-full sibling contract ======================================
+
+#[test]
+fn narrow_path_does_not_run_sibling_dependent_predicates() {
+    // A critic Mote whose `critic_for` target is NOT in this single submit: the
+    // single-Mote path must NOT refuse it (R-4 needs the target sibling, which is
+    // submitted separately) — but the FULL-graph `validate_submission` DOES refuse
+    // it (R-4). This locks the two-surface contract M1.3 relies on.
+    let phantom_target = MoteId::from_bytes([0xAB; 32]);
+    let critic = build_mote(
+        8,
+        NdClass::Pure,
+        EffectPattern::IdempotentByConstruction,
+        Some(phantom_target),
+        false,
+        BTreeMap::new(),
+    );
+
+    // Narrow (boundary) path: Ok — sibling predicates are not run.
+    assert!(
+        validate_mote_submission(&critic, false, &ToolResolution::Resolved(vec![])).is_ok(),
+        "single-Mote path does not run R-4 (the target sibling is submitted separately)"
+    );
+
+    // Full-graph path: refused — R-4 (critic target missing).
+    let mut motes = BTreeMap::new();
+    motes.insert(critic.id, critic);
+    let submission = WorkflowSubmission {
+        run_id: [0u8; 32],
+        master_warrant: warrant(),
+        motes,
+        accept_at_least_once: BTreeMap::new(),
+    };
+    let err = validate_submission(&submission).unwrap_err();
+    assert!(
+        matches!(err, SubmissionRefusal::R4CriticTargetMissing { .. }),
+        "full-graph path runs R-4"
+    );
+}

--- a/crates/kx-refusal/tests/proptest_mote_submission.rs
+++ b/crates/kx-refusal/tests/proptest_mote_submission.rs
@@ -1,0 +1,146 @@
+//! M1.3 property tests for `validate_mote_submission` (SN-4: ≥3 properties).
+//!
+//! P1 — a non-WORLD-MUTATING plain producer is NEVER refused on resolution
+//!      grounds (D66 is WM-only; a non-WM Mote carries no double-fire hazard).
+//! P2 — a WORLD-MUTATING plain producer with UNRESOLVED tools is ALWAYS refused
+//!      (R-1 if its contract is empty+IdempotentByConstruction, else D66) — the
+//!      historical fail-OPEN can never regress.
+//! P3 — a WORLD-MUTATING producer with RESOLVED tools matches the R-10 contract:
+//!      refused iff (some class is AtLeastOnce AND accept_at_least_once is false).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeMap;
+
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, NdClass,
+    PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_refusal::{validate_mote_submission, SubmissionRefusal, ToolResolution};
+use kx_tool_registry::IdempotencyClass;
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+fn plain_mote(
+    seed: u8,
+    nd_class: NdClass,
+    effect_pattern: EffectPattern,
+    tool_contract: BTreeMap<ToolName, ToolVersion>,
+) -> Mote {
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract,
+        nd_class,
+        config_subset: BTreeMap::new(),
+        effect_pattern,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn effect_pattern_strategy() -> impl Strategy<Value = EffectPattern> {
+    prop_oneof![
+        Just(EffectPattern::IdempotentByConstruction),
+        Just(EffectPattern::StageThenCommit),
+        Just(EffectPattern::ValidateThenCommit),
+    ]
+}
+
+fn class_strategy() -> impl Strategy<Value = IdempotencyClass> {
+    prop_oneof![
+        Just(IdempotencyClass::Token),
+        Just(IdempotencyClass::Readback),
+        Just(IdempotencyClass::Staged),
+        Just(IdempotencyClass::AtLeastOnce),
+    ]
+}
+
+fn non_empty_contract() -> BTreeMap<ToolName, ToolVersion> {
+    let mut tc = BTreeMap::new();
+    tc.insert(ToolName("fs-write".into()), ToolVersion("1".into()));
+    tc
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// P1 — a non-WM plain producer is never refused on resolution grounds.
+    #[test]
+    fn p1_non_world_mutating_is_never_refused_on_resolution(
+        is_pure in any::<bool>(),
+        ep in effect_pattern_strategy(),
+        has_tools in any::<bool>(),
+        accept in any::<bool>(),
+        unresolved in any::<bool>(),
+        classes in proptest::collection::vec(class_strategy(), 0..4),
+    ) {
+        let nd = if is_pure { NdClass::Pure } else { NdClass::ReadOnlyNondet };
+        let tc = if has_tools { non_empty_contract() } else { BTreeMap::new() };
+        let mote = plain_mote(1, nd, ep, tc);
+        let resolution = if unresolved {
+            ToolResolution::Unresolved
+        } else {
+            ToolResolution::Resolved(classes)
+        };
+        prop_assert!(
+            validate_mote_submission(&mote, accept, &resolution).is_ok(),
+            "a non-WM plain producer is admitted regardless of tool resolution"
+        );
+    }
+
+    /// P2 — a WM plain producer with UNRESOLVED tools is always refused.
+    #[test]
+    fn p2_world_mutating_unresolved_is_always_refused(
+        ep in effect_pattern_strategy(),
+        has_tools in any::<bool>(),
+        accept in any::<bool>(),
+    ) {
+        let tc = if has_tools { non_empty_contract() } else { BTreeMap::new() };
+        let mote = plain_mote(2, NdClass::WorldMutating, ep, tc.clone());
+        let result = validate_mote_submission(&mote, accept, &ToolResolution::Unresolved);
+        prop_assert!(result.is_err(), "a WM Mote with unresolvable tools is never silently admitted");
+        // R-1 only when the contract is empty AND the pattern is IdempotentByConstruction.
+        let expect_r1 = tc.is_empty() && ep == EffectPattern::IdempotentByConstruction;
+        match result.unwrap_err() {
+            SubmissionRefusal::R1NoIdempotentTool { .. } => prop_assert!(expect_r1),
+            SubmissionRefusal::D66UnresolvableWorldMutatingTools { .. } => prop_assert!(!expect_r1),
+            other => prop_assert!(false, "unexpected refusal {:?}", other),
+        }
+    }
+
+    /// P3 — a WM producer with RESOLVED tools matches the R-10 contract.
+    #[test]
+    fn p3_world_mutating_resolved_matches_r10(
+        ep in effect_pattern_strategy(),
+        accept in any::<bool>(),
+        classes in proptest::collection::vec(class_strategy(), 1..5),
+    ) {
+        // Non-empty contract so R-1 never fires; the resolved classes drive R-10.
+        let mote = plain_mote(3, NdClass::WorldMutating, ep, non_empty_contract());
+        let result = validate_mote_submission(
+            &mote,
+            accept,
+            &ToolResolution::Resolved(classes.clone()),
+        );
+        let has_at_least_once = classes.iter().any(|c| matches!(c, IdempotencyClass::AtLeastOnce));
+        let should_refuse = has_at_least_once && !accept;
+        prop_assert_eq!(result.is_err(), should_refuse);
+        if let Err(err) = result {
+            prop_assert!(
+                matches!(err, SubmissionRefusal::R10AtLeastOnceWithoutAccept { .. }),
+                "a resolved WM refusal must be R-10"
+            );
+        }
+    }
+}

--- a/crates/kx-worker/tests/e2e.rs
+++ b/crates/kx-worker/tests/e2e.rs
@@ -51,9 +51,17 @@ fn storing_executor(store: Arc<LocalFsContentStore>) -> Arc<dyn MoteExecutor> {
 }
 
 async fn submit(svc: &CoordinatorService, mote: &Mote, warrant: &kx_warrant::WarrantSpec) {
+    // M1.3: register the run (idempotent) so the submit passes the
+    // registration-before-submit gate.
+    let _ = svc
+        .register_run(Request::new(kx_coordinator::proto::RegisterRunRequest {
+            recipe_fingerprint: vec![0x5au8; 32],
+        }))
+        .await;
     svc.submit_mote(Request::new(kx_coordinator::proto::SubmitMoteRequest {
         mote: Some(mote.clone().into()),
         warrant: Some(warrant.clone().into()),
+        accept_at_least_once: false,
     }))
     .await
     .unwrap();

--- a/crates/kx-worker/tests/wm_dispatch.rs
+++ b/crates/kx-worker/tests/wm_dispatch.rs
@@ -26,7 +26,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use kx_capability::{
-    idempotency_token_for, BrokerError, BrokerHandle, CapabilityBroker, EffectRequest,
+    idempotency_token_for, run_scoped_token, BrokerError, BrokerHandle, CapabilityBroker,
+    EffectRequest, INSTANCE_ID_LEN,
 };
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_coordinator::proto::coordinator_server::{Coordinator, CoordinatorServer};
@@ -218,9 +219,17 @@ async fn connect(endpoint: &str) -> WorkerClient {
 }
 
 async fn submit(svc: &CoordinatorService, mote: &Mote, warrant: &WarrantSpec) {
+    // M1.3: register the run (idempotent) so the submit passes the
+    // registration-before-submit gate.
+    let _ = svc
+        .register_run(Request::new(kx_coordinator::proto::RegisterRunRequest {
+            recipe_fingerprint: vec![0x5au8; 32],
+        }))
+        .await;
     svc.submit_mote(Request::new(kx_coordinator::proto::SubmitMoteRequest {
         mote: Some(mote.clone().into()),
         warrant: Some(warrant.clone().into()),
+        accept_at_least_once: false,
     }))
     .await
     .unwrap();
@@ -445,11 +454,19 @@ async fn w3_worker_death_after_stage_is_exactly_once() {
         .register_worker(common::WORKER_CLASS, "dying")
         .await
         .unwrap();
-    let (leased, _instance_id) = dying
+    let (leased, instance_id) = dying
         .lease_work(dying_id, common::WORKER_CLASS, 16)
         .await
         .unwrap();
     assert_eq!(leased.len(), 1, "dying worker leased the WM Mote");
+    // M1.3: the run is registered, so the live worker derives a RUN-SCOPED
+    // idempotency token from the leased `instance_id` (`run_scoped_token`). The
+    // dying worker's manual fire must use the SAME token, or the broker won't
+    // dedupe the re-fire and the world effect would happen twice.
+    let iid: [u8; INSTANCE_ID_LEN] = instance_id
+        .as_slice()
+        .try_into()
+        .expect("a registered run surfaces a 16-byte instance_id on lease");
     let id = *wm.id.as_bytes();
     dying.report_effect_staged(id, id, dying_id).await.unwrap();
     // It fired the effect (net effect #1) before crashing — the exact stage→fire→{die}
@@ -458,7 +475,7 @@ async fn w3_worker_death_after_stage_is_exactly_once() {
     let req = EffectRequest {
         payload: Vec::new(),
         pattern: wm.effect_pattern(),
-        idempotency_key: Some(idempotency_token_for(&wm)),
+        idempotency_key: Some(run_scoped_token(&iid, &wm)),
         net_scope: kx_warrant::NetScope::None,
         fs_scope: kx_warrant::FsScope::empty(),
     };


### PR DESCRIPTION
## M1.3 — wire the submission-refusal gate at `SubmitMote` (D64/D66/D98)

Closes the **M1 exit gate**: with M1.1 (run registration) + M1.2 (resolved-version metadata + run-scoped token) + this, a re-submitted recipe starts a fresh registered run, resolved versions appear as metadata, a tool-resolution miss is refused, and cross-boundary exactly-once holds under the run-scoped token.

### Changes
- **`kx-proto`** — additive `bool accept_at_least_once` on `SubmitMoteRequest` (D38 §2c opt-in; default `false` = fail-closed).
- **`kx-refusal`** (NEW leaf crate, 28→29) — the submission-refusal vocabulary extracted out of `kx-executor` so the **control-plane coordinator enforces refusals without linking the inference/llama.cpp stack** (the seam discipline). Adds `ToolResolution`, the `D66UnresolvableWorldMutatingTools` variant, and `validate_mote_submission` — the single-Mote boundary subset: R-1/R-7/R-8/R-14/R-15 + R-10 with **fail-closed-on-tool-resolution-miss** (D66: StageThenCommit is the #1 no-double-fire seam; the runtime won't admit a WM Mote whose tool it can't resolve). `kx-executor` re-exports it — its diff is the **extraction only**, no new engine logic.
- **`kx-coordinator`** — `submit_and_capture` now (1) refuses submit-before-register (`failed_precondition`), and (2) resolves the warrant once, runs `validate_mote_submission`, and maps a refusal to a structured `SUBMIT_STATUS_REJECTED` response. The resolve is shared with the M1.2 capture (resolved exactly once per fresh submit).

### Decision table (after the registration gate)
| nd_class | resolution | result |
|---|---|---|
| PURE/ROND | any | accept (D66 is WM-only; unresolved → capture skipped) |
| WM | Resolved, clean | accept + capture |
| WM | Resolved, AtLeastOnce + !accept | refuse R-10 |
| WM | Resolved, empty-contract IBC | refuse R-1 |
| WM | Unresolved | refuse D66 |

### Thesis test
`kx-scheduler` / `kx-inference` source diff **empty**; `kx-executor` diff is the refusal extraction (the first legitimate M1 executor change, per the build sequence). Canonical projection digest `a6b5c679…` **unchanged** (M1.3 is off the demo/truth path).

### Tests (D95 seven-kind)
- **unit/property** — `kx-refusal` `mote_submission` (11) + `proptest_mote_submission` (3 × 128: non-WM never D66, WM+unresolved always refused, resolved matches R-10).
- **integration/security** — `kx-coordinator/tests/submission_refusal.rs` (registration gate, D66 unregistered-tool + capability-exceeds, R-10 reject→accept, PURE accept paths).
- **exit gate** — `kx-coordinator/tests/m1_exit_gate.rs` (fresh-run-per-recipe, fingerprint round-trip, metadata, resolution-miss refused, cross-boundary exactly-once + per-run namespacing).
- **chaos/durability** — `recovery.rs`: a refused submit writes nothing across drop/reopen; the retry under a resolvable warrant commits. `kx-chaos` 50k seeds all exactly-once under the new gate.
- **scale/perf** — `stress_campaign.rs`: 3,000-Mote DAG stays linear (submit 890ms incl. per-submit resolve+capture, commit 1.28s; both ceilings asserted).
- **real-model e2e** — `a0_guard` digest non-regression + `smoke-test-with-model` (end-to-end inference, greedy determinism).

Existing submit-driving tests migrated to register-first (idempotent auto-register in `common::submit` + a `submit_unregistered` escape hatch; `sample_warrant` now grants a resolvable builtin).

Local gate green: fmt · clippy `--all-targets -D warnings` · **test 1056/0** · deny · doc `-D warnings` · ffi-link · smoke-with-model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)