### PR TITLE
feat: class-aware Compensate/Quarantine recovery — closes the M2 exit gate (M2.3b, D65/D105.4)

### DIFF
--- a/crates/kx-capability/src/broker.rs
+++ b/crates/kx-capability/src/broker.rs
@@ -82,4 +82,38 @@ pub trait CapabilityBroker: Send + Sync {
         capability: &ToolName,
         probe: EffectRequest,
     ) -> Result<Option<BrokerHandle>, BrokerError>;
+
+    /// D65 / M2.3b — deterministic compensation (undo) for an at-most-once
+    /// (`IdempotencyClass::AtLeastOnce`) effect that crash-recovery cannot safely
+    /// re-dispatch (no closing mechanism → a re-dispatch would double-fire).
+    ///
+    /// The broker runs the **same per-call contract checks** as
+    /// [`dispatch`][Self::dispatch] / [`probe_readback`][Self::probe_readback]
+    /// (capability ∈ tool_contract, supports pattern, ∈ warrant.tool_grants,
+    /// request scopes ⊆ warrant scopes) — compensation is a world-mutating effect
+    /// and must NOT bypass the warrant gate — then invokes the capability's
+    /// [`compensate`][crate::Capability::compensate] method:
+    ///
+    /// - `Ok(Some(handle))` — the undo ran; its externally-observable result was
+    ///   staged into the content store. The executor R-11-verifies the staged ref
+    ///   and records a terminal `Failed { reason_class: CompensatedAtLeastOnce }`
+    ///   (no re-dispatch).
+    /// - `Ok(None)` — the capability does NOT support compensation; the executor
+    ///   quarantines the Mote (`Failed { reason_class: QuarantinedAtLeastOnce }`).
+    /// - `Err(_)` — compensation itself failed; surfaced like any other broker
+    ///   error (the executor refuses, fail-closed — never re-dispatches).
+    ///
+    /// **Default `Ok(None)`** so an existing broker that does not implement
+    /// compensation falls through to quarantine. Like `probe_readback`, the
+    /// broker is recovery-state-independent: it only runs the undo and stages.
+    fn compensate(
+        &self,
+        mote: &kx_mote::Mote,
+        warrant: &WarrantSpec,
+        capability: &ToolName,
+        request: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        let _ = (mote, warrant, capability, request);
+        Ok(None)
+    }
 }

--- a/crates/kx-capability/src/local.rs
+++ b/crates/kx-capability/src/local.rs
@@ -276,4 +276,42 @@ impl<S: ContentStore + Send + Sync> CapabilityBroker for LocalCapabilityBroker<S
         };
         Ok(Some(self.stage(&cap_name, &cap_version, bytes)?))
     }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, mote, warrant, request),
+        fields(
+            mote_id = %mote.id,
+            capability = %capability.0,
+            pattern = ?request.pattern,
+        )
+    )]
+    fn compensate(
+        &self,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+        capability: &ToolName,
+        request: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        // SAME per-call contract gate as dispatch/probe_readback — compensation
+        // is a world-mutating undo and must not bypass the warrant (D65 / M2.3b).
+        let guard = self.capabilities.read().expect("RwLock poisoned");
+        let cap = Self::precheck(&guard, mote, warrant, capability, &request)?;
+        let cap_name = cap.name().clone();
+        let cap_version = cap.version().clone();
+        let outcome = cap.compensate(&request);
+        // Drop the read lock BEFORE staging — staging is I/O.
+        drop(guard);
+        let bytes = match outcome {
+            Ok(Some(b)) => b,
+            Ok(None) => return Ok(None),
+            Err(reason) => {
+                return Err(BrokerError::CapabilityFailure {
+                    capability: cap_name,
+                    reason,
+                });
+            }
+        };
+        Ok(Some(self.stage(&cap_name, &cap_version, bytes)?))
+    }
 }

--- a/crates/kx-capability/src/tests.rs
+++ b/crates/kx-capability/src/tests.rs
@@ -574,3 +574,82 @@ fn compensate_defaults_to_unsupported_and_is_overridable() {
     };
     assert_eq!(comp.compensate(&req).unwrap(), Some(b"undone".to_vec()));
 }
+
+// -- M2.3b — broker-level compensate stages the undo, gated by the warrant ----
+
+#[test]
+fn broker_compensate_stages_undo_when_capability_supports_it() {
+    let name = tool_name("c");
+    let version = tool_version("1");
+    let mote = mote_with_tool(&name, &version);
+    let warrant = permissive_warrant_with_grant(ToolGrant {
+        tool_id: name.clone(),
+        tool_version: version.clone(),
+    });
+    let broker = LocalCapabilityBroker::new(InMemoryContentStore::new());
+    broker.register_capability(Box::new(CompensatingCapability {
+        name: name.clone(),
+        version,
+        patterns: vec![EffectPattern::StageThenCommit],
+    }));
+    let req = empty_request_with_pattern(EffectPattern::StageThenCommit, vec![]);
+    let handle = broker
+        .compensate(&mote, &warrant, &name, req)
+        .expect("compensate ok")
+        .expect("expected Some(handle) — capability ran its undo");
+    // The undo's externally-observable result is content-addressed in the store.
+    assert_eq!(handle.staged_ref, ContentRef::of(b"undone"));
+}
+
+#[test]
+fn broker_compensate_returns_none_for_unsupported_capability() {
+    let name = tool_name("rev");
+    let version = tool_version("1");
+    let mote = mote_with_tool(&name, &version);
+    let warrant = permissive_warrant_with_grant(ToolGrant {
+        tool_id: name.clone(),
+        tool_version: version.clone(),
+    });
+    let broker = LocalCapabilityBroker::new(InMemoryContentStore::new());
+    broker.register_capability(Box::new(ReverseCapability::new(
+        "rev",
+        "1",
+        vec![EffectPattern::StageThenCommit],
+    )));
+    let req = empty_request_with_pattern(EffectPattern::StageThenCommit, vec![1, 2, 3]);
+    let outcome = broker
+        .compensate(&mote, &warrant, &name, req)
+        .expect("compensate ok");
+    assert!(
+        outcome.is_none(),
+        "default compensate impl returns None — broker yields None → executor quarantines"
+    );
+}
+
+#[test]
+fn broker_compensate_refuses_capability_outside_warrant() {
+    // Compensation is a world-mutating undo — the broker MUST run the same
+    // warrant gate as dispatch (no unwarranted effect bypass, D65 / M2.3b).
+    let name = tool_name("c");
+    let version = tool_version("1");
+    let mote = mote_with_tool(&name, &version);
+    // A warrant that grants a DIFFERENT tool → the capability is not granted.
+    let warrant = permissive_warrant_with_grant(ToolGrant {
+        tool_id: tool_name("other"),
+        tool_version: version.clone(),
+    });
+    let broker = LocalCapabilityBroker::new(InMemoryContentStore::new());
+    broker.register_capability(Box::new(CompensatingCapability {
+        name: name.clone(),
+        version,
+        patterns: vec![EffectPattern::StageThenCommit],
+    }));
+    let req = empty_request_with_pattern(EffectPattern::StageThenCommit, vec![]);
+    let err = broker
+        .compensate(&mote, &warrant, &name, req)
+        .expect_err("compensate must refuse a capability outside the warrant");
+    assert!(matches!(
+        err,
+        BrokerError::CapabilityExceedsWarrant { .. } | BrokerError::UnknownCapability { .. }
+    ));
+}

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_journal::{
-    FailureReason, Journal, JournalEntry, RepudiationReason, ResolvedCapabilityRecord,
-    ResolvedKindTag, INSTANCE_ID_LEN,
+    FailureReason, IdempotencyClassTag, Journal, JournalEntry, RepudiationReason,
+    ResolvedCapabilityRecord, ResolvedKindTag, INSTANCE_ID_LEN,
 };
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
@@ -494,12 +494,21 @@ fn lease_ready(
     // never re-leased. The ready-set half is NOT gated (those are first dispatches; a
     // StageThenCommit Mote that staged-then-crashed is `Pending`/in the ready-set with the
     // hint present, so it is still offered there).
-    for mote_id in projection.ready_set().into_iter().chain(
-        rescheduleable
-            .iter()
-            .copied()
-            .filter(|id| redispatch_admissible(submitted_defs, projection, id)),
-    ) {
+    for mote_id in projection
+        .ready_set()
+        .into_iter()
+        .chain(
+            rescheduleable
+                .iter()
+                .copied()
+                .filter(|id| redispatch_admissible(submitted_defs, projection, id)),
+        )
+        // M2.3b (D65): an at-most-once effect that has already staged is NEVER
+        // re-offered (no closing mechanism → a re-dispatch would double-fire).
+        // Applied to the COMBINED stream because a staged-then-crashed
+        // StageThenCommit Mote is `Pending` (in the ungated ready set).
+        .filter(|id| !at_least_once_already_staged(submitted_defs, projection, id))
+    {
         if !seen.insert(mote_id) {
             continue;
         }
@@ -547,6 +556,44 @@ fn redispatch_admissible(
         }
         None => false,
     }
+}
+
+/// **M2.3b (D65 / D105.4) — the distributed class-aware quarantine.** `true` iff
+/// re-dispatching `id` would re-fire an **at-most-once** (`IdempotencyClass::AtLeastOnce`)
+/// effect that has **already staged** — there is no closing mechanism, so a re-lease
+/// double-fires. Such a Mote is excluded from BOTH lease candidate halves (the ready
+/// set AND the crash-failed rescheduleable set): a staged-then-crashed
+/// `StageThenCommit` Mote is `Pending` (in the ungated ready set), so gating only
+/// the rescheduleable half would miss it. The Mote is left stuck + operator-recoverable
+/// (the distributed analogue of the single-node executor's quarantine arm).
+///
+/// A **fresh** at-most-once Mote (no `EffectStaged` → `can_redispatch_world_effect`
+/// is `false`) is NOT excluded — its first dispatch proceeds normally. The class is
+/// read from the durable folded `RunVersionsResolved` metadata; a tool with no
+/// resolved record (e.g. a run that journaled no resolution) does not match, so the
+/// behavior is unchanged where the class is not durably known (no regression).
+fn at_least_once_already_staged(
+    submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    projection: &Projection,
+    id: &MoteId,
+) -> bool {
+    match submitted_defs.get(id) {
+        Some((mote, _)) => {
+            mote_dispatches_at_least_once(mote, projection)
+                && projection.can_redispatch_world_effect(id)
+        }
+        None => false,
+    }
+}
+
+/// `true` iff any tool in the Mote's `tool_contract` durably resolved to
+/// [`IdempotencyClass::AtLeastOnce`] (M2.3b). Reads the off-DAG resolved-version
+/// metadata folded from `RunVersionsResolved`; a tool with no resolved record
+/// does not count.
+fn mote_dispatches_at_least_once(mote: &Mote, projection: &Projection) -> bool {
+    mote.def.tool_contract.keys().any(|tool| {
+        projection.idempotency_class_for_tool(&tool.0) == Some(IdempotencyClassTag::AtLeastOnce)
+    })
 }
 
 /// Reap dead workers (D57 §3). For each registered worker the registry now reports
@@ -1138,6 +1185,9 @@ fn capture_run_versions<J: Journal>(
             tool_version: event.tool_version.0,
             resolved_kind: tool_kind_tag(&event.resolved_kind),
             resolved_def_hash: event.resolved_def_hash,
+            // M2.3b (D105.4): persist the resolved class so crash recovery can
+            // pick the class-correct action (see `redispatch_admissible`).
+            idempotency_class: idempotency_class_tag(event.idempotency_class),
         };
         append_run_versions(
             journal,
@@ -1196,6 +1246,17 @@ fn tool_kind_tag(kind: &ToolKind) -> ResolvedKindTag {
         ToolKind::External { .. } => ResolvedKindTag::External,
         ToolKind::Mcp { .. } => ResolvedKindTag::Mcp,
         ToolKind::SelfGenerated { .. } => ResolvedKindTag::SelfGenerated,
+    }
+}
+
+/// Map a resolved [`IdempotencyClass`] to its journal [`IdempotencyClassTag`]
+/// (the closed mirror kept in `kx-journal`). M2.3b (D105.4).
+fn idempotency_class_tag(class: IdempotencyClass) -> IdempotencyClassTag {
+    match class {
+        IdempotencyClass::Token => IdempotencyClassTag::Token,
+        IdempotencyClass::Readback => IdempotencyClassTag::Readback,
+        IdempotencyClass::Staged => IdempotencyClassTag::Staged,
+        IdempotencyClass::AtLeastOnce => IdempotencyClassTag::AtLeastOnce,
     }
 }
 

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -121,6 +121,25 @@ pub fn wm_mote(seed: u8, effect_pattern: EffectPattern) -> Mote {
     )
 }
 
