### PR TITLE
feat: journaled digest seals — checkpoint unforgeability (M2.2c)

### DIFF
--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -107,7 +107,24 @@ use smallvec::SmallVec;
 ///
 /// v4 readers refuse v3 files loudly (no in-place evolution; no production v3
 /// journals are retained across the bump per the corpus, acceptable).
-pub const JOURNAL_SCHEMA_VERSION: u16 = 4;
+///
+/// **v5 (M2.2c, D104) changes** vs v4:
+/// - New `DigestSealed` entry kind (=7) — the journaled digest seal that anchors
+///   the post-recovery `state_digest()` to the trust root, upgrading the M2.2b
+///   checkpoint-sidecar trust model from integrity to **unforgeability** (D103.1
+///   residual retired). Body layout: `through_seq(u64 LE) ‖ state_digest(32)` =
+///   40 bytes (total entry 114 bytes). The header `mote_id` slot carries the
+///   synthetic [`seal_root_id`] (anchored to the seq frontier, NOT a run id — a
+///   single-node run has no `instance_id` in scope); the `idempotency_key` slot
+///   is the all-zero sentinel.
+/// - `DigestSealed` does NOT participate in dedup-by-key (the dedup index stays
+///   `{1, 2, 4}`); it is an off-DAG metadata fact, never an identity input, never
+///   folded into the run-identity product digest. Strictly additive;
+///   `MAX_ENTRY_LEN` is unchanged.
+///
+/// v5 readers refuse v4 files loudly (no in-place evolution; no production v4
+/// journals are retained across the bump per the corpus, acceptable).
+pub const JOURNAL_SCHEMA_VERSION: u16 = 5;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).
 pub const HEADER_LEN: usize = 74;
@@ -176,11 +193,31 @@ pub const KIND_RUN_REGISTERED: u8 = 5;
 /// the `mote_id` slot carries the run's synthetic [`run_root_id`].
 pub const KIND_RUN_VERSIONS_RESOLVED: u8 = 6;
 
+/// `DigestSealed` entry-kind byte (NEW in v5; M2.2c, D103.2/D104).
+///
+/// The journaled digest seal: a `through_seq(u64 LE) ‖ state_digest(32)` fact
+/// asserting that a faithful fold of the journal through `through_seq` yields a
+/// projection whose `state_digest()` equals `state_digest`. Committed *in* the
+/// journal (the trust root), it anchors checkpoint-seeded recovery — a
+/// forged-but-self-consistent sidecar (the M2.2b D103.1 residual) cannot seed a
+/// wrong base state, because the seeded digest would not match the journaled
+/// seal, and forging the seal requires forging the journal itself. This upgrades
+/// the checkpoint trust model from integrity to **unforgeability**. Does NOT
+/// participate in dedup-by-key (the dedup index stays `{1, 2, 4}`); the header
+/// `idempotency_key` slot is the all-zero sentinel and the `mote_id` slot carries
+/// the synthetic [`seal_root_id`]. Off-DAG metadata: never an identity input,
+/// never folded into the run-identity product digest, never gates.
+pub const KIND_DIGEST_SEALED: u8 = 7;
+
 /// Length in bytes of a run's `instance_id` (the registered run nonce).
 pub const INSTANCE_ID_LEN: usize = 16;
 
 /// `RunRegistered` body length: `instance_id(16) + recipe_fingerprint(32) + ts(8)`.
 const RUN_REGISTERED_BODY_LEN: usize = INSTANCE_ID_LEN + 32 + 8;
+
+/// `DigestSealed` body length: `through_seq(u64 LE, 8) + state_digest(32)` = 40
+/// bytes (total entry = `HEADER_LEN` + 40 = 114 bytes).
+const DIGEST_SEALED_BODY_LEN: usize = 8 + 32;
 
 /// The kind of tool a capability resolved as, mirrored as a closed `u8`-tagged
 /// enum so `kx-journal` need not depend on `kx-tool-registry` (the journal must
@@ -626,6 +663,39 @@ pub enum JournalEntry {
         /// Journal-assigned sequence (0 until appended).
         seq: u64,
     },
+
+    /// The journaled digest seal (v5, M2.2c, D103.2/D104) — an off-DAG metadata
+    /// fact anchoring the recovered `state_digest()` to the trust root.
+    ///
+    /// Asserts: a faithful fold of the journal through `through_seq` yields a
+    /// projection whose `kx_projection::Projection::state_digest()` equals
+    /// `state_digest`. The runtime appends one at each checkpoint frontier `S`
+    /// (single-writer ⇒ it lands at `seq = S + 1`), computed *before* the seal is
+    /// appended so the sealed digest is the digest at frontier `S`. On recovery a
+    /// checkpoint-seeded base at offset `S` is trusted only if the journaled seal
+    /// at `through_seq == S` matches the seed's digest; a missing/mismatched seal
+    /// discards the checkpoint and full-folds (fail-closed). Forging a sidecar to
+    /// seed a wrong base state now requires forging the seal too, which requires
+    /// forging the journal — the trust root. This is what upgrades the M2.2b
+    /// checkpoint trust model from integrity to **unforgeability** (D103.1).
+    ///
+    /// **Body** = `through_seq(u64 LE) ‖ state_digest(32)` = 40 bytes. The header
+    /// `mote_id` slot carries the synthetic [`seal_root_id`] (anchored to the seq
+    /// frontier — a single-node run has no `instance_id`); the `idempotency_key`
+    /// slot is the all-zero sentinel; `nondeterminism` is the 0 sentinel (a seal
+    /// is not a Mote). Does NOT participate in dedup-by-key (the dedup index stays
+    /// `{1, 2, 4}`). Never an identity input; never folded into the run-identity
+    /// product digest; the projection folds it as a `last_seq`-only no-op.
+    DigestSealed {
+        /// The journal frontier this seal anchors — a faithful fold of `(0,
+        /// through_seq]` has `state_digest()` equal to `state_digest`.
+        through_seq: u64,
+        /// `kx_projection::Projection::state_digest()` at frontier `through_seq`.
+        state_digest: [u8; 32],
+        /// Journal-assigned sequence (0 until appended); `= through_seq + 1` for a
+        /// fresh seal under the single-writer discipline.
+        seq: u64,
+    },
 }
 
 /// The all-zero sentinel returned as the dedupe key of a `RunRegistered` entry,
@@ -647,6 +717,23 @@ pub fn run_root_id(instance_id: &[u8; INSTANCE_ID_LEN]) -> MoteId {
     MoteId::from_bytes(*hasher.finalize().as_bytes())
 }
 
+/// Derive the synthetic 32-byte "seal root" id that occupies a `DigestSealed`
+/// entry's header `mote_id` slot, from the sealed `through_seq` frontier.
+///
+/// Domain-separated (`"kx-digest-seal-root"`) from real Mote ids AND from
+/// [`run_root_id`] so it can never collide with either. The seal anchors to the
+/// seq frontier (not a run identity) because a single-node run has no journaled
+/// `instance_id`; binding the header to `through_seq` gives the same body-header
+/// consistency property `RunRegistered` has (the decoder re-derives it and
+/// rejects a mismatch). Derived locally in `kx-journal` (no executor dependency).
+#[must_use]
+pub fn seal_root_id(through_seq: u64) -> MoteId {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"kx-digest-seal-root");
+    hasher.update(&through_seq.to_le_bytes());
+    MoteId::from_bytes(*hasher.finalize().as_bytes())
+}
+
 impl JournalEntry {
     /// The entry's `seq` value.
     #[must_use]
@@ -658,7 +745,8 @@ impl JournalEntry {
             | Self::Failed { seq, .. }
             | Self::EffectStaged { seq, .. }
             | Self::RunRegistered { seq, .. }
-            | Self::RunVersionsResolved { seq, .. } => *seq,
+            | Self::RunVersionsResolved { seq, .. }
+            | Self::DigestSealed { seq, .. } => *seq,
         }
     }
 
@@ -681,9 +769,12 @@ impl JournalEntry {
             | Self::EffectStaged {
                 idempotency_key, ..
             } => idempotency_key,
-            // RunRegistered / RunVersionsResolved do not dedup; return the
-            // all-zero sentinel (kinds 5 and 6 are excluded from the dedup gate).
-            Self::RunRegistered { .. } | Self::RunVersionsResolved { .. } => &ZERO_IDEMPOTENCY_KEY,
+            // RunRegistered / RunVersionsResolved / DigestSealed do not dedup;
+            // return the all-zero sentinel (kinds 5, 6, 7 are excluded from the
+            // dedup gate).
+            Self::RunRegistered { .. }
+            | Self::RunVersionsResolved { .. }
+            | Self::DigestSealed { .. } => &ZERO_IDEMPOTENCY_KEY,
         }
     }
 
@@ -701,6 +792,7 @@ impl JournalEntry {
             Self::Repudiated { target_mote_id, .. } => *target_mote_id,
             Self::RunRegistered { instance_id, .. }
             | Self::RunVersionsResolved { instance_id, .. } => run_root_id(instance_id),
+            Self::DigestSealed { through_seq, .. } => seal_root_id(*through_seq),
         }
     }
 
@@ -715,6 +807,7 @@ impl JournalEntry {
             Self::EffectStaged { .. } => KIND_EFFECT_STAGED,
             Self::RunRegistered { .. } => KIND_RUN_REGISTERED,
             Self::RunVersionsResolved { .. } => KIND_RUN_VERSIONS_RESOLVED,
+            Self::DigestSealed { .. } => KIND_DIGEST_SEALED,
         }
     }
 }
