### PR TITLE
feat(mcp,model-harness): first model-driven tool step — kx-mcp McpCapability (M5.2a, D80; IMP-5/15/16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-mcp"
+version = "0.0.1"
+dependencies = [
+ "kx-capability",
+ "kx-content",
+ "kx-mote",
+ "kx-tool-registry",
+ "kx-warrant",
+ "proptest",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kx-memoizer"
 version = "0.0.1"
 dependencies = [
@@ -1271,6 +1288,7 @@ dependencies = [
  "kx-executor",
  "kx-inference",
  "kx-journal",
+ "kx-mcp",
  "kx-memoizer",
  "kx-mote",
  "kx-projection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/kx-critic",
     "crates/kx-capture",
     "crates/kx-refusal",
+    "crates/kx-mcp",
     "crates/kx-model-harness",
 ]
 exclude = [
@@ -126,6 +127,10 @@ kx-capture           = { path = "crates/kx-capture",           version = "0.0.1"
 # can enforce R-1..R-15 + D66 at SubmitMote WITHOUT linking kx-executor's inference
 # stack. kx-executor re-exports it for back-compat.
 kx-refusal           = { path = "crates/kx-refusal",           version = "0.0.1" }
+# MCP adapter (M5.2, D80) — McpCapability, the first production Capability impl, the
+# concrete ToolKind::Mcp dispatch. A thin SYNC client (stdio now; ureq HTTP in M5.2b)
+# so the broker trait + kx-tool-registry stay dependency-clean (no tokio/rmcp).
+kx-mcp               = { path = "crates/kx-mcp",               version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-mcp/Cargo.toml
+++ b/crates/kx-mcp/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name         = "kx-mcp"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx MCP adapter (M5.2, D80): McpCapability — the FIRST production kx_capability::Capability impl, the concrete ToolKind::Mcp dispatch routed through the CapabilityBroker. A thin, SYNCHRONOUS, hand-rolled MCP JSON-RPC client (std::process stdio transport in M5.2a; ureq streamable-HTTP in M5.2b) so the broker trait + kx-tool-registry stay dependency-clean (no tokio/rmcp). MCP is UNTRUSTED: inbound payloads decode FAIL-CLOSED + size-capped (IMP-16); output is provenance-captured (D72); effects default to StageThenCommit (D66); credentials are supplied OUT-OF-BAND and never embedded (D81)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The Capability trait this crate implements + EffectRequest / CapabilityFailureReason.
+kx-capability    = { workspace = true }
+# ToolName / ToolVersion / EffectPattern — the capability's identity + pattern surface.
+kx-mote          = { workspace = true }
+# Host / NetScope — the egress-host derivation the broker's net_scope gate checks (M5.2b).
+kx-warrant       = { workspace = true }
+# McpEndpointId — the ToolKind::Mcp endpoint identity this capability fronts.
+kx-tool-registry = { workspace = true }
+serde            = { workspace = true }
+# JSON-RPC framing ONLY. `raw_value` carries the args/result verbatim as opaque
+# bytes (never decoded into a dynamic `Value` / floats) — mirrors kx-critic's
+# no-float discipline so nothing on the effect path can introduce float-ordering.
+serde_json       = { workspace = true, features = ["raw_value"] }
+thiserror        = { workspace = true }
+tracing          = { workspace = true }
+
+[dev-dependencies]
+# LocalCapabilityBroker + an in-memory ContentStore to dispatch McpCapability through
+# the REAL warrant gate (precheck) in the integration tests.
+kx-content = { workspace = true }
+# SmallVec parents when building test Motes via Mote::new.
+smallvec   = { workspace = true }
+# Property tests: decode_tool_result is total/fail-closed over arbitrary + truncated bytes.
+proptest   = { workspace = true }
+
+# Test-support: a tiny newline-delimited JSON-RPC stdio MCP server the integration
+# tests spawn to exercise the REAL StdioTransport (env-injection + round-trip).
+# Kept out of the lib so the adapter surface stays clean.
+[[bin]]
+name = "kx-mcp-mock-stdio"
+path = "tests/support/mock_stdio_server.rs"
+
+[lints]
+workspace = true

--- a/crates/kx-mcp/src/capability.rs
+++ b/crates/kx-mcp/src/capability.rs
@@ -1,0 +1,149 @@
+//! [`McpCapability`] — the concrete `ToolKind::Mcp` dispatch and the first
+//! production [`kx_capability::Capability`] impl.
+//!
+//! `invoke` frames a JSON-RPC `tools/call` from the (already warrant-validated)
+//! `EffectRequest.payload`, runs it over the configured [`McpTransport`], and
+//! decodes the response fail-closed + size-capped. The broker
+//! (`LocalCapabilityBroker`) is what enforces the warrant (net_scope ⊆ warrant,
+//! tool_grants, pattern) before calling `invoke` and what stages the returned bytes
+//! — this type only produces the effect's result bytes.
+
+use kx_capability::{Capability, CapabilityFailureReason, EffectRequest};
+use kx_mote::{EffectPattern, ToolName, ToolVersion};
+use kx_tool_registry::McpEndpointId;
+use serde_json::value::RawValue;
+
+use crate::decode::{decode_tool_result, MAX_TOOL_RESULT_BYTES_DEFAULT};
+use crate::jsonrpc::ToolsCallRequest;
+use crate::transport::McpTransport;
+
+/// MCP effects are world-mutating by default → `StageThenCommit` (D66). A server
+/// that documents an idempotency key can be modelled with a tighter
+/// `IdempotencyClass` later, but the *pattern* surface stays staged-then-commit.
+const SUPPORTED_PATTERNS: [EffectPattern; 1] = [EffectPattern::StageThenCommit];
+
+/// The concrete `ToolKind::Mcp` capability: a thin MCP client behind the
+/// [`Capability`] trait.
+pub struct McpCapability {
+    name: ToolName,
+    version: ToolVersion,
+    #[allow(dead_code)] // Carried for identity + the M5.2b net_scope host derivation.
+    endpoint: McpEndpointId,
+    remote_name: String,
+    transport: Box<dyn McpTransport>,
+    max_response_bytes: usize,
+    wall_clock_ms: u64,
+}
+
+impl std::fmt::Debug for McpCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn McpTransport` is not `Debug`; elide it.
+        f.debug_struct("McpCapability")
+            .field("name", &self.name)
+            .field("version", &self.version)
+            .field("endpoint", &self.endpoint)
+            .field("remote_name", &self.remote_name)
+            .field("max_response_bytes", &self.max_response_bytes)
+            .field("wall_clock_ms", &self.wall_clock_ms)
+            .finish_non_exhaustive()
+    }
+}
+
+impl McpCapability {
+    /// Build an MCP capability named `name`@`version` that calls the remote tool
+    /// `remote_name` at `endpoint` over `transport`.
+    ///
+    /// The response size cap defaults to [`MAX_TOOL_RESULT_BYTES_DEFAULT`] and the
+    /// per-call wall-clock budget defaults to the transport's own fallback; use
+    /// [`with_max_response_bytes`](Self::with_max_response_bytes) /
+    /// [`with_wall_clock_ms`](Self::with_wall_clock_ms) to bound them from the
+    /// warrant (IMP-16).
+    #[must_use]
+    pub fn new(
+        name: ToolName,
+        version: ToolVersion,
+        endpoint: McpEndpointId,
+        remote_name: impl Into<String>,
+        transport: Box<dyn McpTransport>,
+    ) -> Self {
+        Self {
+            name,
+            version,
+            endpoint,
+            remote_name: remote_name.into(),
+            transport,
+            max_response_bytes: MAX_TOOL_RESULT_BYTES_DEFAULT,
+            wall_clock_ms: 0,
+        }
+    }
+
+    /// Bound the response size (IMP-16). A response larger than this is refused as
+    /// `InvalidResponse` and nothing is staged. A `0` argument is treated as the
+    /// default cap (never "unbounded").
+    #[must_use]
+    pub fn with_max_response_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_response_bytes = if max_bytes == 0 {
+            MAX_TOOL_RESULT_BYTES_DEFAULT
+        } else {
+            max_bytes
+        };
+        self
+    }
+
+    /// Set the per-call wall-clock budget (ms) — typically the warrant's
+    /// `resource_ceiling.wall_clock_ms`. `0` lets the transport apply its default.
+    #[must_use]
+    pub fn with_wall_clock_ms(mut self, wall_clock_ms: u64) -> Self {
+        self.wall_clock_ms = wall_clock_ms;
+        self
+    }
+}
+
+impl Capability for McpCapability {
+    fn name(&self) -> &ToolName {
+        &self.name
+    }
+
+    fn version(&self) -> &ToolVersion {
+        &self.version
+    }
+
+    fn supported_patterns(&self) -> &[EffectPattern] {
+        &SUPPORTED_PATTERNS
+    }
+
+    fn invoke(&self, request: &EffectRequest) -> Result<Vec<u8>, CapabilityFailureReason> {
+        // The args are the validated `EffectRequest.payload`, carried VERBATIM as an
+        // opaque RawValue (never decoded into a dynamic Value / floats). An empty
+        // payload means "no arguments" → `{}`.
+        let args: &RawValue = if request.payload.is_empty() {
+            serde_json::from_str("{}").map_err(|e| {
+                CapabilityFailureReason::Other(format!("internal: empty-args encode: {e}"))
+            })?
+        } else {
+            serde_json::from_slice(&request.payload).map_err(|e| {
+                CapabilityFailureReason::Other(format!("tool args are not valid JSON: {e}"))
+            })?
+        };
+
+        let rpc = ToolsCallRequest::new(1, &self.remote_name, args);
+        let request_bytes = serde_json::to_vec(&rpc).map_err(|e| {
+            CapabilityFailureReason::Other(format!("internal: request encode: {e}"))
+        })?;
+
+        tracing::debug!(remote = %self.remote_name, "mcp tools/call dispatch");
+
+        // Untrusted round-trip: bounded read + wall-clock watchdog in the transport.
+        let response = self.transport.round_trip(
+            &request_bytes,
+            self.max_response_bytes,
+            self.wall_clock_ms,
+        )?;
+
+        // Fail-closed inbound decode (IMP-5 / IMP-16). Returns the result object's
+        // verbatim bytes on success; any malformed / oversize / error response is a
+        // typed failure, never silently accepted.
+        let result = decode_tool_result(&response, self.max_response_bytes)?;
+        Ok(result)
+    }
+}

--- a/crates/kx-mcp/src/credential.rs
+++ b/crates/kx-mcp/src/credential.rs
@@ -1,0 +1,62 @@
+//! [`CredentialRef`] — a reference to a secret, never the secret itself (D81).
+//!
+//! Auth for an MCP server (API keys, OAuth tokens) is supplied **out-of-band**: a
+//! `CredentialRef` names a host environment variable (or, later, a cloud
+//! secret-broker key); the secret *value* is read transiently at transport-setup
+//! time and handed to the child process's environment. The value is never stored on
+//! any struct, never placed in an `EffectRequest`, a `BrokerHandle`, the journal, a
+//! `MoteId`, or a `StepRecord`. `Debug`/`Display` print only the *identity* (the
+//! variable name), so a logged credential ref never leaks the secret.
+
+use std::process::Command;
+
+/// A reference to a credential by the name of the host environment variable that
+/// holds it. The secret value is read on demand at injection time and never stored.
+///
+/// `Debug`/`Display` deliberately print only the variable name (the identity that
+/// acted), never the secret — D81's "records *which* credential identity acted,
+/// never the secret".
+#[derive(Clone, PartialEq, Eq)]
+pub struct CredentialRef(String);
+
+impl CredentialRef {
+    /// Construct a credential reference from the host environment-variable name
+    /// that holds the secret.
+    #[must_use]
+    pub fn from_env_var(var_name: impl Into<String>) -> Self {
+        Self(var_name.into())
+    }
+
+    /// The credential's identity (the env-var name). Safe to log — never the secret.
+    #[must_use]
+    pub fn identity(&self) -> &str {
+        &self.0
+    }
+
+    /// Inject the referenced secret into `cmd`'s environment, reading it from the
+    /// host environment transiently. If the variable is unset, no env entry is
+    /// added (the server then fails its own auth — the runtime never fabricates a
+    /// credential). The secret value is dropped at the end of this call; it is
+    /// never returned or stored.
+    pub fn inject_into(&self, cmd: &mut Command) {
+        if let Ok(secret) = std::env::var(&self.0) {
+            cmd.env(&self.0, secret);
+        }
+    }
+}
+
+// Manual `Debug` — print ONLY the identity, never let a derived Debug expose a
+// future secret-bearing field (the type holds none today, and this keeps it so).
+impl std::fmt::Debug for CredentialRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialRef")
+            .field("identity", &self.0)
+            .finish()
+    }
+}
+
+impl std::fmt::Display for CredentialRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "credential:{}", self.0)
+    }
+}

--- a/crates/kx-mcp/src/decode.rs
+++ b/crates/kx-mcp/src/decode.rs
@@ -1,0 +1,186 @@
+//! The fail-closed inbound decoder (IMP-5 / IMP-16).
+//!
+//! [`decode_tool_result`] is the single point where untrusted MCP server bytes
+//! cross into the runtime. It is **total** (never panics on arbitrary or truncated
+//! input), **size-capped** (rejects before parsing a huge body), and **strict**
+//! (accepts only a well-formed JSON-RPC 2.0 `tools/call` result; anything else is
+//! refused). It never deserializes into a dynamic `serde_json::Value` — the result
+//! object is carried verbatim as bytes, so no float/`Value` interpretation occurs.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use crate::errors::DecodeError;
+
+/// Default per-call response-size cap (IMP-16) when a warrant supplies no positive
+/// ceiling: 1 MiB. The capability prefers a warrant-derived cap; this is the floor.
+pub const MAX_TOOL_RESULT_BYTES_DEFAULT: usize = 1 << 20;
+
+/// A JSON-RPC 2.0 response envelope, decoded into a fixed shape.
+///
+/// `jsonrpc` / `id` are ignored (unknown fields are dropped by serde). Exactly one
+/// of `result` / `error` is expected; `result` is kept verbatim as a [`RawValue`]
+/// so its contents are never interpreted by the adapter.
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse {
+    #[serde(default)]
+    result: Option<Box<RawValue>>,
+    #[serde(default)]
+    error: Option<JsonRpcError>,
+}
+
+/// A JSON-RPC 2.0 `error` object.
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    #[serde(default)]
+    message: String,
+}
+
+/// Decode an MCP `tools/call` JSON-RPC response into the verbatim bytes of its
+/// `result` object — fail-closed.
+///
+/// # Errors
+///
+/// - [`DecodeError::Oversize`] if `bytes.len() > max_bytes` (checked *before*
+///   parsing — a hostile server cannot force a huge allocation).
+/// - [`DecodeError::Malformed`] if the bytes are not JSON, are truncated, are not a
+///   JSON object, or carry neither a `result` nor an `error` member.
+/// - [`DecodeError::ProtocolError`] if the server returned a JSON-RPC `error`.
+///
+/// On success the returned `Vec<u8>` is the canonical JSON of the `result` object
+/// (opaque to the adapter; staged verbatim as the effect's result bytes).
+pub fn decode_tool_result(bytes: &[u8], max_bytes: usize) -> Result<Vec<u8>, DecodeError> {
+    if bytes.len() > max_bytes {
+        return Err(DecodeError::Oversize {
+            got: bytes.len(),
+            max: max_bytes,
+        });
+    }
+
+    // serde_json is total over arbitrary bytes (truncation, non-JSON, non-object,
+    // and over-deep nesting all return Err, never panic) — the fail-closed contract.
+    let resp: JsonRpcResponse =
+        serde_json::from_slice(bytes).map_err(|e| DecodeError::Malformed {
+            // The diagnostic is the parser's structural message, never the payload.
+            diagnostic: e.to_string(),
+        })?;
+
+    // A server-side protocol error takes precedence over an absent result.
+    if let Some(err) = resp.error {
+        return Err(DecodeError::ProtocolError {
+            code: err.code,
+            message: err.message,
+        });
+    }
+
+    match resp.result {
+        Some(raw) => Ok(raw.get().as_bytes().to_vec()),
+        None => Err(DecodeError::Malformed {
+            diagnostic: "JSON-RPC response carried neither `result` nor `error`".to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_a_well_formed_result_verbatim() {
+        let body =
+            br#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}"#;
+        let out = decode_tool_result(body, 4096).unwrap();
+        // The result object is returned verbatim (whitespace-free canonical form).
+        assert_eq!(out, br#"{"content":[{"type":"text","text":"ok"}]}"#);
+    }
+
+    #[test]
+    fn rejects_oversize_before_parsing() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let err = decode_tool_result(body, 4).unwrap_err();
+        assert!(matches!(err, DecodeError::Oversize { max: 4, .. }));
+    }
+
+    #[test]
+    fn rejects_truncated_json() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"result":{"content":"#;
+        assert!(matches!(
+            decode_tool_result(body, 4096),
+            Err(DecodeError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_object_json() {
+        for body in [
+            &b"[1,2,3]"[..],
+            &b"\"a string\""[..],
+            &b"42"[..],
+            &b"null"[..],
+        ] {
+            assert!(
+                matches!(
+                    decode_tool_result(body, 4096),
+                    Err(DecodeError::Malformed { .. })
+                ),
+                "non-object JSON must be refused: {:?}",
+                std::str::from_utf8(body)
+            );
+        }
+    }
+
+    #[test]
+    fn surfaces_a_server_protocol_error() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"no such tool"}}"#;
+        match decode_tool_result(body, 4096) {
+            Err(DecodeError::ProtocolError { code, message }) => {
+                assert_eq!(code, -32601);
+                assert_eq!(message, "no such tool");
+            }
+            other => panic!("expected ProtocolError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_response_with_neither_result_nor_error() {
+        let body = br#"{"jsonrpc":"2.0","id":1}"#;
+        assert!(matches!(
+            decode_tool_result(body, 4096),
+            Err(DecodeError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_input_is_malformed_not_a_panic() {
+        assert!(matches!(
+            decode_tool_result(b"", 4096),
+            Err(DecodeError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn deeply_nested_result_does_not_panic() {
+        // The `result` object is carried verbatim as a RawValue (a flat token scan,
+        // not recursive descent), so deep nesting INSIDE it is accepted without a
+        // stack overflow. This locks the panic-safety property against a future
+        // refactor that might swap RawValue for a recursive `Value`.
+        let depth = 50_000;
+        let nested = format!("[{}{}", "[".repeat(depth), "]".repeat(depth));
+        let body = format!(r#"{{"jsonrpc":"2.0","id":1,"result":{{"d":{nested}}}}}"#);
+        // Cap above the body size so we exercise the parser, not the size guard.
+        let cap = body.len() + 16;
+        let _ = decode_tool_result(body.as_bytes(), cap); // must not panic
+    }
+
+    #[test]
+    fn deeply_nested_top_level_array_does_not_panic() {
+        // A deeply-nested top-level array is NOT recursively descended: serde_json
+        // deserializes the struct from a sequence and captures the nested element
+        // verbatim as a RawValue (flat scan). The point is panic-safety — the call
+        // returns (Ok or Err) and never overflows the stack.
+        let depth = 50_000;
+        let body = format!("{}{}", "[".repeat(depth), "]".repeat(depth));
+        let _ = decode_tool_result(body.as_bytes(), body.len() + 16); // must not panic
+    }
+}

--- a/crates/kx-mcp/src/errors.rs
+++ b/crates/kx-mcp/src/errors.rs
@@ -1,0 +1,89 @@
+//! Typed refusal vocabulary for the MCP adapter: [`DecodeError`] (the fail-closed
+//! inbound decoder's verdict) + [`TransportError`] (a transport round-trip failure).
+//! Both map into [`kx_capability::CapabilityFailureReason`] so the broker surfaces a
+//! typed failure — never a panic, never a silent accept.
+
+use kx_capability::CapabilityFailureReason;
+use thiserror::Error;
+
+/// Why a JSON-RPC `tools/call` response was refused.
+///
+/// Every variant is a **fail-closed** outcome: an MCP server is untrusted, so a
+/// response that is oversized, malformed, truncated, or an explicit protocol error
+/// is refused rather than staged. The decoder is total over arbitrary bytes (it
+/// never panics) — see [`crate::decode_tool_result`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum DecodeError {
+    /// The response exceeded the per-call size cap (IMP-16 — resource-exhaustion
+    /// guard). Carries the observed and maximum byte counts.
+    #[error("MCP response too large: {got} bytes > cap {max}")]
+    Oversize {
+        /// Observed response size in bytes.
+        got: usize,
+        /// The configured cap.
+        max: usize,
+    },
+    /// The response was not a well-formed JSON-RPC `tools/call` result: not JSON,
+    /// truncated, missing the `result` member, or a shape the fixed decoder does
+    /// not accept. Untrusted input is never coerced — this is the refusal.
+    #[error("malformed MCP response: {diagnostic}")]
+    Malformed {
+        /// A short, non-sensitive diagnostic (never echoes the raw payload).
+        diagnostic: String,
+    },
+    /// The server returned a JSON-RPC `error` object (a well-formed protocol-level
+    /// failure). Carries the server's code + message for diagnostics.
+    #[error("MCP server error {code}: {message}")]
+    ProtocolError {
+        /// The JSON-RPC error code.
+        code: i64,
+        /// The JSON-RPC error message (server-supplied diagnostic).
+        message: String,
+    },
+}
+
+/// Why an MCP transport round-trip failed (before any response could be decoded):
+/// the subprocess could not be spawned, stdin/stdout I/O failed, or the call
+/// exceeded its wall-clock budget.
+#[derive(Debug, Error)]
+pub enum TransportError {
+    /// The transport could not be established (subprocess spawn failed, endpoint
+    /// unreachable). Carries a diagnostic; maps to `NetworkUnreachable`.
+    #[error("MCP transport unreachable: {0}")]
+    Unreachable(String),
+    /// An I/O error writing the request or reading the response.
+    #[error("MCP transport I/O error: {0}")]
+    Io(String),
+    /// The round-trip exceeded the per-call wall-clock budget. Maps to `Timeout`.
+    #[error("MCP transport timed out after {wall_clock_ms} ms")]
+    Timeout {
+        /// The budget that was exceeded.
+        wall_clock_ms: u64,
+    },
+}
+
+impl From<DecodeError> for CapabilityFailureReason {
+    fn from(e: DecodeError) -> Self {
+        match e {
+            // Both an oversized and a malformed body are "the response did not match
+            // the expected shape" from the broker's vocabulary.
+            DecodeError::Oversize { .. } | DecodeError::Malformed { .. } => {
+                CapabilityFailureReason::InvalidResponse
+            }
+            // A server-side protocol error is a downstream failure; carry the detail.
+            DecodeError::ProtocolError { code, message } => {
+                CapabilityFailureReason::Other(format!("MCP error {code}: {message}"))
+            }
+        }
+    }
+}
+
+impl From<TransportError> for CapabilityFailureReason {
+    fn from(e: TransportError) -> Self {
+        match e {
+            TransportError::Unreachable(_) => CapabilityFailureReason::NetworkUnreachable,
+            TransportError::Timeout { .. } => CapabilityFailureReason::Timeout,
+            TransportError::Io(msg) => CapabilityFailureReason::Other(msg),
+        }
+    }
+}

--- a/crates/kx-mcp/src/jsonrpc.rs
+++ b/crates/kx-mcp/src/jsonrpc.rs
@@ -1,0 +1,50 @@
+//! Minimal JSON-RPC 2.0 framing for the MCP `tools/call` method.
+//!
+//! Deliberately tiny: a single request shape (the outbound `tools/call`) and a
+//! single response shape (a fixed struct, never a dynamic `Value`). Tool
+//! arguments + the server's result are carried verbatim as
+//! [`serde_json::value::RawValue`] — opaque bytes the adapter never interprets,
+//! so no float/`Value` decoding ever reaches the effect path.
+
+use serde::Serialize;
+use serde_json::value::RawValue;
+
+/// The JSON-RPC method the adapter speaks. M5.2a is single-shot `tools/call`; the
+/// `initialize`/`initialized` handshake a stateful MCP server expects is a
+/// documented forward seam (M5.2b — the test server is handshake-free).
+pub(crate) const METHOD_TOOLS_CALL: &str = "tools/call";
+
+/// An outbound JSON-RPC 2.0 `tools/call` request.
+///
+/// `params.arguments` is the model-proposed args object, carried verbatim from the
+/// validated `EffectRequest.payload` as a borrowed [`RawValue`] (never re-parsed
+/// into a dynamic value).
+#[derive(Debug, Serialize)]
+pub(crate) struct ToolsCallRequest<'a> {
+    pub(crate) jsonrpc: &'static str,
+    pub(crate) id: u64,
+    pub(crate) method: &'static str,
+    pub(crate) params: ToolsCallParams<'a>,
+}
+
+/// `params` for [`ToolsCallRequest`]: the remote tool name + its arguments.
+#[derive(Debug, Serialize)]
+pub(crate) struct ToolsCallParams<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) arguments: &'a RawValue,
+}
+
+impl<'a> ToolsCallRequest<'a> {
+    /// Build a `tools/call` request for `remote_name` with verbatim `arguments`.
+    pub(crate) fn new(id: u64, remote_name: &'a str, arguments: &'a RawValue) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            method: METHOD_TOOLS_CALL,
+            params: ToolsCallParams {
+                name: remote_name,
+                arguments,
+            },
+        }
+    }
+}

--- a/crates/kx-mcp/src/lib.rs
+++ b/crates/kx-mcp/src/lib.rs
@@ -1,0 +1,65 @@
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-mcp — the MCP capability adapter (M5.2, D80)
+//!
+//! [`McpCapability`] is the **first production** [`kx_capability::Capability`]
+//! impl on the live path — the concrete dispatch for `kx_tool_registry::ToolKind::Mcp`.
+//! Until now every `Capability` impl in the workspace was a test fixture; the seam
+//! shipped without a body. This crate gives the runtime its first real,
+//! model-selectable, world-touching tool.
+//!
+//! ## Why a thin, synchronous, hand-rolled client
+//!
+//! [`kx_capability::Capability::invoke`] is **synchronous**. The workspace's only
+//! HTTP client (`ureq`) and JSON codec (`serde_json`) are synchronous too, and
+//! `tokio` is quarantined to the distribution layer. Pulling the async `rmcp` SDK
+//! would force a `block_on` inside `invoke` (a nested-runtime hazard under the
+//! distributed worker's tokio) and a heavy tokio+hyper+reqwest tree that strains
+//! `cargo-deny` + the minimalism rule. So this adapter hand-rolls a minimal MCP
+//! JSON-RPC client over the existing sync stack:
+//!
+//! - **M5.2a (this crate today):** a newline-delimited JSON-RPC `tools/call` over a
+//!   [`StdioTransport`] subprocess — no network, no TLS, CI-friendly.
+//! - **M5.2b (next):** an `ureq` streamable-HTTP [`McpTransport`] impl + the
+//!   `MacOsSandbox`/cloud-broker egress bracket (the OSS `bwrap`-egress gap, D94).
+//!
+//! The transport is a trait ([`McpTransport`]) so the HTTP impl drops in without
+//! touching [`McpCapability`].
+//!
+//! ## Security posture (MCP is UNTRUSTED)
+//!
+//! - **Fail-closed inbound decode (IMP-5/IMP-16):** [`decode::decode_tool_result`]
+//!   is total + panic-free over arbitrary / truncated bytes, size-capped, and
+//!   refuses anything that is not a well-formed JSON-RPC `tools/call` result.
+//! - **Effects are world-mutating by default → `StageThenCommit` (D66):**
+//!   [`McpCapability`]'s `supported_patterns` is exactly `[StageThenCommit]`.
+//! - **Provenance, not hard-integrity (D72):** MCP output is external data; the
+//!   broker stages it with the capability identity as its provenance record.
+//! - **Secrets out-of-band, never embedded (D81):** credentials are referenced by
+//!   [`CredentialRef`] and injected into the transport at dispatch time — never
+//!   placed in an `EffectRequest`, a `BrokerHandle`, the journal, a `MoteId`, or a
+//!   `StepRecord`.
+//!
+//! The warrant gate (net_scope ⊆ warrant, tool_grants, pattern) is enforced by the
+//! existing `kx_capability::LocalCapabilityBroker::precheck` — this crate adds a
+//! `Capability` body, never a second gate.
+
+mod capability;
+mod credential;
+mod decode;
+mod errors;
+mod jsonrpc;
+mod transport;
+
+pub use capability::McpCapability;
+pub use credential::CredentialRef;
+pub use decode::{decode_tool_result, MAX_TOOL_RESULT_BYTES_DEFAULT};
+pub use errors::{DecodeError, TransportError};
+pub use transport::{McpTransport, StdioTransport};

--- a/crates/kx-mcp/src/transport.rs
+++ b/crates/kx-mcp/src/transport.rs
@@ -1,0 +1,183 @@
+//! [`McpTransport`] — the request/response seam, plus the M5.2a [`StdioTransport`].
+//!
+//! The transport is a trait so the M5.2b `ureq` streamable-HTTP impl drops in
+//! behind it without touching [`crate::McpCapability`]. [`StdioTransport`] speaks
+//! newline-delimited JSON-RPC to a subprocess MCP server over its stdin/stdout —
+//! no network, no TLS. Credentials are injected into the child's environment
+//! out-of-band (D81); the response read is **bounded** by the caller's size cap
+//! (IMP-16) and **wall-clock-bounded** (a watchdog kills a hung server).
+
+use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
+
+use crate::credential::CredentialRef;
+use crate::errors::TransportError;
+
+/// Fallback wall-clock budget when the warrant supplies none (`0`): 30 s. Keeps a
+/// hung or chatty server from blocking a dispatch indefinitely while not failing a
+/// legitimately slow tool that simply has no explicit ceiling.
+const DEFAULT_WALL_CLOCK_MS: u64 = 30_000;
+
+/// The MCP transport seam: one synchronous request/response round-trip.
+///
+/// Implementations carry no per-call mutable state (a fresh round-trip per
+/// `invoke`), so `Send + Sync` is trivially satisfied — required because
+/// [`crate::McpCapability`] is held behind a `Send + Sync` `Capability`.
+pub trait McpTransport: Send + Sync {
+    /// Send `request` (a complete JSON-RPC message, without a trailing newline) and
+    /// return the server's raw response bytes.
+    ///
+    /// The implementation MUST bound the response read to at most
+    /// `max_response_bytes + 1` bytes (so the decoder can detect an oversize body
+    /// without the transport buffering an unbounded amount) and MUST abandon the
+    /// call after `wall_clock_ms` (a `0` budget means "use a sane default").
+    ///
+    /// # Errors
+    ///
+    /// [`TransportError`] on spawn/connection failure, I/O failure, or timeout.
+    fn round_trip(
+        &self,
+        request: &[u8],
+        max_response_bytes: usize,
+        wall_clock_ms: u64,
+    ) -> Result<Vec<u8>, TransportError>;
+}
+
+/// A subprocess MCP transport: newline-delimited JSON-RPC over the child's
+/// stdin/stdout.
+///
+/// M5.2a is **single-shot**: write one `tools/call` request, read one response.
+/// The `initialize`/`initialized` handshake a stateful MCP server expects is a
+/// documented forward seam (M5.2b); the bundled test server is handshake-free.
+#[derive(Debug, Default)]
+pub struct StdioTransport {
+    program: OsString,
+    args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
+    credentials: Vec<CredentialRef>,
+}
+
+impl StdioTransport {
+    /// Build a transport that launches `program` as the MCP server subprocess.
+    #[must_use]
+    pub fn new(program: impl Into<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            envs: Vec::new(),
+            credentials: Vec::new(),
+        }
+    }
+
+    /// Append a command-line argument for the server subprocess.
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Set a plain (non-secret) environment variable on the server subprocess.
+    #[must_use]
+    pub fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.envs.push((key.into(), value.into()));
+        self
+    }
+
+    /// Register a credential to inject into the subprocess environment out-of-band
+    /// at dispatch time (D81). The secret value is read transiently when the child
+    /// is spawned and is never stored on this struct.
+    #[must_use]
+    pub fn credential(mut self, credential: CredentialRef) -> Self {
+        self.credentials.push(credential);
+        self
+    }
+}
+
+impl McpTransport for StdioTransport {
+    fn round_trip(
+        &self,
+        request: &[u8],
+        max_response_bytes: usize,
+        wall_clock_ms: u64,
+    ) -> Result<Vec<u8>, TransportError> {
+        let mut cmd = Command::new(&self.program);
+        cmd.args(&self.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        for (key, value) in &self.envs {
+            cmd.env(key, value);
+        }
+        // Out-of-band secret injection (D81): read from the host env into the child
+        // env; the secret never transits an EffectRequest / handle / journal.
+        for credential in &self.credentials {
+            credential.inject_into(&mut cmd);
+        }
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| TransportError::Unreachable(e.to_string()))?;
+
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| TransportError::Io("child stdin unavailable".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| TransportError::Io("child stdout unavailable".to_string()))?;
+
+        // Bound the read to cap+1 bytes so an oversize body is detectable by the
+        // decoder without the transport buffering it all.
+        let read_cap = u64::try_from(max_response_bytes.saturating_add(1)).unwrap_or(u64::MAX);
+        let request_owned = request.to_vec();
+        let (tx, rx) = mpsc::channel();
+        // BOTH the write and the read run on the worker thread, so the wall-clock
+        // watchdog below covers the FULL round-trip. (If the write ran on the parent
+        // and a server filled the OS pipe buffer without draining stdin, the parent
+        // could block in `write_all` BEFORE the watchdog armed — an unkillable hang.)
+        let reader = std::thread::spawn(move || {
+            let write = stdin
+                .write_all(&request_owned)
+                .and_then(|()| stdin.write_all(b"\n"))
+                .and_then(|()| stdin.flush());
+            drop(stdin); // EOF to the server, regardless of write outcome
+            if let Err(e) = write {
+                let _ = tx.send(Err(e));
+                return;
+            }
+            let mut buf = Vec::new();
+            let outcome = stdout.take(read_cap).read_to_end(&mut buf);
+            // The receiver may already be gone (timeout) — ignore a closed channel.
+            let _ = tx.send(outcome.map(|_| buf));
+        });
+
+        let budget = Duration::from_millis(if wall_clock_ms == 0 {
+            DEFAULT_WALL_CLOCK_MS
+        } else {
+            wall_clock_ms
+        });
+
+        let result = match rx.recv_timeout(budget) {
+            Ok(Ok(bytes)) => Ok(bytes),
+            Ok(Err(e)) => Err(TransportError::Io(e.to_string())),
+            Err(RecvTimeoutError::Timeout) => Err(TransportError::Timeout { wall_clock_ms }),
+            Err(RecvTimeoutError::Disconnected) => {
+                Err(TransportError::Io("reader thread disconnected".to_string()))
+            }
+        };
+
+        // Reap the child unconditionally (kill on the error/timeout paths so a hung
+        // server cannot linger); the reader thread then observes EOF and finishes.
+        if result.is_err() {
+            let _ = child.kill();
+        }
+        let _ = child.wait();
+        let _ = reader.join();
+
+        result
+    }
+}

--- a/crates/kx-mcp/tests/common/mod.rs
+++ b/crates/kx-mcp/tests/common/mod.rs
@@ -1,0 +1,121 @@
+//! Shared fixtures for the kx-mcp integration tests: a Mote that declares the MCP
+//! tool in its `tool_contract`, a warrant that grants it (net_scope = None, fs
+//! empty — the stdio transport needs no egress), and an `EffectRequest` builder.
+
+#![allow(
+    dead_code,
+    unreachable_pub,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::doc_markdown
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_capability::EffectRequest;
+use kx_mcp::{McpCapability, StdioTransport};
+use kx_mote::{
+    EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote, MoteDef,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_tool_registry::McpEndpointId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, ToolGrant,
+    WarrantSpec,
+};
+
+/// An `McpCapability` over the bundled stdio echo server (default mode).
+#[must_use]
+pub fn echo_capability(name: ToolName, version: ToolVersion) -> McpCapability {
+    McpCapability::new(
+        name,
+        version,
+        McpEndpointId("stdio://mock".into()),
+        "echo",
+        Box::new(StdioTransport::new(MOCK_SERVER)),
+    )
+}
+
+/// Absolute path to the bundled test stdio MCP server (set by Cargo for this crate's
+/// integration tests because the server is one of this crate's `[[bin]]` targets).
+pub const MOCK_SERVER: &str = env!("CARGO_BIN_EXE_kx-mcp-mock-stdio");
+
+/// The MCP tool the fixtures use: `mcp-echo@1`.
+#[must_use]
+pub fn tool() -> (ToolName, ToolVersion) {
+    (ToolName("mcp-echo".into()), ToolVersion("1".into()))
+}
+
+/// A WorldMutating `StageThenCommit` Mote that declares `(tool_name, tool_version)`
+/// in its `tool_contract` (so `LocalCapabilityBroker::precheck` admits the call).
+#[must_use]
+pub fn sample_mote(tool_name: &ToolName, tool_version: &ToolVersion) -> Mote {
+    let mut tool_contract = BTreeMap::new();
+    tool_contract.insert(tool_name.clone(), tool_version.clone());
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([7; 32]),
+        model_id: ModelId("m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([7; 32]),
+        tool_contract,
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([7; 32]),
+        GraphPosition(vec![7]),
+        smallvec::SmallVec::new(),
+    )
+}
+
+/// A warrant granting exactly `(tool_name, tool_version)`, no egress, no fs.
+#[must_use]
+pub fn warrant_granting(tool_name: &ToolName, tool_version: &ToolVersion) -> WarrantSpec {
+    let mut tool_grants = BTreeSet::new();
+    tool_grants.insert(ToolGrant {
+        tool_id: tool_name.clone(),
+        tool_version: tool_version.clone(),
+    });
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 256,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 5_000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// An `EffectRequest` carrying `args_json` (the tool arguments) under
+/// `StageThenCommit` with no egress / fs.
+#[must_use]
+pub fn effect(args_json: &str) -> EffectRequest {
+    EffectRequest {
+        payload: args_json.as_bytes().to_vec(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+    }
+}

--- a/crates/kx-mcp/tests/defaults_stage_then_commit.rs
+++ b/crates/kx-mcp/tests/defaults_stage_then_commit.rs
@@ -1,0 +1,42 @@
+//! D66 — MCP effects are world-mutating by default: `McpCapability` honors ONLY
+//! `StageThenCommit`, and the broker gate refuses any other pattern.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{echo_capability, effect, sample_mote, tool, warrant_granting};
+use kx_capability::{BrokerError, Capability, CapabilityBroker, LocalCapabilityBroker};
+use kx_content::InMemoryContentStore;
+use kx_mote::EffectPattern;
+
+#[test]
+fn supports_only_stage_then_commit() {
+    let (name, version) = tool();
+    let cap = echo_capability(name, version);
+    assert_eq!(
+        cap.supported_patterns(),
+        &[EffectPattern::StageThenCommit][..],
+        "MCP effects are world-mutating by default (D66)"
+    );
+}
+
+#[test]
+fn unsupported_pattern_is_refused_by_the_gate() {
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(echo_capability(name.clone(), version.clone())));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version);
+    let mut req = effect("{}");
+    req.pattern = EffectPattern::IdempotentByConstruction; // not in supported_patterns
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, req)
+        .expect_err("an unsupported pattern must be refused");
+    assert!(matches!(err, BrokerError::UnsupportedPattern { .. }));
+}

--- a/crates/kx-mcp/tests/dispatch_through_broker.rs
+++ b/crates/kx-mcp/tests/dispatch_through_broker.rs
@@ -1,0 +1,100 @@
+//! D80 — `McpCapability` dispatches THROUGH the real `LocalCapabilityBroker`
+//! (the authoritative warrant gate) over the real `StdioTransport`, and the
+//! staged result carries the MCP capability identity as provenance (D72).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{effect, sample_mote, tool, warrant_granting, MOCK_SERVER};
+use kx_capability::{BrokerError, CapabilityBroker, LocalCapabilityBroker};
+use kx_content::{ContentStore, InMemoryContentStore};
+use kx_mcp::{McpCapability, StdioTransport};
+use kx_mote::ToolName;
+use kx_tool_registry::McpEndpointId;
+use kx_warrant::{NetScope, WarrantField};
+
+fn echo_capability(name: ToolName, version: kx_mote::ToolVersion) -> McpCapability {
+    let transport = Box::new(StdioTransport::new(MOCK_SERVER)); // default echo mode
+    McpCapability::new(
+        name,
+        version,
+        McpEndpointId("stdio://mock".into()),
+        "echo",
+        transport,
+    )
+}
+
+#[test]
+fn dispatches_through_broker_stages_result_with_provenance() {
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store.clone());
+    broker.register_capability(Box::new(echo_capability(name.clone(), version.clone())));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version);
+
+    let handle = broker
+        .dispatch(&mote, &warrant, &name, effect(r#"{"q":"hello"}"#))
+        .expect("MCP dispatch should succeed through the broker");
+
+    // Provenance (D72): the handle records WHICH capability/version produced the bytes.
+    assert_eq!(handle.capability, name);
+    assert_eq!(handle.capability_version, version);
+
+    // The staged bytes are the MCP server's `result` object, verbatim.
+    let staged = store.get(&handle.staged_ref).unwrap();
+    assert_eq!(&*staged, br#"{"echoed":{"q":"hello"}}"#);
+}
+
+#[test]
+fn refused_when_capability_not_in_tool_contract() {
+    // A Mote whose tool_contract does NOT declare the tool ⇒ UnknownCapability,
+    // even though the capability is registered + granted (the broker gate holds).
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(echo_capability(name.clone(), version.clone())));
+
+    let other = ToolName("not-declared".into());
+    let mote = sample_mote(&other, &version); // contract declares `not-declared`, not `mcp-echo`
+    let warrant = warrant_granting(&name, &version);
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect("{}"))
+        .expect_err("a tool not in the contract must be refused");
+    assert!(matches!(err, BrokerError::UnknownCapability { .. }));
+}
+
+#[test]
+fn refused_when_net_scope_exceeds_warrant() {
+    // The broker gate enforces request.net_scope ⊆ warrant.net_scope. An MCP
+    // dispatch that requests egress under a None-egress warrant is refused on the
+    // NetScope axis (the M5.2b HTTP path relies on exactly this gate).
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(echo_capability(name.clone(), version.clone())));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version); // net_scope = None
+    let mut req = effect("{}");
+    req.net_scope = NetScope::EgressAllowlist(
+        [kx_warrant::Host("example.com".into())]
+            .into_iter()
+            .collect(),
+    );
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, req)
+        .expect_err("egress beyond the warrant must be refused");
+    assert!(matches!(
+        err,
+        BrokerError::CapabilityExceedsWarrant {
+            axis: WarrantField::NetScope
+        }
+    ));
+}

--- a/crates/kx-mcp/tests/proptest_decode.rs
+++ b/crates/kx-mcp/tests/proptest_decode.rs
@@ -1,0 +1,41 @@
+//! IMP-5 / IMP-16 — the fail-closed inbound decoder is TOTAL over arbitrary +
+//! truncated bytes (never panics) and always size-capped. SN-4: ≥64 cases.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kx_mcp::{decode_tool_result, DecodeError};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Arbitrary bytes never panic; the result is always `Ok` or a typed `Err`.
+    #[test]
+    fn decode_is_total_over_arbitrary_bytes(
+        bytes in proptest::collection::vec(any::<u8>(), 0..1024),
+        cap in 0usize..2048,
+    ) {
+        let _ = decode_tool_result(&bytes, cap);
+    }
+
+    /// Any cap below the input length is caught as `Oversize`, content-independent.
+    #[test]
+    fn oversize_is_always_caught(bytes in proptest::collection::vec(any::<u8>(), 1..512)) {
+        let cap = bytes.len() - 1;
+        let got = decode_tool_result(&bytes, cap);
+        prop_assert!(
+            matches!(got, Err(DecodeError::Oversize { .. })),
+            "any cap below the input length must be caught as Oversize"
+        );
+    }
+
+    /// Every prefix of a well-formed response decodes without panicking (the full
+    /// string is valid; truncations are refused fail-closed, never crash).
+    #[test]
+    fn every_prefix_of_a_valid_response_is_safe(n in 0usize..90) {
+        const FULL: &[u8] =
+            br#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}"#;
+        let end = n.min(FULL.len());
+        let _ = decode_tool_result(&FULL[..end], 4096);
+    }
+}

--- a/crates/kx-mcp/tests/scale_decode.rs
+++ b/crates/kx-mcp/tests/scale_decode.rs
@@ -1,0 +1,23 @@
+//! Scale-smoke (run explicitly: `cargo test -p kx-mcp --release -- --ignored`).
+//! The decoder stays linear on a near-cap valid result and rejects an over-cap
+//! body in O(1) (the size check precedes any parse).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kx_mcp::decode_tool_result;
+
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored"]
+fn decode_handles_near_cap_and_rejects_over_cap() {
+    let cap = 8 * 1024 * 1024; // 8 MiB
+    let filler = "x".repeat(cap - 1024);
+    let body = format!(r#"{{"jsonrpc":"2.0","id":1,"result":{{"t":"{filler}"}}}}"#);
+    assert!(body.len() < cap, "near-cap body fits the cap");
+
+    let out = decode_tool_result(body.as_bytes(), cap).expect("near-cap valid result decodes");
+    assert!(out.len() > cap - 2048, "the full result object is returned");
+
+    // Over-cap: rejected on the length check, before any allocation/parse (O(1)).
+    let over = vec![b'x'; cap + 1];
+    assert!(decode_tool_result(&over, cap).is_err());
+}

--- a/crates/kx-mcp/tests/secrets_never_leak.rs
+++ b/crates/kx-mcp/tests/secrets_never_leak.rs
@@ -1,0 +1,89 @@
+//! D81 / IMP-15 — a credential supplied out-of-band reaches NONE of the runtime
+//! sinks: the `EffectRequest.payload`, the `BrokerHandle` provenance, the staged
+//! result bytes (the journal/content store), or the `MoteId`. The credential
+//! reference itself also never prints the secret value.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{effect, sample_mote, tool, warrant_granting, MOCK_SERVER};
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_content::{ContentStore, InMemoryContentStore};
+use kx_mcp::{CredentialRef, McpCapability, StdioTransport};
+use kx_tool_registry::McpEndpointId;
+
+/// Distinctive secret value that must never appear in any runtime sink.
+const SECRET: &str = "SUPER_SECRET_sk-DEADBEEF-do-not-leak-0123456789";
+/// The env var that "holds" the secret (the credential identity).
+const CRED_VAR: &str = "KX_MCP_TEST_CRED_SECRETS_LEAK";
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[test]
+fn credential_ref_redacts_the_secret_in_debug_and_display() {
+    // The reference prints only its identity (the var name), never the value.
+    let cred = CredentialRef::from_env_var(CRED_VAR);
+    assert_eq!(cred.identity(), CRED_VAR);
+    assert!(!format!("{cred:?}").contains(SECRET));
+    assert!(!format!("{cred}").contains(SECRET));
+}
+
+#[test]
+fn secret_reaches_no_runtime_sink() {
+    // The secret lives in the runtime's environment and is referenced by the
+    // capability's credential — it is genuinely "in play" for this dispatch.
+    std::env::set_var(CRED_VAR, SECRET);
+
+    let (name, version) = tool();
+    let transport = Box::new(
+        StdioTransport::new(MOCK_SERVER).credential(CredentialRef::from_env_var(CRED_VAR)),
+    );
+    let cap = McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId("stdio://mock".into()),
+        "echo",
+        transport,
+    );
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store.clone());
+    broker.register_capability(Box::new(cap));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version);
+    let req = effect(r#"{"q":"hi"}"#);
+    let payload = req.payload.clone();
+
+    let handle = broker.dispatch(&mote, &warrant, &name, req).unwrap();
+    let staged = store.get(&handle.staged_ref).unwrap();
+
+    let secret = SECRET.as_bytes();
+    // (1) EffectRequest.payload (the tool args) — never the secret.
+    assert!(
+        !contains(&payload, secret),
+        "secret leaked into EffectRequest.payload"
+    );
+    // (2) BrokerHandle provenance — records the capability identity, never the secret.
+    assert!(
+        !format!("{handle:?}").contains(SECRET),
+        "secret leaked into BrokerHandle provenance"
+    );
+    // (3) The staged result bytes (what the journal commits / the content store holds).
+    assert!(
+        !contains(&staged, secret),
+        "secret leaked into the staged result"
+    );
+    // (4) The MoteId.
+    assert!(
+        !contains(mote.id.as_bytes(), secret),
+        "secret leaked into the MoteId"
+    );
+
+    std::env::remove_var(CRED_VAR);
+}

--- a/crates/kx-mcp/tests/staged_result_cap.rs
+++ b/crates/kx-mcp/tests/staged_result_cap.rs
@@ -1,0 +1,54 @@
+//! IMP-16 — a resource-exhausting MCP response is refused fail-closed (nothing is
+//! staged), bounded by the capability's `max_response_bytes` cap.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{effect, sample_mote, tool, warrant_granting, MOCK_SERVER};
+use kx_capability::{
+    BrokerError, CapabilityBroker, CapabilityFailureReason, LocalCapabilityBroker,
+};
+use kx_content::InMemoryContentStore;
+use kx_mcp::{McpCapability, StdioTransport};
+use kx_tool_registry::McpEndpointId;
+
+#[test]
+fn oversize_response_is_refused_and_nothing_is_staged() {
+    let (name, version) = tool();
+    // The server emits ~100 KB; the capability caps the response at 256 bytes.
+    let transport = Box::new(
+        StdioTransport::new(MOCK_SERVER)
+            .env("KX_MCP_MOCK_MODE", "big")
+            .env("KX_MCP_MOCK_BIG_BYTES", "100000"),
+    );
+    let cap = McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId("stdio://mock".into()),
+        "echo",
+        transport,
+    )
+    .with_max_response_bytes(256);
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(cap));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version);
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect("{}"))
+        .expect_err("an over-cap response must be refused");
+    // The oversize decode maps to InvalidResponse; the broker never staged it.
+    assert!(matches!(
+        err,
+        BrokerError::CapabilityFailure {
+            reason: CapabilityFailureReason::InvalidResponse,
+            ..
+        }
+    ));
+}

--- a/crates/kx-mcp/tests/support/mock_stdio_server.rs
+++ b/crates/kx-mcp/tests/support/mock_stdio_server.rs
@@ -1,0 +1,85 @@
+//! Test-support MCP server: a newline-delimited JSON-RPC `tools/call` responder
+//! the integration tests spawn to exercise the REAL [`kx_mcp::StdioTransport`]
+//! (env injection + round-trip). NOT part of the library surface.
+//!
+//! Behaviour is selected by `KX_MCP_MOCK_MODE` (default `echo`):
+//! - `echo` — reply `{"result":{"echoed":<arguments verbatim>}}`, deterministic in the request args (content-addressed dedup on replay).
+//! - `big` — reply with a result string of `KX_MCP_MOCK_BIG_BYTES` chars (drives the IMP-16 oversize-cap refusal).
+//! - `error` — reply with a JSON-RPC `error` object.
+//! - `malformed` — reply with truncated/garbled JSON.
+//! - `slow` — sleep `KX_MCP_MOCK_SLEEP_MS` then `echo` (drives the timeout path).
+//!
+//! A well-behaved server NEVER echoes its environment, so the secrets-never-leak
+//! test can prove an injected credential does not reach any sink.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::io::{BufRead, Write};
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+#[derive(Deserialize)]
+struct Req {
+    params: Params,
+}
+
+#[derive(Deserialize)]
+struct Params {
+    #[serde(default)]
+    arguments: Option<Box<RawValue>>,
+}
+
+fn main() {
+    let mode = std::env::var("KX_MCP_MOCK_MODE").unwrap_or_else(|_| "echo".to_string());
+
+    // Read exactly one JSON-RPC request line from stdin.
+    let mut line = String::new();
+    let stdin = std::io::stdin();
+    let _ = stdin.lock().read_line(&mut line);
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    let response: String = match mode.as_str() {
+        "big" => {
+            let n: usize = std::env::var("KX_MCP_MOCK_BIG_BYTES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1_000_000);
+            let filler = "x".repeat(n);
+            format!(r#"{{"jsonrpc":"2.0","id":1,"result":{{"blob":"{filler}"}}}}"#)
+        }
+        "error" => {
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"mock error"}}"#.to_string()
+        }
+        "malformed" => r#"{"jsonrpc":"2.0","id":1,"result":{"content":"#.to_string(),
+        "slow" => {
+            let ms: u64 = std::env::var("KX_MCP_MOCK_SLEEP_MS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(60_000);
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+            echo(&line)
+        }
+        _ => echo(&line),
+    };
+
+    let _ = writeln!(out, "{response}");
+    let _ = out.flush();
+}
+
+/// Echo the request's `arguments` verbatim inside a JSON-RPC result.
+fn echo(request_line: &str) -> String {
+    match serde_json::from_str::<Req>(request_line) {
+        Ok(req) => {
+            let args = req
+                .params
+                .arguments
+                .map_or_else(|| "{}".to_string(), |a| a.get().to_string());
+            format!(r#"{{"jsonrpc":"2.0","id":1,"result":{{"echoed":{args}}}}}"#)
+        }
+        Err(_) => r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32700,"message":"parse error"}}"#
+            .to_string(),
+    }
+}

--- a/crates/kx-mcp/tests/timeout.rs
+++ b/crates/kx-mcp/tests/timeout.rs
@@ -1,0 +1,68 @@
+//! The transport wall-clock watchdog: a slow/hung MCP server is abandoned within
+//! the per-call budget (it does NOT block the dispatch for the server's full
+//! sleep), reaped without a zombie, and surfaced as a typed `Timeout` failure.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use common::{effect, sample_mote, tool, warrant_granting, MOCK_SERVER};
+use kx_capability::{
+    BrokerError, CapabilityBroker, CapabilityFailureReason, LocalCapabilityBroker,
+};
+use kx_content::InMemoryContentStore;
+use kx_mcp::{McpCapability, StdioTransport};
+use kx_tool_registry::McpEndpointId;
+
+#[test]
+fn slow_server_is_timed_out_promptly() {
+    let (name, version) = tool();
+    // The server sleeps 60s before responding; the capability budgets 150ms.
+    let transport = Box::new(
+        StdioTransport::new(MOCK_SERVER)
+            .env("KX_MCP_MOCK_MODE", "slow")
+            .env("KX_MCP_MOCK_SLEEP_MS", "60000"),
+    );
+    let cap = McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId("stdio://mock".into()),
+        "echo",
+        transport,
+    )
+    .with_wall_clock_ms(150);
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(cap));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version);
+
+    let started = Instant::now();
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect("{}"))
+        .expect_err("a slow server must time out");
+    let elapsed = started.elapsed();
+
+    // The watchdog fired (Timeout), NOT the 60s server sleep completing.
+    assert!(
+        matches!(
+            err,
+            BrokerError::CapabilityFailure {
+                reason: CapabilityFailureReason::Timeout,
+                ..
+            }
+        ),
+        "expected a Timeout failure, got {err:?}"
+    );
+    // And it returned promptly — the dispatch did not wait out the 60s sleep
+    // (generous bound to avoid CI flakiness; the budget was 150ms).
+    assert!(
+        elapsed.as_secs() < 10,
+        "dispatch should abandon the hung server promptly, took {elapsed:?}"
+    );
+}

--- a/crates/kx-model-harness/Cargo.toml
+++ b/crates/kx-model-harness/Cargo.toml
@@ -28,7 +28,9 @@ kx-capture.workspace = true
 blake3.workspace = true
 smallvec.workspace = true
 serde.workspace = true
-serde_json.workspace = true
+# `raw_value` carries a model-proposed tool call's args verbatim (opaque bytes,
+# never a dynamic `Value`/floats) in `toolcall::parse_tool_call` (M5.2, IMP-5).
+serde_json = { workspace = true, features = ["raw_value"] }
 tracing.workspace = true
 
 [build-dependencies]
@@ -40,6 +42,10 @@ tempfile.workspace = true
 # The deterministic-critic evaluator — used by tests to independently re-derive a
 # verdict over a producer's bytes and confirm byte-identity with the committed one.
 kx-critic.workspace = true
+# M5.2: the concrete McpCapability + StdioTransport the model-driven-tool-step tests
+# register on a LocalCapabilityBroker. A DEV-dependency only — the harness lib stays
+# decoupled from the MCP client (it routes through `dyn CapabilityBroker`).
+kx-mcp.workspace = true
 
 [features]
 # Gates the GGUF download (build.rs) + the real-model integration tests. Off by

--- a/crates/kx-model-harness/src/broker.rs
+++ b/crates/kx-model-harness/src/broker.rs
@@ -23,12 +23,12 @@ use std::sync::{Arc, Mutex};
 use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
 use kx_content::ContentStore;
 use kx_inference::{inference_params_from_mote, InferenceBackend};
-use kx_mote::{Mote, MoteId, ToolName, ToolVersion};
+use kx_mote::{EffectPattern, Mote, MoteId, ToolName, ToolVersion};
 use kx_runtime::{CrashPoint, SnapshotSink};
 use kx_tool_registry::ToolRegistry;
-use kx_warrant::WarrantSpec;
+use kx_warrant::{FsScope, NetScope, WarrantSpec};
 
-use crate::{context, prompt};
+use crate::{context, prompt, toolcall};
 
 /// Capability version reported on every harness dispatch.
 const CAPABILITY_VERSION: &str = "kx-model-harness-0.1.0";
@@ -67,6 +67,13 @@ pub struct ModelBroker<B: InferenceBackend, S: ContentStore> {
     observer: Arc<BrokerObserver>,
     sink: SnapshotSink,
     registry: Arc<dyn ToolRegistry>,
+    /// M5.2: where a model-proposed tool call is dispatched after the fail-closed
+    /// decode. Holds the concrete `McpCapability` (registered by the caller) so the
+    /// proposal flows through the authoritative `LocalCapabilityBroker::precheck`
+    /// warrant gate (net_scope ⊆ warrant, tool_grants, pattern) — never a second,
+    /// re-implemented gate. An empty broker means "no tools" (the model's proposals,
+    /// if any, are refused as ungranted before reaching here).
+    tool_broker: Arc<dyn CapabilityBroker>,
 }
 
 impl<B: InferenceBackend, S: ContentStore> std::fmt::Debug for ModelBroker<B, S> {
@@ -79,6 +86,7 @@ impl<B: InferenceBackend, S: ContentStore> std::fmt::Debug for ModelBroker<B, S>
             .field("observer", &self.observer)
             .field("sink", &self.sink)
             .field("registry", &"<dyn ToolRegistry>")
+            .field("tool_broker", &"<dyn CapabilityBroker>")
             .finish_non_exhaustive()
     }
 }
@@ -89,6 +97,7 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
     /// through `observer`, plus the D78 context seams (snapshot sink + tool
     /// registry).
     #[must_use]
+    #[allow(clippy::too_many_arguments)] // Wiring seam; grouped meaningfully (M5.2 adds tool_broker).
     pub fn new(
         backend: Arc<B>,
         store: Arc<S>,
@@ -97,6 +106,7 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
         observer: Arc<BrokerObserver>,
         sink: SnapshotSink,
         registry: Arc<dyn ToolRegistry>,
+        tool_broker: Arc<dyn CapabilityBroker>,
     ) -> Self {
         Self {
             backend,
@@ -106,6 +116,7 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
             observer,
             sink,
             registry,
+            tool_broker,
         }
     }
 
@@ -115,6 +126,17 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
         let mut bytes = b"kx-model-harness-tool:".to_vec();
         bytes.extend_from_slice(mote_id.as_bytes());
         bytes
+    }
+
+    /// Scenario-1 (`PreCommitStc`) crash injection: abort AFTER the effect is staged
+    /// (the staged content + `EffectStaged` journal entry are durable) but BEFORE
+    /// the commit protocol appends `Committed`. Shared by the model-completion and
+    /// the model-driven-MCP staging paths.
+    fn maybe_crash_pre_commit_stc(&self, mote_id: MoteId) {
+        if self.crash_at == Some(CrashPoint::PreCommitStc) && self.stc_crash_target == Some(mote_id)
+        {
+            CrashPoint::PreCommitStc.abort_now();
+        }
     }
 }
 
@@ -169,7 +191,48 @@ where
                     capability: capability.clone(),
                     diagnostic: format!("model dispatch: {e}"),
                 })?;
-            out.bytes
+
+            // M5.2 — IMP-5: decode a model-PROPOSED tool call, fail-closed. The
+            // model selects a tool from the menu M5.1 placed in its context; the
+            // runtime ENFORCES (SN-8). On a valid, warrant-granted call we route it
+            // through `tool_broker` — whose `precheck` is the authoritative warrant
+            // gate (net_scope ⊆ warrant, tool_grants, pattern) — and return its
+            // handle (already carrying the MCP capability identity as provenance,
+            // D72). No call ⇒ commit the completion bytes (byte-identical to
+            // pre-M5.2; the A–J rows grant no tools ⇒ always this arm). A malformed
+            // or ungranted proposal is REFUSED and never fires an effect.
+            match toolcall::parse_tool_call(&out.bytes, warrant, toolcall::max_args_bytes(warrant))
+            {
+                Ok(Some(call)) => {
+                    let effect = EffectRequest {
+                        payload: call.args_bytes,
+                        // MCP effects are world-mutating by default → StageThenCommit (D66).
+                        pattern: EffectPattern::StageThenCommit,
+                        // Run-stable dedup: a recovery re-dispatch re-derives the same
+                        // token (= mote.id) so the staged effect is exactly-once
+                        // (content-addressed). Matches the existing row-G tool path.
+                        // M5.2b note: when the HTTP transport sends a real remote
+                        // `Idempotency-Key` header, switch to `run_scoped_token`
+                        // (kx_capability::token) so a re-SUBMITTED run gets a fresh key.
+                        idempotency_key: Some(token),
+                        // M5.2a stdio transport performs no egress.
+                        net_scope: NetScope::None,
+                        fs_scope: FsScope::empty(),
+                    };
+                    let handle = self
+                        .tool_broker
+                        .dispatch(mote, warrant, &call.name, effect)?;
+                    self.maybe_crash_pre_commit_stc(mote.id);
+                    return Ok(handle);
+                }
+                Ok(None) => out.bytes,
+                Err(reason) => {
+                    return Err(BrokerError::StageWriteFailed {
+                        capability: capability.clone(),
+                        diagnostic: format!("model-proposed tool call rejected: {reason:?}"),
+                    });
+                }
+            }
         } else {
             Self::tool_response(&mote.id)
         };
@@ -189,10 +252,7 @@ where
         // `EffectStaged` is already in the journal because StageThenCommit
         // writes it before calling dispatch) but BEFORE the commit protocol
         // appends `Committed`.
-        if self.crash_at == Some(CrashPoint::PreCommitStc) && self.stc_crash_target == Some(mote.id)
-        {
-            CrashPoint::PreCommitStc.abort_now();
-        }
+        self.maybe_crash_pre_commit_stc(mote.id);
 
         Ok(BrokerHandle {
             staged_ref,

--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -37,6 +37,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
 use kx_content::LocalFsContentStore;
 use kx_executor::{LocalResourceManager, StandardCommitProtocol};
 use kx_inference::LlamaInferenceBackend;
@@ -56,6 +57,7 @@ pub mod evidence;
 pub mod executor;
 pub mod metered;
 pub mod prompt;
+pub mod toolcall;
 pub mod workflows;
 
 pub use broker::{BrokerObserver, ModelBroker};
@@ -216,6 +218,29 @@ impl Harness {
         config: &RuntimeConfig,
         workflow: &DemoWorkflow,
     ) -> Result<RunOutcome, RuntimeError> {
+        // Default: NO MCP capability registered. A model that proposes a tool call
+        // then has no matching `warrant.tool_grants` entry → `parse_tool_call`
+        // returns `Ok(None)` → the path is byte-identical to pre-M5.2 (the A–J
+        // rows are unaffected). The model-driven MCP path is exercised via
+        // [`drive_with_tool_broker`] (M5.2 deterministic tests); a real MCP server
+        // for the bin is M5.2b.
+        let tool_broker: Arc<dyn CapabilityBroker> =
+            Arc::new(LocalCapabilityBroker::new(self.store.clone()));
+        self.drive_with_tool_broker(config, workflow, tool_broker)
+    }
+
+    /// Like [`drive`](Self::drive), but routes a model-proposed tool call through
+    /// `tool_broker` (M5.2). Register the concrete `McpCapability` on a
+    /// `LocalCapabilityBroker` and pass it here: a model Mote whose warrant grants
+    /// that tool can then SELECT it (the runtime decodes the proposal fail-closed
+    /// and dispatches through the warrant gate). An empty broker reproduces
+    /// [`drive`](Self::drive) exactly.
+    pub fn drive_with_tool_broker(
+        &self,
+        config: &RuntimeConfig,
+        workflow: &DemoWorkflow,
+        tool_broker: Arc<dyn CapabilityBroker>,
+    ) -> Result<RunOutcome, RuntimeError> {
         let rm = LocalResourceManager::dev_defaults();
         // D78 context seams: one snapshot sink shared with the orchestrator + a
         // tool registry the assembler resolves tool grants against. The
@@ -238,6 +263,7 @@ impl Harness {
             self.observer.clone(),
             sink.clone(),
             registry,
+            tool_broker,
         ));
         let protocol =
             StandardCommitProtocol::new(self.store.clone(), self.journal.clone(), broker);

--- a/crates/kx-model-harness/src/toolcall.rs
+++ b/crates/kx-model-harness/src/toolcall.rs
@@ -1,0 +1,281 @@
+//! IMP-5 — the fail-closed decode of a **model-proposed** tool call.
+//!
+//! M5.1 put a tool *menu* in front of the model; M5.2 lets the model *pick* one.
+//! Model output is untrusted: [`parse_tool_call`] decodes it into a validated
+//! [`ToolCall`] (or `None` for a normal completion) and is **total + panic-free**
+//! over arbitrary bytes. "Model proposes, runtime enforces" (SN-8): the only tools
+//! a proposal may name are those already in `warrant.tool_grants` — selection is
+//! exact (crypto-equality of the `(name, version)` grant), never fuzzy. The broker
+//! re-checks the grant at dispatch; this is the first, defense-in-depth gate.
+//!
+//! The decoded `args_bytes` are carried VERBATIM (the args object's bytes) into the
+//! `EffectRequest.payload` — validated for *shape* (well-formed JSON), never
+//! executed, never interpreted into a dynamic value here.
+
+use kx_mote::{ToolName, ToolVersion};
+use kx_warrant::{ToolGrant, WarrantSpec};
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+/// A validated, warrant-granted tool call the model proposed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCall {
+    /// The tool's name — guaranteed `∈ warrant.tool_grants`.
+    pub name: ToolName,
+    /// The tool's pinned version — matched exactly against the grant.
+    pub version: ToolVersion,
+    /// The proposed arguments, verbatim JSON bytes (size-capped, never executed).
+    pub args_bytes: Vec<u8>,
+}
+
+/// Why a model output that *looked like* a tool call was refused. (A normal
+/// completion is `Ok(None)`, not an error.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The output began as a JSON object but the tool-call envelope was malformed,
+    /// truncated, or carried trailing garbage. Fail-closed — a half-formed proposal
+    /// never fires an effect.
+    Malformed {
+        /// A short structural diagnostic (never the raw payload).
+        diagnostic: String,
+    },
+    /// The model named a tool that is not in `warrant.tool_grants` (SN-8: the model
+    /// cannot authorize an action the runtime did not grant).
+    UngrantedTool {
+        /// The proposed (ungranted) tool name.
+        name: ToolName,
+        /// The proposed version.
+        version: ToolVersion,
+    },
+    /// The proposed arguments exceed the per-call size cap (IMP-16).
+    Oversize {
+        /// Observed args size in bytes.
+        got: usize,
+        /// The cap.
+        max: usize,
+    },
+}
+
+/// The JSON envelope a model uses to propose a tool call:
+/// `{"tool_call": {"name": "...", "version": "...", "args": { ... }}}`.
+#[derive(Deserialize)]
+struct Envelope {
+    #[serde(default)]
+    tool_call: Option<RawToolCall>,
+}
+
+#[derive(Deserialize)]
+struct RawToolCall {
+    name: String,
+    version: String,
+    args: Box<RawValue>,
+}
+
+/// The per-call args-size cap (IMP-16), derived from the warrant's output ceiling
+/// (`max_output_tokens · 4` — the model produced the args, so the output budget
+/// bounds them). Saturating, mirroring `context::window_bytes_from_warrant`.
+#[must_use]
+pub fn max_args_bytes(warrant: &WarrantSpec) -> usize {
+    (warrant.model_route.max_output_tokens as usize).saturating_mul(4)
+}
+
+/// Decode a model-proposed tool call from raw model output, fail-closed.
+///
+/// Returns `Ok(None)` for a normal completion (prose, non-envelope JSON, or — the
+/// important security default — *any* output when the warrant grants no tools).
+/// Returns `Ok(Some(call))` for a well-formed, warrant-granted, size-bounded call.
+/// Returns `Err` when the model committed to a tool-call envelope that is malformed,
+/// names an ungranted tool, or overshoots the args cap.
+///
+/// Total + panic-free over arbitrary `bytes`.
+pub fn parse_tool_call(
+    bytes: &[u8],
+    warrant: &WarrantSpec,
+    max_args_bytes: usize,
+) -> Result<Option<ToolCall>, DecodeError> {
+    // (0) No grants ⇒ no tool can ever be called. Preserves the M5.1 leaf path
+    //     byte-for-byte (every existing harness row grants no tools) AND is the
+    //     security default: a model cannot conjure a tool the warrant withheld.
+    if warrant.tool_grants.is_empty() {
+        return Ok(None);
+    }
+
+    // (1) Non-UTF-8 or not-a-JSON-object output is a normal completion, not a call.
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return Ok(None);
+    };
+    let trimmed = text.trim_start();
+    if !trimmed.starts_with('{') {
+        return Ok(None);
+    }
+
+    // (2) It looks like JSON. Parse strictly — trailing garbage / truncation /
+    //     bad shape is fail-closed (the injection vector lives here).
+    let envelope: Envelope = serde_json::from_str(trimmed).map_err(|e| DecodeError::Malformed {
+        diagnostic: e.to_string(),
+    })?;
+    let Some(raw) = envelope.tool_call else {
+        // Valid JSON, but not a tool-call envelope ⇒ a normal completion.
+        return Ok(None);
+    };
+
+    // (3) The model committed to a tool call. Enforce tool ∈ warrant.tool_grants
+    //     by EXACT (name, version) crypto-equality — never fuzzy (SN-8 / D70).
+    let name = ToolName(raw.name);
+    let version = ToolVersion(raw.version);
+    let grant = ToolGrant {
+        tool_id: name.clone(),
+        tool_version: version.clone(),
+    };
+    if !warrant.tool_grants.contains(&grant) {
+        return Err(DecodeError::UngrantedTool { name, version });
+    }
+
+    // (4) Carry the args verbatim, size-capped (IMP-16).
+    let args_bytes = raw.args.get().as_bytes().to_vec();
+    if args_bytes.len() > max_args_bytes {
+        return Err(DecodeError::Oversize {
+            got: args_bytes.len(),
+            max: max_args_bytes,
+        });
+    }
+
+    Ok(Some(ToolCall {
+        name,
+        version,
+        args_bytes,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_warrant::{
+        ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+    };
+    use std::collections::BTreeSet;
+
+    fn warrant_granting(tool: Option<(&str, &str)>) -> WarrantSpec {
+        let mut tool_grants = BTreeSet::new();
+        if let Some((id, ver)) = tool {
+            tool_grants.insert(ToolGrant {
+                tool_id: ToolName(id.into()),
+                tool_version: ToolVersion(ver.into()),
+            });
+        }
+        WarrantSpec {
+            mote_class: MoteClass::WorldMutating,
+            nd_class: MoteClass::WorldMutating,
+            fs_scope: FsScope::empty(),
+            net_scope: NetScope::None,
+            syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+            tool_grants,
+            model_route: ModelRoute {
+                model_id: kx_mote::ModelId("m".into()),
+                max_input_tokens: 1024,
+                max_output_tokens: 256,
+                max_calls: 8,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 1000,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::Bwrap,
+        }
+    }
+
+    #[test]
+    fn empty_grants_is_always_none() {
+        let w = warrant_granting(None);
+        // Even a perfectly-formed envelope yields None when nothing is granted.
+        let env = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{}}}"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn prose_is_a_normal_completion() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        assert_eq!(
+            parse_tool_call(b"The sky is blue.", &w, 4096),
+            Ok(None),
+            "prose ⇒ no tool call"
+        );
+    }
+
+    #[test]
+    fn non_envelope_json_is_a_normal_completion() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        assert_eq!(parse_tool_call(br#"{"answer":"blue"}"#, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn well_formed_granted_call_is_decoded() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{"q":"x"}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn garbled_envelope_is_malformed_not_silently_dropped() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Started as a JSON object (committed to a call) but truncated → fail-closed.
+        let env = br#"{"tool_call":{"name":"mcp-echo","version":"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn trailing_garbage_after_envelope_is_malformed() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{}}} then prose"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn ungranted_tool_is_refused() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Right shape, but names a tool/version not in the grant set.
+        let env = br#"{"tool_call":{"name":"mcp-danger","version":"1","args":{}}}"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+        // Same name, wrong version ⇒ also ungranted (exact match, SN-8).
+        let env2 = br#"{"tool_call":{"name":"mcp-echo","version":"2","args":{}}}"#;
+        assert!(matches!(
+            parse_tool_call(env2, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn oversize_args_are_refused() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let big = "x".repeat(100);
+        let env = format!(
+            r#"{{"tool_call":{{"name":"mcp-echo","version":"1","args":{{"q":"{big}"}}}}}}"#
+        );
+        assert!(matches!(
+            parse_tool_call(env.as_bytes(), &w, 8),
+            Err(DecodeError::Oversize { .. })
+        ));
+    }
+
+    #[test]
+    fn non_utf8_is_a_normal_completion_not_a_panic() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        assert_eq!(parse_tool_call(&[0xff, 0xfe, 0x00], &w, 4096), Ok(None));
+    }
+}

--- a/crates/kx-model-harness/src/workflows.rs
+++ b/crates/kx-model-harness/src/workflows.rs
@@ -281,3 +281,62 @@ pub fn tool_stage(model_id: &ModelId, warrant: &WarrantSpec) -> DemoWorkflow {
     let tool_id = tool.id;
     wrap(vec![tool], warrant, tool_id, sentinel_shaper())
 }
+
+/// **M5.2 — first model-driven tool step.** A single WorldMutating
+/// `StageThenCommit` *model* Mote that carries `prompt_text` AND declares the MCP
+/// tool `(tool_id, tool_version)` in its `tool_contract` (so the broker's precheck
+/// passes). Drive it through [`crate::Harness::drive_with_tool_broker`] with a
+/// broker holding an `McpCapability` registered under `tool_id`: the model runs,
+/// the runtime decodes its proposed tool call fail-closed, and dispatches it
+/// through the warrant gate to the MCP capability. The caller's `warrant` MUST
+/// grant `(tool_id, tool_version)`. `stc_crash_target = the Mote` so
+/// `--crash-at pre-commit-stc` exercises exactly-once-under-crash on the MCP path.
+#[must_use]
+pub fn model_tool_call(
+    model_id: &ModelId,
+    warrant: &WarrantSpec,
+    prompt_text: &str,
+    tool_id: &ToolName,
+    tool_version: &kx_mote::ToolVersion,
+) -> DemoWorkflow {
+    let mut config_subset = BTreeMap::new();
+    prompt::put_prompt(&mut config_subset, prompt_text);
+    let mut tool_contract = BTreeMap::new();
+    tool_contract.insert(tool_id.clone(), tool_version.clone());
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([0x50; 32]),
+        model_id: model_id.clone(),
+        prompt_template_hash: PromptTemplateHash::from_bytes([0x50; 32]),
+        tool_contract,
+        nd_class: NdClass::WorldMutating,
+        config_subset,
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: greedy(64),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    let m = Mote::new(
+        def,
+        InputDataId::from_bytes([0x50; 32]),
+        GraphPosition(vec![0x50]),
+        SmallVec::new(),
+    );
+    let m_id = m.id;
+    // The Mote dispatches under the MCP tool's own name (the capability the broker
+    // resolves), not the "kx-model" pseudo-capability — so the OUTER executor's
+    // EffectRequest names the MCP tool and the inner broker's tool_contract +
+    // tool_grants checks are coherent.
+    let motes = vec![WorkflowMote {
+        mote: m,
+        warrant: warrant.clone(),
+        capability: tool_id.clone(),
+    }];
+    DemoWorkflow {
+        motes,
+        stc_crash_target: m_id,
+        vtc_crash_target: sentinel_shaper(),
+        shaper_id: sentinel_shaper(),
+    }
+}

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
 use kx_content::LocalFsContentStore;
 use kx_executor::{LocalResourceManager, StandardCommitProtocol};
 use kx_inference::{InferenceBackend, InferenceError, InferenceInput, InferenceOutput};
@@ -214,6 +215,10 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         registry.clone(),
     );
     let observer = Arc::new(BrokerObserver::default());
+    // M5.2: an empty tool broker (these wiring tests assert the menu/parent bytes
+    // reach the model — not tool selection), so the routing is inert here.
+    let tool_broker: Arc<dyn CapabilityBroker> =
+        Arc::new(LocalCapabilityBroker::new(store.clone()));
     let broker = Arc::new(ModelBroker::new(
         backend,
         store.clone(),
@@ -222,6 +227,7 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         observer,
         sink.clone(),
         registry,
+        tool_broker,
     ));
     let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
     let rm = LocalResourceManager::dev_defaults();

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -1,0 +1,349 @@
+//! M5.2 — the FIRST model-driven tool step, end-to-end through the real
+//! `run_with_seams` orchestrator, deterministically (a stub backend stands in for
+//! the GGUF). Proves:
+//!
+//! - **routing:** a model that emits a tool-call envelope → fail-closed decode →
+//!   dispatch through the warrant/broker gate → `McpCapability` → committed result;
+//! - **determinism/dedup:** two independent runs commit the byte-identical result
+//!   ref (a recovery re-dispatch stages identical bytes ⇒ exactly-once rides the
+//!   unchanged StageThenCommit machinery proven by row-G `kill_and_replay`);
+//! - **fail-closed:** a malformed proposal never fires an effect (nothing commits).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_content::{ContentStore, LocalFsContentStore};
+use kx_executor::{LocalResourceManager, StandardCommitProtocol};
+use kx_inference::{InferenceBackend, InferenceError, InferenceInput, InferenceOutput};
+use kx_journal::SqliteJournal;
+use kx_mcp::{McpCapability, McpTransport, TransportError};
+use kx_model_harness::{harness_warrant, workflows, BrokerObserver, ModelBroker, ModelExecutor};
+use kx_mote::{ModelId, MoteId, ToolName, ToolVersion};
+use kx_projection::{MoteState, Projection};
+use kx_runtime::config::Mode;
+use kx_runtime::{run_with_seams, RunOutcome, RuntimeConfig, RuntimeError, SnapshotSink};
+use kx_tool_registry::{
+    IdempotencyClass, InMemoryToolRegistry, McpEndpointId, ToolDef, ToolKind, ToolProvenance,
+    ToolRegistry,
+};
+use kx_warrant::{FsScope, NetScope, ResourceCeiling, ToolGrant, ToolRequirement, WarrantSpec};
+
+fn model_id() -> ModelId {
+    ModelId("stub-model:test:0".to_string())
+}
+
+/// A registry carrying the builtins PLUS the MCP tool `(tool, version)` so the
+/// M5.1 tool-menu assembler can resolve it (the model selects it from that menu).
+fn registry_with_mcp(tool: &ToolName, version: &ToolVersion) -> InMemoryToolRegistry {
+    let mut reg = InMemoryToolRegistry::with_builtins();
+    let _ = reg.register(
+        ToolDef {
+            tool_id: tool.clone(),
+            tool_version: version.clone(),
+            kind: ToolKind::Mcp {
+                endpoint: McpEndpointId("inproc://const".into()),
+                remote_name: "echo".into(),
+            },
+            required_capability: ToolRequirement {
+                net_scope_required: NetScope::None, // in-proc/stdio: no egress
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: "MCP echo tool (M5.2 test).".into(),
+            idempotency_class: IdempotencyClass::Staged,
+        },
+        ToolProvenance::HumanAuthored {
+            author: "test".into(),
+        },
+    );
+    reg
+}
+
+/// A stub backend that returns a fixed completion regardless of input — standing in
+/// for a model that decided to call a tool.
+struct FixedBackend {
+    completion: Vec<u8>,
+}
+
+impl InferenceBackend for FixedBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &kx_mote::InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        Ok(InferenceOutput {
+            bytes: self.completion.clone(),
+            output_tokens: 1,
+            backend_name: "fixed-stub",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(0),
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "fixed-stub"
+    }
+}
+
+/// An in-process MCP transport returning a constant `tools/call` result — no
+/// subprocess (the real `StdioTransport` is exercised by the kx-mcp crate tests).
+struct ConstResultTransport;
+
+impl McpTransport for ConstResultTransport {
+    fn round_trip(
+        &self,
+        _request: &[u8],
+        _max: usize,
+        _ms: u64,
+    ) -> Result<Vec<u8>, TransportError> {
+        Ok(br#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.to_vec())
+    }
+}
+
+/// The decoded MCP result object the transport above yields (what gets committed).
+const EXPECTED_RESULT: &[u8] = br#"{"ok":true}"#;
+
+fn warrant_granting(tool: &ToolName, version: &ToolVersion) -> WarrantSpec {
+    let mut w = harness_warrant(&model_id(), 64, 5_000);
+    w.tool_grants.insert(ToolGrant {
+        tool_id: tool.clone(),
+        tool_version: version.clone(),
+    });
+    w
+}
+
+fn config_for(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+    }
+}
+
+/// Drive a single-Mote `model_tool_call` workflow with a stub backend whose output
+/// is `completion`, routing tool calls to an `McpCapability` over the const
+/// transport. Returns the run result + the (store, journal) for inspection.
+fn drive(
+    dir: &Path,
+    tool: &ToolName,
+    version: &ToolVersion,
+    completion: &[u8],
+) -> (
+    Result<RunOutcome, RuntimeError>,
+    Arc<LocalFsContentStore>,
+    Arc<SqliteJournal>,
+    MoteId,
+) {
+    let config = config_for(dir);
+    let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+    let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+    let backend = Arc::new(FixedBackend {
+        completion: completion.to_vec(),
+    });
+    let sink = SnapshotSink::new();
+    let registry: Arc<dyn ToolRegistry> = Arc::new(registry_with_mcp(tool, version));
+
+    // The tool broker holds the concrete McpCapability under the granted name.
+    let tool_broker_concrete = LocalCapabilityBroker::new(store.clone());
+    tool_broker_concrete.register_capability(Box::new(McpCapability::new(
+        tool.clone(),
+        version.clone(),
+        McpEndpointId("inproc://const".into()),
+        "echo",
+        Box::new(ConstResultTransport),
+    )));
+    let tool_broker: Arc<dyn CapabilityBroker> = Arc::new(tool_broker_concrete);
+
+    let warrant = warrant_granting(tool, version);
+    let workflow =
+        workflows::model_tool_call(&model_id(), &warrant, "call the tool", tool, version);
+    let m_id = workflow.stc_crash_target;
+
+    let executor = ModelExecutor::new(
+        backend.clone(),
+        store.clone(),
+        sink.clone(),
+        registry.clone(),
+    );
+    let broker = Arc::new(ModelBroker::new(
+        backend,
+        store.clone(),
+        None,
+        Some(workflow.stc_crash_target),
+        Arc::new(BrokerObserver::default()),
+        sink.clone(),
+        registry,
+        tool_broker,
+    ));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let result = run_with_seams(
+        &config,
+        &workflow,
+        store.clone(),
+        journal.clone(),
+        &rm,
+        &executor,
+        &protocol,
+        None,
+        Some(&sink),
+    );
+    (result, store, journal, m_id)
+}
+
+/// A well-formed tool-call envelope naming the granted tool.
+fn envelope(tool: &str, version: &str) -> Vec<u8> {
+    format!(r#"{{"tool_call":{{"name":"{tool}","version":"{version}","args":{{"q":"x"}}}}}}"#)
+        .into_bytes()
+}
+
+#[test]
+fn model_selects_tool_and_runtime_dispatches_through_mcp() {
+    let tool = ToolName("mcp-echo".into());
+    let version = ToolVersion("1".into());
+    let dir = tempfile::tempdir().unwrap();
+
+    let (result, store, journal, m_id) =
+        drive(dir.path(), &tool, &version, &envelope("mcp-echo", "1"));
+
+    let outcome = result.expect("run completes");
+    assert!(
+        outcome.is_complete(),
+        "the single model-tool Mote committed"
+    );
+
+    // The committed result is the MCP capability's output (routed through the gate).
+    let projection = Projection::from_journal(&*journal).unwrap();
+    let result_ref = projection.result_ref_of(&m_id).expect("Mote committed");
+    let bytes = store.get(&result_ref).unwrap();
+    assert_eq!(
+        &*bytes, EXPECTED_RESULT,
+        "committed bytes are the MCP result"
+    );
+}
+
+#[test]
+fn model_driven_dispatch_is_deterministic_across_runs() {
+    let tool = ToolName("mcp-echo".into());
+    let version = ToolVersion("1".into());
+
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let (ra, sa, ja, ma) = drive(dir_a.path(), &tool, &version, &envelope("mcp-echo", "1"));
+    let (rb, sb, jb, mb) = drive(dir_b.path(), &tool, &version, &envelope("mcp-echo", "1"));
+    assert!(ra.unwrap().is_complete() && rb.unwrap().is_complete());
+
+    // Same args ⇒ byte-identical staged bytes ⇒ identical content ref. This is the
+    // property that makes a recovery re-dispatch exactly-once (content-addressed
+    // dedup), riding the unchanged StageThenCommit machinery.
+    let ref_a = Projection::from_journal(&*ja)
+        .unwrap()
+        .result_ref_of(&ma)
+        .unwrap();
+    let ref_b = Projection::from_journal(&*jb)
+        .unwrap()
+        .result_ref_of(&mb)
+        .unwrap();
+    assert_eq!(
+        ref_a, ref_b,
+        "the MCP dispatch is deterministic across runs"
+    );
+    assert_eq!(&*sa.get(&ref_a).unwrap(), EXPECTED_RESULT);
+    assert_eq!(&*sb.get(&ref_b).unwrap(), EXPECTED_RESULT);
+}
+
+#[test]
+fn malformed_proposal_fires_no_effect() {
+    let tool = ToolName("mcp-echo".into());
+    let version = ToolVersion("1".into());
+    let dir = tempfile::tempdir().unwrap();
+
+    // A truncated envelope: the model "committed" to a call but garbled it. The
+    // decode is fail-closed → the effect NEVER fires → the Mote does not commit.
+    let garbled = br#"{"tool_call":{"name":"mcp-echo","version":"#.to_vec();
+    let (result, _store, journal, m_id) = drive(dir.path(), &tool, &version, &garbled);
+
+    // The run does not complete the Mote (it errored or stalled fail-closed).
+    if let Ok(outcome) = &result {
+        assert!(
+            !outcome.is_complete(),
+            "a malformed proposal must not complete the run"
+        );
+    }
+    let state = Projection::from_journal(&*journal).unwrap().state_of(&m_id);
+    assert_ne!(
+        state,
+        MoteState::Committed,
+        "no effect committed on a malformed proposal"
+    );
+}
+
+#[test]
+fn ungranted_proposal_fires_no_effect() {
+    let granted = ToolName("mcp-echo".into());
+    let version = ToolVersion("1".into());
+    let dir = tempfile::tempdir().unwrap();
+
+    // The model names a DIFFERENT tool than the one granted/declared → ungranted →
+    // refused fail-closed; no effect commits. (The Mote's contract/grant is mcp-echo.)
+    let (result, _store, journal, m_id) =
+        drive(dir.path(), &granted, &version, &envelope("mcp-danger", "1"));
+
+    if let Ok(outcome) = &result {
+        assert!(
+            !outcome.is_complete(),
+            "an ungranted proposal must not complete the run"
+        );
+    }
+    let state = Projection::from_journal(&*journal).unwrap().state_of(&m_id);
+    assert_ne!(
+        state,
+        MoteState::Committed,
+        "no effect committed on an ungranted proposal"
+    );
+}
+
+#[test]
+fn oversize_proposal_fires_no_effect() {
+    let tool = ToolName("mcp-echo".into());
+    let version = ToolVersion("1".into());
+    let dir = tempfile::tempdir().unwrap();
+
+    // The warrant grants 64 max_output_tokens ⇒ max_args_bytes = 256. Propose args
+    // well beyond that — the IMP-16 cap refuses fail-closed; no effect commits.
+    let big = "x".repeat(400);
+    let env =
+        format!(r#"{{"tool_call":{{"name":"mcp-echo","version":"1","args":{{"q":"{big}"}}}}}}"#)
+            .into_bytes();
+    let (result, _store, journal, m_id) = drive(dir.path(), &tool, &version, &env);
+
+    if let Ok(outcome) = &result {
+        assert!(
+            !outcome.is_complete(),
+            "an oversize proposal must not complete the run"
+        );
+    }
+    let state = Projection::from_journal(&*journal).unwrap().state_of(&m_id);
+    assert_ne!(
+        state,
+        MoteState::Committed,
+        "no effect committed on an oversize proposal"
+    );
+}


### PR DESCRIPTION
## M5.2a — the first model-driven tool step

The first move of the agentic surface (IMP-1): a model **selects** a tool from the menu M5.1 placed in its context, and the runtime **enforces** — decoding the proposal fail-closed and dispatching it through the existing warrant/broker gate to the **first production `Capability` impl**, an MCP client.

### What's here
- **NEW crate `kx-mcp`** — `McpCapability` (concrete `ToolKind::Mcp` dispatch, D80) over a thin **synchronous, hand-rolled** JSON-RPC client: a `std::process` **stdio** transport behind an `McpTransport` trait (the M5.2b HTTP/`ureq` impl drops in unchanged). Deliberately **not** the async `rmcp` SDK — fits the sync `Capability::invoke`, no tokio/`block_on`, keeps cargo-deny green, honors minimalism (Rule 6).
- **Decode/route seam in `kx-model-harness`** — `toolcall::parse_tool_call` (untrusted model output → validated `ToolCall`) wired into `ModelBroker::dispatch`, routed via `Arc<dyn CapabilityBroker>`. `Harness::drive_with_tool_broker` for the MCP path; `drive` keeps an empty broker so the A–J rows + canonical digest are byte-identical.

### Security (MCP is untrusted) — all fail-closed + proptested
- **IMP-5**: `decode_tool_result` (server output) + `parse_tool_call` (model output) — total/panic-free over arbitrary+truncated+deeply-nested+non-UTF8 bytes; never decode into a dynamic `Value` (RawValue verbatim, no float path).
- **SN-8**: a proposal may name ONLY a tool already in `warrant.tool_grants`, by **exact `(name,version)` crypto-equality** — double-gated (decode + the broker's authoritative `precheck`). Ungranted/malformed ⇒ no effect fires.
- **IMP-15 / D81**: credentials supplied out-of-band via `CredentialRef`, never embedded; property test proves a secret reaches NONE of payload / handle / staged bytes / MoteId.
- **IMP-16**: response size cap before parse + model-args size cap, fail-closed on overflow.
- **D66 / D72**: MCP effects default `StageThenCommit`; output is provenance-captured. Transport wall-clock watchdog covers the full round-trip (write+read), reaps the child (no zombie/thread-leak).

### Invariants held
- Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) diff **EMPTY**.
- Canonical product digest **`a6b5c679…` UNCHANGED** (`a0_guard`).
- Exactly-once-under-crash rides the unchanged StageThenCommit machinery (deterministic re-dispatch ⇒ content-addressed dedup, proven by an e2e determinism test).

### Golden Rule 8 pre-flight
- **(A) Breaks live?** Frozen-trio empty-diff + digest guard; MCP opt-in (tool-less warrant ⇒ byte-identical leaf); double-fire covered by StageThenCommit + mote-id token + content dedup.
- **(A) Perf?** Decode off the journal/fold hot path, capped; `invoke` blocks on I/O but the broker drops its lock first; per-call wall-clock bounded → typed `Timeout`.
- **(A) Security?** Two new untrusted inputs, both bytes-typed + proptest-fenced; egress net_scope ⊆ warrant; secrets out-of-band; model can only pick a granted tool.
- **(B) Forward:** first real effect with a model in the loop; object-safe broker ⇒ the hardened cloud broker swaps in for M5.2b egress; roadmap M5.2b (HTTP) → M5.3 (secrets) → M6 (planner) → M8 (SDK).

### Tests
`kx-mcp`: dispatch-through-broker (+ provenance), net-scope refusal, secrets-never-leak, staged-result cap, defaults-StageThenCommit, fail-closed decode proptest, deep-nesting panic-safety, timeout, scale (`#[ignore]`). `kx-model-harness`: `parse_tool_call` units + proptest, and e2e through `run_with_seams` — routing, determinism/dedup, malformed/ungranted/oversize fire-no-effect. Local gate green (clippy `-D warnings`, fmt, cargo-deny, doc `-D warnings`, 200 suites/0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)