### PR TITLE
feat(mcp,model-harness): HTTP transport + egress sandbox + remote exactly-once (M5.2b, D80/D81/D94)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,8 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tracing",
+ "ureq",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,10 @@ kx-mcp               = { path = "crates/kx-mcp",               version = "0.0.1"
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }
+# Endpoint URL parsing + host extraction for the M5.2b HttpTransport egress sandbox.
+# Already in the tree as a transitive dep of ureq (same locked 2.x) — promoting it to
+# a direct workspace dep adds no new crate.
+url                = "2"
 sha2               = "0.10"
 # Unix-only deps used by kx-executor's hardened spawn paths (fork+execvp +
 # sandbox_init via libc + setrlimit). Both crates are well-audited pure-Rust

--- a/crates/kx-mcp/Cargo.toml
+++ b/crates/kx-mcp/Cargo.toml
@@ -27,6 +27,10 @@ serde            = { workspace = true }
 serde_json       = { workspace = true, features = ["raw_value"] }
 thiserror        = { workspace = true }
 tracing          = { workspace = true }
+# M5.2b HTTP transport (sync; rustls+webpki-roots via the workspace `tls` feature).
+ureq             = { workspace = true }
+# Endpoint URL parse + host extraction for the egress sandbox (already in-tree via ureq).
+url              = { workspace = true }
 
 [dev-dependencies]
 # LocalCapabilityBroker + an in-memory ContentStore to dispatch McpCapability through

--- a/crates/kx-mcp/src/capability.rs
+++ b/crates/kx-mcp/src/capability.rs
@@ -134,10 +134,14 @@ impl Capability for McpCapability {
         tracing::debug!(remote = %self.remote_name, "mcp tools/call dispatch");
 
         // Untrusted round-trip: bounded read + wall-clock watchdog in the transport.
+        // The run-scoped idempotency key (D38 §1) rides through so an HTTP transport
+        // can send a remote `Idempotency-Key` header (remote exactly-once on a
+        // crash-recovery re-dispatch); stdio ignores it.
         let response = self.transport.round_trip(
             &request_bytes,
             self.max_response_bytes,
             self.wall_clock_ms,
+            request.idempotency_key.as_ref(),
         )?;
 
         // Fail-closed inbound decode (IMP-5 / IMP-16). Returns the result object's

--- a/crates/kx-mcp/src/credential.rs
+++ b/crates/kx-mcp/src/credential.rs
@@ -43,6 +43,24 @@ impl CredentialRef {
             cmd.env(&self.0, secret);
         }
     }
+
+    /// Read the referenced secret transiently from the host environment, for
+    /// injection as an HTTP request header (the M5.2b [`crate::HttpTransport`]
+    /// path — stdio injects into the child env instead, [`inject_into`]).
+    ///
+    /// Returns `None` when the variable is unset (the server then fails its own
+    /// auth — the runtime never fabricates a credential). The returned `String` is
+    /// the ONLY place the secret materializes: the caller injects it into a header
+    /// and drops it; it is never stored on this struct, an `EffectRequest`, a
+    /// `BrokerHandle`, the journal, a `MoteId`, or a `StepRecord` (D81). Because
+    /// the type still holds only the variable name, `Debug`/`Display` redaction is
+    /// unaffected.
+    ///
+    /// [`inject_into`]: Self::inject_into
+    #[must_use]
+    pub fn read_secret(&self) -> Option<String> {
+        std::env::var(&self.0).ok()
+    }
 }
 
 // Manual `Debug` — print ONLY the identity, never let a derived Debug expose a

