### PR TITLE
feat(journal,runtime): schema migration — forward-migration + replay corpus (IMP-2, M2.x-E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,17 +367,18 @@ jobs:
         run: just smoke-test-with-model
 
   # ---------------------------------------------------------------------------
-  # scale-smoke — M2.1 + M2.2 / D92 resume-availability gate. Folds a 25k+ Mote
-  # journal in RELEASE and asserts the incremental children-index re-fold stays
-  # ~linear (M2.1) AND that resume-from-FoldCheckpoint reproduces the full fold
-  # exactly with cost bounded by live-state under churn (M2.2). A super-linear
-  # resume is an outage. Promoted to a required status check via an explicitly-
-  # authorized branch-protection PATCH once green on a couple of runs (Golden
-  # Rule 4). Needs the test suite green first.
+  # scale-smoke — M2.1 + M2.2 + M2.x-E / D92 resume-availability gate. Folds a
+  # 25k+ Mote journal in RELEASE and asserts the incremental children-index re-fold
+  # stays ~linear (M2.1) AND that resume-from-FoldCheckpoint reproduces the full
+  # fold exactly with cost bounded by live-state under churn (M2.2) AND that offline
+  # schema migration (migrate_to, IMP-2/M2.x-E) stays O(entries) so resume-after-
+  # upgrade is not an outage. A super-linear resume is an outage. Promoted to a
+  # required status check via an explicitly-authorized branch-protection PATCH once
+  # green on a couple of runs (Golden Rule 4). Needs the test suite green first.
   # ---------------------------------------------------------------------------
   # NOTE: the job `name:` below is the **required status-check context** in
   # branch protection — do NOT rename it (a rename orphans the required check
-  # and blocks merges). M2.2 extends the recipe body, not the context name.
+  # and blocks merges). M2.2 / M2.x-E extend the recipe body, not the context name.
   scale-smoke:
     name: scale-smoke (M2.1 incremental children-index re-fold)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "kx-projection",
  "kx-scheduler",
  "kx-warrant",
+ "rusqlite",
  "smallvec",
  "tempfile",
  "thiserror",

--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -141,8 +141,16 @@ use smallvec::SmallVec;
 ///   `QuarantinedAtLeastOnce`) record the recovery outcome for an at-most-once
 ///   effect. No `Failed`-body layout change (`reason_class` is already a u8).
 ///
-/// v6 readers refuse v5 files loudly (no in-place evolution; no production v5
-/// journals are retained across the bump per the corpus, acceptable).
+/// The strict [`crate::SqliteJournal::open`] refuses any file whose
+/// `schema_version` is not exactly v6 (the loud-refusal contract is unchanged).
+///
+/// **Migration (IMP-2, M2.x-E).** As of the schema-migration work, an older
+/// still-supported version is no longer a dead end: [`crate::migrate_entry`] /
+/// [`crate::ReplayJournal`] up-convert old entries to the current shape for
+/// replay/recovery, and [`crate::migrate_to`] rewrites an old journal into a fresh
+/// v6 one for resume-and-append. The product identity digest is invariant across
+/// migration; see [`crate::migrate_entry`] for the full contract and the
+/// supported version window ([`crate::MIN_SUPPORTED_SCHEMA_VERSION`]..=v6).
 pub const JOURNAL_SCHEMA_VERSION: u16 = 6;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).

--- a/crates/kx-journal/src/lib.rs
+++ b/crates/kx-journal/src/lib.rs
@@ -96,10 +96,14 @@ pub use crate::entry::{
     KIND_REPUDIATED, KIND_RUN_REGISTERED, KIND_RUN_VERSIONS_RESOLVED, MAX_ENTRY_LEN, MAX_PARENTS,
 };
 pub use crate::in_memory::InMemoryJournal;
-pub use crate::sqlite::SqliteJournal;
+pub use crate::migration::{
+    migrate_entry, MIN_SUPPORTED_SCHEMA_VERSION, V5_ABSENT_IDEMPOTENCY_CLASS,
+};
+pub use crate::sqlite::{migrate_to, MigrationReport, ReplayJournal, SqliteJournal};
 
 mod entry;
 mod in_memory;
+mod migration;
 mod sqlite;
 
 use std::ops::Range;