@@ -749,7 +842,7 @@ pub enum DecodeError {
         got: usize,
     },
     /// The kind discriminant byte is not one of the known values
-    /// (Proposed=0 .. RunVersionsResolved=6).
+    /// (Proposed=0 .. DigestSealed=7).
     #[error("unknown kind discriminant: {0}")]
     UnknownKind(u8),
     /// The `nondeterminism` discriminant byte is not one of the three known values.
@@ -783,6 +876,11 @@ pub enum DecodeError {
     /// [`Self::RunRegisteredHeaderMismatch`]).
     #[error("RunVersionsResolved body-header run_root_id mismatch")]
     RunVersionsHeaderMismatch,
+    /// A `DigestSealed` entry's header `mote_id` slot does not equal
+    /// `seal_root_id(through_seq)` (v5 body-header consistency; mirrors
+    /// [`Self::RunRegisteredHeaderMismatch`]).
+    #[error("DigestSealed body-header seal_root_id mismatch")]
+    DigestSealedHeaderMismatch,
     /// A `RunVersionsResolved` entry's `resolved_kind_tag` byte is not one of the
     /// five known [`ResolvedKindTag`] values.
     #[error("unknown resolved_kind tag: {0}")]
@@ -903,6 +1001,12 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
         JournalEntry::RunVersionsResolved {
             instance_id, seq, ..
         } => (run_root_id(instance_id), ZERO_IDEMPOTENCY_KEY, *seq, 0),
+        // v5 (M2.2c): the header `mote_id` slot carries the synthetic seal-root
+        // id derived from `through_seq`; all-zero idempotency key (kind 7 does
+        // not dedup), 0 nd (a seal is not a Mote).
+        JournalEntry::DigestSealed {
+            through_seq, seq, ..
+        } => (seal_root_id(*through_seq), ZERO_IDEMPOTENCY_KEY, *seq, 0),
     };
     out.extend_from_slice(mote_id_for_header.as_bytes());
     out.extend_from_slice(&idempotency_key);
@@ -1012,6 +1116,15 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             if out.len() > MAX_ENTRY_LEN {
                 return Err(EncodeError::RunVersionsTooLarge { got: out.len() });
             }
+        }
+        JournalEntry::DigestSealed {
+            through_seq,
+            state_digest,
+            ..
+        } => {
+            // v5 (M2.2c): body = through_seq(u64 LE) ‖ state_digest(32) = 40 bytes.
+            out.extend_from_slice(&through_seq.to_le_bytes());
+            out.extend_from_slice(state_digest);
         }
     }
 
@@ -1303,6 +1416,34 @@ pub fn decode_entry_with_def_hash(
                 seq,
             })
         }
+        KIND_DIGEST_SEALED => {
+            // v5 (M2.2c): body = through_seq(u64 LE) ‖ state_digest(32) = 40 bytes.
+            // Exact-length (mirrors RunRegistered's `!= RUN_REGISTERED_BODY_LEN`):
+            // over-length surfaces as BodyTooShort rather than a separate
+            // TrailingBytes path. Panic-free: every read is bounds-checked.
+            if body.len() != DIGEST_SEALED_BODY_LEN {
+                return Err(DecodeError::BodyTooShort {
+                    kind,
+                    got: body.len(),
+                    expected: DIGEST_SEALED_BODY_LEN,
+                });
+            }
+            let through_seq = u64::from_le_bytes(body[..8].try_into().expect("8 bytes"));
+            // Body-header consistency: the header `mote_id` slot MUST be the
+            // synthetic seal-root id derived from this `through_seq` (mirrors the
+            // RunRegistered body-vs-header check). A mismatch is a tampered or
+            // malformed seal — reject loudly (fail-closed).
+            if mote_id != seal_root_id(through_seq) {
+                return Err(DecodeError::DigestSealedHeaderMismatch);
+            }
+            let mut state_digest = [0u8; 32];
+            state_digest.copy_from_slice(&body[8..DIGEST_SEALED_BODY_LEN]);
+            Ok(JournalEntry::DigestSealed {
+                through_seq,
+                state_digest,
+                seq,
+            })
+        }
         other => Err(DecodeError::UnknownKind(other)),
     }
 }
@@ -1458,6 +1599,12 @@ mod tests {
                 instance_id: [3u8; INSTANCE_ID_LEN],
                 recipe_fingerprint: [4u8; 32],
                 ts: 0,
+                seq: 0,
+            },
+            // v5 (M2.2c): DigestSealed. Header carries the synthetic seal-root id.
+            JournalEntry::DigestSealed {
+                through_seq: 0,
+                state_digest: [5u8; 32],
                 seq: 0,
             },
         ];
@@ -1793,6 +1940,123 @@ mod tests {
         // blake3-of-16-bytes identity.
         let bare = MoteId::from_bytes(*blake3::hash(&a).as_bytes());
         assert_ne!(run_root_id(&a), bare);
+    }
+
+    // -------------------- v5 (M2.2c): DigestSealed --------------------
+
+    fn sample_digest_sealed(through_seq: u64) -> JournalEntry {
+        JournalEntry::DigestSealed {
+            through_seq,
+            state_digest: [0x5au8; 32],
+            seq: through_seq + 1,
+        }
+    }
+
+    #[test]
+    fn digest_sealed_total_length_is_114() {
+        // v5 (M2.2c): 74 header + 40 body (8 through_seq + 32 state_digest) = 114 bytes.
+        assert_eq!(encode_entry(&sample_digest_sealed(256)).unwrap().len(), 114);
+    }
+
+    #[test]
+    fn digest_sealed_round_trips() {
+        let e = JournalEntry::DigestSealed {
+            through_seq: 0xdead_beef,
+            state_digest: [0xa7u8; 32],
+            seq: 0xdead_beef + 1,
+        };
+        let bytes = encode_entry(&e).unwrap();
+        assert_eq!(decode_entry(&bytes).unwrap(), e);
+    }
+
+    #[test]
+    fn digest_sealed_header_carries_seal_root_id_and_zero_idempotency_key() {
+        let through_seq = 4096u64;
+        let e = sample_digest_sealed(through_seq);
+        let bytes = encode_entry(&e).unwrap();
+        // Header mote_id slot = seal_root_id(through_seq).
+        assert_eq!(&bytes[1..33], seal_root_id(through_seq).as_bytes());
+        // Header idempotency_key slot = the all-zero sentinel (kind 7 doesn't dedup).
+        assert_eq!(&bytes[33..65], &[0u8; 32]);
+        // The nondeterminism slot is the 0 sentinel (a seal is not a Mote).
+        assert_eq!(bytes[73], 0);
+        // The accessors agree.
+        assert_eq!(e.idempotency_key(), &[0u8; 32]);
+        assert_eq!(e.mote_id(), seal_root_id(through_seq));
+        assert_eq!(e.kind(), KIND_DIGEST_SEALED);
+    }
+
+    #[test]
+    fn decode_rejects_digest_sealed_body_too_short() {
+        let mut bytes = encode_entry(&sample_digest_sealed(7)).unwrap();
+        bytes.pop(); // drop one body byte
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::BodyTooShort {
+                kind: KIND_DIGEST_SEALED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_digest_sealed_trailing_bytes() {
+        let mut bytes = encode_entry(&sample_digest_sealed(7)).unwrap();
+        bytes.push(0xff); // over-length body
+                          // Exact-length check (mirrors RunRegistered) surfaces as BodyTooShort.
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::BodyTooShort {
+                kind: KIND_DIGEST_SEALED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_digest_sealed_header_body_mismatch() {
+        let mut bytes = encode_entry(&sample_digest_sealed(99)).unwrap();
+        // Corrupt the header mote_id slot so it no longer equals
+        // seal_root_id(through_seq) — a tampered/forged seal must be rejected.
+        bytes[1] ^= 0xff;
+        assert_eq!(
+            decode_entry(&bytes).unwrap_err(),
+            DecodeError::DigestSealedHeaderMismatch
+        );
+    }
+
+    #[test]
+    fn decode_rejects_digest_sealed_inconsistent_through_seq() {
+        // A seal whose through_seq is rewritten in the BODY (not the header) so the
+        // header seal-root no longer matches → fail-closed. (Flipping the body's
+        // through_seq breaks the seal_root_id(through_seq) == header invariant.)
+        let mut bytes = encode_entry(&sample_digest_sealed(1234)).unwrap();
+        bytes[HEADER_LEN] ^= 0xff; // first body byte = low byte of through_seq
+        assert_eq!(
+            decode_entry(&bytes).unwrap_err(),
+            DecodeError::DigestSealedHeaderMismatch
+        );
+    }
+
+    #[test]
+    fn seal_root_id_is_deterministic_and_domain_separated() {
+        // Deterministic.
+        assert_eq!(seal_root_id(10), seal_root_id(10));
+        // Distinct frontiers → distinct roots.
+        assert_ne!(seal_root_id(10), seal_root_id(11));
+        // Domain-separated from a bare blake3 of the seq bytes.
+        let bare = MoteId::from_bytes(*blake3::hash(&10u64.to_le_bytes()).as_bytes());
+        assert_ne!(seal_root_id(10), bare);
+        // Domain-separated from run_root_id: a seal root can never collide with a
+        // run root even if the byte inputs coincided.
+        let inst = [0u8; INSTANCE_ID_LEN];
+        assert_ne!(seal_root_id(0), run_root_id(&inst));
+    }
+
+    #[test]
+    fn digest_sealed_encode_is_deterministic() {
+        let e = sample_digest_sealed(2048);
+        assert_eq!(encode_entry(&e).unwrap(), encode_entry(&e).unwrap());
     }
 
     // -------------------- v4 (M1.2): RunVersionsResolved --------------------

--- a/crates/kx-journal/src/in_memory.rs
+++ b/crates/kx-journal/src/in_memory.rs
@@ -231,6 +231,7 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Failed { seq, .. }
         | JournalEntry::EffectStaged { seq, .. }
         | JournalEntry::RunRegistered { seq, .. }
-        | JournalEntry::RunVersionsResolved { seq, .. } => *seq = new_seq,
+        | JournalEntry::RunVersionsResolved { seq, .. }
+        | JournalEntry::DigestSealed { seq, .. } => *seq = new_seq,
     }
 }

--- a/crates/kx-journal/src/lib.rs
+++ b/crates/kx-journal/src/lib.rs
@@ -89,11 +89,11 @@
 
 pub use crate::entry::{
     decode_entry, decode_entry_with_def_hash, encode_entry, is_pre_commit_crash,
-    repudiation_idempotency_key, run_root_id, DecodeError, EncodeError, FailureReason,
-    JournalEntry, ParentEntry, RepudiationReason, ResolvedCapabilityRecord, ResolvedKindTag,
-    HEADER_LEN, INSTANCE_ID_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_EFFECT_STAGED,
-    KIND_FAILED, KIND_PROPOSED, KIND_REPUDIATED, KIND_RUN_REGISTERED, KIND_RUN_VERSIONS_RESOLVED,
-    MAX_ENTRY_LEN, MAX_PARENTS,
+    repudiation_idempotency_key, run_root_id, seal_root_id, DecodeError, EncodeError,
+    FailureReason, JournalEntry, ParentEntry, RepudiationReason, ResolvedCapabilityRecord,
+    ResolvedKindTag, HEADER_LEN, INSTANCE_ID_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED,
+    KIND_DIGEST_SEALED, KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED, KIND_REPUDIATED,
+    KIND_RUN_REGISTERED, KIND_RUN_VERSIONS_RESOLVED, MAX_ENTRY_LEN, MAX_PARENTS,
 };
 pub use crate::in_memory::InMemoryJournal;
 pub use crate::sqlite::SqliteJournal;

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -468,7 +468,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Failed { seq, .. }
         | JournalEntry::EffectStaged { seq, .. }
         | JournalEntry::RunRegistered { seq, .. }
-        | JournalEntry::RunVersionsResolved { seq, .. } => *seq = new_seq,
+        | JournalEntry::RunVersionsResolved { seq, .. }
+        | JournalEntry::DigestSealed { seq, .. } => *seq = new_seq,
     }
 }
 