+/// A WORLD-MUTATING `StageThenCommit` Mote whose `tool_contract` names exactly
+/// the given `(tool, version)` — used to exercise the class-aware recovery gate
+/// (M2.3b). `StageThenCommit` is not subject to R-1 (which is IBC-only), so the
+/// contract may name an `AtLeastOnce` tool without an additional idempotent tool.
+#[must_use]
+pub fn wm_mote_with_tool(seed: u8, tool: &str, version: &str) -> Mote {
+    let mut def = mote_def(NdClass::WorldMutating);
+    def.effect_pattern = EffectPattern::StageThenCommit;
+    def.tool_contract = BTreeMap::new();
+    def.tool_contract
+        .insert(ToolName(tool.into()), ToolVersion(version.into()));
+    Mote::new(
+        def,
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
 /// The canonical parentless PURE root Mote.
 #[must_use]
 pub fn pure_root_mote() -> Mote {

--- a/crates/kx-coordinator/tests/wm_reschedule.rs
+++ b/crates/kx-coordinator/tests/wm_reschedule.rs
@@ -23,13 +23,74 @@ use std::time::Duration;
 
 use kx_coordinator::proto::ExecutorClass;
 use kx_coordinator::{
-    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, WorkerRegistry,
+    Clock, CoordinatorService, InMemoryWorkerRegistry, MoteState, RunNonceSource, WorkerRegistry,
 };
 use kx_journal::InMemoryJournal;
-use kx_mote::{EffectPattern, Mote, NdClass};
+use kx_mote::{EffectPattern, Mote, NdClass, ToolName, ToolVersion};
+use kx_tool_registry::{
+    IdempotencyClass, InMemoryToolRegistry, ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+};
+use kx_warrant::{FsScope, NetScope, ResourceCeiling, ToolGrant, ToolRequirement};
 
 const TIMEOUT: Duration = Duration::from_secs(6);
 const MAC: ExecutorClass = ExecutorClass::MacosSandbox;
+
+/// The at-most-once tool the M2.3b distributed-quarantine test registers + grants.
+const ALO_TOOL: &str = "at-most-once-effect";
+
+#[derive(Debug)]
+struct FixedNonce([u8; 16]);
+impl RunNonceSource for FixedNonce {
+    fn fresh_instance_id(&self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// A coordinator whose tool registry has [`ALO_TOOL`] registered as
+/// `IdempotencyClass::AtLeastOnce` (empty requirements → resolves under any
+/// warrant that grants it). Used to journal the durable class so
+/// `redispatch_admissible` can read it back at reschedule.
+fn coordinator_with_alo_tool(clock: Arc<FakeClock>) -> CoordinatorService {
+    let worker_registry: Arc<dyn WorkerRegistry> = Arc::new(
+        InMemoryWorkerRegistry::with_clock_and_timeout(clock.clone(), TIMEOUT),
+    );
+    let mut tools = InMemoryToolRegistry::new();
+    tools
+        .register(
+            ToolDef {
+                tool_id: ToolName(ALO_TOOL.into()),
+                tool_version: ToolVersion("1".into()),
+                kind: ToolKind::Builtin,
+                required_capability: ToolRequirement {
+                    net_scope_required: NetScope::None,
+                    fs_scope_required: FsScope::empty(),
+                    // Exact-match against the granting warrant's syscall ref ([0; 32]).
+                    syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                    min_resource_ceiling: ResourceCeiling {
+                        cpu_milli: 0,
+                        mem_bytes: 0,
+                        wall_clock_ms: 0,
+                        fd_count: 0,
+                        disk_bytes: 0,
+                    },
+                },
+                description: "a token-less, no-readback effect (at-most-once)".into(),
+                idempotency_class: IdempotencyClass::AtLeastOnce,
+            },
+            ToolProvenance::HumanAuthored {
+                author: "ops".into(),
+            },
+        )
+        .unwrap();
+    CoordinatorService::with_tool_registry_and_seams(
+        InMemoryJournal::new(),
+        worker_registry,
+        None,
+        clock,
+        Arc::new(FixedNonce([0x3b; 16])),
+        Arc::new(tools),
+    )
+}
 
 /// A deterministic clock the test advances by hand (mirrors `tests/reschedule.rs`).
 #[derive(Debug)]
@@ -124,6 +185,67 @@ async fn crash_failed_world_mutating_with_effect_staged_is_re_offered() {
     );
     let offered_mote: Mote = offered[0].mote.clone().unwrap().try_into().unwrap();
     assert_eq!(offered_mote.id, m.id);
+}
+
+/// **M2.3b (D65 / D105.4) — the distributed class-aware quarantine.** An
+/// `AtLeastOnce` tool has NO closing mechanism, so a re-dispatch would double-fire
+/// — EVEN with a durable `EffectStaged` hint. Unlike the `StageThenCommit` Mote in
+/// `crash_failed_world_mutating_with_effect_staged_is_re_offered` (which IS
+/// re-offered), the coordinator reads the durable resolved class (journaled in
+/// `RunVersionsResolved`) and refuses to re-offer it — the distributed quarantine
+/// (left stuck, operator-recoverable). This closes the latent double-fire the
+/// pre-M2.3b class-blind gate left open.
+#[tokio::test]
+async fn crash_failed_at_least_once_is_not_re_offered_even_with_effect_staged() {
+    let clock = FakeClock::new(1_000);
+    let svc = coordinator_with_alo_tool(clock.clone());
+
+    // A warrant granting ONLY the at-most-once tool (the custom registry has no
+    // builtins). The tool's empty requirements resolve under these scopes.
+    let mut warrant = common::sample_warrant();
+    let mut grants = std::collections::BTreeSet::new();
+    grants.insert(ToolGrant {
+        tool_id: ToolName(ALO_TOOL.into()),
+        tool_version: ToolVersion("1".into()),
+    });
+    warrant.tool_grants = grants;
+
+    let dying = common::register(&svc, "dying").await;
+    // A StageThenCommit WM Mote whose contract names the at-most-once tool.
+    let m = common::wm_mote_with_tool(7, ALO_TOOL, "1");
+    // accept_at_least_once = true — else R-10 refuses the AtLeastOnce grant at submit.
+    common::submit_accepting(&svc, &m, &warrant).await;
+
+    // The resolved class was journaled durably (the recovery decision reads this).
+    let recs = svc.run_resolved_versions().await.unwrap();
+    let cap = recs
+        .iter()
+        .find_map(|r| r.capability.as_ref())
+        .expect("a resolved capability record");
+    assert_eq!(cap.tool_id, ALO_TOOL);
+    assert_eq!(
+        cap.idempotency_class,
+        kx_journal::IdempotencyClassTag::AtLeastOnce,
+        "the durable class is captured on the RunVersionsResolved fact"
+    );
+
+    // First dispatch is offered; the worker stages its intent then dies.
+    let leased = common::lease_work(&svc, dying, MAC, 16).await;
+    assert_eq!(leased.len(), 1, "first dispatch is offered");
+    common::report_effect_staged(&svc, &m, dying).await;
+
+    // Time advances past the timeout; a live worker polls → reap crash-fails the
+    // dead lease, but the class-aware gate refuses to re-offer the at-most-once Mote.
+    clock.set(1_000 + 6_001);
+    let live = common::register(&svc, "live").await;
+    let offered = common::lease_work(&svc, live, MAC, 16).await;
+    assert!(
+        offered.is_empty(),
+        "an at-most-once Mote is NOT re-offered even WITH EffectStaged (M2.3b quarantine — \
+         a re-dispatch would double-fire)"
+    );
+    // Never progressed to Committed (left stuck, operator-recoverable).
+    assert_ne!(svc.state_of(m.id).await.unwrap(), MoteState::Committed);
 }
 
 /// Regression guard: a crash-failed PURE Mote is always re-offered (recomputable — no

--- a/crates/kx-executor/src/commit_protocol.rs
+++ b/crates/kx-executor/src/commit_protocol.rs
@@ -59,8 +59,9 @@
 
 use kx_capability::{CapabilityBroker, EffectRequest};
 use kx_content::{ContentRef, ContentStore};
-use kx_journal::{Journal, JournalEntry};
+use kx_journal::{FailureReason, Journal, JournalEntry};
 use kx_mote::{EffectPattern, Mote, MoteDefHash, MoteId, ToolName};
+use kx_tool_registry::IdempotencyClass;
 use kx_warrant::WarrantSpec;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -143,6 +144,20 @@ pub enum CommitProtocolError {
         /// The Mote whose recovery probe failed.
         mote_id: MoteId,
         /// Diagnostic from the broker's `probe_readback`.
+        reason: String,
+    },
+
+    /// **M2.3b (D65 / D105.4)** — the broker's `compensate` (undo) call errored
+    /// while recovering a staged-uncommitted at-most-once
+    /// (`IdempotencyClass::AtLeastOnce`) effect. Recovery cannot prove the world
+    /// is clean, so it refuses (fail-closed): the Mote is left in-flight +
+    /// surfaced, never re-dispatched. A recovery refusal (sibling of
+    /// [`Self::ProbeFailed`] / [`Self::R13WmReDispatchRefused`]).
+    #[error("M2.3b: compensation failed for Mote {mote_id:?}: {reason}; recovery refused (fail-closed, D65)")]
+    CompensateFailed {
+        /// The Mote whose compensation failed.
+        mote_id: MoteId,
+        /// Diagnostic from the broker's `compensate`.
         reason: String,
     },
 
@@ -243,6 +258,7 @@ impl CommitProtocolError {
             | Self::R12CommittedNotProofOfValidity { mote_id, .. }
             | Self::R13WmReDispatchRefused { mote_id, .. }
             | Self::ProbeFailed { mote_id, .. }
+            | Self::CompensateFailed { mote_id, .. }
             | Self::BrokerDispatchFailed { mote_id, .. }
             | Self::ContentStorePutFailed { mote_id, .. }
             | Self::JournalAppendCommittedFailed { mote_id, .. }
@@ -277,7 +293,9 @@ impl CommitProtocolError {
     pub fn is_recovery_refusal(&self) -> bool {
         matches!(
             self,
-            Self::R13WmReDispatchRefused { .. } | Self::ProbeFailed { .. }
+            Self::R13WmReDispatchRefused { .. }
+                | Self::ProbeFailed { .. }
+                | Self::CompensateFailed { .. }
         )
     }
 }
@@ -357,6 +375,34 @@ pub trait CommitProtocol: Send + Sync {
         let _ = input;
         Ok(None)
     }
+
+    /// **M2.3b (D65 / D105.4) — recovery compensation (undo).** For a
+    /// staged-uncommitted at-most-once (`IdempotencyClass::AtLeastOnce`)
+    /// WORLD-MUTATING Mote on the recovery path, attempt the capability's
+    /// deterministic undo (via [`kx_capability::CapabilityBroker::compensate`])
+    /// instead of a blind re-dispatch (which would double-fire — there is no
+    /// closing mechanism for this class):
+    ///
+    /// - `Ok(Some(seq))` — the undo ran (R-11-verified its staged result) and a
+    ///   terminal `Failed { reason_class: CompensatedAtLeastOnce }` was appended;
+    ///   the Mote is terminal, never re-dispatched. Returns the `Failed` seq.
+    /// - `Ok(None)` — the capability does NOT support compensation; the caller
+    ///   QUARANTINES the Mote (terminal `Failed { QuarantinedAtLeastOnce }`).
+    /// - `Err(CommitProtocolError::CompensateFailed)` — the undo itself errored;
+    ///   recovery refuses (fail-closed), never re-dispatching.
+    ///
+    /// The **default returns `Ok(None)`** — a protocol with no broker (test
+    /// doubles) opts out and the caller quarantines.
+    ///
+    /// # Errors
+    /// [`CommitProtocolError::CompensateFailed`] if the undo errors;
+    /// [`CommitProtocolError::R11ResultRefIncomplete`] /
+    /// [`CommitProtocolError::JournalAppendCommittedFailed`] if persisting the
+    /// terminal `Failed` after a successful undo fails.
+    fn try_compensate(&self, input: CommitInput<'_>) -> Result<Option<u64>, CommitProtocolError> {
+        let _ = input;
+        Ok(None)
+    }
 }
 
 /// Input bundle for `CommitProtocol::commit`. Carries the Mote being
@@ -407,6 +453,17 @@ pub struct CommitInput<'a> {
     /// commit refuses). Lifecycle layer constructs from
     /// `(workflow_id, mote_id.to_hex())`.
     pub diagnostic_context: &'a str,
+    /// **M2.3b (D105.4 / D65)** — the dispatched capability's DURABLE resolved
+    /// [`IdempotencyClass`], or `None` when the class is not durably known.
+    ///
+    /// Drives the class-aware recovery decision in
+    /// [`crate::redispatch_wm_mote`]: `Some(AtLeastOnce)` recovers via
+    /// compensate/quarantine (no blind re-dispatch); `Some(Readback)` probes;
+    /// `Some(Token | Staged)` / `None` re-dispatches as before. `None` preserves
+    /// today's exact behavior for callers that have no durable class (e.g. the
+    /// single-node demo with a vacuous tool contract). On the normal (non-recovery)
+    /// commit path this field is unread.
+    pub idempotency_class: Option<IdempotencyClass>,
 }
 
 /// The standard `CommitProtocol` implementation — wires
@@ -510,6 +567,54 @@ where
                 reason: format!("{e:?}"),
             }
         })?;
+        Ok(Some(written.seq()))
+    }
+
+    fn try_compensate(&self, input: CommitInput<'_>) -> Result<Option<u64>, CommitProtocolError> {
+        let mote_id = input.mote.id;
+
+        // D65 / M2.3b: run the capability's deterministic undo (warrant-gated by
+        // the broker, same precheck as dispatch). The default `Capability::compensate`
+        // returns `Ok(None)`, so a tool without an undo yields `Ok(None)` → the
+        // caller quarantines instead of risking a double-fire.
+        let handle = match self.broker.compensate(
+            input.mote,
+            input.warrant,
+            &input.capability,
+            input.effect_request,
+        ) {
+            Ok(Some(handle)) => handle, // undo ran → record terminal Failed{Compensated}
+            Ok(None) => return Ok(None), // unsupported → caller quarantines
+            Err(e) => {
+                // Indeterminate world state — fail closed (never re-dispatch).
+                return Err(CommitProtocolError::CompensateFailed {
+                    mote_id,
+                    reason: format!("{e:?}"),
+                });
+            }
+        };
+
+        // R-11 verify the undo's externally-observable result is durable (audit
+        // evidence the compensation actually ran) before recording the outcome.
+        enforce_r11(&*self.store, mote_id, &handle.staged_ref)?;
+
+        // The effect was undone — the Mote is TERMINAL `Failed{Compensated}`,
+        // never re-dispatched. `Failed` carries no `result_ref`; the undo's
+        // staged bytes live in the content store for audit.
+        let entry = JournalEntry::Failed {
+            mote_id,
+            idempotency_key: input.idempotency_key,
+            seq: 0, // journal-assigned
+            reason_class: FailureReason::CompensatedAtLeastOnce,
+            reporter_id: 0,
+        };
+        let written = self
+            .journal
+            .append(entry)
+            .map_err(|e| CommitProtocolError::Internal {
+                mote_id,
+                reason: format!("append Failed{{Compensated}} failed: {e:?}"),
+            })?;
         Ok(Some(written.seq()))
     }
 