--- a/crates/kx-journal/src/migration.rs
+++ b/crates/kx-journal/src/migration.rs
@@ -1,0 +1,301 @@
+//! Schema migration — the forward-migration story (IMP-2, M2.x-E).
+//!
+//! A durability product that cannot be upgraded is not durable. Every prior
+//! `JOURNAL_SCHEMA_VERSION` bump shipped a *loud refusal* of the previous version
+//! (`SchemaVersionMismatch`) and no migration, so shipping a new binary would
+//! orphan every durable run on disk. This module closes that gap **before real
+//! journals exist in the wild**: it up-converts an entry encoded under an older,
+//! still-supported schema version into the current in-memory [`JournalEntry`]
+//! shape, on the fly, without mutating the source bytes.
+//!
+//! ## What migration guarantees (and what it does not)
+//!
+//! - **Product identity is invariant across migration.** The run-identity product
+//!   digest (`kx-runtime::digest_projection`) is computed over committed facts only
+//!   (`mote_id ‖ result_ref ‖ nd_class`); none of the fields a bump adds are
+//!   identity inputs. A migrated run keeps its identity. *This is the durability
+//!   law.*
+//! - **The resume/state digest is version-local.** `kx_projection`'s full-state
+//!   `state_digest()` includes lineage metadata (e.g. a resolved capability's
+//!   `idempotency_class`), so it is **not** byte-stable across a digest-shape
+//!   bump. A pre-bump seal therefore will not match a post-migration re-fold; the
+//!   checkpoint self-heals (full-fold + re-seal), since seals are discardable
+//!   optimizations, never authoritative (D92/D103).
+//!
+//! ## The ladder
+//!
+//! [`migrate_entry`] dispatches on the on-disk `from_version`. Each older version
+//! has a single-step up-converter to the current shape; the next real bump adds
+//! one arm here plus one frozen fixture in `tests/fixtures/`, never a rewrite.
+//! Versions newer than this binary, or older than [`MIN_SUPPORTED_SCHEMA_VERSION`],
+//! are refused loudly (forward-compat preserved).
+//!
+//! ### v5 → v6 (the only production link today)
+//!
+//! The *only* on-disk byte difference between v5 and v6 is that a v6
+//! `RunVersionsResolved` (kind 6) capability-present body carries a **trailing**
+//! `idempotency_class` tag byte (M2.3b, D105.4) that v5 lacks. Because the
+//! capability is the last field of the body, a v5 capability-present entry is
+//! exactly a v6 one minus its final byte — so up-conversion appends the safe
+//! default and delegates to the canonical [`decode_entry_with_def_hash`] (one
+//! source of truth for parsing/validation). Every other v5 byte — including a
+//! capability-absent `RunVersionsResolved` and a `DigestSealed` (kind 7, whose
+//! 40-byte body is unchanged across v5→v6) — decodes identically under current
+//! code, so it passes through untouched.
+
+use kx_mote::MoteDefHash;
+
+use crate::entry::{
+    decode_entry_with_def_hash, IdempotencyClassTag, JournalEntry, HEADER_LEN, INSTANCE_ID_LEN,
+    JOURNAL_SCHEMA_VERSION, KIND_RUN_VERSIONS_RESOLVED,
+};
+use crate::JournalError;
+
+/// The oldest on-disk schema version this binary can replay or migrate. Files
+/// older than this are refused loudly (`SchemaVersionMismatch`) — no production
+/// journals are retained across the pre-v5 bumps per the corpus, so inventing
+/// fixtures for versions that never shipped durably would be dead weight.
+pub const MIN_SUPPORTED_SCHEMA_VERSION: u16 = 5;
+
+/// The idempotency class assigned to a v5 resolved-capability record that
+/// predates the durable `idempotency_class` field (added v6, M2.3b/D105.4).
+///
+/// [`IdempotencyClassTag::AtLeastOnce`] is the **safest** choice: it has no
+/// closing mechanism, so crash recovery never auto-redispatches a migrated
+/// world-mutating effect — the worst case is a Quarantine/Compensate, never a
+/// silent double-fire. Migration therefore cannot weaken exactly-once. This value
+/// is baked into the frozen replay-corpus goldens, so it must not change without
+/// re-baselining the corpus.
+pub const V5_ABSENT_IDEMPOTENCY_CLASS: IdempotencyClassTag = IdempotencyClassTag::AtLeastOnce;
+
+/// Up-convert one entry's canonical on-disk bytes from `from_version` to the
+/// current in-memory [`JournalEntry`]. The source bytes are never mutated.
+///
+/// `def_hash` supplies the `mote_def_hash` metadata for `Committed` entries (it is
+/// not in the canonical body bytes; the journal backend stores it in a column).
+/// It is ignored for every other kind, exactly as [`decode_entry_with_def_hash`].
+///
+/// Refuses (`SchemaVersionMismatch`) a `from_version` newer than this binary's
+/// [`JOURNAL_SCHEMA_VERSION`] or older than [`MIN_SUPPORTED_SCHEMA_VERSION`]; a
+/// malformed body for a supported version surfaces as `Decode`.
+///
+/// When `from_version == JOURNAL_SCHEMA_VERSION` this is a thin pass-through to
+/// [`decode_entry_with_def_hash`] — the current read path is behaviour-identical.
+pub fn migrate_entry(
+    bytes: &[u8],
+    from_version: u16,
+    def_hash: MoteDefHash,
+) -> Result<JournalEntry, JournalError> {
+    if !(MIN_SUPPORTED_SCHEMA_VERSION..=JOURNAL_SCHEMA_VERSION).contains(&from_version) {
+        return Err(JournalError::SchemaVersionMismatch {
+            expected: JOURNAL_SCHEMA_VERSION,
+            found: from_version,
+        });
+    }
+    if from_version == JOURNAL_SCHEMA_VERSION {
+        // Current version: no transform, single source of truth for decode.
+        return Ok(decode_entry_with_def_hash(bytes, def_hash)?);
+    }
+    // The only older supported version today is v5 (MIN == 5, CURRENT == 6); when a
+    // future link lands, add an arm here. `from_version` is guaranteed in
+    // [MIN_SUPPORTED, CURRENT) at this point, i.e. exactly 5.
+    upconvert_v5_to_current(bytes, def_hash)
+}
+
+/// v5 → current up-converter. The lone transform is appending the safe-default
+/// `idempotency_class` byte to a capability-present `RunVersionsResolved`; all
+/// other v5 bytes are already valid current-version bytes and pass through.
+fn upconvert_v5_to_current(
+    bytes: &[u8],
+    def_hash: MoteDefHash,
+) -> Result<JournalEntry, JournalError> {
+    if v5_run_versions_has_capability(bytes) {
+        let mut upconverted = Vec::with_capacity(bytes.len() + 1);
+        upconverted.extend_from_slice(bytes);
+        upconverted.push(V5_ABSENT_IDEMPOTENCY_CLASS.as_u8());
+        Ok(decode_entry_with_def_hash(&upconverted, def_hash)?)
+    } else {
+        Ok(decode_entry_with_def_hash(bytes, def_hash)?)
+    }
+}
+
+/// Returns `true` **only** when `bytes` is confidently a kind-6
+/// (`RunVersionsResolved`) entry with `has_cap == 1`. Any bounds ambiguity yields
+/// `false` so the canonical decoder (not this sniff) is the one to report the
+/// error — keeping migration fail-closed. Total; never panics.
+fn v5_run_versions_has_capability(bytes: &[u8]) -> bool {
+    // Body prefix = instance_id(16) ‖ warrant_ref(32), then a u16-LE model_id_len.
+    const PREFIX: usize = INSTANCE_ID_LEN + 32;
+    if bytes.first() != Some(&KIND_RUN_VERSIONS_RESOLVED) {
+        return false;
+    }
+    let Some(body) = bytes.get(HEADER_LEN..) else {
+        return false;
+    };
+    let Some(model_id_len_bytes) = body.get(PREFIX..PREFIX + 2) else {
+        return false;
+    };
+    let model_id_len = u16::from_le_bytes([model_id_len_bytes[0], model_id_len_bytes[1]]) as usize;
+    // has_cap byte sits immediately after the (variable) model_id.
+    let has_cap_offset = PREFIX + 2 + model_id_len;
+    body.get(has_cap_offset) == Some(&1u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entry::{encode_entry, ResolvedCapabilityRecord, ResolvedKindTag};
+    use kx_content::ContentRef;
+
+    // Build a current-version (v6) RunVersionsResolved entry with a capability,
+    // using the given idempotency class.
+    fn v6_run_versions_with_cap(class: IdempotencyClassTag) -> JournalEntry {
+        JournalEntry::RunVersionsResolved {
+            instance_id: [7u8; INSTANCE_ID_LEN],
+            warrant_ref: ContentRef::from_bytes([9u8; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            capability: Some(ResolvedCapabilityRecord {
+                tool_id: "fs.read".to_string(),
+                tool_version: "1.2.3".to_string(),
+                resolved_kind: ResolvedKindTag::Builtin,
+                resolved_def_hash: ContentRef::from_bytes([3u8; 32]),
+                idempotency_class: class,
+            }),
+            seq: 42,
+        }
+    }
+
+    // Derive the *v5* on-disk bytes of a capability-present RunVersionsResolved by
+    // encoding it at v6 and dropping the trailing idempotency_class byte — the one
+    // and only v5→v6 delta. (This mirrors what the frozen fixtures hold.)
+    fn v5_bytes_with_cap() -> Vec<u8> {
+        let v6 = v6_run_versions_with_cap(IdempotencyClassTag::Token);
+        let mut bytes = encode_entry(&v6).unwrap();
+        bytes.pop(); // remove trailing idempotency_class tag → v5 shape
+        bytes
+    }
+
+    #[test]
+    fn refuses_version_newer_than_current() {
+        let bytes = encode_entry(&v6_run_versions_with_cap(IdempotencyClassTag::Token)).unwrap();
+        let err = migrate_entry(
+            &bytes,
+            JOURNAL_SCHEMA_VERSION + 1,
+            MoteDefHash::from_bytes([0u8; 32]),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            JournalError::SchemaVersionMismatch { found, .. } if found == JOURNAL_SCHEMA_VERSION + 1
+        ));
+    }
+
+    #[test]
+    fn refuses_version_older_than_min_supported() {
+        let bytes = encode_entry(&v6_run_versions_with_cap(IdempotencyClassTag::Token)).unwrap();
+        let err = migrate_entry(
+            &bytes,
+            MIN_SUPPORTED_SCHEMA_VERSION - 1,
+            MoteDefHash::from_bytes([0u8; 32]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, JournalError::SchemaVersionMismatch { .. }));
+    }
+
+    #[test]
+    fn current_version_is_passthrough() {
+        let entry = v6_run_versions_with_cap(IdempotencyClassTag::Readback);
+        let bytes = encode_entry(&entry).unwrap();
+        let migrated = migrate_entry(
+            &bytes,
+            JOURNAL_SCHEMA_VERSION,
+            MoteDefHash::from_bytes([0u8; 32]),
+        )
+        .unwrap();
+        assert_eq!(migrated, entry);
+    }
+
+    #[test]
+    fn v5_capability_defaults_to_at_least_once() {
+        let v5 = v5_bytes_with_cap();
+        let migrated = migrate_entry(&v5, 5, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        match migrated {
+            JournalEntry::RunVersionsResolved {
+                capability: Some(cap),
+                ..
+            } => {
+                assert_eq!(cap.idempotency_class, IdempotencyClassTag::AtLeastOnce);
+                assert_eq!(cap.tool_id, "fs.read");
+                assert_eq!(cap.tool_version, "1.2.3");
+                assert_eq!(cap.resolved_kind, ResolvedKindTag::Builtin);
+            }
+            other => panic!("expected RunVersionsResolved with capability, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn v5_capability_matches_v6_with_explicit_default() {
+        // Up-converting a v5 cap entry must equal the v6 entry that carries the
+        // explicit default class — the migration adds nothing else.
+        let v5 = v5_bytes_with_cap();
+        let migrated = migrate_entry(&v5, 5, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        let expected = v6_run_versions_with_cap(V5_ABSENT_IDEMPOTENCY_CLASS);
+        assert_eq!(migrated, expected);
+    }
+
+    #[test]
+    fn v5_no_capability_is_byte_identical() {
+        // A capability-absent RunVersionsResolved is unchanged v5→v6: migrating its
+        // bytes equals decoding them directly.
+        let no_cap = JournalEntry::RunVersionsResolved {
+            instance_id: [4u8; INSTANCE_ID_LEN],
+            warrant_ref: ContentRef::from_bytes([5u8; 32]),
+            model_id: "m".to_string(),
+            capability: None,
+            seq: 3,
+        };
+        let bytes = encode_entry(&no_cap).unwrap();
+        let migrated = migrate_entry(&bytes, 5, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        let direct =
+            decode_entry_with_def_hash(&bytes, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        assert_eq!(migrated, direct);
+        assert_eq!(migrated, no_cap);
+    }
+
+    #[test]
+    fn v5_other_kinds_pass_through_unchanged() {
+        // A DigestSealed (kind 7) body is unchanged across v5→v6; migrating it must
+        // equal decoding it directly (the sniff must not touch non-kind-6 bytes).
+        let sealed = JournalEntry::DigestSealed {
+            through_seq: 10,
+            state_digest: [0xAB; 32],
+            seq: 11,
+        };
+        let bytes = encode_entry(&sealed).unwrap();
+        let migrated = migrate_entry(&bytes, 5, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        assert_eq!(migrated, sealed);
+        assert!(!v5_run_versions_has_capability(&bytes));
+    }
+
+    #[test]
+    fn sniff_detects_capability_present_and_absent() {
+        assert!(v5_run_versions_has_capability(&v5_bytes_with_cap()));
+        let no_cap = JournalEntry::RunVersionsResolved {
+            instance_id: [1u8; INSTANCE_ID_LEN],
+            warrant_ref: ContentRef::from_bytes([2u8; 32]),
+            model_id: "x".to_string(),
+            capability: None,
+            seq: 1,
+        };
+        assert!(!v5_run_versions_has_capability(
+            &encode_entry(&no_cap).unwrap()
+        ));
+    }
+
+    #[test]
+    fn malformed_v5_bytes_fail_closed() {
+        // Truncated garbage must never silently decode — it errors.
+        let garbage = vec![KIND_RUN_VERSIONS_RESOLVED, 0u8, 1u8, 2u8];
+        assert!(migrate_entry(&garbage, 5, MoteDefHash::from_bytes([0u8; 32])).is_err());
+    }
+}

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -43,7 +43,7 @@
 //! rowids on rollback, so a failed/aborted txn does not burn a `seq` value — matching
 //! `journal-txn.md` §6 ("Assignment is final on successful commit only").
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use kx_content::ContentRef;
 use kx_mote::{MoteDefHash, MoteId};
@@ -53,6 +53,7 @@ use crate::entry::{
     decode_entry_with_def_hash, encode_entry, repudiation_idempotency_key, JournalEntry,
     JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, KIND_EFFECT_STAGED, KIND_REPUDIATED, MAX_ENTRY_LEN,
 };
+use crate::migration::{migrate_entry, MIN_SUPPORTED_SCHEMA_VERSION};
 use crate::{Journal, JournalError};
 
 const METADATA_SCHEMA_VERSION_KEY: &str = "schema_version";
@@ -484,5 +485,340 @@ fn vec_to_mote_def_hash(v: Option<Vec<u8>>) -> MoteDefHash {
             MoteDefHash::from_bytes(out)
         }
         Some(_) => MoteDefHash::from_bytes([0u8; 32]),
+    }
+}
+
+/// Read the on-disk `schema_version` (LE u16) from the `metadata` table without
+/// comparing it to this binary's — the migration entry points need the value, not
+/// a refusal. (The strict `SqliteJournal::verify_schema_version` is unchanged.)
+fn read_schema_version(conn: &Connection) -> Result<u16, JournalError> {
+    let stored: Vec<u8> = conn.query_row(
+        "SELECT value FROM metadata WHERE key = ?1",
+        params![METADATA_SCHEMA_VERSION_KEY],
+        |r| r.get(0),
+    )?;
+    if stored.len() != 2 {
+        return Err(JournalError::Invariant(
+            "metadata.schema_version is not 2 bytes",
+        ));
+    }
+    Ok(u16::from_le_bytes([stored[0], stored[1]]))
+}
+
+// ===========================================================================
+// Schema migration — read-only replay + offline rewrite (IMP-2, M2.x-E)
+// ===========================================================================
+
+/// A **read-only**, schema-version-aware view over a journal file, used to replay
+/// or recover a run written by an *older* (still-supported) binary.
+///
+/// Unlike [`SqliteJournal::open`] — which refuses any file whose `schema_version`
+/// is not exactly this binary's — [`ReplayJournal::open`] accepts any version in
+/// `[MIN_SUPPORTED_SCHEMA_VERSION, JOURNAL_SCHEMA_VERSION]` and up-converts each
+/// entry to the current in-memory shape on the fly (see [`crate::migrate_entry`]).
+/// The on-disk **committed content is never modified** (the handle performs no
+/// appends; writes are rejected at the Rust API by [`ReplayJournal::append`]).
+///
+/// This is the read half of the upgrade story: a current binary can fold/recover
+/// an old journal. To obtain a *writable* current-version journal (to resume and
+/// append new entries), use [`migrate_to`].
+pub struct ReplayJournal {
+    conn: std::sync::Mutex<Connection>,
+    from_version: u16,
+}
+
+impl std::fmt::Debug for ReplayJournal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplayJournal")
+            .field("from_version", &self.from_version)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReplayJournal {
+    /// Open a journal file for **read-only replay**, up-converting an older
+    /// on-disk schema to the current in-memory shape.
+    ///
+    /// Refuses (`SchemaVersionMismatch`) a file newer than this binary's
+    /// [`JOURNAL_SCHEMA_VERSION`] or older than [`MIN_SUPPORTED_SCHEMA_VERSION`] —
+    /// the same loud-refusal contract as [`SqliteJournal::open`], just with a
+    /// supported-range window instead of an exact match.
+    ///
+    /// Opens read-write at the SQLite layer (so a crashed journal's WAL can be
+    /// recovered) but immediately sets `PRAGMA query_only` so the engine rejects
+    /// any data write — the source's committed content is never altered.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, JournalError> {
+        let conn = Connection::open_with_flags(
+            path.as_ref(),
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        // Logical read-only: allow WAL recovery on open, reject data writes.
+        conn.execute_batch("PRAGMA query_only = ON;")?;
+        let from_version = read_schema_version(&conn)?;
+        if !(MIN_SUPPORTED_SCHEMA_VERSION..=JOURNAL_SCHEMA_VERSION).contains(&from_version) {
+            return Err(JournalError::SchemaVersionMismatch {
+                expected: JOURNAL_SCHEMA_VERSION,
+                found: from_version,
+            });
+        }
+        Ok(Self {
+            conn: std::sync::Mutex::new(conn),
+            from_version,
+        })
+    }
+
+    /// The on-disk schema version this handle is replaying from.
+    #[must_use]
+    pub fn from_version(&self) -> u16 {
+        self.from_version
+    }
+}
+
+impl Journal for ReplayJournal {
+    fn append(&self, _entry: JournalEntry) -> Result<JournalEntry, JournalError> {
+        Err(JournalError::Invariant(
+            "ReplayJournal is read-only; use migrate_to to obtain a writable current-version journal",
+        ))
+    }
+
+    fn append_batch(&self, _entries: Vec<JournalEntry>) -> Result<Vec<JournalEntry>, JournalError> {
+        Err(JournalError::Invariant(
+            "ReplayJournal is read-only; use migrate_to to obtain a writable current-version journal",
+        ))
+    }
+
+    fn read_committed(&self, mote_id: &MoteId) -> Result<Option<JournalEntry>, JournalError> {
+        let conn = self.conn.lock().expect("poisoned mutex");
+        let row: Option<(Vec<u8>, Option<Vec<u8>>)> = conn
+            .query_row(
+                "SELECT entry_bytes, mote_def_hash
+                   FROM entries
+                  WHERE mote_id = ?1 AND kind = ?2",
+                params![mote_id.as_bytes().to_vec(), KIND_COMMITTED as i64],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()?;
+        match row {
+            None => Ok(None),
+            Some((bytes, dh)) => Ok(Some(migrate_entry(
+                &bytes,
+                self.from_version,
+                vec_to_mote_def_hash(dh),
+            )?)),
+        }
+    }
+
+    fn read_entries_by_seq(
+        &self,
+        range: std::ops::Range<u64>,
+    ) -> Result<Box<dyn Iterator<Item = JournalEntry> + '_>, JournalError> {
+        let conn = self.conn.lock().expect("poisoned mutex");
+        let mut stmt = conn.prepare(
+            "SELECT entry_bytes, mote_def_hash
+               FROM entries
+              WHERE seq >= ?1 AND seq < ?2
+              ORDER BY seq ASC",
+        )?;
+        let rows: Vec<(Vec<u8>, Option<Vec<u8>>)> = stmt
+            .query_map(params![range.start as i64, range.end as i64], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })?
+            .collect::<Result<_, _>>()?;
+        // Version-aware decode; a migration failure surfaces (fail-closed) rather
+        // than panicking the way the current-version `SqliteJournal` read path does.
+        let decoded: Vec<JournalEntry> = rows
+            .into_iter()
+            .map(|(b, dh)| migrate_entry(&b, self.from_version, vec_to_mote_def_hash(dh)))
+            .collect::<Result<_, _>>()?;
+        Ok(Box::new(decoded.into_iter()))
+    }
+
+    fn list_committed_refs(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = ContentRef> + '_>, JournalError> {
+        let conn = self.conn.lock().expect("poisoned mutex");
+        let mut stmt =
+            conn.prepare("SELECT entry_bytes FROM entries WHERE kind = ?1 ORDER BY seq ASC")?;
+        let rows: Vec<Vec<u8>> = stmt
+            .query_map(params![KIND_COMMITTED as i64], |r| r.get(0))?
+            .collect::<Result<_, _>>()?;
+        let mut refs: Vec<ContentRef> = Vec::with_capacity(rows.len());
+        for bytes in rows {
+            // mote_def_hash is irrelevant for ref enumeration; pass zeros.
+            if let JournalEntry::Committed { result_ref, .. } = migrate_entry(
+                &bytes,
+                self.from_version,
+                MoteDefHash::from_bytes([0u8; 32]),
+            )? {
+                refs.push(result_ref);
+            }
+        }
+        Ok(Box::new(refs.into_iter()))
+    }
+
+    fn list_committed_by_mote_def_hash(
+        &self,
+        h: &MoteDefHash,
+    ) -> Result<Box<dyn Iterator<Item = JournalEntry> + '_>, JournalError> {
+        let conn = self.conn.lock().expect("poisoned mutex");
+        let mut stmt = conn.prepare(
+            "SELECT entry_bytes, mote_def_hash
+               FROM entries
+              WHERE kind = ?1 AND mote_def_hash = ?2
+              ORDER BY seq ASC",
+        )?;
+        let rows: Vec<(Vec<u8>, Option<Vec<u8>>)> = stmt
+            .query_map(params![KIND_COMMITTED as i64, h.as_bytes().to_vec()], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })?
+            .collect::<Result<_, _>>()?;
+        let decoded: Vec<JournalEntry> = rows
+            .into_iter()
+            .map(|(b, dh)| migrate_entry(&b, self.from_version, vec_to_mote_def_hash(dh)))
+            .collect::<Result<_, _>>()?;
+        Ok(Box::new(decoded.into_iter()))
+    }
+
+    fn current_seq(&self) -> Result<u64, JournalError> {
+        let conn = self.conn.lock().expect("poisoned mutex");
+        let v: i64 = conn.query_row("SELECT COALESCE(MAX(seq), 0) FROM entries", [], |r| {
+            r.get(0)
+        })?;
+        Ok(v as u64)
+    }
+
+    fn count_entries(&self) -> Result<u64, JournalError> {
+        let conn = self.conn.lock().expect("poisoned mutex");
+        let v: i64 = conn.query_row("SELECT COUNT(*) FROM entries", [], |r| r.get(0))?;
+        Ok(v as u64)
+    }
+}
+
+/// Outcome of an offline [`migrate_to`] rewrite — a small audit record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationReport {
+    /// The source journal's on-disk schema version.
+    pub from_version: u16,
+    /// The schema version the destination was written at (always
+    /// [`JOURNAL_SCHEMA_VERSION`]).
+    pub to_version: u16,
+    /// Total entries copied into the destination.
+    pub entries_migrated: u64,
+    /// Of those, how many required a non-identity up-conversion (e.g. a v5
+    /// capability record gaining its default `idempotency_class`).
+    pub entries_upconverted: u64,
+}
+
+/// Offline-migrate the journal at `src` (any supported older version) into a
+/// fresh **current-version** journal at `dst`, preserving every `seq`. After this
+/// the destination opens with the strict [`SqliteJournal::open`] and can be
+/// resumed and appended to.
+///
+/// Crash-safe: the destination is built at a temporary sibling of `dst`, fully
+/// committed and WAL-checkpointed, then atomically `rename`d into place — a crash
+/// mid-rewrite leaves `src` untouched and `dst` absent (retry is safe). Idempotent:
+/// a `src` already at the current version is rebuilt into a logically-equivalent
+/// current journal (`entries_upconverted == 0`).
+///
+/// The product identity (`kx-runtime`'s committed-facts digest) is invariant
+/// across this rewrite. The migration refuses loudly
+/// (`Invariant("source seq not preserved")`) rather than silently remap a `seq` if
+/// the source is non-contiguous (corruption) — `DigestSealed::through_seq` and
+/// committed `seq` references depend on exact preservation.
+///
+/// `src` must be quiesced (no concurrent writer).
+pub fn migrate_to(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+) -> Result<MigrationReport, JournalError> {
+    let replay = ReplayJournal::open(src.as_ref())?;
+    let from_version = replay.from_version;
+    let dst = dst.as_ref();
+    let tmp = temp_sibling(dst);
+
+    // Clear any stale temp from a previously-aborted migration.
+    remove_sqlite_family(&tmp);
+
+    let counts = migrate_into_temp(&replay, from_version, &tmp);
+    match counts {
+        Ok((entries_migrated, entries_upconverted)) => {
+            std::fs::rename(&tmp, dst)?;
+            Ok(MigrationReport {
+                from_version,
+                to_version: JOURNAL_SCHEMA_VERSION,
+                entries_migrated,
+                entries_upconverted,
+            })
+        }
+        Err(e) => {
+            remove_sqlite_family(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// Build the current-version journal at `tmp` from `replay`'s up-converted
+/// entries, returning `(entries_migrated, entries_upconverted)`. Single
+/// transaction (group commit) + WAL checkpoint + clean close.
+fn migrate_into_temp(
+    replay: &ReplayJournal,
+    from_version: u16,
+    tmp: &Path,
+) -> Result<(u64, u64), JournalError> {
+    let out = SqliteJournal::open(tmp)?; // initialize() stamps the CURRENT version
+    let mut conn = out.conn.lock().expect("poisoned mutex");
+    let mut entries_migrated = 0u64;
+    let mut entries_upconverted = 0u64;
+    {
+        let txn = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let head = replay.current_seq()?;
+        for entry in replay.read_entries_by_seq(0..head + 1)? {
+            let src_seq = entry.seq();
+            let upconverted = from_version < JOURNAL_SCHEMA_VERSION
+                && matches!(
+                    &entry,
+                    JournalEntry::RunVersionsResolved {
+                        capability: Some(_),
+                        ..
+                    }
+                );
+            let durable = append_one(&txn, entry)?;
+            if durable.seq() != src_seq {
+                return Err(JournalError::Invariant(
+                    "migrate_to: source seq not preserved (non-contiguous journal)",
+                ));
+            }
+            entries_migrated += 1;
+            if upconverted {
+                entries_upconverted += 1;
+            }
+        }
+        txn.commit()?;
+    }
+    // Merge the WAL into the main db + truncate so the renamed file is a single,
+    // self-contained, cleanly-closeable database.
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    drop(conn);
+    drop(out);
+    Ok((entries_migrated, entries_upconverted))
+}
+
+/// A temp path in the SAME directory as `dst` (so the final `rename` is atomic on
+/// one filesystem), derived from `dst`'s file name.
+fn temp_sibling(dst: &Path) -> PathBuf {
+    let mut file_name = dst
+        .file_name()
+        .map_or_else(|| std::ffi::OsString::from("journal"), ToOwned::to_owned);
+    file_name.push(".kx-migrate.tmp");
+    dst.with_file_name(file_name)
+}
+
+/// Best-effort removal of a SQLite database file plus its `-wal`/`-shm` siblings.
+fn remove_sqlite_family(path: &Path) {
+    let _ = std::fs::remove_file(path);
+    for suffix in ["-wal", "-shm"] {
+        let mut sibling = path.as_os_str().to_owned();
+        sibling.push(suffix);
+        let _ = std::fs::remove_file(PathBuf::from(sibling));
     }
 }

--- a/crates/kx-journal/tests/dod.rs
+++ b/crates/kx-journal/tests/dod.rs
@@ -19,6 +19,7 @@ use kx_journal::{
     decode_entry_with_def_hash, encode_entry, repudiation_idempotency_key, FailureReason,
     InMemoryJournal, Journal, JournalEntry, JournalError, ParentEntry, RepudiationReason,
     SqliteJournal, JOURNAL_SCHEMA_VERSION, KIND_COMMITTED, MAX_ENTRY_LEN,
+    MIN_SUPPORTED_SCHEMA_VERSION,
 };
 use kx_mote::{MoteDefHash, MoteId, NdClass};
 use rusqlite::Connection;
@@ -308,6 +309,16 @@ fn obligation_13_schema_version_mismatch_loud_refusal() {
 #[test]
 fn schema_version_is_v6() {
     assert_eq!(JOURNAL_SCHEMA_VERSION, 6);
+}
+
+/// IMP-2 (M2.x-E): pin the migration floor. The schema-migration ladder
+/// (`migrate_entry` / `ReplayJournal` / `migrate_to`) replays any on-disk version
+/// in `[MIN_SUPPORTED_SCHEMA_VERSION, JOURNAL_SCHEMA_VERSION]`; lowering the floor
+/// (supporting an older version) is an intentional, reviewable change that must
+/// ship its own frozen fixture + ladder link.
+#[test]
+fn min_supported_schema_version_is_v5() {
+    assert_eq!(MIN_SUPPORTED_SCHEMA_VERSION, 5);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kx-journal/tests/proptest_schema_evolution.rs
+++ b/crates/kx-journal/tests/proptest_schema_evolution.rs
@@ -1,0 +1,239 @@
+// Integration-test file: compiled as a separate crate from the host lib.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! Property tests for schema migration (IMP-2, M2.x-E).
+//!
+//! Two families:
+//!
+//! - **P1 — current-version identity round-trip** (`decode∘encode == id`) for the
+//!   kinds/variants the existing `proptest_entry.rs` does not cover:
+//!   `RunVersionsResolved` (arbitrary `idempotency_class` + strings + optional
+//!   capability), `DigestSealed`, and `Failed` over the two v6 `FailureReason`
+//!   variants. This is the corpus's `encode∘decode==id` fuzz.
+//!
+//! - **P2 — versioned-decode correctness.** For an arbitrary *v5-shaped* entry
+//!   (current bytes minus the trailing capability class byte), [`migrate_entry`]
+//!   (1) defaults an absent class to the safe `AtLeastOnce`, (2) equals exactly
+//!   "append the default byte, then decode" — the migration mechanism is a pure
+//!   transform composed with the canonical decoder, so it generalizes to future
+//!   ladder links — and (3) is a fixed point on already-current bytes (idempotent).
+
+use kx_content::ContentRef;
+use kx_journal::{
+    decode_entry, decode_entry_with_def_hash, encode_entry, migrate_entry, FailureReason,
+    IdempotencyClassTag, JournalEntry, ResolvedCapabilityRecord, ResolvedKindTag, INSTANCE_ID_LEN,
+    JOURNAL_SCHEMA_VERSION, V5_ABSENT_IDEMPOTENCY_CLASS,
+};
+use kx_mote::MoteDefHash;
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_byte_array_32() -> impl Strategy<Value = [u8; 32]> {
+    proptest::array::uniform32(any::<u8>())
+}
+
+fn arb_instance_id() -> impl Strategy<Value = [u8; INSTANCE_ID_LEN]> {
+    proptest::array::uniform16(any::<u8>())
+}
+
+fn arb_short_str() -> impl Strategy<Value = String> {
+    // Bounded, valid UTF-8; covers empty and typical identifiers.
+    proptest::string::string_regex("[a-zA-Z0-9._/-]{0,32}").unwrap()
+}
+
+fn arb_idempotency_class() -> impl Strategy<Value = IdempotencyClassTag> {
+    prop_oneof![
+        Just(IdempotencyClassTag::Token),
+        Just(IdempotencyClassTag::Readback),
+        Just(IdempotencyClassTag::Staged),
+        Just(IdempotencyClassTag::AtLeastOnce),
+    ]
+}
+
+fn arb_resolved_kind() -> impl Strategy<Value = ResolvedKindTag> {
+    prop_oneof![
+        Just(ResolvedKindTag::Builtin),
+        Just(ResolvedKindTag::LocalScript),
+        Just(ResolvedKindTag::External),
+        Just(ResolvedKindTag::Mcp),
+        Just(ResolvedKindTag::SelfGenerated),
+    ]
+}
+
+fn arb_capability() -> impl Strategy<Value = ResolvedCapabilityRecord> {
+    (
+        arb_short_str(),
+        arb_short_str(),
+        arb_resolved_kind(),
+        arb_byte_array_32(),
+        arb_idempotency_class(),
+    )
+        .prop_map(
+            |(tool_id, tool_version, resolved_kind, def_hash, idempotency_class)| {
+                ResolvedCapabilityRecord {
+                    tool_id,
+                    tool_version,
+                    resolved_kind,
+                    resolved_def_hash: ContentRef::from_bytes(def_hash),
+                    idempotency_class,
+                }
+            },
+        )
+}
+
+fn arb_run_versions_resolved() -> impl Strategy<Value = JournalEntry> {
+    (
+        arb_instance_id(),
+        arb_byte_array_32(),
+        arb_short_str(),
+        proptest::option::of(arb_capability()),
+        any::<u64>(),
+    )
+        .prop_map(|(instance_id, warrant_ref, model_id, capability, seq)| {
+            JournalEntry::RunVersionsResolved {
+                instance_id,
+                warrant_ref: ContentRef::from_bytes(warrant_ref),
+                model_id,
+                capability,
+                seq,
+            }
+        })
+}
+
+fn arb_digest_sealed() -> impl Strategy<Value = JournalEntry> {
+    (any::<u64>(), arb_byte_array_32(), any::<u64>()).prop_map(|(through_seq, digest, seq)| {
+        JournalEntry::DigestSealed {
+            through_seq,
+            state_digest: digest,
+            seq,
+        }
+    })
+}
+
+fn arb_failed_v6() -> impl Strategy<Value = JournalEntry> {
+    let reason = prop_oneof![
+        Just(FailureReason::CompensatedAtLeastOnce),
+        Just(FailureReason::QuarantinedAtLeastOnce),
+    ];
+    (
+        arb_byte_array_32(),
+        arb_byte_array_32(),
+        reason,
+        any::<u128>(),
+    )
+        .prop_map(
+            |(mote_id, key, reason_class, reporter_id)| JournalEntry::Failed {
+                mote_id: kx_mote::MoteId::from_bytes(mote_id),
+                idempotency_key: key,
+                seq: 0,
+                reason_class,
+                reporter_id,
+            },
+        )
+}
+
+const ZERO_DEF_HASH: fn() -> MoteDefHash = || MoteDefHash::from_bytes([0u8; 32]);
+
+/// Derive v5-shaped bytes from a current entry: if it's a capability-present
+/// `RunVersionsResolved`, drop the trailing `idempotency_class` byte (the lone
+/// v5→v6 delta); otherwise the bytes are already v5-valid.
+fn to_v5_bytes(entry: &JournalEntry) -> Vec<u8> {
+    let mut bytes = encode_entry(entry).unwrap();
+    if matches!(
+        entry,
+        JournalEntry::RunVersionsResolved {
+            capability: Some(_),
+            ..
+        }
+    ) {
+        bytes.pop();
+    }
+    bytes
+}
+
+// ---------------------------------------------------------------------------
+// P1 — current-version identity round-trips
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    #[test]
+    fn prop_run_versions_resolved_round_trips(entry in arb_run_versions_resolved()) {
+        let bytes = encode_entry(&entry).unwrap();
+        let decoded = decode_entry(&bytes).unwrap();
+        prop_assert_eq!(decoded, entry);
+    }
+
+    #[test]
+    fn prop_digest_sealed_round_trips(entry in arb_digest_sealed()) {
+        let bytes = encode_entry(&entry).unwrap();
+        let decoded = decode_entry(&bytes).unwrap();
+        prop_assert_eq!(decoded, entry);
+    }
+
+    #[test]
+    fn prop_failed_v6_variants_round_trip(entry in arb_failed_v6()) {
+        let bytes = encode_entry(&entry).unwrap();
+        let decoded = decode_entry(&bytes).unwrap();
+        prop_assert_eq!(decoded, entry);
+    }
+
+    // ---------------------------------------------------------------------
+    // P2 — versioned-decode correctness
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn prop_v5_capability_defaults_to_safe_class(entry in arb_run_versions_resolved()) {
+        // Only meaningful when a capability is present.
+        prop_assume!(matches!(entry, JournalEntry::RunVersionsResolved { capability: Some(_), .. }));
+        let v5 = to_v5_bytes(&entry);
+        let migrated = migrate_entry(&v5, 5, ZERO_DEF_HASH()).unwrap();
+        match migrated {
+            JournalEntry::RunVersionsResolved { capability: Some(cap), .. } => {
+                prop_assert_eq!(cap.idempotency_class, V5_ABSENT_IDEMPOTENCY_CLASS);
+                prop_assert_eq!(cap.idempotency_class, IdempotencyClassTag::AtLeastOnce);
+            }
+            other => prop_assert!(false, "expected cap-present RunVersionsResolved, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn prop_v5_upconvert_equals_append_default_then_decode(entry in arb_run_versions_resolved()) {
+        // The migration mechanism is exactly "append the safe-default byte to a
+        // capability-present body, then run the canonical decoder" — a pure
+        // transform composed with decode. This is the invariant that lets the
+        // ladder generalize to future links.
+        let v5 = to_v5_bytes(&entry);
+        let migrated = migrate_entry(&v5, 5, ZERO_DEF_HASH()).unwrap();
+
+        let expected = if matches!(entry, JournalEntry::RunVersionsResolved { capability: Some(_), .. }) {
+            let mut appended = v5.clone();
+            appended.push(V5_ABSENT_IDEMPOTENCY_CLASS.as_u8());
+            decode_entry_with_def_hash(&appended, ZERO_DEF_HASH()).unwrap()
+        } else {
+            decode_entry_with_def_hash(&v5, ZERO_DEF_HASH()).unwrap()
+        };
+        prop_assert_eq!(migrated, expected);
+    }
+
+    #[test]
+    fn prop_migrate_current_version_is_fixed_point(entry in arb_run_versions_resolved()) {
+        // Migrating already-current bytes equals decoding them (idempotent).
+        let bytes = encode_entry(&entry).unwrap();
+        let migrated = migrate_entry(&bytes, JOURNAL_SCHEMA_VERSION, ZERO_DEF_HASH()).unwrap();
+        prop_assert_eq!(migrated, entry);
+    }
+
+    #[test]
+    fn prop_v5_non_capability_kinds_decode_unchanged(entry in arb_digest_sealed()) {
+        // A version-stable kind (DigestSealed) migrates identically to decoding.
+        let bytes = encode_entry(&entry).unwrap();
+        let migrated = migrate_entry(&bytes, 5, ZERO_DEF_HASH()).unwrap();
+        let direct = decode_entry_with_def_hash(&bytes, ZERO_DEF_HASH()).unwrap();
+        prop_assert_eq!(migrated.clone(), direct);
+        prop_assert_eq!(migrated, entry);
+    }
+}

--- a/crates/kx-journal/tests/schema_evolution.rs
+++ b/crates/kx-journal/tests/schema_evolution.rs
@@ -1,0 +1,459 @@
+// Integration-test file: compiled as a separate crate from the host lib.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! Schema-evolution replay corpus (IMP-2, carrier M2.x-E).
+//!
+//! Proves the forward-migration story: a journal written under an older,
+//! still-supported schema version can be replayed read-only ([`ReplayJournal`])
+//! and rewritten into a fresh current-version journal ([`migrate_to`]) that the
+//! strict [`SqliteJournal::open`] accepts, resumes, and appends to — without
+//! changing the run's committed facts.
+//!
+//! ## The frozen v5 representation
+//!
+//! No production journals exist in the wild yet, so the v5 fixture is built
+//! deterministically by [`build_v5_journal`]: write a current-version (v6)
+//! journal via the normal backend, then *downgrade* it with raw SQL to the exact
+//! v5 byte shape — strip the trailing `idempotency_class` byte from every
+//! capability-present `RunVersionsResolved` (the one and only v5→v6 delta) and
+//! stamp `metadata.schema_version = 5`. The v5 shape is therefore defined, as the
+//! corpus documents it, as "v6 minus the trailing capability class byte". The
+//! `migrate_entry` unit tests pin that byte-level relationship independently.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use kx_content::ContentRef;
+use kx_journal::{
+    decode_entry_with_def_hash, migrate_to, FailureReason, IdempotencyClassTag, Journal,
+    JournalEntry, JournalError, ParentEntry, ReplayJournal, ResolvedCapabilityRecord,
+    ResolvedKindTag, SqliteJournal, INSTANCE_ID_LEN, JOURNAL_SCHEMA_VERSION,
+    MIN_SUPPORTED_SCHEMA_VERSION, V5_ABSENT_IDEMPOTENCY_CLASS,
+};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use rusqlite::{params, Connection};
+use smallvec::SmallVec;
+
+// ---------------------------------------------------------------------------
+// Fixture: a small, representative v5 journal
+// ---------------------------------------------------------------------------
+
+/// The curated v5 entry set (constructed at v6, downgraded in `build_v5_journal`):
+/// a run registration, two committed Motes (B depends on A), a resolved-capability
+/// record (the entry that actually up-converts), a zero-grant resolved-versions
+/// record, a terminal failure, and a digest seal (kind 7, version-stable body).
+fn curated_v6_entries() -> Vec<JournalEntry> {
+    let instance_id = [1u8; INSTANCE_ID_LEN];
+    let a = MoteId::from_bytes([10u8; 32]);
+    vec![
+        JournalEntry::RunRegistered {
+            instance_id,
+            recipe_fingerprint: [2u8; 32],
+            ts: 0,
+            seq: 0,
+        },
+        JournalEntry::Committed {
+            mote_id: a,
+            idempotency_key: [10u8; 32],
+            seq: 0,
+            nondeterminism: NdClass::Pure,
+            result_ref: ContentRef::from_bytes([110u8; 32]),
+            parents: SmallVec::new(),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([20u8; 32]),
+        },
+        JournalEntry::Committed {
+            mote_id: MoteId::from_bytes([11u8; 32]),
+            idempotency_key: [11u8; 32],
+            seq: 0,
+            nondeterminism: NdClass::ReadOnlyNondet,
+            result_ref: ContentRef::from_bytes([111u8; 32]),
+            parents: {
+                let mut p = SmallVec::new();
+                p.push(ParentEntry {
+                    parent_id: a,
+                    edge_kind: 0, // Data
+                    non_cascade: 0,
+                });
+                p
+            },
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([21u8; 32]),
+        },
+        JournalEntry::RunVersionsResolved {
+            instance_id,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            // Original resolved class was Token; v5 did not record it, so migration
+            // must apply the SAFE default (AtLeastOnce), not recover Token.
+            capability: Some(ResolvedCapabilityRecord {
+                tool_id: "fs.read".to_string(),
+                tool_version: "1.0.0".to_string(),
+                resolved_kind: ResolvedKindTag::Builtin,
+                resolved_def_hash: ContentRef::from_bytes([30u8; 32]),
+                idempotency_class: IdempotencyClassTag::Token,
+            }),
+            seq: 0,
+        },
+        JournalEntry::RunVersionsResolved {
+            instance_id,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            capability: None,
+            seq: 0,
+        },
+        JournalEntry::Failed {
+            mote_id: MoteId::from_bytes([12u8; 32]),
+            idempotency_key: [12u8; 32],
+            seq: 0,
+            reason_class: FailureReason::TimedOut,
+            reporter_id: 0,
+        },
+        JournalEntry::DigestSealed {
+            through_seq: 6,
+            state_digest: [0xEE; 32],
+            seq: 0,
+        },
+    ]
+}
+
+/// Build the v5 fixture journal at `dir/sample_v5.kxjournal` and return its path.
+fn build_v5_journal(dir: &Path) -> PathBuf {
+    let path = dir.join("sample_v5.kxjournal");
+    {
+        let j = SqliteJournal::open(&path).unwrap();
+        j.append_batch(curated_v6_entries()).unwrap();
+    }
+    downgrade_to_v5(&path);
+    path
+}
+
+/// Raw-SQL downgrade of a v6 journal file to the v5 byte shape: strip the trailing
+/// `idempotency_class` byte from each capability-present `RunVersionsResolved`, and
+/// stamp `metadata.schema_version = 5`. Wrapped in one transaction.
+fn downgrade_to_v5(path: &Path) {
+    let mut conn = Connection::open(path).unwrap();
+    let kind6: Vec<(i64, Vec<u8>)> = {
+        let mut stmt = conn
+            .prepare("SELECT seq, entry_bytes FROM entries WHERE kind = 6")
+            .unwrap();
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    };
+    let txn = conn.transaction().unwrap();
+    for (seq, bytes) in kind6 {
+        let entry = decode_entry_with_def_hash(&bytes, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        if matches!(
+            entry,
+            JournalEntry::RunVersionsResolved {
+                capability: Some(_),
+                ..
+            }
+        ) {
+            let v5 = &bytes[..bytes.len() - 1]; // drop the trailing class byte
+            txn.execute(
+                "UPDATE entries SET entry_bytes = ?1 WHERE seq = ?2",
+                params![v5, seq],
+            )
+            .unwrap();
+        }
+    }
+    let v5_ver: [u8; 2] = 5u16.to_le_bytes();
+    txn.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
+        params![&v5_ver[..]],
+    )
+    .unwrap();
+    txn.commit().unwrap();
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .unwrap();
+}
+
+fn read_all<J: Journal>(j: &J) -> Vec<JournalEntry> {
+    let head = j.current_seq().unwrap();
+    j.read_entries_by_seq(0..head + 1).unwrap().collect()
+}
+
+// ---------------------------------------------------------------------------
+// Read-side: ReplayJournal up-converts an old journal on the fly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_still_refuses_v5_loudly() {
+    // Regression guard: the strict open() contract is UNCHANGED — it must still
+    // refuse an older version loudly (migration is a separate, additive path).
+    let tmp = tempfile::tempdir().unwrap();
+    let path = build_v5_journal(tmp.path());
+    let err = SqliteJournal::open(&path).unwrap_err();
+    assert!(matches!(
+        err,
+        JournalError::SchemaVersionMismatch { found: 5, expected } if expected == JOURNAL_SCHEMA_VERSION
+    ));
+}
+
+#[test]
+fn replay_reads_v5_and_upconverts_capability() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = build_v5_journal(tmp.path());
+
+    let replay = ReplayJournal::open(&path).unwrap();
+    assert_eq!(replay.from_version(), 5);
+    assert_eq!(replay.count_entries().unwrap(), 7);
+
+    let entries = read_all(&replay);
+    let cap = entries
+        .iter()
+        .find_map(|e| match e {
+            JournalEntry::RunVersionsResolved {
+                capability: Some(c),
+                ..
+            } => Some(c),
+            _ => None,
+        })
+        .expect("a capability-present RunVersionsResolved");
+    // The original class was Token; v5 lost it; migration applies the safe default.
+    assert_eq!(cap.idempotency_class, V5_ABSENT_IDEMPOTENCY_CLASS);
+    assert_eq!(cap.idempotency_class, IdempotencyClassTag::AtLeastOnce);
+    assert_eq!(cap.tool_id, "fs.read");
+}
+
+#[test]
+fn replay_journal_is_read_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = build_v5_journal(tmp.path());
+    let replay = ReplayJournal::open(&path).unwrap();
+    let attempt = replay.append(JournalEntry::Failed {
+        mote_id: MoteId::from_bytes([99u8; 32]),
+        idempotency_key: [99u8; 32],
+        seq: 0,
+        reason_class: FailureReason::TimedOut,
+        reporter_id: 0,
+    });
+    assert!(matches!(attempt, Err(JournalError::Invariant(_))));
+}
+
+#[test]
+fn open_for_replay_refuses_future_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("future.kxjournal");
+    {
+        let _ = SqliteJournal::open(&path).unwrap();
+    }
+    set_schema_version(&path, JOURNAL_SCHEMA_VERSION + 1);
+    let err = ReplayJournal::open(&path).unwrap_err();
+    assert!(matches!(
+        err,
+        JournalError::SchemaVersionMismatch { found, .. } if found == JOURNAL_SCHEMA_VERSION + 1
+    ));
+}
+
+#[test]
+fn open_for_replay_refuses_too_old() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("ancient.kxjournal");
+    {
+        let _ = SqliteJournal::open(&path).unwrap();
+    }
+    set_schema_version(&path, MIN_SUPPORTED_SCHEMA_VERSION - 1);
+    let err = ReplayJournal::open(&path).unwrap_err();
+    assert!(matches!(
+        err,
+        JournalError::SchemaVersionMismatch { found, .. } if found == MIN_SUPPORTED_SCHEMA_VERSION - 1
+    ));
+}
+
+fn set_schema_version(path: &Path, v: u16) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
+        params![&v.to_le_bytes()[..]],
+    )
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Write-side: migrate_to rewrites a v5 journal into a strict v6 journal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn migrate_to_produces_strict_v6_journal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5_journal(tmp.path());
+    let dst = tmp.path().join("migrated_v6.kxjournal");
+
+    let report = migrate_to(&src, &dst).unwrap();
+    assert_eq!(report.from_version, 5);
+    assert_eq!(report.to_version, JOURNAL_SCHEMA_VERSION);
+    assert_eq!(report.entries_migrated, 7);
+    assert_eq!(report.entries_upconverted, 1); // exactly the one cap record
+
+    // The migrated journal is accepted by the STRICT open() (its version is v6).
+    let j = SqliteJournal::open(&dst).unwrap();
+    assert_eq!(j.count_entries().unwrap(), 7);
+}
+
+#[test]
+fn migrate_to_matches_replay_readback() {
+    // The whole point: rewriting via migrate_to yields exactly the same logical
+    // entries as reading the source via the up-converting ReplayJournal.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5_journal(tmp.path());
+    let dst = tmp.path().join("migrated_v6.kxjournal");
+    migrate_to(&src, &dst).unwrap();
+
+    let via_replay = read_all(&ReplayJournal::open(&src).unwrap());
+    let via_migrate = read_all(&SqliteJournal::open(&dst).unwrap());
+    assert_eq!(via_replay, via_migrate);
+}
+
+#[test]
+fn migrate_to_preserves_committed_facts_byte_identical() {
+    // Product identity (committed facts) is invariant across migration: the
+    // Committed entries are byte-for-byte unchanged (only kind-6 cap bodies grow).
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5_journal(tmp.path());
+    let dst = tmp.path().join("migrated_v6.kxjournal");
+    migrate_to(&src, &dst).unwrap();
+
+    let committed_bytes = |p: &Path| -> Vec<Vec<u8>> {
+        let conn = Connection::open(p).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT entry_bytes FROM entries WHERE kind = 1 ORDER BY seq")
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, Vec<u8>>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    };
+    assert_eq!(committed_bytes(&src), committed_bytes(&dst));
+}
+
+#[test]
+fn migrate_to_preserves_seqs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5_journal(tmp.path());
+    let dst = tmp.path().join("migrated_v6.kxjournal");
+    migrate_to(&src, &dst).unwrap();
+
+    let src_seqs: Vec<u64> = read_all(&ReplayJournal::open(&src).unwrap())
+        .iter()
+        .map(JournalEntry::seq)
+        .collect();
+    let dst_seqs: Vec<u64> = read_all(&SqliteJournal::open(&dst).unwrap())
+        .iter()
+        .map(JournalEntry::seq)
+        .collect();
+    assert_eq!(src_seqs, dst_seqs);
+    assert_eq!(src_seqs, vec![1, 2, 3, 4, 5, 6, 7]);
+}
+
+#[test]
+fn migrate_to_enables_resume_and_append() {
+    // The upgrade story: after migrating, the v6 journal resumes and appends.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5_journal(tmp.path());
+    let dst = tmp.path().join("migrated_v6.kxjournal");
+    migrate_to(&src, &dst).unwrap();
+
+    let j = SqliteJournal::open(&dst).unwrap();
+    let appended = j
+        .append(JournalEntry::Failed {
+            mote_id: MoteId::from_bytes([200u8; 32]),
+            idempotency_key: [200u8; 32],
+            seq: 0,
+            reason_class: FailureReason::WorkerCrashed,
+            reporter_id: 7,
+        })
+        .unwrap();
+    assert_eq!(appended.seq(), 8); // continues the sequence after the 7 migrated
+    assert_eq!(j.count_entries().unwrap(), 8);
+}
+
+#[test]
+fn migrate_to_is_idempotent_on_current_version() {
+    // Migrating an already-current journal yields a logically-equivalent current
+    // journal with nothing up-converted.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("already_v6.kxjournal");
+    {
+        let j = SqliteJournal::open(&src).unwrap();
+        j.append_batch(curated_v6_entries()).unwrap();
+    }
+    let dst = tmp.path().join("recopied_v6.kxjournal");
+    let report = migrate_to(&src, &dst).unwrap();
+    assert_eq!(report.from_version, JOURNAL_SCHEMA_VERSION);
+    assert_eq!(report.to_version, JOURNAL_SCHEMA_VERSION);
+    assert_eq!(report.entries_upconverted, 0);
+
+    let before = read_all(&SqliteJournal::open(&src).unwrap());
+    let after = read_all(&SqliteJournal::open(&dst).unwrap());
+    assert_eq!(before, after);
+}
+
+// ---------------------------------------------------------------------------
+// Scale: migration is O(entries) — resume after upgrade is not an outage
+// ---------------------------------------------------------------------------
+
+/// Build a v5 journal of `n` capability-present `RunVersionsResolved` entries
+/// (every entry up-converts — the worst case for migration cost).
+fn build_v5_cap_journal(dir: &Path, n: u32) -> PathBuf {
+    let path = dir.join(format!("scale_{n}.kxjournal"));
+    let instance_id = [1u8; INSTANCE_ID_LEN];
+    let entries: Vec<JournalEntry> = (0..n)
+        .map(|i| JournalEntry::RunVersionsResolved {
+            instance_id,
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            model_id: "m".to_string(),
+            capability: Some(ResolvedCapabilityRecord {
+                tool_id: format!("tool-{i}"),
+                tool_version: "1".to_string(),
+                resolved_kind: ResolvedKindTag::Builtin,
+                resolved_def_hash: ContentRef::from_bytes([7u8; 32]),
+                idempotency_class: IdempotencyClassTag::Token,
+            }),
+            seq: 0,
+        })
+        .collect();
+    {
+        let j = SqliteJournal::open(&path).unwrap();
+        j.append_batch(entries).unwrap();
+    }
+    downgrade_to_v5(&path);
+    path
+}
+
+#[test]
+#[ignore = "scale: run --release --test schema_evolution -- --ignored --nocapture"]
+fn migrate_25k_is_linear() {
+    const SIZES: &[u32] = &[1_000, 5_000, 10_000, 25_000];
+    let tmp = tempfile::tempdir().unwrap();
+    let mut per_entry_us: Vec<f64> = Vec::with_capacity(SIZES.len());
+
+    for &n in SIZES {
+        let src = build_v5_cap_journal(tmp.path(), n);
+        let dst = tmp.path().join(format!("scale_{n}_v6.kxjournal"));
+        let start = Instant::now();
+        let report = migrate_to(&src, &dst).unwrap();
+        let elapsed = start.elapsed();
+        assert_eq!(report.entries_migrated, u64::from(n));
+        assert_eq!(report.entries_upconverted, u64::from(n));
+        let us = elapsed.as_secs_f64() * 1e6;
+        let per = us / f64::from(n);
+        per_entry_us.push(per);
+        eprintln!(
+            "n={n:>6}  migrate={:>9.2}ms  per_entry={per:>7.3}us",
+            us / 1e3
+        );
+    }
+
+    let ratio = per_entry_us.last().unwrap() / per_entry_us.first().unwrap();
+    eprintln!("per-entry migrate cost ratio (25k/1k) = {ratio:.2}  (quadratic would be ~25x)");
+    if !cfg!(debug_assertions) {
+        assert!(
+            ratio < 8.0,
+            "migrate_to per-entry cost grew {ratio:.1}x (1k->25k) — super-linear; \
+             resume-after-upgrade must stay O(entries)"
+        );
+    }
+}

--- a/crates/kx-runtime/Cargo.toml
+++ b/crates/kx-runtime/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+rusqlite = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kx-runtime/src/error.rs
+++ b/crates/kx-runtime/src/error.rs
@@ -41,4 +41,22 @@ pub enum RuntimeError {
     /// CLI / config error (bad argument, missing path).
     #[error("config: {0}")]
     Config(String),
+
+    /// A verified schema migration ([`crate::migrate_and_verify`]) rewrote the
+    /// journal but the result did not preserve the run's product identity — the
+    /// up-converted source and the migrated destination fold to different
+    /// committed-facts digests. Indicates a migration bug; the destination must
+    /// not be trusted.
+    #[error(
+        "migration verification failed (from schema v{from_version}): \
+         source digest {src_digest} != destination digest {dst_digest}"
+    )]
+    MigrationVerificationFailed {
+        /// The source journal's on-disk schema version.
+        from_version: u16,
+        /// Committed-facts digest of the up-converted source (hex).
+        src_digest: String,
+        /// Committed-facts digest of the migrated destination (hex).
+        dst_digest: String,
+    },
 }