--- a/crates/kx-mcp/src/egress.rs
+++ b/crates/kx-mcp/src/egress.rs
@@ -1,0 +1,388 @@
+//! Application-layer egress policy for the HTTP transport (M5.2b, D80/D94).
+//!
+//! The broker already gates `request.net_scope ⊆ warrant.net_scope` declaratively
+//! (`LocalCapabilityBroker::precheck`). This module is the **second, behavioural**
+//! half: it binds the host the [`crate::HttpTransport`] is *allowed* to dial to the
+//! host it *actually* resolves+connects to, and refuses the SSRF / DNS-rebind /
+//! cloud-metadata vectors that a declarative host check alone cannot see.
+//!
+//! It is deliberately **pure** (zero I/O): [`classify_ip`] + [`EgressPolicy`] +
+//! [`vet_resolved_addr`] are total functions over their inputs, so the security
+//! decision surface is unit-testable without a socket. The transport's
+//! `VettingResolver` is the only place that performs DNS and then calls
+//! [`vet_resolved_addr`] on each resolved address.
+//!
+//! ## Honest OSS boundary (D94, risk #8)
+//!
+//! This is an **application-layer** control. A *compromised in-process tool* could
+//! issue its own syscalls and bypass this resolver entirely; only kernel-level
+//! egress isolation (`bwrap` + nftables, NET_ADMIN — a `kx-cloud` concern) closes
+//! that. The OSS guarantee is: the runtime's own HTTP path never dials a host the
+//! warrant did not grant, never follows a cross-host redirect, and never reaches a
+//! private/loopback/link-local address via a public hostname (rebind defense).
+
+use std::collections::BTreeSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use kx_warrant::NetScope;
+
+/// Classification of a resolved IP address for SSRF / rebind defense.
+///
+/// Every variant except [`IpClass::Public`] is an address that must not be reached
+/// *implicitly* (via a public hostname). It may be reached only when the operator
+/// allowlisted that exact literal address — see [`vet_resolved_addr`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpClass {
+    /// A globally-routable address — reachable when its host is allowlisted.
+    Public,
+    /// `127.0.0.0/8`, `::1`.
+    Loopback,
+    /// `169.254.0.0/16` (**includes the `169.254.169.254` cloud-metadata IP**),
+    /// `fe80::/10`.
+    LinkLocal,
+    /// `10/8`, `172.16/12`, `192.168/16`, `fc00::/7` (IPv6 ULA).
+    Private,
+    /// `0.0.0.0`, `::`.
+    Unspecified,
+    /// `224.0.0.0/4`, `ff00::/8`.
+    Multicast,
+}
+
+impl IpClass {
+    /// True for every class that must not be reached implicitly (anything but
+    /// [`IpClass::Public`]).
+    #[must_use]
+    pub fn is_non_public(self) -> bool {
+        !matches!(self, IpClass::Public)
+    }
+}
+
+/// Classify `ip` into an [`IpClass`].
+///
+/// Ranges are matched **by raw octets** (not the unstable `std::net` `is_*` family)
+/// so classification is identical across toolchains. IPv4-mapped IPv6
+/// (`::ffff:a.b.c.d`) is un-mapped first so a mapped loopback/private address is
+/// classified by its embedded IPv4 (a mapped `::ffff:127.0.0.1` is loopback, never
+/// public).
+#[must_use]
+pub fn classify_ip(ip: &IpAddr) -> IpClass {
+    match ip {
+        IpAddr::V4(v4) => classify_v4(*v4),
+        IpAddr::V6(v6) => classify_v6(v6),
+    }
+}
+
+fn classify_v4(v4: Ipv4Addr) -> IpClass {
+    let o = v4.octets();
+    match o {
+        [0, 0, 0, 0] => IpClass::Unspecified,
+        [127, ..] => IpClass::Loopback,
+        // 169.254/16 link-local — INCLUDES 169.254.169.254 (cloud metadata).
+        [169, 254, ..] => IpClass::LinkLocal,
+        // 10/8, 192.168/16, and 172.16/12 (the guarded second octet).
+        [10, ..] | [192, 168, ..] => IpClass::Private,
+        [172, b, ..] if (16..=31).contains(&b) => IpClass::Private,
+        // 224.0.0.0/4 multicast (224–239 in the first octet).
+        [a, ..] if (224..=239).contains(&a) => IpClass::Multicast,
+        _ => IpClass::Public,
+    }
+}
+
+fn classify_v6(v6: &Ipv6Addr) -> IpClass {
+    // Un-map `::ffff:a.b.c.d` so a mapped IPv4 is classified by its embedded form.
+    // (`to_ipv4_mapped` matches ONLY `::ffff:x.x.x.x`, never `::1`/`::`, so it does
+    // not mis-fold loopback/unspecified.)
+    if let Some(v4) = v6.to_ipv4_mapped() {
+        return classify_v4(v4);
+    }
+    let o = v6.octets();
+    if o == [0; 16] {
+        return IpClass::Unspecified; // ::
+    }
+    if o == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] {
+        return IpClass::Loopback; // ::1
+    }
+    if o[0] == 0xff {
+        return IpClass::Multicast; // ff00::/8
+    }
+    if (o[0] & 0xfe) == 0xfc {
+        return IpClass::Private; // fc00::/7 (unique-local)
+    }
+    if o[0] == 0xfe && (o[1] & 0xc0) == 0x80 {
+        return IpClass::LinkLocal; // fe80::/10
+    }
+    IpClass::Public
+}
+
+/// The set of hosts the [`crate::HttpTransport`] may dial, derived from the
+/// warrant-validated `net_scope` of the resolved tool.
+///
+/// Host matching is **host-only** (no port, no scheme) and case-insensitive, to
+/// agree with `kx_warrant::NetScope`'s host-set `is_subset_of` semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressPolicy {
+    allowed_hosts: BTreeSet<String>,
+}
+
+impl EgressPolicy {
+    /// Build a policy from the granted `net_scope`. `NetScope::None` yields an
+    /// **empty** policy (every dial refused — fail-closed); an allowlist yields the
+    /// normalized host set.
+    #[must_use]
+    pub fn from_net_scope(scope: &NetScope) -> Self {
+        let allowed_hosts = match scope {
+            NetScope::None => BTreeSet::new(),
+            NetScope::EgressAllowlist(hosts) => {
+                hosts.iter().map(|h| normalize_host(&h.0)).collect()
+            }
+        };
+        Self { allowed_hosts }
+    }
+
+    /// True iff `host` (normalized) is explicitly allowlisted.
+    #[must_use]
+    pub fn permits_host(&self, host: &str) -> bool {
+        self.allowed_hosts.contains(&normalize_host(host))
+    }
+
+    /// True iff this policy permits no egress at all (a `NetScope::None` tool).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allowed_hosts.is_empty()
+    }
+}
+
+/// Normalize a host for comparison: trim, lowercase, strip a trailing FQDN dot and
+/// surrounding IPv6 brackets, so `Example.COM`, `example.com.`, and `[::1]`/`::1`
+/// compare equal to their canonical form.
+fn normalize_host(host: &str) -> String {
+    let h = host.trim().trim_end_matches('.');
+    let h = h
+        .strip_prefix('[')
+        .map_or(h, |rest| rest.strip_suffix(']').unwrap_or(rest));
+    h.to_ascii_lowercase()
+}
+
+/// Why a resolved address was refused egress.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressDenied {
+    /// The host is not in the warrant-derived allowlist.
+    HostNotAllowed {
+        /// The refused host (safe to log — never a secret).
+        host: String,
+    },
+    /// The host resolved to a non-public address (SSRF / DNS-rebind / metadata)
+    /// and was **not** an explicitly-allowlisted private literal.
+    PrivateAddressRefused {
+        /// The host whose resolution was refused.
+        host: String,
+        /// The class of the refused address.
+        class: IpClass,
+    },
+}
+
+/// Vet a resolved `addr` for `host` against `policy`. `Ok(())` ⇒ the transport may
+/// dial it; `Err` ⇒ refuse.
+///
+/// The rule (rebind / SSRF defense): a non-public address is refused **unless the
+/// host is a literal IP equal to that address** — i.e. the operator explicitly
+/// allowlisted that private/loopback literal. A *public hostname* that
+/// resolves (or rebinds) to a private/loopback/link-local address never parses as
+/// an IP literal, so it is always refused — a public name can never reach the
+/// metadata endpoint or an internal host through this transport.
+///
+/// # Errors
+///
+/// [`EgressDenied::HostNotAllowed`] if `host` is not allowlisted;
+/// [`EgressDenied::PrivateAddressRefused`] if it resolves to a non-public address
+/// it was not explicitly allowed to reach.
+pub fn vet_resolved_addr(
+    host: &str,
+    addr: &SocketAddr,
+    policy: &EgressPolicy,
+) -> Result<(), EgressDenied> {
+    if !policy.permits_host(host) {
+        return Err(EgressDenied::HostNotAllowed {
+            host: host.to_string(),
+        });
+    }
+    let class = classify_ip(&addr.ip());
+    if class == IpClass::Public {
+        return Ok(());
+    }
+    // Non-public: permit ONLY when the host is a literal IP equal to this address
+    // (an explicit operator opt-in, e.g. an allowlisted `127.0.0.1`). A DNS name
+    // that resolved here does not parse as an IP literal ⇒ refused (rebind/SSRF).
+    if let Ok(host_ip) = host.parse::<IpAddr>() {
+        if host_ip == addr.ip() {
+            return Ok(());
+        }
+    }
+    Err(EgressDenied::PrivateAddressRefused {
+        host: host.to_string(),
+        class,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_warrant::Host;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn classify_ipv4_ranges() {
+        assert_eq!(classify_ip(&v4(0, 0, 0, 0)), IpClass::Unspecified);
+        assert_eq!(classify_ip(&v4(127, 0, 0, 1)), IpClass::Loopback);
+        assert_eq!(classify_ip(&v4(127, 13, 9, 2)), IpClass::Loopback);
+        // The cloud-metadata endpoint MUST classify link-local.
+        assert_eq!(classify_ip(&v4(169, 254, 169, 254)), IpClass::LinkLocal);
+        assert_eq!(classify_ip(&v4(169, 254, 1, 1)), IpClass::LinkLocal);
+        assert_eq!(classify_ip(&v4(10, 0, 0, 1)), IpClass::Private);
+        assert_eq!(classify_ip(&v4(172, 16, 0, 1)), IpClass::Private);
+        assert_eq!(classify_ip(&v4(172, 31, 255, 255)), IpClass::Private);
+        // 172.32 is OUTSIDE the private block — public.
+        assert_eq!(classify_ip(&v4(172, 32, 0, 1)), IpClass::Public);
+        assert_eq!(classify_ip(&v4(172, 15, 0, 1)), IpClass::Public);
+        assert_eq!(classify_ip(&v4(192, 168, 1, 1)), IpClass::Private);
+        assert_eq!(classify_ip(&v4(192, 169, 1, 1)), IpClass::Public);
+        assert_eq!(classify_ip(&v4(224, 0, 0, 1)), IpClass::Multicast);
+        assert_eq!(classify_ip(&v4(239, 255, 255, 255)), IpClass::Multicast);
+        assert_eq!(classify_ip(&v4(8, 8, 8, 8)), IpClass::Public);
+        assert_eq!(classify_ip(&v4(1, 1, 1, 1)), IpClass::Public);
+    }
+
+    #[test]
+    fn classify_ipv6_ranges() {
+        assert_eq!(
+            classify_ip(&IpAddr::V6(Ipv6Addr::UNSPECIFIED)),
+            IpClass::Unspecified
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            IpClass::Loopback
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("fe80::1".parse().unwrap())),
+            IpClass::LinkLocal
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("fc00::1".parse().unwrap())),
+            IpClass::Private
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("fd12:3456::1".parse().unwrap())),
+            IpClass::Private
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("ff02::1".parse().unwrap())),
+            IpClass::Multicast
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("2606:4700::1111".parse().unwrap())),
+            IpClass::Public
+        );
+        // IPv4-mapped loopback must un-map to loopback, never public.
+        assert_eq!(
+            classify_ip(&IpAddr::V6("::ffff:127.0.0.1".parse().unwrap())),
+            IpClass::Loopback
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("::ffff:169.254.169.254".parse().unwrap())),
+            IpClass::LinkLocal
+        );
+        assert_eq!(
+            classify_ip(&IpAddr::V6("::ffff:8.8.8.8".parse().unwrap())),
+            IpClass::Public
+        );
+    }
+
+    fn policy(hosts: &[&str]) -> EgressPolicy {
+        let set: BTreeSet<Host> = hosts.iter().map(|h| Host((*h).to_string())).collect();
+        EgressPolicy::from_net_scope(&NetScope::EgressAllowlist(set))
+    }
+
+    #[test]
+    fn none_scope_is_empty_policy() {
+        let p = EgressPolicy::from_net_scope(&NetScope::None);
+        assert!(p.is_empty());
+        assert!(!p.permits_host("example.com"));
+    }
+
+    #[test]
+    fn permits_host_is_case_and_dot_and_bracket_insensitive() {
+        let p = policy(&["Example.COM", "127.0.0.1"]);
+        assert!(p.permits_host("example.com"));
+        assert!(p.permits_host("EXAMPLE.com."));
+        assert!(p.permits_host("127.0.0.1"));
+        assert!(!p.permits_host("evil.com"));
+        // Bracketed IPv6 literal normalizes to its bare form.
+        let p6 = policy(&["::1"]);
+        assert!(p6.permits_host("[::1]"));
+        assert!(p6.permits_host("::1"));
+    }
+
+    #[test]
+    fn vet_allows_public_allowlisted_host() {
+        let p = policy(&["api.example.com"]);
+        let addr = SocketAddr::new(v4(93, 184, 216, 34), 443);
+        assert_eq!(vet_resolved_addr("api.example.com", &addr, &p), Ok(()));
+    }
+
+    #[test]
+    fn vet_refuses_unallowlisted_host() {
+        let p = policy(&["api.example.com"]);
+        let addr = SocketAddr::new(v4(93, 184, 216, 34), 443);
+        assert!(matches!(
+            vet_resolved_addr("evil.com", &addr, &p),
+            Err(EgressDenied::HostNotAllowed { .. })
+        ));
+    }
+
+    #[test]
+    fn vet_refuses_public_host_rebinding_to_private() {
+        // The killer case: an allowlisted PUBLIC hostname that resolves/rebinds to a
+        // private or metadata IP. The host is not an IP literal ⇒ refused.
+        let p = policy(&["api.example.com"]);
+        for ip in [
+            v4(169, 254, 169, 254), // cloud metadata
+            v4(127, 0, 0, 1),
+            v4(10, 0, 0, 5),
+            v4(192, 168, 1, 1),
+        ] {
+            let addr = SocketAddr::new(ip, 80);
+            assert!(
+                matches!(
+                    vet_resolved_addr("api.example.com", &addr, &p),
+                    Err(EgressDenied::PrivateAddressRefused { .. })
+                ),
+                "rebind to {ip} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn vet_allows_explicit_private_literal() {
+        // An operator may explicitly allowlist a private/loopback LITERAL (e.g. a
+        // hermetic test server, or an on-prem internal host by IP).
+        let p = policy(&["127.0.0.1"]);
+        let addr = SocketAddr::new(v4(127, 0, 0, 1), 8080);
+        assert_eq!(vet_resolved_addr("127.0.0.1", &addr, &p), Ok(()));
+    }
+
+    #[test]
+    fn vet_refuses_private_literal_resolving_elsewhere() {
+        // A literal that (somehow) resolves to a DIFFERENT private IP than itself is
+        // refused — the opt-in is for the exact address only.
+        let p = policy(&["127.0.0.1"]);
+        let addr = SocketAddr::new(v4(10, 0, 0, 1), 8080);
+        assert!(matches!(
+            vet_resolved_addr("127.0.0.1", &addr, &p),
+            Err(EgressDenied::PrivateAddressRefused { .. })
+        ));
+    }
+}

--- a/crates/kx-mcp/src/http_transport.rs
+++ b/crates/kx-mcp/src/http_transport.rs
@@ -1,0 +1,392 @@
+//! [`HttpTransport`] — the M5.2b `ureq` HTTP [`McpTransport`] impl + its
+//! application-layer egress sandbox.
+//!
+//! This is the transport real MCP/external tools use (the M5.2a [`StdioTransport`]
+//! proved the seam over a subprocess). It POSTs the JSON-RPC `tools/call` body to a
+//! warrant-scoped endpoint and decodes the response fail-closed — exactly like the
+//! stdio path — but it also opens the network egress surface, so it is hardened on
+//! four independent fronts:
+//!
+//! 1. **Host-allowlist binding.** The endpoint host MUST be in the warrant-derived
+//!    [`EgressPolicy`] (built from the resolved tool's `net_scope`). The broker's
+//!    `precheck` already proved `request.net_scope ⊆ warrant.net_scope`; this binds
+//!    the *actually-dialed* host to that grant.
+//! 2. **SSRF / DNS-rebind defense.** A custom [`Resolver`](ureq::Resolver) vets every
+//!    resolved address through [`egress::vet_resolved_addr`] and refuses
+//!    private/loopback/link-local targets (incl. the `169.254.169.254` cloud-metadata
+//!    IP) unless the host is an explicitly-allowlisted literal — so a public hostname
+//!    can never rebind to an internal address.
+//! 3. **Redirect refusal.** The agent is built with `redirects(0)`; a `3xx` response
+//!    is refused outright (a cross-host redirect cannot smuggle egress past the gate).
+//! 4. **Hard wall-clock + size bounds.** A watchdog thread (mirroring
+//!    [`StdioTransport`]) guarantees the caller returns within the budget even if the
+//!    server slow-tricks; the response read is capped at `max_response_bytes + 1`.
+//!
+//! Secrets ride out-of-band: a [`CredentialRef`] is read transiently at dispatch and
+//! injected as a request header, never stored / journaled / staged (D81). The run's
+//! `idempotency_key` is sent as an `Idempotency-Key` header so a crash-recovery
+//! re-dispatch makes the *remote* effect exactly-once (D38 §1 / M1.2).
+//!
+//! OS-level egress isolation (`bwrap`/nftables) is **out of OSS scope** (D94) — see
+//! [`crate::egress`] for the honest boundary.
+
+use std::io::Read;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
+
+use url::Url;
+
+use crate::credential::CredentialRef;
+use crate::egress::{vet_resolved_addr, EgressPolicy};
+use crate::errors::TransportError;
+use crate::transport::{McpTransport, DEFAULT_WALL_CLOCK_MS};
+
+/// Slack added to the per-call budget for ureq's own request timeout, so a worker
+/// the watchdog has already abandoned still self-terminates (instead of lingering
+/// until the OS gives up). It is deliberately LARGER than the watchdog's grace so
+/// the watchdog always wins the race and the caller-facing outcome is a clean
+/// `Timeout` (not a ureq transport error). The watchdog (the warrant's
+/// `wall_clock_ms`) is the authoritative caller-facing bound.
+const WORKER_BACKSTOP_SLACK_MS: u64 = 5_000;
+
+/// Scheduling slack the watchdog allows beyond the budget before declaring a
+/// timeout (covers thread wake-up jitter; far smaller than the worker backstop).
+const WATCHDOG_GRACE_MS: u64 = 250;
+
+/// An HTTP MCP transport over a pooled [`ureq::Agent`].
+///
+/// The agent is built **once** (its connection pool + TLS session cache are reused
+/// across round-trips — no per-dispatch TLS handshake) and is cheap to `clone`
+/// (it shares the pool by `Arc`). It is wired with the vetting resolver +
+/// `redirects(0)` at construction, so every dial it can ever make is already
+/// egress-bound.
+pub struct HttpTransport {
+    agent: ureq::Agent,
+    endpoint: Url,
+    /// `header-name → credential` pairs injected transiently at dispatch (D81).
+    credentials: Vec<(String, CredentialRef)>,
+}
+
+impl std::fmt::Debug for HttpTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Print only header NAMES + the credential identities (never a secret);
+        // elide the agent (not `Debug`-meaningful).
+        f.debug_struct("HttpTransport")
+            .field("endpoint", &self.endpoint.as_str())
+            .field("credentials", &self.credentials)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HttpTransport {
+    /// Build an HTTP transport that POSTs to `endpoint_url`, permitted to dial only
+    /// hosts in `net_scope` (the resolved tool's warrant-validated egress).
+    ///
+    /// # Errors
+    ///
+    /// [`TransportError::Unreachable`] if `endpoint_url` is not a valid `http(s)`
+    /// URL with a host, or if that host is not permitted by `net_scope` (a
+    /// misconfiguration — the broker's `net_scope ⊆ warrant` gate would also refuse
+    /// it, but failing here keeps a mis-scoped transport from ever being built).
+    pub fn new(
+        endpoint_url: &str,
+        net_scope: &kx_warrant::NetScope,
+    ) -> Result<Self, TransportError> {
+        let endpoint = Url::parse(endpoint_url)
+            .map_err(|e| TransportError::Unreachable(format!("invalid endpoint URL: {e}")))?;
+        match endpoint.scheme() {
+            "http" | "https" => {}
+            other => {
+                return Err(TransportError::Unreachable(format!(
+                    "unsupported endpoint scheme: {other}"
+                )));
+            }
+        }
+        let host = endpoint
+            .host_str()
+            .ok_or_else(|| TransportError::Unreachable("endpoint has no host".to_string()))?
+            .to_string();
+
+        let policy = EgressPolicy::from_net_scope(net_scope);
+        if !policy.permits_host(&host) {
+            return Err(TransportError::Unreachable(format!(
+                "endpoint host {host} is not in the granted egress allowlist"
+            )));
+        }
+
+        let agent = ureq::AgentBuilder::new()
+            .resolver(VettingResolver {
+                policy: policy.clone(),
+            })
+            // Refuse ALL redirects: a 3xx surfaces as an Ok response we reject in
+            // `round_trip`, so a cross-host redirect can never smuggle egress.
+            .redirects(0)
+            // Safety is the host-allowlist + the vetting resolver, NOT the scheme:
+            // the hermetic test server is plaintext `http://127.0.0.1`. A
+            // TLS-required policy is a forward warrant axis (M5.3+).
+            .https_only(false)
+            // No FIXED agent-wide timeout: a per-call ureq timeout (set in
+            // `round_trip`, derived from the warrant budget) is the worker backstop,
+            // so a large legitimate budget is never pre-empted by a shared ceiling.
+            .build();
+
+        Ok(Self {
+            agent,
+            endpoint,
+            credentials: Vec::new(),
+        })
+    }
+
+    /// Register a credential to inject as the `header_name` request header,
+    /// transiently at dispatch time (D81). For a bearer token the caller supplies
+    /// the full value convention (e.g. an env var holding `Bearer <token>`); the
+    /// value is injected verbatim and never stored.
+    #[must_use]
+    pub fn header_credential(
+        mut self,
+        header_name: impl Into<String>,
+        credential: CredentialRef,
+    ) -> Self {
+        self.credentials.push((header_name.into(), credential));
+        self
+    }
+}
+
+impl McpTransport for HttpTransport {
+    fn round_trip(
+        &self,
+        request: &[u8],
+        max_response_bytes: usize,
+        wall_clock_ms: u64,
+        idempotency_key: Option<&[u8; 32]>,
+    ) -> Result<Vec<u8>, TransportError> {
+        let read_cap = u64::try_from(max_response_bytes.saturating_add(1)).unwrap_or(u64::MAX);
+        let budget_ms = if wall_clock_ms == 0 {
+            DEFAULT_WALL_CLOCK_MS
+        } else {
+            wall_clock_ms
+        };
+        let budget = Duration::from_millis(budget_ms);
+        // The worker's own (looser) ureq timeout: strictly larger than the watchdog
+        // so the watchdog wins the race (caller sees `Timeout`, not a ureq error),
+        // while an abandoned worker still self-terminates rather than lingering.
+        let worker_timeout =
+            Duration::from_millis(budget_ms.saturating_add(WORKER_BACKSTOP_SLACK_MS));
+
+        // Resolve credential secrets transiently HERE (they live only in this local
+        // Vec for the duration of the call, then drop — never on `self`).
+        let headers: Vec<(String, String)> = self
+            .credentials
+            .iter()
+            .filter_map(|(name, cred)| cred.read_secret().map(|val| (name.clone(), val)))
+            .collect();
+        let idempotency_header = idempotency_key.map(hex32);
+
+        // Clone the pooled agent (Arc-shared) + owned inputs onto the worker thread,
+        // so BOTH the send and the body read run under the wall-clock watchdog —
+        // mirrors StdioTransport (ureq's per-read timeout is not a hard *total*
+        // bound, and ureq has no in-flight cancel, so the watchdog is authoritative).
+        let agent = self.agent.clone();
+        let url = self.endpoint.to_string();
+        let body = request.to_vec();
+        let (tx, rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let mut req = agent
+                .post(&url)
+                .timeout(worker_timeout)
+                .set("Content-Type", "application/json")
+                .set("Accept", "application/json");
+            if let Some(ref key) = idempotency_header {
+                req = req.set("Idempotency-Key", key);
+            }
+            for (name, value) in &headers {
+                req = req.set(name, value);
+            }
+            // `headers` (and the secrets inside) drop at the end of this closure.
+
+            let outcome = match req.send_bytes(&body) {
+                Ok(resp) => read_capped(resp, read_cap),
+                // ureq classifies 4xx/5xx as `Status`; a `tools/call` over those is
+                // not a result — surface as Io (the decoder would also fail-closed).
+                Err(ureq::Error::Status(code, _)) => {
+                    Err(TransportError::Io(format!("http status {code}")))
+                }
+                // Transport errors: connect refused, TLS failure, and — crucially —
+                // the vetting resolver's egress refusal (an io::Error it raised).
+                Err(ureq::Error::Transport(t)) => Err(TransportError::Unreachable(t.to_string())),
+            };
+            let _ = tx.send(outcome);
+        });
+
+        match rx.recv_timeout(budget.saturating_add(Duration::from_millis(WATCHDOG_GRACE_MS))) {
+            Ok(result) => {
+                let _ = worker.join();
+                result
+            }
+            // The worker is left to self-terminate (its ureq per-call timeout fires
+            // at `budget`, then it exits) — joining here would re-block the caller
+            // past the budget, defeating the watchdog.
+            Err(RecvTimeoutError::Timeout) => Err(TransportError::Timeout { wall_clock_ms }),
+            Err(RecvTimeoutError::Disconnected) => {
+                Err(TransportError::Io("worker thread disconnected".to_string()))
+            }
+        }
+    }
+}
+
+/// Read a response body, refusing a redirect (3xx) and bounding the read to
+/// `read_cap` bytes (`max_response_bytes + 1`, so the decoder detects oversize).
+fn read_capped(resp: ureq::Response, read_cap: u64) -> Result<Vec<u8>, TransportError> {
+    let status = resp.status();
+    // `redirects(0)` returns a 3xx as Ok — refuse it (cross-host redirect defense).
+    if (300..400).contains(&status) {
+        return Err(TransportError::Unreachable(format!(
+            "redirect refused (status {status})"
+        )));
+    }
+    if !(200..300).contains(&status) {
+        return Err(TransportError::Io(format!("http status {status}")));
+    }
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .take(read_cap)
+        .read_to_end(&mut buf)
+        .map_err(|e| TransportError::Io(e.to_string()))?;
+    Ok(buf)
+}
+
+/// Lower-hex-encode a 32-byte token for the `Idempotency-Key` header (no dep).
+fn hex32(bytes: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(64);
+    for &b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+/// A [`ureq::Resolver`] that performs DNS, then vets every resolved address through
+/// the [`EgressPolicy`] — the behavioural half of the egress sandbox.
+struct VettingResolver {
+    policy: EgressPolicy,
+}
+
+impl ureq::Resolver for VettingResolver {
+    fn resolve(&self, netloc: &str) -> std::io::Result<Vec<SocketAddr>> {
+        let host = host_of_netloc(netloc);
+        if !self.policy.permits_host(host) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "egress host not in allowlist",
+            ));
+        }
+        let vetted: Vec<SocketAddr> = netloc
+            .to_socket_addrs()?
+            .filter(|addr| vet_resolved_addr(host, addr, &self.policy).is_ok())
+            .collect();
+        if vetted.is_empty() {
+            // Either DNS returned nothing, or every address failed egress vetting
+            // (SSRF / rebind). Surface a typed io error — ureq wraps it as a
+            // Transport error → `TransportError::Unreachable` (no why-leak).
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "no egress-permitted address for host",
+            ));
+        }
+        Ok(vetted)
+    }
+}
+
+/// Extract the bare host from a ureq `netloc` (`host:port`, or `[ipv6]:port`).
+fn host_of_netloc(netloc: &str) -> &str {
+    if let Some(rest) = netloc.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            return &rest[..end]; // bracketed IPv6 literal
+        }
+    }
+    // Domains / IPv4 have no internal colon; split on the LAST one to drop the port.
+    netloc.rsplit_once(':').map_or(netloc, |(h, _)| h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_warrant::{Host, NetScope};
+    use ureq::Resolver as _;
+
+    fn scope(hosts: &[&str]) -> NetScope {
+        NetScope::EgressAllowlist(hosts.iter().map(|h| Host((*h).to_string())).collect())
+    }
+
+    #[test]
+    fn host_of_netloc_handles_domain_ipv4_ipv6() {
+        assert_eq!(host_of_netloc("example.com:443"), "example.com");
+        assert_eq!(host_of_netloc("127.0.0.1:8080"), "127.0.0.1");
+        assert_eq!(host_of_netloc("[::1]:8080"), "::1");
+        assert_eq!(host_of_netloc("[2606:4700::1111]:443"), "2606:4700::1111");
+    }
+
+    #[test]
+    fn hex32_is_lowercase_64_chars() {
+        let mut b = [0u8; 32];
+        b[0] = 0xab;
+        b[31] = 0x0f;
+        let h = hex32(&b);
+        assert_eq!(h.len(), 64);
+        assert!(h.starts_with("ab"));
+        assert!(h.ends_with("0f"));
+        assert!(h
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn new_refuses_endpoint_host_outside_allowlist() {
+        let err = HttpTransport::new("https://evil.com/mcp", &scope(&["api.example.com"]))
+            .expect_err("host not allowlisted must refuse");
+        assert!(matches!(err, TransportError::Unreachable(_)));
+    }
+
+    #[test]
+    fn new_refuses_none_scope() {
+        let err = HttpTransport::new("https://api.example.com/mcp", &NetScope::None)
+            .expect_err("None egress must refuse every host");
+        assert!(matches!(err, TransportError::Unreachable(_)));
+    }
+
+    #[test]
+    fn new_refuses_non_http_scheme() {
+        let err = HttpTransport::new("ftp://api.example.com/mcp", &scope(&["api.example.com"]))
+            .expect_err("non-http scheme must refuse");
+        assert!(matches!(err, TransportError::Unreachable(_)));
+    }
+
+    #[test]
+    fn new_accepts_allowlisted_endpoint() {
+        let t = HttpTransport::new("https://api.example.com/mcp", &scope(&["api.example.com"]))
+            .expect("allowlisted endpoint builds");
+        let _ = t;
+    }
+
+    #[test]
+    fn vetting_resolver_refuses_unlisted_host() {
+        let r = VettingResolver {
+            policy: EgressPolicy::from_net_scope(&scope(&["api.example.com"])),
+        };
+        // A host not in the allowlist is refused before any DNS happens.
+        assert!(r.resolve("evil.com:443").is_err());
+    }
+
+    #[test]
+    fn vetting_resolver_refuses_loopback_for_public_host() {
+        // Even if a permitted-looking netloc resolves to loopback via a literal, a
+        // non-literal host whose name is not in the list is refused at the gate.
+        let r = VettingResolver {
+            policy: EgressPolicy::from_net_scope(&scope(&["127.0.0.1"])),
+        };
+        // An explicitly-allowlisted loopback literal IS permitted to resolve.
+        assert!(r.resolve("127.0.0.1:8080").is_ok());
+    }
+}

--- a/crates/kx-mcp/src/lib.rs
+++ b/crates/kx-mcp/src/lib.rs
@@ -25,10 +25,14 @@
 //! `cargo-deny` + the minimalism rule. So this adapter hand-rolls a minimal MCP
 //! JSON-RPC client over the existing sync stack:
 //!
-//! - **M5.2a (this crate today):** a newline-delimited JSON-RPC `tools/call` over a
-//!   [`StdioTransport`] subprocess — no network, no TLS, CI-friendly.
-//! - **M5.2b (next):** an `ureq` streamable-HTTP [`McpTransport`] impl + the
-//!   `MacOsSandbox`/cloud-broker egress bracket (the OSS `bwrap`-egress gap, D94).
+//! - **M5.2a:** a newline-delimited JSON-RPC `tools/call` over a [`StdioTransport`]
+//!   subprocess — no network, no TLS, CI-friendly.
+//! - **M5.2b (this crate now):** an `ureq` HTTP [`HttpTransport`] + an
+//!   application-layer **egress sandbox** ([`EgressPolicy`]): host-allowlist binding,
+//!   an SSRF/DNS-rebind vetting resolver (refuses the `169.254.169.254` metadata IP +
+//!   private/loopback targets reached via a public name), `redirects(0)` refusal, and
+//!   a hard wall-clock watchdog. OS-level egress isolation (`bwrap`/nftables) stays a
+//!   `kx-cloud` concern (D94) — see [`EgressPolicy`] for the honest boundary.
 //!
 //! The transport is a trait ([`McpTransport`]) so the HTTP impl drops in without
 //! touching [`McpCapability`].
@@ -54,12 +58,16 @@
 mod capability;
 mod credential;
 mod decode;
+mod egress;
 mod errors;
+mod http_transport;
 mod jsonrpc;
 mod transport;
 
 pub use capability::McpCapability;
 pub use credential::CredentialRef;
 pub use decode::{decode_tool_result, MAX_TOOL_RESULT_BYTES_DEFAULT};
+pub use egress::{classify_ip, vet_resolved_addr, EgressDenied, EgressPolicy, IpClass};
 pub use errors::{DecodeError, TransportError};
+pub use http_transport::HttpTransport;
 pub use transport::{McpTransport, StdioTransport};

--- a/crates/kx-mcp/src/transport.rs
+++ b/crates/kx-mcp/src/transport.rs
@@ -18,8 +18,9 @@ use crate::errors::TransportError;
 
 /// Fallback wall-clock budget when the warrant supplies none (`0`): 30 s. Keeps a
 /// hung or chatty server from blocking a dispatch indefinitely while not failing a
-/// legitimately slow tool that simply has no explicit ceiling.
-const DEFAULT_WALL_CLOCK_MS: u64 = 30_000;
+/// legitimately slow tool that simply has no explicit ceiling. Shared with the
+/// HTTP transport so both transports honour the same default budget.
+pub(crate) const DEFAULT_WALL_CLOCK_MS: u64 = 30_000;
 
 /// The MCP transport seam: one synchronous request/response round-trip.
 ///
@@ -35,6 +36,13 @@ pub trait McpTransport: Send + Sync {
     /// without the transport buffering an unbounded amount) and MUST abandon the
     /// call after `wall_clock_ms` (a `0` budget means "use a sane default").
     ///
+    /// `idempotency_key` is the run-scoped cross-boundary dedup token (D38 §1 /
+    /// M1.2 `run_scoped_token`). A transport that maps to a protocol with a
+    /// first-class dedup header (the HTTP `Idempotency-Key`) SHOULD send it, so a
+    /// crash-recovery re-dispatch makes the *remote* effect exactly-once. A
+    /// transport with no such header (stdio) ignores it — recovery dedup there is
+    /// the content-addressed staging key, not a wire header.
+    ///
     /// # Errors
     ///
     /// [`TransportError`] on spawn/connection failure, I/O failure, or timeout.
@@ -43,6 +51,7 @@ pub trait McpTransport: Send + Sync {
         request: &[u8],
         max_response_bytes: usize,
         wall_clock_ms: u64,
+        idempotency_key: Option<&[u8; 32]>,
     ) -> Result<Vec<u8>, TransportError>;
 }
 
@@ -102,7 +111,12 @@ impl McpTransport for StdioTransport {
         request: &[u8],
         max_response_bytes: usize,
         wall_clock_ms: u64,
+        idempotency_key: Option<&[u8; 32]>,
     ) -> Result<Vec<u8>, TransportError> {
+        // stdio has no wire header for a dedup key; recovery dedup is the
+        // content-addressed staging key (the broker's idempotency token), so the
+        // key is intentionally unused here.
+        let _ = idempotency_key;
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args)
             .stdin(Stdio::piped())

--- a/crates/kx-mcp/tests/common/mod.rs
+++ b/crates/kx-mcp/tests/common/mod.rs
@@ -119,3 +119,261 @@ pub fn effect(args_json: &str) -> EffectRequest {
         fs_scope: FsScope::empty(),
     }
 }
+
+// ---------------------------------------------------------------------------
+// M5.2b — HTTP transport test support: a hermetic in-process TcpListener mock
+// (no `[[bin]]`, no live network, no new dep) + HTTP egress fixtures.
+// ---------------------------------------------------------------------------
+
+use std::io::{Read as _, Write as _};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use kx_mcp::HttpTransport;
+use kx_warrant::Host;
+
+/// What the mock HTTP server does with the one request it receives.
+#[derive(Clone)]
+pub enum HttpMode {
+    /// 200 with `result.echoed = <request body's params.arguments>` (deterministic
+    /// in the args — content-addressed dedup, like the stdio echo).
+    Echo,
+    /// 200 with a `result` string of `n` bytes (drives the IMP-16 oversize cap).
+    Big(usize),
+    /// 200 with a JSON-RPC `error` object (decoder ProtocolError path).
+    Error,
+    /// 200 with truncated JSON (decoder Malformed path).
+    Malformed,
+    /// Sleep `d`, then echo (drives the wall-clock watchdog).
+    Slow(Duration),
+    /// 302 with `Location: http://evil.example.com/` (drives redirect refusal).
+    Redirect,
+    /// 200 with `result.saw_auth = <bool>` reporting WHETHER an `Authorization`
+    /// header was present — proves credential injection is in-play WITHOUT echoing
+    /// the secret value (the secret-never-leak sweep then asserts absence).
+    AuthProbe,
+}
+
+/// One captured inbound request (headers lowercased) for test assertions.
+#[derive(Clone)]
+pub struct Captured {
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+impl Captured {
+    #[must_use]
+    pub fn header(&self, name: &str) -> Option<&str> {
+        let name = name.to_ascii_lowercase();
+        self.headers
+            .iter()
+            .find(|(k, _)| *k == name)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// A hermetic in-process HTTP/1.1 mock on `127.0.0.1:0`. Each connection is handled
+/// on its own detached thread so a `Slow` handler never blocks the accept loop (or
+/// `Drop`). Stops cleanly on drop.
+pub struct MockHttpServer {
+    pub addr: SocketAddr,
+    captured: Arc<Mutex<Vec<Captured>>>,
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl MockHttpServer {
+    #[must_use]
+    pub fn start(mode: HttpMode) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock http");
+        let addr = listener.local_addr().expect("local_addr");
+        let captured: Arc<Mutex<Vec<Captured>>> = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (cap_t, stop_t) = (captured.clone(), stop.clone());
+        let handle = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if stop_t.load(Ordering::SeqCst) {
+                    break;
+                }
+                if let Ok(stream) = stream {
+                    let (mode, cap) = (mode.clone(), cap_t.clone());
+                    std::thread::spawn(move || handle_conn(stream, &mode, &cap));
+                }
+            }
+        });
+        Self {
+            addr,
+            captured,
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    /// The endpoint URL a transport dials.
+    #[must_use]
+    pub fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/mcp", self.addr.port())
+    }
+
+    /// A `net_scope` granting egress to this server's bound (loopback) host literal.
+    #[must_use]
+    pub fn net_scope(&self) -> NetScope {
+        NetScope::EgressAllowlist([Host(self.addr.ip().to_string())].into_iter().collect())
+    }
+
+    /// All requests captured so far (cloned).
+    #[must_use]
+    pub fn captured(&self) -> Vec<Captured> {
+        self.captured.lock().unwrap().clone()
+    }
+}
+
+impl Drop for MockHttpServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        // Wake the blocked `accept` by connecting once, then join the accept loop.
+        let _ = TcpStream::connect(self.addr);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn handle_conn(mut stream: TcpStream, mode: &HttpMode, captured: &Arc<Mutex<Vec<Captured>>>) {
+    let Some(req) = read_request(&mut stream) else {
+        return;
+    };
+    let saw_auth = req.header("authorization").is_some();
+    let args = extract_arguments(&req.body);
+    captured.lock().unwrap().push(req);
+
+    if let HttpMode::Slow(d) = mode {
+        std::thread::sleep(*d);
+    }
+
+    let response: String = match mode {
+        HttpMode::Big(n) => {
+            let filler = "x".repeat(*n);
+            jsonrpc_ok(&format!(r#"{{"blob":"{filler}"}}"#))
+        }
+        HttpMode::Error => {
+            http_200(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"mock error"}}"#)
+        }
+        HttpMode::Malformed => http_200(r#"{"jsonrpc":"2.0","id":1,"result":{"content":"#),
+        HttpMode::Redirect => {
+            "HTTP/1.1 302 Found\r\nLocation: http://evil.example.com/\r\nContent-Length: 0\r\n\r\n"
+                .to_string()
+        }
+        HttpMode::AuthProbe => jsonrpc_ok(&format!(r#"{{"saw_auth":{saw_auth}}}"#)),
+        HttpMode::Echo | HttpMode::Slow(_) => jsonrpc_ok(&format!(r#"{{"echoed":{args}}}"#)),
+    };
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// Read an HTTP/1.1 request: headers up to `\r\n\r\n`, then `Content-Length` bytes.
+fn read_request(stream: &mut TcpStream) -> Option<Captured> {
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    // Read until the header terminator.
+    while !buf.ends_with(b"\r\n\r\n") {
+        match stream.read(&mut byte) {
+            Ok(0) | Err(_) => return None,
+            Ok(_) => buf.push(byte[0]),
+        }
+        if buf.len() > 64 * 1024 {
+            return None;
+        }
+    }
+    let head = String::from_utf8_lossy(&buf);
+    let mut headers = Vec::new();
+    let mut content_length = 0usize;
+    for line in head.lines().skip(1) {
+        if let Some((k, v)) = line.split_once(':') {
+            let (k, v) = (k.trim().to_ascii_lowercase(), v.trim().to_string());
+            if k == "content-length" {
+                content_length = v.parse().unwrap_or(0);
+            }
+            headers.push((k, v));
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 && stream.read_exact(&mut body).is_err() {
+        return None;
+    }
+    Some(Captured { headers, body })
+}
+
+/// Pull `params.arguments` (verbatim JSON) out of a JSON-RPC request body; `{}` if
+/// absent — mirrors the stdio echo server.
+fn extract_arguments(body: &[u8]) -> String {
+    #[derive(serde::Deserialize)]
+    struct Req {
+        params: Params,
+    }
+    #[derive(serde::Deserialize)]
+    struct Params {
+        #[serde(default)]
+        arguments: Option<Box<serde_json::value::RawValue>>,
+    }
+    serde_json::from_slice::<Req>(body)
+        .ok()
+        .and_then(|r| r.params.arguments)
+        .map_or_else(|| "{}".to_string(), |a| a.get().to_string())
+}
+
+fn jsonrpc_ok(result_obj: &str) -> String {
+    http_200(&format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{result_obj}}}"#
+    ))
+}
+
+fn http_200(body: &str) -> String {
+    format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    )
+}
+
+/// An `McpCapability` over a real `HttpTransport` pointed at `server` (echo etc.).
+#[must_use]
+pub fn http_capability(
+    name: ToolName,
+    version: ToolVersion,
+    server: &MockHttpServer,
+) -> McpCapability {
+    let transport = HttpTransport::new(&server.url(), &server.net_scope())
+        .expect("http transport builds for the loopback mock");
+    McpCapability::new(
+        name,
+        version,
+        McpEndpointId(server.url()),
+        "echo",
+        Box::new(transport),
+    )
+}
+
+/// A warrant granting `(tool, version)` PLUS egress to the loopback mock host.
+#[must_use]
+pub fn warrant_granting_egress(tool_name: &ToolName, tool_version: &ToolVersion) -> WarrantSpec {
+    let mut w = warrant_granting(tool_name, tool_version);
+    w.net_scope = NetScope::EgressAllowlist([Host("127.0.0.1".to_string())].into_iter().collect());
+    w
+}
+
+/// An `EffectRequest` carrying `args_json` under `StageThenCommit`, scoped to the
+/// loopback egress host (so the broker `precheck` admits the HTTP dispatch).
+#[must_use]
+pub fn effect_egress(args_json: &str) -> EffectRequest {
+    EffectRequest {
+        payload: args_json.as_bytes().to_vec(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: Some([0x11; 32]),
+        net_scope: NetScope::EgressAllowlist([Host("127.0.0.1".to_string())].into_iter().collect()),
+        fs_scope: FsScope::empty(),
+    }
+}

--- a/crates/kx-mcp/tests/http_chaos.rs
+++ b/crates/kx-mcp/tests/http_chaos.rs
@@ -1,0 +1,132 @@
+//! M5.2b chaos — the HTTP transport fails CLOSED + promptly under adversarial
+//! servers: a slow server is timed out by the watchdog, a redirect is refused, an
+//! oversize body is capped. Every failure is a typed `CapabilityFailureReason`
+//! (never a panic, never a partial stage).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use common::{effect_egress, sample_mote, tool, warrant_granting_egress, HttpMode, MockHttpServer};
+use kx_capability::{
+    BrokerError, CapabilityBroker, CapabilityFailureReason, LocalCapabilityBroker,
+};
+use kx_content::InMemoryContentStore;
+use kx_mcp::{HttpTransport, McpCapability};
+use kx_mote::{ToolName, ToolVersion};
+use kx_tool_registry::McpEndpointId;
+
+fn broker_with(
+    server: &MockHttpServer,
+    name: &ToolName,
+    version: &ToolVersion,
+    cap_mut: impl FnOnce(McpCapability) -> McpCapability,
+) -> LocalCapabilityBroker<Arc<InMemoryContentStore>> {
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    let transport = HttpTransport::new(&server.url(), &server.net_scope()).unwrap();
+    let cap = McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId(server.url()),
+        "echo",
+        Box::new(transport),
+    );
+    broker.register_capability(Box::new(cap_mut(cap)));
+    broker
+}
+
+#[test]
+fn slow_server_is_timed_out_promptly() {
+    let server = MockHttpServer::start(HttpMode::Slow(Duration::from_secs(5)));
+    let (name, version) = tool();
+    let broker = broker_with(&server, &name, &version, |c| c.with_wall_clock_ms(200));
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+
+    let start = Instant::now();
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect_egress("{}"))
+        .expect_err("a slow server must be abandoned");
+    let elapsed = start.elapsed();
+
+    assert!(
+        matches!(
+            err,
+            BrokerError::CapabilityFailure {
+                reason: CapabilityFailureReason::Timeout,
+                ..
+            }
+        ),
+        "expected a Timeout failure, got {err:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "the watchdog must return within ~the budget, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn cross_host_redirect_is_refused_and_nothing_staged() {
+    let server = MockHttpServer::start(HttpMode::Redirect);
+    let (name, version) = tool();
+    let broker = broker_with(&server, &name, &version, |c| c);
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect_egress("{}"))
+        .expect_err("a redirect must be refused (no following)");
+    assert!(
+        matches!(
+            err,
+            BrokerError::CapabilityFailure {
+                reason: CapabilityFailureReason::NetworkUnreachable,
+                ..
+            }
+        ),
+        "a 3xx is refused as unreachable, got {err:?}"
+    );
+}
+
+#[test]
+fn oversize_response_is_capped_and_refused() {
+    let server = MockHttpServer::start(HttpMode::Big(8192));
+    let (name, version) = tool();
+    let broker = broker_with(&server, &name, &version, |c| {
+        c.with_max_response_bytes(1024)
+    });
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect_egress("{}"))
+        .expect_err("an oversize body must be refused");
+    assert!(
+        matches!(
+            err,
+            BrokerError::CapabilityFailure {
+                reason: CapabilityFailureReason::InvalidResponse,
+                ..
+            }
+        ),
+        "oversize → InvalidResponse, got {err:?}"
+    );
+}
+
+#[test]
+fn server_protocol_error_is_surfaced_not_staged() {
+    let server = MockHttpServer::start(HttpMode::Error);
+    let (name, version) = tool();
+    let broker = broker_with(&server, &name, &version, |c| c);
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect_egress("{}"))
+        .expect_err("a JSON-RPC error object must not be staged as a result");
+    assert!(matches!(err, BrokerError::CapabilityFailure { .. }));
+}

--- a/crates/kx-mcp/tests/http_dispatch_through_broker.rs
+++ b/crates/kx-mcp/tests/http_dispatch_through_broker.rs
@@ -1,0 +1,81 @@
+//! M5.2b — `McpCapability` over the real `HttpTransport` dispatches THROUGH the
+//! real `LocalCapabilityBroker` (the authoritative warrant gate, including the
+//! net_scope egress check) against a hermetic in-process HTTP server, and the
+//! staged result carries the capability identity as provenance (D72).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{
+    effect_egress, http_capability, sample_mote, tool, warrant_granting_egress, HttpMode,
+    MockHttpServer,
+};
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_content::{ContentStore, InMemoryContentStore};
+
+#[test]
+fn http_dispatch_stages_echo_result_with_provenance() {
+    let server = MockHttpServer::start(HttpMode::Echo);
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store.clone());
+    broker.register_capability(Box::new(http_capability(
+        name.clone(),
+        version.clone(),
+        &server,
+    )));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+
+    let handle = broker
+        .dispatch(&mote, &warrant, &name, effect_egress(r#"{"q":"hello"}"#))
+        .expect("HTTP MCP dispatch should succeed through the broker");
+
+    // Provenance (D72): the handle records WHICH capability/version produced the bytes.
+    assert_eq!(handle.capability, name);
+    assert_eq!(handle.capability_version, version);
+
+    // The staged bytes are the MCP server's `result` object, verbatim.
+    let staged = store.get(&handle.staged_ref).unwrap();
+    assert_eq!(&*staged, br#"{"echoed":{"q":"hello"}}"#);
+
+    // The server actually received the POST (the egress happened, warrant-scoped).
+    let reqs = server.captured();
+    assert_eq!(reqs.len(), 1, "exactly one request reached the server");
+    // The run-scoped idempotency key rode as the Idempotency-Key header (remote
+    // exactly-once seam) — present and 64 lower-hex chars.
+    let key = reqs[0]
+        .header("idempotency-key")
+        .expect("Idempotency-Key header is sent");
+    assert_eq!(key.len(), 64);
+    assert!(key.bytes().all(|b| b.is_ascii_hexdigit()));
+}
+
+#[test]
+fn http_dispatch_is_deterministic_across_calls() {
+    // Same args ⇒ byte-identical staged bytes ⇒ identical content ref (the property
+    // that makes a recovery re-dispatch exactly-once at staging).
+    let server = MockHttpServer::start(HttpMode::Echo);
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store.clone());
+    broker.register_capability(Box::new(http_capability(
+        name.clone(),
+        version.clone(),
+        &server,
+    )));
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+
+    let a = broker
+        .dispatch(&mote, &warrant, &name, effect_egress(r#"{"q":"x"}"#))
+        .unwrap();
+    let b = broker
+        .dispatch(&mote, &warrant, &name, effect_egress(r#"{"q":"x"}"#))
+        .unwrap();
+    assert_eq!(a.staged_ref, b.staged_ref);
+}

--- a/crates/kx-mcp/tests/http_scale.rs
+++ b/crates/kx-mcp/tests/http_scale.rs
@@ -1,0 +1,60 @@
+//! M5.2b scale — many concurrent HTTP dispatches share ONE pooled `ureq::Agent`
+//! (proving `Send + Sync` + connection-pool reuse, no per-dispatch TLS handshake,
+//! no FD exhaustion). HTTP is OFF the projection/fold path, so the `scale-smoke`
+//! 25k-Mote re-fold gate is structurally unaffected by this transport — this test
+//! only guards the transport's own concurrency.
+//!
+//! `#[ignore]` (a bounded perf/concurrency smoke, run explicitly), mirroring the
+//! kx-projection scale tests.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{effect_egress, sample_mote, tool, warrant_granting_egress, HttpMode, MockHttpServer};
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_content::InMemoryContentStore;
+
+#[test]
+#[ignore = "scale/concurrency smoke — run explicitly"]
+fn many_concurrent_dispatches_share_one_pooled_agent() {
+    const N: usize = 64;
+    let server = MockHttpServer::start(HttpMode::Echo);
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = Arc::new(LocalCapabilityBroker::new(store));
+    broker.register_capability(Box::new(common::http_capability(
+        name.clone(),
+        version.clone(),
+        &server,
+    )));
+    let warrant = Arc::new(warrant_granting_egress(&name, &version));
+
+    let mut handles = Vec::with_capacity(N);
+    for i in 0..N {
+        let (broker, warrant, name) = (broker.clone(), warrant.clone(), name.clone());
+        let version = version.clone();
+        handles.push(std::thread::spawn(move || {
+            let mote = sample_mote(&name, &version);
+            let args = format!(r#"{{"i":{i}}}"#);
+            broker
+                .dispatch(&mote, &warrant, &name, effect_egress(&args))
+                .map(|h| h.staged_ref)
+        }));
+    }
+
+    let mut ok = 0usize;
+    for h in handles {
+        if h.join().unwrap().is_ok() {
+            ok += 1;
+        }
+    }
+    assert_eq!(ok, N, "all {N} concurrent dispatches completed");
+    assert_eq!(
+        server.captured().len(),
+        N,
+        "the server received all {N} requests over the pooled agent"
+    );
+}

--- a/crates/kx-mcp/tests/http_secret_sweep.rs
+++ b/crates/kx-mcp/tests/http_secret_sweep.rs
@@ -1,0 +1,92 @@
+//! M5.2b — D81 over the HTTP header path. A credential bound to the transport is
+//! injected as an `Authorization` header (genuinely in-play: the server reports it
+//! saw the header), yet the secret VALUE reaches NONE of the runtime sinks: the
+//! `EffectRequest.payload`, the `BrokerHandle`, the staged result (journal/content
+//! store), the `MoteId`, or any `Debug`. The server reports only WHETHER the header
+//! was present, never its value.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{effect_egress, sample_mote, tool, warrant_granting_egress, HttpMode, MockHttpServer};
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_content::{ContentStore, InMemoryContentStore};
+use kx_mcp::{CredentialRef, HttpTransport, McpCapability};
+use kx_tool_registry::McpEndpointId;
+
+const SECRET: &str = "SUPER_SECRET_sk-HTTP-DEADBEEF-do-not-leak-0123456789";
+const CRED_VAR: &str = "KX_MCP_TEST_CRED_HTTP_SECRETS_LEAK";
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[test]
+fn credential_ref_redacts_in_debug_and_display() {
+    let cred = CredentialRef::from_env_var(CRED_VAR);
+    assert!(!format!("{cred:?}").contains(SECRET));
+    assert!(!format!("{cred}").contains(SECRET));
+}
+
+#[test]
+fn http_secret_reaches_no_runtime_sink() {
+    std::env::set_var(CRED_VAR, SECRET);
+
+    let server = MockHttpServer::start(HttpMode::AuthProbe);
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store.clone());
+
+    let transport = HttpTransport::new(&server.url(), &server.net_scope())
+        .unwrap()
+        .header_credential("Authorization", CredentialRef::from_env_var(CRED_VAR));
+    let cap = McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId(server.url()),
+        "echo",
+        Box::new(transport),
+    );
+    // The transport's Debug must not carry the secret value (only the var name).
+    assert!(!format!("{cap:?}").contains(SECRET));
+    broker.register_capability(Box::new(cap));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+    let req = effect_egress(r#"{"q":"hello"}"#);
+    assert!(
+        !contains(&req.payload, SECRET.as_bytes()),
+        "payload free of secret"
+    );
+
+    let handle = broker
+        .dispatch(&mote, &warrant, &name, req)
+        .expect("dispatch succeeds with the credential injected");
+
+    // PROOF the credential was genuinely in-play: the server saw the Authorization
+    // header (it reports presence, never the value).
+    let staged = store.get(&handle.staged_ref).unwrap();
+    assert_eq!(
+        &*staged, br#"{"saw_auth":true}"#,
+        "the server received the injected Authorization header"
+    );
+
+    // The secret VALUE appears in NO sink.
+    assert!(
+        !contains(&staged, SECRET.as_bytes()),
+        "staged bytes free of secret"
+    );
+    assert!(
+        !format!("{handle:?}").contains(SECRET),
+        "BrokerHandle free of secret"
+    );
+    assert!(
+        !contains(mote.id.as_bytes(), SECRET.as_bytes()),
+        "MoteId free of secret"
+    );
+
+    std::env::remove_var(CRED_VAR);
+}

--- a/crates/kx-mcp/tests/http_security.rs
+++ b/crates/kx-mcp/tests/http_security.rs
@@ -1,0 +1,143 @@
+//! M5.2b security — the egress sandbox holds end-to-end through the broker:
+//!
+//! 1. **SSRF / rebind:** an allowlisted *hostname* that resolves to a loopback
+//!    address is refused (a public name can never reach an internal/metadata IP) —
+//!    proven hermetically via `localhost` → `127.0.0.1`.
+//! 2. **net_scope ⊆ warrant:** an HTTP dispatch requesting egress beyond the
+//!    warrant is refused on the NetScope axis (the broker gate), transport untouched.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{
+    effect_egress, http_capability, sample_mote, tool, warrant_granting, warrant_granting_egress,
+    HttpMode, MockHttpServer,
+};
+use kx_capability::{
+    BrokerError, CapabilityBroker, CapabilityFailureReason, LocalCapabilityBroker,
+};
+use kx_content::InMemoryContentStore;
+use kx_mcp::{HttpTransport, McpCapability};
+use kx_mote::EffectPattern;
+use kx_tool_registry::McpEndpointId;
+use kx_warrant::{FsScope, Host, NetScope};
+
+#[test]
+fn allowlisted_name_resolving_to_loopback_is_refused() {
+    // `localhost` is allowlisted (a NAME), the endpoint points at it, and it
+    // resolves to a loopback address (127.0.0.1 / ::1) hermetically via /etc/hosts.
+    // The vetting resolver refuses it because the host is not an IP LITERAL — the
+    // exact public-name-rebinds-to-internal-IP vector. The request never leaves.
+    let server = MockHttpServer::start(HttpMode::Echo);
+    let (name, version) = tool();
+    let localhost_scope =
+        NetScope::EgressAllowlist([Host("localhost".to_string())].into_iter().collect());
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    let endpoint = format!("http://localhost:{}/mcp", server.addr.port());
+    let transport = HttpTransport::new(&endpoint, &localhost_scope)
+        .expect("transport builds (localhost is allowlisted by name)");
+    broker.register_capability(Box::new(McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId(endpoint),
+        "echo",
+        Box::new(transport),
+    )));
+
+    let mote = sample_mote(&name, &version);
+    let mut warrant = warrant_granting(&name, &version);
+    warrant.net_scope = localhost_scope.clone();
+    let mut req = effect_egress("{}");
+    req.net_scope = localhost_scope;
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, req)
+        .expect_err("a name resolving to loopback must be refused (SSRF/rebind)");
+    assert!(
+        matches!(
+            err,
+            BrokerError::CapabilityFailure {
+                reason: CapabilityFailureReason::NetworkUnreachable,
+                ..
+            }
+        ),
+        "expected NetworkUnreachable (egress vetting refusal), got {err:?}"
+    );
+    assert!(
+        server.captured().is_empty(),
+        "no request may reach the server when egress is refused"
+    );
+}
+
+#[test]
+fn egress_beyond_warrant_is_refused_on_netscope_axis() {
+    // The capability+transport are egress-capable, but the warrant grants NO egress.
+    // The broker gate refuses on NetScope before the transport is ever invoked.
+    let server = MockHttpServer::start(HttpMode::Echo);
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(http_capability(
+        name.clone(),
+        version.clone(),
+        &server,
+    )));
+
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting(&name, &version); // net_scope = None
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect_egress("{}"))
+        .expect_err("egress beyond the warrant must be refused");
+    assert!(
+        matches!(
+            err,
+            BrokerError::CapabilityExceedsWarrant {
+                axis: kx_warrant::WarrantField::NetScope
+            }
+        ),
+        "expected CapabilityExceedsWarrant{{NetScope}}, got {err:?}"
+    );
+    assert!(server.captured().is_empty(), "no egress occurred");
+}
+
+#[test]
+fn unscoped_egress_request_under_none_warrant_never_dials() {
+    // Belt-and-suspenders: even a fully-egress EffectRequest under a None warrant is
+    // refused; assert the fs axis stays empty and nothing is staged.
+    let server = MockHttpServer::start(HttpMode::Echo);
+    let (name, version) = tool();
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(http_capability(
+        name.clone(),
+        version.clone(),
+        &server,
+    )));
+    let mote = sample_mote(&name, &version);
+    let warrant = warrant_granting_egress(&name, &version);
+    // Request egress to a host the warrant does NOT grant.
+    let req = kx_capability::EffectRequest {
+        payload: b"{}".to_vec(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: Some([0x22; 32]),
+        net_scope: NetScope::EgressAllowlist(
+            [Host("example.com".to_string())].into_iter().collect(),
+        ),
+        fs_scope: FsScope::empty(),
+    };
+    let err = broker
+        .dispatch(&mote, &warrant, &name, req)
+        .expect_err("egress to an ungranted host is refused");
+    assert!(matches!(
+        err,
+        BrokerError::CapabilityExceedsWarrant {
+            axis: kx_warrant::WarrantField::NetScope
+        }
+    ));
+}

--- a/crates/kx-model-harness/src/broker.rs
+++ b/crates/kx-model-harness/src/broker.rs
@@ -20,13 +20,15 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
+use kx_capability::{
+    run_scoped_token, BrokerError, BrokerHandle, CapabilityBroker, EffectRequest, INSTANCE_ID_LEN,
+};
 use kx_content::ContentStore;
 use kx_inference::{inference_params_from_mote, InferenceBackend};
 use kx_mote::{EffectPattern, Mote, MoteId, ToolName, ToolVersion};
 use kx_runtime::{CrashPoint, SnapshotSink};
 use kx_tool_registry::ToolRegistry;
-use kx_warrant::{FsScope, NetScope, WarrantSpec};
+use kx_warrant::{FsScope, WarrantSpec};
 
 use crate::{context, prompt, toolcall};
 
@@ -74,6 +76,12 @@ pub struct ModelBroker<B: InferenceBackend, S: ContentStore> {
     /// re-implemented gate. An empty broker means "no tools" (the model's proposals,
     /// if any, are refused as ungranted before reaching here).
     tool_broker: Arc<dyn CapabilityBroker>,
+    /// M5.2b: the registered run's `instance_id` (D64/M1.1) — the root of the
+    /// run-scoped idempotency token a model-driven dispatch sends to a remote tool
+    /// as its `Idempotency-Key` (remote exactly-once on a crash-recovery
+    /// re-dispatch, M1.2). The single-node demo path grants no tools, so the value
+    /// is inert there; a real tool-firing run anchors it to its registered identity.
+    instance_id: [u8; INSTANCE_ID_LEN],
 }
 
 impl<B: InferenceBackend, S: ContentStore> std::fmt::Debug for ModelBroker<B, S> {
@@ -97,7 +105,7 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
     /// through `observer`, plus the D78 context seams (snapshot sink + tool
     /// registry).
     #[must_use]
-    #[allow(clippy::too_many_arguments)] // Wiring seam; grouped meaningfully (M5.2 adds tool_broker).
+    #[allow(clippy::too_many_arguments)] // Wiring seam; grouped meaningfully (M5.2 adds tool_broker + instance_id).
     pub fn new(
         backend: Arc<B>,
         store: Arc<S>,
@@ -107,6 +115,7 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
         sink: SnapshotSink,
         registry: Arc<dyn ToolRegistry>,
         tool_broker: Arc<dyn CapabilityBroker>,
+        instance_id: [u8; INSTANCE_ID_LEN],
     ) -> Self {
         Self {
             backend,
@@ -117,6 +126,7 @@ impl<B: InferenceBackend, S: ContentStore> ModelBroker<B, S> {
             sink,
             registry,
             tool_broker,
+            instance_id,
         }
     }
 
@@ -204,19 +214,37 @@ where
             match toolcall::parse_tool_call(&out.bytes, warrant, toolcall::max_args_bytes(warrant))
             {
                 Ok(Some(call)) => {
+                    // M5.2b — derive the egress this dispatch requires from the
+                    // RESOLVED tool's declared requirement (never hardcoded). The
+                    // registry lookup yields the approved ToolDef; its
+                    // `net_scope_required` is the egress the broker `precheck` then
+                    // gates ⊆ warrant. A stdio/in-proc tool declares `None` (→
+                    // byte-identical to M5.2a); an HTTP tool declares its host
+                    // allowlist. A tool that does not resolve is refused fail-closed
+                    // (no effect fires).
+                    let net_scope = match self.registry.lookup(&call.name, &call.version) {
+                        Some(def) => def.required_capability.net_scope_required,
+                        None => {
+                            return Err(BrokerError::StageWriteFailed {
+                                capability: capability.clone(),
+                                diagnostic: format!(
+                                    "tool {:?}@{:?} not resolvable for egress derivation",
+                                    call.name, call.version
+                                ),
+                            });
+                        }
+                    };
                     let effect = EffectRequest {
                         payload: call.args_bytes,
                         // MCP effects are world-mutating by default → StageThenCommit (D66).
                         pattern: EffectPattern::StageThenCommit,
-                        // Run-stable dedup: a recovery re-dispatch re-derives the same
-                        // token (= mote.id) so the staged effect is exactly-once
-                        // (content-addressed). Matches the existing row-G tool path.
-                        // M5.2b note: when the HTTP transport sends a real remote
-                        // `Idempotency-Key` header, switch to `run_scoped_token`
-                        // (kx_capability::token) so a re-SUBMITTED run gets a fresh key.
-                        idempotency_key: Some(token),
-                        // M5.2a stdio transport performs no egress.
-                        net_scope: NetScope::None,
+                        // M5.2b: the RUN-SCOPED idempotency token (D38 §1 / M1.2). A
+                        // recovery re-dispatch of the SAME run re-derives the SAME
+                        // token → the HTTP transport re-sends the SAME `Idempotency-Key`
+                        // → the remote dedups (remote exactly-once). A re-SUBMITTED run
+                        // (fresh instance_id) gets a fresh token and fires afresh (D64).
+                        idempotency_key: Some(run_scoped_token(&self.instance_id, mote)),
+                        net_scope,
                         fs_scope: FsScope::empty(),
                     };
                     let handle = self

--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -264,6 +264,12 @@ impl Harness {
             sink.clone(),
             registry,
             tool_broker,
+            // The A–J demo grants no tools, so the tool-dispatch arm (the only user
+            // of instance_id, for the run-scoped remote idempotency key) is never
+            // entered — an all-zero sentinel is inert here. A real tool-firing run
+            // constructs `ModelBroker` directly with its registered instance_id
+            // (D64), as the M5.2 e2e tests do.
+            [0u8; kx_capability::INSTANCE_ID_LEN],
         ));
         let protocol =
             StandardCommitProtocol::new(self.store.clone(), self.journal.clone(), broker);

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -228,6 +228,9 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         sink.clone(),
         registry,
         tool_broker,
+        // These wiring tests grant no tools (the tool arm is never entered), so the
+        // instance_id is inert — an all-zero sentinel suffices.
+        [0u8; kx_capability::INSTANCE_ID_LEN],
     ));
     let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
     let rm = LocalResourceManager::dev_defaults();

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -1,0 +1,410 @@
+//! M5.2b — the M5 EXIT GATE end-to-end: a single-Mote run selects a tool, the
+//! runtime derives the egress from the resolved tool's `net_scope`, dispatches an
+//! **external HTTP** tool through the real `HttpTransport` + warrant/broker gate
+//! against a hermetic loopback server, captures provenance, and commits — with the
+//! egress warrant-scoped, the run-scoped `Idempotency-Key` sent (remote
+//! exactly-once), and the credential never journaled.
+//!
+//! Hermetic: an in-process `TcpListener` HTTP server on `127.0.0.1` (no live
+//! network, no `[[bin]]` — kx-model-harness can't reach the kx-mcp test helpers).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+use std::io::{Read as _, Write as _};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker, INSTANCE_ID_LEN};
+use kx_content::{ContentStore, LocalFsContentStore};
+use kx_executor::{LocalResourceManager, StandardCommitProtocol};
+use kx_inference::{InferenceBackend, InferenceError, InferenceInput, InferenceOutput};
+use kx_journal::SqliteJournal;
+use kx_mcp::{HttpTransport, McpCapability};
+use kx_model_harness::{harness_warrant, workflows, BrokerObserver, ModelBroker, ModelExecutor};
+use kx_mote::{ModelId, MoteId, ToolName, ToolVersion};
+use kx_projection::Projection;
+use kx_runtime::config::Mode;
+use kx_runtime::{run_with_seams, RunOutcome, RuntimeConfig, RuntimeError, SnapshotSink};
+use kx_tool_registry::{
+    IdempotencyClass, InMemoryToolRegistry, McpEndpointId, ToolDef, ToolKind, ToolProvenance,
+    ToolRegistry,
+};
+use kx_warrant::{
+    FsScope, Host, NetScope, ResourceCeiling, ToolGrant, ToolRequirement, WarrantSpec,
+};
+
+fn model_id() -> ModelId {
+    ModelId("stub-model:test:0".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Hermetic in-process HTTP mock (loopback), capturing the Idempotency-Key.
+// ---------------------------------------------------------------------------
+
+struct MockHttp {
+    addr: SocketAddr,
+    keys: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl MockHttp {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let keys: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (k, s) = (keys.clone(), stop.clone());
+        let handle = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if s.load(Ordering::SeqCst) {
+                    break;
+                }
+                if let Ok(stream) = stream {
+                    let k = k.clone();
+                    std::thread::spawn(move || handle_conn(stream, &k));
+                }
+            }
+        });
+        Self {
+            addr,
+            keys,
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/mcp", self.addr.port())
+    }
+
+    fn idempotency_keys(&self) -> Vec<String> {
+        self.keys.lock().unwrap().clone()
+    }
+}
+
+impl Drop for MockHttp {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(self.addr);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn handle_conn(mut stream: TcpStream, keys: &Arc<Mutex<Vec<String>>>) {
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+    while !buf.ends_with(b"\r\n\r\n") {
+        match stream.read(&mut byte) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => buf.push(byte[0]),
+        }
+        if buf.len() > 64 * 1024 {
+            return;
+        }
+    }
+    let head = String::from_utf8_lossy(&buf);
+    let mut content_length = 0usize;
+    for line in head.lines().skip(1) {
+        if let Some((k, v)) = line.split_once(':') {
+            let (k, v) = (k.trim().to_ascii_lowercase(), v.trim());
+            if k == "content-length" {
+                content_length = v.parse().unwrap_or(0);
+            }
+            if k == "idempotency-key" {
+                keys.lock().unwrap().push(v.to_string());
+            }
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    let _ = stream.read_exact(&mut body);
+    let resp_body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        resp_body.len(),
+        resp_body
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+const EXPECTED_RESULT: &[u8] = br#"{"ok":true}"#;
+
+// ---------------------------------------------------------------------------
+// Fixtures.
+// ---------------------------------------------------------------------------
+
+struct FixedBackend {
+    completion: Vec<u8>,
+}
+
+impl InferenceBackend for FixedBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &kx_mote::InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        Ok(InferenceOutput {
+            bytes: self.completion.clone(),
+            output_tokens: 1,
+            backend_name: "fixed-stub",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(0),
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "fixed-stub"
+    }
+}
+
+/// A registry whose MCP tool declares it needs egress to `127.0.0.1` (an HTTP tool).
+fn registry_with_http_tool(
+    tool: &ToolName,
+    version: &ToolVersion,
+    endpoint: &str,
+) -> InMemoryToolRegistry {
+    let mut reg = InMemoryToolRegistry::with_builtins();
+    let _ = reg.register(
+        ToolDef {
+            tool_id: tool.clone(),
+            tool_version: version.clone(),
+            kind: ToolKind::Mcp {
+                endpoint: McpEndpointId(endpoint.to_string()),
+                remote_name: "echo".into(),
+            },
+            required_capability: ToolRequirement {
+                net_scope_required: NetScope::EgressAllowlist(
+                    [Host("127.0.0.1".to_string())].into_iter().collect(),
+                ),
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: "HTTP MCP echo tool (M5.2b e2e).".into(),
+            idempotency_class: IdempotencyClass::Staged,
+        },
+        ToolProvenance::HumanAuthored {
+            author: "test".into(),
+        },
+    );
+    reg
+}
+
+fn warrant_for(tool: &ToolName, version: &ToolVersion, egress: NetScope) -> WarrantSpec {
+    let mut w = harness_warrant(&model_id(), 64, 5_000);
+    w.tool_grants.insert(ToolGrant {
+        tool_id: tool.clone(),
+        tool_version: version.clone(),
+    });
+    w.net_scope = egress;
+    w
+}
+
+fn config_for(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+    }
+}
+
+fn envelope(tool: &str, version: &str) -> Vec<u8> {
+    format!(r#"{{"tool_call":{{"name":"{tool}","version":"{version}","args":{{"q":"x"}}}}}}"#)
+        .into_bytes()
+}
+
+/// Drive a single-Mote model→HTTP-tool run. Returns the outcome + (store, journal,
+/// mote id) and the registered instance_id used.
+#[allow(clippy::type_complexity)]
+fn drive(
+    dir: &Path,
+    server: &MockHttp,
+    warrant_egress: NetScope,
+    instance_id: [u8; INSTANCE_ID_LEN],
+) -> (
+    Result<RunOutcome, RuntimeError>,
+    Arc<LocalFsContentStore>,
+    Arc<SqliteJournal>,
+    MoteId,
+) {
+    let tool = ToolName("mcp-http".into());
+    let version = ToolVersion("1".into());
+    let config = config_for(dir);
+    let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+    let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+    let backend = Arc::new(FixedBackend {
+        completion: envelope("mcp-http", "1"),
+    });
+    let sink = SnapshotSink::new();
+    let registry: Arc<dyn ToolRegistry> =
+        Arc::new(registry_with_http_tool(&tool, &version, &server.url()));
+
+    // The tool broker holds the McpCapability over a REAL HttpTransport → the mock.
+    let tool_broker_concrete = LocalCapabilityBroker::new(store.clone());
+    let transport = HttpTransport::new(
+        &server.url(),
+        &NetScope::EgressAllowlist([Host("127.0.0.1".to_string())].into_iter().collect()),
+    )
+    .expect("http transport builds for loopback");
+    tool_broker_concrete.register_capability(Box::new(McpCapability::new(
+        tool.clone(),
+        version.clone(),
+        McpEndpointId(server.url()),
+        "echo",
+        Box::new(transport),
+    )));
+    let tool_broker: Arc<dyn CapabilityBroker> = Arc::new(tool_broker_concrete);
+
+    let warrant = warrant_for(&tool, &version, warrant_egress);
+    let workflow =
+        workflows::model_tool_call(&model_id(), &warrant, "call the tool", &tool, &version);
+    let m_id = workflow.stc_crash_target;
+
+    let executor = ModelExecutor::new(
+        backend.clone(),
+        store.clone(),
+        sink.clone(),
+        registry.clone(),
+    );
+    let broker = Arc::new(ModelBroker::new(
+        backend,
+        store.clone(),
+        None,
+        Some(workflow.stc_crash_target),
+        Arc::new(BrokerObserver::default()),
+        sink.clone(),
+        registry,
+        tool_broker,
+        instance_id,
+    ));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let result = run_with_seams(
+        &config,
+        &workflow,
+        store.clone(),
+        journal.clone(),
+        &rm,
+        &executor,
+        &protocol,
+        None,
+        Some(&sink),
+    );
+    (result, store, journal, m_id)
+}
+
+fn loopback_egress() -> NetScope {
+    NetScope::EgressAllowlist([Host("127.0.0.1".to_string())].into_iter().collect())
+}
+
+#[test]
+fn model_dispatches_external_http_tool_egress_scoped() {
+    // THE M5 EXIT GATE: select Mote+model, assemble context, dispatch an external
+    // HTTP tool with resolved params, capture provenance, commit — egress
+    // warrant-scoped.
+    let server = MockHttp::start();
+    let dir = tempfile::tempdir().unwrap();
+    let instance_id = [0x7au8; INSTANCE_ID_LEN];
+
+    let (result, store, journal, m_id) = drive(dir.path(), &server, loopback_egress(), instance_id);
+    let outcome = result.expect("run completes");
+    assert!(outcome.is_complete(), "the model→HTTP-tool Mote committed");
+
+    let projection = Projection::from_journal(&*journal).unwrap();
+    let result_ref = projection.result_ref_of(&m_id).expect("Mote committed");
+    let bytes = store.get(&result_ref).unwrap();
+    assert_eq!(
+        &*bytes, EXPECTED_RESULT,
+        "committed bytes are the HTTP MCP result"
+    );
+
+    // The egress actually happened, and a run-scoped Idempotency-Key was sent
+    // (64 lower-hex chars). That it IS the run-scoped token — varying with the run —
+    // is proven by `recovery_redispatch_same_run_sends_same_idempotency_key`.
+    let keys = server.idempotency_keys();
+    assert_eq!(keys.len(), 1, "exactly one HTTP request egressed");
+    assert_eq!(keys[0].len(), 64, "Idempotency-Key is a 32-byte hex token");
+    assert!(keys[0]
+        .bytes()
+        .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()));
+}
+
+#[test]
+fn recovery_redispatch_same_run_sends_same_idempotency_key() {
+    // Two dispatches of the SAME run (same instance_id) send the SAME
+    // Idempotency-Key → the remote dedups (remote exactly-once on crash-recovery).
+    // A DIFFERENT run (fresh instance_id) sends a DIFFERENT key (re-submit fires
+    // afresh, D64).
+    let server = MockHttp::start();
+    let run_a = [0x11u8; INSTANCE_ID_LEN];
+    let run_b = [0x22u8; INSTANCE_ID_LEN];
+
+    let d1 = tempfile::tempdir().unwrap();
+    let d2 = tempfile::tempdir().unwrap();
+    let d3 = tempfile::tempdir().unwrap();
+    let _ = drive(d1.path(), &server, loopback_egress(), run_a);
+    let _ = drive(d2.path(), &server, loopback_egress(), run_a); // same run → same key
+    let _ = drive(d3.path(), &server, loopback_egress(), run_b); // different run
+
+    let keys = server.idempotency_keys();
+    assert_eq!(keys.len(), 3);
+    assert_eq!(
+        keys[0], keys[1],
+        "same run ⇒ same Idempotency-Key (remote dedup)"
+    );
+    assert_ne!(
+        keys[0], keys[2],
+        "different run ⇒ different Idempotency-Key"
+    );
+}
+
+#[test]
+fn none_egress_warrant_refuses_the_http_tool() {
+    // NEGATIVE CONTROL: the resolved tool needs egress, but the warrant grants
+    // NONE. The broker gate refuses fail-closed — no commit, no egress.
+    let server = MockHttp::start();
+    let dir = tempfile::tempdir().unwrap();
+
+    let (result, _store, journal, m_id) = drive(
+        dir.path(),
+        &server,
+        NetScope::None,
+        [0x33u8; INSTANCE_ID_LEN],
+    );
+
+    if let Ok(outcome) = &result {
+        assert!(
+            !outcome.is_complete(),
+            "a None-egress warrant must not complete the tool"
+        );
+    }
+    let state = Projection::from_journal(&*journal).unwrap().state_of(&m_id);
+    assert_ne!(
+        state,
+        kx_projection::MoteState::Committed,
+        "no effect committed"
+    );
+    assert!(
+        server.idempotency_keys().is_empty(),
+        "no HTTP request may egress under a None-egress warrant"
+    );
+}

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -110,6 +110,7 @@ impl McpTransport for ConstResultTransport {
         _request: &[u8],
         _max: usize,
         _ms: u64,
+        _idempotency_key: Option<&[u8; 32]>,
     ) -> Result<Vec<u8>, TransportError> {
         Ok(br#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.to_vec())
     }
@@ -191,6 +192,10 @@ fn drive(
         sink.clone(),
         registry,
         tool_broker,
+        // A fixed registered-run instance_id (D64): both runs in the determinism
+        // test use the same id, so the run-scoped token (and thus the remote
+        // Idempotency-Key) is stable — the staged ref is content-addressed anyway.
+        [0x5au8; kx_capability::INSTANCE_ID_LEN],
     ));
     let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
     let rm = LocalResourceManager::dev_defaults();


### PR DESCRIPTION
## M5.2b — completes the M5 exit gate

A single-Mote run selects a tool → assembles context → dispatches an **external HTTP** tool with resolved params → provenance captured → **egress warrant-scoped** → secrets not journaled. This is the agentic surface's first real network-touching tool path (M5.2a proved the seam over stdio).

### What changed
- **`kx-mcp/egress.rs`** (pure, zero-I/O): `EgressPolicy` + `classify_ip` (hand-rolled octets, toolchain-independent) + `vet_resolved_addr` — the single SSRF/rebind decision surface.
- **`kx-mcp/http_transport.rs`**: `HttpTransport` over a **pooled `ureq::Agent`** + a `VettingResolver`, `redirects(0)` refusal, host-allowlist binding, a hard wall-clock watchdog (mirrors `StdioTransport`), `take(cap+1)` bounded read. Credentials injected as a **transient header** (D81); the run-scoped `Idempotency-Key` header makes the remote effect exactly-once. `url` promoted to a direct dep (already in-tree via `ureq` — **no new crate**).
- **`McpTransport::round_trip`** gains an `idempotency_key` arg (stdio ignores it; HTTP sends the header).
- **`kx-model-harness/broker.rs`**: the model-driven tool arm now **derives `net_scope` from the resolved tool** (was hardcoded `None`) and keys the effect with `run_scoped_token` (instance_id-anchored) — remote exactly-once on a crash-recovery re-dispatch.

### Pre-flight risk analysis (Golden Rule 8, both passes)
**Defensive:** egress can only fail *closed* past four independent gates (registry `resolve`, broker `precheck`, transport `EgressPolicy`, vetting resolver); SSRF/metadata/rebind refused (a public name can never reach `169.254.169.254` or an internal IP); `redirects(0)` + explicit 3xx refusal; secrets never stored/journaled; oversize/slow-loris bounded; StageThenCommit (D66) holds → recovery re-derives the same `Idempotency-Key`.
**Forward / honest boundary (D94):** OS-level egress isolation (`bwrap`/nftables, NET_ADMIN) is **out of OSS scope** — a `kx-cloud` concern behind the same `McpTransport` seam. A compromised in-process tool could bypass the app-layer resolver via its own syscalls; only kernel isolation closes that. Documented, not claimed as full containment.

### Testing (D95 seven-kind matrix)
unit (16) · integration · property (secret-sweep + reused decode proptest) · chaos (slow→Timeout, redirect→refused, oversize→capped) · scale (`#[ignore]` 64 concurrent over one pooled Agent) · security (**hermetic SSRF/rebind via `localhost`→loopback**, `net_scope⊄warrant`) · e2e (full exit gate through a real `HttpTransport` + same-run/different-run key + fail-closed control).

### Invariants
- Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) source diff **EMPTY**.
- Canonical projection digest `a6b5c679…` **UNCHANGED**.
- Gate: fmt · clippy `-D warnings` · test --workspace (0 failures) · deny · doc `-D warnings` · scale-smoke · **I1.c byte-determinism PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)