### PR TITLE
perf(kx-projection): M2.1 incremental children-index — sub-linear cold re-fold (D92)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,3 +365,45 @@ jobs:
 
       - name: just smoke-test-with-model
         run: just smoke-test-with-model
+
+  # ---------------------------------------------------------------------------
+  # scale-smoke — M2.1 / D92 resume-availability gate. Folds a 25k+ Mote
+  # journal in RELEASE and asserts the incremental children-index re-fold stays
+  # ~linear (a super-linear resume is an outage). ADVISORY for now: this is NOT
+  # yet a required status check — it is promoted to required via an explicitly-
+  # authorized branch-protection PATCH once it is green on a couple of runs
+  # (Golden Rule 4). Needs the test suite green first.
+  # ---------------------------------------------------------------------------
+  scale-smoke:
+    name: scale-smoke (M2.1 incremental children-index re-fold)
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: |
+          rustup show active-toolchain
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-scale-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-scale-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Configure RUSTFLAGS for path-stripping
+        run: |
+          echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}= -Cmetadata=kortecx-v0" >> $GITHUB_ENV
+
+      - name: just scale-smoke
+        run: just scale-smoke

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ version = "0.0.1"
 dependencies = [
  "bincode",
  "blake3",
+ "criterion",
  "kx-content",
  "kx-critic-types",
  "kx-journal",

--- a/crates/kx-projection/Cargo.toml
+++ b/crates/kx-projection/Cargo.toml
@@ -27,6 +27,11 @@ tracing    = { workspace = true }
 tempfile           = { workspace = true }
 tracing-subscriber = { workspace = true }
 proptest           = { workspace = true }
+criterion          = { workspace = true }
+
+[[bench]]
+name    = "children_index"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/kx-projection/benches/children_index.rs
+++ b/crates/kx-projection/benches/children_index.rs
@@ -1,0 +1,120 @@
+//! Children-index throughput — the M2.1 incremental-index hot paths (run with
+//! `cargo bench -p kx-projection`).
+//!
+//! Two axes, both on a **hubless** chain DAG (bounded fan-in/out) so the
+//! measurement reflects the per-op incremental cost rather than a degenerate
+//! star:
+//! - `fold_committed` — the recovery re-fold: N `Committed` entries folded into
+//!   a fresh `Projection` (the D92 resume path);
+//! - `register` — N `register_mote` declarations (the live submission path).
+//!
+//! Before M2.1 each fold/register ran a full O(n) `rebuild_children_index`, so
+//! the whole loop was O(n^2); the incremental update makes it O(n). This bench
+//! is the criterion regression guard behind `bench-no-regress` (D95).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    missing_docs
+)]
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use kx_content::ContentRef;
+use kx_journal::{JournalEntry, ParentEntry};
+use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use kx_projection::{Projection, RegisterMote};
+use smallvec::SmallVec;
+
+fn mid_n(i: u32) -> MoteId {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&i.to_le_bytes());
+    MoteId::from_bytes(bytes)
+}
+
+/// Hubless adjacency: mote i depends on i-1 (Data) and i-2 (Control) — fan-out
+/// bounded at 2, so children-index inserts stay O(1).
+fn parents_of(i: u32) -> Vec<ParentRef> {
+    let mut ps = Vec::new();
+    if i >= 1 {
+        ps.push(ParentRef {
+            parent_id: mid_n(i - 1),
+            edge: EdgeMeta::data(),
+        });
+    }
+    if i >= 2 {
+        ps.push(ParentRef {
+            parent_id: mid_n(i - 2),
+            edge: EdgeMeta::control(),
+        });
+    }
+    ps
+}
+
+fn committed(i: u32) -> JournalEntry {
+    let pe: SmallVec<[ParentEntry; 4]> = parents_of(i)
+        .iter()
+        .map(ParentEntry::from_parent_ref)
+        .collect();
+    JournalEntry::Committed {
+        mote_id: mid_n(i),
+        idempotency_key: *mid_n(i).as_bytes(),
+        seq: u64::from(i) + 1,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([7u8; 32]),
+        parents: pe,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+fn register(i: u32) -> RegisterMote {
+    RegisterMote {
+        mote_id: mid_n(i),
+        nd_class: NdClass::Pure,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        parents: parents_of(i).into_iter().collect(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+    }
+}
+
+fn bench_children_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("children_index");
+    for &n in &[1_000u32, 5_000, 10_000] {
+        group.throughput(Throughput::Elements(u64::from(n)));
+
+        group.bench_with_input(BenchmarkId::new("fold_committed", n), &n, |b, &n| {
+            let entries: Vec<JournalEntry> = (0..n).map(committed).collect();
+            b.iter_batched(
+                Projection::new,
+                |mut p| {
+                    for e in &entries {
+                        p.fold(e).unwrap();
+                    }
+                    p
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("register", n), &n, |b, &n| {
+            let regs: Vec<RegisterMote> = (0..n).map(register).collect();
+            b.iter_batched(
+                Projection::new,
+                |mut p| {
+                    for r in &regs {
+                        p.register_mote(r.clone());
+                    }
+                    p
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_children_index);
+criterion_main!(benches);

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -160,16 +160,19 @@ impl Projection {
     /// workflow author may update parents before submission; the journal-side
     /// dedupe-by-key path is the authoritative arbiter for identity equality).
     pub fn register_mote(&mut self, reg: RegisterMote) {
-        let info = self.state.moteinfo_mut(&reg.mote_id);
-        info.declared = Some(DeclaredInfo {
+        let declared = DeclaredInfo {
             nd_class: reg.nd_class,
             effect_pattern: reg.effect_pattern,
             critic_for: reg.critic_for,
             is_topology_shaper: reg.is_topology_shaper,
             parents: reg.parents,
             warrant_ref: reg.warrant_ref,
-        });
-        self.state.rebuild_children_index();
+        };
+        // D92 / M2.1: incremental children-index update (was a full O(n)
+        // `rebuild_children_index`). `set_declared` captures the prior declared
+        // parent set before overwrite so a re-registration that changes parents
+        // removes the stale edges.
+        self.state.set_declared(reg.mote_id, declared);
     }
 
     /// Apply one journal entry. **Caller must invoke in `seq` order**; the fold is
@@ -204,6 +207,14 @@ impl Projection {
                 mote_def_hash,
                 ..
             } => {
+                // D92 / M2.1: capture the child's CURRENT effective parents
+                // (the edges it contributes to the index now) BEFORE setting
+                // `committed`, so the incremental re-index can diff old→new. For
+                // a Mote already declared this is the declared set (a no-op
+                // re-derive, declared keeps precedence); for a committed-without-
+                // declare Mote (pure recovery) it is empty and the committed
+                // parents are inserted fresh.
+                let old_effective = self.state.parents_of_id(mote_id);
                 let info = self.state.moteinfo_mut(mote_id);
                 if info.committed.is_some() {
                     return Err(ProjectionError::DuplicateCommitted(*mote_id));
@@ -218,10 +229,12 @@ impl Projection {
                     repudiated: false,
                 });
                 self.state.last_seq = self.state.last_seq.max(*seq);
-                // Rebuild children index since this Committed entry may introduce
-                // parent→child edges not previously visible (e.g., entry written
-                // for a Mote that wasn't pre-registered).
-                self.state.rebuild_children_index();
+                // D92 / M2.1: incrementally fold THIS Mote's edges into the
+                // reverse index (was a full O(n) `rebuild_children_index` per
+                // commit — the resume-availability O(n²) wall). Reads parents via
+                // `parents_of_id` (declared precedence + the same `to_parent_ref`
+                // filter as the rebuild) and diffs against `old_effective`.
+                self.state.index_committed(*mote_id, &old_effective);
 
                 // **P1.11 / D48 + D49 + PR 11.5 KG-1-close.** Topology
                 // materializer hook. If a materializer is wired AND the

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -268,8 +268,16 @@ impl State {
         SmallVec::new()
     }
 
-    /// Rebuild the child→parent reverse index from the declared-or-committed
-    /// adjacency. Cheap given typical workflow sizes; recomputed on graph mutation.
+    /// Rebuild the entire child→parent reverse index from scratch — O(n) over
+    /// every Mote. **No longer on the hot path** (D92, M2.1): `set_declared` and
+    /// the `Committed` fold now use the incremental [`Self::reindex_child_edges`]
+    /// helper, which touches only the edges of the Mote it introduces. This full
+    /// rebuild is retained as the **differential oracle** — the
+    /// `debug_assert!` in `reindex_child_edges` compares the incrementally-
+    /// maintained index against a fresh rebuild on every mutation, and the
+    /// inline unit + property tests assert byte-equality. Compiled only under
+    /// `test` / `debug_assertions`.
+    #[cfg(any(test, debug_assertions))]
     pub(crate) fn rebuild_children_index(&mut self) {
         let mut idx: BTreeMap<MoteId, Vec<(MoteId, EdgeMeta)>> = BTreeMap::new();
         let ids: Vec<MoteId> = self.motes.keys().copied().collect();
@@ -283,5 +291,242 @@ impl State {
             v.sort_by(|a, b| a.0.cmp(&b.0));
         }
         self.children = idx;
+    }
+
+    /// Insert one `(child, edge)` into `parent`'s adjacency list, preserving the
+    /// sort-by-child-`MoteId` order the cascade walk
+    /// ([`crate::helpers::transitive_consumers_impl`], the D22 poison-cascade)
+    /// depends on. `partition_point(<= child)` returns the index one past the
+    /// last entry whose child id is `<= child`, so the insert lands **after**
+    /// any existing equal-child entry — matching the *stable* `sort_by(child)`
+    /// in [`Self::rebuild_children_index`] byte-for-byte (the only source of
+    /// equal-child entries is a child that declares the SAME parent twice with
+    /// different `EdgeMeta`, e.g. a Data and a Control edge). Not idempotent on
+    /// its own; callers go through [`Self::reindex_child_edges`], which clears a
+    /// child's existing entries first.
+    fn insert_child_edge(&mut self, parent: MoteId, child: MoteId, edge: EdgeMeta) {
+        let v = self.children.entry(parent).or_default();
+        let pos = v.partition_point(|probe| probe.0 <= child);
+        v.insert(pos, (child, edge));
+    }
+
+    /// Remove every entry for `child` from `parent`'s adjacency list, dropping
+    /// the parent key entirely if its list becomes empty — a from-scratch
+    /// rebuild never leaves an empty-`Vec` key, so this keeps the map
+    /// byte-identical to one.
+    fn remove_child_entries(&mut self, parent: MoteId, child: MoteId) {
+        if let Some(v) = self.children.get_mut(&parent) {
+            v.retain(|(c, _)| *c != child);
+            if v.is_empty() {
+                self.children.remove(&parent);
+            }
+        }
+    }
+
+    /// Incrementally re-derive `child_id`'s outgoing edges in the reverse index
+    /// after a state change — the O(parents·k) replacement for the per-mutation
+    /// O(n) [`Self::rebuild_children_index`] (D92, M2.1).
+    ///
+    /// `old_effective` is [`Self::parents_of_id`] captured **before** the change
+    /// — the edges `child_id` currently contributes to the index. This method
+    /// removes exactly those, then inserts `child_id`'s NEW effective edges
+    /// (`parents_of_id` read after the change). Because a child's effective
+    /// parents change only via the declared-vs-committed precedence (a fresh
+    /// `set_declared`, or a `Committed` for a Mote with no declared info), the
+    /// before/after diff captures every edge transition the full rebuild would —
+    /// including the register-after-commit case where the source flips from
+    /// committed parents to declared parents. Inserts preserve parents-list
+    /// order (stable, matching the rebuild). A `debug_assert!` verifies the
+    /// result equals a full rebuild on every call (compiled out in release).
+    fn reindex_child_edges(&mut self, child_id: MoteId, old_effective: &[(MoteId, EdgeMeta)]) {
+        for (parent_id, _) in old_effective {
+            self.remove_child_entries(*parent_id, child_id);
+        }
+        for (parent_id, edge) in self.parents_of_id(&child_id) {
+            self.insert_child_edge(parent_id, child_id, edge);
+        }
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            self.children_index_matches_full_rebuild(),
+            "M2.1 invariant: incremental children index diverged from full rebuild"
+        );
+    }
+
+    /// Set (overwrite) the declared info for `mote_id`, then incrementally update
+    /// the reverse index. Captures the child's CURRENT effective parents (which
+    /// may be declared- OR committed-derived) **before** the overwrite, so a
+    /// re-registration that drops/changes a parent — or a registration that
+    /// arrives after a committed-without-declare and flips the precedence to the
+    /// new declared set — removes the stale edges (the full rebuild handled this
+    /// implicitly).
+    pub(crate) fn set_declared(&mut self, mote_id: MoteId, declared: DeclaredInfo) {
+        let old_effective = self.parents_of_id(&mote_id);
+        self.moteinfo_mut(&mote_id).declared = Some(declared);
+        self.reindex_child_edges(mote_id, &old_effective);
+    }
+
+    /// Fold a `Committed` entry's edges into the reverse index incrementally.
+    /// `old_effective` is the child's effective parents captured **before**
+    /// `committed` was set. When the Mote was already declared, `parents_of_id`
+    /// keeps returning the declared set (precedence) so this is a no-op re-derive;
+    /// when it was committed-without-declare (pure `from_journal` recovery), the
+    /// effective set flips from empty to the committed parents and those edges
+    /// are inserted.
+    pub(crate) fn index_committed(
+        &mut self,
+        mote_id: MoteId,
+        old_effective: &[(MoteId, EdgeMeta)],
+    ) {
+        self.reindex_child_edges(mote_id, old_effective);
+    }
+
+    /// Differential oracle: does the incrementally-maintained `children` index
+    /// equal a from-scratch [`Self::rebuild_children_index`]? Used ONLY inside
+    /// the `debug_assert!` in [`Self::reindex_child_edges`] (compiled out in
+    /// release — the scale test + bench run `--release` and pay zero). Clones to
+    /// avoid mutating `self`. Compiled under `test` too so the inline + property
+    /// tests can use it as an explicit oracle even under `cargo test --release`.
+    #[cfg(any(test, debug_assertions))]
+    fn children_index_matches_full_rebuild(&self) -> bool {
+        let mut oracle = self.clone();
+        oracle.rebuild_children_index();
+        oracle.children == self.children
+    }
+}
+
+#[cfg(test)]
+mod incremental_index_tests {
+    use super::{
+        ContentRef, DeclaredInfo, EdgeMeta, EffectPattern, MoteId, NdClass, ParentRef, SmallVec,
+        State,
+    };
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    fn parent(id: u8, edge: EdgeMeta) -> ParentRef {
+        ParentRef {
+            parent_id: mid(id),
+            edge,
+        }
+    }
+
+    fn declared_with(parents: SmallVec<[ParentRef; 4]>) -> DeclaredInfo {
+        DeclaredInfo {
+            nd_class: NdClass::Pure,
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            parents,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        }
+    }
+
+    fn parents(refs: &[ParentRef]) -> SmallVec<[ParentRef; 4]> {
+        refs.iter().copied().collect()
+    }
+
+    #[test]
+    fn insert_keeps_children_sorted_by_child_id() {
+        let mut s = State::default();
+        s.insert_child_edge(mid(1), mid(30), EdgeMeta::data());
+        s.insert_child_edge(mid(1), mid(10), EdgeMeta::data());
+        s.insert_child_edge(mid(1), mid(20), EdgeMeta::control());
+        let ids: Vec<u8> = s.children[&mid(1)]
+            .iter()
+            .map(|(c, _)| c.as_bytes()[0])
+            .collect();
+        assert_eq!(
+            ids,
+            vec![10, 20, 30],
+            "sorted by child MoteId regardless of insert order"
+        );
+    }
+
+    #[test]
+    fn insert_duplicate_child_appends_after_equal_stable() {
+        // The only equal-child case: the same parent declared twice with
+        // different edge meta (a Data and a Control edge to one parent).
+        let mut s = State::default();
+        s.insert_child_edge(mid(1), mid(10), EdgeMeta::data());
+        s.insert_child_edge(mid(1), mid(10), EdgeMeta::control());
+        assert_eq!(
+            s.children[&mid(1)],
+            vec![(mid(10), EdgeMeta::data()), (mid(10), EdgeMeta::control())],
+            "stable: first-inserted precedes second, matching rebuild's stable sort"
+        );
+    }
+
+    #[test]
+    fn remove_drops_all_matching_and_empties_key() {
+        let mut s = State::default();
+        s.insert_child_edge(mid(1), mid(10), EdgeMeta::data());
+        s.insert_child_edge(mid(1), mid(10), EdgeMeta::control());
+        s.insert_child_edge(mid(1), mid(20), EdgeMeta::data());
+        s.remove_child_entries(mid(1), mid(10));
+        assert_eq!(s.children[&mid(1)], vec![(mid(20), EdgeMeta::data())]);
+        s.remove_child_entries(mid(1), mid(20));
+        assert!(
+            !s.children.contains_key(&mid(1)),
+            "empty parent key dropped to stay byte-identical to a fresh rebuild"
+        );
+    }
+
+    #[test]
+    fn set_declared_matches_full_rebuild() {
+        let mut s = State::default();
+        s.set_declared(
+            mid(10),
+            declared_with(parents(&[
+                parent(1, EdgeMeta::data()),
+                parent(2, EdgeMeta::control()),
+            ])),
+        );
+        s.set_declared(
+            mid(20),
+            declared_with(parents(&[parent(1, EdgeMeta::data())])),
+        );
+        assert_eq!(
+            s.children[&mid(1)],
+            vec![(mid(10), EdgeMeta::data()), (mid(20), EdgeMeta::data())]
+        );
+        assert_eq!(s.children[&mid(2)], vec![(mid(10), EdgeMeta::control())]);
+        assert!(s.children_index_matches_full_rebuild());
+    }
+
+    #[test]
+    fn re_registration_with_changed_parents_removes_stale_edge() {
+        let mut s = State::default();
+        s.set_declared(
+            mid(10),
+            declared_with(parents(&[parent(1, EdgeMeta::data())])),
+        );
+        assert!(s.children.contains_key(&mid(1)));
+        // Re-register child 10 with a DIFFERENT parent (2 replaces 1).
+        s.set_declared(
+            mid(10),
+            declared_with(parents(&[parent(2, EdgeMeta::data())])),
+        );
+        assert!(
+            !s.children.contains_key(&mid(1)),
+            "stale edge under the dropped parent removed"
+        );
+        assert_eq!(s.children[&mid(2)], vec![(mid(10), EdgeMeta::data())]);
+        assert!(s.children_index_matches_full_rebuild());
+    }
+
+    #[test]
+    fn re_register_same_parents_is_idempotent() {
+        let mut s = State::default();
+        let p = parents(&[parent(1, EdgeMeta::data()), parent(2, EdgeMeta::control())]);
+        s.set_declared(mid(10), declared_with(p.clone()));
+        let before = s.children.clone();
+        s.set_declared(mid(10), declared_with(p));
+        assert_eq!(
+            s.children, before,
+            "re-registering identical parents is a no-op on the index"
+        );
+        assert!(s.children_index_matches_full_rebuild());
     }
 }

--- a/crates/kx-projection/tests/incremental_children_index.rs
+++ b/crates/kx-projection/tests/incremental_children_index.rs
@@ -1,0 +1,339 @@
+// Integration-test file: compiled as a separate crate from the host lib;
+// inherits the workspace `[lints]` deny on `unwrap_used` / `expect_used` but
+// tests legitimately use `.unwrap()` for fixture construction. The `pedantic`
+// group is allowed for the usual small-int-cast / helper-after-let friction.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! M2.1 — incremental children-index (D92): differential equivalence,
+//! recovery-parity, and sub-linear re-fold.
+//!
+//! The crate-internal `debug_assert!` in `State::reindex_child_edges` compares
+//! the incrementally-maintained children index against a from-scratch
+//! `rebuild_children_index` on **every** mutation, and it is active in every
+//! debug test build. So the tests below — which drive the public
+//! `register_mote` + `fold` surface over diverse, colliding traces — exercise
+//! that equivalence oracle for free: any divergence between the incremental
+//! path and the full rebuild panics the test. On top of it they assert the
+//! public-API invariants the cascade walk and recovery depend on:
+//!
+//! 1. children lists stay **sorted by child `MoteId`** (the D22 poison-cascade
+//!    BFS order),
+//! 2. a pure-recovery re-fold is **deterministic** (re-folding the same
+//!    committed entries yields a byte-identical index),
+//! 3. the live (register-then-commit) path and the pure-recovery (fold-only)
+//!    path build the **same committed-edge index**,
+//! 4. (`#[ignore]`, `--release`) the re-fold is **sub-linear** — the D92
+//!    resume-availability invariant: a super-linear resume is an outage.
+
+use std::time::Instant;
+
+use kx_content::ContentRef;
+use kx_journal::{JournalEntry, ParentEntry};
+use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use kx_projection::{Projection, RegisterMote};
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn mid(b: u8) -> MoteId {
+    MoteId::from_bytes([b; 32])
+}
+
+/// A distinct `MoteId` per `u32` (the first 4 bytes carry `i`), for the
+/// large-N scale test where a single byte would collide.
+fn mid_n(i: u32) -> MoteId {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&i.to_le_bytes());
+    MoteId::from_bytes(bytes)
+}
+
+fn pref(id: MoteId, edge: EdgeMeta) -> ParentRef {
+    ParentRef {
+        parent_id: id,
+        edge,
+    }
+}
+
+fn register(id: MoteId, parents: &[ParentRef]) -> RegisterMote {
+    RegisterMote {
+        mote_id: id,
+        nd_class: NdClass::Pure,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        parents: parents.iter().copied().collect(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+    }
+}
+
+fn committed_with(id: MoteId, seq: u64, parents: &[ParentRef]) -> JournalEntry {
+    let pe: SmallVec<[ParentEntry; 4]> = parents.iter().map(ParentEntry::from_parent_ref).collect();
+    JournalEntry::Committed {
+        mote_id: id,
+        idempotency_key: *id.as_bytes(),
+        seq,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([7u8; 32]),
+        parents: pe,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Targeted cases — the requirement matrix from the M2.1 plan.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declared_then_committed_no_duplicate() {
+    let mut p = Projection::new();
+    p.register_mote(register(mid(10), &[pref(mid(1), EdgeMeta::data())]));
+    p.fold(&committed_with(
+        mid(10),
+        1,
+        &[pref(mid(1), EdgeMeta::data())],
+    ))
+    .unwrap();
+    assert_eq!(
+        p.children_of(&mid(1)),
+        vec![(mid(10), EdgeMeta::data())],
+        "declared-then-committed must not duplicate the edge"
+    );
+}
+
+#[test]
+fn committed_without_declare_recovery_shape() {
+    // Pure-recovery shape: a Committed folded with no prior register (the
+    // `from_journal` path never calls register_mote).
+    let mut p = Projection::new();
+    p.fold(&committed_with(
+        mid(10),
+        1,
+        &[pref(mid(1), EdgeMeta::data())],
+    ))
+    .unwrap();
+    assert_eq!(p.children_of(&mid(1)), vec![(mid(10), EdgeMeta::data())]);
+}
+
+#[test]
+fn re_registration_changing_parents_removes_stale_edge() {
+    let mut p = Projection::new();
+    p.register_mote(register(mid(10), &[pref(mid(1), EdgeMeta::data())]));
+    assert_eq!(p.children_of(&mid(1)), vec![(mid(10), EdgeMeta::data())]);
+    // Re-register child 10 with a DIFFERENT parent.
+    p.register_mote(register(mid(10), &[pref(mid(2), EdgeMeta::data())]));
+    assert!(
+        p.children_of(&mid(1)).is_empty(),
+        "stale edge under the dropped parent must be removed"
+    );
+    assert_eq!(p.children_of(&mid(2)), vec![(mid(10), EdgeMeta::data())]);
+}
+
+#[test]
+fn duplicate_parent_two_edges_kept_stable() {
+    // The ONLY equal-child case: a child declaring the same parent twice with
+    // different edge meta (a Data and a Control edge). The full rebuild keeps
+    // both (push + stable sort), so the incremental path must too.
+    let mut p = Projection::new();
+    p.register_mote(register(
+        mid(10),
+        &[
+            pref(mid(1), EdgeMeta::data()),
+            pref(mid(1), EdgeMeta::control()),
+        ],
+    ));
+    assert_eq!(
+        p.children_of(&mid(1)),
+        vec![(mid(10), EdgeMeta::data()), (mid(10), EdgeMeta::control()),],
+        "both edges kept, in parents-list order (stable)"
+    );
+}
+
+#[test]
+fn live_and_recovery_paths_build_identical_index() {
+    // Build a small DAG two ways and compare children_of for every parent:
+    //   LIVE:     register each child (declared parents) then fold its Committed.
+    //   RECOVERY: fold only the Committed entries (parents_in_entry).
+    let edges: &[(u8, &[(u8, EdgeMeta)])] = &[
+        (1, &[]),
+        (2, &[(1, EdgeMeta::data())]),
+        (3, &[(1, EdgeMeta::control())]),
+        (4, &[(2, EdgeMeta::data()), (3, EdgeMeta::data())]),
+    ];
+    let mut live = Projection::new();
+    let mut rec = Projection::new();
+    for (seq, (child, ps)) in (1u64..).zip(edges.iter()) {
+        let prefs: Vec<ParentRef> = ps.iter().map(|(pp, e)| pref(mid(*pp), *e)).collect();
+        live.register_mote(register(mid(*child), &prefs));
+        live.fold(&committed_with(mid(*child), seq, &prefs))
+            .unwrap();
+        rec.fold(&committed_with(mid(*child), seq, &prefs)).unwrap();
+    }
+    for parent in [1u8, 2, 3, 4] {
+        assert_eq!(
+            live.children_of(&mid(parent)),
+            rec.children_of(&mid(parent)),
+            "live vs recovery children_of disagree for parent {parent}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property test — diverse traces drive the internal differential oracle.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum Op {
+    Register { child: u8, parents: Vec<ParentRef> },
+    Commit { child: u8, parents: Vec<ParentRef> },
+}
+
+fn arb_parent() -> impl Strategy<Value = ParentRef> {
+    (0u8..8, 0u8..3).prop_map(|(pid, kind)| {
+        let edge = match kind {
+            0 => EdgeMeta::data(),
+            1 => EdgeMeta::control(),
+            _ => EdgeMeta::control_non_cascading(),
+        };
+        pref(mid(pid), edge)
+    })
+}
+
+fn arb_op() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        (8u8..16, prop::collection::vec(arb_parent(), 0..3))
+            .prop_map(|(child, parents)| Op::Register { child, parents }),
+        (8u8..16, prop::collection::vec(arb_parent(), 0..3))
+            .prop_map(|(child, parents)| Op::Commit { child, parents }),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Drive arbitrary {register, re-register-with-changed-parents,
+    /// commit-with-declare, commit-without-declare} traces. The internal
+    /// `debug_assert!` (incremental == full rebuild) fires on every op; on top
+    /// of it we assert children lists stay sorted and recovery is deterministic.
+    #[test]
+    fn prop_index_sorted_and_recovery_deterministic(ops in prop::collection::vec(arb_op(), 0..40)) {
+        // child ids live in 8..16, parents in 0..8 — disjoint, so a child is
+        // never its own parent and parent/child collide across motes.
+        let mut p = Projection::new();
+        let mut committed: Vec<JournalEntry> = Vec::new();
+        let mut committed_ids: std::collections::BTreeSet<u8> = std::collections::BTreeSet::new();
+        let mut seq = 1u64;
+        for op in &ops {
+            match op {
+                Op::Register { child, parents } => {
+                    p.register_mote(register(mid(*child), parents));
+                }
+                Op::Commit { child, parents } => {
+                    // At most one Committed per id (a second is a journal-impl
+                    // bug — DuplicateCommitted — not the index's concern).
+                    if committed_ids.insert(*child) {
+                        let e = committed_with(mid(*child), seq, parents);
+                        p.fold(&e).unwrap();
+                        committed.push(e);
+                        seq += 1;
+                    }
+                }
+            }
+        }
+
+        // INVARIANT 1: every children_of list is sorted by child MoteId.
+        for parent in 0u8..16 {
+            let kids = p.children_of(&mid(parent));
+            let ids: Vec<MoteId> = kids.iter().map(|(c, _)| *c).collect();
+            let mut sorted = ids.clone();
+            sorted.sort_unstable();
+            prop_assert_eq!(ids, sorted, "children_of must be sorted by child MoteId for parent {}", parent);
+        }
+
+        // INVARIANT 2: a pure-recovery re-fold of the committed entries is
+        // deterministic (byte-identical index across two independent folds).
+        let mut rec_a = Projection::new();
+        let mut rec_b = Projection::new();
+        for e in &committed { rec_a.fold(e).unwrap(); }
+        for e in &committed { rec_b.fold(e).unwrap(); }
+        for parent in 0u8..16 {
+            prop_assert_eq!(
+                rec_a.children_of(&mid(parent)),
+                rec_b.children_of(&mid(parent)),
+                "recovery re-fold must be deterministic for parent {}", parent
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scale test (`#[ignore]`) — the D92 resume-availability gate.
+//   cargo test -p kx-projection --release --test incremental_children_index \
+//     -- --ignored --nocapture --test-threads=1
+// MUST run `--release`: in a debug build the differential `debug_assert!`
+// re-imposes the O(n^2) full rebuild on every fold, so the ratio assertion is
+// skipped (and only printed) under `debug_assertions`.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "scale: run --release --test incremental_children_index -- --ignored --nocapture"]
+fn scale_refold_is_sub_linear() {
+    const SIZES: &[u32] = &[1_000, 5_000, 10_000, 25_000];
+    let mut per_mote_us: Vec<f64> = Vec::with_capacity(SIZES.len());
+
+    for &n in SIZES {
+        // A wide-but-HUBLESS DAG: mote i depends on i-1 (Data) and, for i>=2,
+        // also i-2 (Control). Bounded fan-in (<=2) and fan-out (<=2) — no hub,
+        // so each children-index insert is O(1) and a correct incremental fold
+        // is O(n). (A hub/star is the known residual addressed by Option B in a
+        // follow-up; this test pins the common-case linear scaling.)
+        let mut entries: Vec<JournalEntry> = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            let mut ps: Vec<ParentRef> = Vec::new();
+            if i >= 1 {
+                ps.push(pref(mid_n(i - 1), EdgeMeta::data()));
+            }
+            if i >= 2 {
+                ps.push(pref(mid_n(i - 2), EdgeMeta::control()));
+            }
+            entries.push(committed_with(mid_n(i), u64::from(i) + 1, &ps));
+        }
+
+        let start = Instant::now();
+        let mut p = Projection::new();
+        for e in &entries {
+            p.fold(e).unwrap();
+        }
+        let elapsed = start.elapsed();
+        assert_eq!(p.committed_count(), n as usize, "all motes committed");
+
+        let us = elapsed.as_secs_f64() * 1e6;
+        let per = us / f64::from(n);
+        per_mote_us.push(per);
+        eprintln!(
+            "n={n:>6}  fold={:>9.2}ms  per_mote={per:>7.3}us",
+            us / 1000.0
+        );
+    }
+
+    let ratio = per_mote_us.last().unwrap() / per_mote_us.first().unwrap();
+    eprintln!("per-Mote re-fold cost ratio (25k/1k) = {ratio:.2}  (quadratic would be ~25x)");
+
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "NOTE: debug build — the differential oracle makes the fold O(n^2); \
+             ratio assertion skipped. Re-run with --release for the real gate."
+        );
+    } else {
+        // Per-Mote cost must stay ~flat (linear total). A quadratic fold makes
+        // per-Mote grow ~25x from 1k->25k; allow a generous 8x for the log
+        // factor + cache effects and still catch quadratic by a wide margin.
+        assert!(
+            ratio < 8.0,
+            "re-fold per-Mote cost grew {ratio:.1}x (1k->25k) — super-linear; \
+             the D92 resume-availability invariant is violated"
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ check: fmt-check clippy test
 # Exact mirror of the CI workflow's gates (in dependency order). Runs every
 # job .github/workflows/ci.yml runs in parallel, here sequentially. Modify
 # this recipe in lock-step with ci.yml.
-ci: fmt-check clippy test deny doc ffi-link check-reproducible
+ci: fmt-check clippy test deny doc ffi-link check-reproducible scale-smoke
 
 # Verify code is formatted per rustfmt.toml. Fails on any drift.
 fmt-check:
@@ -97,6 +97,18 @@ check-reproducible:
 # need network access.
 smoke-test-with-model:
     cargo test -p kx-llamacpp --features model-smoke-test -- --nocapture
+
+# ============================================================================
+# Scale / performance gate
+# ============================================================================
+
+# Scale smoke (M2.1 / D92 — the resume-availability invariant): fold a 25k+
+# Mote journal in RELEASE and assert the incremental children-index re-fold
+# stays ~linear (a super-linear resume is an outage, and resume IS the product).
+# `--release` is REQUIRED — in a debug build the differential oracle re-imposes
+# the O(n^2) full rebuild on every fold and the ratio assertion is skipped.
+scale-smoke:
+    cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
 
 # ============================================================================
 # Preflight diagnostic


### PR DESCRIPTION
## What & why

The next roadmap step (**M2** — mid-failure resume + snapshot-the-fold) opens with **M2.1**, the highest-severity scalability item (pivot-v2 Risk #1). Recovery is a **pure fold of the journal**, and the fold called `rebuild_children_index` — a **full O(n) adjacency rebuild** — on *every* `register_mote` and *every* `Committed` entry. Over a run that is **O(n²)**, super-linear past ~10k Motes. A super-linear resume is an outage, and **resume IS the product**.

This makes the cold re-fold sub-linear, **provably bit-identical** to the prior behavior.

## Pre-flight risk analysis (Golden Rule 8)

- **(a) Breaks if live?** Idempotence (re-fold), determinism (cascade BFS order), re-registration-with-changed-parents, and the register-after-commit precedence flip. Guarded by an always-on differential `debug_assert!` (incremental == full rebuild) + a differential proptest. *The oracle caught a real register-after-commit divergence during development — now fixed by diffing effective parents before/after each mutation.*
- **(b) Performance?** Removes the dominant recovery cost. Per-commit O(n) → O(parents·log k). Residual: single-parent hub fan-out stays O(k)/insert — a known, bounded residual addressable later by switching the inner `Vec` to a `BTreeMap` (its own PR).
- **(c) Security?** No new surface — crate-private, additive, no new deserialization; inherits the existing `to_parent_ref` filter via `parents_of_id`. Poison-cascade correctness guarded by the differential proptest + the kx-chaos repudiation-cascade sweep.

## Implementation (crate-private to `kx-projection`; additive; no schema bump, no public-API change)

- `reindex_child_edges(child, old_effective)` — removes the child's old effective edges (`parents_of_id` captured *before* the mutation) and inserts the new ones in **stable sort-by-child-MoteId** order (`partition_point`), preserving the D22 poison-cascade BFS order byte-for-byte.
- `set_declared` / `index_committed` capture `old_effective` before mutating, so re-registration and the register-after-commit precedence flip both drop stale edges exactly as the full rebuild would.
- `rebuild_children_index` retained as a **differential oracle** — `debug_assert!` compares incremental vs rebuild on every mutation (active in all debug tests; compiled out in release).

**Result:** 25k-Mote recovery re-fold = **16.8 ms**; per-Mote cost **flat at ~0.7µs** across 1k→25k (ratio **0.78**; quadratic would be ~25×). **O(n²) → O(n).**

## Tests (D95 kinds)

- Inline unit tests for the index helpers.
- New `tests/incremental_children_index.rs`: differential **proptest** (256 cases), targeted requirement-matrix cases, and an `#[ignore]` **scale test** asserting ~linear re-fold.
- New criterion **bench** `benches/children_index.rs`.
- Regression: kx-chaos 2048-seed exit-gate sweep, `cold_refold_topology` (R49 P1–P4), `cross_product` (9-cell), `dod` — all green.

## CI

- New **advisory** `scale-smoke` job + `just scale-smoke` recipe (wired into `just ci`). Promotion to a *required* status check is a separate, explicitly-authorized branch-protection step.

## Gates (local)

fmt · clippy `-D warnings` · `test --workspace` (184 bins) · cargo-deny · doc `-D warnings` · **I1.c byte-determinism** (with CI RUSTFLAGS) · **scale-smoke** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)