--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -304,7 +304,7 @@ pub use fact_zero::{
 pub use factory::{default_executor, executor_for_class};
 pub use lifecycle::{
     redispatch_wm_mote, run_pure_mote, run_wm_mote, LifecycleCommit, LifecycleError,
-    TestMoteExecutor, WmLifecycleCommit, WmRedispatchOracle,
+    RecoveryAction, TestMoteExecutor, WmLifecycleCommit, WmRecoveryOutcome, WmRedispatchOracle,
 };
 pub use native_critic::run_native_critic_mote;
 // Submission-time refusal vocabulary + predicates. Extracted to the `kx-refusal`

--- a/crates/kx-executor/src/lifecycle.rs
+++ b/crates/kx-executor/src/lifecycle.rs
@@ -23,8 +23,9 @@ use std::sync::Arc;
 
 use kx_capability::EffectRequest;
 use kx_content::ContentRef;
-use kx_journal::{Journal, JournalEntry};
+use kx_journal::{FailureReason, Journal, JournalEntry};
 use kx_mote::{Mote, MoteId, NdClass, ToolName};
+use kx_tool_registry::IdempotencyClass;
 use kx_warrant::WarrantSpec;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -109,6 +110,83 @@ pub struct WmLifecycleCommit {
     /// the submission, the critic's `Proposed` entry seq. `None` for
     /// `IdempotentByConstruction` / `StageThenCommit` paths (no critic).
     pub critic_proposed_seq: Option<u64>,
+}
+
+/// **M2.3b (D65 / D105.4).** The realized recovery action for a staged-uncommitted
+/// WORLD-MUTATING Mote — the typed, class-aware decision that closes the M2 exit
+/// gate ("resume-or-compensate proven per `IdempotencyClass`").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryAction {
+    /// The effect was re-dispatched (Token/Staged, or class-unknown): a fresh
+    /// `Committed` via the broker. Token-boundary / `EffectStaged` dedup makes
+    /// this exactly-once.
+    Redispatch,
+    /// A Readback probe found the effect already applied → committed from the
+    /// probed `result_ref` with NO re-dispatch (exactly-once).
+    CommitFromReadback,
+    /// An at-most-once (`AtLeastOnce`) effect was undone via the capability's
+    /// `compensate`; a terminal `Failed { CompensatedAtLeastOnce }` was recorded.
+    Compensate,
+    /// An at-most-once (`AtLeastOnce`) effect could not be undone (no compensation
+    /// support); the Mote was quarantined as terminal
+    /// `Failed { QuarantinedAtLeastOnce }`, never re-dispatched, surfaced via
+    /// `anomaly_motes()`.
+    Quarantine,
+}
+
+/// The upfront, class-driven route a staged-uncommitted WM Mote takes at recovery.
+/// Pure function of the durable [`IdempotencyClass`] — see [`recovery_route_for`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryRoute {
+    /// Token / Readback / Staged / unknown(`None`): probe, then commit-from-readback
+    /// or re-dispatch. The class has a closing mechanism (or is unknown → today's
+    /// behavior), so re-dispatch is safe.
+    ProbeThenRedispatch,
+    /// `AtLeastOnce`: no closing mechanism, so a blind re-dispatch would double-fire.
+    /// Compensate (undo) if supported, else quarantine.
+    CompensateOrQuarantine,
+}
+
+/// The class-driven recovery route (M2.3b, D65). Pure + total + testable: the
+/// exhaustive match means a NEW [`IdempotencyClass`] variant is a compile error
+/// here until its recovery route is decided (Rule 5.2 — illegal states
+/// unrepresentable).
+fn recovery_route_for(class: Option<IdempotencyClass>) -> RecoveryRoute {
+    match class {
+        // No closing mechanism → never blind-redispatch (would double-fire).
+        Some(IdempotencyClass::AtLeastOnce) => RecoveryRoute::CompensateOrQuarantine,
+        // Token (remote token dedup), Staged (EffectStaged dedup), Readback
+        // (deterministic probe), or unknown (None → today's exact behavior):
+        // re-dispatch / probe-then-commit is the safe, exactly-once action.
+        Some(IdempotencyClass::Token | IdempotencyClass::Readback | IdempotencyClass::Staged)
+        | None => RecoveryRoute::ProbeThenRedispatch,
+    }
+}
+
+/// **M2.3b.** The outcome of [`redispatch_wm_mote`]. Recovery now either commits
+/// the Mote (Redispatch / CommitFromReadback) OR terminates it (Compensate /
+/// Quarantine) — the latter produces a `Failed`, not a `Committed`, so the result
+/// is a sum type rather than the commit-only [`WmLifecycleCommit`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WmRecoveryOutcome {
+    /// The Mote committed during recovery. Carries the commit info + which action.
+    Committed {
+        /// The successful commit details (seq, `result_ref`, critic Proposed seq).
+        commit: WmLifecycleCommit,
+        /// Whether the commit came from a re-dispatch or a readback.
+        action: RecoveryAction,
+    },
+    /// The Mote terminally failed during recovery (an at-most-once effect that was
+    /// compensated or quarantined). No `Committed`; the run does not progress past
+    /// this Mote.
+    TerminallyFailed {
+        /// The Mote that was terminated.
+        mote_id: MoteId,
+        /// The seq of the terminal `Failed` entry.
+        failed_seq: u64,
+        /// Whether the effect was compensated (undone) or quarantined.
+        action: RecoveryAction,
+    },
 }
 
 /// The **P0.4 hard gate** (P3.3): if `mote_id` is already `Committed` in the journal,
@@ -306,12 +384,13 @@ pub fn redispatch_wm_mote<J, R, CP, O>(
     warrant: &WarrantSpec,
     capability: ToolName,
     effect_request: EffectRequest,
+    idempotency_class: Option<IdempotencyClass>,
     submission_motes: &BTreeMap<MoteId, Mote>,
     journal: &J,
     resource_manager: &R,
     commit_protocol: &CP,
     oracle: &O,
-) -> Result<WmLifecycleCommit, LifecycleError>
+) -> Result<WmRecoveryOutcome, LifecycleError>
 where
     J: Journal + ?Sized,
     R: ResourceManager + ?Sized,
@@ -349,18 +428,6 @@ where
     // intent. The broker's idempotency_key dedup is the load-bearing
     // safety here.
 
-    // Step 4: the recovery decision (M2.3a, D38 §2a / D65). For a
-    // staged-uncommitted WM Mote the recovery action is one of three outcomes,
-    // encoded by `try_commit_from_readback`'s `Result<Option<u64>>`:
-    //   • Ok(Some) = COMMIT-FROM-READBACK — the probe found the effect applied;
-    //     the protocol committed the probed result_ref WITHOUT re-dispatching
-    //     (exactly-once for Readback-class tools).
-    //   • Ok(None) = REDISPATCH — no readback support (default probe) or the
-    //     effect did not land → fall through to the normal re-dispatch.
-    //   • Err(ProbeFailed) = REFUSE — the probe errored; world state is
-    //     indeterminate, so re-dispatch is refused (fail-closed, no double-fire).
-    // (M2.3b extends this to a typed Compensate/Quarantine arm once the
-    // IdempotencyClass is durable.)
     let commit_input = CommitInput {
         mote,
         warrant,
@@ -371,57 +438,183 @@ where
         idempotency_key,
         parents: SmallVec::new(),
         diagnostic_context: "lifecycle::redispatch_wm_mote",
+        idempotency_class,
     };
-    let committed_seq = match commit_protocol.try_commit_from_readback(commit_input.clone()) {
-        Ok(Some(seq)) => seq, // probe: effect already applied → committed from readback
-        Ok(None) => match commit_protocol.commit(commit_input) {
-            Ok(seq) => seq,
+
+    // Step 4: the class-aware recovery decision (M2.3b, D38 §2a / D65). The
+    // durable `IdempotencyClass` routes the staged-uncommitted WM Mote:
+    //   • ProbeThenRedispatch (Token/Readback/Staged/unknown) — the M2.3a path:
+    //       Ok(Some) = COMMIT-FROM-READBACK (probe found it applied → committed
+    //                  the probed result_ref WITHOUT re-dispatching),
+    //       Ok(None) = REDISPATCH (no readback / not applied → re-dispatch),
+    //       Err(ProbeFailed) = REFUSE (indeterminate → fail-closed).
+    //   • CompensateOrQuarantine (AtLeastOnce — no closing mechanism, a blind
+    //       re-dispatch would double-fire):
+    //       Ok(Some) = COMPENSATE (undo ran → terminal Failed{Compensated}),
+    //       Ok(None) = QUARANTINE (no undo → terminal Failed{Quarantined}),
+    //       Err(CompensateFailed) = REFUSE (fail-closed).
+    match recovery_route_for(idempotency_class) {
+        RecoveryRoute::CompensateOrQuarantine => {
+            let outcome = compensate_or_quarantine(
+                mote,
+                idempotency_key,
+                journal,
+                commit_protocol,
+                commit_input,
+            );
+            // Release the slot regardless of outcome; never re-dispatch.
+            let _ = resource_manager.release(slot);
+            return outcome;
+        }
+        RecoveryRoute::ProbeThenRedispatch => {}
+    }
+
+    let (committed_seq, action) =
+        match commit_protocol.try_commit_from_readback(commit_input.clone()) {
+            // probe: effect already applied → committed from readback
+            Ok(Some(seq)) => (seq, RecoveryAction::CommitFromReadback),
+            Ok(None) => match commit_protocol.commit(commit_input) {
+                Ok(seq) => (seq, RecoveryAction::Redispatch),
+                Err(e) => {
+                    let _ = resource_manager.release(slot);
+                    return Err(LifecycleError::CommitProtocol(e));
+                }
+            },
             Err(e) => {
+                // ProbeFailed (fail-closed) — never re-dispatch on an indeterminate probe.
                 let _ = resource_manager.release(slot);
                 return Err(LifecycleError::CommitProtocol(e));
             }
-        },
+        };
+
+    // Step 5: critic-Mote child scheduling (same as run_wm_mote).
+    let critic_proposed_seq = match schedule_sibling_critic(
+        mote,
+        submission_motes,
+        journal,
+        warrant_ref,
+        " (recovery)",
+    ) {
+        Ok(seq) => seq,
         Err(e) => {
-            // ProbeFailed (fail-closed) — never re-dispatch on an indeterminate probe.
             let _ = resource_manager.release(slot);
-            return Err(LifecycleError::CommitProtocol(e));
+            return Err(e);
         }
     };
 
-    // Step 5: critic-Mote child scheduling (same as run_wm_mote).
-    let critic_proposed_seq =
-        if mote.def.effect_pattern == kx_mote::EffectPattern::ValidateThenCommit {
-            let critic = submission_motes
-                .values()
-                .find(|sibling| sibling.def.critic_for == Some(mote.id));
-            match critic {
-                Some(critic_mote) => {
-                    let critic_proposed = JournalEntry::Proposed {
-                        mote_id: critic_mote.id,
-                        idempotency_key: *critic_mote.id.as_bytes(),
-                        seq: 0,
-                        nondeterminism: critic_mote.def.nd_class,
-                        placement_hint: 0,
-                        warrant_ref,
-                    };
-                    match journal.append(critic_proposed) {
-                        Ok(entry) => Some(entry.seq()),
-                        Err(e) => {
-                            let _ = resource_manager.release(slot);
-                            return Err(LifecycleError::JournalAppend(format!(
-                                "critic Proposed (recovery): {e:?}"
-                            )));
-                        }
-                    }
-                }
-                None => None,
-            }
-        } else {
-            None
-        };
+    let result_ref = match read_committed_result_ref(journal, mote.id, committed_seq) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = resource_manager.release(slot);
+            return Err(e);
+        }
+    };
 
