### PR TITLE
feat(runtime,capture): on-by-default step capture — wire kx-capture into the runtime (M3.1, D67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "bincode",
  "blake3",
  "kx-capability",
+ "kx-capture",
  "kx-content",
  "kx-executor",
  "kx-journal",

--- a/crates/kx-capture/tests/scale.rs
+++ b/crates/kx-capture/tests/scale.rs
@@ -1,0 +1,61 @@
+//! Scale-smoke: the on-by-default capture store (D67) is flat per-record at scale.
+//!
+//! `#[ignore]`d — run in `--release` via the `scale-smoke` recipe. The runtime's
+//! on-by-default capture (M3.1) records one [`StepRecord::action`] per committed
+//! Mote into an [`InMemoryCaptureStore`]; this proves that record path is
+//! O(N·log N) (a `BTreeMap` insert per action), so capture-on-by-default cannot
+//! turn a large run super-linear. The other half of the engine's capture sweep —
+//! `Projection::result_ref_of` — is a `BTreeMap` read held flat by
+//! `kx-projection`'s `incremental_children_index` scale test; the kx-runtime
+//! `stress_throughput::h3_capture_sweep_is_flat_per_mote` campaign case measures
+//! the two together end-to-end.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Instant;
+
+use kx_capture::{CaptureConsent, InMemoryCaptureStore, StepRecord};
+use kx_content::ContentRef;
+use kx_mote::MoteId;
+
+const SIZES: &[usize] = &[1_000, 5_000, 10_000, 25_000];
+
+/// A unique `MoteId` for index `i` (the index encoded into the id bytes).
+fn mote_at(i: usize) -> MoteId {
+    let mut b = [0u8; 32];
+    b[..8].copy_from_slice(&(i as u64).to_le_bytes());
+    MoteId::from_bytes(b)
+}
+
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn capture_store_is_flat_per_record() {
+    let cref = ContentRef::from_bytes([3u8; 32]);
+    let mut per_record_ns: Vec<(usize, f64)> = Vec::new();
+    for &n in SIZES {
+        let mut store = InMemoryCaptureStore::new(CaptureConsent::actions_only());
+        let start = Instant::now();
+        for i in 0..n {
+            store.record(StepRecord::action(mote_at(i), cref));
+        }
+        let elapsed = start.elapsed();
+        // Exactly-once: every distinct Mote recorded, none dropped.
+        assert_eq!(store.len(), n, "one record per Mote at n={n}");
+        #[allow(clippy::cast_precision_loss)]
+        let per = elapsed.as_nanos() as f64 / n as f64;
+        println!(
+            "capture-store: n={n} total_ms={} per_record_ns={per:.1}",
+            elapsed.as_millis()
+        );
+        per_record_ns.push((n, per));
+    }
+    // Flat per-record: a `BTreeMap` insert is O(log N), so the 25k/1k ratio is
+    // ~log(25k)/log(1k) ≈ 1.47×. Allow generous headroom for small-N timing noise
+    // while still catching a genuine super-linear regression (quadratic ≈ 25×).
+    let first = per_record_ns.first().unwrap().1;
+    let last = per_record_ns.last().unwrap().1;
+    assert!(
+        last <= first * 4.0,
+        "per-record insert must stay flat (n=1k {first:.1}ns vs n=25k {last:.1}ns)"
+    );
+}

--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -283,6 +283,9 @@ impl Harness {
             &protocol,
             None,
             Some(&sink),
+            // capture_sink — off for the harness; the runtime seam captures only
+            // the action, and `Full` reasoning/thinking enrichment is M3.2 (D67).
+            None,
         )
     }
 }

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -244,6 +244,7 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         &protocol,
         None,
         Some(&sink),
+        None, // capture_sink (D67) — off for this assemble-wiring test
     );
     let captured = inputs.lock().unwrap().clone();
     (result, captured)

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -308,6 +308,7 @@ fn drive(
         &protocol,
         None,
         Some(&sink),
+        None, // capture_sink (D67) — off for this MCP HTTP e2e test
     );
     (result, store, journal, m_id)
 }

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -209,6 +209,7 @@ fn drive(
         &protocol,
         None,
         Some(&sink),
+        None, // capture_sink (D67) — off for this MCP model-driven test
     );
     (result, store, journal, m_id)
 }

