### PR TITLE
feat(executor,capability): wire the Readback probe into recovery (M2.3a, D38 §2a / D65)

### DIFF
--- a/crates/kx-capability/src/capability.rs
+++ b/crates/kx-capability/src/capability.rs
@@ -67,4 +67,28 @@ pub trait Capability: Send + Sync {
         let _ = request;
         Ok(None)
     }
+
+    /// Compensate (undo) an effect that may have partially applied (D65 —
+    /// the recovery seam, M2.3). Default returns `Ok(None)` (capability does
+    /// not support compensation; recovery quarantines rather than risking a
+    /// double-fire).
+    ///
+    /// A capability whose effect cannot be made idempotent (no token, no
+    /// readback) and whose double-application is harmful overrides this to
+    /// reverse the effect deterministically, keyed on `MoteId`. `Ok(Some(bytes))`
+    /// proves the compensating action ran (the bytes are the undo's
+    /// externally-observable result); `Ok(None)` means "compensation
+    /// unsupported"; `Err` means the compensation itself failed.
+    ///
+    /// **Like [`probe`][Capability::probe] this is a deterministic action**,
+    /// **never a model call.** Reserved for the M2.3b class-aware
+    /// `Compensate`-vs-`Redispatch` recovery decision; the M2.3a probe path
+    /// does not invoke it.
+    fn compensate(
+        &self,
+        request: &EffectRequest,
+    ) -> Result<Option<Vec<u8>>, CapabilityFailureReason> {
+        let _ = request;
+        Ok(None)
+    }
 }

--- a/crates/kx-capability/src/tests.rs
+++ b/crates/kx-capability/src/tests.rs
@@ -534,3 +534,43 @@ fn registered_count_reflects_register_calls() {
     )));
     assert_eq!(broker.registered_count(), 2);
 }
+
+/// A capability that overrides `compensate` (the M2.3 recovery seam).
+struct CompensatingCapability {
+    name: ToolName,
+    version: ToolVersion,
+    patterns: Vec<EffectPattern>,
+}
+impl Capability for CompensatingCapability {
+    fn name(&self) -> &ToolName {
+        &self.name
+    }
+    fn version(&self) -> &ToolVersion {
+        &self.version
+    }
+    fn supported_patterns(&self) -> &[EffectPattern] {
+        &self.patterns
+    }
+    fn invoke(&self, _: &EffectRequest) -> Result<Vec<u8>, CapabilityFailureReason> {
+        Ok(b"forward".to_vec())
+    }
+    fn compensate(&self, _: &EffectRequest) -> Result<Option<Vec<u8>>, CapabilityFailureReason> {
+        Ok(Some(b"undone".to_vec()))
+    }
+}
+
+#[test]
+fn compensate_defaults_to_unsupported_and_is_overridable() {
+    let req = empty_request_with_pattern(EffectPattern::StageThenCommit, Vec::new());
+    // M2.3a: the default `compensate` returns Ok(None) — compensation unsupported,
+    // so recovery quarantines rather than risking a double-fire.
+    let plain = ReverseCapability::new("r", "1", vec![EffectPattern::StageThenCommit]);
+    assert_eq!(plain.compensate(&req).unwrap(), None);
+    // A capability that overrides it runs its deterministic undo.
+    let comp = CompensatingCapability {
+        name: tool_name("c"),
+        version: tool_version("1"),
+        patterns: vec![EffectPattern::StageThenCommit],
+    };
+    assert_eq!(comp.compensate(&req).unwrap(), Some(b"undone".to_vec()));
+}

--- a/crates/kx-executor/src/commit_protocol.rs
+++ b/crates/kx-executor/src/commit_protocol.rs
@@ -130,6 +130,22 @@ pub enum CommitProtocolError {
         reason: String,
     },
 
+    /// **M2.3a (D38 §2a / D65).** At recovery time, the readback probe
+    /// (`CapabilityBroker::probe_readback`) for a staged-uncommitted
+    /// WORLD-MUTATING Mote returned an error — the executor cannot determine
+    /// whether the effect already landed, so re-dispatch is REFUSED
+    /// (fail-closed; re-dispatching on an indeterminate probe risks a
+    /// double-fire). A recovery refusal (sibling of
+    /// [`Self::R13WmReDispatchRefused`]): the Mote is left in-flight + surfaced,
+    /// never re-dispatched.
+    #[error("M2.3a: readback probe failed for Mote {mote_id:?}: {reason}; re-dispatch refused (fail-closed, D38 §2a)")]
+    ProbeFailed {
+        /// The Mote whose recovery probe failed.
+        mote_id: MoteId,
+        /// Diagnostic from the broker's `probe_readback`.
+        reason: String,
+    },
+
     /// The capability broker's `dispatch` call returned a typed error. The
     /// body has not run; no `Committed` entry is appended. The lifecycle
     /// layer surfaces this as a `Failed` journal entry.