-    let result_ref = journal
-        .read_committed(&mote.id)
+    resource_manager.release(slot)?;
+
+    Ok(WmRecoveryOutcome::Committed {
+        commit: WmLifecycleCommit {
+            committed_seq,
+            result_ref,
+            mote_id: mote.id,
+            critic_proposed_seq,
+        },
+        action,
+    })
+}
+
+/// **M2.3b.** The `AtLeastOnce` recovery branch: compensate (undo) the
+/// staged-uncommitted effect if the capability supports it, else quarantine the
+/// Mote. NEVER re-dispatches — there is no closing mechanism, so a re-dispatch
+/// would double-fire. Both arms produce a TERMINAL `Failed` (non-redispatchable);
+/// the caller releases the resource slot.
+fn compensate_or_quarantine<J, CP>(
+    mote: &Mote,
+    idempotency_key: [u8; 32],
+    journal: &J,
+    commit_protocol: &CP,
+    commit_input: CommitInput<'_>,
+) -> Result<WmRecoveryOutcome, LifecycleError>
+where
+    J: Journal + ?Sized,
+    CP: CommitProtocol + ?Sized,
+{
+    match commit_protocol.try_compensate(commit_input) {
+        // The undo ran; the protocol recorded terminal Failed{Compensated}.
+        Ok(Some(failed_seq)) => Ok(WmRecoveryOutcome::TerminallyFailed {
+            mote_id: mote.id,
+            failed_seq,
+            action: RecoveryAction::Compensate,
+        }),
+        // No compensation support → quarantine: append terminal Failed{Quarantined}
+        // (no broker call). The fold marks the Mote quarantined + surfaces it via
+        // `anomaly_motes()`; the recovery oracle then refuses any re-dispatch.
+        Ok(None) => {
+            let entry = JournalEntry::Failed {
+                mote_id: mote.id,
+                idempotency_key,
+                seq: 0, // journal-assigned
+                reason_class: FailureReason::QuarantinedAtLeastOnce,
+                reporter_id: 0,
+            };
+            let written = journal.append(entry).map_err(|e| {
+                LifecycleError::JournalAppend(format!("append Failed{{Quarantined}}: {e:?}"))
+            })?;
+            Ok(WmRecoveryOutcome::TerminallyFailed {
+                mote_id: mote.id,
+                failed_seq: written.seq(),
+                action: RecoveryAction::Quarantine,
+            })
+        }
+        // The undo itself errored → fail-closed (never re-dispatch).
+        Err(e) => Err(LifecycleError::CommitProtocol(e)),
+    }
+}
+
+/// Schedule the `ValidateThenCommit` producer's sibling critic by appending its
+/// `Proposed` entry (shared by `run_wm_mote` + `redispatch_wm_mote`). Returns the
+/// critic's `Proposed` seq, or `None` when the producer is not VTC / has no sibling
+/// critic in the submission. On a journal-append error the caller releases its
+/// resource slot. `label` distinguishes the operator diagnostic (e.g. recovery).
+fn schedule_sibling_critic<J: Journal + ?Sized>(
+    mote: &Mote,
+    submission_motes: &BTreeMap<MoteId, Mote>,
+    journal: &J,
+    warrant_ref: ContentRef,
+    label: &str,
+) -> Result<Option<u64>, LifecycleError> {
+    if mote.def.effect_pattern != kx_mote::EffectPattern::ValidateThenCommit {
+        return Ok(None);
+    }
+    let Some(critic_mote) = submission_motes
+        .values()
+        .find(|sibling| sibling.def.critic_for == Some(mote.id))
+    else {
+        return Ok(None);
+    };
+    let critic_proposed = JournalEntry::Proposed {
+        mote_id: critic_mote.id,
+        idempotency_key: *critic_mote.id.as_bytes(),
+        seq: 0, // journal-assigned
+        nondeterminism: critic_mote.def.nd_class,
+        placement_hint: 0,
+        warrant_ref,
+    };
+    journal
+        .append(critic_proposed)
+        .map(|entry| Some(entry.seq()))
+        .map_err(|e| LifecycleError::JournalAppend(format!("critic Proposed{label}: {e:?}")))
+}
+
+/// Read back the `result_ref` of the `Committed` entry the commit protocol just
+/// wrote for `mote_id` (shared by `run_wm_mote` + `redispatch_wm_mote`).
+fn read_committed_result_ref<J: Journal + ?Sized>(
+    journal: &J,
+    mote_id: MoteId,
+    committed_seq: u64,
+) -> Result<ContentRef, LifecycleError> {
+    journal
+        .read_committed(&mote_id)
         .map_err(|e| LifecycleError::JournalAppend(format!("read Committed: {e:?}")))?
         .and_then(|e| match e {
             JournalEntry::Committed { result_ref, .. } => Some(result_ref),
@@ -431,16 +624,7 @@ where
             LifecycleError::Internal(format!(
                 "commit_protocol returned Ok({committed_seq}) but no Committed entry visible"
             ))
-        })?;
-
-    resource_manager.release(slot)?;
-
-    Ok(WmLifecycleCommit {
-        committed_seq,
-        result_ref,
-        mote_id: mote.id,
-        critic_proposed_seq,
-    })
+        })
 }
 
 /// Run a single WORLD-MUTATING Mote end-to-end via the commit_protocol.
@@ -555,6 +739,9 @@ where
         idempotency_key,
         parents: SmallVec::new(),
         diagnostic_context: "lifecycle::run_wm_mote",
+        // Fresh (non-recovery) dispatch: the class-aware recovery decision is not
+        // taken here, so the field is unread on this path.
+        idempotency_class: None,
     };
     let committed_seq = match commit_protocol.commit(commit_input) {
         Ok(seq) => seq,
@@ -568,53 +755,23 @@ where
     // The submission's sibling map is the source of truth — R-2 ensured
     // a critic exists at submission time (or refused the submission).
     let critic_proposed_seq =
-        if mote.def.effect_pattern == kx_mote::EffectPattern::ValidateThenCommit {
-            let critic = submission_motes
-                .values()
-                .find(|sibling| sibling.def.critic_for == Some(mote.id));
-            match critic {
-                Some(critic_mote) => {
-                    let critic_proposed = JournalEntry::Proposed {
-                        mote_id: critic_mote.id,
-                        idempotency_key: *critic_mote.id.as_bytes(),
-                        seq: 0, // journal-assigned
-                        nondeterminism: critic_mote.def.nd_class,
-                        placement_hint: 0,
-                        warrant_ref,
-                    };
-                    match journal.append(critic_proposed) {
-                        Ok(entry) => Some(entry.seq()),
-                        Err(e) => {
-                            let _ = resource_manager.release(slot);
-                            return Err(LifecycleError::JournalAppend(format!(
-                                "critic Proposed: {e:?}"
-                            )));
-                        }
-                    }
-                }
-                None => None,
+        match schedule_sibling_critic(mote, submission_motes, journal, warrant_ref, "") {
+            Ok(seq) => seq,
+            Err(e) => {
+                let _ = resource_manager.release(slot);
+                return Err(e);
             }
-        } else {
-            None
         };
 
-    // The producer's result_ref is the broker's staged response. Recover
-    // it by reading the Committed entry the protocol just wrote. (We
-    // can't read it back cheaply without journal lookups; for the
-    // PR 9b-6 scope we record committed_seq + signal completion. Callers
-    // who need result_ref read it from the journal.)
-    let result_ref = journal
-        .read_committed(&mote.id)
-        .map_err(|e| LifecycleError::JournalAppend(format!("read Committed: {e:?}")))?
-        .and_then(|e| match e {
-            JournalEntry::Committed { result_ref, .. } => Some(result_ref),
-            _ => None,
-        })
-        .ok_or_else(|| {
-            LifecycleError::Internal(format!(
-                "commit_protocol returned Ok({committed_seq}) but no Committed entry visible"
-            ))
-        })?;
+    // The producer's result_ref is the broker's staged response — read it back
+    // from the Committed entry the protocol just wrote.
+    let result_ref = match read_committed_result_ref(journal, mote.id, committed_seq) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = resource_manager.release(slot);
+            return Err(e);
+        }
+    };
 
     // Step 6: release the slot.
     resource_manager.release(slot)?;
@@ -690,5 +847,37 @@ impl MoteExecutor for TestMoteExecutor {
         // Test backend supports every class — the integration test fixture
         // explicitly opts in to the test backend regardless of warrant.executor_class.
         true
+    }
+}
+
+#[cfg(test)]
+mod recovery_route_tests {
+    use super::{recovery_route_for, RecoveryRoute};
+    use kx_tool_registry::IdempotencyClass;
+
+    /// **M2.3b (D65).** The class-aware recovery route is exhaustive + total: only
+    /// `AtLeastOnce` (no closing mechanism) takes the compensate/quarantine path;
+    /// every other class — and the unknown (`None`) case — re-dispatches/probes,
+    /// preserving today's exactly-once behavior. The exhaustive match in
+    /// `recovery_route_for` means a NEW `IdempotencyClass` variant is a compile
+    /// error there until its route is decided.
+    #[test]
+    fn only_at_least_once_routes_to_compensate_or_quarantine() {
+        assert_eq!(
+            recovery_route_for(Some(IdempotencyClass::AtLeastOnce)),
+            RecoveryRoute::CompensateOrQuarantine,
+        );
+        for safe in [
+            None,
+            Some(IdempotencyClass::Token),
+            Some(IdempotencyClass::Readback),
+            Some(IdempotencyClass::Staged),
+        ] {
+            assert_eq!(
+                recovery_route_for(safe),
+                RecoveryRoute::ProbeThenRedispatch,
+                "class {safe:?} must take the probe-then-redispatch route",
+            );
+        }
     }
 }

--- a/crates/kx-executor/tests/integration_commit_protocol.rs
+++ b/crates/kx-executor/tests/integration_commit_protocol.rs
@@ -302,6 +302,7 @@ fn commit_input_constructs_with_required_fields() {
         idempotency_key: [5; 32],
         parents: SmallVec::new(),
         diagnostic_context: "test",
+        idempotency_class: None,
     };
     assert_eq!(input.mote.id, mote.id);
     assert_eq!(input.diagnostic_context, "test");
