### PR TITLE
build(just): make check-reproducible self-contained — default the I1.c RUSTFLAGS

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,6 +77,14 @@ ffi-link:
 check-reproducible:
     #!/usr/bin/env bash
     set -euo pipefail
+    # I1.c is path- + metadata-sensitive: without pinned crate metadata and a
+    # stripped absolute workspace path, two clean builds embed path-dependent
+    # bytes and differ. CI exports these in $GITHUB_ENV before calling this
+    # recipe; locally we DEFAULT them (only if unset) so `just ci` / `just
+    # check-reproducible` reproduce CI's result without a manual export. CI's
+    # own value (using $GITHUB_WORKSPACE) is preserved when already set.
+    : "${RUSTFLAGS:=--remap-path-prefix={{justfile_directory()}}= -Cmetadata=kortecx-v0}"
+    export RUSTFLAGS
     cargo clean
     cargo build --release --workspace
     find target/release -maxdepth 1 -type f \( -name "*.rlib" -o -name "*.a" \) -print0 \


### PR DESCRIPTION
## Problem (flagged by Golden Rule 8 during M2.1)

The `check-reproducible` recipe runs two clean release builds and diffs them, but does **not** set the path-strip + metadata-pin RUSTFLAGS itself — it relies on the caller's environment. CI's `reproducible` job exports `--remap-path-prefix=$GITHUB_WORKSPACE= -Cmetadata=kortecx-v0` before invoking the recipe (so CI passes), but a bare local `just ci` / `just check-reproducible` **without that manual export embeds path-dependent crate metadata and fails I1.c every time** — even on a clean `main`. The local gate never actually mirrored CI.

During M2.1, a bare local `check-reproducible` reported 12 files differing (incl. `libkx_projection.rlib` and `libkx_worker.rlib`); re-running with the CI RUSTFLAGS produced bit-identical builds — confirming the gap is environmental, not a code regression.

## Fix

Default `RUSTFLAGS` inside the recipe (only when unset) to the same value CI uses, with `{{justfile_directory()}}` for the absolute workspace path:

```
: "${RUSTFLAGS:=--remap-path-prefix={{justfile_directory()}}= -Cmetadata=kortecx-v0}"
export RUSTFLAGS
```

CI's own value (using `$GITHUB_WORKSPACE`) is **preserved when already set**, so CI behavior is unchanged; local runs now reproduce CI's bit-identical result.

## Scope / risk

`justfile`-only; no code/schema/API change. CI `reproducible` job behavior unchanged (RUSTFLAGS already set there). Verified: the recipe's rendered default equals the exact flag string already proven to give bit-identical builds during M2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)