--- a/crates/kx-runtime/Cargo.toml
+++ b/crates/kx-runtime/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 kx-mote       = { workspace = true }
+kx-capture    = { workspace = true }
 kx-content    = { workspace = true }
 kx-journal    = { workspace = true }
 kx-projection = { workspace = true }

--- a/crates/kx-runtime/src/capture_sink.rs
+++ b/crates/kx-runtime/src/capture_sink.rs
@@ -1,0 +1,217 @@
+//! [`CaptureSink`] — the D67 on-by-default step-capture seam.
+//!
+//! The orchestrator ([`crate::run_with_seams`]) owns the live
+//! [`kx_projection::Projection`]; immediately AFTER each Mote's `Committed` entry
+//! folds in, it records that Mote's **action** (its committed `result_ref`) into a
+//! disposable [`kx_capture::InMemoryCaptureStore`] behind this handle. Capture is
+//! the reliability/resumability story (D67): an in-memory `MoteId → result_ref`
+//! ledger over truth, queryable for resume/compensation without re-reading the
+//! whole journal.
+//!
+//! Like [`crate::SnapshotSink`] it is **OFF THE TRUTH PATH**: capture is never
+//! journaled, is never a `MoteId` input, and never gates scheduling / promotion /
+//! eviction (the dependency wall in `kx-capture/tests/boundary.rs` is the
+//! compiler-enforced tripwire). Turning it ON changes only the *quantity
+//! captured*, never its trust status — so the canonical product digest
+//! `a6b5c679…` is byte-unchanged.
+//!
+//! It is an **additive** seam: [`crate::run_with_seams`] takes `Option<&CaptureSink>`;
+//! `None` disables capture (the byte-identity-without-overhead path), and the
+//! canonical demo [`crate::run`] passes `Some` with [`CaptureScope::ActionsOnly`]
+//! (the privacy-safe default — the D67 flip). The runtime seam only ever records
+//! the **action** ([`StepRecord::action`]); reasoning/thinking enrichment under
+//! [`CaptureScope::Full`] is the real-model harness's job (and PII-gated in M3.2).
+//!
+//! [`CaptureScope::ActionsOnly`]: kx_capture::CaptureScope::ActionsOnly
+//! [`CaptureScope::Full`]: kx_capture::CaptureScope::Full
+
+use std::sync::{Arc, PoisonError, RwLock};
+
+use kx_capture::{CaptureConsent, InMemoryCaptureStore, StepRecord};
+
+/// A cheap, cloneable handle over a disposable [`InMemoryCaptureStore`] (D67).
+///
+/// Clones share one slot (an `Arc<RwLock<…>>`), so the orchestrator and any
+/// reader observe the same store. Consent is fixed at construction
+/// ([`kx_capture::CaptureScope::ActionsOnly`] the safe default;
+/// [`kx_capture::CaptureScope::Full`] opt-in-with-consent) and re-enforced inside
+/// the store on every [`Self::record`].
+#[derive(Clone, Debug)]
+pub struct CaptureSink {
+    store: Arc<RwLock<InMemoryCaptureStore>>,
+}
+
+impl CaptureSink {
+    /// A new sink retaining at most what `consent` allows.
+    #[must_use]
+    pub fn new(consent: CaptureConsent) -> Self {
+        Self {
+            store: Arc::new(RwLock::new(InMemoryCaptureStore::new(consent))),
+        }
+    }
+
+    /// The on-by-default safe sink: [`kx_capture::CaptureScope::ActionsOnly`]
+    /// (retain only each committed action's `result_ref` — a 32-byte join key
+    /// back to truth; reasoning/thinking/input are never retained).
+    #[must_use]
+    pub fn actions_only() -> Self {
+        Self::new(CaptureConsent::actions_only())
+    }
+
+    /// Record (or overwrite) a Mote's step. The store enforces consent at the
+    /// boundary: a non-`Full` session keeps only the action join key, stripping
+    /// reasoning/thinking/input even if supplied. Overwrite-by-`MoteId` makes a
+    /// re-record of an already-captured Mote idempotent.
+    ///
+    /// Lock poisoning is recovered (never propagated): capture is non-authoritative
+    /// off-truth-path exhaust, so a prior panic-while-recording must not crash the
+    /// runtime — the worst case is a missing-by-one record.
+    pub fn record(&self, rec: StepRecord) {
+        self.store
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .record(rec);
+    }
+
+    /// A clone of the current store (a point-in-time snapshot of all captured
+    /// steps). The caller holds no lock across iteration. Lock poisoning is
+    /// recovered (see [`Self::record`]).
+    #[must_use]
+    pub fn store(&self) -> InMemoryCaptureStore {
+        self.store
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Number of captured steps (cheap; avoids cloning the store). Lock poisoning
+    /// is recovered (see [`Self::record`]).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.store
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len()
+    }
+
+    /// `true` when nothing is captured yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use kx_capture::CaptureScope;
+    use kx_content::ContentRef;
+    use kx_mote::MoteId;
+
+    use super::*;
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+    fn cref(b: u8) -> ContentRef {
+        ContentRef::from_bytes([b; 32])
+    }
+
+    #[test]
+    fn actions_only_sink_records_committed_action() {
+        let sink = CaptureSink::actions_only();
+        assert!(sink.is_empty());
+        sink.record(StepRecord::action(mid(7), cref(9)));
+        assert_eq!(sink.len(), 1);
+        let store = sink.store();
+        let got = store.get(&mid(7)).expect("recorded");
+        assert_eq!(got.output_ref, Some(cref(9)));
+    }
+
+    #[test]
+    fn actions_only_strips_opt_in_fields_at_the_sink() {
+        let sink = CaptureSink::actions_only();
+        // Supply a full record; the store must strip the opt-in fields because
+        // the session did not consent to `Full`.
+        sink.record(StepRecord::full(
+            mid(3),
+            Some(cref(1)),
+            Some(cref(2)),
+            Some(cref(3)),
+            Some(cref(4)),
+        ));
+        let store = sink.store();
+        let got = store.get(&mid(3)).expect("recorded");
+        assert_eq!(got.output_ref, Some(cref(2)));
+        assert_eq!(got.input_ref, None);
+        assert_eq!(got.reasoning_ref, None);
+        assert_eq!(got.thinking_ref, None);
+    }
+
+    #[test]
+    fn full_sink_retains_all_fields() {
+        // `Full` is reachable + testable at the seam without a config knob
+        // (the CLI/config override is M3.2).
+        let sink = CaptureSink::new(CaptureConsent::full());
+        assert!(sink.store().consent().captures_steps());
+        sink.record(StepRecord::full(
+            mid(5),
+            Some(cref(1)),
+            Some(cref(2)),
+            Some(cref(3)),
+            Some(cref(4)),
+        ));
+        let store = sink.store();
+        let got = store.get(&mid(5)).expect("recorded");
+        assert_eq!(got.input_ref, Some(cref(1)));
+        assert_eq!(got.output_ref, Some(cref(2)));
+        assert_eq!(got.reasoning_ref, Some(cref(3)));
+        assert_eq!(got.thinking_ref, Some(cref(4)));
+    }
+
+    #[test]
+    fn new_uses_the_supplied_scope() {
+        let sink = CaptureSink::new(CaptureConsent {
+            scope: CaptureScope::ActionsOnly,
+        });
+        assert!(!sink.store().consent().captures_steps());
+    }
+
+    #[test]
+    fn record_overwrites_by_mote_id() {
+        let sink = CaptureSink::actions_only();
+        sink.record(StepRecord::action(mid(2), cref(1)));
+        sink.record(StepRecord::action(mid(2), cref(8)));
+        assert_eq!(sink.len(), 1);
+        assert_eq!(
+            sink.store().get(&mid(2)).expect("recorded").output_ref,
+            Some(cref(8))
+        );
+    }
+
+    #[test]
+    fn clone_shares_one_slot() {
+        let sink = CaptureSink::actions_only();
+        let clone = sink.clone();
+        clone.record(StepRecord::action(mid(1), cref(1)));
+        // The original observes the clone's write (shared Arc slot).
+        assert_eq!(sink.len(), 1);
+        assert!(sink.store().get(&mid(1)).is_some());
+    }
+
+    #[test]
+    fn poisoning_is_recovered() {
+        let sink = CaptureSink::actions_only();
+        let clone = sink.clone();
+        // Poison the lock from a panicking thread holding the write guard.
+        let _ = std::thread::spawn(move || {
+            let _guard = clone.store.write().unwrap();
+            panic!("poison the capture lock");
+        })
+        .join();
+        // Subsequent record/read still succeed (poison recovered, never propagated).
+        sink.record(StepRecord::action(mid(4), cref(4)));
+        assert_eq!(sink.len(), 1);
+    }
+}

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use kx_capability::EffectRequest;
+use kx_capture::StepRecord;
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_executor::{
     redispatch_wm_mote, run_native_critic_mote, run_pure_mote, run_wm_mote, CommitProtocol,
@@ -30,6 +31,7 @@ use kx_scheduler::{LocalPlacement, Scheduler};
 use kx_warrant::{FsScope, NetScope};
 
 use crate::broker::DemoBroker;
+use crate::capture_sink::CaptureSink;
 use crate::checkpoint_io;
 use crate::config::{Mode, RuntimeConfig};
 use crate::crash::CrashPoint;
@@ -81,12 +83,33 @@ enum Action {
 /// outcome, or aborts the process at the configured crash point (which never
 /// returns).
 ///
-/// This is the thin demo-defaults wrapper over [`run_with_seams`]: it wires the
-/// deterministic stub seams (`TestMoteExecutor::deterministic()` + `DemoBroker`)
-/// and the canonical topology shaper, then drives the real orchestrator. Its
-/// output is byte-identical to the pre-seam engine (digest `a6b5c679…`, 8/8) —
-/// the seam injects, it does not change, the truth path.
+/// This is the thin demo-defaults wrapper over [`run_with_capture`] /
+/// [`run_with_seams`]: it wires the deterministic stub seams
+/// (`TestMoteExecutor::deterministic()` + `DemoBroker`) and the canonical topology
+/// shaper, then drives the real orchestrator. Its output is byte-identical to the
+/// pre-seam engine (digest `a6b5c679…`, 8/8) — the seam injects, it does not
+/// change, the truth path.
+///
+/// **D67:** capture is ON by default (`CaptureScope::ActionsOnly`). The ledger is
+/// internal here (the demo discards it); a caller that wants the captured
+/// `MoteId → action result_ref` ledger drives [`run_with_capture`] with its own
+/// [`CaptureSink`]. Capture is OFF the truth path — it is never journaled — so the
+/// digest is byte-unchanged whether capture is on, off, or inspected.
 pub fn run(config: &RuntimeConfig) -> Result<RunOutcome, RuntimeError> {
+    let capture = CaptureSink::actions_only();
+    run_with_capture(config, Some(&capture))
+}
+
+/// As [`run`], but drives the canonical demo with the caller's `capture_sink`, so
+/// the captured action ledger (D67) is inspectable after the run. `None` disables
+/// capture entirely (the byte-identity-without-overhead path). Because capture is
+/// OFF the truth path (never journaled, never a `MoteId` input, never a gate), the
+/// reported digest is identical for any `capture_sink` — `None`, `ActionsOnly`, or
+/// `Full`.
+pub fn run_with_capture(
+    config: &RuntimeConfig,
+    capture_sink: Option<&CaptureSink>,
+) -> Result<RunOutcome, RuntimeError> {
     let workflow = DemoWorkflow::canonical();
 
     let store = Arc::new(LocalFsContentStore::open(&config.content_root)?);
@@ -133,6 +156,7 @@ pub fn run(config: &RuntimeConfig) -> Result<RunOutcome, RuntimeError> {
         // The deterministic demo assembles no context: `None` ⇒ no snapshot is
         // ever published ⇒ the truth path (digest `a6b5c679…`) is byte-unchanged.
         None,
+        capture_sink,
     )
 }
 
@@ -179,6 +203,7 @@ pub fn run_with_seams<S, E, CP>(
     protocol: &CP,
     shaper: Option<(&WorkflowMote, &TopologyDecision)>,
     snapshot_sink: Option<&SnapshotSink>,
+    capture_sink: Option<&CaptureSink>,
 ) -> Result<RunOutcome, RuntimeError>
 where
     S: ContentStore + Send + Sync + 'static,
@@ -351,6 +376,19 @@ where
     // the seal) tail. Skipped if the cadence already captured this exact frontier.
     if config.checkpoint_every.is_some() && folded_through > last_checkpoint_at {
         write_checkpoint(&projection, &journal, &sidecar_path, folded_through);
+    }
+
+    // D67: capture each committed Mote's ACTION (its `result_ref`) off the truth
+    // path, once, at return. A single O(committed·log) sweep over the final
+    // committed projection — flat per-Mote, no super-linear per-iteration rescan.
+    // The returned ledger is identical to a per-step capture because there is no
+    // concurrent observer in M3.1 (live streaming is M11); a crash loses the
+    // in-memory ledger anyway and recovery re-derives it from the journal. No-op
+    // for `None` (the byte-identity-without-overhead path). A pure `result_ref_of`
+    // read + an in-memory insert: NEVER touches the journal/projection fold, so the
+    // product digest `a6b5c679…` is byte-unchanged.
+    if let Some(sink) = capture_sink {
+        capture_committed_actions(&runnable, &projection, sink);
     }
 
     let outcome = outcome(&runnable, &projection);
@@ -592,6 +630,27 @@ fn effect_request_for(w: &WorkflowMote) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+    }
+}
+
+/// Record the committed action (`result_ref`) of every committed runnable Mote
+/// into the off-truth-path capture sink (D67).
+///
+/// `runnable` is the authoritative full Mote set (materialized shaper children are
+/// extended into it — the same set [`outcome`] counts over), so iterating it once
+/// is complete. Reads only `result_ref_of` (in-memory projection state) — no
+/// content-store read, no journal write. `O(committed·log)`, flat per-Mote.
+/// Recording is idempotent (overwrite by `MoteId`). Capture is `ActionsOnly`
+/// exhaust; `Full` reasoning/thinking enrichment is the real-model harness's job.
+fn capture_committed_actions(
+    runnable: &[WorkflowMote],
+    projection: &Projection,
+    sink: &CaptureSink,
+) {
+    for w in runnable {
+        if let Some(result_ref) = projection.result_ref_of(&w.mote.id) {
+            sink.record(StepRecord::action(w.mote.id, result_ref));
+        }
     }
 }
 