@@ -226,6 +242,7 @@ impl CommitProtocolError {
             Self::R11ResultRefIncomplete { mote_id, .. }
             | Self::R12CommittedNotProofOfValidity { mote_id, .. }
             | Self::R13WmReDispatchRefused { mote_id, .. }
+            | Self::ProbeFailed { mote_id, .. }
             | Self::BrokerDispatchFailed { mote_id, .. }
             | Self::ContentStorePutFailed { mote_id, .. }
             | Self::JournalAppendCommittedFailed { mote_id, .. }
@@ -258,7 +275,10 @@ impl CommitProtocolError {
     /// ```
     #[must_use]
     pub fn is_recovery_refusal(&self) -> bool {
-        matches!(self, Self::R13WmReDispatchRefused { .. })
+        matches!(
+            self,
+            Self::R13WmReDispatchRefused { .. } | Self::ProbeFailed { .. }
+        )
     }
 }
 
@@ -304,6 +324,39 @@ pub trait CommitProtocol: Send + Sync {
     /// Returns a `CommitProtocolError` variant for any refusal or failure
     /// in the commit path. See variant docs for the per-case semantics.
     fn commit(&self, input: CommitInput<'_>) -> Result<u64, CommitProtocolError>;
+
+    /// **M2.3a (D38 §2a / D65) — recovery readback probe.** For a
+    /// staged-uncommitted WORLD-MUTATING Mote on the recovery path, probe
+    /// whether the effect already landed (via
+    /// [`kx_capability::CapabilityBroker::probe_readback`])
+    /// **before** re-dispatching:
+    ///
+    /// - `Ok(Some(seq))` — the probe found the effect applied; the protocol
+    ///   committed the probed `result_ref` (R-11-verified) and returns the
+    ///   `Committed` seq. The caller MUST NOT re-dispatch — the effect is
+    ///   exactly-once.
+    /// - `Ok(None)` — no readback support (the default `Capability::probe`
+    ///   returns `Ok(None)`) or the probe found the effect not applied; the
+    ///   caller proceeds to the normal re-dispatch ([`Self::commit`]).
+    /// - `Err(CommitProtocolError::ProbeFailed)` — the probe itself errored;
+    ///   recovery cannot determine whether the effect landed, so it refuses
+    ///   re-dispatch (fail-closed).
+    ///
+    /// The **default returns `Ok(None)`** — a protocol with no broker (test
+    /// doubles) opts out and the caller re-dispatches as before.
+    ///
+    /// # Errors
+    /// [`CommitProtocolError::ProbeFailed`] if the probe errors;
+    /// [`CommitProtocolError::R11ResultRefIncomplete`] /
+    /// [`CommitProtocolError::JournalAppendCommittedFailed`] if the
+    /// commit-from-readback step fails after a positive probe.
+    fn try_commit_from_readback(
+        &self,
+        input: CommitInput<'_>,
+    ) -> Result<Option<u64>, CommitProtocolError> {
+        let _ = input;
+        Ok(None)
+    }
 }
 
 /// Input bundle for `CommitProtocol::commit`. Carries the Mote being
@@ -404,6 +457,62 @@ where
     J: Journal + Send + Sync,
     B: CapabilityBroker + Send + Sync,
 {
+    fn try_commit_from_readback(
+        &self,
+        input: CommitInput<'_>,
+    ) -> Result<Option<u64>, CommitProtocolError> {
+        let mote_id = input.mote.id;
+
+        // D38 §2a: probe the world state (deterministic, keyed on MoteId via the
+        // idempotency key) BEFORE re-dispatching. The default `Capability::probe`
+        // returns `Ok(None)`, so a non-readback tool's `probe_readback` is
+        // `Ok(None)` → the caller falls through to the normal re-dispatch.
+        let handle = match self.broker.probe_readback(
+            input.mote,
+            input.warrant,
+            &input.capability,
+            input.effect_request,
+        ) {
+            Ok(Some(handle)) => handle,  // effect already applied → commit it
+            Ok(None) => return Ok(None), // not applied / no readback → re-dispatch
+            Err(e) => {
+                // Indeterminate world state — fail closed (no re-dispatch).
+                return Err(CommitProtocolError::ProbeFailed {
+                    mote_id,
+                    reason: format!("{e:?}"),
+                });
+            }
+        };
+        let result_ref = handle.staged_ref;
+
+        // R-11 verify the probed ref is durable before journaling Committed —
+        // same defense the dispatch path uses against a hostile/buggy broker.
+        enforce_r11(&*self.store, mote_id, &result_ref)?;
+
+        // Commit-from-readback: append Committed with the PROBED result_ref and
+        // NO `broker.dispatch`. The fold sees EffectStaged + Committed (cell 4/6)
+        // → done; downstream reads `result_ref`. Exactly-once: the external
+        // effect ran exactly once (pre-crash), and recovery commits its result
+        // without re-applying it.
+        let entry = JournalEntry::Committed {
+            mote_id,
+            idempotency_key: input.idempotency_key,
+            seq: 0, // journal-assigned
+            nondeterminism: input.mote.def.nd_class,
+            result_ref,
+            parents: input.parents,
+            warrant_ref: input.warrant_ref,
+            mote_def_hash: input.mote_def_hash,
+        };
+        let written = self.journal.append(entry).map_err(|e| {
+            CommitProtocolError::JournalAppendCommittedFailed {
+                mote_id,
+                reason: format!("{e:?}"),
+            }
+        })?;
+        Ok(Some(written.seq()))
+    }
+
     fn commit(&self, input: CommitInput<'_>) -> Result<u64, CommitProtocolError> {
         let pattern = input.mote.def.effect_pattern;
         match pattern {

--- a/crates/kx-executor/src/lifecycle.rs
+++ b/crates/kx-executor/src/lifecycle.rs
@@ -349,7 +349,18 @@ where
     // intent. The broker's idempotency_key dedup is the load-bearing
     // safety here.
 
-    // Step 4: commit_protocol routes per effect_pattern.
+    // Step 4: the recovery decision (M2.3a, D38 §2a / D65). For a
+    // staged-uncommitted WM Mote the recovery action is one of three outcomes,
+    // encoded by `try_commit_from_readback`'s `Result<Option<u64>>`:
+    //   • Ok(Some) = COMMIT-FROM-READBACK — the probe found the effect applied;
+    //     the protocol committed the probed result_ref WITHOUT re-dispatching
+    //     (exactly-once for Readback-class tools).
+    //   • Ok(None) = REDISPATCH — no readback support (default probe) or the
+    //     effect did not land → fall through to the normal re-dispatch.
+    //   • Err(ProbeFailed) = REFUSE — the probe errored; world state is
+    //     indeterminate, so re-dispatch is refused (fail-closed, no double-fire).
+    // (M2.3b extends this to a typed Compensate/Quarantine arm once the
+    // IdempotencyClass is durable.)
     let commit_input = CommitInput {
         mote,
         warrant,
@@ -361,9 +372,17 @@ where
         parents: SmallVec::new(),
         diagnostic_context: "lifecycle::redispatch_wm_mote",
     };
-    let committed_seq = match commit_protocol.commit(commit_input) {
-        Ok(seq) => seq,
+    let committed_seq = match commit_protocol.try_commit_from_readback(commit_input.clone()) {
+        Ok(Some(seq)) => seq, // probe: effect already applied → committed from readback
+        Ok(None) => match commit_protocol.commit(commit_input) {
+            Ok(seq) => seq,
+            Err(e) => {
+                let _ = resource_manager.release(slot);
+                return Err(LifecycleError::CommitProtocol(e));
+            }
+        },
         Err(e) => {
+            // ProbeFailed (fail-closed) — never re-dispatch on an indeterminate probe.
             let _ = resource_manager.release(slot);
             return Err(LifecycleError::CommitProtocol(e));
         }

--- a/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
+++ b/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
@@ -382,3 +382,180 @@ fn redispatch_validate_then_commit_schedules_critic_proposed() {
     assert!(matches!(&entries[0], JournalEntry::Committed { .. }));
     assert!(matches!(&entries[1], JournalEntry::Proposed { .. }));
 }
+
+// ============================================================================
+// M2.3a (D38 §2a / D65) — the readback probe in recovery. A Readback-class
+// capability's `probe_readback` decides the recovery action BEFORE re-dispatch:
+//   Some(applied) → commit-from-readback (NO dispatch); None → re-dispatch;
+//   Err → ProbeFailed (fail-closed, NO dispatch).
+// ============================================================================
+
+/// What the probe reports.
+enum ProbeMode {
+    /// The effect already landed — return a handle staging the probed bytes.
+    Applied,
+    /// The effect did not land — proceed to re-dispatch.
+    NotApplied,
+    /// The probe itself errored — world state is indeterminate.
+    Errored,
+}
+
+/// A broker whose `probe_readback` is configurable and whose `dispatch` records
+/// whether it was called. The probe stages DISTINCT bytes from dispatch so a
+/// test can prove the Committed `result_ref` came from the probe, not a dispatch.
+struct ProbeBroker {
+    store: Arc<InMemoryContentStore>,
+    mode: ProbeMode,
+    dispatched: AtomicBool,
+}
+impl std::fmt::Debug for ProbeBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProbeBroker").finish()
+    }
+}
+impl CapabilityBroker for ProbeBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        self.dispatched.store(true, Ordering::SeqCst);
+        let r = self.store.put(b"DISPATCH-resp").expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("probe".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        match self.mode {
+            ProbeMode::Applied => {
+                let r = self.store.put(b"PROBE-readback-resp").expect("put");
+                Ok(Some(BrokerHandle {
+                    staged_ref: r,
+                    capability: ToolName("probe".into()),
+                    capability_version: ToolVersion("0.1.0".into()),
+                }))
+            }
+            ProbeMode::NotApplied => Ok(None),
+            ProbeMode::Errored => Err(BrokerError::SandboxRefused {
+                capability: capability.clone(),
+                reason: "probe unavailable".into(),
+            }),
+        }
+    }
+}
+
+fn redispatch_with_probe(
+    mode: ProbeMode,
+) -> (
+    Arc<InMemoryJournal>,
+    Arc<InMemoryContentStore>,
+    Arc<ProbeBroker>,
+    Result<kx_executor::WmLifecycleCommit, LifecycleError>,
+) {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(ProbeBroker {
+        store: store.clone(),
+        mode,
+        dispatched: AtomicBool::new(false),
+    });
+    let broker_ref = broker.clone();
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    // Oracle approves (cell 2/3: EffectStaged, no Committed, no terminal) — the
+    // probe is the NEW layer on top of the existing redispatch-allowed gate.
+    let oracle = StubOracle {
+        can_redispatch: true,
+        consulted: AtomicBool::new(false),
+    };
+    let mote = wm_mote(0x07, EffectPattern::StageThenCommit);
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((mote.id, mote.clone())).collect();
+    let out = redispatch_wm_mote(
+        &mote,
+        &warrant(),
+        ToolName("probe".into()),
+        empty_request(EffectPattern::StageThenCommit),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &oracle,
+    );
+    (journal, store, broker_ref, out)
+}
+
+#[test]
+fn probe_says_applied_commits_from_readback_without_dispatch() {
+    let (journal, store, broker, out) = redispatch_with_probe(ProbeMode::Applied);
+    let commit = out.expect("commit-from-readback must succeed");
+
+    // The effect was NEVER re-dispatched — exactly-once.
+    assert!(
+        !broker.dispatched.load(Ordering::SeqCst),
+        "a positive probe must NOT re-dispatch the world effect"
+    );
+    // Exactly one Committed entry, carrying the PROBED bytes (not a dispatch's).
+    let entries: Vec<JournalEntry> = journal.read_entries_by_seq(0..u64::MAX).unwrap().collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "commit-from-readback appends Committed only"
+    );
+    match &entries[0] {
+        JournalEntry::Committed { result_ref, .. } => {
+            assert_eq!(*result_ref, commit.result_ref);
+            // The committed bytes are the PROBE's, proving no dispatch occurred.
+            let bytes = store.get(result_ref).expect("committed ref is durable");
+            assert_eq!(bytes.as_ref(), b"PROBE-readback-resp");
+        }
+        other => panic!("expected Committed, got {other:?}"),
+    }
+}
+
+#[test]
+fn probe_says_not_applied_falls_through_to_redispatch() {
+    let (journal, _store, broker, out) = redispatch_with_probe(ProbeMode::NotApplied);
+    out.expect("re-dispatch must succeed when the probe finds nothing");
+
+    // No readback → the existing re-dispatch path fired.
+    assert!(
+        broker.dispatched.load(Ordering::SeqCst),
+        "a None probe must fall through to re-dispatch"
+    );
+    let entries: Vec<JournalEntry> = journal.read_entries_by_seq(0..u64::MAX).unwrap().collect();
+    // StageThenCommit re-dispatch: EffectStaged + Committed.
+    assert!(entries
+        .iter()
+        .any(|e| matches!(e, JournalEntry::Committed { .. })));
+}
+
+#[test]
+fn probe_error_refuses_redispatch_fail_closed() {
+    let (journal, store, broker, out) = redispatch_with_probe(ProbeMode::Errored);
+    let err = out.expect_err("an errored probe must refuse re-dispatch");
+
+    match err {
+        LifecycleError::CommitProtocol(e @ CommitProtocolError::ProbeFailed { .. }) => {
+            assert!(e.is_recovery_refusal(), "ProbeFailed is a recovery refusal");
+        }
+        other => panic!("expected ProbeFailed, got {other:?}"),
+    }
+    // Fail-closed: no dispatch, no Committed — the Mote is left in-flight.
+    assert!(
+        !broker.dispatched.load(Ordering::SeqCst),
+        "an indeterminate probe must NOT re-dispatch (no double-fire)"
+    );
+    assert_eq!(journal.count_entries().unwrap(), 0);
+    assert_eq!(store.len(), 0);
+}


### PR DESCRIPTION
## M2.3a — the compensation seam, part 1 (Readback probe)

Closes a real correctness gap: at crash recovery a staged-uncommitted world-mutating Mote was re-dispatched relying **only** on the broker's idempotency-key dedup — sound only for **Token-class** tools — while the `broker.probe_readback` machinery (D38 §2a) sat **wired to nothing**. So the "exactly-once across a failure" headline (D63) was only true for Token tools.

### What changed
`redispatch_wm_mote` now **probes before re-dispatching** (class-free — driven by capability `probe` support, not the IdempotencyClass):

| Probe outcome | Recovery action |
|---|---|
| `Ok(Some)` — effect already applied | **commit-from-readback** (R-11-verified, **no dispatch**) — exactly-once for Readback tools |
| `Ok(None)` — not applied / no readback support (default `probe`) | fall through to today's **re-dispatch** (unchanged) |
| `Err` — probe itself failed | **`ProbeFailed` refusal** (fail-closed; an indeterminate probe never re-dispatches → **no double-fire**) |

`Capability::compensate` (default `Ok(None)`) added as the forward seam for M2.3b.

### Pre-flight risk + forward-enhancement (Golden Rule 8 + 9)
- **(a) correctness:** safe-by-default (non-readback tools' `probe` → `Ok(None)` → byte-identical fall-through); positive probe commits through the **same R-11 verify**; probe error fails **closed**. Product digest `a6b5c679…` unchanged (a clean run never recovers, so never probes).
- **(b) perf:** zero hot-path cost — the probe fires only on the recovery path.
- **(c) security:** no new untrusted input/egress/secrets; the probe goes through the same `CapabilityBroker` warrant-subset contract.
- **Frozen trio:** `kx-scheduler`/`kx-inference` untouched; `kx-executor` is legitimately changed (recovery is the executor's job — a core feature, not a distribution layer).

### Scope
`kx-capability` + `kx-executor` only (5 files, +373/-4). No schema bump, **no new dependency**. `kx-runtime`/`kx-projection`/`kx-journal` source unchanged.

### Tests
- 3 new probe-then-act integration tests (`integration_redispatch_wm_mote.rs`): applied→commit-from-readback (no dispatch; the **probe's** bytes committed); none→re-dispatch; error→`ProbeFailed` fail-closed (no dispatch, no Committed).
- `Capability::compensate` default/override test.
- **No-regression:** `kill_and_replay` (8) + `checkpoint_recovery` digest guard + the **kx-chaos 2,048-seed exactly-once sweep** all green (the demo/chaos brokers' `probe_readback` returns `Ok(None)` → byte-identical fall-through).
- **Gate:** fmt, clippy `--workspace --all-targets -D warnings`, `cargo test --workspace` (187 suites / 1127 / 0 failed), deny, doc `-D warnings`, doctests; **SN-7** on Apple Silicon (local).

### Deferred
- The runtime-level Readback-*applied* subprocess scenario (needs demo-broker Readback plumbing + a crash point; the probe-then-act logic is fully proven at the executor layer).
- **M2.3b** — class-aware Compensate/Quarantine: journal `idempotency_class` on `ResolvedCapabilityRecord` (schema v5→v6) + the typed decision; closes the M2 exit gate.

Also this session: **M2.2d (rkyv codec) was built, measured (0.52× — slower than bincode's 0.61×, both lose to the M2.1 fold), and rejected** — clean-log resume is structurally un-winnable by a codec; roadmap item B closed (measure-don't-claim, Rule 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)