### PR TITLE
docs: inline the recovery cross-product + refusal rationale (self-contained)

### DIFF
--- a/crates/kx-projection/src/lib.rs
+++ b/crates/kx-projection/src/lib.rs
@@ -40,6 +40,33 @@
 //! - **Cycle tolerant.** Cycles in the dependency graph do not crash, hang, or
 //!   corrupt the fold. Traversals (`transitive_consumers`) use visited-sets.
 //!
+//! ## Recovery: how the fold survives a crash mid-effect
+//!
+//! Recovery is just re-folding the log. The interesting case is a crash *inside*
+//! a world-mutating step. Under the `StageThenCommit` protocol the executor writes
+//! an `EffectStaged` fact **before** it touches the world and a `Committed` fact
+//! **after**; the gap between them is the crash window. On re-fold, the
+//! combination of facts observed for a Mote decides whether re-dispatch is safe —
+//! computed by `can_redispatch_world_effect` (see `state.rs`):
+//!
+//! | Observed on re-fold | Meaning | Recovery decision |
+//! |---|---|---|
+//! | `Committed` present | the effect landed durably | **done** — serve the result, NEVER re-dispatch |
+//! | `EffectStaged`, no `Committed`, `Failed` (timed-out / worker-crashed) | a *pre-commit* crash — the effect may not have landed | **re-dispatch** — the tool's idempotency closes the window |
+//! | `EffectStaged`, no `Committed`, `Failed` (terminal: refused / validator-rejected / …) | a *terminal* failure | **do NOT re-dispatch** — re-firing could double-apply |
+//! | `EffectStaged`, no `Committed`, nothing terminal | in-flight when the crash hit | **re-dispatch** permitted |
+//! | `EffectStaged` + `Repudiated`, no `Committed` | a fact-ordering anomaly | **quarantine** (`Inconsistent`) — surfaced for an operator |
+//! | no `EffectStaged`, no `Committed` | not yet attempted (or the effect carries its own idempotency) | ordinary scheduling |
+//!
+//! **Load-bearing ordering invariant:** a *terminal* failure is checked **before**
+//! the in-flight (`EffectStaged`) case. Swapping them would let a terminally-failed
+//! world effect be re-dispatched — re-opening the double-fire window. This ordering
+//! is enforced in `State::state_of_id` / `can_redispatch_world_effect_id` and pinned
+//! by the cross-product regression tests in `tests/cross_product.rs`. The flags it
+//! reads (`effect_staged_observed`, `terminal_failure_observed`, `inconsistent`)
+//! are **monotonic-true**: once set during a fold they are never reset, so a longer
+//! prefix can only narrow re-dispatch, never widen it.
+//!
 //! ## Topology-shaper materialization (P1.11 / D48 + D49)
 //!
 //! `projection.md` §5/§6/§7 (post-D48/D49 amendment) specify that the projection

--- a/crates/kx-refusal/src/refusal.rs
+++ b/crates/kx-refusal/src/refusal.rs
@@ -1,6 +1,16 @@
-//! Submission-time refusal predicates (R-1..R-9 + R-8b + R-10 + R-14 + R-15 +
-//! D66 + `ValidatorTypeError` + `AttemptedWiden`) per
-//! `docs/design/validate-then-commit.md` §7 + the D66 fail-closed gate (M1.3).
+//! Submission-time refusal predicates — the gate that refuses an UNSAFE
+//! world-mutating construction *before* anything dispatches.
+//!
+//! **Why refuse at submit:** a world-mutating step the runtime cannot make
+//! exactly-once is a step it cannot guarantee — so it is rejected up front rather
+//! than mid-run, after a partial effect. Each predicate guards one such hazard:
+//! a world-mutating step with no idempotency-supporting tool (`R1NoIdempotentTool`),
+//! no validating critic where one is required (`R2NoCritic`), an ill-formed
+//! critic/shaper relationship (`R4`–`R9`, `R8`/`R8b`/`R14`), an at-least-once tool
+//! used without explicit operator consent (`R10`), or an unresolvable /
+//! privilege-exceeding tool grant (`D66UnresolvableWorldMutatingTools`). The
+//! `#[error(...)]` message on each variant states the exact trigger and why it is
+//! unsafe.
 //!
 //! Each refusal results in a single `Failed::UnsafeWorldMutatingConstruction`
 //! journal entry; no broker dispatch, no inference call, no commit beyond the


### PR DESCRIPTION
## Why

The reality check found **500+ references to a private design corpus** in public code — a contributor could read the code but not the *why* behind the hardest invariants. This inlines the two highest-value ones into public doc-comments, in plain language (no private-doc paths, no design-corpus citations). Third deliverable of the approachability milestone.

## What (doc-comments only)

- **`kx-projection` (lib.rs):** a new **"Recovery: how the fold survives a crash mid-effect"** section — the `EffectStaged`/`Committed`/`Failed`/`Repudiated` cross-product as a table (which combination is re-dispatched / served / refused / quarantined), plus the load-bearing **terminal-before-in-flight** ordering invariant and the monotonic-true flag contract. This is the crash-recovery logic a contributor must grasp before touching the fold — previously only in the private corpus.
- **`kx-refusal` (refusal.rs):** a **"why refuse at submit"** framing on the module header (grouping the predicates by the hazard each guards), and dropped the private `docs/design/*.md` path citation.

## Scope / safety

Doc-comments only; **no code/schema/behavior change**. `fmt` + `doc -D warnings` clean; **leak-check clean** (verified no private paths/names in the additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)