--- a/crates/kx-journal/tests/dod.rs
+++ b/crates/kx-journal/tests/dod.rs
@@ -257,7 +257,8 @@ fn set_seq(entry: &mut JournalEntry, new_seq: u64) {
         | JournalEntry::Failed { seq, .. }
         | JournalEntry::EffectStaged { seq, .. }
         | JournalEntry::RunRegistered { seq, .. }
-        | JournalEntry::RunVersionsResolved { seq, .. } => *seq = new_seq,
+        | JournalEntry::RunVersionsResolved { seq, .. }
+        | JournalEntry::DigestSealed { seq, .. } => *seq = new_seq,
     }
 }
 
@@ -299,12 +300,13 @@ fn obligation_13_schema_version_mismatch_loud_refusal() {
     }
 }
 
-/// M1.2 (D79): pin the schema version so the v3→v4 bump (the new
-/// `RunVersionsResolved` kind) is an intentional, reviewable change — a future
-/// edit that touches the entry encoding must bump this in lock-step.
+/// M2.2c (D103.2/D104): pin the schema version so the v4→v5 bump (the new
+/// `DigestSealed` kind) is an intentional, reviewable change — a future edit that
+/// touches the entry encoding must bump this in lock-step. (Prior bumps: v3→v4
+/// added `RunVersionsResolved`, M1.2/D79.)
 #[test]
-fn schema_version_is_v4() {
-    assert_eq!(JOURNAL_SCHEMA_VERSION, 4);
+fn schema_version_is_v5() {
+    assert_eq!(JOURNAL_SCHEMA_VERSION, 5);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kx-journal/tests/proptest_entry.rs
+++ b/crates/kx-journal/tests/proptest_entry.rs
@@ -233,6 +233,20 @@ fn arb_run_versions_resolved() -> impl Strategy<Value = JournalEntry> {
         })
 }
 