--- a/crates/kx-runtime/src/lib.rs
+++ b/crates/kx-runtime/src/lib.rs
@@ -61,6 +61,7 @@ pub mod crash;
 pub mod digest;
 pub mod engine;
 pub mod error;
+pub mod migrate;
 pub mod snapshot_sink;
 pub mod topology;
 pub mod workflow;
@@ -72,5 +73,6 @@ pub use engine::{
     canonical_mote_ids, canonical_targets, digest_only, run, run_with_seams, RunOutcome,
 };
 pub use error::RuntimeError;
+pub use migrate::migrate_and_verify;
 pub use snapshot_sink::SnapshotSink;
 pub use workflow::DemoWorkflow;

--- a/crates/kx-runtime/src/migrate.rs
+++ b/crates/kx-runtime/src/migrate.rs
@@ -1,0 +1,50 @@
+//! Verified offline schema migration (IMP-2, M2.x-E).
+//!
+//! [`kx_journal::migrate_to`] performs the byte-level rewrite of an older journal
+//! into a fresh current-version one. This module adds the **trust-but-verify**
+//! layer the enterprise upgrade story needs: after rewriting, fold *both* the
+//! source (read-only, up-converting) and the destination and refuse unless their
+//! committed-facts product digests are byte-identical. The product identity digest
+//! is the durability law — a migration that changed it would be a bug, and this
+//! catches it before the destination is trusted for resume-and-append.
+
+use std::path::Path;
+
+use kx_journal::{migrate_to, MigrationReport, ReplayJournal, SqliteJournal};
+
+use crate::digest::digest_journal;
+use crate::error::RuntimeError;
+
+/// Migrate the journal at `src` into a fresh current-version journal at `dst`,
+/// then verify the rewrite preserved the run's product identity.
+///
+/// Returns the [`MigrationReport`] on success. Returns
+/// [`RuntimeError::MigrationVerificationFailed`] if the up-converted source and
+/// the migrated destination fold to different committed-facts digests (a
+/// migration bug — the destination is not trusted). `src` is never modified;
+/// `dst` is written atomically by [`migrate_to`].
+pub fn migrate_and_verify(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+) -> Result<MigrationReport, RuntimeError> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+
+    let report = migrate_to(src, dst)?;
+
+    // Fold both sides and compare the committed-facts product digest. The source
+    // is read through the up-converting ReplayJournal; the destination through the
+    // strict current-version open(). Identity must be invariant across migration.
+    let src_digest = digest_journal(&ReplayJournal::open(src)?)?;
+    let dst_digest = digest_journal(&SqliteJournal::open(dst)?)?;
+
+    if src_digest != dst_digest {
+        return Err(RuntimeError::MigrationVerificationFailed {
+            from_version: report.from_version,
+            src_digest: src_digest.to_hex(),
+            dst_digest: dst_digest.to_hex(),
+        });
+    }
+
+    Ok(report)
+}