@@ -343,6 +344,7 @@ fn commit_protocol_is_object_safe_send_sync() {
         idempotency_key: [5; 32],
         parents: SmallVec::new(),
         diagnostic_context: "stub-test",
+        idempotency_class: None,
     };
     let r = dyn_protocol.commit(input);
     assert!(matches!(

--- a/crates/kx-executor/tests/integration_compensate_quarantine.rs
+++ b/crates/kx-executor/tests/integration_compensate_quarantine.rs
@@ -1,0 +1,376 @@
+//! M2.3b (D65 / D105.4) — the class-aware `AtLeastOnce` recovery arm of
+//! `redispatch_wm_mote`. A staged-uncommitted at-most-once effect has no closing
+//! mechanism, so recovery must NEVER blind-redispatch (that would double-fire).
+//! Instead it either:
+//!   - **Compensates** (the capability supports an undo) → terminal
+//!     `Failed { CompensatedAtLeastOnce }`, NO broker dispatch, NO Committed; or
+//!   - **Quarantines** (no undo support) → terminal `Failed { QuarantinedAtLeastOnce }`,
+//!     surfaced via `anomaly_motes()`; or
+//!   - **Refuses** (the undo itself errors) → `CompensateFailed`, fail-closed.
+//!
+//! The load-bearing invariant: the world effect is NEVER re-applied, and a second
+//! recovery pass is a no-op (the terminal `Failed` makes the oracle refuse).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_executor::{
+    redispatch_wm_mote, CommitProtocolError, LifecycleError, LocalResourceManager, RecoveryAction,
+    StandardCommitProtocol, WmRecoveryOutcome, WmRedispatchOracle,
+};
+use kx_journal::{FailureReason, InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
+    PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_projection::{AnomalyKind, MoteState, Projection};
+use kx_tool_registry::IdempotencyClass;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("local".into()),
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+            max_calls: 0,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+fn wm_mote(seed: u8) -> Mote {
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+fn empty_request() -> EffectRequest {
+    EffectRequest {
+        payload: Vec::new(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}
+
+/// Oracle stub. `can_redispatch_world_effect` is consulted at Step 0; the
+/// AtLeastOnce arm runs only when it returns `true` (a real staged-uncommitted
+/// Mote), so we set `true` here and additionally verify the SECOND pass (after a
+/// terminal Failed lands) refuses via the real projection oracle.
+struct StubOracle {
+    can_redispatch: bool,
+}
+impl WmRedispatchOracle for StubOracle {
+    fn can_redispatch_world_effect(&self, _mote_id: &MoteId) -> bool {
+        self.can_redispatch
+    }
+}
+
+/// How the broker's `compensate` behaves.
+#[derive(Clone, Copy)]
+enum CompensateMode {
+    /// The capability supports an undo → broker stages the undo's result.
+    Supported,
+    /// The capability does NOT support compensation (default `Ok(None)`).
+    Unsupported,
+    /// The undo itself errors.
+    Errors,
+}
+
+/// A broker that counts world effects. `dispatch` is the load-bearing
+/// double-fire witness: it MUST stay at 0 on the AtLeastOnce recovery arm.
+struct CompensatingBroker {
+    store: Arc<InMemoryContentStore>,
+    mode: CompensateMode,
+    dispatched: AtomicUsize,
+    compensated: AtomicUsize,
+}
+impl std::fmt::Debug for CompensatingBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompensatingBroker").finish()
+    }
+}
+impl CapabilityBroker for CompensatingBroker {
+    fn dispatch(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<BrokerHandle, BrokerError> {
+        // A blind re-dispatch of an AtLeastOnce effect — the bug M2.3b closes.
+        self.dispatched.fetch_add(1, Ordering::SeqCst);
+        let r = self.store.put(b"REDISPATCH-double-fire").expect("put");
+        Ok(BrokerHandle {
+            staged_ref: r,
+            capability: ToolName("wm".into()),
+            capability_version: ToolVersion("0.1.0".into()),
+        })
+    }
+    fn probe_readback(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _probe: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        Ok(None)
+    }
+    fn compensate(
+        &self,
+        _mote: &Mote,
+        _warrant: &WarrantSpec,
+        _capability: &ToolName,
+        _request: EffectRequest,
+    ) -> Result<Option<BrokerHandle>, BrokerError> {
+        match self.mode {
+            CompensateMode::Supported => {
+                self.compensated.fetch_add(1, Ordering::SeqCst);
+                let r = self.store.put(b"UNDO-result").expect("put");
+                Ok(Some(BrokerHandle {
+                    staged_ref: r,
+                    capability: ToolName("wm".into()),
+                    capability_version: ToolVersion("0.1.0".into()),
+                }))
+            }
+            CompensateMode::Unsupported => Ok(None),
+            CompensateMode::Errors => Err(BrokerError::CapabilityFailure {
+                capability: ToolName("wm".into()),
+                reason: kx_capability::CapabilityFailureReason::Other("undo blew up".into()),
+            }),
+        }
+    }
+}
+
+/// Drive the AtLeastOnce recovery arm once. Returns the outcome + the broker so
+/// callers can assert the dispatch/compensate counters + the journal.
+fn drive_at_least_once(
+    mode: CompensateMode,
+) -> (
+    Result<WmRecoveryOutcome, LifecycleError>,
+    Arc<InMemoryJournal>,
+    Arc<CompensatingBroker>,
+) {
+    let store = Arc::new(InMemoryContentStore::new());
+    let journal = Arc::new(InMemoryJournal::new());
+    let broker = Arc::new(CompensatingBroker {
+        store: store.clone(),
+        mode,
+        dispatched: AtomicUsize::new(0),
+        compensated: AtomicUsize::new(0),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker.clone());
+    let rm = LocalResourceManager::dev_defaults();
+    let oracle = StubOracle {
+        can_redispatch: true,
+    };
+    let mote = wm_mote(0x4a);
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((mote.id, mote.clone())).collect();
+    let out = redispatch_wm_mote(
+        &mote,
+        &warrant(),
+        ToolName("wm".into()),
+        empty_request(),
+        Some(IdempotencyClass::AtLeastOnce),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &oracle,
+    );
+    (out, journal, broker)
+}
+
+fn only_entry(journal: &InMemoryJournal) -> JournalEntry {
+    let entries: Vec<JournalEntry> = journal.read_entries_by_seq(0..u64::MAX).unwrap().collect();
+    assert_eq!(entries.len(), 1, "expected exactly one journal entry");
+    entries.into_iter().next().unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Compensate arm
+// ---------------------------------------------------------------------------
+
+#[test]
+fn at_least_once_with_compensation_undoes_and_terminally_fails() {
+    let (out, journal, broker) = drive_at_least_once(CompensateMode::Supported);
+    let outcome = out.expect("compensation must succeed");
+
+    match outcome {
+        WmRecoveryOutcome::TerminallyFailed {
+            action, mote_id, ..
+        } => {
+            assert_eq!(action, RecoveryAction::Compensate);
+            assert_eq!(mote_id, wm_mote(0x4a).id);
+        }
+        other => panic!("expected TerminallyFailed{{Compensate}}, got {other:?}"),
+    }
+
+    // The effect was NEVER re-dispatched (no double-fire); the undo ran once.
+    assert_eq!(broker.dispatched.load(Ordering::SeqCst), 0);
+    assert_eq!(broker.compensated.load(Ordering::SeqCst), 1);
+
+    // The journal carries a terminal Failed{Compensated} — no Committed.
+    match only_entry(&journal) {
+        JournalEntry::Failed { reason_class, .. } => {
+            assert_eq!(reason_class, FailureReason::CompensatedAtLeastOnce);
+        }
+        other => panic!("expected Failed{{Compensated}}, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quarantine arm
+// ---------------------------------------------------------------------------
+
+#[test]
+fn at_least_once_without_compensation_quarantines() {
+    let (out, journal, broker) = drive_at_least_once(CompensateMode::Unsupported);
+    let outcome = out.expect("quarantine is a successful (non-error) recovery outcome");
+
+    match outcome {
+        WmRecoveryOutcome::TerminallyFailed { action, .. } => {
+            assert_eq!(action, RecoveryAction::Quarantine);
+        }
+        other => panic!("expected TerminallyFailed{{Quarantine}}, got {other:?}"),
+    }
+
+    // Never re-dispatched, never compensated.
+    assert_eq!(broker.dispatched.load(Ordering::SeqCst), 0);
+    assert_eq!(broker.compensated.load(Ordering::SeqCst), 0);
+
+    // Terminal Failed{Quarantined}, and the fold surfaces it as a quarantine anomaly.
+    match only_entry(&journal) {
+        JournalEntry::Failed { reason_class, .. } => {
+            assert_eq!(reason_class, FailureReason::QuarantinedAtLeastOnce);
+        }
+        other => panic!("expected Failed{{Quarantined}}, got {other:?}"),
+    }
+    let p = Projection::from_journal(&*journal).unwrap();
+    let mid = wm_mote(0x4a).id;
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+    assert!(p
+        .anomaly_motes()
+        .contains(&(mid, AnomalyKind::QuarantinedAtLeastOnceEffect)));
+}
+
+// ---------------------------------------------------------------------------
+// CompensateFailed — fail-closed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn at_least_once_compensation_error_refuses_fail_closed() {
+    let (out, journal, broker) = drive_at_least_once(CompensateMode::Errors);
+    let err = out.expect_err("a failing undo must refuse, not commit");
+
+    match err {
+        LifecycleError::CommitProtocol(e @ CommitProtocolError::CompensateFailed { .. }) => {
+            assert!(
+                e.is_recovery_refusal(),
+                "CompensateFailed is a recovery refusal"
+            );
+        }
+        other => panic!("expected CompensateFailed, got {other:?}"),
+    }
+
+    // Fail-closed: no re-dispatch, and NO journal mutation (no Committed, no Failed).
+    assert_eq!(broker.dispatched.load(Ordering::SeqCst), 0);
+    assert_eq!(journal.count_entries().unwrap(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Prefix-monotonic terminality: a SECOND recovery pass is refused.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn second_recovery_pass_after_quarantine_is_refused_by_the_oracle() {
+    // Pass 1: quarantine an AtLeastOnce Mote (terminal Failed{Quarantined}).
+    let (out, journal, _broker) = drive_at_least_once(CompensateMode::Unsupported);
+    out.expect("pass 1 quarantine");
+
+    // Pass 2: fold the journal into a REAL projection oracle (which now sees the
+    // terminal Failed) and re-run recovery. The oracle must refuse at Step 0 —
+    // the quarantine is durable + prefix-monotonic, so no double-fire ever.
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = Arc::new(CompensatingBroker {
+        store: store.clone(),
+        mode: CompensateMode::Supported,
+        dispatched: AtomicUsize::new(0),
+        compensated: AtomicUsize::new(0),
+    });
+    let protocol = StandardCommitProtocol::new(store, journal.clone(), broker.clone());
+    let rm = LocalResourceManager::dev_defaults();
+    let projection = Projection::from_journal(&*journal).unwrap();
+    let mote = wm_mote(0x4a);
+    let submission_motes: BTreeMap<MoteId, Mote> =
+        std::iter::once((mote.id, mote.clone())).collect();
+
+    let result = redispatch_wm_mote(
+        &mote,
+        &warrant(),
+        ToolName("wm".into()),
+        empty_request(),
+        Some(IdempotencyClass::AtLeastOnce),
+        &submission_motes,
+        &*journal,
+        &rm,
+        &protocol,
+        &projection,
+    );
+    assert!(matches!(
+        result,
+        Err(LifecycleError::CommitProtocol(
+            CommitProtocolError::R13WmReDispatchRefused { .. }
+        ))
+    ));
+    // No undo, no dispatch on the refused second pass.
+    assert_eq!(broker.dispatched.load(Ordering::SeqCst), 0);
+    assert_eq!(broker.compensated.load(Ordering::SeqCst), 0);
+}

--- a/crates/kx-executor/tests/integration_cross_product_recovery.rs
+++ b/crates/kx-executor/tests/integration_cross_product_recovery.rs
@@ -36,8 +36,17 @@ use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
 use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
 use kx_executor::{
     redispatch_wm_mote, CommitProtocolError, LifecycleError, LocalResourceManager,
-    StandardCommitProtocol,
+    StandardCommitProtocol, WmLifecycleCommit, WmRecoveryOutcome,
 };
+
+/// Unwrap a `Committed` recovery outcome; these cross-product tests only exercise
+/// the probe-then-redispatch path (class `None` → no compensate/quarantine).
+fn into_commit(out: WmRecoveryOutcome) -> WmLifecycleCommit {
+    match out {
+        WmRecoveryOutcome::Committed { commit, .. } => commit,
+        other => panic!("expected a Committed recovery outcome, got {other:?}"),
+    }
+}
 use kx_journal::{
     repudiation_idempotency_key, FailureReason, InMemoryJournal, Journal, JournalEntry,
     RepudiationReason,
@@ -252,12 +261,14 @@ fn drive_redispatch(
         &warrant(),
         ToolName("xprod".into()),
         empty_request(),
+        None,
         &submission_motes,
         &*journal,
         &rm,
         &protocol,
         &*projection,
-    );
+    )
+    .map(into_commit);
     (result, journal)
 }
 

--- a/crates/kx-executor/tests/integration_idempotent_commit.rs
+++ b/crates/kx-executor/tests/integration_idempotent_commit.rs
@@ -172,6 +172,7 @@ fn input_for<'a>(mote: &'a Mote, warrant: &'a WarrantSpec, diagnostic: &'a str) 
         idempotency_key: [5; 32],
         parents: SmallVec::new(),
         diagnostic_context: diagnostic,
+        idempotency_class: None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
+++ b/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
@@ -14,8 +14,17 @@ use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
 use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
 use kx_executor::{
     redispatch_wm_mote, CommitProtocolError, LifecycleError, LocalResourceManager,
-    StandardCommitProtocol, WmRedispatchOracle,
+    StandardCommitProtocol, WmLifecycleCommit, WmRecoveryOutcome, WmRedispatchOracle,
 };
+
+/// Unwrap a recovery outcome that must be a `Committed` (Redispatch /
+/// CommitFromReadback) into the commit details these PR 9b-7 / M2.3a tests assert.
+fn into_commit(out: WmRecoveryOutcome) -> WmLifecycleCommit {
+    match out {
+        WmRecoveryOutcome::Committed { commit, .. } => commit,
+        other => panic!("expected a Committed recovery outcome, got {other:?}"),
+    }
+}
 use kx_journal::{InMemoryJournal, Journal, JournalEntry};
 use kx_mote::{
     EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
@@ -168,6 +177,7 @@ fn r13_fires_before_broker_dispatch_when_oracle_refuses() {
         &warrant(),
         ToolName("test".into()),
         empty_request(EffectPattern::StageThenCommit),
+        None,
         &submission_motes,
         &*journal,
         &rm,
@@ -229,18 +239,21 @@ fn oracle_approves_then_commit_protocol_proceeds_no_fresh_proposed() {
     let submission_motes: BTreeMap<MoteId, Mote> =
         std::iter::once((mote.id, mote.clone())).collect();
 
-    let result = redispatch_wm_mote(
-        &mote,
-        &warrant(),
-        ToolName("test".into()),
-        empty_request(EffectPattern::IdempotentByConstruction),
-        &submission_motes,
-        &*journal,
-        &rm,
-        &protocol,
-        &oracle,
-    )
-    .expect("oracle-approved re-dispatch must succeed");
+    let result = into_commit(
+        redispatch_wm_mote(
+            &mote,
+            &warrant(),
+            ToolName("test".into()),
+            empty_request(EffectPattern::IdempotentByConstruction),
+            None,
+            &submission_motes,
+            &*journal,
+            &rm,
+            &protocol,
+            &oracle,
+        )
+        .expect("oracle-approved re-dispatch must succeed"),
+    );
 
     assert_eq!(result.mote_id, mote.id);
     assert!(oracle.consulted.load(Ordering::SeqCst));
@@ -293,6 +306,7 @@ fn redispatch_wm_mote_refuses_pure_motes() {
         &warrant(),
         ToolName("never-called".into()),
         empty_request(EffectPattern::IdempotentByConstruction),
+        None,
         &submission_motes,
         &*journal,
         &rm,
@@ -352,18 +366,21 @@ fn redispatch_validate_then_commit_schedules_critic_proposed() {
     submission_motes.insert(producer.id, producer.clone());
     submission_motes.insert(critic.id, critic.clone());
 
-    let result = redispatch_wm_mote(
-        &producer,
-        &warrant(),
-        ToolName("test".into()),
-        empty_request(EffectPattern::ValidateThenCommit),
-        &submission_motes,
-        &*journal,
-        &rm,
-        &protocol,
-        &oracle,
-    )
-    .expect("re-dispatch must succeed");
+    let result = into_commit(
+        redispatch_wm_mote(
+            &producer,
+            &warrant(),
+            ToolName("test".into()),
+            empty_request(EffectPattern::ValidateThenCommit),
+            None,
+            &submission_motes,
+            &*journal,
+            &rm,
+            &protocol,
+            &oracle,
+        )
+        .expect("re-dispatch must succeed"),
+    );
 
     let critic_seq = result
         .critic_proposed_seq
@@ -486,12 +503,14 @@ fn redispatch_with_probe(
         &warrant(),
         ToolName("probe".into()),
         empty_request(EffectPattern::StageThenCommit),
+        None,
         &submission_motes,
         &*journal,
         &rm,
         &protocol,
         &oracle,
-    );
+    )
+    .map(into_commit);
     (journal, store, broker_ref, out)
 }
 

--- a/crates/kx-executor/tests/integration_stage_then_commit.rs
+++ b/crates/kx-executor/tests/integration_stage_then_commit.rs
@@ -158,6 +158,7 @@ fn input_for<'a>(mote: &'a Mote, warrant: &'a WarrantSpec, diagnostic: &'a str) 
         idempotency_key: [5; 32],
         parents: SmallVec::new(),
         diagnostic_context: diagnostic,
+        idempotency_class: None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_validate_then_commit.rs
+++ b/crates/kx-executor/tests/integration_validate_then_commit.rs
@@ -159,6 +159,7 @@ fn input_for<'a>(mote: &'a Mote, warrant: &'a WarrantSpec, diagnostic: &'a str) 
         idempotency_key: [5; 32],
         parents: SmallVec::new(),
         diagnostic_context: diagnostic,
+        idempotency_class: None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_wm_crash_recovery_e2e.rs
+++ b/crates/kx-executor/tests/integration_wm_crash_recovery_e2e.rs
@@ -50,8 +50,17 @@ use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
 use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
 use kx_executor::{
     redispatch_wm_mote, run_wm_mote, CommitProtocolError, LifecycleError, LocalResourceManager,
-    StandardCommitProtocol,
+    StandardCommitProtocol, WmLifecycleCommit, WmRecoveryOutcome,
 };
+
+/// Unwrap a `Committed` recovery outcome (this e2e exercises the Staged-class
+/// probe-then-redispatch path; class `None` → no compensate/quarantine).
+fn into_commit(out: WmRecoveryOutcome) -> WmLifecycleCommit {
+    match out {
+        WmRecoveryOutcome::Committed { commit, .. } => commit,
+        other => panic!("expected a Committed recovery outcome, got {other:?}"),
+    }
+}
 use kx_journal::{InMemoryJournal, Journal, JournalEntry};
 use kx_mote::{
     EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass,
@@ -265,18 +274,21 @@ fn wm_mote_crash_recovery_end_to_end_runtime_promise() {
     // commit.
     // ---------------------------------------------------------------------
     let projection = Arc::new(Projection::from_journal(&*journal).expect("from_journal"));
-    let phase2 = redispatch_wm_mote(
-        &producer,
-        &w,
-        ToolName("staged-tool".into()),
-        empty_request(),
-        &submission_motes,
-        &*journal,
-        &rm,
-        &protocol,
-        &*projection,
-    )
-    .expect("phase 2: recovery dispatch must succeed");
+    let phase2 = into_commit(
+        redispatch_wm_mote(
+            &producer,
+            &w,
+            ToolName("staged-tool".into()),
+            empty_request(),
+            None,
+            &submission_motes,
+            &*journal,
+            &rm,
+            &protocol,
+            &*projection,
+        )
+        .expect("phase 2: recovery dispatch must succeed"),
+    );
 
     assert_eq!(phase2.mote_id, producer.id);
     assert_eq!(
@@ -337,6 +349,7 @@ fn wm_mote_crash_recovery_end_to_end_runtime_promise() {
         &w,
         ToolName("staged-tool".into()),
         empty_request(),
+        None,
         &submission_motes,
         &*journal,
         &rm,
@@ -421,6 +434,7 @@ fn wm_mote_terminal_failure_recovery_refused_cell_4_hazard_guard() {
         &warrant(),
         ToolName("staged-tool".into()),
         empty_request(),
+        None,
         &submission_motes,
         &*journal,
         &rm,

--- a/crates/kx-executor/tests/proptest_idempotent_commit.rs
+++ b/crates/kx-executor/tests/proptest_idempotent_commit.rs
@@ -181,6 +181,7 @@ fn input_for<'a>(
         idempotency_key,
         parents: SmallVec::new(),
         diagnostic_context: "proptest",
+        idempotency_class: None,
     }
 }
 

--- a/crates/kx-executor/tests/proptest_stage_then_commit.rs
+++ b/crates/kx-executor/tests/proptest_stage_then_commit.rs
@@ -206,6 +206,7 @@ fn input_for<'a>(
         idempotency_key,
         parents: SmallVec::new(),
         diagnostic_context: "proptest",
+        idempotency_class: None,
     }
 }
 

--- a/crates/kx-executor/tests/proptest_validate_then_commit.rs
+++ b/crates/kx-executor/tests/proptest_validate_then_commit.rs
@@ -172,6 +172,7 @@ fn input_for<'a>(
         idempotency_key,
         parents: SmallVec::new(),
         diagnostic_context: "proptest",
+        idempotency_class: None,
     }
 }
 

--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -57,6 +57,7 @@
 //!     tool_version       [u8; tool_version_len] (UTF-8)
 //!     resolved_kind_tag  u8 (Builtin=0 .. SelfGenerated=4)
 //!     resolved_def_hash  [u8;32]
+//!     idempotency_class  u8 (Token=0, Readback=1, Staged=2, AtLeastOnce=3) (v6, M2.3b, D105.4)
 //!
 //! ParentEntry (34 bytes):
 //!     parent_id        [u8;32]
@@ -124,7 +125,25 @@ use smallvec::SmallVec;
 ///
 /// v5 readers refuse v4 files loudly (no in-place evolution; no production v4
 /// journals are retained across the bump per the corpus, acceptable).
-pub const JOURNAL_SCHEMA_VERSION: u16 = 5;
+///
+/// **v6 (M2.3b, D105.4) changes** vs v5:
+/// - `ResolvedCapabilityRecord` gains a trailing `idempotency_class` (one u8 tag,
+///   [`IdempotencyClassTag`]) inside the `RunVersionsResolved` body's
+///   capability-present arm. This makes the per-tool `IdempotencyClass` DURABLE
+///   so crash recovery can pick the class-correct action (Redispatch /
+///   CommitFromReadback / Compensate / Quarantine) for a staged-uncommitted
+///   WORLD-MUTATING Mote, instead of relying on the Token-only idempotency-key
+///   dedup. Body layout for a present capability becomes
+///   `… ‖ resolved_kind_tag(u8) ‖ resolved_def_hash(32) ‖ idempotency_class_tag(u8)`
+///   (+1 byte). Still off-DAG, never an identity input, never folded into any
+///   digest; the dedup index stays `{1, 2, 4}`; `MAX_ENTRY_LEN` is unchanged.
+/// - Two new terminal [`FailureReason`] variants (`CompensatedAtLeastOnce`,
+///   `QuarantinedAtLeastOnce`) record the recovery outcome for an at-most-once
+///   effect. No `Failed`-body layout change (`reason_class` is already a u8).
+///
+/// v6 readers refuse v5 files loudly (no in-place evolution; no production v5
+/// journals are retained across the bump per the corpus, acceptable).
+pub const JOURNAL_SCHEMA_VERSION: u16 = 6;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).
 pub const HEADER_LEN: usize = 74;
@@ -261,8 +280,54 @@ impl ResolvedKindTag {
     }
 }
 
+/// The resolved tool's idempotency class, mirrored as a closed `u8`-tagged enum
+/// so `kx-journal` need not depend on `kx-tool-registry` (the journal must stay
+/// dependency-clean, like [`ResolvedKindTag`]). Tags MUST mirror
+/// `kx_tool_registry::IdempotencyClass`'s variant order (Token=0, Readback=1,
+/// Staged=2, AtLeastOnce=3); the coordinator maps `IdempotencyClass →
+/// IdempotencyClassTag` when building the entry. Adding a variant is a
+/// `schema_version` bump.
+///
+/// Made durable by M2.3b (D105.4 Option A): the resolved `IdempotencyClass` is
+/// otherwise transient (resolved at submit for the R-10 refusal, then dropped),
+/// so crash recovery could only safely re-dispatch Token-class effects. This tag
+/// lets recovery pick the class-correct action for every class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum IdempotencyClassTag {
+    /// Tool accepts an idempotency token (`kx_tool_registry::IdempotencyClass::Token`).
+    Token = 0,
+    /// Deterministic read-back probe (`kx_tool_registry::IdempotencyClass::Readback`).
+    Readback = 1,
+    /// Staged-intent via the `EffectStaged` kind (`kx_tool_registry::IdempotencyClass::Staged`).
+    Staged = 2,
+    /// No closing mechanism; explicit author ack (`kx_tool_registry::IdempotencyClass::AtLeastOnce`).
+    AtLeastOnce = 3,
+}
+
+impl IdempotencyClassTag {
+    /// The tag's discriminant byte.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Parse a tag byte; `None` for an unknown discriminant (decoder rejects).
+    #[must_use]
+    pub const fn from_u8(b: u8) -> Option<Self> {
+        Some(match b {
+            0 => Self::Token,
+            1 => Self::Readback,
+            2 => Self::Staged,
+            3 => Self::AtLeastOnce,
+            _ => return None,
+        })
+    }
+}
+
 /// One resolved capability captured in a [`JournalEntry::RunVersionsResolved`]
-/// fact (M1.2, D79). Audit/lineage metadata — never an identity input.
+/// fact (M1.2, D79; `idempotency_class` added M2.3b/D105.4). Audit/lineage
+/// metadata — never an identity input.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResolvedCapabilityRecord {
     /// The resolved tool's name (opaque identifier).
@@ -273,6 +338,11 @@ pub struct ResolvedCapabilityRecord {
     pub resolved_kind: ResolvedKindTag,
     /// `blake3(canonical_bincode(ToolDef))` — pins the exact resolved `ToolDef`.
     pub resolved_def_hash: ContentRef,
+    /// The resolved tool's durable idempotency class (M2.3b, D105.4). Carried
+    /// explicitly because the resolved `ToolDef` is never content-stored, so the
+    /// class cannot be recovered from `resolved_def_hash`. Drives the class-aware
+    /// recovery decision for a staged-uncommitted WORLD-MUTATING Mote.
+    pub idempotency_class: IdempotencyClassTag,
 }
 
 // ---------------------------------------------------------------------------
@@ -349,6 +419,19 @@ pub enum FailureReason {
     /// Submission-time refusal: WORLD-MUTATING + no idempotency strategy + no critic
     /// (`mote.md` §4 anti-pattern; refusal predicate in `validate-then-commit.md` §7).
     UnsafeWorldMutatingConstruction = 5,
+    /// **Recovery-time outcome (M2.3b, D105.4 / D65).** A staged-uncommitted
+    /// at-most-once (`IdempotencyClass::AtLeastOnce`) WORLD-MUTATING effect could
+    /// not be safely re-dispatched (that would double-fire), so recovery ran the
+    /// capability's deterministic `compensate` (undo). The effect was reversed;
+    /// the Mote is terminal. Distinct from `UnsafeWorldMutatingConstruction`
+    /// (a *submission-time* refusal) — this is a *recovery-time* clean-up.
+    CompensatedAtLeastOnce = 6,
+    /// **Recovery-time outcome (M2.3b, D105.4 / D65).** Same situation as
+    /// `CompensatedAtLeastOnce`, but the capability does NOT support compensation,
+    /// so recovery quarantined the Mote rather than risk a double-fire: it is
+    /// terminal (never re-dispatched) and surfaced via the projection's
+    /// `AnomalyKind`/`anomaly_motes` for operator review.
+    QuarantinedAtLeastOnce = 7,
 }
 
 impl FailureReason {
@@ -369,6 +452,8 @@ impl FailureReason {
             3 => Self::WorkerCrashed,
             4 => Self::UpstreamRepudiated,
             5 => Self::UnsafeWorldMutatingConstruction,
+            6 => Self::CompensatedAtLeastOnce,
+            7 => Self::QuarantinedAtLeastOnce,
             _ => return None,
         })
     }
@@ -885,6 +970,12 @@ pub enum DecodeError {
     /// five known [`ResolvedKindTag`] values.
     #[error("unknown resolved_kind tag: {0}")]
     UnknownResolvedKind(u8),
+    /// A `RunVersionsResolved` entry's `idempotency_class` tag byte is not one of
+    /// the four known [`IdempotencyClassTag`] values (v6, M2.3b). A v5-shaped body
+    /// lacking the trailing byte fails the exact-cursor check as `TrailingBytes`
+    /// before reaching here; this guards a present-but-corrupt tag.
+    #[error("unknown idempotency_class tag: {0}")]
+    UnknownIdempotencyClass(u8),
     /// A `RunVersionsResolved` entry's `has_cap` flag is neither 0 nor 1.
     #[error("has_cap flag is not boolean: {0}")]
     NonBooleanHasCap(u8),
@@ -1095,9 +1186,10 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             capability,
             ..
         } => {
-            // v4 (M1.2): body = instance_id(16) ‖ warrant_ref(32) ‖
+            // v4 (M1.2) + v6 (M2.3b): body = instance_id(16) ‖ warrant_ref(32) ‖
             // u16-prefixed model_id ‖ has_cap(u8) ‖ [if has_cap: u16-prefixed
-            // tool_id ‖ u16-prefixed tool_version ‖ kind_tag(u8) ‖ def_hash(32)].
+            // tool_id ‖ u16-prefixed tool_version ‖ kind_tag(u8) ‖ def_hash(32) ‖
+            // idempotency_class_tag(u8)].
             out.extend_from_slice(instance_id);
             out.extend_from_slice(warrant_ref.as_bytes());
             push_len_prefixed_str(&mut out, model_id)?;
@@ -1109,6 +1201,7 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
                     push_len_prefixed_str(&mut out, &cap.tool_version)?;
                     out.push(cap.resolved_kind.as_u8());
                     out.extend_from_slice(cap.resolved_def_hash.as_bytes());
+                    out.push(cap.idempotency_class.as_u8());
                 }
             }
             // Pathological-id guard (real-id bodies are ~100 B). Mirrors the
@@ -1396,11 +1489,16 @@ pub fn decode_entry_with_def_hash(
                     let resolved_kind = ResolvedKindTag::from_u8(tag_byte)
                         .ok_or(DecodeError::UnknownResolvedKind(tag_byte))?;
                     let def_hash_bytes = read_array32(body, &mut cursor, kind)?;
+                    // v6 (M2.3b): trailing idempotency_class tag byte.
+                    let class_byte = read_u8(body, &mut cursor, kind)?;
+                    let idempotency_class = IdempotencyClassTag::from_u8(class_byte)
+                        .ok_or(DecodeError::UnknownIdempotencyClass(class_byte))?;
                     Some(ResolvedCapabilityRecord {
                         tool_id,
                         tool_version,
                         resolved_kind,
                         resolved_def_hash: ContentRef::from_bytes(def_hash_bytes),
+                        idempotency_class,
                     })
                 }
                 other => return Err(DecodeError::NonBooleanHasCap(other)),
@@ -2077,6 +2175,7 @@ mod tests {
             tool_version: "1.0.0".to_owned(),
             resolved_kind: ResolvedKindTag::Builtin,
             resolved_def_hash: ContentRef::from_bytes([0x77; 32]),
+            idempotency_class: IdempotencyClassTag::Readback,
         }
     }
 
@@ -2144,14 +2243,74 @@ mod tests {
     fn decode_rejects_run_versions_unknown_kind_tag() {
         let e = sample_run_versions(Some(sample_capability()));
         let bytes = encode_entry(&e).unwrap();
-        // The kind tag byte sits just before the trailing 32-byte def_hash.
-        let tag_idx = bytes.len() - 33;
+        // Body tail (v6): kind_tag(1) ‖ def_hash(32) ‖ class_tag(1). The kind tag
+        // sits 34 bytes from the end (33 trailing bytes after it, plus itself).
+        let tag_idx = bytes.len() - 34;
         let mut corrupted = bytes.clone();
         corrupted[tag_idx] = 0xff;
         assert_eq!(
             decode_entry(&corrupted).unwrap_err(),
             DecodeError::UnknownResolvedKind(0xff)
         );
+    }
+
+    #[test]
+    fn decode_rejects_run_versions_unknown_idempotency_class() {
+        // v6 (M2.3b): the idempotency_class tag is the LAST body byte.
+        let e = sample_run_versions(Some(sample_capability()));
+        let bytes = encode_entry(&e).unwrap();
+        let class_idx = bytes.len() - 1;
+        let mut corrupted = bytes.clone();
+        corrupted[class_idx] = 0xff;
+        assert_eq!(
+            decode_entry(&corrupted).unwrap_err(),
+            DecodeError::UnknownIdempotencyClass(0xff)
+        );
+    }
+
+    #[test]
+    fn decode_rejects_v5_shaped_run_versions_body_missing_class_byte() {
+        // A v5-shaped capability body (no trailing class byte) is a body-too-short
+        // under v6 — the decoder reads through def_hash then runs out of bytes
+        // reading the class tag. Fail-closed; backstopped by the schema-version gate.
+        let e = sample_run_versions(Some(sample_capability()));
+        let mut bytes = encode_entry(&e).unwrap();
+        bytes.pop(); // drop the trailing idempotency_class tag → v5 shape
+        assert!(matches!(
+            decode_entry(&bytes),
+            Err(DecodeError::BodyTooShort {
+                kind: KIND_RUN_VERSIONS_RESOLVED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn idempotency_class_tag_round_trips_and_rejects_unknown() {
+        for tag in [
+            IdempotencyClassTag::Token,
+            IdempotencyClassTag::Readback,
+            IdempotencyClassTag::Staged,
+            IdempotencyClassTag::AtLeastOnce,
+        ] {
+            assert_eq!(IdempotencyClassTag::from_u8(tag.as_u8()), Some(tag));
+        }
+        assert_eq!(IdempotencyClassTag::from_u8(4), None);
+    }
+
+    #[test]
+    fn recovery_failure_reasons_round_trip_and_are_terminal() {
+        for r in [
+            FailureReason::CompensatedAtLeastOnce,
+            FailureReason::QuarantinedAtLeastOnce,
+        ] {
+            assert_eq!(FailureReason::from_u8(r.as_u8()), Some(r));
+            // Both recovery outcomes are TERMINAL — never re-dispatched.
+            assert!(!is_pre_commit_crash(r));
+        }
+        assert_eq!(FailureReason::CompensatedAtLeastOnce.as_u8(), 6);
+        assert_eq!(FailureReason::QuarantinedAtLeastOnce.as_u8(), 7);
+        assert_eq!(FailureReason::from_u8(8), None);
     }
 
     #[test]

--- a/crates/kx-journal/src/lib.rs
+++ b/crates/kx-journal/src/lib.rs
@@ -90,10 +90,10 @@
 pub use crate::entry::{
     decode_entry, decode_entry_with_def_hash, encode_entry, is_pre_commit_crash,
     repudiation_idempotency_key, run_root_id, seal_root_id, DecodeError, EncodeError,
-    FailureReason, JournalEntry, ParentEntry, RepudiationReason, ResolvedCapabilityRecord,
-    ResolvedKindTag, HEADER_LEN, INSTANCE_ID_LEN, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED,
-    KIND_DIGEST_SEALED, KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED, KIND_REPUDIATED,
-    KIND_RUN_REGISTERED, KIND_RUN_VERSIONS_RESOLVED, MAX_ENTRY_LEN, MAX_PARENTS,
+    FailureReason, IdempotencyClassTag, JournalEntry, ParentEntry, RepudiationReason,
+    ResolvedCapabilityRecord, ResolvedKindTag, HEADER_LEN, INSTANCE_ID_LEN, JOURNAL_SCHEMA_VERSION,
+    KIND_COMMITTED, KIND_DIGEST_SEALED, KIND_EFFECT_STAGED, KIND_FAILED, KIND_PROPOSED,
+    KIND_REPUDIATED, KIND_RUN_REGISTERED, KIND_RUN_VERSIONS_RESOLVED, MAX_ENTRY_LEN, MAX_PARENTS,
 };
 pub use crate::in_memory::InMemoryJournal;
 pub use crate::sqlite::SqliteJournal;

--- a/crates/kx-journal/tests/dod.rs
+++ b/crates/kx-journal/tests/dod.rs
@@ -300,13 +300,14 @@ fn obligation_13_schema_version_mismatch_loud_refusal() {
     }
 }
 
-/// M2.2c (D103.2/D104): pin the schema version so the v4→v5 bump (the new
-/// `DigestSealed` kind) is an intentional, reviewable change — a future edit that
-/// touches the entry encoding must bump this in lock-step. (Prior bumps: v3→v4
-/// added `RunVersionsResolved`, M1.2/D79.)
+/// M2.3b (D105.4): pin the schema version so the v5→v6 bump (the
+/// `ResolvedCapabilityRecord.idempotency_class` field + two recovery `FailureReason`
+/// variants) is an intentional, reviewable change — a future edit that touches the
+/// entry encoding must bump this in lock-step. (Prior bumps: v3→v4 added
+/// `RunVersionsResolved`, M1.2/D79; v4→v5 added `DigestSealed`, M2.2c/D104.)
 #[test]
-fn schema_version_is_v5() {
-    assert_eq!(JOURNAL_SCHEMA_VERSION, 5);
+fn schema_version_is_v6() {
+    assert_eq!(JOURNAL_SCHEMA_VERSION, 6);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kx-journal/tests/proptest_entry.rs
+++ b/crates/kx-journal/tests/proptest_entry.rs
@@ -196,6 +196,12 @@ fn arb_resolved_kind() -> impl Strategy<Value = kx_journal::ResolvedKindTag> {
     ]
 }
 
+/// **v6 (M2.3b): IdempotencyClassTag strategy** — one of the four closed variants.
+fn arb_idempotency_class() -> impl Strategy<Value = kx_journal::IdempotencyClassTag> {
+    use kx_journal::IdempotencyClassTag::{AtLeastOnce, Readback, Staged, Token};
+    prop_oneof![Just(Token), Just(Readback), Just(Staged), Just(AtLeastOnce)]
+}
+
 /// **v4 (M1.2): RunVersionsResolved strategy.** `instance_id` is the 16-byte run
 /// nonce; `model_id`/`tool_id`/`tool_version` are bounded UTF-8 ids; the
 /// capability is present or absent (zero-grant warrant).
@@ -205,15 +211,19 @@ fn arb_run_versions_resolved() -> impl Strategy<Value = JournalEntry> {
         "[a-z0-9._-]{0,16}",
         arb_resolved_kind(),
         arb_byte_array_32(),
+        arb_idempotency_class(),
     )
-        .prop_map(|(tool_id, tool_version, resolved_kind, def_hash)| {
-            kx_journal::ResolvedCapabilityRecord {
-                tool_id,
-                tool_version,
-                resolved_kind,
-                resolved_def_hash: ContentRef::from_bytes(def_hash),
-            }
-        });
+        .prop_map(
+            |(tool_id, tool_version, resolved_kind, def_hash, idempotency_class)| {
+                kx_journal::ResolvedCapabilityRecord {
+                    tool_id,
+                    tool_version,
+                    resolved_kind,
+                    resolved_def_hash: ContentRef::from_bytes(def_hash),
+                    idempotency_class,
+                }
+            },
+        );
     (
         proptest::array::uniform16(any::<u8>()),
         arb_byte_array_32(),

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -424,7 +424,7 @@ struct CheckpointState {
     run_resolved_versions: Vec<RunResolvedVersionsDto>,
 }
 
-// Mirrors `MoteInfo`'s five flags 1:1 — same `struct_excessive_bools` allow.
+// Mirrors `MoteInfo`'s flags 1:1 — same `struct_excessive_bools` allow.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize)]
 struct MoteInfoDto {
@@ -435,6 +435,7 @@ struct MoteInfoDto {
     effect_staged_observed: bool,
     terminal_failure_observed: bool,
     inconsistent: bool,
+    quarantined: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -512,6 +513,7 @@ impl From<&MoteInfo> for MoteInfoDto {
             effect_staged_observed,
             terminal_failure_observed,
             inconsistent,
+            quarantined,
         } = mi;
         Self {
             declared: declared.as_ref().map(DeclaredInfoDto::from),
@@ -521,6 +523,7 @@ impl From<&MoteInfo> for MoteInfoDto {
             effect_staged_observed: *effect_staged_observed,
             terminal_failure_observed: *terminal_failure_observed,
             inconsistent: *inconsistent,
+            quarantined: *quarantined,
         }
     }
 }
@@ -645,6 +648,7 @@ impl TryFrom<MoteInfoDto> for MoteInfo {
             effect_staged_observed,
             terminal_failure_observed,
             inconsistent,
+            quarantined,
         } = dto;
         Ok(MoteInfo {
             declared: declared.map(DeclaredInfo::from),
@@ -654,6 +658,7 @@ impl TryFrom<MoteInfoDto> for MoteInfo {
             effect_staged_observed,
             terminal_failure_observed,
             inconsistent,
+            quarantined,
         })
     }
 }

--- a/crates/kx-projection/src/enums.rs
+++ b/crates/kx-projection/src/enums.rs
@@ -46,6 +46,13 @@ pub enum AnomalyKind {
     /// folded in between. Repudiated targets a Committed that doesn't exist; the
     /// fold quarantines the Mote (sets `info.inconsistent`) rather than aborting.
     EffectStagedThenRepudiatedNoCommitted,
+    /// **Recovery-time quarantine (M2.3b, D105.4 / D65).** A staged-uncommitted
+    /// at-most-once (`IdempotencyClass::AtLeastOnce`) WORLD-MUTATING effect could
+    /// not be safely re-dispatched (no closing mechanism) and the capability does
+    /// not support compensation, so recovery quarantined it: a terminal
+    /// `Failed { reason_class: QuarantinedAtLeastOnce }` was appended (the Mote is
+    /// `MoteState::Failed`, never re-dispatched). Surfaced here for operator review.
+    QuarantinedAtLeastOnceEffect,
 }
 
 /// 3c (validate-then-commit) promotion state, per D18 + D20.

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -474,6 +474,14 @@ impl Projection {
                     if !kx_journal::is_pre_commit_crash(*reason_class) {
                         info.terminal_failure_observed = true;
                     }
+                    // **v6 (M2.3b, D105.4).** A recovery-time quarantine of a
+                    // staged-uncommitted at-most-once effect: mark it so
+                    // `anomaly_motes` surfaces it for operator review. Set-once;
+                    // terminal_failure_observed is already set above (the variant
+                    // is not pre-commit-crash), so it is non-redispatchable too.
+                    if *reason_class == kx_journal::FailureReason::QuarantinedAtLeastOnce {
+                        info.quarantined = true;
+                    }
                 }
                 self.state.last_seq = self.state.last_seq.max(*seq);
             }
@@ -908,6 +916,34 @@ impl Projection {
     #[must_use]
     pub fn run_resolved_versions(&self) -> &[crate::state::RunResolvedVersions] {
         &self.state.run_resolved_versions
+    }
+
+    /// The durable resolved [`kx_journal::IdempotencyClassTag`] for a tool, folded
+    /// from the run's `RunVersionsResolved` metadata (M2.3b, D105.4). `None` if no
+    /// resolved record names this tool (e.g. a run that journaled no resolution —
+    /// the single-node demo path — or a tool outside the run's grants).
+    ///
+    /// This is the durable source the class-aware recovery decision reads: the
+    /// resolved class is otherwise transient (used at submit for the R-10 refusal,
+    /// then dropped), so a crash-recovered run could only safely re-dispatch
+    /// Token-class effects without it. A tool resolves to exactly one class per
+    /// run; the first matching record wins (records for one run share a class per
+    /// tool by construction).
+    ///
+    /// **Audit/lineage metadata, never identity** — like [`Self::run_resolved_versions`],
+    /// reading it moves no digest and gates no scheduling/identity decision (it
+    /// only informs the recovery action).
+    #[must_use]
+    pub fn idempotency_class_for_tool(
+        &self,
+        tool_id: &str,
+    ) -> Option<kx_journal::IdempotencyClassTag> {
+        self.state
+            .run_resolved_versions
+            .iter()
+            .filter_map(|r| r.capability.as_ref())
+            .find(|cap| cap.tool_id == tool_id)
+            .map(|cap| cap.idempotency_class)
     }
 
     /// Count of Motes currently in `MoteState::Repudiated`.

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -74,6 +74,15 @@ pub(crate) struct MoteInfo {
     /// **Prefix-monotonic-true** — never reset. Quarantines the Mote per
     /// STEP 5.3.
     pub(crate) inconsistent: bool,
+    /// **v6 (M2.3b, D105.4 / D65).** `true` if a terminal
+    /// `Failed { reason_class: QuarantinedAtLeastOnce }` was folded for this
+    /// MoteId — recovery quarantined a staged-uncommitted at-most-once effect
+    /// (no closing mechanism, compensation unsupported) rather than risk a
+    /// double-fire. **Prefix-monotonic-true** — never reset. Distinct from
+    /// `inconsistent` (the cell-8 Repudiated anomaly); a quarantined Mote is
+    /// terminal `Failed` (via `terminal_failure_observed`), surfaced via
+    /// [`crate::AnomalyKind::QuarantinedAtLeastOnceEffect`].
+    pub(crate) quarantined: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -235,15 +244,24 @@ impl State {
     }
 
     /// Enumerate every Mote currently flagged anomalous, with its anomaly kind.
+    ///
+    /// A Mote can carry more than one anomaly (the cell-8 `inconsistent` flag and
+    /// the M2.3b `quarantined` flag are independent, set-once facts), so each is
+    /// emitted as its own `(MoteId, AnomalyKind)` entry. Entries are grouped by
+    /// `MoteId` (the map iterates in key order); the per-Mote kind order is
+    /// `inconsistent` then `quarantined`.
     pub(crate) fn anomaly_motes_iter(&self) -> Vec<(MoteId, AnomalyKind)> {
         self.motes
             .iter()
-            .filter_map(|(id, info)| {
+            .flat_map(|(id, info)| {
+                let mut kinds: SmallVec<[AnomalyKind; 2]> = SmallVec::new();
                 if info.inconsistent {
-                    Some((*id, AnomalyKind::EffectStagedThenRepudiatedNoCommitted))
-                } else {
-                    None
+                    kinds.push(AnomalyKind::EffectStagedThenRepudiatedNoCommitted);
                 }
+                if info.quarantined {
+                    kinds.push(AnomalyKind::QuarantinedAtLeastOnceEffect);
+                }
+                kinds.into_iter().map(move |k| (*id, k))
             })
             .collect()
     }

--- a/crates/kx-projection/tests/cross_product.rs
+++ b/crates/kx-projection/tests/cross_product.rs
@@ -406,3 +406,42 @@ fn is_pre_commit_crash_classifies_canonically_terminal_variants() {
         FailureReason::UnsafeWorldMutatingConstruction
     ));
 }
+
+// ---------------------------------------------------------------------------
+// M2.3b (D105.4): recovery-time quarantine of a staged-uncommitted at-most-once
+// effect. The fold sees `EffectStaged` then a terminal `Failed { reason_class:
+// QuarantinedAtLeastOnce }` (written by recovery, no `Committed`). The Mote must
+// be terminal `Failed`, never re-dispatchable, and surfaced via `anomaly_motes`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quarantined_at_least_once_is_terminal_and_surfaced() {
+    let mid = MoteId([0xC1; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 1, FailureReason::QuarantinedAtLeastOnce),
+    ]);
+
+    // Terminal `Failed` — never re-dispatched (the recovery oracle refuses).
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+
+    // Surfaced as a quarantine anomaly for operator review (distinct from cell-8).
+    let anomalies = p.anomaly_motes();
+    assert!(anomalies.contains(&(mid, AnomalyKind::QuarantinedAtLeastOnceEffect)));
+    assert!(!anomalies.contains(&(mid, AnomalyKind::EffectStagedThenRepudiatedNoCommitted)));
+}
+
+#[test]
+fn compensated_at_least_once_is_terminal_but_not_an_anomaly() {
+    // A *successful* compensation also ends terminal `Failed`, but is NOT a
+    // quarantine anomaly (the world was cleaned up; nothing for an operator).
+    let mid = MoteId([0xC2; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 1, FailureReason::CompensatedAtLeastOnce),
+    ]);
+    assert_eq!(p.state_of(&mid), MoteState::Failed);
+    assert!(!p.can_redispatch_world_effect(&mid));
+    assert!(p.anomaly_motes().is_empty());
+}

--- a/crates/kx-projection/tests/proptest_fold.rs
+++ b/crates/kx-projection/tests/proptest_fold.rs
@@ -559,6 +559,7 @@ fn sample_cap_record() -> kx_journal::ResolvedCapabilityRecord {
         tool_version: "1.0.0".to_owned(),
         resolved_kind: kx_journal::ResolvedKindTag::Builtin,
         resolved_def_hash: ContentRef::from_bytes([0x42; 32]),
+        idempotency_class: kx_journal::IdempotencyClassTag::Readback,
     }
 }
 
@@ -584,6 +585,13 @@ fn run_versions_resolved_fold_is_off_dag_and_appends_metadata() {
     assert_eq!(recs[0].model_id, "qwen");
     assert_eq!(recs[0].capability.as_ref().unwrap().tool_id, "fs-read");
     assert!(recs[1].capability.is_none());
+
+    // **M2.3b:** the durable class lookup the recovery decision reads.
+    assert_eq!(
+        p.idempotency_class_for_tool("fs-read"),
+        Some(kx_journal::IdempotencyClassTag::Readback)
+    );
+    assert_eq!(p.idempotency_class_for_tool("unknown-tool"), None);
 }
 
 /// **Scale (D95):** folding a large run-metadata log stays O(1) **off the

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -271,6 +271,11 @@ where
                         &wm.warrant,
                         wm.capability.clone(),
                         request,
+                        // Single-node demo: vacuous tool contract → no durable
+                        // resolved class, so recovery uses today's probe-then-
+                        // redispatch path. M2.3b class-aware routing is exercised
+                        // on the coordinator path + the executor integration tests.
+                        None,
                         &submission_motes,
                         &*journal,
                         rm,

--- a/crates/kx-tool-registry/src/registry.rs
+++ b/crates/kx-tool-registry/src/registry.rs
@@ -452,6 +452,7 @@ impl ToolRegistry for InMemoryToolRegistry {
             tool_version: grant.tool_version.clone(),
             resolved_kind: rec.def.kind.clone(),
             resolved_def_hash,
+            idempotency_class: rec.def.idempotency_class,
         };
         let event_ref = event.to_ref();
 

--- a/crates/kx-tool-registry/src/tests.rs
+++ b/crates/kx-tool-registry/src/tests.rs
@@ -515,6 +515,7 @@ fn tool_resolution_event_ref_is_deterministic() {
         tool_version: ToolVersion("1".into()),
         resolved_kind: ToolKind::Builtin,
         resolved_def_hash: ContentRef::from_bytes([0; 32]),
+        idempotency_class: IdempotencyClass::Token,
     };
     assert_eq!(event.to_ref(), event.to_ref());
 }
@@ -526,6 +527,7 @@ fn tool_resolution_event_ref_changes_with_kind() {
         tool_version: ToolVersion("1".into()),
         resolved_kind: ToolKind::Builtin,
         resolved_def_hash: ContentRef::from_bytes([0; 32]),
+        idempotency_class: IdempotencyClass::Token,
     };
     let e2 = ToolResolutionEvent {
         tool_id: ToolName("t".into()),
@@ -534,6 +536,21 @@ fn tool_resolution_event_ref_changes_with_kind() {
             source_url: "https://example.com/t".into(),
         },
         resolved_def_hash: ContentRef::from_bytes([0; 32]),
+        idempotency_class: IdempotencyClass::Token,
     };
     assert_ne!(e1.to_ref(), e2.to_ref());
+}
+
+#[test]
+fn tool_resolution_event_ref_changes_with_idempotency_class() {
+    let base = ToolResolutionEvent {
+        tool_id: ToolName("t".into()),
+        tool_version: ToolVersion("1".into()),
+        resolved_kind: ToolKind::Builtin,
+        resolved_def_hash: ContentRef::from_bytes([0; 32]),
+        idempotency_class: IdempotencyClass::Token,
+    };
+    let mut changed = base.clone();
+    changed.idempotency_class = IdempotencyClass::AtLeastOnce;
+    assert_ne!(base.to_ref(), changed.to_ref());
 }

--- a/crates/kx-tool-registry/src/tool_def.rs
+++ b/crates/kx-tool-registry/src/tool_def.rs
@@ -81,6 +81,15 @@ pub struct ToolResolutionEvent {
     /// blake3 of the resolved `ToolDef`'s canonical bytes. Pins the exact
     /// `ToolDef` shape that was used for this resolution.
     pub resolved_def_hash: ContentRef,
+    /// The resolved tool's declared idempotency mechanism (D38 §2 / D65).
+    ///
+    /// Carried explicitly (in addition to being implied by `resolved_def_hash`)
+    /// because the resolved `ToolDef` is **never content-stored** — so the class
+    /// could not otherwise be recovered from the hash. The coordinator persists it
+    /// on the `RunVersionsResolved` metadata fact (M2.3b, D105.4 Option A) so crash
+    /// recovery can pick the class-correct action (Redispatch / CommitFromReadback /
+    /// Compensate / Quarantine) for a staged-uncommitted WORLD-MUTATING Mote.
+    pub idempotency_class: IdempotencyClass,
 }
 
 impl ToolResolutionEvent {
@@ -92,7 +101,7 @@ impl ToolResolutionEvent {
     /// # Example
     ///
     /// ```
-    /// use kx_tool_registry::{ToolKind, ToolResolutionEvent};
+    /// use kx_tool_registry::{IdempotencyClass, ToolKind, ToolResolutionEvent};
     /// use kx_mote::{ToolName, ToolVersion};
     /// use kx_content::ContentRef;
     ///
@@ -101,6 +110,7 @@ impl ToolResolutionEvent {
     ///     tool_version: ToolVersion("1".into()),
     ///     resolved_kind: ToolKind::Builtin,
     ///     resolved_def_hash: ContentRef::from_bytes([0; 32]),
+    ///     idempotency_class: IdempotencyClass::Readback,
     /// };
     /// // Same event → same ref (deterministic).
     /// assert_eq!(event.to_ref(), event.to_ref());

--- a/crates/kx-tool-registry/tests/proptest_registry.rs
+++ b/crates/kx-tool-registry/tests/proptest_registry.rs
@@ -281,12 +281,14 @@ proptest! {
         name in arb_tool_name(),
         version in arb_tool_version(),
         kind in arb_tool_kind(),
+        class in arb_idempotency_class(),
     ) {
         let event = ToolResolutionEvent {
             tool_id: name,
             tool_version: version,
             resolved_kind: kind,
             resolved_def_hash: ContentRef::from_bytes([42; 32]),
+            idempotency_class: class,
         };
         prop_assert_eq!(event.to_ref(), event.to_ref());
     }


### PR DESCRIPTION
## M2.3b — class-aware Compensate/Quarantine recovery (closes the M2 exit gate)

Makes the per-capability `IdempotencyClass` **durable** and closes the M2 exit gate — *"resume-or-compensate proven per `IdempotencyClass`"* (D65). Before this PR a staged-uncommitted **AtLeastOnce** world-mutating effect was re-dispatched on the Token-only idempotency-key dedup → a latent **double-fire**.

### What changed (7 crates, dependency order)
- **kx-tool-registry** — `ToolResolutionEvent.idempotency_class`.
- **kx-journal (v5→v6)** — `idempotency_class` on `ResolvedCapabilityRecord` (local `IdempotencyClassTag`, +1 byte in the `RunVersionsResolved` body, refuse-v5-loudly); two new terminal `FailureReason`s.
- **kx-coordinator** — captures the class; class-aware lease gate refuses to re-offer a staged AtLeastOnce Mote (the distributed quarantine, applied to the combined ready ∪ rescheduleable stream).
- **kx-projection** — `MoteInfo.quarantined` (checkpoint-mirrored), `AnomalyKind::QuarantinedAtLeastOnceEffect`, `idempotency_class_for_tool()`.
- **kx-capability** — broker-level `compensate` (same warrant precheck as dispatch/probe).
- **kx-executor** — typed 4-arm `RecoveryAction { Redispatch | CommitFromReadback | Compensate | Quarantine }` + `CommitProtocol::try_compensate` + `CompensateFailed`; `redispatch_wm_mote` returns `WmRecoveryOutcome`.
- **kx-runtime** — single-node passes `None` (vacuous demo contract → unchanged behavior).

### Recovery decision (D65)
Token/Staged → Redispatch · Readback → CommitFromReadback · **AtLeastOnce** → Compensate (undo → terminal `Failed{Compensated}`) or Quarantine (terminal `Failed{Quarantined}`, surfaced via `anomaly_motes()`). Compensate error → `CompensateFailed` (fail-closed, never re-dispatch).

### Pre-flight (Rule 8) + forward-enhancement (Rule 9)
- **Recovery idempotency holds** — a Compensate/Quarantine writes a *terminal* `Failed` → the oracle refuses every later pass (prefix-monotonic).
- **Security** — the compensate undo runs the identical warrant precheck as dispatch; deterministic, never a model call; fail-closed everywhere.
- **Perf** — +1 off-DAG byte/run; cold-path lookup; no hot-path allocation.
- Sequenced follow-ons: distributed compensate-via-worker-RPC, chaos PRNG seed-sweep scenario, compensate retry/backoff, operator quarantine-resolution tooling.

### Verification
`fmt` · `clippy --workspace --all-targets -D warnings` · `test --workspace` **1143/0** · `deny` · `doc -D warnings` · **product digest `a6b5c679…` unchanged** (`a0_guard` + `seals_do_not_change_product_digest`) · **frozen pair `kx-scheduler`/`kx-inference` source byte-unchanged** · `scale-smoke` (25k re-fold / churn-bounded SQLite resume / off-DAG fold). New tests: 4-arm executor decision incl. `CompensateFailed` + second-pass refusal, journal v6 round-trip/reject + schema pin, projection quarantine surface, broker warrant-gate, distributed death/re-lease quarantine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)