+/// **v5 (M2.2c): DigestSealed strategy.** `through_seq` is the sealed frontier;
+/// `state_digest` is a 32-byte blake3 digest; `seq` is the journal-assigned seq
+/// (`= through_seq + 1` in practice, but the encoding is independent of that, so
+/// the strategy ranges freely to exercise the wire format).
+fn arb_digest_sealed() -> impl Strategy<Value = JournalEntry> {
+    (any::<u64>(), arb_byte_array_32(), any::<u64>()).prop_map(
+        |(through_seq, state_digest, seq)| JournalEntry::DigestSealed {
+            through_seq,
+            state_digest,
+            seq,
+        },
+    )
+}
+
 /// **v2 (PR 7): EffectStaged strategy.** Header-only; no body fields.
 fn arb_effect_staged() -> impl Strategy<Value = JournalEntry> {
     (arb_mote_id(), arb_byte_array_32(), any::<u64>()).prop_map(
@@ -374,6 +388,24 @@ proptest! {
             bytes.len(),
             MAX_ENTRY_LEN
         );
+    }
+
+    // **v5 (M2.2c)** — encode/decode round-trip for DigestSealed entries.
+    // Fixed 114-byte size (74 header + 40 body).
+    #[test]
+    fn prop_digest_sealed_round_trip(entry in arb_digest_sealed()) {
+        let bytes = encode_entry(&entry).expect("encode");
+        prop_assert_eq!(bytes.len(), 114);
+        let decoded = decode_entry(&bytes).expect("decode");
+        prop_assert_eq!(decoded, entry);
+    }
+
+    // **v5 (M2.2c)** — encoding determinism for DigestSealed (byte-determinism / I1.c).
+    #[test]
+    fn prop_encoding_is_deterministic_digest_sealed(entry in arb_digest_sealed()) {
+        let a = encode_entry(&entry).expect("encode a");
+        let b = encode_entry(&entry).expect("encode b");
+        prop_assert_eq!(a, b);
     }
 
     // **v4 (M1.2)** — encode/decode round-trip for RunVersionsResolved entries

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -27,16 +27,22 @@
 //!   checked on decode; a future format / codec (e.g. an rkyv zero-copy payload)
 //!   bumps these and old checkpoints cleanly invalidate → full fold.
 //!
-//! ## Integrity vs unforgeability (honest scope)
+//! ## Integrity → unforgeability (M2.2c, D103.2)
 //!
-//! The digest proves **integrity against accidental corruption** (bit-rot, torn
-//! write, truncation), not unforgeability — a writer of the sidecar could craft
-//! a self-consistent blob. That is acceptable because a checkpoint lives in the
-//! **same trust domain as the journal** (the runtime's own state dir): anyone who
-//! can forge it can already forge the journal. A stronger end-to-end guarantee
-//! (verify the reconstructed [`crate::Projection::state_digest`] against a
-//! *journaled* digest seal) is the roadmap follow-on (M2.2c) and reuses the same
-//! digest function.
+//! The envelope `digest` alone proves **integrity against accidental corruption**
+//! (bit-rot, torn write, truncation), not unforgeability — a writer of the
+//! sidecar could craft a self-consistent blob seeding a *wrong* base state (the
+//! D103.1 residual). **M2.2c closes that gap:** the runtime co-commits a
+//! `DigestSealed{through_seq, state_digest}` entry _in the journal_ (the trust
+//! root) at each checkpoint frontier, and
+//! [`crate::Projection::from_journal_with_checkpoint`] trusts a seeded base only
+//! if its reconstructed [`crate::Projection::state_digest`] matches that journaled
+//! seal (gate 6 in `try_seed_state`; a missing/mismatched seal →
+//! [`FullFoldReason::SealMissing`] / [`FullFoldReason::SealMismatch`] → full
+//! fold). Forging a sidecar to seed a wrong state now requires forging the seal,
+//! which requires forging the journal — so the read path is **unforgeable** under
+//! the single-node trust model. (Distributed/untrusted-storage journals need
+//! *signed* seals — the deferred coordinator-parity follow-on.)
 
 use std::collections::BTreeMap;
 
@@ -93,6 +99,23 @@ impl FoldCheckpoint {
     #[must_use]
     pub fn digest(&self) -> [u8; 32] {
         self.digest
+    }
+
+    /// The **state-content digest** of this checkpoint — `blake3(payload)`.
+    ///
+    /// By construction the payload is the canonical `encode_state(state)` (see
+    /// [`Self::from_state`]), so this equals [`state_content_digest`] of the
+    /// decoded state AND equals the value the runtime journals in a
+    /// `DigestSealed` seal at this frontier (the runtime seals
+    /// `projection.state_digest()` == `blake3(encode_state(state))`). The M2.2c
+    /// recovery gate compares this against the journaled seal **without
+    /// re-encoding** the decoded state — and it is *stricter*: a non-canonical
+    /// payload (one that decodes to a state but is not its canonical encoding)
+    /// fails to match, so only a byte-exact canonical seed is ever trusted.
+    #[inline]
+    #[must_use]
+    pub(crate) fn payload_state_digest(&self) -> [u8; 32] {
+        *blake3::hash(&self.payload).as_bytes()
     }
 
     /// The payload codec tag ([`PAYLOAD_CODEC`] today).
@@ -330,6 +353,16 @@ pub enum FullFoldReason {
     OffsetMismatch,
     /// The checkpoint's run instance-id does not match the journal's (wrong run).
     WrongRun,
+    /// **M2.2c (D103.2).** No journaled `DigestSealed{through_seq == offset}` seal
+    /// was found to anchor the seeded state — the seed is un-anchored, so it is
+    /// discarded (a sidecar without a co-committed seal, e.g. the M2.2b world, or
+    /// a crash between the sidecar write and the seal append).
+    SealMissing,
+    /// **M2.2c (D103.2).** A journaled seal exists at the seed offset but its
+    /// `state_digest` does not match the seeded state's digest — the seed is
+    /// **forged or corrupt** (the D103.1 attack: a self-consistent sidecar seeding
+    /// a wrong base state). Discarded; recovery full-folds the trust root.
+    SealMismatch,
 }
 
 // ---------------------------------------------------------------------------
@@ -351,9 +384,10 @@ pub(crate) fn encode_state(state: &State) -> Vec<u8> {
 
 /// The canonical **full-state** digest: `blake3(encode_state(state))`. A pure
 /// function of the folded state content (includes `last_seq` + run registration,
-/// so it is self-anchoring). Reused by [`crate::Projection::state_digest`] and,
-/// in the roadmap, by the journaled digest seal (M2.2c). Distinct from the
-/// committed-facts product digest in `kx-runtime`.
+/// so it is self-anchoring). Reused by [`crate::Projection::state_digest`] and by
+/// the journaled digest seal (M2.2c) — the runtime seals this value at each
+/// checkpoint frontier and recovery anchors the seeded state against it.
+/// Distinct from the committed-facts product digest in `kx-runtime`.
 pub(crate) fn state_content_digest(state: &State) -> [u8; 32] {
     *blake3::hash(&encode_state(state)).as_bytes()
 }

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -160,11 +160,12 @@ impl Projection {
     /// **Fail-safe.** The checkpoint is *never authoritative* — on any anomaly
     /// (failed integrity check, unsupported version/codec, decode failure, an
     /// offset past the journal head, an encoded `last_seq` that disagrees with the
-    /// offset, or a run-id that does not match the journal's `RunRegistered`) this
-    /// silently **discards the checkpoint and runs the full fold**. Passing
-    /// `None` is always a full fold. The result is bit-identical to
-    /// [`Self::from_journal`] either way — the checkpoint only changes *how much*
-    /// is re-folded, never the outcome.
+    /// offset, a run-id that does not match the journal's `RunRegistered`, or —
+    /// M2.2c — a seeded digest that is not anchored by a matching journaled
+    /// `DigestSealed` seal) this silently **discards the checkpoint and runs the
+    /// full fold**. Passing `None` is always a full fold. The result is
+    /// bit-identical to [`Self::from_journal`] either way — the checkpoint only
+    /// changes *how much* is re-folded, never the outcome.
     pub fn from_journal_with_checkpoint<J: Journal>(
         journal: &J,
         checkpoint: Option<&FoldCheckpoint>,
@@ -287,7 +288,51 @@ impl Projection {
                 }
             }
         }
+        // (6) **M2.2c (D103.2) — unforgeability anchor.** The seeded state's
+        // digest MUST equal a `state_digest` journaled IN the trust root. The
+        // seed's digest at frontier `S = cp.journal_offset()` (== `state.last_seq`,
+        // gate 4) is `blake3(payload)` (`payload_state_digest`) — the canonical
+        // encoding the writer also sealed; no re-encode of the decoded state, and
+        // it is `last_seq`-correct because the payload was captured at frontier S.
+        // We compare it to the `DigestSealed{through_seq == S}` the writer
+        // co-committed at `S + 1`. A missing or mismatched seal discards the
+        // checkpoint and full-folds — a forged-but-self-consistent sidecar (the
+        // D103.1 residual) cannot seed a wrong base state, because forging the seal
+        // requires forging the journal. Fail-closed; recovery is bit-identical to
+        // a full fold either way.
+        let offset = cp.journal_offset();
+        match Self::journal_seal_at(journal, offset)? {
+            None => return Ok(Err(FullFoldReason::SealMissing)),
+            Some(sealed_digest) => {
+                if sealed_digest != cp.payload_state_digest() {
+                    return Ok(Err(FullFoldReason::SealMismatch));
+                }
+            }
+        }
         Ok(Ok(state))
+    }
+
+    /// The `state_digest` journaled by a `DigestSealed{through_seq == through}`
+    /// seal, if one is present at `seq = through + 1` (where the single-writer
+    /// runtime co-commits it with the checkpoint at frontier `through`). `None`
+    /// if no matching seal is there. Used by the M2.2c unforgeability gate.
+    fn journal_seal_at<J: Journal>(
+        journal: &J,
+        through: u64,
+    ) -> Result<Option<[u8; 32]>, ProjectionError> {
+        for entry in journal.read_entries_by_seq((through + 1)..(through + 2))? {
+            if let JournalEntry::DigestSealed {
+                through_seq,
+                state_digest,
+                ..
+            } = entry
+            {
+                if through_seq == through {
+                    return Ok(Some(state_digest));
+                }
+            }
+        }
+        Ok(None)
     }
 
     /// The journal's registered run instance id, read from the `RunRegistered`
@@ -473,20 +518,28 @@ impl Projection {
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
             // Off-DAG run-metadata facts (extracted to keep `fold` under the
-            // line budget): both record an O(1) field and NEVER touch
+            // line budget): each records an O(1) field and NEVER touches
             // `rebuild_children_index` (the per-mutation O(n²) D92 path).
-            JournalEntry::RunRegistered { .. } | JournalEntry::RunVersionsResolved { .. } => {
+            // `DigestSealed` (M2.2c) is a pure `last_seq`-only frontier advance —
+            // it names no Mote, registers no `MoteInfo`, and is verified at
+            // recovery (in `try_seed_state`), never materialized into state.
+            JournalEntry::RunRegistered { .. }
+            | JournalEntry::RunVersionsResolved { .. }
+            | JournalEntry::DigestSealed { .. } => {
                 self.fold_run_metadata(entry);
             }
         }
         Ok(prev)
     }
 
-    /// Fold an off-DAG run-metadata fact (`RunRegistered` / `RunVersionsResolved`).
+    /// Fold an off-DAG run-metadata fact (`RunRegistered` / `RunVersionsResolved`
+    /// / `DigestSealed`).
     ///
-    /// Both name no Mote, so this registers NO `MoteInfo` and does NOT call
-    /// `rebuild_children_index` — O(1), off the Mote-DAG. The data is **metadata,
-    /// never identity**: no scheduling/identity/digest decision reads it.
+    /// None of these name a Mote, so this registers NO `MoteInfo` and does NOT
+    /// call `rebuild_children_index` — O(1), off the Mote-DAG. The data is
+    /// **metadata, never identity**: no scheduling/identity/digest decision reads
+    /// it (`DigestSealed` in particular is invisible to the run-identity product
+    /// digest, which folds only `Committed` Motes).
     fn fold_run_metadata(&mut self, entry: &JournalEntry) {
         match entry {
             JournalEntry::RunRegistered {
@@ -522,6 +575,13 @@ impl Projection {
                         model_id: model_id.clone(),
                         capability: capability.clone(),
                     });
+                self.state.last_seq = self.state.last_seq.max(*seq);
+            }
+            JournalEntry::DigestSealed { seq, .. } => {
+                // v5 (M2.2c, D103.2). A pure frontier advance: the seal writes
+                // NOTHING into `State` (so it never enters `state_digest()` — that
+                // would be a chicken-and-egg cycle — and never the product digest).
+                // Its digest is verified at recovery in `try_seed_state`, not here.
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
             _ => unreachable!("fold_run_metadata called with a non-run-metadata kind"),

--- a/crates/kx-projection/tests/digest_seal.rs
+++ b/crates/kx-projection/tests/digest_seal.rs
@@ -1,0 +1,204 @@
+// Integration-test file: compiled as a separate crate from the host lib; tests
+// legitimately `.unwrap()` for fixture construction.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! M2.2c — journaled digest seals (D103.2): the unforgeability anchor for
+//! checkpoint-seeded recovery.
+//!
+//! A checkpoint-seeded base at offset `S` is trusted ONLY if a journaled
+//! `DigestSealed{through_seq == S}` (committed by the runtime at `S + 1`) matches
+//! the seed's digest. This file proves the four outcomes at the projection level:
+//!
+//! - **match** → `Seeded` and bit-identical to a full fold;
+//! - **mismatch** (a forged-but-self-consistent sidecar — the D103.1 attack) →
+//!   `FullFold{SealMismatch}`, recovery falls back to the trust root;
+//! - **missing** (the M2.2b world — a sidecar with no co-committed seal) →
+//!   `FullFold{SealMissing}`;
+//! - **stale** (a seal whose `through_seq` does not match the offset) →
+//!   `FullFold{SealMissing}`.
+//!
+//! In every case recovery is **bit-identical** to a full fold (fail-closed).
+
+use kx_content::ContentRef;
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use kx_projection::{CheckpointOutcome, FoldCheckpoint, FullFoldReason, Projection};
+use smallvec::SmallVec;
+
+fn mid(b: u8) -> MoteId {
+    MoteId::from_bytes([b; 32])
+}
+
+fn committed(m: u8) -> JournalEntry {
+    JournalEntry::Committed {
+        mote_id: mid(m),
+        idempotency_key: *mid(m).as_bytes(),
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([7u8; 32]),
+        parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+/// Fold the journal prefix `[1, k]` into a fresh projection (the contiguous-prefix
+/// precondition `fold_checkpoint` requires).
+fn seed_through(journal: &InMemoryJournal, k: u64) -> Projection {
+    let mut p = Projection::new();
+    for e in journal.read_entries_by_seq(0..(k + 1)).unwrap() {
+        p.fold(&e).unwrap();
+    }
+    p
+}
+
+/// A journal that commits motes 1..=2, co-commits the M2.2c seal for frontier 2
+/// (optionally with a tampered digest / through_seq), then commits motes 3..=5.
+/// Returns the journal and the checkpoint captured at frontier 2 (pre-seal).
+fn journal_with_seal(
+    seal_digest: Option<[u8; 32]>,
+    seal_through: u64,
+) -> (InMemoryJournal, FoldCheckpoint) {
+    let journal = InMemoryJournal::new();
+    journal.append(committed(1)).unwrap();
+    journal.append(committed(2)).unwrap();
+    let cp = seed_through(&journal, 2).fold_checkpoint();
+    assert_eq!(cp.journal_offset(), 2);
+    let digest = seal_digest.unwrap_or_else(|| seed_through(&journal, 2).state_digest());
+    journal
+        .append(JournalEntry::DigestSealed {
+            through_seq: seal_through,
+            state_digest: digest,
+            seq: 0,
+        })
+        .unwrap();
+    journal.append(committed(3)).unwrap();
+    journal.append(committed(4)).unwrap();
+    journal.append(committed(5)).unwrap();
+    (journal, cp)
+}
+
+/// Assert the recovered projection is bit-identical (full-state digest + frontier)
+/// to a from-scratch full fold of the same journal — the fail-safe invariant.
+fn assert_bit_identical(journal: &InMemoryJournal, resumed: &Projection, ctx: &str) {
+    let full = Projection::from_journal(journal).unwrap();
+    assert_eq!(
+        resumed.state_digest(),
+        full.state_digest(),
+        "{ctx}: state digest"
+    );
+    assert_eq!(resumed.current_seq(), full.current_seq(), "{ctx}: frontier");
+}
+
+/// A matching seal anchors the seed: `Seeded` + bit-identical.
+#[test]
+fn matching_seal_seeds_and_is_bit_identical() {
+    let (journal, cp) = journal_with_seal(None, 2);
+    let (resumed, outcome) =
+        Projection::from_journal_with_checkpoint_reported(&journal, Some(&cp)).unwrap();
+    // Tail (2, 6] = the seal + commits 3,4,5 = four entries.
+    assert_eq!(
+        outcome,
+        CheckpointOutcome::Seeded {
+            offset: 2,
+            tail_entries: 4
+        }
+    );
+    assert_bit_identical(&journal, &resumed, "matching seal");
+}
+
+/// **The D103.1 attack, now caught.** A forged-but-self-consistent checkpoint
+/// (a valid envelope decoding to a *wrong* base state) whose digest does not match
+/// the journaled seal is rejected → `SealMismatch` → full fold (correct state).
+#[test]
+fn forged_seed_with_mismatched_seal_full_folds() {
+    // The journal's seal anchors the genuine state-at-2. Build a checkpoint that
+    // encodes a DIFFERENT (wrong) base state at offset 2 (mote 99 committed instead
+    // of motes 1,2) but is internally self-consistent (valid envelope digest).
+    let (journal, _genuine_cp) = journal_with_seal(None, 2);
+
+    let wrong = InMemoryJournal::new();
+    wrong.append(committed(98)).unwrap();
+    wrong.append(committed(99)).unwrap();
+    let forged_cp =
+        FoldCheckpoint::from_bytes(&seed_through(&wrong, 2).fold_checkpoint().to_bytes()).unwrap();
+    assert_eq!(forged_cp.journal_offset(), 2); // same frontier — passes gates 1-5
+    assert!(
+        forged_cp.verify(),
+        "the forged sidecar is internally self-consistent"
+    );
+
+    let (resumed, outcome) =
+        Projection::from_journal_with_checkpoint_reported(&journal, Some(&forged_cp)).unwrap();
+    assert_eq!(
+        outcome,
+        CheckpointOutcome::FullFold {
+            reason: FullFoldReason::SealMismatch
+        }
+    );
+    // The forged seed is discarded; recovery reproduces the genuine full fold.
+    assert_bit_identical(&journal, &resumed, "forged seed rejected");
+    // Sanity: the genuine state has motes 1..=5, NOT the forged 98/99.
+    assert_eq!(resumed.iter_motes().count(), 5);
+}
+
+/// The M2.2b world: a valid checkpoint with NO co-committed seal → `SealMissing` →
+/// full fold (bit-identical). An un-anchored seed is never trusted.
+#[test]
+fn seed_without_seal_full_folds() {
+    let journal = InMemoryJournal::new();
+    journal.append(committed(1)).unwrap();
+    journal.append(committed(2)).unwrap();
+    let cp = seed_through(&journal, 2).fold_checkpoint();
+    journal.append(committed(3)).unwrap(); // seq 3 is a commit, NOT a seal
+
+    let (resumed, outcome) =
+        Projection::from_journal_with_checkpoint_reported(&journal, Some(&cp)).unwrap();
+    assert_eq!(
+        outcome,
+        CheckpointOutcome::FullFold {
+            reason: FullFoldReason::SealMissing
+        }
+    );
+    assert_bit_identical(&journal, &resumed, "seed without seal");
+}
+
+/// A seal present at `S + 1` but carrying the WRONG `through_seq` does not anchor
+/// offset `S` → `SealMissing` (the lookup requires `through_seq == S`).
+#[test]
+fn stale_seal_through_seq_is_treated_as_missing() {
+    // Seal claims through_seq = 1 but sits at seq 3 (frontier 2's slot).
+    let (journal, cp) = journal_with_seal(None, 1);
+    let (resumed, outcome) =
+        Projection::from_journal_with_checkpoint_reported(&journal, Some(&cp)).unwrap();
+    assert_eq!(
+        outcome,
+        CheckpointOutcome::FullFold {
+            reason: FullFoldReason::SealMissing
+        }
+    );
+    assert_bit_identical(&journal, &resumed, "stale seal");
+}
+
+/// `DigestSealed` is a pure `last_seq`-only fold no-op: folding it changes neither
+/// the Mote set nor the children index nor any per-Mote flag — only the frontier.
+#[test]
+fn seal_folds_as_pure_frontier_advance() {
+    let journal = InMemoryJournal::new();
+    journal.append(committed(1)).unwrap();
+    let before = seed_through(&journal, 1);
+    let motes_before: Vec<_> = before.iter_motes().collect();
+
+    journal
+        .append(JournalEntry::DigestSealed {
+            through_seq: 1,
+            state_digest: before.state_digest(),
+            seq: 0,
+        })
+        .unwrap();
+    let after = seed_through(&journal, 2);
+
+    // The Mote set is unchanged; only the frontier advanced (1 -> 2).
+    assert_eq!(after.iter_motes().collect::<Vec<_>>(), motes_before);
+    assert_eq!(before.current_seq(), 1);
+    assert_eq!(after.current_seq(), 2);
+}

--- a/crates/kx-projection/tests/fold_checkpoint.rs
+++ b/crates/kx-projection/tests/fold_checkpoint.rs
@@ -373,14 +373,26 @@ fn wrong_run_checkpoint_falls_back() {
 /// length, and the seeded projection equals the full fold.
 #[test]
 fn reported_happy_resume_is_seeded_with_tail_len() {
-    let journal = build_journal(&[
-        TraceOp::Commit(1),
-        TraceOp::Commit(2),
-        TraceOp::Commit(3),
-        TraceOp::Commit(4),
-        TraceOp::Commit(5),
-    ]);
-    // Seed at offset 2; the tail (2, 5] is three entries.
+    // Build a journal that interleaves the M2.2c digest seal at the checkpoint
+    // frontier (exactly as the live runtime does): Commit(1), Commit(2), then the
+    // seal anchoring frontier 2, then Commit(3..5). The seal lands at seq 3, so
+    // the tail (2, 6] is four entries (the seal + three commits).
+    let journal = InMemoryJournal::new();
+    journal.append(committed_entry(1, &[])).unwrap();
+    journal.append(committed_entry(2, &[])).unwrap();
+    let seed_digest = seed_through(&journal, 2).state_digest();
+    journal
+        .append(JournalEntry::DigestSealed {
+            through_seq: 2,
+            state_digest: seed_digest,
+            seq: 0,
+        })
+        .unwrap();
+    journal.append(committed_entry(3, &[])).unwrap();
+    journal.append(committed_entry(4, &[])).unwrap();
+    journal.append(committed_entry(5, &[])).unwrap();
+
+    // Seed at offset 2; the tail (2, 6] is four entries (seal + three commits).
     let cp = seed_through(&journal, 2).fold_checkpoint();
     assert_eq!(cp.journal_offset(), 2);
     let (resumed, outcome) =
@@ -389,7 +401,7 @@ fn reported_happy_resume_is_seeded_with_tail_len() {
         outcome,
         CheckpointOutcome::Seeded {
             offset: 2,
-            tail_entries: 3
+            tail_entries: 4
         }
     );
     let full = Projection::from_journal(&journal).unwrap();
@@ -515,10 +527,32 @@ fn stub(fired: &Arc<Mutex<Vec<MoteId>>>) -> Box<StubMaterializer> {
 
 #[test]
 fn checkpoint_resume_with_materializer_matches_full_and_does_not_refire() {
-    // Journal: shaper commits (seq 1) -> materializes 101, 102; then each child
-    // commits (seq 2, 3) carrying its Control edge back to the shaper.
+    // Journal: shaper commits (seq 1) -> materializes 101, 102; the M2.2c seal
+    // anchoring frontier 1 lands at seq 2; then each child commits (seq 3, 4)
+    // carrying its Control edge back to the shaper. The seal is interleaved at the
+    // checkpoint frontier exactly as the live runtime emits it.
     let journal = InMemoryJournal::new();
     journal.append(committed_entry(100, &[])).unwrap();
+
+    // Seed at offset 1 (after the shaper commit + its materialization) and capture
+    // the checkpoint BEFORE the seal/children land.
+    let seed_fired = Arc::new(Mutex::new(Vec::new()));
+    let mut seed = Projection::with_materializer(stub(&seed_fired));
+    for e in journal.read_entries_by_seq(0..2).unwrap() {
+        seed.fold(&e).unwrap();
+    }
+    let cp = FoldCheckpoint::from_bytes(&seed.fold_checkpoint().to_bytes()).unwrap();
+    assert_eq!(cp.journal_offset(), 1);
+
+    // M2.2c: co-commit the journaled seal anchoring the seeded digest at frontier 1,
+    // then the tail child commits.
+    journal
+        .append(JournalEntry::DigestSealed {
+            through_seq: 1,
+            state_digest: seed.state_digest(),
+            seq: 0,
+        })
+        .unwrap();
     journal
         .append(committed_entry(101, &[pref(mid(100), EdgeMeta::control())]))
         .unwrap();
@@ -526,7 +560,8 @@ fn checkpoint_resume_with_materializer_matches_full_and_does_not_refire() {
         .append(committed_entry(102, &[pref(mid(100), EdgeMeta::control())]))
         .unwrap();
 
-    // Full materializer fold (the comparison target).
+    // Full materializer fold (the comparison target). The seal folds as a no-op, so
+    // the shaper is still materialized exactly once.
     let full_fired = Arc::new(Mutex::new(Vec::new()));
     let full = Projection::from_journal_with_checkpoint_with_materializer(
         &journal,
@@ -539,15 +574,6 @@ fn checkpoint_resume_with_materializer_matches_full_and_does_not_refire() {
         vec![mid(100)],
         "full fold materializes the shaper exactly once"
     );
-
-    // Seed at offset 1 (after the shaper commit + its materialization).
-    let seed_fired = Arc::new(Mutex::new(Vec::new()));
-    let mut seed = Projection::with_materializer(stub(&seed_fired));
-    for e in journal.read_entries_by_seq(0..2).unwrap() {
-        seed.fold(&e).unwrap();
-    }
-    let cp = FoldCheckpoint::from_bytes(&seed.fold_checkpoint().to_bytes()).unwrap();
-    assert_eq!(cp.journal_offset(), 1);
 
     // Resume: the ≤offset shaper must NOT be re-materialized; the tail child
     // commits fold against the seeded (already-declared) children.
@@ -660,19 +686,39 @@ fn scale_resume_is_bounded_by_live_state_not_churn() {
     }
     let total = journal.current_seq().unwrap();
 
-    // Baseline: a full cold re-fold of the whole churned log.
+    // Capture the head checkpoint at frontier `total` (the digest the seal anchors).
+    let pre_seal = Projection::from_journal(&journal).unwrap();
+    assert_eq!(pre_seal.committed_count(), M as usize);
+    let seed_digest = pre_seal.state_digest();
+    let bytes = pre_seal.fold_checkpoint().to_bytes();
+    drop(pre_seal);
+
+    // M2.2c: co-commit the journaled seal at the checkpoint frontier (as the runtime
+    // does) so the resume can anchor + seed; without it recovery full-folds.
+    journal
+        .append(JournalEntry::DigestSealed {
+            through_seq: total,
+            state_digest: seed_digest,
+            seq: 0,
+        })
+        .unwrap();
+
+    // Baseline: a full cold re-fold of the whole churned log (now `total + 1` entries).
     let t0 = Instant::now();
     let full = Projection::from_journal(&journal).unwrap();
     let full_us = t0.elapsed().as_secs_f64() * 1e6;
-    assert_eq!(full.committed_count(), M as usize);
 
-    // Resume: read one sidecar blob + decode live state + fold an empty tail.
-    let bytes = full.fold_checkpoint().to_bytes();
+    // Resume: read one sidecar blob + decode live state + verify the seal + fold the
+    // (1-entry: the seal) tail.
     let t1 = Instant::now();
     let cp = FoldCheckpoint::from_bytes(&bytes).unwrap();
-    let resumed = Projection::from_journal_with_checkpoint(&journal, Some(&cp)).unwrap();
+    let (resumed, outcome) =
+        Projection::from_journal_with_checkpoint_reported(&journal, Some(&cp)).unwrap();
     let resume_us = t1.elapsed().as_secs_f64() * 1e6;
-
+    assert!(
+        matches!(outcome, CheckpointOutcome::Seeded { offset, .. } if offset == total),
+        "resume must anchor on the journaled seal; got {outcome:?}"
+    );
     assert_eq!(
         resumed.state_digest(),
         full.state_digest(),
@@ -807,26 +853,48 @@ fn scale_resume_through_sqlite_is_bounded_by_live_state() {
     }
     let total = SqliteJournal::open(&jpath).unwrap().current_seq().unwrap();
 
-    // Capture the head checkpoint and persist it as an on-disk sidecar blob.
-    let full_for_cp = Projection::from_journal(&SqliteJournal::open(&jpath).unwrap()).unwrap();
-    let reference = full_for_cp.state_digest();
+    // Capture the head checkpoint at frontier `total` and persist it as an on-disk
+    // sidecar blob (`seed_digest` is the digest the M2.2c seal will anchor).
+    let pre_seal = Projection::from_journal(&SqliteJournal::open(&jpath).unwrap()).unwrap();
+    let seed_digest = pre_seal.state_digest();
     let sidecar = dir.path().join("scale.sqlite.ckpt");
-    std::fs::write(&sidecar, full_for_cp.fold_checkpoint().to_bytes()).unwrap();
-    drop(full_for_cp);
+    std::fs::write(&sidecar, pre_seal.fold_checkpoint().to_bytes()).unwrap();
+    drop(pre_seal);
 
-    // Baseline: a full cold re-fold reading every row from a freshly-opened journal.
+    // M2.2c: co-commit the journaled digest seal at the checkpoint frontier (exactly
+    // as the live runtime does right after writing the sidecar). Without it, recovery
+    // refuses to seed (`SealMissing`) and full-folds — so this also guards the
+    // unforgeability-gate-vs-perf interaction: an anchored seed MUST stay bounded by
+    // live state, not journal length.
+    SqliteJournal::open(&jpath)
+        .unwrap()
+        .append(JournalEntry::DigestSealed {
+            through_seq: total,
+            state_digest: seed_digest,
+            seq: 0,
+        })
+        .unwrap();
+
+    // Baseline: a full cold re-fold reading every row (now `total + 1`, incl. the seal).
     let t0 = Instant::now();
     let full = Projection::from_journal(&SqliteJournal::open(&jpath).unwrap()).unwrap();
     let full_us = t0.elapsed().as_secs_f64() * 1e6;
-    assert_eq!(full.state_digest(), reference);
+    let reference = full.state_digest();
 
-    // Seeded recovery: read the sidecar from disk + decode + fold the (empty) tail.
+    // Seeded recovery: read the sidecar, verify it against the journaled seal, fold
+    // the (1-entry: the seal) tail. The seed MUST anchor on the seal (`Seeded`).
     let t1 = Instant::now();
     let cp = FoldCheckpoint::from_bytes(&std::fs::read(&sidecar).unwrap()).unwrap();
-    let seeded =
-        Projection::from_journal_with_checkpoint(&SqliteJournal::open(&jpath).unwrap(), Some(&cp))
-            .unwrap();
+    let (seeded, outcome) = Projection::from_journal_with_checkpoint_reported(
+        &SqliteJournal::open(&jpath).unwrap(),
+        Some(&cp),
+    )
+    .unwrap();
     let seeded_us = t1.elapsed().as_secs_f64() * 1e6;
+    assert!(
+        matches!(outcome, CheckpointOutcome::Seeded { offset, .. } if offset == total),
+        "seeded recovery must anchor on the journaled seal; got {outcome:?}"
+    );
     assert_eq!(
         seeded.state_digest(),
         reference,

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -21,7 +21,7 @@ use kx_executor::{
     redispatch_wm_mote, run_native_critic_mote, run_pure_mote, run_wm_mote, CommitProtocol,
     LocalResourceManager, MoteExecutor, StandardCommitProtocol, TestMoteExecutor,
 };
-use kx_journal::{Journal, SqliteJournal};
+use kx_journal::{Journal, JournalEntry, SqliteJournal};
 use kx_mote::{MoteId, NdClass, TopologyDecision};
 use kx_projection::{
     CheckpointOutcome, ContentStoreVerdicts, MoteState, Projection, VerdictLookup,
@@ -312,17 +312,18 @@ where
         maybe_checkpoint(
             config,
             &projection,
+            &journal,
             &sidecar_path,
             folded_through,
             &mut last_checkpoint_at,
         );
     }
 
-    // Graceful-completion checkpoint: leave a fresh sidecar so a restart of a
-    // completed/drained run seeds the full final state and folds an empty tail.
-    // Skipped if the cadence already captured this exact frontier.
+    // Graceful-completion checkpoint: leave a fresh sidecar + seal so a restart of
+    // a completed/drained run seeds the full final state and folds the (1-entry:
+    // the seal) tail. Skipped if the cadence already captured this exact frontier.
     if config.checkpoint_every.is_some() && folded_through > last_checkpoint_at {
-        write_checkpoint(&projection, &sidecar_path, folded_through);
+        write_checkpoint(&projection, &journal, &sidecar_path, folded_through);
     }
 
     let outcome = outcome(&runnable, &projection);
@@ -391,6 +392,7 @@ fn log_recovery(outcome: CheckpointOutcome, head: u64, elapsed: Duration) {
 fn maybe_checkpoint(
     config: &RuntimeConfig,
     projection: &Projection,
+    journal: &SqliteJournal,
     sidecar_path: &Path,
     folded_through: u64,
     last_checkpoint_at: &mut u64,
@@ -401,14 +403,29 @@ fn maybe_checkpoint(
     if folded_through == 0 || folded_through.saturating_sub(*last_checkpoint_at) < cadence {
         return;
     }
-    write_checkpoint(projection, sidecar_path, folded_through);
+    write_checkpoint(projection, journal, sidecar_path, folded_through);
     *last_checkpoint_at = folded_through;
 }
 
-/// Capture the projection's current `FoldCheckpoint` and persist it atomically.
-/// A write failure is **non-fatal** — the checkpoint is never authoritative, so a
-/// failed persist only means the next restart full-folds. Logged, never returned.
-fn write_checkpoint(projection: &Projection, sidecar_path: &Path, folded_through: u64) {
+/// Capture the projection's current `FoldCheckpoint`, persist it atomically, then
+/// (M2.2c) co-commit a journaled `DigestSealed` seal at the same frontier.
+///
+/// **Order matters: sidecar first, then seal.** A crash between them leaves a
+/// sidecar with no anchoring seal → recovery discards it (`SealMissing`) and
+/// full-folds — never the reverse. Both writes are **non-fatal**: the checkpoint
+/// is never authoritative, and an orphan/absent seal only costs a slower restart.
+///
+/// The seal records `projection.state_digest()` (== `blake3(checkpoint payload)`)
+/// at frontier `folded_through`, committed *in* the journal (the trust root), so a
+/// forged-but-self-consistent sidecar cannot seed a wrong base state on restart
+/// (D103.1 → unforgeable; M2.2c). The single-writer discipline lands the seal at
+/// `seq = folded_through + 1`, where recovery's `journal_seal_at` looks for it.
+fn write_checkpoint(
+    projection: &Projection,
+    journal: &SqliteJournal,
+    sidecar_path: &Path,
+    folded_through: u64,
+) {
     let bytes = projection.fold_checkpoint().to_bytes();
     match checkpoint_io::write_atomic(sidecar_path, &bytes) {
         Ok(()) => tracing::debug!(
@@ -416,10 +433,32 @@ fn write_checkpoint(projection: &Projection, sidecar_path: &Path, folded_through
             bytes = bytes.len(),
             "checkpoint persisted"
         ),
+        Err(error) => {
+            tracing::warn!(
+                through = folded_through,
+                %error,
+                "checkpoint persist failed (continuing; recovery falls back to full fold)"
+            );
+            // No sidecar → a seal would anchor nothing. Skip it.
+            return;
+        }
+    }
+    // M2.2c: anchor the sidecar to the trust root.
+    let seal = JournalEntry::DigestSealed {
+        through_seq: folded_through,
+        state_digest: projection.state_digest(),
+        seq: 0,
+    };
+    match journal.append(seal) {
+        Ok(sealed) => tracing::debug!(
+            through = folded_through,
+            seq = sealed.seq(),
+            "digest seal committed"
+        ),
         Err(error) => tracing::warn!(
             through = folded_through,
             %error,
-            "checkpoint persist failed (continuing; recovery falls back to full fold)"
+            "digest seal append failed (continuing; recovery falls back to full fold)"
         ),
     }
 }

--- a/crates/kx-runtime/tests/checkpoint_recovery.rs
+++ b/crates/kx-runtime/tests/checkpoint_recovery.rs
@@ -9,7 +9,7 @@
 
 use std::path::Path;
 
-use kx_journal::{Journal, SqliteJournal};
+use kx_journal::{Journal, JournalEntry, SqliteJournal};
 use kx_projection::{CheckpointOutcome, FoldCheckpoint, Projection};
 use kx_runtime::checkpoint_io;
 use kx_runtime::config::Mode;
@@ -37,14 +37,27 @@ fn first_run_no_sidecar_completes_and_writes_one() {
     let outcome = kx_runtime::run(&c).unwrap();
     assert_eq!((outcome.committed, outcome.total), (8, 8));
 
-    // The completed run leaves a usable sidecar folded through the final head.
+    // The completed run leaves a usable sidecar folded through the final frontier,
+    // plus (M2.2c) a journaled `DigestSealed` anchoring it as the very last entry.
+    // So the checkpoint frontier is `head - 1` and the seal occupies `head`.
     let sidecar = checkpoint_io::sidecar_path(&c.journal_path);
     let cp = checkpoint_io::read_checkpoint(&sidecar).expect("a sidecar after a completed run");
-    let head = SqliteJournal::open(&c.journal_path)
+    let journal = SqliteJournal::open(&c.journal_path).unwrap();
+    let head = journal.current_seq().unwrap();
+    assert_eq!(
+        cp.journal_offset(),
+        head - 1,
+        "graceful checkpoint at the frontier just before its seal"
+    );
+    let last = journal
+        .read_entries_by_seq(head..(head + 1))
         .unwrap()
-        .current_seq()
-        .unwrap();
-    assert_eq!(cp.journal_offset(), head, "graceful checkpoint at the head");
+        .next()
+        .expect("a head entry");
+    assert!(
+        matches!(last, JournalEntry::DigestSealed { through_seq, .. } if through_seq == cp.journal_offset()),
+        "the last entry is the digest seal anchoring the graceful checkpoint frontier"
+    );
 }
 
 /// **T8 (disabled)** — `checkpoint_every: None` writes no sidecar at all.
@@ -60,9 +73,11 @@ fn cadence_none_writes_no_sidecar() {
     );
 }
 
-/// The graceful-completion sidecar is at the journal head, so a fresh recovery
-/// reports `Seeded { offset: head, tail_entries: 0 }` (the structured
-/// observability signal) and folds an empty tail.
+/// The graceful-completion sidecar is at frontier `head - 1`, anchored by a
+/// `DigestSealed` at `head` (M2.2c). A fresh recovery reports
+/// `Seeded { offset: head - 1, tail_entries: 1 }` (the structured observability
+/// signal) and folds the 1-entry tail (the seal, a `last_seq` no-op), ending at
+/// `head`. This proves the seal anchors the seed end-to-end through the runtime.
 ///
 /// NB: the runtime captures checkpoints AFTER `scheduler.submit`, so the payload
 /// carries the workflow's *declared* Motes — a richer state than a bare
@@ -73,7 +88,7 @@ fn cadence_none_writes_no_sidecar() {
 /// via the children re-index — is proven by `replay_bit_identical_with_and_without_sidecar`
 /// below and the subprocess `kill_and_replay` checkpoint scenarios.
 #[test]
-fn head_checkpoint_reports_seeded_empty_tail() {
+fn head_checkpoint_seeds_anchored_by_seal() {
     let dir = tempfile::tempdir().unwrap();
     let c = cfg(dir.path(), Some(2));
     kx_runtime::run(&c).unwrap();
@@ -81,19 +96,28 @@ fn head_checkpoint_reports_seeded_empty_tail() {
     let journal = SqliteJournal::open(&c.journal_path).unwrap();
     let head = journal.current_seq().unwrap();
     let cp = checkpoint_io::read_checkpoint(&checkpoint_io::sidecar_path(&c.journal_path)).unwrap();
-    assert_eq!(cp.journal_offset(), head);
+    let offset = cp.journal_offset();
+    assert_eq!(
+        offset,
+        head - 1,
+        "checkpoint frontier sits just before its seal"
+    );
 
     let (seeded, outcome) =
         Projection::from_journal_with_checkpoint_reported(&journal, Some(&cp)).unwrap();
     assert_eq!(
         outcome,
         CheckpointOutcome::Seeded {
-            offset: head,
-            tail_entries: 0
+            offset,
+            tail_entries: 1
         },
-        "a head checkpoint seeds with an empty tail"
+        "a head checkpoint seeds, anchored by its 1-entry seal tail"
     );
-    assert_eq!(seeded.current_seq(), head, "seeded frontier is the head");
+    assert_eq!(
+        seeded.current_seq(),
+        head,
+        "seeded frontier reaches the head"
+    );
 }
 
 /// **T1 / T3 (in-process)** — the runtime's product digest of a replay is identical
@@ -123,6 +147,52 @@ fn replay_bit_identical_with_and_without_sidecar() {
     assert_eq!(
         full.digest, first.digest,
         "full-fold replay (no sidecar) is bit-identical to the seeded replay"
+    );
+}
+
+/// **M2.2c product-digest invariant (guards `a6b5c679…`).** A seal-writing run
+/// (cadence on) and a seal-free run (cadence off) produce the SAME product digest:
+/// `DigestSealed` is off-DAG metadata, invisible to `digest_projection` (which
+/// folds only `Committed` Motes). Also proves the cadence does not runaway-seal —
+/// each seal anchors a distinct, strictly-increasing frontier.
+#[test]
+fn seals_do_not_change_product_digest_and_do_not_runaway() {
+    let d_sealed = tempfile::tempdir().unwrap();
+    let c_sealed = cfg(d_sealed.path(), Some(2));
+    let sealed = kx_runtime::run(&c_sealed).unwrap();
+
+    let d_plain = tempfile::tempdir().unwrap();
+    let plain = kx_runtime::run(&cfg(d_plain.path(), None)).unwrap();
+
+    assert_eq!((sealed.committed, sealed.total), (8, 8));
+    assert_eq!((plain.committed, plain.total), (8, 8));
+    assert_eq!(
+        sealed.digest, plain.digest,
+        "journaled seals must NOT change the product digest"
+    );
+
+    // The cadence run wrote seals; their frontiers are distinct + strictly
+    // increasing (a runaway would re-seal the same frontier), and each seal sits
+    // AFTER the frontier it anchors (`seq == through_seq + 1` under single-writer).
+    let journal = SqliteJournal::open(&c_sealed.journal_path).unwrap();
+    let head = journal.current_seq().unwrap();
+    let seal_frontiers: Vec<u64> = journal
+        .read_entries_by_seq(1..(head + 1))
+        .unwrap()
+        .filter_map(|e| match e {
+            JournalEntry::DigestSealed {
+                through_seq, seq, ..
+            } => {
+                assert!(seq > through_seq, "a seal sits after its frontier");
+                Some(through_seq)
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(!seal_frontiers.is_empty(), "the cadence run wrote ≥1 seal");
+    assert!(
+        seal_frontiers.windows(2).all(|w| w[0] < w[1]),
+        "seal frontiers must be strictly increasing (no runaway re-sealing): {seal_frontiers:?}"
     );
 }
 

--- a/crates/kx-runtime/tests/kill_and_replay.rs
+++ b/crates/kx-runtime/tests/kill_and_replay.rs
@@ -393,3 +393,83 @@ fn corrupt_sidecar_recovers_via_full_fold() {
     );
     assert_exactly_once(&p.journal);
 }
+
+/// **The D103.1 attack — caught by M2.2c journaled seals (process boundary).**
+///
+/// Unlike a *corrupt* sidecar (garbage that fails `from_bytes`), a *forged-but-
+/// self-consistent* sidecar is a VALID checkpoint envelope (passes `verify()` +
+/// `decode`) that seeds a **wrong base state** at the genuine frontier. Pre-M2.2c
+/// it slipped through all the seed gates and recovery diverged. Now the runtime
+/// has co-committed a `DigestSealed` anchoring the genuine state digest *in the
+/// journal*, so the forged seed fails the seal gate (`SealMismatch`) and recovery
+/// falls back to the trust root — bit-identical to the clean run.
+#[test]
+fn forged_sidecar_is_rejected_by_the_journaled_seal() {
+    use kx_content::ContentRef;
+    use kx_journal::InMemoryJournal;
+    use kx_mote::{MoteDefHash, NdClass};
+    use kx_projection::Projection;
+    use smallvec::SmallVec;
+
+    let reference = clean_reference_digest();
+    let p = paths();
+
+    // A clean, completed run leaves a genuine sidecar + a journaled seal anchoring
+    // the final frontier S (the seal sits at S + 1, the journal head).
+    let done = invoke_ck("run", &p, None, Some(2));
+    assert!(done.status.success(), "clean run must complete");
+    let genuine = kx_runtime::checkpoint_io::read_checkpoint(&sidecar_path(&p.journal))
+        .expect("a genuine sidecar after a completed run");
+    let offset = genuine.journal_offset();
+    assert!(offset >= 8, "the canonical run folds through ≥ 8 entries");
+
+    // Forge a self-consistent sidecar that decodes to a DIFFERENT state at the SAME
+    // frontier: S commits of unrelated, distinct motes → last_seq == S, valid
+    // envelope, no run-registration (so the wrong-run gate is skipped). Gates 1–5
+    // all pass; only the M2.2c seal gate (6) can catch it.
+    let wrong = InMemoryJournal::new();
+    for i in 0..offset {
+        let mut id = [0u8; 32];
+        id[..8].copy_from_slice(&i.to_le_bytes());
+        id[31] = 0xF0; // disjoint from any canonical mote id
+        let mote_id = MoteId::from_bytes(id);
+        wrong
+            .append(JournalEntry::Committed {
+                mote_id,
+                idempotency_key: id,
+                seq: 0,
+                nondeterminism: NdClass::Pure,
+                result_ref: ContentRef::from_bytes([0xEE; 32]),
+                parents: SmallVec::new(),
+                warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+                mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+            })
+            .unwrap();
+    }
+    let mut forged = Projection::new();
+    for e in wrong.read_entries_by_seq(0..(offset + 1)).unwrap() {
+        forged.fold(&e).unwrap();
+    }
+    let forged_cp = forged.fold_checkpoint();
+    assert_eq!(
+        forged_cp.journal_offset(),
+        offset,
+        "the forged frontier matches the genuine one (passes the offset gates)"
+    );
+    assert!(
+        forged_cp.verify(),
+        "the forged sidecar is internally self-consistent (a valid envelope)"
+    );
+
+    // Overwrite the genuine sidecar with the forgery; a seeding replay must reject
+    // it via the seal and full-fold to the genuine result.
+    std::fs::write(sidecar_path(&p.journal), forged_cp.to_bytes()).unwrap();
+    let replay = invoke_ck("replay", &p, None, Some(2));
+    assert_eq!(
+        digest_of(&replay),
+        reference,
+        "the forged sidecar is rejected by the journaled seal (SealMismatch) → \
+         recovery full-folds the trust root and reproduces the clean run"
+    );
+    assert_exactly_once(&p.journal);
+}


### PR DESCRIPTION
## M2.2c — Journaled Digest Seals

Anchors the post-recovery `state_digest()` to a `DigestSealed{through_seq, state_digest}` entry committed **in the journal** (the trust root), upgrading the M2.2b checkpoint-sidecar trust model from **integrity → unforgeability**. A forged-but-self-consistent sidecar can no longer seed a wrong base state on recovery — forging the anchoring seal requires forging the journal itself. Single-node only (`kx-runtime`); the distributed coordinator read path stays deferred ("coordinator parity").

### What changed
- **`kx-journal`** — new `JournalEntry::DigestSealed` (kind=7), schema **v4→v5** (refuses v4 loudly — the established additive pattern). Header anchors to a synthetic `seal_root_id(through_seq)` with a body-header consistency check (a single-node run has no `instance_id`). Off-DAG, not deduped, panic-free + fail-closed decode.
- **`kx-projection`** — a 6th `try_seed_state` gate verifies the seeded payload digest (`blake3(payload)` — no re-encode) against the journaled seal at `S+1`. Missing/mismatched seal → `FullFold{SealMissing | SealMismatch}` → full fold (fail-closed). The seal folds as a pure `last_seq`-only no-op — never materialized into state, invisible to `state_digest()` and the run-identity product digest.
- **`kx-runtime`** — `write_checkpoint` co-commits the seal **after** the sidecar write (sidecar-first ordering ⇒ a crash between them is fail-safe). Reuses `checkpoint_every`; no new config knob.

### Pre-flight risk analysis (Golden Rule 8)
- **Breaks live:** schema bump refuses v4 journals (intended, matches every prior kind addition); a fail-OPEN bug would reintroduce D103.1 → the gate **fails CLOSED** (full fold reads only the trust root). Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) source **byte-unchanged** (thesis diff EMPTY).
- **Perf:** seed-anchoring is **O(1)** (one `blake3` over the in-hand payload, no per-entry work); full fold verifies no seal. Measured: in-memory churn resume **2.2×**, SQLite **3.9×** (scale-smoke).
- **Security:** the seal *is* the improvement (closes D103.1). New decode input is panic-free/fail-closed; no secrets in the seal. Distributed/untrusted-storage needs *signed* seals — an additive follow-on, out of scope here.

### Forward-enhancement (Golden Rule 9)
Unlocks coordinator-parity read path (the hard prerequisite); composes with rkyv M2.2d (the seal anchors logical state, codec-independent); signed seals + Merkle-chained journal are sequenced follow-ons.

### Tests (deep)
- Journal: round-trip + byte-determinism proptests, schema pin v5, malformed/header-mismatch rejection.
- Projection (`tests/digest_seal.rs`): the **D103.1 forged-seed attack → `SealMismatch`**, missing/stale → `SealMissing`, seal-is-a-fold-no-op; all bit-identical to a full fold.
- Runtime: kill-and-replay subprocess **forged-sidecar attack now caught**; **product digest unchanged by seals** (guards `a6b5c679…`) + no runaway sealing; seeded-anchored head recovery.
- Full local gate green: fmt, clippy `-D warnings`, `test --workspace`, deny, doc, **I1.c byte-determinism PASS**, scale-smoke.

Decisions = **D103.2** (frozen) + **D104** (implementation sub-decisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)