--- a/crates/kx-runtime/src/lib.rs
+++ b/crates/kx-runtime/src/lib.rs
@@ -55,6 +55,7 @@
 //! folding only the journal reconstructs a bit-identical projection.
 
 pub mod broker;
+pub mod capture_sink;
 pub mod checkpoint_io;
 pub mod config;
 pub mod crash;
@@ -66,11 +67,13 @@ pub mod snapshot_sink;
 pub mod topology;
 pub mod workflow;
 
+pub use capture_sink::CaptureSink;
 pub use config::{Mode, RuntimeConfig};
 pub use crash::CrashPoint;
 pub use digest::{digest_journal, digest_projection, ProjectionDigest};
 pub use engine::{
-    canonical_mote_ids, canonical_targets, digest_only, run, run_with_seams, RunOutcome,
+    canonical_mote_ids, canonical_targets, digest_only, run, run_with_capture, run_with_seams,
+    RunOutcome,
 };
 pub use error::RuntimeError;
 pub use migrate::migrate_and_verify;

--- a/crates/kx-runtime/tests/capture_flip.rs
+++ b/crates/kx-runtime/tests/capture_flip.rs
@@ -1,0 +1,135 @@
+//! M3.1 — on-by-default capture (D67) integration.
+//!
+//! Proves the three load-bearing properties of the flip:
+//! 1. **It works** — every committed Mote's action (its `result_ref`) is captured
+//!    exactly once, `ActionsOnly` retains only the action join key.
+//! 2. **It is byte-invisible to truth** — the product digest is identical whether
+//!    capture is `None`, `ActionsOnly`, or inspected (capture is never journaled).
+//! 3. **It survives recovery deterministically** — a replay re-derives a
+//!    bit-identical ledger (capture is a pure function of the folded journal), and
+//!    re-capture is idempotent (exactly-once per Mote).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kx_runtime::config::Mode;
+use kx_runtime::{engine, CaptureSink, RuntimeConfig};
+
+fn cfg(dir: &std::path::Path, mode: Mode) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("journal.sqlite"),
+        content_root: dir.join("content"),
+        mode,
+        crash_at: None,
+        // Cadence 2 over the 8-Mote demo: capture co-exists with checkpointing
+        // (both fire at the loop-bottom frontier) without perturbing either.
+        checkpoint_every: Some(2),
+    }
+}
+
+#[test]
+fn every_committed_mote_action_is_captured() {
+    let dir = tempfile::tempdir().unwrap();
+    let sink = CaptureSink::actions_only();
+    let outcome = engine::run_with_capture(&cfg(dir.path(), Mode::Run), Some(&sink)).unwrap();
+    assert!(outcome.is_complete(), "every workflow Mote commits");
+    assert_eq!(outcome.committed, 8);
+
+    let store = sink.store();
+    // One captured action per committed Mote — exactly once (a single final sweep).
+    assert_eq!(
+        store.len(),
+        outcome.committed,
+        "exactly one captured action per committed Mote"
+    );
+    // ActionsOnly: each record holds the action join key and strips the rest.
+    for (_id, rec) in store.iter() {
+        assert!(
+            rec.output_ref.is_some(),
+            "the committed action result_ref is captured"
+        );
+        assert!(
+            rec.input_ref.is_none(),
+            "input is stripped under ActionsOnly"
+        );
+        assert!(
+            rec.reasoning_ref.is_none(),
+            "reasoning is stripped under ActionsOnly"
+        );
+        assert!(
+            rec.thinking_ref.is_none(),
+            "thinking is stripped under ActionsOnly"
+        );
+    }
+    // Every declared canonical Mote is present (the 2 materialized children fill
+    // out the count to 8).
+    for id in engine::canonical_mote_ids() {
+        assert!(store.get(&id).is_some(), "declared Mote {id:?} is captured");
+    }
+}
+
+#[test]
+fn capture_on_does_not_change_the_product_digest() {
+    let on_dir = tempfile::tempdir().unwrap();
+    let off_dir = tempfile::tempdir().unwrap();
+    let sink = CaptureSink::actions_only();
+    let on = engine::run_with_capture(&cfg(on_dir.path(), Mode::Run), Some(&sink)).unwrap();
+    let off = engine::run_with_capture(&cfg(off_dir.path(), Mode::Run), None).unwrap();
+    assert_eq!(
+        on.digest, off.digest,
+        "capture is OFF the truth path — the product digest is identical with it on or off"
+    );
+    assert_eq!(sink.len(), 8, "the `Some` run populated the ledger");
+}
+
+#[test]
+fn capture_refs_are_deterministic_across_independent_runs() {
+    // Captured action refs are content-addressed, so two independent clean runs
+    // capture the identical `MoteId → result_ref` ledger — proving the captured
+    // join key IS the real committed result, not an incidental value.
+    let d1 = tempfile::tempdir().unwrap();
+    let d2 = tempfile::tempdir().unwrap();
+    let s1 = CaptureSink::actions_only();
+    let s2 = CaptureSink::actions_only();
+    engine::run_with_capture(&cfg(d1.path(), Mode::Run), Some(&s1)).unwrap();
+    engine::run_with_capture(&cfg(d2.path(), Mode::Run), Some(&s2)).unwrap();
+    let (a, b) = (s1.store(), s2.store());
+    assert_eq!(a.len(), b.len());
+    for (id, rec) in a.iter() {
+        assert_eq!(
+            b.get(id).unwrap().output_ref,
+            rec.output_ref,
+            "same Mote → same content-addressed action ref across runs"
+        );
+    }
+}
+
+#[test]
+fn replay_recaptures_the_same_ledger_exactly_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let s_run = CaptureSink::actions_only();
+    let run = engine::run_with_capture(&cfg(dir.path(), Mode::Run), Some(&s_run)).unwrap();
+    assert_eq!(s_run.len(), 8);
+
+    // A fresh process replaying the completed journal re-derives a bit-identical
+    // ledger — capture is a pure function of the folded truth, and recording is
+    // idempotent (overwrite by `MoteId`), so each action lands exactly once.
+    let s_replay = CaptureSink::actions_only();
+    let replay = engine::run_with_capture(&cfg(dir.path(), Mode::Replay), Some(&s_replay)).unwrap();
+    assert_eq!(
+        run.digest, replay.digest,
+        "replay is bit-identical with capture on (capture cannot perturb recovery)"
+    );
+    assert_eq!(
+        s_replay.len(),
+        s_run.len(),
+        "replay re-captures every committed action exactly once"
+    );
+    let (r, p) = (s_run.store(), s_replay.store());
+    for (id, rec) in r.iter() {
+        assert_eq!(
+            p.get(id).unwrap().output_ref,
+            rec.output_ref,
+            "replay re-derives the identical action ref for {id:?}"
+        );
+    }
+}

