### PR TITLE
feat(projection): discardable FoldCheckpoint for churn-bounded resume (M2.2, D92(b))

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,13 +367,17 @@ jobs:
         run: just smoke-test-with-model
 
   # ---------------------------------------------------------------------------
-  # scale-smoke — M2.1 / D92 resume-availability gate. Folds a 25k+ Mote
+  # scale-smoke — M2.1 + M2.2 / D92 resume-availability gate. Folds a 25k+ Mote
   # journal in RELEASE and asserts the incremental children-index re-fold stays
-  # ~linear (a super-linear resume is an outage). ADVISORY for now: this is NOT
-  # yet a required status check — it is promoted to required via an explicitly-
-  # authorized branch-protection PATCH once it is green on a couple of runs
-  # (Golden Rule 4). Needs the test suite green first.
+  # ~linear (M2.1) AND that resume-from-FoldCheckpoint reproduces the full fold
+  # exactly with cost bounded by live-state under churn (M2.2). A super-linear
+  # resume is an outage. Promoted to a required status check via an explicitly-
+  # authorized branch-protection PATCH once green on a couple of runs (Golden
+  # Rule 4). Needs the test suite green first.
   # ---------------------------------------------------------------------------
+  # NOTE: the job `name:` below is the **required status-check context** in
+  # branch protection — do NOT rename it (a rename orphans the required check
+  # and blocks merges). M2.2 extends the recipe body, not the context name.
   scale-smoke:
     name: scale-smoke (M2.1 incremental children-index re-fold)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,7 @@ dependencies = [
  "kx-mote",
  "kx-warrant",
  "proptest",
+ "serde",
  "smallvec",
  "tempfile",
  "thiserror",

--- a/crates/kx-projection/Cargo.toml
+++ b/crates/kx-projection/Cargo.toml
@@ -19,6 +19,7 @@ kx-critic-types = { workspace = true }
 kx-journal = { workspace = true }
 kx-mote    = { workspace = true }
 kx-warrant = { workspace = true }
+serde      = { workspace = true }
 smallvec   = { workspace = true }
 thiserror  = { workspace = true }
 tracing    = { workspace = true }

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -1,0 +1,859 @@
+//! [`FoldCheckpoint`] — a **discardable** snapshot of the folded projection
+//! state (D92(b), M2.2).
+//!
+//! ## What it is
+//!
+//! A projection is a deterministic left-fold over the seq-ordered journal, so
+//! `fold(0,N] == fold(K,N] ∘ fold(0,K]`. A [`FoldCheckpoint`] stores `fold(0,K]`
+//! materialized (a canonical-bincode encoding of the private [`State`]) plus a
+//! `journal_offset = K` and an integrity `digest`. Cold recovery can then seed a
+//! [`crate::Projection`] from the checkpoint and fold only the tail
+//! `(K, current]` instead of re-folding `(0, current]` from scratch
+//! ([`crate::Projection::from_journal_with_checkpoint`]).
+//!
+//! ## Hard contract (do not weaken)
+//!
+//! - **Never authoritative.** The journal is the only source of truth. A
+//!   corrupt / stale / wrong-run checkpoint is **silently discarded** and the
+//!   full fold runs — recovery is correct with or without it. Every fallible
+//!   path in [`FoldCheckpoint::from_bytes`] returns `Err` (never panics), and
+//!   [`crate::Projection::from_journal_with_checkpoint`] treats any anomaly as
+//!   "fall back to the full fold".
+//! - **Never journaled, never an identity input, never gates.** The checkpoint
+//!   digest is a *full-state* integrity digest, **distinct** from the
+//!   committed-facts product digest (`kx-runtime`'s `digest_projection`, the
+//!   canonical `a6b5c679…`). It is exact-equality only (SN-8); no fuzzy match.
+//! - **Self-healing format.** [`CURRENT_FORMAT_VERSION`] + [`PAYLOAD_CODEC`] are
+//!   checked on decode; a future format / codec (e.g. an rkyv zero-copy payload)
+//!   bumps these and old checkpoints cleanly invalidate → full fold.
+//!
+//! ## Integrity vs unforgeability (honest scope)
+//!
+//! The digest proves **integrity against accidental corruption** (bit-rot, torn
+//! write, truncation), not unforgeability — a writer of the sidecar could craft
+//! a self-consistent blob. That is acceptable because a checkpoint lives in the
+//! **same trust domain as the journal** (the runtime's own state dir): anyone who
+//! can forge it can already forge the journal. A stronger end-to-end guarantee
+//! (verify the reconstructed [`crate::Projection::state_digest`] against a
+//! *journaled* digest seal) is the roadmap follow-on (M2.2c) and reuses the same
+//! digest function.
+
+use std::collections::BTreeMap;
+
+use kx_content::ContentRef;
+use kx_journal::{ParentEntry, ResolvedCapabilityRecord, INSTANCE_ID_LEN};
+use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+use crate::state::{
+    CommittedInfo, DeclaredInfo, MoteInfo, RunRegistration, RunResolvedVersions, State,
+};
+
+/// The on-disk format version. Bump on **any** change to the envelope layout or
+/// the `CheckpointState` payload encoding — old checkpoints then fail
+/// [`FoldCheckpoint::from_bytes`] and recovery falls back to a full fold (self-healing).
+pub const CURRENT_FORMAT_VERSION: u16 = 1;
+
+/// Payload codec tag. `0` = canonical-bincode (LE + fixed-int, the house
+/// [`kx_mote::canonical_config`]). Reserved for a future rkyv zero-copy payload
+/// (`1`, roadmap M2.2d) — an **additive** bump, never a breaking change.
+pub const PAYLOAD_CODEC: u8 = 0;
+
+/// Envelope header length: `version(2) ‖ codec(1) ‖ journal_offset(8) ‖ digest(32)`.
+const HEADER_LEN: usize = 2 + 1 + 8 + 32;
+
+// ---------------------------------------------------------------------------
+// FoldCheckpoint — the public, durable artifact
+// ---------------------------------------------------------------------------
+
+/// A discardable, byte-serializable snapshot of the folded projection state at a
+/// journal offset. See the module-level docs for the full contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoldCheckpoint {
+    format_version: u16,
+    payload_codec: u8,
+    journal_offset: u64,
+    digest: [u8; 32],
+    payload: Vec<u8>,
+}
+
+impl FoldCheckpoint {
+    /// The journal `seq` this checkpoint folds **through** (inclusive). Recovery
+    /// seeds from here and folds `(journal_offset, current]`.
+    #[inline]
+    #[must_use]
+    pub fn journal_offset(&self) -> u64 {
+        self.journal_offset
+    }
+
+    /// The full-state integrity digest (blake3 over the envelope header +
+    /// payload). Exact-equality only.
+    #[inline]
+    #[must_use]
+    pub fn digest(&self) -> [u8; 32] {
+        self.digest
+    }
+
+    /// The payload codec tag ([`PAYLOAD_CODEC`] today).
+    #[inline]
+    #[must_use]
+    pub fn payload_codec(&self) -> u8 {
+        self.payload_codec
+    }
+
+    /// Build a checkpoint from a folded [`State`] (crate-internal; the public
+    /// entry point is [`crate::Projection::fold_checkpoint`]).
+    pub(crate) fn from_state(state: &State) -> Self {
+        let payload = encode_state(state);
+        let journal_offset = state.last_seq;
+        let digest = envelope_digest(
+            CURRENT_FORMAT_VERSION,
+            PAYLOAD_CODEC,
+            journal_offset,
+            &payload,
+        );
+        Self {
+            format_version: CURRENT_FORMAT_VERSION,
+            payload_codec: PAYLOAD_CODEC,
+            journal_offset,
+            digest,
+            payload,
+        }
+    }
+
+    /// Recompute the integrity digest over this checkpoint's envelope + payload
+    /// and compare it to the stored digest.
+    ///
+    /// Proves **internal integrity** (the bytes were not corrupted), not journal
+    /// provenance — see the module-level docs. Cheap; no payload decode.
+    #[must_use]
+    pub fn verify(&self) -> bool {
+        self.format_version == CURRENT_FORMAT_VERSION
+            && self.payload_codec == PAYLOAD_CODEC
+            && envelope_digest(
+                self.format_version,
+                self.payload_codec,
+                self.journal_offset,
+                &self.payload,
+            ) == self.digest
+    }
+
+    /// Serialize to a durable byte blob: `version_le ‖ codec ‖ offset_le ‖ digest ‖ payload`.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HEADER_LEN + self.payload.len());
+        out.extend_from_slice(&self.format_version.to_le_bytes());
+        out.push(self.payload_codec);
+        out.extend_from_slice(&self.journal_offset.to_le_bytes());
+        out.extend_from_slice(&self.digest);
+        out.extend_from_slice(&self.payload);
+        out
+    }
+
+    /// Parse a durable byte blob. **Panic-free and fully validating**: every
+    /// failure (short buffer, unknown version/codec, digest mismatch) is an
+    /// [`CheckpointError`], so a malformed/truncated/hostile blob can only ever
+    /// be discarded, never trusted.
+    ///
+    /// # Errors
+    /// [`CheckpointError`] for any envelope or integrity failure.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CheckpointError> {
+        // Length first — every field is read via `.get(..)` / `try_into`, never
+        // by panicking index-slice, so a short buffer is an Err not a panic.
+        if bytes.len() < HEADER_LEN {
+            return Err(CheckpointError::TooShort {
+                got: bytes.len(),
+                need: HEADER_LEN,
+            });
+        }
+        let version = u16::from_le_bytes(bytes.get(0..2).and_then(|s| s.try_into().ok()).ok_or(
+            CheckpointError::TooShort {
+                got: bytes.len(),
+                need: HEADER_LEN,
+            },
+        )?);
+        if version != CURRENT_FORMAT_VERSION {
+            return Err(CheckpointError::UnsupportedVersion { got: version });
+        }
+        let codec = *bytes.get(2).ok_or(CheckpointError::TooShort {
+            got: bytes.len(),
+            need: HEADER_LEN,
+        })?;
+        if codec != PAYLOAD_CODEC {
+            return Err(CheckpointError::UnsupportedCodec { got: codec });
+        }
+        let journal_offset =
+            u64::from_le_bytes(bytes.get(3..11).and_then(|s| s.try_into().ok()).ok_or(
+                CheckpointError::TooShort {
+                    got: bytes.len(),
+                    need: HEADER_LEN,
+                },
+            )?);
+        let digest: [u8; 32] =
+            bytes
+                .get(11..43)
+                .and_then(|s| s.try_into().ok())
+                .ok_or(CheckpointError::TooShort {
+                    got: bytes.len(),
+                    need: HEADER_LEN,
+                })?;
+        let payload = bytes
+            .get(HEADER_LEN..)
+            .ok_or(CheckpointError::TooShort {
+                got: bytes.len(),
+                need: HEADER_LEN,
+            })?
+            .to_vec();
+
+        if envelope_digest(version, codec, journal_offset, &payload) != digest {
+            return Err(CheckpointError::DigestMismatch);
+        }
+        Ok(Self {
+            format_version: version,
+            payload_codec: codec,
+            journal_offset,
+            digest,
+            payload,
+        })
+    }
+
+    /// Decode the payload into a folded [`State`]. Re-validates structural
+    /// invariants the encoder cannot (each parent edge via
+    /// [`ParentEntry::to_parent_ref`]). Lazy — called only on resume after the
+    /// envelope + digest checks pass.
+    ///
+    /// # Errors
+    /// [`CheckpointError::Decode`] on a bincode failure or trailing bytes;
+    /// [`CheckpointError::MalformedParent`] on an invalid parent edge.
+    pub(crate) fn decode_state(&self) -> Result<State, CheckpointError> {
+        let (dto, consumed): (CheckpointState, usize) =
+            bincode::serde::decode_from_slice(&self.payload, kx_mote::canonical_config())
+                .map_err(|e| CheckpointError::Decode(e.to_string()))?;
+        if consumed != self.payload.len() {
+            return Err(CheckpointError::Decode(format!(
+                "trailing bytes: consumed {consumed} of {}",
+                self.payload.len()
+            )));
+        }
+        State::try_from(dto)
+    }
+}
+
+/// Errors from decoding / validating a [`FoldCheckpoint`]. Every variant is a
+/// "discard the checkpoint and full-fold" signal — never fatal to recovery.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CheckpointError {
+    /// The blob is shorter than the fixed envelope header.
+    #[error("checkpoint too short: got {got} bytes, need at least {need}")]
+    TooShort {
+        /// Bytes available.
+        got: usize,
+        /// Bytes required for the header.
+        need: usize,
+    },
+    /// The blob's format version is not [`CURRENT_FORMAT_VERSION`].
+    #[error("unsupported checkpoint format version {got} (current is {CURRENT_FORMAT_VERSION})")]
+    UnsupportedVersion {
+        /// The version read from the blob.
+        got: u16,
+    },
+    /// The blob's payload codec is not [`PAYLOAD_CODEC`].
+    #[error("unsupported checkpoint payload codec {got} (current is {PAYLOAD_CODEC})")]
+    UnsupportedCodec {
+        /// The codec tag read from the blob.
+        got: u8,
+    },
+    /// The recomputed integrity digest does not match the stored digest.
+    #[error("checkpoint digest mismatch (corrupt or tampered)")]
+    DigestMismatch,
+    /// The payload failed bincode decode or carried trailing bytes.
+    #[error("checkpoint payload decode failed: {0}")]
+    Decode(String),
+    /// A decoded parent edge violates the [`ParentEntry`] invariant
+    /// (unknown `edge_kind`, or a Data edge with `non_cascade` set).
+    #[error("checkpoint payload has a malformed parent edge (kind={edge_kind}, non_cascade={non_cascade})")]
+    MalformedParent {
+        /// The offending `edge_kind` byte.
+        edge_kind: u8,
+        /// The offending `non_cascade` byte.
+        non_cascade: u8,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Canonical encoding helpers (shared by the checkpoint + the state digest)
+// ---------------------------------------------------------------------------
+
+/// Canonical-bincode encoding of the full folded state (the checkpoint payload).
+/// Infallible for [`CheckpointState`] (no custom `Serialize`); the `expect`
+/// mirrors the house pattern (`kx_mote::def`, `kx_critic_types::verdict`).
+// SAFETY (expect_used): `CheckpointState` has no `f32`/`f64`, no custom
+// `Serialize`, and no non-encodable variant; bincode encode over it cannot fail
+// (the only `EncodeError`s are I/O/size, neither reachable for an in-memory Vec
+// sink). Documented-infallible production use per the workspace lint policy.
+#[allow(clippy::expect_used)]
+pub(crate) fn encode_state(state: &State) -> Vec<u8> {
+    bincode::serde::encode_to_vec(CheckpointState::from(state), kx_mote::canonical_config())
+        .expect("canonical bincode encode of CheckpointState is infallible")
+}
+
+/// The canonical **full-state** digest: `blake3(encode_state(state))`. A pure
+/// function of the folded state content (includes `last_seq` + run registration,
+/// so it is self-anchoring). Reused by [`crate::Projection::state_digest`] and,
+/// in the roadmap, by the journaled digest seal (M2.2c). Distinct from the
+/// committed-facts product digest in `kx-runtime`.
+pub(crate) fn state_content_digest(state: &State) -> [u8; 32] {
+    *blake3::hash(&encode_state(state)).as_bytes()
+}
+
+/// The checkpoint envelope integrity digest:
+/// `blake3(version_le ‖ codec ‖ offset_le ‖ payload)`. Binds the format header
+/// to the payload so a header edit (e.g. a moved offset) is caught too.
+fn envelope_digest(version: u16, codec: u8, offset: u64, payload: &[u8]) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(&version.to_le_bytes());
+    h.update(&[codec]);
+    h.update(&offset.to_le_bytes());
+    h.update(payload);
+    *h.finalize().as_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// CheckpointState — the crate-private serde DTO mirroring `State`
+// ---------------------------------------------------------------------------
+//
+// DTOs mirror the private `State` graph using only serde-friendly shapes (the
+// one non-serde type, `ParentEntry`, becomes a `(MoteId,u8,u8)` triple). The
+// `From`/`TryFrom` bodies DESTRUCTURE every source/target struct WITHOUT `..`,
+// so adding a field to `State`/`MoteInfo`/`CommittedInfo`/`DeclaredInfo`/
+// `RunRegistration`/`RunResolvedVersions` fails to COMPILE until the DTO is
+// updated — "losslessly mirrors State" is enforced by the compiler, not review.
+
+#[derive(Serialize, Deserialize)]
+struct CheckpointState {
+    motes: BTreeMap<MoteId, MoteInfoDto>,
+    children: BTreeMap<MoteId, Vec<(MoteId, EdgeMeta)>>,
+    last_seq: u64,
+    run_registration: Option<RunRegistrationDto>,
+    run_resolved_versions: Vec<RunResolvedVersionsDto>,
+}
+
+// Mirrors `MoteInfo`'s five flags 1:1 — same `struct_excessive_bools` allow.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Serialize, Deserialize)]
+struct MoteInfoDto {
+    declared: Option<DeclaredInfoDto>,
+    committed: Option<CommittedInfoDto>,
+    has_proposed: bool,
+    failed_pending_reattempt: bool,
+    effect_staged_observed: bool,
+    terminal_failure_observed: bool,
+    inconsistent: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DeclaredInfoDto {
+    nd_class: NdClass,
+    effect_pattern: EffectPattern,
+    critic_for: Option<MoteId>,
+    is_topology_shaper: bool,
+    parents: Vec<ParentRef>,
+    warrant_ref: ContentRef,
+}
+
+#[derive(Serialize, Deserialize)]
+struct CommittedInfoDto {
+    seq: u64,
+    result_ref: ContentRef,
+    nondeterminism: NdClass,
+    /// `ParentEntry` is not serde-derived (it controls its on-disk journal
+    /// width); mirror it as `(parent_id, edge_kind, non_cascade)`.
+    parents_in_entry: Vec<(MoteId, u8, u8)>,
+    warrant_ref: ContentRef,
+    mote_def_hash: MoteDefHash,
+    repudiated: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RunRegistrationDto {
+    instance_id: [u8; INSTANCE_ID_LEN],
+    recipe_fingerprint: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize)]
+struct RunResolvedVersionsDto {
+    instance_id: [u8; INSTANCE_ID_LEN],
+    warrant_ref: ContentRef,
+    model_id: String,
+    capability: Option<ResolvedCapabilityRecord>,
+}
+
+// ----- State -> DTO (infallible; destructure-without-`..` drift guard) -----
+
+impl From<&State> for CheckpointState {
+    fn from(state: &State) -> Self {
+        // Destructure WITHOUT `..` — a new `State` field breaks this build.
+        let State {
+            motes,
+            children,
+            last_seq,
+            run_registration,
+            run_resolved_versions,
+        } = state;
+        Self {
+            motes: motes
+                .iter()
+                .map(|(id, mi)| (*id, MoteInfoDto::from(mi)))
+                .collect(),
+            children: children.clone(),
+            last_seq: *last_seq,
+            run_registration: run_registration.as_ref().map(RunRegistrationDto::from),
+            run_resolved_versions: run_resolved_versions
+                .iter()
+                .map(RunResolvedVersionsDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<&MoteInfo> for MoteInfoDto {
+    fn from(mi: &MoteInfo) -> Self {
+        let MoteInfo {
+            declared,
+            committed,
+            has_proposed,
+            failed_pending_reattempt,
+            effect_staged_observed,
+            terminal_failure_observed,
+            inconsistent,
+        } = mi;
+        Self {
+            declared: declared.as_ref().map(DeclaredInfoDto::from),
+            committed: committed.as_ref().map(CommittedInfoDto::from),
+            has_proposed: *has_proposed,
+            failed_pending_reattempt: *failed_pending_reattempt,
+            effect_staged_observed: *effect_staged_observed,
+            terminal_failure_observed: *terminal_failure_observed,
+            inconsistent: *inconsistent,
+        }
+    }
+}
+
+impl From<&DeclaredInfo> for DeclaredInfoDto {
+    fn from(d: &DeclaredInfo) -> Self {
+        let DeclaredInfo {
+            nd_class,
+            effect_pattern,
+            critic_for,
+            is_topology_shaper,
+            parents,
+            warrant_ref,
+        } = d;
+        Self {
+            nd_class: *nd_class,
+            effect_pattern: *effect_pattern,
+            critic_for: *critic_for,
+            is_topology_shaper: *is_topology_shaper,
+            parents: parents.to_vec(),
+            warrant_ref: *warrant_ref,
+        }
+    }
+}
+
+impl From<&CommittedInfo> for CommittedInfoDto {
+    fn from(c: &CommittedInfo) -> Self {
+        let CommittedInfo {
+            seq,
+            result_ref,
+            nondeterminism,
+            parents_in_entry,
+            warrant_ref,
+            mote_def_hash,
+            repudiated,
+        } = c;
+        Self {
+            seq: *seq,
+            result_ref: *result_ref,
+            nondeterminism: *nondeterminism,
+            parents_in_entry: parents_in_entry
+                .iter()
+                .map(|p| (p.parent_id, p.edge_kind, p.non_cascade))
+                .collect(),
+            warrant_ref: *warrant_ref,
+            mote_def_hash: *mote_def_hash,
+            repudiated: *repudiated,
+        }
+    }
+}
+
+impl From<&RunRegistration> for RunRegistrationDto {
+    fn from(r: &RunRegistration) -> Self {
+        let RunRegistration {
+            instance_id,
+            recipe_fingerprint,
+        } = r;
+        Self {
+            instance_id: *instance_id,
+            recipe_fingerprint: *recipe_fingerprint,
+        }
+    }
+}
+
+impl From<&RunResolvedVersions> for RunResolvedVersionsDto {
+    fn from(r: &RunResolvedVersions) -> Self {
+        let RunResolvedVersions {
+            instance_id,
+            warrant_ref,
+            model_id,
+            capability,
+        } = r;
+        Self {
+            instance_id: *instance_id,
+            warrant_ref: *warrant_ref,
+            model_id: model_id.clone(),
+            capability: capability.clone(),
+        }
+    }
+}
+
+// ----- DTO -> State (fallible: revalidates each parent edge) -----
+
+impl TryFrom<CheckpointState> for State {
+    type Error = CheckpointError;
+
+    fn try_from(dto: CheckpointState) -> Result<Self, Self::Error> {
+        // Destructure WITHOUT `..` — a new `CheckpointState` field breaks this build.
+        let CheckpointState {
+            motes,
+            children,
+            last_seq,
+            run_registration,
+            run_resolved_versions,
+        } = dto;
+        let mut decoded_motes = BTreeMap::new();
+        for (id, mi) in motes {
+            decoded_motes.insert(id, MoteInfo::try_from(mi)?);
+        }
+        Ok(State {
+            motes: decoded_motes,
+            children,
+            last_seq,
+            run_registration: run_registration.map(RunRegistration::from),
+            run_resolved_versions: run_resolved_versions
+                .into_iter()
+                .map(RunResolvedVersions::from)
+                .collect(),
+        })
+    }
+}
+
+impl TryFrom<MoteInfoDto> for MoteInfo {
+    type Error = CheckpointError;
+
+    fn try_from(dto: MoteInfoDto) -> Result<Self, Self::Error> {
+        let MoteInfoDto {
+            declared,
+            committed,
+            has_proposed,
+            failed_pending_reattempt,
+            effect_staged_observed,
+            terminal_failure_observed,
+            inconsistent,
+        } = dto;
+        Ok(MoteInfo {
+            declared: declared.map(DeclaredInfo::from),
+            committed: committed.map(CommittedInfo::try_from).transpose()?,
+            has_proposed,
+            failed_pending_reattempt,
+            effect_staged_observed,
+            terminal_failure_observed,
+            inconsistent,
+        })
+    }
+}
+
+impl From<DeclaredInfoDto> for DeclaredInfo {
+    fn from(dto: DeclaredInfoDto) -> Self {
+        let DeclaredInfoDto {
+            nd_class,
+            effect_pattern,
+            critic_for,
+            is_topology_shaper,
+            parents,
+            warrant_ref,
+        } = dto;
+        DeclaredInfo {
+            nd_class,
+            effect_pattern,
+            critic_for,
+            is_topology_shaper,
+            parents: SmallVec::from_vec(parents),
+            warrant_ref,
+        }
+    }
+}
+
+impl TryFrom<CommittedInfoDto> for CommittedInfo {
+    type Error = CheckpointError;
+
+    fn try_from(dto: CommittedInfoDto) -> Result<Self, Self::Error> {
+        let CommittedInfoDto {
+            seq,
+            result_ref,
+            nondeterminism,
+            parents_in_entry,
+            warrant_ref,
+            mote_def_hash,
+            repudiated,
+        } = dto;
+        let mut parents: SmallVec<[ParentEntry; 4]> = SmallVec::new();
+        for (parent_id, edge_kind, non_cascade) in parents_in_entry {
+            let pe = ParentEntry {
+                parent_id,
+                edge_kind,
+                non_cascade,
+            };
+            // Re-validate the edge invariant the journal encoder enforces — a
+            // hostile/corrupt blob cannot smuggle an illegal edge into the index.
+            if pe.to_parent_ref().is_none() {
+                return Err(CheckpointError::MalformedParent {
+                    edge_kind,
+                    non_cascade,
+                });
+            }
+            parents.push(pe);
+        }
+        Ok(CommittedInfo {
+            seq,
+            result_ref,
+            nondeterminism,
+            parents_in_entry: parents,
+            warrant_ref,
+            mote_def_hash,
+            repudiated,
+        })
+    }
+}
+
+impl From<RunRegistrationDto> for RunRegistration {
+    fn from(dto: RunRegistrationDto) -> Self {
+        let RunRegistrationDto {
+            instance_id,
+            recipe_fingerprint,
+        } = dto;
+        RunRegistration {
+            instance_id,
+            recipe_fingerprint,
+        }
+    }
+}
+
+impl From<RunResolvedVersionsDto> for RunResolvedVersions {
+    fn from(dto: RunResolvedVersionsDto) -> Self {
+        let RunResolvedVersionsDto {
+            instance_id,
+            warrant_ref,
+            model_id,
+            capability,
+        } = dto;
+        RunResolvedVersions {
+            instance_id,
+            warrant_ref,
+            model_id,
+            capability,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    /// A folded state exercising **every** DTO arm + **every** `MoteInfo` flag,
+    /// so the lossless round-trip is a comprehensive field-coverage oracle:
+    /// declared (with `critic_for` + a parent), committed (WORLD-MUTATING, a
+    /// control parent, `mote_def_hash`), `effect_staged_observed`, `has_proposed`,
+    /// `failed_pending_reattempt`, `terminal_failure_observed`, `inconsistent`,
+    /// committed+`repudiated`, run registration, and a resolved-versions record.
+    fn sample_state() -> State {
+        let mut s = State::default();
+        // declared child 10 with parent 1 (data edge) + a critic relationship
+        s.set_declared(
+            mid(10),
+            DeclaredInfo {
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                critic_for: Some(mid(7)),
+                is_topology_shaper: false,
+                parents: SmallVec::from_vec(vec![ParentRef {
+                    parent_id: mid(1),
+                    edge: EdgeMeta::data(),
+                }]),
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            },
+        );
+        // committed mote 1 with a control parent 2, plus effect_staged_observed
+        let info = s.moteinfo_mut(&mid(1));
+        info.committed = Some(CommittedInfo {
+            seq: 3,
+            result_ref: ContentRef::from_bytes([7; 32]),
+            nondeterminism: NdClass::WorldMutating,
+            parents_in_entry: SmallVec::from_vec(vec![ParentEntry {
+                parent_id: mid(2),
+                edge_kind: 1,
+                non_cascade: 0,
+            }]),
+            warrant_ref: ContentRef::from_bytes([0xbb; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([9; 32]),
+            repudiated: false,
+        });
+        info.effect_staged_observed = true;
+        s.index_committed(mid(1), &[]);
+        // committed + repudiated
+        let r = s.moteinfo_mut(&mid(24));
+        r.committed = Some(CommittedInfo {
+            seq: 4,
+            result_ref: ContentRef::from_bytes([8; 32]),
+            nondeterminism: NdClass::Pure,
+            parents_in_entry: SmallVec::new(),
+            warrant_ref: ContentRef::from_bytes([0xcc; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([1; 32]),
+            repudiated: true,
+        });
+        // the remaining per-flag motes
+        s.moteinfo_mut(&mid(20)).has_proposed = true;
+        s.moteinfo_mut(&mid(21)).failed_pending_reattempt = true;
+        s.moteinfo_mut(&mid(22)).terminal_failure_observed = true;
+        s.moteinfo_mut(&mid(23)).inconsistent = true;
+        s.last_seq = 4;
+        s.run_registration = Some(RunRegistration {
+            instance_id: [5; INSTANCE_ID_LEN],
+            recipe_fingerprint: [6; 32],
+        });
+        s.run_resolved_versions.push(RunResolvedVersions {
+            instance_id: [5; INSTANCE_ID_LEN],
+            warrant_ref: ContentRef::from_bytes([0xdd; 32]),
+            model_id: "qwen-0.5b".to_string(),
+            capability: None,
+        });
+        s
+    }
+
+    #[test]
+    fn roundtrip_state_is_lossless() {
+        let s = sample_state();
+        let cp = FoldCheckpoint::from_state(&s);
+        let decoded = cp.decode_state().expect("decode");
+        assert_eq!(
+            decoded, s,
+            "decoded State must equal the source bit-for-bit"
+        );
+        assert_eq!(cp.journal_offset(), 4);
+    }
+
+    #[test]
+    fn bytes_roundtrip_and_verify() {
+        let cp = FoldCheckpoint::from_state(&sample_state());
+        let bytes = cp.to_bytes();
+        let back = FoldCheckpoint::from_bytes(&bytes).expect("from_bytes");
+        assert_eq!(back, cp);
+        assert!(back.verify());
+    }
+
+    #[test]
+    fn from_bytes_rejects_short_buffers_without_panic() {
+        for len in [0usize, 1, HEADER_LEN - 1] {
+            let buf = vec![0u8; len];
+            assert!(matches!(
+                FoldCheckpoint::from_bytes(&buf),
+                Err(CheckpointError::TooShort { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn from_bytes_rejects_wrong_version() {
+        let mut bytes = FoldCheckpoint::from_state(&sample_state()).to_bytes();
+        bytes[0] = bytes[0].wrapping_add(1); // perturb version
+        assert!(matches!(
+            FoldCheckpoint::from_bytes(&bytes),
+            // version is part of the digest preimage, so this is caught as a
+            // version OR digest mismatch — both are fail-safe discards.
+            Err(CheckpointError::UnsupportedVersion { .. } | CheckpointError::DigestMismatch)
+        ));
+    }
+
+    #[test]
+    fn from_bytes_rejects_unknown_codec() {
+        let mut bytes = FoldCheckpoint::from_state(&sample_state()).to_bytes();
+        bytes[2] = 9; // unknown codec
+        assert!(matches!(
+            FoldCheckpoint::from_bytes(&bytes),
+            Err(CheckpointError::UnsupportedCodec { got: 9 } | CheckpointError::DigestMismatch)
+        ));
+    }
+
+    #[test]
+    fn from_bytes_detects_flipped_payload_byte() {
+        let bytes = FoldCheckpoint::from_state(&sample_state()).to_bytes();
+        let mut corrupt = bytes.clone();
+        let last = corrupt.len() - 1;
+        corrupt[last] ^= 0xff;
+        assert_eq!(
+            FoldCheckpoint::from_bytes(&corrupt),
+            Err(CheckpointError::DigestMismatch)
+        );
+    }
+
+    #[test]
+    fn verify_detects_mutated_digest_field() {
+        let mut cp = FoldCheckpoint::from_state(&sample_state());
+        cp.digest[0] ^= 0xff;
+        assert!(!cp.verify());
+    }
+
+    #[test]
+    fn decode_rejects_malformed_parent_edge() {
+        // Hand-build a state with an illegal Data edge that carries non_cascade=1
+        // (the journal encoder would reject this; the checkpoint decoder must too).
+        let mut s = State::default();
+        let info = s.moteinfo_mut(&mid(1));
+        info.committed = Some(CommittedInfo {
+            seq: 1,
+            result_ref: ContentRef::from_bytes([0; 32]),
+            nondeterminism: NdClass::Pure,
+            parents_in_entry: SmallVec::from_vec(vec![ParentEntry {
+                parent_id: mid(2),
+                edge_kind: 0,   // Data
+                non_cascade: 1, // illegal on a Data edge
+            }]),
+            warrant_ref: ContentRef::from_bytes([0; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([0; 32]),
+            repudiated: false,
+        });
+        s.last_seq = 1;
+        let cp = FoldCheckpoint::from_state(&s);
+        assert!(matches!(
+            cp.decode_state(),
+            Err(CheckpointError::MalformedParent {
+                edge_kind: 0,
+                non_cascade: 1
+            })
+        ));
+    }
+
+    #[test]
+    fn state_digest_is_deterministic_and_content_sensitive() {
+        let a = state_content_digest(&sample_state());
+        let b = state_content_digest(&sample_state());
+        assert_eq!(a, b, "same state -> same digest");
+        let mut mutated = sample_state();
+        mutated.last_seq = 5; // any content change moves the digest
+        assert_ne!(a, state_content_digest(&mutated));
+    }
+}

--- a/crates/kx-projection/src/lib.rs
+++ b/crates/kx-projection/src/lib.rs
@@ -110,9 +110,15 @@
 //!   before any journal entry exists for it.
 //! - [`Projection`] — the in-memory fold state; mutate via `register_mote` + `fold`.
 //! - [`Snapshot`] — an immutable point-in-time view of the projection.
+//! - [`FoldCheckpoint`] — a **discardable** durable snapshot of the folded state
+//!   (D92(b), M2.2). Lets cold recovery fold `(checkpoint_offset, current]`
+//!   instead of `(0, current]` via [`Projection::from_journal_with_checkpoint`].
+//!   Never authoritative — a corrupt/stale/wrong-run checkpoint is silently
+//!   discarded and the full fold runs.
 //! - The 7-method read API surface (`state_of`, `parents_of`, `children_of`,
 //!   `transitive_consumers`, `result_ref_of`, `ready_set`, `promotion_state`).
 
+mod checkpoint;
 mod child_resolver;
 mod enums;
 mod errors;
@@ -125,6 +131,7 @@ mod register;
 mod snapshot;
 mod state;
 
+pub use checkpoint::{CheckpointError, FoldCheckpoint, CURRENT_FORMAT_VERSION, PAYLOAD_CODEC};
 pub use child_resolver::{ChildResolver, InheritFromShaperResolver};
 pub use enums::{AnomalyKind, MoteState, PromotionState};
 pub use errors::ProjectionError;

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -7,6 +7,7 @@ use kx_journal::{Journal, JournalEntry};
 use kx_mote::{EdgeMeta, MoteId, NdClass};
 use smallvec::SmallVec;
 
+use crate::checkpoint::FoldCheckpoint;
 use crate::enums::{AnomalyKind, MoteState, PromotionState};
 use crate::errors::ProjectionError;
 use crate::helpers::{promotion_state_impl, ready_set_impl, transitive_consumers_impl};
@@ -150,6 +151,128 @@ impl Projection {
             p.fold(&entry)?;
         }
         Ok(p)
+    }
+
+    /// Cold recovery that **resumes from a discardable [`FoldCheckpoint`]** when
+    /// one is usable (D92(b), M2.2): seed the folded state from the checkpoint and
+    /// fold only the tail `(checkpoint_offset, current]` instead of `(0, current]`.
+    ///
+    /// **Fail-safe.** The checkpoint is *never authoritative* — on any anomaly
+    /// (failed integrity check, unsupported version/codec, decode failure, an
+    /// offset past the journal head, an encoded `last_seq` that disagrees with the
+    /// offset, or a run-id that does not match the journal's `RunRegistered`) this
+    /// silently **discards the checkpoint and runs the full fold**. Passing
+    /// `None` is always a full fold. The result is bit-identical to
+    /// [`Self::from_journal`] either way — the checkpoint only changes *how much*
+    /// is re-folded, never the outcome.
+    pub fn from_journal_with_checkpoint<J: Journal>(
+        journal: &J,
+        checkpoint: Option<&FoldCheckpoint>,
+    ) -> Result<Self, ProjectionError> {
+        Self::build_from_journal(journal, checkpoint, None)
+    }
+
+    /// The materializer-wired counterpart of [`Self::from_journal_with_checkpoint`]
+    /// (the cold-re-fold equivalent of [`Self::from_journal_with_materializer`]).
+    ///
+    /// On a checkpoint hit the materialized children committed at `seq ≤ offset`
+    /// are restored from the seeded state; the materializer fires **only** for
+    /// shaper commits in the tail `(offset, current]`, so no child is
+    /// re-materialized. On any anomaly it falls back to a full
+    /// [`Self::from_journal_with_materializer`].
+    pub fn from_journal_with_checkpoint_with_materializer<J: Journal>(
+        journal: &J,
+        materializer: Box<dyn TopologyMaterializer>,
+        checkpoint: Option<&FoldCheckpoint>,
+    ) -> Result<Self, ProjectionError> {
+        Self::build_from_journal(journal, checkpoint, Some(materializer))
+    }
+
+    /// Shared body for the checkpoint-aware cold-recovery entry points: try to
+    /// seed from the checkpoint, then fold the remaining tail; fall back to a
+    /// full fold (`start_exclusive = 0`) when the checkpoint is unusable.
+    fn build_from_journal<J: Journal>(
+        journal: &J,
+        checkpoint: Option<&FoldCheckpoint>,
+        materializer: Option<Box<dyn TopologyMaterializer>>,
+    ) -> Result<Self, ProjectionError> {
+        let current = journal.current_seq()?;
+        let seed = match checkpoint {
+            Some(cp) => Self::try_seed_state(journal, cp, current)?,
+            None => None,
+        };
+        let (mut p, start_exclusive) = match seed {
+            Some(state) => {
+                let offset = state.last_seq;
+                (
+                    Self {
+                        state,
+                        materializer,
+                    },
+                    offset,
+                )
+            }
+            None => (
+                Self {
+                    state: State::default(),
+                    materializer,
+                },
+                0,
+            ),
+        };
+        for entry in journal.read_entries_by_seq((start_exclusive + 1)..(current + 1))? {
+            p.fold(&entry)?;
+        }
+        Ok(p)
+    }
+
+    /// Validate a checkpoint against the journal and decode its seeded state, or
+    /// return `Ok(None)` to signal "discard and full-fold". Journal I/O errors
+    /// propagate; every *checkpoint* defect is a graceful `None`.
+    fn try_seed_state<J: Journal>(
+        journal: &J,
+        cp: &FoldCheckpoint,
+        current: u64,
+    ) -> Result<Option<State>, ProjectionError> {
+        // (1) integrity — the envelope digest must verify.
+        if !cp.verify() {
+            return Ok(None);
+        }
+        // (2) the offset must not run past the journal head (stale / truncated log).
+        if cp.journal_offset() > current {
+            return Ok(None);
+        }
+        // (3) decode the payload; a malformed/hostile blob is discarded.
+        let Ok(state) = cp.decode_state() else {
+            return Ok(None);
+        };
+        // (4) the encoded frontier must equal the declared offset (consistency).
+        if state.last_seq != cp.journal_offset() {
+            return Ok(None);
+        }
+        // (5) wrong-run guard (best effort): if both name a run, the ids must match.
+        if let Some(reg) = state.run_registration {
+            if let Some(journal_instance) = Self::journal_run_instance(journal)? {
+                if journal_instance != reg.instance_id {
+                    return Ok(None);
+                }
+            }
+        }
+        Ok(Some(state))
+    }
+
+    /// The journal's registered run instance id, read from the `RunRegistered`
+    /// fact (M1.1 establishes it at `seq = 1`). `None` if the journal carries no
+    /// such fact (e.g. a test/legacy log) — then the wrong-run guard is skipped.
+    fn journal_run_instance<J: Journal>(
+        journal: &J,
+    ) -> Result<Option<[u8; kx_journal::INSTANCE_ID_LEN]>, ProjectionError> {
+        for entry in journal.read_entries_by_seq(1..2)? {
+            if let JournalEntry::RunRegistered { instance_id, .. } = entry {
+                return Ok(Some(instance_id));
+            }
+        }
+        Ok(None)
     }
 
     /// Register a workflow-declared Mote.
@@ -405,6 +528,41 @@ impl Projection {
         Snapshot {
             state: self.state.clone(),
         }
+    }
+
+    /// The canonical **full-state digest** of the current fold — a deterministic
+    /// blake3 over a canonical encoding of the entire projection state (every
+    /// Mote's declared/committed/flag fields, the children index, `last_seq`, and
+    /// the run metadata).
+    ///
+    /// This is the digest a [`FoldCheckpoint`] embeds, and the digest the roadmap
+    /// journaled seal (M2.2c) will store + verify recovery against. It is
+    /// **distinct** from `kx-runtime`'s committed-facts *product* digest (the
+    /// canonical run-identity `a6b5c679…`): this one covers the *whole* state for
+    /// recovery integrity, never run identity. Exact-equality only (SN-8).
+    #[must_use]
+    pub fn state_digest(&self) -> [u8; 32] {
+        crate::checkpoint::state_content_digest(&self.state)
+    }
+
+    /// Capture a discardable [`FoldCheckpoint`] of the current fold (D92(b), M2.2).
+    ///
+    /// **Caller invariant:** only checkpoint a projection that has been folded
+    /// **contiguously over `[1, last_seq]`** (no skipped `seq ≤ last_seq`, no entry
+    /// `seq > last_seq` applied). [`Self::from_journal`] /
+    /// [`Self::from_journal_with_materializer`] always satisfy this; an incremental
+    /// caller must checkpoint only at a drained frontier. The checkpoint's
+    /// `journal_offset` is `last_seq`; recovery folds `(offset, current]` on top.
+    #[must_use]
+    pub fn fold_checkpoint(&self) -> FoldCheckpoint {
+        let cp = FoldCheckpoint::from_state(&self.state);
+        // Capture-time oracle (compiled out in release): the checkpoint must
+        // decode back to this exact state.
+        debug_assert!(
+            matches!(cp.decode_state(), Ok(s) if s == self.state),
+            "fold_checkpoint round-trip diverged from the source State"
+        );
+        cp
     }
 
     // ----- Read API (delegates to State; same surface as Snapshot) -----

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -13,7 +13,7 @@ use smallvec::SmallVec;
 
 use crate::enums::{AnomalyKind, MoteState};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct CommittedInfo {
     pub(crate) seq: u64,
     pub(crate) result_ref: ContentRef,
@@ -44,7 +44,7 @@ pub(crate) struct CommittedInfo {
 // the per-flag invariants the fold + state_of_id depend on. Each flag's
 // reset/no-reset semantics is named at its field-level doc comment.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct MoteInfo {
     /// Workflow-author-declared properties (when registered).
     pub(crate) declared: Option<DeclaredInfo>,
@@ -76,7 +76,7 @@ pub(crate) struct MoteInfo {
     pub(crate) inconsistent: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
 // `nd_class`, `effect_pattern`, `critic_for`, `is_topology_shaper`,
 // `warrant_ref` are stored at registration but unread in P1.5. P1.9 (the
@@ -121,7 +121,7 @@ pub struct RunResolvedVersions {
     pub capability: Option<kx_journal::ResolvedCapabilityRecord>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct State {
     /// Per-MoteId info — declared, committed, and any in-flight state.
     pub(crate) motes: BTreeMap<MoteId, MoteInfo>,

--- a/crates/kx-projection/tests/fold_checkpoint.rs
+++ b/crates/kx-projection/tests/fold_checkpoint.rs
@@ -1,0 +1,642 @@
+// Integration-test file: compiled as a separate crate from the host lib;
+// inherits the workspace `[lints]` deny on `unwrap_used` / `expect_used` but
+// tests legitimately `.unwrap()` for fixture construction. `pedantic` is allowed
+// for the usual small-int-cast / helper-after-let friction.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! M2.2 — discardable `FoldCheckpoint` (D92(b)): resume-from-checkpoint
+//! equivalence, fail-safe fallback, durable-byte round-trip, determinism, and
+//! the materializer no-refire property.
+//!
+//! The load-bearing theorem is fold associativity:
+//! `fold(0,N] == fold(K,N] ∘ fold(0,K]`. The checkpoint stores `fold(0,K]`; a
+//! resume folds the tail on top and MUST reproduce the full fold **for every
+//! offset K**. The checkpoint is never authoritative — every corruption /
+//! staleness / wrong-run path falls back to a full fold and still matches.
+
+use std::sync::{Arc, Mutex};
+
+use kx_content::ContentRef;
+use kx_journal::{
+    repudiation_idempotency_key, FailureReason, InMemoryJournal, Journal, JournalEntry,
+    ParentEntry, RepudiationReason, INSTANCE_ID_LEN,
+};
+use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use kx_projection::{
+    CheckpointError, FoldCheckpoint, Projection, ProjectionError, RegisterMote,
+    TopologyMaterializer,
+};
+use proptest::prelude::*;
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn mid(b: u8) -> MoteId {
+    MoteId::from_bytes([b; 32])
+}
+
+/// A distinct idempotency key per call-counter, so appended entries never dedup
+/// (the journal would collapse duplicate (key,kind) pairs and skip a `seq`).
+fn ukey(n: u64) -> [u8; 32] {
+    let mut k = [0xEEu8; 32];
+    k[..8].copy_from_slice(&n.to_le_bytes());
+    k
+}
+
+fn war() -> ContentRef {
+    ContentRef::from_bytes([0xaa; 32])
+}
+
+fn pref(id: MoteId, edge: EdgeMeta) -> ParentRef {
+    ParentRef {
+        parent_id: id,
+        edge,
+    }
+}
+
+fn committed_entry(m: u8, parents: &[ParentRef]) -> JournalEntry {
+    let pe: SmallVec<[ParentEntry; 4]> = parents.iter().map(ParentEntry::from_parent_ref).collect();
+    JournalEntry::Committed {
+        mote_id: mid(m),
+        idempotency_key: *mid(m).as_bytes(),
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([7u8; 32]),
+        parents: pe,
+        warrant_ref: war(),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+/// Fold the journal prefix `[1, k]` into a fresh (materializer-less) projection —
+/// the contiguous-prefix precondition `fold_checkpoint` requires.
+fn seed_through(journal: &InMemoryJournal, k: u64) -> Projection {
+    let mut p = Projection::new();
+    for e in journal.read_entries_by_seq(0..(k + 1)).unwrap() {
+        p.fold(&e).unwrap();
+    }
+    p
+}
+
+/// Strong structural equality of two projections via the full-state digest, plus
+/// a public-API spot-check (every known Mote's state + the seq frontier).
+fn assert_projection_eq(a: &Projection, b: &Projection, ctx: &str) {
+    assert_eq!(
+        a.state_digest(),
+        b.state_digest(),
+        "{ctx}: full-state digest mismatch"
+    );
+    assert_eq!(
+        a.current_seq(),
+        b.current_seq(),
+        "{ctx}: seq frontier mismatch"
+    );
+    let am: Vec<_> = a.iter_motes().collect();
+    let bm: Vec<_> = b.iter_motes().collect();
+    assert_eq!(am, bm, "{ctx}: (MoteId, MoteState) sets differ");
+}
+
+// ---------------------------------------------------------------------------
+// Proptest generator — arbitrary journal-entry traces (no register_mote, so the
+// comparison target is `from_journal`, which never replays declarations).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum TraceOp {
+    Propose(u8),
+    Commit(u8),
+    Fail(u8, bool), // (mote, terminal?)
+    Stage(u8),
+    Repudiate(u8),
+}
+
+fn arb_op() -> impl Strategy<Value = TraceOp> {
+    prop_oneof![
+        (0u8..10).prop_map(TraceOp::Propose),
+        (0u8..10).prop_map(TraceOp::Commit),
+        (0u8..10, any::<bool>()).prop_map(|(m, t)| TraceOp::Fail(m, t)),
+        (0u8..10).prop_map(TraceOp::Stage),
+        (0u8..10).prop_map(TraceOp::Repudiate),
+    ]
+}
+
+/// Interpret an op trace against a live `InMemoryJournal`, which assigns dense
+/// monotonic seqs. Returns the populated journal. Commits are deduped per Mote
+/// (a second is a journal bug, not the checkpoint's concern); Repudiate only
+/// fires against an already-committed, not-yet-repudiated target.
+fn build_journal(ops: &[TraceOp]) -> InMemoryJournal {
+    let journal = InMemoryJournal::new();
+    let mut committed: std::collections::BTreeMap<u8, u64> = std::collections::BTreeMap::new();
+    let mut repudiated: std::collections::BTreeSet<u8> = std::collections::BTreeSet::new();
+    let mut ctr = 0u64;
+    for op in ops {
+        ctr += 1;
+        match op {
+            TraceOp::Propose(m) => {
+                journal
+                    .append(JournalEntry::Proposed {
+                        mote_id: mid(*m),
+                        idempotency_key: ukey(ctr),
+                        seq: 0,
+                        nondeterminism: NdClass::Pure,
+                        placement_hint: 0,
+                        warrant_ref: war(),
+                    })
+                    .unwrap();
+            }
+            TraceOp::Commit(m) => {
+                if !committed.contains_key(m) {
+                    let parents = if *m > 0 {
+                        vec![pref(mid(m - 1), EdgeMeta::data())]
+                    } else {
+                        vec![]
+                    };
+                    let r = journal.append(committed_entry(*m, &parents)).unwrap();
+                    committed.insert(*m, r.seq());
+                }
+            }
+            TraceOp::Fail(m, terminal) => {
+                let reason = if *terminal {
+                    FailureReason::ExecutorRefused
+                } else {
+                    FailureReason::TimedOut
+                };
+                journal
+                    .append(JournalEntry::Failed {
+                        mote_id: mid(*m),
+                        idempotency_key: ukey(ctr),
+                        seq: 0,
+                        reason_class: reason,
+                        reporter_id: 0,
+                    })
+                    .unwrap();
+            }
+            TraceOp::Stage(m) => {
+                journal
+                    .append(JournalEntry::EffectStaged {
+                        mote_id: mid(*m),
+                        idempotency_key: ukey(ctr),
+                        seq: 0,
+                    })
+                    .unwrap();
+            }
+            TraceOp::Repudiate(m) => {
+                if let Some(cs) = committed.get(m) {
+                    if repudiated.insert(*m) {
+                        journal
+                            .append(JournalEntry::Repudiated {
+                                target_mote_id: mid(*m),
+                                idempotency_key: repudiation_idempotency_key(&mid(*m), *cs),
+                                seq: 0,
+                                target_committed_seq: *cs,
+                                reason_class: RepudiationReason::OperatorAction,
+                                repudiator_id: 0,
+                            })
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+    journal
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 192, ..ProptestConfig::default() })]
+
+    /// **The DoD line: cold-fold-from-offset == cold-fold-from-zero.** For an
+    /// arbitrary trace, resume from a checkpoint taken at EVERY offset K in
+    /// `[0, last_seq]` and assert the resumed projection equals the full fold.
+    #[test]
+    fn prop_resume_from_every_offset(ops in prop::collection::vec(arb_op(), 0..16)) {
+        let journal = build_journal(&ops);
+        let n = journal.current_seq().unwrap();
+        let full = Projection::from_journal(&journal).unwrap();
+
+        for k in 0..=n {
+            let cp = seed_through(&journal, k).fold_checkpoint();
+            prop_assert_eq!(cp.journal_offset(), k, "checkpoint offset must equal the prefix frontier");
+            // Round-trip through the durable bytes too — the real recovery path.
+            let cp = FoldCheckpoint::from_bytes(&cp.to_bytes()).unwrap();
+            let resumed = Projection::from_journal_with_checkpoint(&journal, Some(&cp)).unwrap();
+            prop_assert_eq!(
+                resumed.state_digest(), full.state_digest(),
+                "resume from offset {} diverged from the full fold", k
+            );
+            prop_assert_eq!(resumed.current_seq(), full.current_seq());
+        }
+    }
+
+    /// **Discardability:** `to_bytes -> from_bytes -> resume (empty tail)` equals
+    /// the source projection (drop/recreate the checkpoint -> identical state).
+    #[test]
+    fn prop_roundtrip_is_lossless(ops in prop::collection::vec(arb_op(), 0..16)) {
+        let journal = build_journal(&ops);
+        let full = Projection::from_journal(&journal).unwrap();
+        let cp = FoldCheckpoint::from_bytes(&full.fold_checkpoint().to_bytes()).unwrap();
+        // Offset == head, so the tail is empty; the resume is pure decode.
+        let resumed = Projection::from_journal_with_checkpoint(&journal, Some(&cp)).unwrap();
+        prop_assert_eq!(resumed.state_digest(), full.state_digest());
+    }
+
+    /// **Re-fold + canonical-encoding determinism:** two independent journals
+    /// built from the same trace produce byte-identical checkpoints.
+    #[test]
+    fn prop_bytes_are_deterministic(ops in prop::collection::vec(arb_op(), 0..16)) {
+        let a = Projection::from_journal(&build_journal(&ops)).unwrap().fold_checkpoint().to_bytes();
+        let b = Projection::from_journal(&build_journal(&ops)).unwrap().fold_checkpoint().to_bytes();
+        prop_assert_eq!(a, b, "checkpoint bytes must be deterministic for an identical trace");
+    }
+
+    /// **Fail-safe:** any single-byte flip OR truncation of the durable blob is a
+    /// graceful `Err` (digest / length check), never a panic, never silent trust.
+    #[test]
+    fn prop_corrupt_or_truncated_fails_safe(
+        ops in prop::collection::vec(arb_op(), 1..12),
+        flip_idx in any::<usize>(),
+        flip_mask in 1u8..=255,
+        trunc in any::<usize>(),
+    ) {
+        let journal = build_journal(&ops);
+        let bytes = Projection::from_journal(&journal).unwrap().fold_checkpoint().to_bytes();
+
+        // A flipped byte must be rejected (no panic).
+        let mut flipped = bytes.clone();
+        let i = flip_idx % flipped.len();
+        flipped[i] ^= flip_mask;
+        prop_assert!(
+            FoldCheckpoint::from_bytes(&flipped).is_err(),
+            "a corrupted checkpoint must be rejected, not trusted"
+        );
+
+        // A truncation (any length < full) must be rejected (no panic).
+        let cut = trunc % bytes.len();
+        prop_assert!(FoldCheckpoint::from_bytes(&bytes[..cut]).is_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic edge-case tests
+// ---------------------------------------------------------------------------
+
+/// A trace deliberately hitting committed / repudiated / failed-terminal /
+/// failed-pending / proposed / effect-staged cells, checkpointed at every
+/// offset — a fixed counterpart to the proptest's breadth.
+#[test]
+fn resume_equivalence_over_mixed_cells() {
+    let ops = vec![
+        TraceOp::Propose(1),
+        TraceOp::Commit(1),
+        TraceOp::Stage(2),
+        TraceOp::Commit(2),
+        TraceOp::Fail(3, false), // pre-commit (retry permitted)
+        TraceOp::Fail(4, true),  // terminal
+        TraceOp::Commit(5),
+        TraceOp::Repudiate(5),
+        TraceOp::Propose(6),
+    ];
+    let journal = build_journal(&ops);
+    let n = journal.current_seq().unwrap();
+    let full = Projection::from_journal(&journal).unwrap();
+    for k in 0..=n {
+        let cp = seed_through(&journal, k).fold_checkpoint();
+        let resumed = Projection::from_journal_with_checkpoint(&journal, Some(&cp)).unwrap();
+        assert_projection_eq(&resumed, &full, &format!("offset {k}"));
+    }
+}
+
+/// `None` checkpoint and an empty journal both resolve to the full fold.
+#[test]
+fn none_checkpoint_is_full_fold() {
+    let journal = build_journal(&[TraceOp::Commit(1), TraceOp::Commit(2)]);
+    let full = Projection::from_journal(&journal).unwrap();
+    let resumed = Projection::from_journal_with_checkpoint(&journal, None).unwrap();
+    assert_projection_eq(&resumed, &full, "None checkpoint");
+}
+
+/// **Fail-safe fallback:** a checkpoint whose offset is past the (truncated)
+/// journal head is discarded; recovery silently full-folds the short journal.
+#[test]
+fn stale_offset_falls_back_to_full_fold() {
+    // A 5-entry journal -> a checkpoint at offset 5.
+    let long = build_journal(&[
+        TraceOp::Commit(1),
+        TraceOp::Commit(2),
+        TraceOp::Commit(3),
+        TraceOp::Commit(4),
+        TraceOp::Commit(5),
+    ]);
+    let cp = Projection::from_journal(&long).unwrap().fold_checkpoint();
+    assert_eq!(cp.journal_offset(), 5);
+
+    // A different, SHORTER journal (head = 3) — the stale checkpoint must not seed it.
+    let short = build_journal(&[TraceOp::Commit(1), TraceOp::Commit(2), TraceOp::Commit(3)]);
+    let resumed = Projection::from_journal_with_checkpoint(&short, Some(&cp)).unwrap();
+    let full_short = Projection::from_journal(&short).unwrap();
+    assert_projection_eq(&resumed, &full_short, "stale-offset fallback");
+}
+
+/// **Wrong-run guard:** a checkpoint carrying run A's `instance_id` must not seed
+/// a journal registered under run B; recovery falls back to the full fold.
+#[test]
+fn wrong_run_checkpoint_falls_back() {
+    fn run_journal(instance: u8) -> InMemoryJournal {
+        let j = InMemoryJournal::new();
+        j.append(JournalEntry::RunRegistered {
+            instance_id: [instance; INSTANCE_ID_LEN],
+            recipe_fingerprint: [0xab; 32],
+            ts: 0,
+            seq: 0,
+        })
+        .unwrap();
+        j.append(committed_entry(1, &[])).unwrap();
+        j
+    }
+    let run_a = run_journal(0xAA);
+    let cp_a = Projection::from_journal(&run_a).unwrap().fold_checkpoint();
+
+    let run_b = run_journal(0xBB);
+    let resumed = Projection::from_journal_with_checkpoint(&run_b, Some(&cp_a)).unwrap();
+    let full_b = Projection::from_journal(&run_b).unwrap();
+    assert_projection_eq(&resumed, &full_b, "wrong-run fallback");
+}
+
+// ---------------------------------------------------------------------------
+// Materializer path — seeded shaper children + tail-fold, no re-materialization
+// ---------------------------------------------------------------------------
+
+/// A deterministic stub: the Mote `shaper` materializes `children` (each a PURE
+/// Mote with a Control edge back to the shaper). Records every shaper id it
+/// *actually materializes*, so a resume can assert the ≤offset shaper is not
+/// re-fired.
+struct StubMaterializer {
+    shaper: MoteId,
+    children: Vec<MoteId>,
+    fired: Arc<Mutex<Vec<MoteId>>>,
+}
+
+impl TopologyMaterializer for StubMaterializer {
+    fn try_materialize(
+        &self,
+        shaper_mote_id: MoteId,
+        _def_hash: MoteDefHash,
+        _result_ref: ContentRef,
+        _warrant_ref: ContentRef,
+    ) -> Result<Option<Vec<RegisterMote>>, ProjectionError> {
+        if shaper_mote_id != self.shaper {
+            return Ok(None); // not a shaper — the common fast path
+        }
+        self.fired.lock().unwrap().push(shaper_mote_id);
+        let regs = self
+            .children
+            .iter()
+            .map(|c| RegisterMote {
+                mote_id: *c,
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                critic_for: None,
+                is_topology_shaper: false,
+                parents: SmallVec::from_vec(vec![pref(self.shaper, EdgeMeta::control())]),
+                warrant_ref: ContentRef::from_bytes([0xcc; 32]),
+            })
+            .collect();
+        Ok(Some(regs))
+    }
+}
+
+fn stub(fired: &Arc<Mutex<Vec<MoteId>>>) -> Box<StubMaterializer> {
+    Box::new(StubMaterializer {
+        shaper: mid(100),
+        children: vec![mid(101), mid(102)],
+        fired: Arc::clone(fired),
+    })
+}
+
+#[test]
+fn checkpoint_resume_with_materializer_matches_full_and_does_not_refire() {
+    // Journal: shaper commits (seq 1) -> materializes 101, 102; then each child
+    // commits (seq 2, 3) carrying its Control edge back to the shaper.
+    let journal = InMemoryJournal::new();
+    journal.append(committed_entry(100, &[])).unwrap();
+    journal
+        .append(committed_entry(101, &[pref(mid(100), EdgeMeta::control())]))
+        .unwrap();
+    journal
+        .append(committed_entry(102, &[pref(mid(100), EdgeMeta::control())]))
+        .unwrap();
+
+    // Full materializer fold (the comparison target).
+    let full_fired = Arc::new(Mutex::new(Vec::new()));
+    let full = Projection::from_journal_with_checkpoint_with_materializer(
+        &journal,
+        stub(&full_fired),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        *full_fired.lock().unwrap(),
+        vec![mid(100)],
+        "full fold materializes the shaper exactly once"
+    );
+
+    // Seed at offset 1 (after the shaper commit + its materialization).
+    let seed_fired = Arc::new(Mutex::new(Vec::new()));
+    let mut seed = Projection::with_materializer(stub(&seed_fired));
+    for e in journal.read_entries_by_seq(0..2).unwrap() {
+        seed.fold(&e).unwrap();
+    }
+    let cp = FoldCheckpoint::from_bytes(&seed.fold_checkpoint().to_bytes()).unwrap();
+    assert_eq!(cp.journal_offset(), 1);
+
+    // Resume: the ≤offset shaper must NOT be re-materialized; the tail child
+    // commits fold against the seeded (already-declared) children.
+    let resume_fired = Arc::new(Mutex::new(Vec::new()));
+    let resumed = Projection::from_journal_with_checkpoint_with_materializer(
+        &journal,
+        stub(&resume_fired),
+        Some(&cp),
+    )
+    .unwrap();
+
+    assert!(
+        resume_fired.lock().unwrap().is_empty(),
+        "the checkpointed shaper must NOT be re-materialized on resume"
+    );
+    assert_projection_eq(&resumed, &full, "materializer resume");
+    // Spot-check the materialized topology survived the checkpoint round-trip.
+    assert_eq!(
+        resumed.children_of(&mid(100)).len(),
+        2,
+        "shaper keeps 2 children"
+    );
+    assert_eq!(
+        resumed.parents_of(&mid(101)),
+        full.parents_of(&mid(101)),
+        "child 101's narrowed parent edge is preserved"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scale / perf (`#[ignore]`) — the HONEST checkpoint win. Run:
+//   cargo test -p kx-projection --release --test fold_checkpoint \
+//     -- --ignored --nocapture --test-threads=1
+//
+// What this measures (and what it deliberately does NOT claim):
+//
+//   * The win is NOT "a bincode decode beats a re-fold" — M2.1 already made the
+//     in-memory fold ~0.5us/Mote, and a full-state decode of a *clean* log is
+//     roughly a wash (the rkyv zero-copy codec, roadmap M2.2d, is what makes the
+//     clean case a win). We do not pretend otherwise.
+//   * The REAL win is decoupling resume cost from journal CHURN: under a
+//     crash-loopy workload (the Risk #1 scenario — many Proposed/Failed attempts
+//     per Mote before a commit) total entries >> distinct Motes. A full fold pays
+//     for every entry; the checkpoint decode pays only for live state. So resume
+//     time is bounded by live-state size, not journal length.
+// ---------------------------------------------------------------------------
+
+/// A distinct `MoteId` per `u32` (a single byte would collide at scale).
+fn mid_n(i: u32) -> MoteId {
+    let mut b = [0u8; 32];
+    b[..4].copy_from_slice(&i.to_le_bytes());
+    MoteId::from_bytes(b)
+}
+
+#[test]
+#[ignore = "scale: run --release --test fold_checkpoint -- --ignored --nocapture"]
+fn scale_resume_is_bounded_by_live_state_not_churn() {
+    use std::time::Instant;
+
+    const M: u32 = 10_000; // distinct Motes (live state)
+    const CHURN: u32 = 10; // Proposed+Failed(pre-commit) cycles before each commit
+
+    // High-churn journal: each Mote retries CHURN times, then commits. Total
+    // entries = M*(2*CHURN+1); distinct Motes = M. Pre-commit (`TimedOut`)
+    // failures keep every Mote terminally clean -> all commit.
+    let journal = InMemoryJournal::new();
+    let mut ctr = 0u64;
+    for i in 0..M {
+        for _ in 0..CHURN {
+            ctr += 2;
+            journal
+                .append(JournalEntry::Proposed {
+                    mote_id: mid_n(i),
+                    idempotency_key: ukey(ctr),
+                    seq: 0,
+                    nondeterminism: NdClass::Pure,
+                    placement_hint: 0,
+                    warrant_ref: war(),
+                })
+                .unwrap();
+            journal
+                .append(JournalEntry::Failed {
+                    mote_id: mid_n(i),
+                    idempotency_key: ukey(ctr + 1),
+                    seq: 0,
+                    reason_class: FailureReason::TimedOut,
+                    reporter_id: 0,
+                })
+                .unwrap();
+        }
+        let parents = if i >= 1 {
+            vec![pref(mid_n(i - 1), EdgeMeta::data())]
+        } else {
+            vec![]
+        };
+        let pe: SmallVec<[ParentEntry; 4]> =
+            parents.iter().map(ParentEntry::from_parent_ref).collect();
+        journal
+            .append(JournalEntry::Committed {
+                mote_id: mid_n(i),
+                idempotency_key: *mid_n(i).as_bytes(),
+                seq: 0,
+                nondeterminism: NdClass::Pure,
+                result_ref: ContentRef::from_bytes([7u8; 32]),
+                parents: pe,
+                warrant_ref: war(),
+                mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+            })
+            .unwrap();
+    }
+    let total = journal.current_seq().unwrap();
+
+    // Baseline: a full cold re-fold of the whole churned log.
+    let t0 = Instant::now();
+    let full = Projection::from_journal(&journal).unwrap();
+    let full_us = t0.elapsed().as_secs_f64() * 1e6;
+    assert_eq!(full.committed_count(), M as usize);
+
+    // Resume: read one sidecar blob + decode live state + fold an empty tail.
+    let bytes = full.fold_checkpoint().to_bytes();
+    let t1 = Instant::now();
+    let cp = FoldCheckpoint::from_bytes(&bytes).unwrap();
+    let resumed = Projection::from_journal_with_checkpoint(&journal, Some(&cp)).unwrap();
+    let resume_us = t1.elapsed().as_secs_f64() * 1e6;
+
+    assert_eq!(
+        resumed.state_digest(),
+        full.state_digest(),
+        "resume must reproduce the full fold exactly"
+    );
+
+    let speedup = full_us / resume_us;
+    eprintln!(
+        "total_entries={total} live_motes={M} churn={CHURN}x  \
+         full_refold={:.2}ms  resume={:.2}ms  speedup={speedup:.1}x",
+        full_us / 1000.0,
+        resume_us / 1000.0
+    );
+    // Under churn, resume (bounded by live state) must beat a full re-fold
+    // (bounded by total entries). Conservative gate to avoid CI flake while
+    // catching a regression that re-couples resume to journal length.
+    assert!(
+        speedup > 1.5,
+        "resume should be bounded by live state, not journal churn; got \
+         {speedup:.1}x (full={full_us:.0}us, resume={resume_us:.0}us, total_entries={total})"
+    );
+}
+
+/// Correctness-at-scale (no perf gate): a clean 25k-distinct-Mote journal
+/// resumes to a bit-identical projection. The clean case is a perf *wash* for
+/// the bincode codec (see the churn test above) — this pins correctness only.
+#[test]
+#[ignore = "scale: run --release --test fold_checkpoint -- --ignored --nocapture"]
+fn scale_resume_matches_full_fold_at_25k() {
+    const N: u32 = 25_000;
+    let journal = InMemoryJournal::new();
+    for i in 0..N {
+        let parents = if i >= 1 {
+            vec![pref(mid_n(i - 1), EdgeMeta::data())]
+        } else {
+            vec![]
+        };
+        let pe: SmallVec<[ParentEntry; 4]> =
+            parents.iter().map(ParentEntry::from_parent_ref).collect();
+        journal
+            .append(JournalEntry::Committed {
+                mote_id: mid_n(i),
+                idempotency_key: *mid_n(i).as_bytes(),
+                seq: 0,
+                nondeterminism: NdClass::Pure,
+                result_ref: ContentRef::from_bytes([7u8; 32]),
+                parents: pe,
+                warrant_ref: war(),
+                mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+            })
+            .unwrap();
+    }
+    let full = Projection::from_journal(&journal).unwrap();
+    // Resume from a mid-log checkpoint (offset = 20k), folding a 5k tail.
+    let cp = seed_through(&journal, 20_000).fold_checkpoint();
+    let resumed = Projection::from_journal_with_checkpoint(&journal, Some(&cp)).unwrap();
+    assert_eq!(resumed.state_digest(), full.state_digest());
+    assert_eq!(resumed.committed_count(), N as usize);
+}
+
+// A compile-time + smoke check that the public error type is matchable by
+// downstream recovery code.
+#[test]
+fn checkpoint_error_is_public_and_matchable() {
+    let err = FoldCheckpoint::from_bytes(&[0u8; 4]).unwrap_err();
+    assert!(matches!(err, CheckpointError::TooShort { .. }));
+}

--- a/justfile
+++ b/justfile
@@ -110,13 +110,16 @@ smoke-test-with-model:
 # Scale / performance gate
 # ============================================================================
 
-# Scale smoke (M2.1 / D92 — the resume-availability invariant): fold a 25k+
-# Mote journal in RELEASE and assert the incremental children-index re-fold
-# stays ~linear (a super-linear resume is an outage, and resume IS the product).
+# Scale smoke (M2.1 + M2.2 / D92 — the resume-availability invariant): fold a
+# 25k+ Mote journal in RELEASE and assert (M2.1) the incremental children-index
+# re-fold stays ~linear, and (M2.2) resume-from-`FoldCheckpoint` reproduces the
+# full fold exactly + its cost is bounded by live-state size under churn (not by
+# journal length). A super-linear resume is an outage, and resume IS the product.
 # `--release` is REQUIRED — in a debug build the differential oracle re-imposes
-# the O(n^2) full rebuild on every fold and the ratio assertion is skipped.
+# the O(n^2) full rebuild on every fold and the ratio assertions are skipped.
 scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
 
 # ============================================================================
 # Preflight diagnostic


### PR DESCRIPTION
## M2.2 — Discardable `FoldCheckpoint` (D92(b), `kx-projection`)

Crate-private, **discardable** `FoldCheckpoint`: cold recovery seeds the folded
`State` from a durable checkpoint and re-folds only the tail
`(checkpoint_offset, current]` instead of `(0, current]`. Rests on fold
associativity `fold(0,N] == fold(K,N] ∘ fold(0,K]`. The checkpoint is **never
authoritative** — `from_journal_with_checkpoint[_with_materializer]` falls back to
a full fold on *any* anomaly, so recovery is bit-identical with or without it.

### Golden Rule 8 — pre-flight risk + improvement analysis

**(a) What breaks (correctness / recovery / determinism / drift):** silent
resume≠full-fold divergence is the catastrophic case → mitigated by *never
authoritative* + full-fold fallback on every anomaly (bad digest, unknown
version/codec, decode failure, offset past head, `last_seq`/offset disagreement,
wrong-run instance id); equivalence is proptest-proven (resume-from-**every**-offset
== fold-from-zero) + a capture-time round-trip `debug_assert`. The canonical
product digest `a6b5c679…` (kx-runtime) is **untouched** — the checkpoint digest
is a *distinct full-state* digest. Frozen trio (scheduler/executor/inference)
diff is **EMPTY**. A DTO destructure-without-`..` makes a new `State` field a
**compile error** until the checkpoint is updated.

**(b) What degrades (perf) — MEASURED, not assumed:** a *clean*-log resume is a
**wash/slight loss** (0.6× at 25k — M2.1 already made the fold ~0.5µs/Mote, so a
full-state bincode decode costs more than re-folding; we do **not** claim a
clean-log speedup). The real win is decoupling resume cost from journal **churn**
(bounded by live-state, not journal length): **2.4× at 10× churn** (210k entries /
10k live Motes — the Risk #1 crash-loop case). The large clean-log win is the
rkyv codec (M2.2d), which the `payload_codec` seam enables non-breakingly. Zero
new allocation in `fold`/`register_mote`; D93 hot structures un-churned.

**(c) What opens a security hole:** the only new input is the checkpoint blob.
`from_bytes` is **panic-free + fully validating** (length via `.get()`/`try_into`,
version + codec check, digest recompute) → any failure is `Err` → fail-safe
discard, never fail-open. Never an identity/gate/audit input (SN-8: exact blake3,
no similarity). No secrets in the blob. *Honest residual:* the digest proves
integrity vs accidental corruption, not unforgeability — acceptable because the
sidecar shares the journal's trust domain, and this PR has **no production read
path** (mechanism only).

**How it makes the runtime better:** strengthens the durability spine (bounded
resume under crash-loops), with zero compromise to determinism/identity, and
lays the codec + digest seams for the committed roadmap.

### Forward seams folded in (cheap now, prevent a breaking change later)
- 1-byte `payload_codec` tag → the rkyv zero-copy upgrade (M2.2d) is additive.
- `Projection::state_digest()` → the future journaled digest seal (M2.2c) reuses
  the exact same full-state digest (one digest, two consumers, zero drift).

### Tests + gate (all green locally)
- 9 inline + 10 integration (resume-from-every-offset, lossless roundtrip,
  deterministic bytes, corrupt/truncated fail-safe, materializer **no-refire**,
  stale-offset + wrong-run fallback) + 2 scale cases (25k correctness + churn 2.4×).
- `fmt` · `clippy --workspace --all-targets -D warnings` · `test --workspace`
  (185 suites, 0 fail) · `deny` · `doc -D warnings` · `ffi-link` ·
  **`check-reproducible` (I1.c byte-determinism PASS)** · `scale-smoke` (M2.1 + M2.2).
- a0_guard: canonical digest `a6b5c679…` **unchanged**. Thesis diff: **empty**.

### Roadmap (committed; each its own PR)
M2.2b live-recovery wiring + atomic sidecar + observability → **M2.2c journaled
digest seals** (end-to-end replay verification; retires the integrity residual) →
**M2.2d rkyv zero-copy** (the large clean-log win) → determinism guardrails
(clippy disallowed-types/methods) → schema-evolution replay corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