--- a/crates/kx-runtime/tests/schema_evolution.rs
+++ b/crates/kx-runtime/tests/schema_evolution.rs
@@ -1,0 +1,188 @@
+// Integration-test: schema-migration identity preservation (IMP-2, M2.x-E).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! The headline durability guarantee: migrating a journal from an older schema
+//! version preserves the run's PRODUCT IDENTITY — the committed-facts digest is
+//! byte-identical before (read via the up-converting [`ReplayJournal`]) and after
+//! ([`migrate_and_verify`] rewrites to the current version). The resume/state
+//! digest is version-local and may change, but identity is the durability law.
+
+use std::path::{Path, PathBuf};
+
+use kx_journal::{
+    decode_entry_with_def_hash, FailureReason, IdempotencyClassTag, Journal, JournalEntry,
+    ParentEntry, ReplayJournal, ResolvedCapabilityRecord, ResolvedKindTag, SqliteJournal,
+    INSTANCE_ID_LEN,
+};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use kx_runtime::{digest_journal, migrate_and_verify};
+use rusqlite::{params, Connection};
+use smallvec::SmallVec;
+
+/// The frozen golden product digest for the `build_v5` fixture under current code.
+/// Recorded once; the migrated and replayed folds must both equal it. (If a future
+/// schema bump legitimately changes committed-fact shape this is re-baselined as
+/// part of that bump's migration protocol; a lineage-only bump must NOT change it.)
+const EXPECTED_PRODUCT_DIGEST: &str =
+    "6bf5b52dddb4ef94f56947365de215261745208180192bd151bf9a8aeaf7abf3";
+
+fn curated_v6_entries() -> Vec<JournalEntry> {
+    let instance_id = [1u8; INSTANCE_ID_LEN];
+    let a = MoteId::from_bytes([10u8; 32]);
+    vec![
+        JournalEntry::RunRegistered {
+            instance_id,
+            recipe_fingerprint: [2u8; 32],
+            ts: 0,
+            seq: 0,
+        },
+        JournalEntry::Committed {
+            mote_id: a,
+            idempotency_key: [10u8; 32],
+            seq: 0,
+            nondeterminism: NdClass::Pure,
+            result_ref: kx_content::ContentRef::from_bytes([110u8; 32]),
+            parents: SmallVec::new(),
+            warrant_ref: kx_content::ContentRef::from_bytes([0xaa; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([20u8; 32]),
+        },
+        JournalEntry::Committed {
+            mote_id: MoteId::from_bytes([11u8; 32]),
+            idempotency_key: [11u8; 32],
+            seq: 0,
+            nondeterminism: NdClass::ReadOnlyNondet,
+            result_ref: kx_content::ContentRef::from_bytes([111u8; 32]),
+            parents: {
+                let mut p: SmallVec<[ParentEntry; 4]> = SmallVec::new();
+                p.push(ParentEntry {
+                    parent_id: a,
+                    edge_kind: 0,
+                    non_cascade: 0,
+                });
+                p
+            },
+            warrant_ref: kx_content::ContentRef::from_bytes([0xaa; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([21u8; 32]),
+        },
+        JournalEntry::RunVersionsResolved {
+            instance_id,
+            warrant_ref: kx_content::ContentRef::from_bytes([0xaa; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            capability: Some(ResolvedCapabilityRecord {
+                tool_id: "fs.read".to_string(),
+                tool_version: "1.0.0".to_string(),
+                resolved_kind: ResolvedKindTag::Builtin,
+                resolved_def_hash: kx_content::ContentRef::from_bytes([30u8; 32]),
+                idempotency_class: IdempotencyClassTag::Token,
+            }),
+            seq: 0,
+        },
+        JournalEntry::Failed {
+            mote_id: MoteId::from_bytes([12u8; 32]),
+            idempotency_key: [12u8; 32],
+            seq: 0,
+            reason_class: FailureReason::TimedOut,
+            reporter_id: 0,
+        },
+    ]
+}
+
+/// Build a v5 fixture: write v6, then downgrade with raw SQL (strip the trailing
+/// capability class byte; stamp schema_version = 5).
+fn build_v5(dir: &Path) -> PathBuf {
+    let path = dir.join("run_v5.kxjournal");
+    {
+        let j = SqliteJournal::open(&path).unwrap();
+        j.append_batch(curated_v6_entries()).unwrap();
+    }
+    let mut conn = Connection::open(&path).unwrap();
+    let kind6: Vec<(i64, Vec<u8>)> = {
+        let mut stmt = conn
+            .prepare("SELECT seq, entry_bytes FROM entries WHERE kind = 6")
+            .unwrap();
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    };
+    let txn = conn.transaction().unwrap();
+    for (seq, bytes) in kind6 {
+        let entry = decode_entry_with_def_hash(&bytes, MoteDefHash::from_bytes([0u8; 32])).unwrap();
+        if matches!(
+            entry,
+            JournalEntry::RunVersionsResolved {
+                capability: Some(_),
+                ..
+            }
+        ) {
+            let v5 = &bytes[..bytes.len() - 1];
+            txn.execute(
+                "UPDATE entries SET entry_bytes = ?1 WHERE seq = ?2",
+                params![v5, seq],
+            )
+            .unwrap();
+        }
+    }
+    txn.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
+        params![&5u16.to_le_bytes()[..]],
+    )
+    .unwrap();
+    txn.commit().unwrap();
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .unwrap();
+    path
+}
+
+#[test]
+fn migrate_and_verify_preserves_product_identity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5(tmp.path());
+    let dst = tmp.path().join("run_v6.kxjournal");
+
+    let report = migrate_and_verify(&src, &dst).unwrap();
+    assert_eq!(report.from_version, 5);
+    assert_eq!(report.to_version, 6);
+    assert_eq!(report.entries_upconverted, 1);
+
+    // The up-converted source and the migrated destination fold to the same
+    // committed-facts digest (migrate_and_verify already enforced this, but assert
+    // it explicitly + pin the frozen golden).
+    let src_digest = digest_journal(&ReplayJournal::open(&src).unwrap()).unwrap();
+    let dst_digest = digest_journal(&SqliteJournal::open(&dst).unwrap()).unwrap();
+    assert_eq!(src_digest, dst_digest, "migration must preserve identity");
+    eprintln!("PRODUCT DIGEST (record as golden): {}", dst_digest.to_hex());
+    assert_eq!(
+        dst_digest.to_hex(),
+        EXPECTED_PRODUCT_DIGEST,
+        "product identity digest drifted from the frozen golden"
+    );
+}
+
+#[test]
+fn migrated_journal_resumes_and_appends() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v5(tmp.path());
+    let dst = tmp.path().join("run_v6.kxjournal");
+    migrate_and_verify(&src, &dst).unwrap();
+
+    // The migrated v6 journal opens with the STRICT backend and accepts a new
+    // committed Mote — the run resumes after the binary upgrade.
+    let j = SqliteJournal::open(&dst).unwrap();
+    let before = j.count_entries().unwrap();
+    j.append(JournalEntry::Committed {
+        mote_id: MoteId::from_bytes([13u8; 32]),
+        idempotency_key: [13u8; 32],
+        seq: 0,
+        nondeterminism: NdClass::Pure,
+        result_ref: kx_content::ContentRef::from_bytes([113u8; 32]),
+        parents: SmallVec::new(),
+        warrant_ref: kx_content::ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([23u8; 32]),
+    })
+    .unwrap();
+    assert_eq!(j.count_entries().unwrap(), before + 1);
+
+    // The new committed fact changes the product digest (a genuinely new run state).
+    let resumed_digest = digest_journal(&j).unwrap();
+    assert_ne!(resumed_digest.to_hex(), EXPECTED_PRODUCT_DIGEST);
+}

--- a/justfile
+++ b/justfile
@@ -110,20 +110,22 @@ smoke-test-with-model:
 # Scale / performance gate
 # ============================================================================
 
-# Scale smoke (M2.1 + M2.2 + M2.2b / D92 — the resume-availability invariant): fold
-# a 25k+ Mote journal in RELEASE and assert (M2.1) the incremental children-index
-# re-fold stays ~linear, (M2.2) resume-from-`FoldCheckpoint` reproduces the full
-# fold exactly + its cost is bounded by live-state size under churn (not by journal
-# length), and (M2.2b) the SAME bound holds end-to-end over a real disk-backed
-# SQLite journal + an on-disk checkpoint sidecar. All cases live in `kx-projection`
-# (no `kx-llamacpp` C++ FFI in this lean job — the M2.2b SQLite case folds via
-# `kx-journal::SqliteJournal`, llamacpp-free). A super-linear resume is an outage,
-# and resume IS the product. `--release` is REQUIRED — in a debug build the
-# differential oracle re-imposes the O(n^2) full rebuild on every fold and the ratio
-# assertions are skipped.
+# Scale smoke (M2.1 + M2.2 + M2.2b + M2.x-E / D92 — the resume-availability
+# invariant): fold a 25k+ Mote journal in RELEASE and assert (M2.1) the incremental
+# children-index re-fold stays ~linear, (M2.2) resume-from-`FoldCheckpoint`
+# reproduces the full fold exactly + its cost is bounded by live-state size under
+# churn (not by journal length), (M2.2b) the SAME bound holds end-to-end over a real
+# disk-backed SQLite journal + an on-disk checkpoint sidecar, and (M2.x-E / IMP-2)
+# offline schema migration (`migrate_to`) stays O(entries) so resume-after-upgrade
+# is not an outage. The first three cases live in `kx-projection`; the migration
+# case in `kx-journal` (both llamacpp-free — no C++ FFI in this lean job). A
+# super-linear resume is an outage, and resume IS the product. `--release` is
+# REQUIRED — in a debug build the differential oracle re-imposes the O(n^2) full
+# rebuild on every fold and the ratio assertions are skipped.
 scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
 
 # ============================================================================
 # Preflight diagnostic


### PR DESCRIPTION
## What & why

Closes the **KILLER** "durability product that can't be upgraded" gap (IMP-2). Today every `JOURNAL_SCHEMA_VERSION` bump is *refuse v(n-1) loudly, no migration* (`sqlite.rs` `verify_schema_version` → `SchemaVersionMismatch`), so shipping a new binary orphans every durable run on disk. This builds the forward-migration story **before real journals exist in the wild** (carrier **M2.x-E**, owning crate `kx-journal`).

**Scope (full upgrade story):** read-side replay/recover an old journal **and** the offline `migrate_to` rewrite so a v6 binary can **resume-and-append** an old run.

## The two-digest finding (ground truth)

| Digest | Inputs | Under v5→v6 migration |
|---|---|---|
| **Product identity** `a6b5c679…` (`kx-runtime::digest_projection`) | committed facts only (`mote_id ‖ result_ref ‖ nd_class`) | **STABLE** — `idempotency_class` is not an identity input. A migrated run keeps its identity. *This is the durability law.* |
| **Resume-integrity state** (`state_content_digest`) | full folded state incl. `run_resolved_versions.idempotency_class` | **version-local** — a v5 seal won't match a v6 re-fold → `SealMismatch`/`SealMissing` → safe full-fold + re-seal (self-healing, seals discardable). |

So migration is **digest-deterministic, not digest-identical**: identity is preserved, the resume optimization self-heals.

## Design (all additive — `Journal` trait, `open()`, `decode_entry`, `verify_schema_version`, fold semantics unchanged)

- **`kx-journal/src/migration.rs`** — generic ladder. `migrate_entry(bytes, from_version, def_hash)` up-converts to the current shape; refuses outside `[MIN_SUPPORTED_SCHEMA_VERSION=5, JOURNAL_SCHEMA_VERSION=6]`. The lone v5→v6 delta (a capability-present `RunVersionsResolved` gaining a trailing `idempotency_class` byte) is up-converted by appending the **safe default `AtLeastOnce`** (recovery never auto-redispatches a migrated effect — cannot weaken exactly-once) then delegating to the canonical decoder.
- **`kx-journal/src/sqlite.rs`** — `ReplayJournal` (read-only, version-aware decode; `append()` rejects → mixed-version write structurally impossible) + `migrate_to(src,dst)` (seq-preserving, atomic temp+WAL-checkpoint+rename, idempotent, refuses a non-contiguous source rather than remap a `seq`).
- **`kx-runtime/src/migrate.rs`** — `migrate_and_verify(src,dst)` folds both sides and refuses unless the committed-facts product digests match (trust-but-verify the trust-root rewrite).

## Verification (local gate green)

- `fmt`, `clippy --workspace --all-targets -D warnings`, `test --workspace` (0 failed), `cargo deny`, `doc -D warnings` ✓
- **Thesis diff EMPTY** — `git diff <base> -- crates/kx-scheduler crates/kx-executor crates/kx-inference` ✓
- **`a0_guard` canonical product digest `a6b5c679…` UNCHANGED** ✓
- **scale-smoke** new `migrate_25k_is_linear`: 25k/1k per-entry ratio **0.58** (sub-linear; bar < 8.0) ✓ — wired into the existing `scale-smoke` job (no branch-protection context rename)
- byte-determinism (I1.c) runs in CI

Tests: 9 migration unit + 11 `schema_evolution` (replay/migrate/refusal/resume-and-append) + 7 proptest (round-trip incl. the v6 `FailureReason` variants the prior fuzz omitted + versioned-decode correctness + idempotence) + 2 runtime identity/resume + `dod` schema-version pins.

## Golden Rule 8

**Pass A (defensive).** *Break-live:* the `.expect("on-disk entry decodes")` read path stays behind `open()`'s version validation; replay/migrate route through `migrate_entry`; `ReplayJournal` is read-only → no mixed-version append; the existing loud-refusal + schema-pin tests still pass. *Security:* new old-bytes decode surface stays fail-closed (only the known v5→v6 delta handled; unknown kinds/truncation still error); `AtLeastOnce` default is fail-safe; identity (`instance_id`, `MoteId`, product digest) preserved bit-for-bit. *Crash-safety:* `migrate_to` is atomic (temp+WAL-checkpoint+rename), `src` untouched, idempotent. *Perf:* O(entries), measured.

**Pass B (forward).** Closes the upgrade-survival KILLER; adds a standing measured migration gate + a clean per-version ladder seam; `migrate_and_verify` raises the enterprise-trust bar. Follow-on (own PR, Rule 1): a `kx-projection` lineage-stable seal digest (so future lineage-only bumps keep checkpoints valid) and a `kx-journal migrate` CLI.

No new crate (30); no new external dependency (`rusqlite` promoted to a dev-dep where it was already a normal dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)