### PR TITLE
docs: ARCHITECTURE + CONTRIBUTING + GLOSSARY for contributor approachability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,157 @@
+# Architecture
+
+A map of the kortecx runtime for contributors. Read [README.md](README.md) first
+for *what* kortecx is and *why*; this document is *how it's built* — the crates,
+how they stack, how a step flows through the system, and where the extension
+points are. Pair it with [GLOSSARY.md](GLOSSARY.md) for the vocabulary.
+
+> Status: early development. Internals are real and tested; interfaces will move
+> before 1.0.
+
+## The one-paragraph model
+
+kortecx is an **execution kernel** for AI agents. The unit of work is a **Mote** —
+one step, content-addressed by its definition + inputs, so identical work has an
+identical identity. The single source of truth is an append-only **journal**: the
+runtime never holds authoritative state in memory, it *appends facts* (proposed,
+committed, failed, …) to the log. All live state is a **projection** — a pure
+*fold* of the journal, re-derived from scratch on restart. That is what makes the
+runtime durable: a crash loses no truth, because the truth is the log, and
+recovery is just folding it again. A step that changes the outside world is
+driven through a **commit protocol** that records intent before it acts, so the
+effect lands **exactly once** even across crashes, retries, and redistribution.
+
+Everything else — scheduling, capability enforcement, inference, distribution —
+is a layer around that journal/projection/commit spine.
+
+## Crate map
+
+29 crates, a clean layered DAG (no cycles). The foundation is a narrow waist that
+almost everything depends on; the engine and the distributed layer stack cleanly
+on top. Legend:
+
+- **core** — the single-node guarantee path. To understand the runtime, read these.
+- **engine** — scheduling/execution/inference built on core.
+- **distributed (P2/P3)** — the multi-node layer. *Not needed to run or understand
+  single-node.* Distribution is wiring on top of the same seams, not a rewrite.
+- **forward-seam** — built ahead of its consumer; off the guarantee path. Safe to
+  skip on a first read.
+- **ffi / harness** — native inference bindings and the test instrument.
+
+```
+                          kx-critic-types ── kx-llamacpp-sys        (leaves)
+                                 │                  │
+   ┌──────────── kx-mote ────────┘            kx-llamacpp           [ffi]
+   │   (Mote, MoteId, MoteDef, NdClass, EdgeMeta, …)
+   │      │
+   │   kx-content ── ContentStore + ContentRef (content-addressed bytes)
+   │      │
+   │   kx-journal ── Journal + JournalEntry (the append-only log of facts)   [core]
+   │      │
+   │   kx-warrant ── capabilities, roles, scopes (what a Mote may do)        [core]
+   │      │
+   │   kx-projection ── the pure fold: log → live state (ready set, cascade) [core]
+   │
+   ├── kx-capability ── CapabilityBroker (the ONLY door to world effects)    [core]
+   ├── kx-tool-registry ── tool resolution + IdempotencyClass
+   ├── kx-context-assembler ── builds a Mote's input context (model menu)
+   ├── kx-model-validator / kx-inference / kx-llamacpp ── the model seam     [engine]
+   ├── kx-critic-types / kx-critic ── deterministic verdicts (the exit gate)
+   │
+   ├── kx-scheduler ── picks the ready set from the projection               [engine]
+   ├── kx-executor ── the Mote lifecycle + commit protocols + recovery       [engine]
+   └── kx-runtime ── the single-node engine + the `run`/`replay` binary      [engine]
+
+   distributed (P2/P3 — optional for single-node):
+     kx-proto (gRPC schema) → kx-coordinator (sole journal writer, worker
+     registry) → kx-worker (leases work, dispatches, proposes back) ;
+     kx-chaos (seed-deterministic kill-and-replay harness)
+
+   forward-seams (off the guarantee path):
+     kx-capture (step capture), kx-dataset (typed committed data + retrieval),
+     kx-memoizer (exact-equality cache), kx-tiering (storage tiering),
+     kx-normalizer (input canonicalization)
+
+   harness: kx-model-harness (drives a real GGUF through the runtime via the seams)
+```
+
+The waist — `kx-mote` → `kx-content` → `kx-journal` → `kx-warrant` → `kx-projection`
+— is where the load-bearing invariants live. Changes there ripple widely; changes
+in a leaf or forward-seam are local. **If you're new, start by reading a leaf or
+an example, not the executor.**
+
+## How a step flows (the lifecycle)
+
+```
+  submit ─► register run (immutable instance id)
+         ─► submit Mote ─► REFUSAL GATE (refuse unsafe constructions up front)
+         ─► journal.append(Proposed)
+                 │
+   scheduler ◄───┴── reads ready_set from the projection fold
+         │           (a Mote is ready when its parents are committed)
+         ▼
+   executor ── dispatches under a commit protocol:
+         │       • IdempotentByConstruction → effect → append(Committed)
+         │       • StageThenCommit          → append(EffectStaged) → effect → append(Committed)
+         │       • ValidateThenCommit        → effect → critic verdict → append(Committed|Repudiated)
+         │     (world effects go ONLY through the CapabilityBroker)
+         ▼
+   journal ── append(Committed)  ─►  projection folds it  ─►  consumers unblock
+```
+
+**Recovery** is the same machinery in reverse: on restart the runtime re-folds the
+journal. If it sees an `EffectStaged` with no matching `Committed`, an oracle
+decides whether the effect is safe to re-dispatch (a pre-commit crash) or must be
+quarantined (a terminal failure) — that is how exactly-once survives a crash in
+the middle of a world-mutating step. Try it with the demo in the README.
+
+## The trait seams (extension + deployment boundaries)
+
+Six traits are the load-bearing seams. The same trait is implemented one way for
+the local single-node stack and (later) another way for the hosted/distributed
+deployment — the trait *shape* is the boundary, so distribution and cloud are new
+implementations, not a rewrite of the engine.
+
+| Seam | Trait | Defined in | Abstracts |
+|---|---|---|---|
+| Journal | `Journal` | `kx-journal/src/lib.rs` | the append-only log of facts (local: SQLite) |
+| Content store | `ContentStore` | `kx-content/src/lib.rs` | content-addressed bytes (local: filesystem) |
+| Capability broker | `CapabilityBroker` | `kx-capability/src/broker.rs` | the single door to world effects + idempotency |
+| Resource manager | `ResourceManager` | `kx-executor/src/resource_manager.rs` | admission/slots for dispatch |
+| Inference backend | `InferenceBackend` | `kx-inference/src/backend.rs` | model inference (local: llama.cpp) |
+| Worker registry | `WorkerRegistry` | `kx-coordinator/src/registry.rs` | worker liveness (distributed only) |
+
+(`MoteExecutor` in `kx-executor/src/executor_trait.rs` is a seventh, engine-internal
+seam for how a Mote body runs.)
+
+## Identity, durability, and determinism
+
+- **Identity is content-addressed.** A `MoteId` is derived from the Mote's
+  definition + its inputs, so re-submitting the same recipe with the same inputs
+  yields the same id — that is what makes deduplication and "serve, don't re-run"
+  sound. (Each *run* also gets a fresh registered instance id; see GLOSSARY.)
+- **Durability/resumability is the headline guarantee.** Register the run; if a
+  Mote fails midway, the journal + recovery fold let it resume or compensate —
+  exactly-once across the failure, never a silent double-fire.
+- **Byte-for-byte replay is a sub-case, not the headline.** For pure/read-only
+  steps, a re-fold reproduces an identical projection digest; for world-mutating
+  steps the guarantee is *exactly-once*, not bit-equality. (CI's byte-determinism
+  gate is about reproducible *builds*, a separate, supply-chain concern.)
+
+## Where to look
+
+| You want to understand… | Read |
+|---|---|
+| The unit of work + identity | `kx-mote/src/{mote,id,def,ndclass,edge}.rs` |
+| The log + its entry kinds | `kx-journal/src/{lib,entry}.rs` |
+| Live state / the fold / recovery | `kx-projection/src/{lib,projection,state}.rs` |
+| The lifecycle + commit protocols | `kx-executor/src/{lifecycle,commit_protocol}.rs` |
+| What gets refused at submit, and why | `kx-refusal/src/refusal.rs` |
+| The single-node engine + CLI | `kx-runtime/src/{engine,main}.rs` |
+| A minimal Mote body | `kx-executor/examples/` |
+
+For the deeper *design rationale* (the "why" behind specific invariants and
+decisions), the public doc-comments on the core types are the source of truth for
+contributors; the project's full design corpus is maintained privately. If a
+public doc-comment is unclear or references something you can't find, that's a
+documentation bug worth an issue — see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,135 @@
+# Contributing to kortecx
+
+Contributions are welcome. kortecx is an execution kernel for AI agents — the
+guarantees are load-bearing, so the bar for changes to the core is high, but
+there is plenty of approachable work, and this guide is meant to get you from
+clone to first PR without spelunking.
+
+Read [ARCHITECTURE.md](ARCHITECTURE.md) and [GLOSSARY.md](GLOSSARY.md) first — a
+30-minute investment that makes the codebase legible.
+
+> kortecx is in early development. Interfaces will change before 1.0. Open an
+> issue to discuss any substantial change before sending a PR, so we can point
+> you at the right seam and flag invariants you'd otherwise have to discover.
+
+## Prerequisites
+
+- **Rust 1.94.0+** (pinned in `rust-toolchain.toml`; `rustup` will honor it).
+- For the native inference crate (`kx-llamacpp`): a C++ toolchain + CMake +
+  libclang, and the `llama.cpp` submodule.
+  - Linux: `sudo apt-get install -y libclang-dev clang cmake build-essential`
+  - macOS: Xcode Command Line Tools (`xcode-select --install`)
+  - `git submodule update --init --recursive`
+- `just check-reproducible`'s byte-determinism check and the inference smoke need
+  those native deps; the rest of the workspace builds without them.
+
+Run `just doctor` (if you have [`just`](https://github.com/casey/just)) for a
+preflight check of toolchain + native deps + submodule.
+
+## Build and test
+
+```bash
+git clone https://github.com/Kortecx/kortecx.git
+cd kortecx
+cargo build --workspace
+cargo test  --workspace
+```
+
+To exercise the core guarantee end to end, run the crash-and-replay demo in the
+[README](README.md#try-it).
+
+## The pre-merge gate (run it before you push)
+
+CI **gates the merge** — a PR cannot merge until every required check is green,
+and they run *before* merge, not after. Mirror the full gate locally:
+
+```bash
+just ci      # fmt-check · clippy -D warnings · test · cargo-deny · doc -D warnings
+             # · ffi-link · check-reproducible · scale-smoke
+```
+
+If `just` isn't on your PATH, the gate is a handful of cargo invocations:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo deny check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+```
+
+The remaining gates (`ffi-link`, `check-reproducible`, `scale-smoke`) are slower;
+CI runs them on every PR. `cargo fmt --all` before committing saves a round trip.
+
+## Where to start
+
+The dependency graph is a clean layered DAG (see ARCHITECTURE.md). **Touch a leaf
+or a forward-seam before you touch the waist.**
+
+- **Approachable:** doc-comments (especially turning a terse invariant into a clear
+  explanation), additional unit/property tests, a new runnable example, a leaf
+  crate (`kx-critic-types`, `kx-normalizer`), or a forward-seam crate
+  (`kx-tiering`, `kx-capture`).
+- **Handle with care (high concept-density, cross-cutting invariants):**
+  `kx-journal/src/entry.rs` (the log format + recovery fold), `kx-projection`
+  (the pure fold + cascade), `kx-executor/src/{lifecycle,commit_protocol}.rs`
+  (the exactly-once spine), `kx-refusal/src/refusal.rs` (the submission gate).
+  Changes here want a design discussion in an issue first.
+- **Off-limits without a decision:** anything that changes a `JournalEntry`
+  encoding, `MoteId` derivation, or the commit protocol changes the on-disk/
+  on-the-wire contract. These are versioned, schema-bumped, and reviewed
+  carefully — open an issue.
+
+## How we keep the core trustworthy (working norms)
+
+These are the practices the project holds itself to; new contributions are
+reviewed against them. They're not bureaucracy — each one prevents a class of
+bug that corrupts the log or breaks a guarantee.
+
+1. **Interface mindfulness, asymmetric strictness.** Maximum care on the six trait
+   seams + the Mote/journal core (an honest signature there is load-bearing for
+   both the local and the future hosted implementation); pragmatic inside a crate.
+2. **Warnings are signal.** Don't silence a warning — especially on the lifecycle/
+   journal/recovery paths, where a warning is often the visible edge of an
+   ordering or lifecycle bug. Understand it, fix the cause, add a test.
+3. **Thin `lib.rs`.** `lib.rs` is module declarations + re-exports; real code lives
+   in sibling modules, one concern per file. New crates are born this way.
+4. **CI gates the merge.** It runs before merge; keep `just ci` green.
+5. **Choose the right type/structure.** Make illegal states unrepresentable
+   (enums over bool-soup, typed ids, honest `Result` errors); incremental over
+   re-compute on hot paths; deterministic structures on the journal/content path.
+6. **Adopt better crates at the point of use** — not speculatively, and always
+   clearing `cargo-deny` (permissive licenses only).
+7. **Pre-flight every change.** Before implementing, reason about — and surface in
+   the PR — what could break if it ships, what could degrade performance, what
+   could open a security hole, and how the change makes the runtime better. Then
+   present the risks and recommend the best option. No silent decisions; no
+   compromise on reliability or efficiency.
+
+A structural refactor is its own PR — never bundled with a feature. Keep diffs
+focused so the change says exactly what it does.
+
+## Pull requests
+
+- Branch from `main`, keep the PR scoped to one concern, and write a clear title
+  + body (what, why, how it was tested).
+- Public items get doc-comments. Behavior changes get tests (unit/property; and,
+  for anything on the guarantee path, a failure/recovery test).
+- Be ready for review focused on the invariants above. We'd rather discuss a seam
+  change up front than unwind it later.
+
+## A note on the design corpus
+
+The full design rationale (the long-form "why" behind individual decisions) is
+maintained in a private corpus; the public repo carries the code, the public
+doc-comments, and these guides. For contribution you should not need the private
+material — the public doc-comments on the core types are intended to be
+self-contained. **If a public doc-comment is unclear, references something you
+can't find, or an invariant isn't explained where you'd expect it, that's a
+documentation bug** — open an issue and we'll fix the public docs. Improving that
+public legibility is itself some of the most valuable contribution you can make.
+
+## License
+
+By contributing you agree your contributions are licensed under the
+[Apache License, Version 2.0](LICENSE).

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,136 @@
+# Glossary
+
+The vocabulary of the kortecx runtime, for contributors. Each term notes where
+it's defined in the code. See [ARCHITECTURE.md](ARCHITECTURE.md) for how the
+pieces fit.
+
+### Mote
+The unit of work — one step an agent takes (call a model, run logic, hit a tool).
+A Mote is *content-addressed*: its identity is derived from its definition plus
+its inputs. `kx-mote/src/mote.rs`.
+
+### MoteId
+The 32-byte content-addressed identity of a Mote, derived from its definition
+hash + input data + position in the graph. Identical work → identical id, which
+is what makes "serve the committed result instead of re-running" sound.
+`kx-mote/src/id.rs`.
+
+### MoteDef
+The author-side *definition* of a Mote: which logic/model/prompt, its tool
+contract, its non-determinism class, its effect pattern, etc. The def hash is one
+input to the `MoteId`. `kx-mote/src/def.rs`.
+
+### MoteGraph
+An author-side container of Motes + their declared parent edges — the shape you
+build before submission. The runtime never reads it directly; it folds the
+journal. `kx-mote/src/graph.rs`.
+
+### NdClass (non-determinism class)
+A three-way tag on every Mote that drives recovery + storage:
+**Pure** (deterministic, safe to re-run, droppable/recomputable),
+**ReadOnlyNondet** (samples a non-deterministic source but changes no world state;
+committed once, served on replay), **WorldMutating** (changes the outside world;
+exactly-once, never silently re-run). `kx-mote/src/ndclass.rs`.
+
+### EffectPattern
+How a world-mutating Mote is made safe under crashes — its commit protocol:
+**IdempotentByConstruction** (the effect carries its own idempotency, safe to
+retry), **StageThenCommit** (record intent, then act, then commit — the default),
+**ValidateThenCommit** (act, then a critic validates before commit).
+`kx-mote/src/effect.rs`.
+
+### EdgeKind / EdgeMeta
+Typed dependency edges between Motes. **Data** edges (a parent's output is the
+child's input) always cascade on repudiation; **Control** edges (ordering only)
+cascade by default but can opt out (`non_cascade`). `kx-mote/src/edge.rs`.
+
+### Journal / JournalEntry
+The append-only log that is the single source of truth. Entry kinds include
+`Proposed`, `Committed`, `Failed`, `Repudiated`, `EffectStaged`, and run-metadata
+facts. The `Journal` trait is a seam (local impl: SQLite).
+`kx-journal/src/{lib,entry}.rs`.
+
+### Projection / fold
+The read-side: a **pure fold** of the journal into live state (per-Mote status,
+the ready set, the dependency index). It is never stored authoritatively — it is
+re-derived from the log on restart. "Two folds of the same log prefix produce
+equivalent state." `kx-projection/src/{lib,projection}.rs`.
+
+### Ready set
+The Motes whose parents are all committed and which are therefore eligible to
+run. Computed from the projection; consumed by the scheduler.
+`kx-projection` (`ready_set`).
+
+### Commit protocol
+The executor-side state machine that drives a Mote's effect to a durable
+`Committed` fact according to its `EffectPattern`. The heart of the exactly-once
+guarantee. `kx-executor/src/commit_protocol.rs`.
+
+### EffectStaged
+A journal fact recording that a world-mutating effect is *about to* happen,
+written **before** the effect under `StageThenCommit`. On recovery, an
+`EffectStaged` with no matching `Committed` tells the runtime a crash happened in
+the window — and an oracle decides whether re-dispatch is safe. `kx-journal`.
+
+### Recovery / re-fold
+Restart behavior: re-fold the journal to rebuild the projection, then resume.
+Committed steps are *served, not re-run*; in-flight world effects are resumed or
+quarantined based on the recovery oracle. `kx-runtime/src/engine.rs`,
+`kx-executor/src/lifecycle.rs`.
+
+### Repudiation / cascade
+Marking a committed result invalid (operator action, a critic verdict, an
+upstream failure). Repudiation **cascades** to dependents along edges (Data always;
+Control unless opted out), so nothing downstream trusts an invalidated input.
+`kx-projection` (`transitive_consumers`), `kx-journal` (`Repudiated`).
+
+### Warrant / Capability / CapabilityBroker
+A **warrant** scopes what a Mote may do (filesystem, network, tools, resources).
+A **capability** is a grantable power. The **CapabilityBroker** is the *single
+door* through which all world effects pass — enforcement happens here, and it
+carries the per-tool idempotency contract. `kx-warrant`, `kx-capability/src/broker.rs`.
+
+### IdempotencyClass
+Per-tool declaration of *how* cross-boundary exactly-once is achieved (idempotency
+token / deterministic readback / staged intent / at-least-once-with-consent). The
+runtime is fail-closed without one. `kx-tool-registry`.
+
+### Critic / CriticVerdict / CheckSpec
+A **critic** is a deterministic check on a producer's output. A **CheckSpec**
+describes the check as data (schema / dedup / statistical bounds / PII); the
+**CriticVerdict** is the content-addressed `Valid`/`Invalid` fact — compared by
+exact equality, never a fuzzy score. `kx-critic-types`, `kx-critic`.
+
+### Promotion
+A gate that withholds a world-mutating producer's consumers until its declared
+critic has committed a `Valid` verdict — fail-closed otherwise. `kx-projection`
+(`promotion`).
+
+### Run / instance id / recipe fingerprint
+Each submission is a **run** with a fresh, registered, immutable **instance id**
+(the cross-boundary idempotency token). The def/content hash survives only as a
+**recipe fingerprint** for discovery/reuse — never as run identity. So
+re-submitting the same recipe is a *new run*. `kx-journal` (`RunRegistered`).
+
+### ContentRef / ContentStore
+Payloads (results, inputs) are stored content-addressed; the journal carries a
+32-byte **ContentRef**, not bytes. The **ContentStore** is a seam (local impl:
+filesystem). `kx-content/src/lib.rs`.
+
+### Topology shaper / materializer
+A Mote that, when committed, *produces the next slice of the graph* (dynamic
+fan-out). The **materializer** deterministically derives the child Motes from the
+shaper's committed decision, so a re-fold reconstructs the identical children.
+`kx-projection/src/materializer.rs`.
+
+### Submission refusal
+The runtime *refuses unsafe constructions at submit*, before any dispatch — e.g.
+a world-mutating Mote with no idempotency-supporting tool, or a run that wasn't
+registered first. The refusal vocabulary is one enum; each variant guards a
+specific safety invariant. `kx-refusal/src/refusal.rs`.
+
+### Coordinator / Worker (distributed)
+The multi-node layer: the **coordinator** is the sole journal writer + worker
+registry; **workers** lease ready Motes, dispatch them, and propose results back.
+Same guarantees as single-node — distribution is wiring on the same seams, not a
+rewrite. Optional for single-node. `kx-coordinator`, `kx-worker`, `kx-proto`.

--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ on Linux x86_64 in CI; macOS Apple Silicon (Metal) is verified locally on every 
 
 ## Contributing
 
-Contributions are welcome. Please open an issue to discuss substantial changes before sending a
-pull request.
+Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the build/test/gate
+path and where to begin, [ARCHITECTURE.md](ARCHITECTURE.md) for how the crates fit together, and
+[GLOSSARY.md](GLOSSARY.md) for the vocabulary. Please open an issue to discuss substantial changes
+before sending a pull request.
 
 ## License
 


### PR DESCRIPTION
## Why

Post-M2.1 reality check finding: the public repo has a strong README but **no architecture overview, no contributor guide, no glossary**, and the code carries **500+ references to a private design corpus** a public contributor can't read. A newcomer could read the code but not safely change it, and couldn't tell load-bearing core from optional forward-seams. First deliverable of the **approachability milestone**.

## What

Three public contributor artifacts (root, like README) + a README link:

- **ARCHITECTURE.md** — one-paragraph model; the crate-dependency map (clean layered DAG: `kx-critic-types`→`kx-mote`→`kx-content`→`kx-journal`/`kx-warrant`→`kx-projection` waist) with a **core / distributed (P2/P3) / forward-seam** legend; the submit→journal→fold→dispatch→commit→recover lifecycle; the **six trait seams** with file pointers; the post-pivot identity/durability/determinism framing.
- **CONTRIBUTING.md** — prerequisites, build/test/the pre-merge gate (`just ci` + cargo equivalents), where to start (touch a leaf before the waist; the concept-density cliffs; off-limits on-disk/on-wire contracts), the working norms, PR conventions.
- **GLOSSARY.md** — ~24 core terms, each with its definition site.

## Scope / safety

Public artifacts only; **no code/schema change**. Extracts the public *what + how-to-contribute*, never the private design rationale (SN-2): no private repo name, no `kx-cloud` reference, no `D##`/design-doc citation — verified leak-check-clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)