--- a/crates/kx-runtime/tests/stress_throughput.rs
+++ b/crates/kx-runtime/tests/stress_throughput.rs
@@ -206,6 +206,79 @@ fn h1_throughput_wide_and_deep() {
     println!("H1: ceiling WIDE={wide_ceiling} DEEP={deep_ceiling}");
 }
 
+/// H3 — the M3.1 on-by-default capture (D67) sweep is flat per Mote at scale.
+///
+/// Commits a WIDE PURE DAG of `n` Motes, then times the exact operations the
+/// engine's `capture_committed_actions` sweep performs at return —
+/// `Projection::result_ref_of` + `CaptureSink::record` per committed Mote — across
+/// the ramp. Asserts exactly-once (`sink.len() == n`) and a flat per-Mote cost, so
+/// turning capture on by default cannot make a large run super-linear.
+#[test]
+#[ignore = "stress: run with --release --ignored --nocapture --test-threads=1"]
+fn h3_capture_sweep_is_flat_per_mote() {
+    let warrant = pure_warrant();
+    let mut per_mote_ns: Vec<(usize, f64)> = Vec::new();
+    for &n in SIZES {
+        let motes = build_dag(n, Shape::Wide);
+        let journal = SqliteJournal::open_in_memory().unwrap();
+        let rm = LocalResourceManager::dev_defaults();
+        let executor = TestMoteExecutor::deterministic();
+        let mut projection = Projection::new();
+        let mut scheduler = Scheduler::new(LocalPlacement);
+        for m in &motes {
+            scheduler
+                .submit(m.clone(), warrant.clone(), &mut projection)
+                .unwrap();
+        }
+        for m in &motes {
+            run_pure_mote(m, &warrant, &journal, &rm, &executor).unwrap();
+        }
+        let projection = Projection::from_journal(&journal).unwrap();
+        assert_eq!(projection.committed_count(), n);
+
+        // Time the capture sweep over the committed projection (the engine's
+        // final-sweep cost): result_ref_of + record per committed Mote.
+        let sink = kx_runtime::CaptureSink::actions_only();
+        let start = Instant::now();
+        for m in &motes {
+            if let Some(rr) = projection.result_ref_of(&m.id) {
+                sink.record(kx_capture::StepRecord::action(m.id, rr));
+            }
+        }
+        let elapsed = start.elapsed();
+        assert_eq!(
+            sink.len(),
+            n,
+            "every committed action captured exactly once at n={n}"
+        );
+        let per = elapsed.as_nanos() as f64 / n as f64;
+        println!(
+            "H3 capture-sweep: n={n} sweep_ms={} per_mote_ns={per:.1} exactly-once=ok",
+            elapsed.as_millis()
+        );
+        per_mote_ns.push((n, per));
+
+        if elapsed > WALL_CEILING {
+            break;
+        }
+    }
+    // Capture is O(committed·log): one `result_ref_of` BTreeMap read + one
+    // BTreeMap insert per Mote (both O(log N)). The per-Mote time rises by a small
+    // CONSTANT factor at scale (the 25k-entry projection map falls out of cache →
+    // memory-latency-bound lookups), NOT algorithmically. This bound catches a
+    // genuine super-linear regression — a quadratic sweep would be ~625× at 25k vs
+    // 1k — with generous headroom for the cache factor (observed ~3-4×). The
+    // absolute wall time printed above (≈20ms for 25k) is the meaningful guarantee:
+    // capture adds negligible overhead to a run that takes far longer to execute.
+    let first = per_mote_ns.first().unwrap().1;
+    let last = per_mote_ns.last().unwrap().1;
+    assert!(
+        last <= first * 8.0,
+        "capture sweep must stay sub-quadratic per Mote (n=1k {first:.1}ns vs n=25k {last:.1}ns)"
+    );
+    println!("H3: capture-sweep sub-quadratic per_mote 1k={first:.1}ns 25k={last:.1}ns");
+}
+
 #[test]
 #[ignore = "stress: run with --release --ignored --nocapture --test-threads=1"]
 fn h2_largest_dag_is_byte_reproducible() {

--- a/justfile
+++ b/justfile
@@ -126,6 +126,7 @@ scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
     cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-capture --release --test scale -- --ignored --nocapture --test-threads=1
 
 # ============================================================================
 # Preflight diagnostic


### PR DESCRIPTION
## M3.1 — On-by-default capture (D67)

Flips `kx-capture` from **built-but-unwired** to **ON by default** in the runtime — the last unshipped *front-loaded-correctness* milestone (M0–M3) and the D63/D67 **reliability/resumability** story. Each committed Mote's **action** (its `result_ref`) is recorded into a disposable, dependency-walled `InMemoryCaptureStore` via a new optional `CaptureSink` seam that mirrors M5.1's `SnapshotSink`.

The demo `run()` turns capture on with `CaptureScope::ActionsOnly` (the privacy-safe default); a new thin public `run_with_capture(config, Option<&CaptureSink>)` is the read path for the captured ledger.

### What changed
- **NEW** `crates/kx-runtime/src/capture_sink.rs` — `CaptureSink` (`Arc<RwLock<InMemoryCaptureStore>>`, poison-recovering, cheap-clone).
- `engine.rs` — a 10th optional seam `capture_sink: Option<&CaptureSink>` on `run_with_seams`; a single `capture_committed_actions` sweep at return; `run()` delegates to the new public `run_with_capture` (the flip).
- The 4 `kx-model-harness` `run_with_seams` call sites pass `None`.
- `kx-runtime` gains a `kx-capture` dep (already a workspace member; no new external crate).

### Off the truth path — proven
- **Digest `a6b5c679…` byte-unchanged** with capture on (`a0_guard` green) — capture is never journaled, never a `MoteId` input, never a gate.
- **Dependency wall green** (`kx-capture/tests/boundary.rs`) — `kx-runtime` sits above the guarantee path, so wiring it does not trip the wall.
- **Replay re-captures a bit-identical ledger exactly-once** — capture is a pure function of the folded journal and cannot perturb recovery.

### Golden Rule 8 — both passes

**Pass A (defensive).**
- *Breaks:* the new seam param breaks the 5 `run_with_seams` callers + capture is byte-invisible to the demo digest — both compile-enforced / `a0_guard`-gated. No recovery/idempotency/determinism impact (capture is downstream of commit, integer-only, `BTreeMap`-ordered).
- *Perf:* a single O(committed·log) sweep at return — **flat per-Mote** (kx-capture store 189→154 ns/record; H3 full sweep 246→910 ns/Mote at 25k, ~22 ms total). Zero added content-store I/O (`result_ref_of` is in-memory). The original per-iteration design was an O(N²) rescan; replaced by the single sweep. Memory O(committed), ~150 B/record under `ActionsOnly`.
- *Security:* `ActionsOnly` default retains only the `result_ref` — a join key already on the journal — so the flip adds **no new information surface**. The runtime seam is action-only by construction (it never builds reasoning/thinking refs), so even under `Full` consent the runtime cannot leak them; `Full` enrichment + its `kx-critic::PiiLeak` gate is M3.2.

**Pass B (forward).** Capture is the D67 resumability index over truth (queryable without re-reading the journal). Unblocks **M11** (trace = a fold over capture) and **M12** (flywheel corpus). Sequenced next: **M3.2** (PII gate, per-run scope CLI override, retention TTL — `forget` already exists) → capture persistence behind a trait → harness `Full`-mode enrichment.

### Scope
M3.1 only (flip + seam + byte-invisibility + scale proof). M3.2 is a gated follow-on (mirrors M2.2/b/c).

### Tests
`capture_sink` unit (7) · NEW `capture_flip` integration (4) · `a0_guard` digest tripwire · `boundary` wall · all kx-runtime suites green with capture ON · scale-smoke `kx-capture::scale` (wired into the recipe; required-context name unchanged) · campaign `stress_throughput::h3_capture_sweep_is_flat_per_mote`.

Decisions = **D67 implemented** (no new D). Frozen trio `kx-scheduler`/`kx-executor`/`kx-inference` source byte-unchanged (thesis diff EMPTY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
