### PR TITLE
docs: tag the distributed crates with a point-of-contact phase note

### DIFF
--- a/crates/kx-chaos/src/lib.rs
+++ b/crates/kx-chaos/src/lib.rs
@@ -1,5 +1,9 @@
 //! # kx-chaos — the P3 exit-gate failure-injection harness (P3.7)
 //!
+//! > **Phase: distributed (P2/P3) — test harness.** Drives the coordinator/worker
+//! > layer under injected faults; not part of the runtime you deploy, and not
+//! > needed to build, run, or understand single-node kortecx. See `ARCHITECTURE.md`.
+//!
 //! This crate is kortecx's **product core proof**: a *seed-deterministic* engine
 //! that kills workers mid-Mote across a sweep of seeds and proves, for **every**
 //! seed, the three guarantees the P3 exit gate names:

--- a/crates/kx-coordinator/src/lib.rs
+++ b/crates/kx-coordinator/src/lib.rs
@@ -13,6 +13,11 @@
 
 //! # kx-coordinator — the kortecx P2.2 coordinator service (the control plane)
 //!
+//! > **Phase: distributed (P2/P3).** The multi-node control plane — wiring on the
+//! > same trait seams as the single-node core, *not* a rewrite of it. You do
+//! > **not** need this crate to build, run, or understand single-node kortecx
+//! > (`kx-runtime`). See `ARCHITECTURE.md` for the core-vs-distributed legend.
+//!
 //! The coordinator is the hub of a distributed run. It:
 //!
 //! 1. **hosts the P1 scheduler verbatim** — submitted Motes are registered through

--- a/crates/kx-proto/src/lib.rs
+++ b/crates/kx-proto/src/lib.rs
@@ -13,6 +13,11 @@
 
 //! # kx-proto — kortecx P2.1 gRPC schema (the distribution boundary)
 //!
+//! > **Phase: distributed (P2/P3).** The gRPC schema for the multi-node control
+//! > plane — wiring on the same trait seams as the single-node core, *not* a
+//! > rewrite of it. You do **not** need this crate to build, run, or understand
+//! > single-node kortecx (`kx-runtime`). See `ARCHITECTURE.md`.
+//!
 //! tonic/prost gRPC schema for the coordinator/worker control plane: **submit
 //! Mote**, **report commit**, **heartbeat**, **register worker**. This is the
 //! first step of P2 (coordinator/worker distribution) and the **cross-language

--- a/crates/kx-worker/src/lib.rs
+++ b/crates/kx-worker/src/lib.rs
@@ -13,6 +13,11 @@
 
 //! # kx-worker — the kortecx worker (the `CoordinatorClient`)
 //!
+//! > **Phase: distributed (P2/P3).** Part of the multi-node layer — wiring on the
+//! > same trait seams as the single-node core, *not* a rewrite of it. You do
+//! > **not** need this crate to build, run, or understand single-node kortecx
+//! > (`kx-runtime`). See `ARCHITECTURE.md` for the core-vs-distributed legend.
+//!
 //! A worker is a gRPC **client** of the coordinator. It:
 //!
 //! 1. **registers** with the coordinator ([`Worker::register`] → `RegisterWorker`),


### PR DESCRIPTION
## Why

`ARCHITECTURE.md` carries the **core / distributed / forward-seam** legend, but a contributor who opens `kx-coordinator`/`kx-worker`/`kx-proto`/`kx-chaos` directly — the ~6.4k-LOC P2/P3 layer, the chunk most easily mistaken for core — had no signal at the point of contact. Final deliverable of the approachability milestone.

## What

A one-line blockquote at each of the four distributed crates' module-doc head:

> **Phase: distributed (P2/P3).** … wiring on the same trait seams as the single-node core, *not* a rewrite of it. You do **not** need this crate to build, run, or understand single-node kortecx (`kx-runtime`). See `ARCHITECTURE.md`.

## Why this shape (Golden Rule 8: proportionate, no churn)

- **Chosen over `workspace.default-members`** — that silently narrows a bare `cargo test` (a footgun) for marginal benefit; CI already runs `--workspace`.
- **Skipped the forward-seam crates** — they already self-describe (`kx-capture`: "OPT-IN, OFF-TRUTH-PATH"; `kx-dataset`: "seam"; etc.).

Doc-only; no code/schema change. `fmt` + `doc -D warnings` + leak-check clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)