### PR TITLE
feat(planner): M6 — model proposal → registered Mote DAG (kx-planner, D73–D78)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
 name = "kx-model-harness"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "blake3",
  "kx-capability",
  "kx-capture",
@@ -1293,6 +1294,7 @@ dependencies = [
  "kx-mcp",
  "kx-memoizer",
  "kx-mote",
+ "kx-planner",
  "kx-projection",
  "kx-runtime",
  "kx-tool-registry",
@@ -1345,6 +1347,22 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "kx-planner"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "kx-content",
+ "kx-critic-types",
+ "kx-mote",
+ "kx-warrant",
+ "kx-workflow",
+ "proptest",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crates/kx-capture",
     "crates/kx-refusal",
     "crates/kx-mcp",
+    "crates/kx-planner",
     "crates/kx-model-harness",
 ]
 exclude = [
@@ -131,6 +132,12 @@ kx-refusal           = { path = "crates/kx-refusal",           version = "0.0.1"
 # concrete ToolKind::Mcp dispatch. A thin SYNC client (stdio now; ureq HTTP in M5.2b)
 # so the broker trait + kx-tool-registry stay dependency-clean (no tokio/rmcp).
 kx-mcp               = { path = "crates/kx-mcp",               version = "0.0.1" }
+# The planner (M6, D73) — lowers an untrusted model PROPOSAL into a registered
+# Mote DAG (decode fail-closed; select ROLES not permissions; compile is the
+# structural gate). Sits above the scheduler; PURE lowering lib — depends only on
+# kx-workflow/kx-mote/kx-warrant/kx-critic-types (NEVER scheduler/projection/
+# executor/inference — the thesis dependency-ban, asserted in kx-model-harness).
+kx-planner           = { path = "crates/kx-planner",           version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-model-harness/Cargo.toml
+++ b/crates/kx-model-harness/Cargo.toml
@@ -22,6 +22,10 @@ kx-tool-registry.workspace = true
 kx-memoizer.workspace = true
 kx-runtime.workspace = true
 kx-workflow.workspace = true
+# M6: the planner — lower a committed plan FACT into a registered Mote DAG. The
+# model-runs-once + read-the-plan-back wiring lives HERE (the harness), keeping
+# kx-planner a pure lowering lib with no projection/inference coupling.
+kx-planner.workspace = true
 kx-dataset.workspace = true
 kx-critic-types.workspace = true
 kx-capture.workspace = true
@@ -39,6 +43,9 @@ sha2.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+# Canonical-bincode staging of a planner-produced TopologyDecision / WarrantSpec
+# in the M6 replan e2e (same content-addressing the materializer decodes).
+bincode.workspace = true
 # The deterministic-critic evaluator — used by tests to independently re-derive a
 # verdict over a producer's bytes and confirm byte-identity with the committed one.
 kx-critic.workspace = true

--- a/crates/kx-model-harness/src/workflows.rs
+++ b/crates/kx-model-harness/src/workflows.rs
@@ -15,6 +15,7 @@ use kx_mote::{
 use kx_runtime::workflow::WorkflowMote;
 use kx_runtime::DemoWorkflow;
 use kx_warrant::WarrantSpec;
+use kx_workflow::CompiledWorkflow;
 use smallvec::SmallVec;
 
 use crate::prompt;
@@ -336,6 +337,63 @@ pub fn model_tool_call(
     DemoWorkflow {
         motes,
         stc_crash_target: m_id,
+        vtc_crash_target: sentinel_shaper(),
+        shaper_id: sentinel_shaper(),
+    }
+}
+
+/// **M6 — the planner step.** A single READ-ONLY-NONDET *model* Mote carrying the
+/// `planning_prompt`; the model's output (a structured plan envelope) commits as
+/// the Mote's `result_ref` — the plan is a content-addressed FACT (D74). The
+/// warrant grants no tools, so the broker's fail-closed `parse_tool_call` returns
+/// `None` and the completion bytes (the plan) are committed verbatim. ROND ⇒ the
+/// planner re-samples on a *fresh* run by design, but on REPLAY the committed plan
+/// is served, never re-sampled (`vtc_crash_target = the planner`, so the
+/// `post-commit-vtc` crash test proves a recovered run re-reads the plan).
+///
+/// Drive it through the same orchestrator as the A–J rows, read the committed plan
+/// back via `projection.result_ref_of(&planner_id)` → `store.get`, then
+/// `kx_planner::compile_plan` it and run the result via [`from_compiled`].
+#[must_use]
+pub fn planner_mote(
+    model_id: &ModelId,
+    warrant: &WarrantSpec,
+    planning_prompt: &str,
+) -> DemoWorkflow {
+    let planner = mote(
+        0x60,
+        model_id,
+        Some(planning_prompt),
+        sampled(256, 0x0050_1a2b),
+        NdClass::ReadOnlyNondet,
+        EffectPattern::IdempotentByConstruction,
+        None,
+        None,
+        &[],
+    );
+    let planner_id = planner.id;
+    // ROND ⇒ a crash AFTER commit must re-READ the plan (served, not re-sampled).
+    wrap(vec![planner], warrant, sentinel_shaper(), planner_id)
+}
+
+/// **M6 — run a planner-produced DAG.** Map a `kx_planner::compile_plan` result
+/// (`CompiledMote { mote, warrant, capability }`) 1:1 to a flat (shaperless)
+/// [`DemoWorkflow`], so it drives through `run_with_seams` with NO new execution
+/// mechanism — a planner-produced DAG is "just another built workflow" (pivot §3.6).
+#[must_use]
+pub fn from_compiled(compiled: &CompiledWorkflow) -> DemoWorkflow {
+    let motes = compiled
+        .motes
+        .iter()
+        .map(|cm| WorkflowMote {
+            mote: cm.mote.clone(),
+            warrant: cm.warrant.clone(),
+            capability: cm.capability.clone(),
+        })
+        .collect();
+    DemoWorkflow {
+        motes,
+        stc_crash_target: sentinel_shaper(),
         vtc_crash_target: sentinel_shaper(),
         shaper_id: sentinel_shaper(),
     }

--- a/crates/kx-model-harness/tests/planner_e2e.rs
+++ b/crates/kx-model-harness/tests/planner_e2e.rs
@@ -1,0 +1,377 @@
+//! M6 — the agentic loop end-to-end: prompt → committed plan → decode → lower →
+//! compile → registered Mote DAG → run → result.
+//!
+//! Runs WITHOUT the GGUF model (a stub `InferenceBackend` returns a fixed plan
+//! envelope for the planner step and a fixed completion for the worker steps), so
+//! it gates in plain `cargo test`. Proves the M6 DoD directly:
+//!
+//! - **plan-committed-as-a-fact (D74):** the planner Mote's committed `result_ref`
+//!   IS the plan bytes; the runtime reads them back and compiles them.
+//! - **replays, never re-runs (D74):** re-driving the same journal serves the
+//!   committed plan and dispatches the model ZERO times.
+//! - **re-run resamples (D74):** two fresh runs with different model output commit
+//!   different plans (the planner is ROND), each compiling deterministically.
+//! - **role-centric authority (D75):** every produced Mote's warrant is
+//!   `intersect(parent, role)` — no widening.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_content::{ContentStore, LocalFsContentStore};
+use kx_executor::{LocalResourceManager, StandardCommitProtocol};
+use kx_inference::{InferenceBackend, InferenceError, InferenceInput, InferenceOutput};
+use kx_journal::SqliteJournal;
+use kx_model_harness::{workflows, BrokerObserver, ModelBroker, ModelExecutor};
+use kx_mote::{
+    EffectPattern, InferenceParams, LogicRef, ModelId, NdClass, PromptTemplateHash, RoleId,
+    ToolName,
+};
+use kx_planner::{
+    compile_plan, decode_plan, max_plan_bytes, seed_from_plan_bytes, InMemoryRoleRecipes,
+    RoleRecipe, PLAN_PROMPT_KEY,
+};
+use kx_projection::{fold_run_metadata, Projection};
+use kx_runtime::config::Mode;
+use kx_runtime::{
+    run_with_seams, DemoWorkflow, RunOutcome, RuntimeConfig, RuntimeError, SnapshotSink,
+};
+use kx_tool_registry::{InMemoryToolRegistry, ToolRegistry};
+use kx_warrant::{
+    ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    Role, WarrantSpec,
+};
+
+/// The planning instruction the planner Mote carries.
+const PLANNING_PROMPT: &str = "Plan: read the input, then summarize it.";
+
+/// A fixed, well-formed plan the stub "model" emits: reader → summarizer (Data edge).
+const PLAN_JSON: &str = r#"{"plan":{"version":1,"steps":[{"role":"reader","intent":"read the input"},{"role":"summarizer","intent":"summarize it"}],"edges":[{"parent":0,"child":1}]}}"#;
+
+/// A *different* valid plan (a single reader step) — used to prove ROND resampling.
+const PLAN_JSON_ALT: &str =
+    r#"{"plan":{"version":1,"steps":[{"role":"reader","intent":"just read"}]}}"#;
+
+fn model_id() -> ModelId {
+    ModelId("stub-model:test:0".to_string())
+}
+
+/// A stub backend that returns a fixed `reply` for every dispatch and counts how
+/// many times it was called (so a test can prove "served, never re-run").
+struct StubBackend {
+    reply: Vec<u8>,
+    calls: Arc<AtomicUsize>,
+    inputs: Arc<Mutex<Vec<String>>>,
+}
+
+impl InferenceBackend for StubBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let text = match input {
+            InferenceInput::Text(s) => s.clone(),
+            InferenceInput::Multimodal { text, .. } => text.clone(),
+        };
+        self.inputs.lock().unwrap().push(text);
+        Ok(InferenceOutput {
+            bytes: self.reply.clone(),
+            output_tokens: 1,
+            backend_name: "stub",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(0),
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "stub"
+    }
+}
+
+/// A permissive parent warrant granting no tools (the planner's output is the
+/// plan, never a tool call), routed to `model_id`.
+fn parent_warrant(model_id: &ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: model_id.clone(),
+            max_input_tokens: 8192,
+            max_output_tokens: 1024,
+            max_calls: 64,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 1000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// Register the `reader` + `summarizer` roles (warrant templates within the
+/// parent) and their vetted recipes (PURE model steps, no tools).
+fn registries(
+    model_id: &ModelId,
+    parent: &WarrantSpec,
+) -> (InMemoryRoleRegistry, InMemoryRoleRecipes) {
+    let roles = InMemoryRoleRegistry::new();
+    let recipes = InMemoryRoleRecipes::new();
+    for (i, name) in ["reader", "summarizer"].iter().enumerate() {
+        let tag = u8::try_from(i).unwrap();
+        // Role warrant = a within-parent clone (no tools, same syscall profile).
+        let mut spec = parent.clone();
+        spec.mote_class = MoteClass::Pure;
+        spec.nd_class = MoteClass::Pure;
+        roles.register(
+            RoleId((*name).into()),
+            Role {
+                name: (*name).into(),
+                version: 1,
+                spec,
+                description: String::new(),
+            },
+        );
+        recipes.register(
+            RoleId((*name).into()),
+            RoleRecipe {
+                logic_ref: LogicRef::from_bytes([0x70 + tag; 32]),
+                model_id: model_id.clone(),
+                prompt_template_hash: PromptTemplateHash::from_bytes([0x80 + tag; 32]),
+                tool_contract: BTreeMap::new(),
+                capability: ToolName("kx-model".into()),
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                inference_params: InferenceParams::default(),
+                deterministic_check: None,
+            },
+        );
+    }
+    (roles, recipes)
+}
+
+fn config_for(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+    }
+}
+
+/// Drive `workflow` through the real orchestrator with a stub backend returning
+/// `reply`. Returns the run result + the dispatch count.
+fn drive(
+    workflow: &DemoWorkflow,
+    dir: &Path,
+    reply: &[u8],
+) -> (Result<RunOutcome, RuntimeError>, usize) {
+    let config = config_for(dir);
+    let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+    let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+    let calls = Arc::new(AtomicUsize::new(0));
+    let backend = Arc::new(StubBackend {
+        reply: reply.to_vec(),
+        calls: calls.clone(),
+        inputs: Arc::new(Mutex::new(Vec::new())),
+    });
+    let sink = SnapshotSink::new();
+    let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+    let executor = ModelExecutor::new(
+        backend.clone(),
+        store.clone(),
+        sink.clone(),
+        registry.clone(),
+    );
+    let observer = Arc::new(BrokerObserver::default());
+    let tool_broker: Arc<dyn CapabilityBroker> =
+        Arc::new(LocalCapabilityBroker::new(store.clone()));
+    let broker = Arc::new(ModelBroker::new(
+        backend,
+        store.clone(),
+        None,
+        Some(workflow.stc_crash_target),
+        observer,
+        sink.clone(),
+        registry,
+        tool_broker,
+        [0u8; kx_capability::INSTANCE_ID_LEN],
+    ));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let rm = LocalResourceManager::dev_defaults();
+    let result = run_with_seams(
+        &config,
+        workflow,
+        store,
+        journal,
+        &rm,
+        &executor,
+        &protocol,
+        None,
+        Some(&sink),
+        None,
+    );
+    (result, calls.load(Ordering::SeqCst))
+}
+
+/// Read the planner Mote's committed plan bytes back from the journal/store.
+fn read_committed_plan(dir: &Path, planner_id: kx_mote::MoteId) -> Vec<u8> {
+    let config = config_for(dir);
+    let store = LocalFsContentStore::open(&config.content_root).unwrap();
+    let journal = SqliteJournal::open(&config.journal_path).unwrap();
+    let projection = Projection::from_journal(&journal).unwrap();
+    let plan_ref = projection
+        .result_ref_of(&planner_id)
+        .expect("planner committed its plan");
+    store.get(&plan_ref).expect("plan bytes in store").to_vec()
+}
+
+#[test]
+fn plan_commits_as_a_fact_compiles_and_runs() {
+    let id = model_id();
+    let warrant = parent_warrant(&id);
+    let (roles, recipes) = registries(&id, &warrant);
+
+    // (1) Run the planner Mote — its output (the plan) commits as its result_ref.
+    let planner_wf = workflows::planner_mote(&id, &warrant, PLANNING_PROMPT);
+    let planner_id = planner_wf.motes[0].mote.id;
+    let plan_dir = tempfile::tempdir().unwrap();
+    let (r1, calls1) = drive(&planner_wf, plan_dir.path(), PLAN_JSON.as_bytes());
+    assert!(r1.unwrap().is_complete(), "planner committed");
+    assert_eq!(calls1, 1, "the planner dispatched the model exactly once");
+
+    // (2) Read the plan back as a FACT and decode + compile it.
+    let plan_bytes = read_committed_plan(plan_dir.path(), planner_id);
+    assert_eq!(
+        plan_bytes.as_slice(),
+        PLAN_JSON.as_bytes(),
+        "committed plan == model output"
+    );
+    let plan = decode_plan(&plan_bytes, max_plan_bytes(&warrant)).expect("decodes");
+    let seed = seed_from_plan_bytes(&plan_bytes);
+    let compiled = compile_plan(&plan, seed, &warrant, &roles, &recipes).expect("compiles");
+    assert_eq!(compiled.motes.len(), 2, "reader + summarizer");
+    // D75: every produced warrant ⊆ parent (no widening).
+    for m in &compiled.motes {
+        assert!(m.warrant.tool_grants.is_subset(&warrant.tool_grants));
+    }
+    // The intent reached identity-bearing config under the prompt key.
+    let reader_cfg = &compiled.motes[0].mote.def.config_subset;
+    assert!(
+        reader_cfg.contains_key(&kx_mote::ConfigKey(PLAN_PROMPT_KEY.to_string())),
+        "the intent is carried under the prompt key"
+    );
+
+    // (3) Run the planner-produced DAG — no new execution mechanism.
+    let dag = workflows::from_compiled(&compiled);
+    let run_dir = tempfile::tempdir().unwrap();
+    let (r2, calls2) = drive(&dag, run_dir.path(), b"ok");
+    assert!(
+        r2.unwrap().is_complete(),
+        "the compiled DAG ran to completion"
+    );
+    assert_eq!(calls2, 2, "each model worker dispatched once");
+
+    // (4) M6.2 — fold the run's journal into planner-ready metadata (D78). The
+    // observability the planner would propose its NEXT round over: 2 committed
+    // workers + their distinct recipe fingerprints.
+    let journal = SqliteJournal::open(&config_for(run_dir.path()).journal_path).unwrap();
+    let md = fold_run_metadata(&journal).unwrap();
+    assert_eq!(md.committed, 2, "metadata fold sees both committed workers");
+    assert_eq!(
+        md.recipe_fingerprints.len(),
+        2,
+        "two distinct worker recipes"
+    );
+    let summary = String::from_utf8(md.summary_bytes()).unwrap();
+    assert!(
+        summary.contains("committed=2"),
+        "summary is planner-readable: {summary}"
+    );
+}
+
+#[test]
+fn replay_serves_the_committed_plan_never_re_runs_the_model() {
+    let id = model_id();
+    let warrant = parent_warrant(&id);
+    let planner_wf = workflows::planner_mote(&id, &warrant, PLANNING_PROMPT);
+    let planner_id = planner_wf.motes[0].mote.id;
+    let dir = tempfile::tempdir().unwrap();
+
+    // First run commits the plan.
+    let (r1, calls1) = drive(&planner_wf, dir.path(), PLAN_JSON.as_bytes());
+    assert!(r1.unwrap().is_complete());
+    assert_eq!(calls1, 1);
+    let first = read_committed_plan(dir.path(), planner_id);
+
+    // Re-drive over the SAME journal with a tripwire backend that would emit
+    // DIFFERENT bytes if called. The committed plan is served, the model is NOT
+    // re-run — so the tripwire fires zero times and the plan is byte-identical.
+    let (r2, calls2) = drive(&planner_wf, dir.path(), b"DIFFERENT-SHOULD-NOT-COMMIT");
+    assert!(r2.unwrap().is_complete());
+    assert_eq!(
+        calls2, 0,
+        "replay served the committed plan; the model never re-ran"
+    );
+    let second = read_committed_plan(dir.path(), planner_id);
+    assert_eq!(
+        first, second,
+        "the committed plan FACT is unchanged on replay"
+    );
+    assert_eq!(first.as_slice(), PLAN_JSON.as_bytes());
+}
+
+#[test]
+fn re_run_resamples_distinct_plans_each_compiling_deterministically() {
+    let id = model_id();
+    let warrant = parent_warrant(&id);
+    let (roles, recipes) = registries(&id, &warrant);
+    let planner_wf = workflows::planner_mote(&id, &warrant, PLANNING_PROMPT);
+    let planner_id = planner_wf.motes[0].mote.id;
+
+    // Two fresh runs whose ROND planner "resamples" different plans.
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    drive(&planner_wf, dir_a.path(), PLAN_JSON.as_bytes())
+        .0
+        .unwrap();
+    drive(&planner_wf, dir_b.path(), PLAN_JSON_ALT.as_bytes())
+        .0
+        .unwrap();
+    let a = read_committed_plan(dir_a.path(), planner_id);
+    let b = read_committed_plan(dir_b.path(), planner_id);
+    assert_ne!(a, b, "ROND: distinct samples commit distinct plans (D74)");
+
+    // Each committed plan re-compiles deterministically (pure lowering).
+    for bytes in [&a, &b] {
+        let plan = decode_plan(bytes, max_plan_bytes(&warrant)).unwrap();
+        let seed = seed_from_plan_bytes(bytes);
+        let c1 = compile_plan(&plan, seed, &warrant, &roles, &recipes).unwrap();
+        let c2 = compile_plan(&plan, seed, &warrant, &roles, &recipes).unwrap();
+        let ids1: Vec<_> = c1.motes.iter().map(|m| m.mote.id).collect();
+        let ids2: Vec<_> = c2.motes.iter().map(|m| m.mote.id).collect();
+        assert_eq!(
+            ids1, ids2,
+            "re-compile of a committed plan is deterministic"
+        );
+    }
+}

--- a/crates/kx-model-harness/tests/planner_invariants.rs
+++ b/crates/kx-model-harness/tests/planner_invariants.rs
@@ -1,0 +1,62 @@
+//! M6 invariant guards that need both crates in scope.
+//!
+//! - The planner carries a step's intent under its own `PLAN_PROMPT_KEY`; for a
+//!   model executor to USE it as the instruction, that key MUST equal the
+//!   harness's `prompt::PROMPT_KEY`. A drift guard pins the two constants equal
+//!   (cheap protection against the hand-mirrored-constant hazard, IMP-7).
+//! - The thesis dependency-ban (D73): `kx-planner`'s `[dependencies]` must name
+//!   none of `kx-scheduler` / `kx-projection` / `kx-executor` / `kx-inference`,
+//!   so the planner layer can never couple to the engine it sits above.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+#[test]
+fn plan_prompt_key_matches_the_harness_prompt_convention() {
+    assert_eq!(
+        kx_planner::PLAN_PROMPT_KEY,
+        kx_model_harness::prompt::PROMPT_KEY,
+        "kx_planner::PLAN_PROMPT_KEY must equal kx_model_harness::prompt::PROMPT_KEY — \
+         otherwise a planner step's intent would not be read as the model instruction"
+    );
+}
+
+#[test]
+fn kx_planner_does_not_depend_on_the_engine_crates_thesis_ban() {
+    // Read kx-planner's manifest from disk and assert the [dependencies] table
+    // names none of the banned engine crates (D73 / the P2 thesis test).
+    let manifest = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../kx-planner/Cargo.toml"
+    ))
+    .expect("read kx-planner/Cargo.toml");
+
+    // Isolate the [dependencies] section (up to the next top-level table).
+    let deps = manifest
+        .split_once("[dependencies]")
+        .expect("kx-planner has a [dependencies] table")
+        .1;
+    let deps = deps.split("\n[").next().unwrap_or(deps);
+
+    // Collect the dependency KEYS only (the token before `=`/`.`), ignoring
+    // comments — so a banned name mentioned in a comment never trips the guard.
+    let keys: Vec<&str> = deps
+        .lines()
+        .filter_map(|line| line.split('#').next()) // strip trailing comments
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(|l| l.split(['=', '.', ' ']).next().unwrap_or(l).trim())
+        .collect();
+
+    for banned in [
+        "kx-scheduler",
+        "kx-projection",
+        "kx-executor",
+        "kx-inference",
+    ] {
+        assert!(
+            !keys.contains(&banned),
+            "kx-planner must NOT depend on {banned} (D73 / thesis test) — found it as a \
+             [dependencies] key"
+        );
+    }
+}

--- a/crates/kx-model-harness/tests/replan_e2e.rs
+++ b/crates/kx-model-harness/tests/replan_e2e.rs
@@ -1,0 +1,283 @@
+//! M6 — D76/D77 iterative replanning end-to-end.
+//!
+//! An agentic loop is NOT a DAG cycle: it lowers (via
+//! `kx_planner::lower_loop_to_topology_decision`) to a `TopologyDecision` a ROND
+//! shaper commits, which the SHIPPED `DefaultTopologyMaterializer` materializes
+//! into children deterministically. This proves:
+//!
+//! - a planner-PRODUCED `TopologyDecision` drives the real materializer (children
+//!   materialize, appear ready, parent = the shaper);
+//! - a re-plan **appends** a fresh round (a distinct committed `TopologyDecision`
+//!   fact) and NEVER mutates a committed Mote — round-1's entries + states are
+//!   byte-unchanged after round-2 folds (D76 / D-LOCK-4);
+//! - cold re-fold reproduces identical identities (R49).
+//!
+//! Fully deterministic (no model, clock, network). The planner's "samples" are
+//! the two fixed `LoopProposal`s.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_journal::{InMemoryJournal, Journal, JournalEntry};
+use kx_mote::{
+    canonical_config, derive_mote_id, EffectPattern, GraphPosition, InferenceParams, InputDataId,
+    LogicRef, ModelId, MoteDef, MoteId, NdClass, PromptTemplateHash, RoleId, ToolName,
+    TopologyDecision, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_planner::{
+    lower_loop_to_topology_decision, InMemoryRoleRecipes, LoopProposal, PlanStep, PlanStepKind,
+    RoleRecipe,
+};
+use kx_projection::{
+    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
+    Projection,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    Role, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+fn permissive_warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("test-model".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 1024,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 20,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// A ROND topology-shaper MoteDef (R-14: a shaper is never WORLD-MUTATING). The
+/// `seed` distinguishes round-1 (planner) from round-2 (replanner).
+fn shaper_def(seed: u8) -> MoteDef {
+    MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef([seed; 32]),
+        model_id: ModelId("planner".into()),
+        prompt_template_hash: PromptTemplateHash([seed; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: true,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+fn shaper_id(def: &MoteDef, position: u8) -> MoteId {
+    derive_mote_id(
+        &def.hash(),
+        &InputDataId::from_bytes([0u8; 32]),
+        &GraphPosition(vec![position]),
+    )
+}
+
+fn pure_recipe(seed: u8) -> RoleRecipe {
+    RoleRecipe {
+        logic_ref: LogicRef::from_bytes([seed; 32]),
+        model_id: ModelId("worker".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([seed; 32]),
+        tool_contract: BTreeMap::new(),
+        capability: ToolName("kx-model".into()),
+        nd_class: NdClass::Pure,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        inference_params: InferenceParams::default(),
+        deterministic_check: None,
+    }
+}
+
+fn plain_step(role: &str) -> PlanStep {
+    PlanStep {
+        role: role.into(),
+        intent: format!("do {role}"),
+        kind: PlanStepKind::Plain,
+        producer: None,
+    }
+}
+
+fn stage_td(store: &InMemoryContentStore, td: &TopologyDecision) -> ContentRef {
+    let bytes = bincode::serde::encode_to_vec(td, canonical_config()).unwrap();
+    store.put(&bytes).unwrap()
+}
+
+fn stage_warrant(store: &InMemoryContentStore) -> ContentRef {
+    let bytes = bincode::serde::encode_to_vec(permissive_warrant(), canonical_config()).unwrap();
+    store.put(&bytes).unwrap()
+}
+
+fn committed_shaper(
+    shaper: MoteId,
+    seq: u64,
+    td_ref: ContentRef,
+    warrant_ref: ContentRef,
+    def_hash: kx_mote::MoteDefHash,
+) -> JournalEntry {
+    JournalEntry::Committed {
+        mote_id: shaper,
+        idempotency_key: shaper.0,
+        seq,
+        nondeterminism: NdClass::ReadOnlyNondet,
+        result_ref: td_ref,
+        parents: SmallVec::new(),
+        warrant_ref,
+        mote_def_hash: def_hash,
+    }
+}
+
+#[test]
+fn replanning_appends_a_fresh_round_and_never_mutates_round_one() {
+    // ---- Recipes (for kx_planner) + roles (for the materializer warrant) ----
+    let recipes = InMemoryRoleRecipes::new();
+    recipes.register(RoleId("reader".into()), pure_recipe(0xA1));
+    recipes.register(RoleId("summarizer".into()), pure_recipe(0xB2));
+    recipes.register(RoleId("refiner".into()), pure_recipe(0xC3));
+
+    // Round 1 + round 2 proposals → distinct TopologyDecisions via the planner.
+    let round1 = LoopProposal {
+        next_steps: vec![plain_step("reader"), plain_step("summarizer")],
+    };
+    let round2 = LoopProposal {
+        next_steps: vec![plain_step("refiner")],
+    };
+    let td1 = lower_loop_to_topology_decision(&round1, &recipes).unwrap();
+    let td2 = lower_loop_to_topology_decision(&round2, &recipes).unwrap();
+    assert_ne!(
+        td1.hash(),
+        td2.hash(),
+        "a re-plan is a DISTINCT committed fact"
+    );
+    assert_eq!(td1.children.len(), 2);
+    assert_eq!(td2.children.len(), 1);
+
+    // ---- Materializer wiring (the SHIPPED runtime path) ----
+    let store = Arc::new(InMemoryContentStore::new());
+    let def_registry = Arc::new(InMemoryMoteDefRegistry::new());
+    let role_registry = Arc::new(InMemoryRoleRegistry::new());
+    let role = Role {
+        name: "default".into(),
+        version: 1,
+        spec: permissive_warrant(),
+        description: String::new(),
+    };
+    for r in ["reader", "summarizer", "refiner"] {
+        role_registry.register(RoleId(r.into()), role.clone());
+    }
+    let s1 = shaper_def(0x01);
+    let s2 = shaper_def(0x02);
+    def_registry.register(s1.clone());
+    def_registry.register(s2.clone());
+    let s1_id = shaper_id(&s1, 0x01);
+    let s2_id = shaper_id(&s2, 0x02);
+    let warrant_ref = stage_warrant(&store);
+    let td1_ref = stage_td(&store, &td1);
+    let td2_ref = stage_td(&store, &td2);
+
+    // ---- Round 1: planner shaper commits td1 → materialize 2 children ----
+    let journal = InMemoryJournal::new();
+    let e1 = committed_shaper(s1_id, 1, td1_ref, warrant_ref, s1.hash());
+    journal.append(e1).unwrap();
+
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        Arc::clone(&store),
+        Arc::clone(&def_registry),
+        Arc::clone(&role_registry),
+        InheritFromShaperResolver,
+    ));
+    let mut projection =
+        Projection::from_journal_with_materializer(&journal, materializer).unwrap();
+    assert_eq!(projection.len(), 3, "shaper-1 + 2 children");
+    let round1_children = projection.ready_set();
+    assert_eq!(
+        round1_children.len(),
+        2,
+        "round-1 children materialized + ready"
+    );
+    for c in &round1_children {
+        assert_eq!(
+            projection.parents_of(c)[0].0,
+            s1_id,
+            "child parent = the shaper"
+        );
+    }
+
+    // Commit round-1 children.
+    for (i, c) in round1_children.iter().enumerate() {
+        let e = JournalEntry::Committed {
+            mote_id: *c,
+            idempotency_key: c.0,
+            seq: 2 + i as u64,
+            nondeterminism: NdClass::Pure,
+            result_ref: ContentRef::from_bytes([(0x30 + i as u8); 32]),
+            parents: SmallVec::new(),
+            warrant_ref,
+            mote_def_hash: kx_mote::MoteDefHash::from_bytes([(0x40 + i as u8); 32]),
+        };
+        journal.append(e.clone()).unwrap();
+        projection.fold(&e).unwrap();
+    }
+    assert_eq!(
+        projection.committed_count(),
+        3,
+        "shaper-1 + 2 children committed"
+    );
+    let round1_committed: Vec<MoteId> = round1_children.clone();
+
+    // ---- Round 2: replanner shaper APPENDS td2 → materialize a fresh child ----
+    let e_replan = committed_shaper(s2_id, 4, td2_ref, warrant_ref, s2.hash());
+    journal.append(e_replan.clone()).unwrap();
+    projection.fold(&e_replan).unwrap();
+
+    // The fresh round materialized; round-1 committed Motes are UNCHANGED (D76).
+    assert_eq!(projection.len(), 5, "shaper-1 + 2 + shaper-2 + 1 refiner");
+    assert_eq!(projection.state_of(&s1_id), MoteState::Committed);
+    for c in &round1_committed {
+        assert_eq!(
+            projection.state_of(c),
+            MoteState::Committed,
+            "a re-plan never mutates a committed Mote (D76)"
+        );
+    }
+    let refiner = projection
+        .ready_set()
+        .into_iter()
+        .find(|m| projection.parents_of(m).first().map(|p| p.0) == Some(s2_id))
+        .expect("round-2 refiner materialized under the replanner");
+    assert_eq!(projection.state_of(&refiner), MoteState::Pending);
+
+    // ---- Cold re-fold reproduces identical identities (R49) ----
+    let materializer2 = Box::new(DefaultTopologyMaterializer::new(
+        Arc::clone(&store),
+        Arc::clone(&def_registry),
+        Arc::clone(&role_registry),
+        InheritFromShaperResolver,
+    ));
+    let re = Projection::from_journal_with_materializer(&journal, materializer2).unwrap();
+    let live: Vec<MoteId> = projection.iter_motes().map(|(id, _)| id).collect();
+    let cold: Vec<MoteId> = re.iter_motes().map(|(id, _)| id).collect();
+    assert_eq!(
+        live, cold,
+        "R49: cold re-fold = live fold across two rounds"
+    );
+}

--- a/crates/kx-planner/Cargo.toml
+++ b/crates/kx-planner/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "kx-planner"
+version = "0.0.1"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "kortecx planner (M6) — lowers an untrusted model PROPOSAL into a registered Mote DAG. Decodes plan bytes fail-closed (IMP-5), selects ROLES not raw permissions (D75 — warrant = intersect(parent, role)), and lowers to a kx_workflow::WorkflowDef (compiled by kx_workflow::compile, the structural gate) or a kx_mote::TopologyDecision (loop → shaper, D76). PURE lowering library: sits ABOVE the scheduler and depends ONLY on kx-workflow + kx-mote + kx-warrant + kx-critic-types — NEVER kx-scheduler/kx-projection/kx-executor/kx-inference (the P2 thesis test). The model-runs-once + context-assembly wiring lives in kx-model-harness."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Thesis-clean deps ONLY. None of these pulls kx-scheduler / kx-projection /
+# kx-executor / kx-inference (verified via `cargo tree`), so kx-planner cannot
+# couple the planner layer to the engine it sits above (P2 thesis test). The
+# dependency-ban is asserted in kx-model-harness/tests (cargo_dependency_ban).
+kx-workflow     = { workspace = true } # WorkflowDef / StepDef / StepRole / compile / CompiledWorkflow / CompileError
+kx-mote         = { workspace = true } # RoleId / ChildDescriptor / TopologyDecision / LogicRef / NdClass / EffectPattern / ModelId / ToolName / ToolVersion / InferenceParams / EdgeMeta / ConfigKey / ConfigVal
+kx-warrant      = { workspace = true } # RoleRegistry / Role / WarrantSpec / intersect / NarrowingError
+kx-critic-types = { workspace = true } # CheckSpec (a DeterministicCritic step's check comes from the vetted recipe, never the model)
+
+serde      = { workspace = true } # derive on the plan envelope (Deserialize only)
+serde_json = { workspace = true } # strict envelope decode into fixed flat structs (never a dynamic Value)
+thiserror  = { workspace = true }
+blake3     = { workspace = true } # the caller derives a replay-stable WorkflowDef seed from the committed plan bytes
+
+[dev-dependencies]
+proptest   = { workspace = true } # fail-closed-decode + role-cannot-widen property sweeps
+kx-content = { workspace = true } # ContentRef, only to build test WarrantSpecs (leaf; not an engine crate)
+
+[lints]
+workspace = true

--- a/crates/kx-planner/src/decode.rs
+++ b/crates/kx-planner/src/decode.rs
@@ -1,0 +1,86 @@
+//! IMP-5 — the fail-closed decode of a **model-proposed** plan.
+//!
+//! Model output is untrusted. [`decode_plan`] turns raw bytes into a validated
+//! [`Plan`] and is **total + panic-free** over arbitrary input. It mirrors the
+//! shipped fail-closed decoders [`kx_model_harness::toolcall::parse_tool_call`]
+//! and [`kx_mcp::decode_tool_result`]: size-checked BEFORE parsing, strict
+//! envelope (`deny_unknown_fields`), and decoded into fixed flat structs — never
+//! a dynamic `serde_json::Value`, so no float/NaN/unbounded-recursion path
+//! exists. Unlike a tool call (which is *optional* — a normal completion is
+//! `Ok(None)`), a plan is *mandatory*: anything that is not a well-formed
+//! `{"plan": …}` envelope is an `Err`.
+
+use kx_warrant::WarrantSpec;
+
+use crate::error::PlanError;
+use crate::plan::{Envelope, Plan};
+
+/// Hard structural cap on declared steps — a `DoS` bound independent of the byte
+/// cap. A plan with more steps is refused before lowering touches the graph.
+pub const MAX_PLAN_STEPS: usize = 256;
+
+/// Hard structural cap on declared edges (`DoS` bound).
+pub const MAX_PLAN_EDGES: usize = 1024;
+
+/// The per-plan byte cap, derived from the warrant's output ceiling
+/// (`max_output_tokens · 4` — the model produced the plan, so its output budget
+/// bounds it). Saturating, mirroring `kx_model_harness::toolcall::max_args_bytes`
+/// / `context::window_bytes_from_warrant`.
+#[must_use]
+pub fn max_plan_bytes(warrant: &WarrantSpec) -> usize {
+    (warrant.model_route.max_output_tokens as usize).saturating_mul(4)
+}
+
+/// Decode a model-proposed plan, fail-closed.
+///
+/// Returns `Ok(plan)` only for a strict, size-bounded `{"plan": …}` envelope with
+/// `version == 1` and `1..=MAX_PLAN_STEPS` steps / `..=MAX_PLAN_EDGES` edges.
+/// Returns `Err` for everything else — oversized bytes, non-JSON / non-object /
+/// truncated / trailing-garbage / unexpected-key payloads, an unknown version,
+/// an empty plan, or an over-cap step/edge count.
+///
+/// Total + panic-free over arbitrary `bytes`.
+pub fn decode_plan(bytes: &[u8], max_plan_bytes: usize) -> Result<Plan, PlanError> {
+    // (1) Size cap BEFORE parse — a hostile model cannot force a large parse
+    //     allocation by overshooting the budget.
+    if bytes.len() > max_plan_bytes {
+        return Err(PlanError::Oversize {
+            got: bytes.len(),
+            max: max_plan_bytes,
+        });
+    }
+
+    // (2) Parse strictly into fixed flat structs. `serde_json::from_slice` is
+    //     total over arbitrary bytes (non-UTF-8 / non-JSON / non-object /
+    //     truncation / trailing garbage / unknown keys all → Err, never panic).
+    //     `deny_unknown_fields` (on every plan struct) makes an unexpected key a
+    //     hard refusal, closing the "smuggle an extra field" vector.
+    let envelope: Envelope = serde_json::from_slice(bytes).map_err(|e| PlanError::Malformed {
+        diagnostic: e.to_string(),
+    })?;
+    let plan = envelope.plan;
+
+    // (3) Envelope invariants — fail closed on each.
+    if plan.version != 1 {
+        return Err(PlanError::UnknownVersion {
+            version: plan.version,
+        });
+    }
+    if plan.steps.is_empty() {
+        return Err(PlanError::EmptyPlan);
+    }
+    if plan.steps.len() > MAX_PLAN_STEPS {
+        return Err(PlanError::TooManySteps {
+            got: plan.steps.len(),
+            max: MAX_PLAN_STEPS,
+        });
+    }
+    if plan.edges.len() > MAX_PLAN_EDGES {
+        return Err(PlanError::TooManyEdges {
+            got: plan.edges.len(),
+            max: MAX_PLAN_EDGES,
+        });
+    }
+
+    Ok(plan)
+}

--- a/crates/kx-planner/src/error.rs
+++ b/crates/kx-planner/src/error.rs
@@ -1,0 +1,110 @@
+//! [`PlanError`] — the closed vocabulary for every way a plan is refused, from
+//! fail-closed decode (IMP-5) through role resolution (D75) to the structural
+//! gate ([`kx_workflow::compile`]). Derives `PartialEq + Eq` (every embedded
+//! error does too) so property tests can assert the exact refusal.
+
+use kx_mote::RoleId;
+use kx_warrant::NarrowingError;
+use kx_workflow::CompileError;
+use thiserror::Error;
+
+/// Why a model-proposed plan was refused. A refusal NEVER produces a partial DAG
+/// — the plan is rejected whole, fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PlanError {
+    // ----- decode (IMP-5): the untrusted-bytes surface -----
+    /// The plan bytes exceed the per-plan cap (checked BEFORE parsing, so a
+    /// hostile model cannot force a large allocation).
+    #[error("plan bytes {got} exceed the cap {max}")]
+    Oversize {
+        /// Observed plan size in bytes.
+        got: usize,
+        /// The cap.
+        max: usize,
+    },
+    /// The envelope was malformed: non-JSON, non-object, truncated, trailing
+    /// garbage, or an unexpected key (`deny_unknown_fields`). Fail-closed.
+    #[error("plan envelope malformed: {diagnostic}")]
+    Malformed {
+        /// A short structural diagnostic (never the raw payload).
+        diagnostic: String,
+    },
+    /// The envelope declared a schema `version` this binary does not understand.
+    #[error("unknown plan schema version {version}")]
+    UnknownVersion {
+        /// The unrecognized version.
+        version: u32,
+    },
+    /// The plan declared zero steps (there is nothing to register).
+    #[error("plan declared zero steps")]
+    EmptyPlan,
+    /// The plan declared more steps than [`crate::MAX_PLAN_STEPS`] (`DoS` bound).
+    #[error("plan declared {got} steps, exceeding the cap {max}")]
+    TooManySteps {
+        /// Observed step count.
+        got: usize,
+        /// The cap.
+        max: usize,
+    },
+    /// The plan declared more edges than [`crate::MAX_PLAN_EDGES`] (`DoS` bound).
+    #[error("plan declared {got} edges, exceeding the cap {max}")]
+    TooManyEdges {
+        /// Observed edge count.
+        got: usize,
+        /// The cap.
+        max: usize,
+    },
+
+    // ----- role resolution / lowering (D75): authority + identity -----
+    /// A critic/deterministic-critic step omitted its `producer`, or named a
+    /// `producer` index that does not precede it (`producer >= this step`) or is
+    /// out of range. Producers MUST precede critics.
+    #[error("step {step} has an invalid producer reference {producer:?}")]
+    InvalidProducer {
+        /// The critic step index.
+        step: usize,
+        /// The (missing / out-of-range / non-preceding) producer index.
+        producer: Option<usize>,
+    },
+    /// The plan named a role that is not in the warrant `RoleRegistry` (no fuzzy
+    /// fallback — exact `RoleId` equality, D70).
+    #[error("plan named role {0:?}, which is not registered in the role registry")]
+    UnknownRole(RoleId),
+    /// The plan named a role for which no [`crate::RoleRecipe`] is registered
+    /// (the heavy `MoteDef` axes are unknown — refuse rather than guess).
+    #[error("plan named role {0:?}, for which no recipe is registered")]
+    UnknownRecipe(RoleId),
+    /// A [`PlanStepKind::DeterministicCritic`](crate::PlanStepKind::DeterministicCritic)
+    /// step's recipe carries no `CheckSpec` (a deterministic critic with no
+    /// check is meaningless).
+    #[error("role {0:?} is used as a deterministic critic but its recipe declares no check")]
+    MissingCheck(RoleId),
+    /// The role's recipe declares a tool the role's warrant does not grant — a
+    /// step could never legally call it, so the plan is refused (IMP-5: refuse
+    /// ungrantable tools up front).
+    #[error("role {role:?} recipe requires tool {tool} which the role warrant does not grant")]
+    UngrantableTool {
+        /// The offending role.
+        role: RoleId,
+        /// The ungranted tool (`name@version`).
+        tool: String,
+    },
+    /// Computing the step's warrant via `intersect(parent, role)` failed — the
+    /// role proposed authority wider than the parent (D75: never widens).
+    #[error("role {role:?} cannot be granted under the parent warrant: {source}")]
+    Ungrantable {
+        /// The offending role.
+        role: RoleId,
+        /// The underlying narrowing error.
+        #[source]
+        source: NarrowingError,
+    },
+
+    // ----- the structural gate (delegated to kx_workflow::compile) -----
+    /// The lowered plan is not a valid Mote DAG. `kx_workflow::compile` is the
+    /// sole structural gate: a cycle (an agentic loop authored as a back-edge
+    /// instead of a shaper), a critic that does not follow its producer, a
+    /// duplicate edge, or an out-of-range index all surface here.
+    #[error("compiled plan is not a valid Mote DAG: {0}")]
+    Compile(#[from] CompileError),
+}

--- a/crates/kx-planner/src/lib.rs
+++ b/crates/kx-planner/src/lib.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-planner` (M6) — turn an untrusted model **proposal** into a **registered
+//! Mote DAG**. The front of the agentic pipe: prompt → plan → tools → result.
+//!
+//! # The contract (D74)
+//!
+//! A plan is a **PROPOSAL captured as a fact**, never an authorization. The
+//! model's plan-generation is itself a Mote (ROND if it samples, PURE if a
+//! deterministic template); its committed `result_ref` IS the structured plan —
+//! a content-addressed fact re-read on replay, **never re-run**. The runtime
+//! compiles that committed plan and registers the resulting Motes; identity is
+//! `kx_mote::Mote::new`-derived. **Reproducibility comes from committing the
+//! plan, not from model determinism** — a planner step re-samples on re-run by
+//! design.
+//!
+//! # What the model may name (IMP-5 / D70 / D75 — minimal trust surface)
+//!
+//! The model output is the new untrusted input. The strict plan envelope carries
+//! **only** what a model may legitimately choose — role *names*, per-step *intent*
+//! strings, and *edges* — and **nothing** that participates in Mote identity or
+//! capability. [`decode_plan`] is fail-closed (total, panic-free, size-capped,
+//! strict envelope). The heavy `MoteDef` axes (`logic_ref`, `model_id`,
+//! `tool_contract`, `nd_class`, `effect_pattern`, …) come from a **vetted**
+//! [`RoleRecipe`] keyed by exact [`kx_mote::RoleId`] equality — never from model
+//! output, never by fuzzy match.
+//!
+//! # The two lowering targets
+//!
+//! - [`lower_plan`] / [`compile_plan`] — a static plan → [`kx_workflow::WorkflowDef`]
+//!   → [`kx_workflow::compile`] (the **structural gate**: acyclic /
+//!   critic-precedes-producer / deterministic order). Every produced step's
+//!   warrant is `kx_warrant::intersect(parent, role)` — narrowing-only, so the
+//!   planner can **never escalate privilege** (D75).
+//! - [`lower_loop_to_topology_decision`] — an agentic loop is **not** a DAG cycle;
+//!   it lowers to a [`kx_mote::TopologyDecision`] a ROND shaper commits (D76). The
+//!   projection materializes children deterministically (reusing the shipped
+//!   `DefaultTopologyMaterializer`); a re-plan **appends** a fresh round, never
+//!   mutating a committed Mote.
+//!
+//! # Thesis test
+//!
+//! This crate sits ABOVE the scheduler and depends ONLY on `kx-workflow` +
+//! `kx-mote` + `kx-warrant` + `kx-critic-types` — never `kx-scheduler` /
+//! `kx-projection` / `kx-executor` / `kx-inference`. It is a **pure lowering
+//! library**: no I/O, no model loop. The model-runs-once + context-assembly
+//! wiring lives in `kx-model-harness`.
+
+#![forbid(unsafe_code)]
+// Pedantic lints kept as warnings workspace-wide; these few are noise for this
+// crate's shape (mirrors the allow-set used by `kx-workflow` / `kx-warrant`).
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate
+)]
+// Inline test modules are exempt from the workspace deny on unwrap/expect.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod decode;
+mod error;
+mod lower;
+mod plan;
+mod role;
+
+pub use decode::{decode_plan, max_plan_bytes, MAX_PLAN_EDGES, MAX_PLAN_STEPS};
+pub use error::PlanError;
+pub use lower::{
+    compile_plan, lower_loop_to_topology_decision, lower_plan, seed_from_plan_bytes, LoopProposal,
+    PLAN_PROMPT_KEY,
+};
+pub use plan::{Plan, PlanEdge, PlanStep, PlanStepKind};
+pub use role::{InMemoryRoleRecipes, RoleRecipe, RoleRecipeResolver};
+
+#[cfg(test)]
+mod tests;

--- a/crates/kx-planner/src/lower.rs
+++ b/crates/kx-planner/src/lower.rs
@@ -1,0 +1,263 @@
+//! Lowering — turn a decoded [`Plan`] (or a loop [`LoopProposal`]) into the
+//! runtime's registered-DAG shapes. This is where D74/D75/D76 become code:
+//!
+//! - [`lower_plan`] / [`compile_plan`]: a static plan → [`WorkflowDef`] →
+//!   [`kx_workflow::compile`] (the structural gate). Each step's warrant is
+//!   `kx_warrant::intersect(parent, role)` — the **only** warrant path in the
+//!   crate, narrowing-only, so the planner can never escalate privilege (D75).
+//!   The heavy `MoteDef` axes come from the vetted [`RoleRecipe`], never the
+//!   model (IMP-5 / D70). The planner never hand-derives identity or hand-builds
+//!   edges — `compile` derives `MoteId`s and enforces acyclicity /
+//!   critic-precedence / deterministic order.
+//! - [`lower_loop_to_topology_decision`]: an agentic loop is NOT a DAG back-edge;
+//!   it lowers to a [`TopologyDecision`] a ROND shaper commits (D76). The
+//!   projection materializes children deterministically (the shipped
+//!   `DefaultTopologyMaterializer` narrows each child's warrant via `intersect`).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_mote::{ChildDescriptor, ConfigKey, ConfigVal, EdgeMeta, RoleId, TopologyDecision};
+use kx_warrant::{intersect, RoleRegistry, WarrantSpec};
+use kx_workflow::{
+    compile, CompileError, CompiledWorkflow, StepDef, StepRef, StepRole, WorkflowDef,
+};
+
+use crate::error::PlanError;
+use crate::plan::{Plan, PlanStep, PlanStepKind};
+use crate::role::{RoleRecipe, RoleRecipeResolver};
+
+/// The `config_subset` key under which a step's `intent` is carried — the same
+/// stable convention `kx_model_harness::prompt::PROMPT_KEY` reads, so a model
+/// executor uses the intent as the step's instruction. Identity-bearing (two
+/// plans with different intents compile to different `MoteId`s). A drift guard
+/// in `kx-model-harness` asserts the two constants stay equal.
+pub const PLAN_PROMPT_KEY: &str = "prompt";
+
+/// Derive a replay-stable `WorkflowDef` seed from the committed plan bytes.
+///
+/// `blake3(plan_bytes)[..4]` as a little-endian `u32`. Deterministic — the same
+/// committed plan re-compiles to the same DAG on replay (never a clock).
+#[must_use]
+pub fn seed_from_plan_bytes(plan_bytes: &[u8]) -> u32 {
+    let h = blake3::hash(plan_bytes);
+    let b = h.as_bytes();
+    u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+/// Resolve a role's warrant template + recipe, returning the intersected child
+/// warrant and the recipe. The single warrant path: `intersect(parent, role)`.
+fn resolve_step(
+    role_id: &RoleId,
+    parent_warrant: &WarrantSpec,
+    role_registry: &dyn RoleRegistry,
+    recipe_resolver: &dyn RoleRecipeResolver,
+) -> Result<(WarrantSpec, RoleRecipe), PlanError> {
+    let role = role_registry
+        .resolve(role_id)
+        .ok_or_else(|| PlanError::UnknownRole(role_id.clone()))?;
+    let warrant = intersect(parent_warrant, &role).map_err(|source| PlanError::Ungrantable {
+        role: role_id.clone(),
+        source,
+    })?;
+    let recipe = recipe_resolver
+        .recipe(role_id)
+        .ok_or_else(|| PlanError::UnknownRecipe(role_id.clone()))?;
+
+    // IMP-5: refuse a recipe that names a tool the role's (intersected) warrant
+    // does not grant — a step that could never legally call it. Exact
+    // (name, version) membership (SN-8), never fuzzy.
+    for (name, version) in &recipe.tool_contract {
+        let granted = warrant
+            .tool_grants
+            .iter()
+            .any(|g| &g.tool_id == name && &g.tool_version == version);
+        if !granted {
+            return Err(PlanError::UngrantableTool {
+                role: role_id.clone(),
+                tool: format!("{}@{}", name.0, version.0),
+            });
+        }
+    }
+    Ok((warrant, recipe))
+}
+
+/// Build a step's `config_subset` carrying the intent under [`PLAN_PROMPT_KEY`].
+fn config_with_intent(intent: &str) -> BTreeMap<ConfigKey, ConfigVal> {
+    let mut config = BTreeMap::new();
+    config.insert(
+        ConfigKey(PLAN_PROMPT_KEY.to_string()),
+        ConfigVal(intent.as_bytes().to_vec()),
+    );
+    config
+}
+
+/// Map a [`PlanStep`]'s structural kind to a [`StepRole`], validating producer
+/// references early (clearer error than `compile`'s `InvalidCritic`, and it
+/// guarantees `refs[producer]` exists). `refs` holds the `StepRef`s of the
+/// already-pushed steps (so a valid producer satisfies `producer < this index`).
+fn step_role_for(
+    step_index: usize,
+    step: &PlanStep,
+    recipe: &RoleRecipe,
+    role_id: &RoleId,
+    refs: &[StepRef],
+) -> Result<StepRole, PlanError> {
+    match step.kind {
+        PlanStepKind::Plain => Ok(StepRole::Plain),
+        PlanStepKind::TopologyShaper => Ok(StepRole::TopologyShaper),
+        PlanStepKind::Critic => {
+            let producer = valid_producer(step_index, step.producer)?;
+            Ok(StepRole::Critic {
+                producer: refs[producer],
+            })
+        }
+        PlanStepKind::DeterministicCritic => {
+            let producer = valid_producer(step_index, step.producer)?;
+            let check = recipe
+                .deterministic_check
+                .clone()
+                .ok_or_else(|| PlanError::MissingCheck(role_id.clone()))?;
+            Ok(StepRole::DeterministicCritic {
+                producer: refs[producer],
+                check,
+            })
+        }
+    }
+}
+
+/// A producer index is valid iff it is present and strictly precedes the critic.
+fn valid_producer(step_index: usize, producer: Option<usize>) -> Result<usize, PlanError> {
+    match producer {
+        Some(p) if p < step_index => Ok(p),
+        other => Err(PlanError::InvalidProducer {
+            step: step_index,
+            producer: other,
+        }),
+    }
+}
+
+/// Lower a decoded [`Plan`] into a [`WorkflowDef`], ready to [`compile`].
+///
+/// `seed` is the workflow-input seed (identity-bearing); derive it
+/// deterministically from the committed plan bytes via [`seed_from_plan_bytes`]
+/// — never a clock. `compile` is the structural gate; this function leaves
+/// acyclicity / critic-precedence to it (surfacing a clearer [`PlanError::InvalidProducer`]
+/// for an out-of-order producer up front). A `Critic` / `DeterministicCritic`
+/// step's required producer→critic dependency edge is added automatically (if
+/// not already declared), so `compile`'s `InvalidCritic` precedence check passes.
+pub fn lower_plan(
+    plan: &Plan,
+    seed: u32,
+    parent_warrant: &WarrantSpec,
+    role_registry: &dyn RoleRegistry,
+    recipe_resolver: &dyn RoleRecipeResolver,
+) -> Result<WorkflowDef, PlanError> {
+    let mut wf = WorkflowDef::new(seed);
+    let mut refs: Vec<StepRef> = Vec::with_capacity(plan.steps.len());
+    // Critic dependency edges to auto-add after the author-declared edges
+    // (producer_index, critic_index).
+    let mut critic_edges: Vec<(usize, usize)> = Vec::new();
+
+    for (i, s) in plan.steps.iter().enumerate() {
+        let role_id = RoleId(s.role.clone());
+        let (warrant, recipe) =
+            resolve_step(&role_id, parent_warrant, role_registry, recipe_resolver)?;
+        let role = step_role_for(i, s, &recipe, &role_id, &refs)?;
+        if let StepRole::Critic { .. } | StepRole::DeterministicCritic { .. } = role {
+            if let Some(p) = s.producer {
+                critic_edges.push((p, i));
+            }
+        }
+        let step = StepDef {
+            logic_ref: recipe.logic_ref,
+            model_id: recipe.model_id.clone(),
+            prompt_template_hash: recipe.prompt_template_hash,
+            tool_contract: recipe.tool_contract.clone(),
+            nd_class: recipe.nd_class,
+            config_subset: config_with_intent(&s.intent),
+            effect_pattern: recipe.effect_pattern,
+            inference_params: recipe.inference_params.clone(),
+            role,
+            warrant,
+            capability: recipe.capability.clone(),
+        };
+        refs.push(wf.add_step(step));
+    }
+
+    // Track declared edges so an auto critic edge never duplicates one.
+    let mut declared: BTreeSet<(usize, usize)> = BTreeSet::new();
+    for e in &plan.edges {
+        let parent = *refs
+            .get(e.parent)
+            .ok_or(CompileError::StepIndexOutOfRange(e.parent))?;
+        let child = *refs
+            .get(e.child)
+            .ok_or(CompileError::StepIndexOutOfRange(e.child))?;
+        wf.add_edge(parent, child, EdgeMeta::data())?;
+        declared.insert((e.parent, e.child));
+    }
+    // Auto-wire each critic's producer→critic Data edge (the critic reads the
+    // producer's committed bytes to validate them) unless the author declared it.
+    for (producer, critic) in critic_edges {
+        if declared.contains(&(producer, critic)) {
+            continue;
+        }
+        wf.add_edge(refs[producer], refs[critic], EdgeMeta::data())?;
+    }
+
+    Ok(wf)
+}
+
+/// [`lower_plan`] then [`compile`] — the one-call path from a decoded plan to a
+/// registered Mote DAG. `compile` is the structural gate (acyclic / critic
+/// precedence / deterministic order); its `CompileError` surfaces as
+/// [`PlanError::Compile`].
+pub fn compile_plan(
+    plan: &Plan,
+    seed: u32,
+    parent_warrant: &WarrantSpec,
+    role_registry: &dyn RoleRegistry,
+    recipe_resolver: &dyn RoleRecipeResolver,
+) -> Result<CompiledWorkflow, PlanError> {
+    let wf = lower_plan(plan, seed, parent_warrant, role_registry, recipe_resolver)?;
+    Ok(compile(&wf)?)
+}
+
+/// The model's proposal for ONE replanning round: the child steps to spawn next.
+/// Same minimal trust surface as a [`Plan`] step — role name + intent only; it
+/// carries **no score**, so confidence can never reach the promotion gate (D77).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoopProposal {
+    /// The next round's steps. Each lowers to a [`ChildDescriptor`].
+    pub next_steps: Vec<PlanStep>,
+}
+
+/// Lower an agentic-loop proposal into a [`TopologyDecision`] a ROND shaper
+/// commits (D76). Each next-step becomes a [`ChildDescriptor`] whose
+/// `role_id` / `logic_ref` / `nd_class` / `effect_pattern` come from the vetted
+/// [`RoleRecipe`] (never model output). The child's warrant is computed
+/// downstream by the projection materializer via `intersect(shaper.warrant,
+/// role)` — narrowing-only.
+///
+/// Pure + total + unit-testable without the full e2e (no store / journal /
+/// projection). A re-plan APPENDS a fresh `TopologyDecision` (a new committed
+/// fact); it never mutates a prior one (D76 / D-LOCK-4).
+pub fn lower_loop_to_topology_decision(
+    proposal: &LoopProposal,
+    recipe_resolver: &dyn RoleRecipeResolver,
+) -> Result<TopologyDecision, PlanError> {
+    let mut children = Vec::with_capacity(proposal.next_steps.len());
+    for s in &proposal.next_steps {
+        let role_id = RoleId(s.role.clone());
+        let recipe = recipe_resolver
+            .recipe(&role_id)
+            .ok_or_else(|| PlanError::UnknownRecipe(role_id.clone()))?;
+        children.push(ChildDescriptor {
+            role_id,
+            logic_ref: recipe.logic_ref,
+            nd_class: recipe.nd_class,
+            effect_pattern: recipe.effect_pattern,
+        });
+    }
+    Ok(TopologyDecision { children })
+}

--- a/crates/kx-planner/src/plan.rs
+++ b/crates/kx-planner/src/plan.rs
@@ -1,0 +1,94 @@
+//! The typed plan structures the model proposes — deliberately the **minimal
+//! trust surface** (IMP-5 / D70 / D75): a step names a *role* and an *intent*,
+//! an edge names two step *indices*. Nothing here participates in Mote identity
+//! or capability — the heavy `MoteDef` axes come from a vetted [`crate::RoleRecipe`]
+//! (keyed by the role name), never from this model-authored data.
+//!
+//! Every type derives `serde::Deserialize` with `#[serde(deny_unknown_fields)]`
+//! so a trailing or unexpected key fails the decode closed. The structs are flat
+//! (strings + `usize` + a small unit enum): there is no unbounded recursive
+//! descent, so [`crate::decode_plan`] is total over arbitrary bytes.
+
+use serde::Deserialize;
+
+/// The strict outer envelope: `{ "plan": { … } }`. `deny_unknown_fields` rejects
+/// any sibling key, so a payload that merely *contains* a plan is refused.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Envelope {
+    pub plan: Plan,
+}
+
+/// A model-proposed plan: an ordered list of steps plus the dependency edges
+/// between them. Compiled (after role resolution) into a [`kx_workflow::WorkflowDef`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Plan {
+    /// Envelope schema version. Only `1` is accepted in M6; any other value is
+    /// refused as [`crate::PlanError::UnknownVersion`] (forward-compatible — a
+    /// newer planner bumps this and old binaries fail closed rather than
+    /// mis-interpret).
+    pub version: u32,
+    /// The steps, in author/intent order. Step `i` is referenced by index `i`
+    /// from [`PlanStep::producer`] and [`PlanEdge`].
+    pub steps: Vec<PlanStep>,
+    /// The directed `parent → child` dependency edges (Data edges in M6.1).
+    #[serde(default)]
+    pub edges: Vec<PlanEdge>,
+}
+
+/// One proposed step. The model picks a `role` (resolved against the vetted
+/// registries — never a raw permission or logic hash) and writes a free-form
+/// `intent` (carried as the step's identity-bearing instruction; never parsed
+/// for enforcement).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanStep {
+    /// The role name. Resolved to a `kx_warrant::Role` (for the warrant, via
+    /// `intersect`) AND a [`crate::RoleRecipe`] (for the `MoteDef` axes). An
+    /// unregistered name is refused — there is no fuzzy fallback (D70).
+    pub role: String,
+    /// Free-form human intent. Carried verbatim into the step's `config_subset`
+    /// under [`crate::PLAN_PROMPT_KEY`] (identity-bearing); NEVER parsed for
+    /// enforcement.
+    pub intent: String,
+    /// The structural role this step plays. Defaults to [`PlanStepKind::Plain`].
+    #[serde(default)]
+    pub kind: PlanStepKind,
+    /// The producer step index this step validates — REQUIRED iff `kind` is
+    /// [`PlanStepKind::Critic`] or [`PlanStepKind::DeterministicCritic`], and
+    /// MUST be `< this step's index` (the producer precedes the critic). Absent
+    /// otherwise.
+    #[serde(default)]
+    pub producer: Option<usize>,
+}
+
+/// The structural role a step plays — flat (a unit enum + a separate `producer`
+/// index field on the step), so the JSON a model writes is plain (`"kind":
+/// "critic"`), not nested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStepKind {
+    /// An ordinary producer step.
+    #[default]
+    Plain,
+    /// A model-validated critic for the step named by [`PlanStep::producer`].
+    Critic,
+    /// A deterministic critic for [`PlanStep::producer`]; its `CheckSpec` comes
+    /// from the vetted recipe (the model cannot author a check).
+    DeterministicCritic,
+    /// An agentic-loop / runtime-fan-out shaper step (lowered to a
+    /// [`kx_mote::TopologyDecision`], never a DAG back-edge).
+    TopologyShaper,
+}
+
+/// A directed dependency edge by step index. `parent` must commit before
+/// `child`; a Data edge feeds `parent`'s committed bytes into `child`'s input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanEdge {
+    /// The upstream step index.
+    pub parent: usize,
+    /// The downstream step index that depends on `parent`.
+    pub child: usize,
+}

--- a/crates/kx-planner/src/role.rs
+++ b/crates/kx-planner/src/role.rs
@@ -1,0 +1,106 @@
+//! The vetted **role → recipe** seam. The model names a role; the runtime
+//! supplies the heavy `MoteDef` axes from a [`RoleRecipe`] — never from model
+//! output. This is the crate-private analog of the D48 `ChildResolver` /
+//! `MoteDefRegistry` idea, kept inside `kx-planner` so it is NOT a change to
+//! `kx-projection`'s traits (the thesis dependency-ban holds).
+//!
+//! Two registries, one key. A [`kx_mote::RoleId`] resolves against BOTH:
+//! - the `kx_warrant::RoleRegistry` → a `Role` (the warrant template / capability),
+//!   intersected with the parent warrant at lowering time (D75); and
+//! - a [`RoleRecipeResolver`] → a [`RoleRecipe`] (the identity axes).
+//!
+//! Keying both on one `RoleId` keeps a step's warrant and `MoteDef` coherent.
+//! (Forward note: M7's catalog unifies the two into one content-addressed role
+//! catalog — see the SN-5 plan.)
+
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use kx_critic_types::CheckSpec;
+use kx_mote::{
+    EffectPattern, InferenceParams, LogicRef, ModelId, NdClass, PromptTemplateHash, RoleId,
+    ToolName, ToolVersion,
+};
+
+/// The vetted recipe for a role: every Mote-identity + capability axis the model
+/// is **not** allowed to choose. Looked up by the same [`RoleId`] the warrant
+/// `RoleRegistry` resolves, so a step's warrant and `MoteDef` flow from one named
+/// role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoleRecipe {
+    /// `MoteDef.logic_ref` — what code the step runs (vetted, never model output).
+    pub logic_ref: LogicRef,
+    /// `MoteDef.model_id` — the pinned model for the step.
+    pub model_id: ModelId,
+    /// `MoteDef.prompt_template_hash`.
+    pub prompt_template_hash: PromptTemplateHash,
+    /// `MoteDef.tool_contract` — the closed tool set, each pinned. MUST be a
+    /// subset of the role's warrant `tool_grants` (enforced at lowering).
+    pub tool_contract: BTreeMap<ToolName, ToolVersion>,
+    /// The capability a WORLD-MUTATING / READ-ONLY-NONDET dispatch routes
+    /// through (PURE steps ignore it), carried verbatim to submission. For a
+    /// model step with no external tool this is the model pseudo-capability
+    /// (e.g. `kx-model`); for a tool step it is the tool's name.
+    pub capability: ToolName,
+    /// `MoteDef.nd_class` — PURE / `ReadOnlyNondet` / `WorldMutating`.
+    pub nd_class: NdClass,
+    /// `MoteDef.effect_pattern`.
+    pub effect_pattern: EffectPattern,
+    /// `MoteDef.inference_params` (decoding params; identity-bearing, D50).
+    pub inference_params: InferenceParams,
+    /// The deterministic check — REQUIRED iff a step using this role is a
+    /// deterministic critic; `None` otherwise.
+    pub deterministic_check: Option<CheckSpec>,
+}
+
+/// Resolve a [`RoleId`] to its vetted [`RoleRecipe`].
+///
+/// MUST be deterministic over one plan lowering: resolving the same `RoleId`
+/// twice MUST return identical recipes (replay-faithfulness rests on this, like
+/// `kx_warrant::RoleRegistry`). Object-safe + `Send + Sync` so callers can hold
+/// an `Arc<dyn RoleRecipeResolver>`.
+pub trait RoleRecipeResolver: Send + Sync {
+    /// Resolve a role's recipe, or `None` if the role is not registered.
+    fn recipe(&self, role_id: &RoleId) -> Option<RoleRecipe>;
+}
+
+/// OSS-default [`RoleRecipeResolver`] backed by an in-memory `BTreeMap` (mirrors
+/// `kx_warrant::InMemoryRoleRegistry`). Authors register recipes before lowering
+/// a plan.
+#[derive(Default, Debug)]
+pub struct InMemoryRoleRecipes {
+    recipes: RwLock<BTreeMap<RoleId, RoleRecipe>>,
+}
+
+impl InMemoryRoleRecipes {
+    /// Construct an empty resolver.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a recipe under a role handle. Overwriting the same handle is
+    /// permitted but is an author smell — determinism rests on registered
+    /// recipes staying stable across a lowering.
+    pub fn register(&self, role_id: RoleId, recipe: RoleRecipe) {
+        if let Ok(mut map) = self.recipes.write() {
+            map.insert(role_id, recipe);
+        }
+    }
+
+    /// Number of registered recipes (useful for asserting setup in tests).
+    pub fn len(&self) -> usize {
+        self.recipes.read().map(|m| m.len()).unwrap_or(0)
+    }
+
+    /// `true` if no recipes are registered.
+    pub fn is_empty(&self) -> bool {
+        self.recipes.read().map(|m| m.is_empty()).unwrap_or(true)
+    }
+}
+
+impl RoleRecipeResolver for InMemoryRoleRecipes {
+    fn recipe(&self, role_id: &RoleId) -> Option<RoleRecipe> {
+        self.recipes.read().ok()?.get(role_id).cloned()
+    }
+}

--- a/crates/kx-planner/src/tests.rs
+++ b/crates/kx-planner/src/tests.rs
@@ -1,0 +1,461 @@
+//! Unit + property tests for the planner: fail-closed decode (IMP-5), the
+//! never-widen warrant property (D75), loop→shaper-not-cycle (D76), the
+//! no-confidence-channel guard (D77), exact-role-equality (D70), and
+//! deterministic lowering (D74).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_content::ContentRef;
+use kx_critic_types::{CheckSpec, SchemaSpec, SchemaTag};
+use kx_mote::{
+    EffectPattern, InferenceParams, LogicRef, ModelId, NdClass, PromptTemplateHash, RoleId,
+    ToolName, ToolVersion,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    Role, ToolGrant, WarrantSpec,
+};
+use proptest::prelude::*;
+
+use crate::{
+    compile_plan, decode_plan, lower_loop_to_topology_decision, lower_plan, seed_from_plan_bytes,
+    InMemoryRoleRecipes, LoopProposal, PlanError, PlanStep, PlanStepKind, RoleRecipe,
+};
+
+const SYSCALL: [u8; 32] = [7; 32];
+
+/// A permissive parent warrant: grants tools `t1@1` and `t2@1`, no egress.
+fn parent_warrant() -> WarrantSpec {
+    let mut tool_grants = BTreeSet::new();
+    tool_grants.insert(ToolGrant {
+        tool_id: ToolName("t1".into()),
+        tool_version: ToolVersion("1".into()),
+    });
+    tool_grants.insert(ToolGrant {
+        tool_id: ToolName("t2".into()),
+        tool_version: ToolVersion("1".into()),
+    });
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes(SYSCALL),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 4096,
+            max_output_tokens: 1024,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 256,
+            disk_bytes: 1 << 30,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+    }
+}
+
+/// A role whose spec narrows `parent` to the given tool grants (same syscall
+/// profile — `intersect` requires equality — and no egress).
+fn role_with_tools(name: &str, grants: &[(&str, &str)]) -> Role {
+    let mut spec = parent_warrant();
+    let mut tg = BTreeSet::new();
+    for (id, ver) in grants {
+        tg.insert(ToolGrant {
+            tool_id: ToolName((*id).into()),
+            tool_version: ToolVersion((*ver).into()),
+        });
+    }
+    spec.tool_grants = tg;
+    Role {
+        name: name.into(),
+        version: 1,
+        spec,
+        description: String::new(),
+    }
+}
+
+fn recipe(
+    nd_class: NdClass,
+    capability: &str,
+    tools: &[(&str, &str)],
+    check: Option<CheckSpec>,
+) -> RoleRecipe {
+    let mut tool_contract = BTreeMap::new();
+    for (id, ver) in tools {
+        tool_contract.insert(ToolName((*id).into()), ToolVersion((*ver).into()));
+    }
+    RoleRecipe {
+        logic_ref: LogicRef::from_bytes([0xA1; 32]),
+        model_id: ModelId("m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([0xB2; 32]),
+        tool_contract,
+        capability: ToolName(capability.into()),
+        nd_class,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        inference_params: InferenceParams::default(),
+        deterministic_check: check,
+    }
+}
+
+/// Register a standard set of within-parent roles + recipes for the lowering
+/// tests: `reader`/`summarizer`/`producer` (PURE, no tools) and `checker` (a
+/// PURE deterministic critic carrying a Text-schema check).
+fn standard_registries() -> (InMemoryRoleRegistry, InMemoryRoleRecipes) {
+    let roles = InMemoryRoleRegistry::new();
+    let recipes = InMemoryRoleRecipes::new();
+    for name in ["reader", "summarizer", "producer"] {
+        roles.register(RoleId(name.into()), role_with_tools(name, &[]));
+        recipes.register(
+            RoleId(name.into()),
+            recipe(NdClass::Pure, "kx-model", &[], None),
+        );
+    }
+    roles.register(RoleId("checker".into()), role_with_tools("checker", &[]));
+    recipes.register(
+        RoleId("checker".into()),
+        recipe(
+            NdClass::Pure,
+            "kx-model",
+            &[],
+            Some(CheckSpec::Schema(SchemaSpec {
+                expected: SchemaTag::Text,
+            })),
+        ),
+    );
+    (roles, recipes)
+}
+
+fn json(s: &str) -> Vec<u8> {
+    s.as_bytes().to_vec()
+}
+
+// ---------------------------------------------------------------------------
+// decode (IMP-5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn well_formed_plan_decodes() {
+    let bytes = json(
+        r#"{"plan":{"version":1,"steps":[{"role":"reader","intent":"read"},{"role":"summarizer","intent":"sum"}],"edges":[{"parent":0,"child":1}]}}"#,
+    );
+    let plan = decode_plan(&bytes, 8192).expect("a valid plan decodes");
+    assert_eq!(plan.steps.len(), 2);
+    assert_eq!(plan.edges.len(), 1);
+    assert_eq!(plan.steps[0].kind, PlanStepKind::Plain);
+}
+
+#[test]
+fn oversize_is_refused_before_parse() {
+    // A 10 KiB buffer with a 4-byte cap must refuse on size alone (no parse).
+    let big = vec![b'{'; 10_240];
+    assert!(matches!(
+        decode_plan(&big, 4),
+        Err(PlanError::Oversize {
+            got: 10_240,
+            max: 4
+        })
+    ));
+}
+
+#[test]
+fn malformed_inputs_fail_closed() {
+    // truncated
+    assert!(matches!(
+        decode_plan(br#"{"plan":{"version":1,"steps":["#, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // not an object
+    assert!(matches!(
+        decode_plan(b"[]", 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // missing the `plan` envelope key
+    assert!(matches!(
+        decode_plan(br#"{"steps":[]}"#, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // trailing garbage after a valid envelope
+    assert!(matches!(
+        decode_plan(
+            br#"{"plan":{"version":1,"steps":[{"role":"r","intent":"i"}]}} then prose"#,
+            8192
+        ),
+        Err(PlanError::Malformed { .. })
+    ));
+    // non-UTF-8
+    assert!(matches!(
+        decode_plan(&[0xff, 0xfe, 0x00], 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn unknown_field_is_refused_no_confidence_channel_d77() {
+    // deny_unknown_fields: a smuggled "confidence" score on a step is refused.
+    // This is the structural proof that the plan schema offers NO score channel
+    // a model could use to influence the deterministic promotion gate (D77).
+    let bytes = json(
+        r#"{"plan":{"version":1,"steps":[{"role":"reader","intent":"i","confidence":0.99}]}}"#,
+    );
+    assert!(matches!(
+        decode_plan(&bytes, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn unknown_version_zero_steps_and_caps_are_refused() {
+    assert!(matches!(
+        decode_plan(
+            br#"{"plan":{"version":2,"steps":[{"role":"r","intent":"i"}]}}"#,
+            8192
+        ),
+        Err(PlanError::UnknownVersion { version: 2 })
+    ));
+    assert!(matches!(
+        decode_plan(br#"{"plan":{"version":1,"steps":[]}}"#, 8192),
+        Err(PlanError::EmptyPlan)
+    ));
+    // > MAX_PLAN_STEPS steps.
+    let mut steps = String::new();
+    for _ in 0..=crate::MAX_PLAN_STEPS {
+        steps.push_str(r#"{"role":"r","intent":"i"},"#);
+    }
+    steps.pop(); // trailing comma
+    let bytes = json(&format!(r#"{{"plan":{{"version":1,"steps":[{steps}]}}}}"#));
+    assert!(matches!(
+        decode_plan(&bytes, 1 << 20),
+        Err(PlanError::TooManySteps { .. })
+    ));
+}
+
+proptest! {
+    /// decode is total + panic-free over arbitrary bytes.
+    #[test]
+    fn decode_never_panics_on_arbitrary_bytes(bytes: Vec<u8>) {
+        let _ = decode_plan(&bytes, 4096);
+    }
+
+    /// Deeply-nested input does not overflow the stack — serde_json's recursion
+    /// limit makes it a bounded `Err`, never a panic.
+    #[test]
+    fn deep_nesting_is_bounded_err(depth in 1usize..50_000) {
+        let mut s = String::from(r#"{"plan":{"version":1,"steps":"#);
+        s.push_str(&"[".repeat(depth));
+        let r = decode_plan(s.as_bytes(), 1 << 20);
+        prop_assert!(r.is_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// lowering: role selection + warrant narrowing (D75) + exact equality (D70)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compiles_a_chain_deterministically() {
+    let (roles, recipes) = standard_registries();
+    let bytes = json(
+        r#"{"plan":{"version":1,"steps":[{"role":"reader","intent":"read"},{"role":"summarizer","intent":"sum"}],"edges":[{"parent":0,"child":1}]}}"#,
+    );
+    let plan = decode_plan(&bytes, 8192).unwrap();
+    let seed = seed_from_plan_bytes(&bytes);
+    let parent = parent_warrant();
+
+    let a = compile_plan(&plan, seed, &parent, &roles, &recipes).expect("compiles");
+    let b = compile_plan(&plan, seed, &parent, &roles, &recipes).expect("compiles");
+    assert_eq!(a.motes.len(), 2);
+    // Lowering + compile are pure: same plan + seed ⇒ identical MoteIds.
+    let ids_a: Vec<_> = a.motes.iter().map(|m| m.mote.id).collect();
+    let ids_b: Vec<_> = b.motes.iter().map(|m| m.mote.id).collect();
+    assert_eq!(ids_a, ids_b);
+    // Each produced step's warrant is no wider than the parent (D75).
+    for m in &a.motes {
+        assert!(m.warrant.tool_grants.is_subset(&parent.tool_grants));
+    }
+}
+
+#[test]
+fn deterministic_critic_chain_auto_wires_producer_edge() {
+    let (roles, recipes) = standard_registries();
+    // producer (step 0) → checker (step 1, deterministic_critic of 0). No edge
+    // declared: lowering auto-wires producer→critic so compile's precedence
+    // check passes.
+    let bytes = json(
+        r#"{"plan":{"version":1,"steps":[{"role":"producer","intent":"make"},{"role":"checker","intent":"check","kind":"deterministic_critic","producer":0}]}}"#,
+    );
+    let plan = decode_plan(&bytes, 8192).unwrap();
+    let cw = compile_plan(&plan, 1, &parent_warrant(), &roles, &recipes).expect("compiles");
+    assert_eq!(cw.motes.len(), 2);
+}
+
+#[test]
+fn unknown_role_and_recipe_and_near_miss_refuse_d70() {
+    let (roles, recipes) = standard_registries();
+    let parent = parent_warrant();
+    // Exact-equality only: a near-miss name does NOT fuzzy-match a real role.
+    for bad in ["Reader", "reader ", "summarise", "READER"] {
+        let bytes = json(&format!(
+            r#"{{"plan":{{"version":1,"steps":[{{"role":"{bad}","intent":"i"}}]}}}}"#
+        ));
+        let plan = decode_plan(&bytes, 8192).unwrap();
+        assert!(matches!(
+            lower_plan(&plan, 1, &parent, &roles, &recipes),
+            Err(PlanError::UnknownRole(_))
+        ));
+    }
+    // A role registered for the warrant but with no recipe → UnknownRecipe.
+    let roles2 = InMemoryRoleRegistry::new();
+    roles2.register(RoleId("orphan".into()), role_with_tools("orphan", &[]));
+    let recipes2 = InMemoryRoleRecipes::new();
+    let bytes = json(r#"{"plan":{"version":1,"steps":[{"role":"orphan","intent":"i"}]}}"#);
+    let plan = decode_plan(&bytes, 8192).unwrap();
+    assert!(matches!(
+        lower_plan(&plan, 1, &parent, &roles2, &recipes2),
+        Err(PlanError::UnknownRecipe(_))
+    ));
+}
+
+#[test]
+fn ungrantable_tool_in_recipe_is_refused() {
+    // A role whose warrant grants only t1, but whose recipe declares t2 → the
+    // step could never legally call t2 → refused up front (IMP-5).
+    let roles = InMemoryRoleRegistry::new();
+    roles.register(RoleId("r".into()), role_with_tools("r", &[("t1", "1")]));
+    let recipes = InMemoryRoleRecipes::new();
+    recipes.register(
+        RoleId("r".into()),
+        recipe(NdClass::Pure, "t2", &[("t2", "1")], None),
+    );
+    let bytes = json(r#"{"plan":{"version":1,"steps":[{"role":"r","intent":"i"}]}}"#);
+    let plan = decode_plan(&bytes, 8192).unwrap();
+    assert!(matches!(
+        lower_plan(&plan, 1, &parent_warrant(), &roles, &recipes),
+        Err(PlanError::UngrantableTool { .. })
+    ));
+}
+
+#[test]
+fn invalid_producer_is_refused() {
+    let (roles, recipes) = standard_registries();
+    // critic with no producer
+    let b1 =
+        json(r#"{"plan":{"version":1,"steps":[{"role":"checker","intent":"c","kind":"critic"}]}}"#);
+    assert!(matches!(
+        lower_plan(
+            &decode_plan(&b1, 8192).unwrap(),
+            1,
+            &parent_warrant(),
+            &roles,
+            &recipes
+        ),
+        Err(PlanError::InvalidProducer { .. })
+    ));
+    // critic whose producer does not precede it (producer == self)
+    let b2 = json(
+        r#"{"plan":{"version":1,"steps":[{"role":"checker","intent":"c","kind":"critic","producer":0}]}}"#,
+    );
+    assert!(matches!(
+        lower_plan(
+            &decode_plan(&b2, 8192).unwrap(),
+            1,
+            &parent_warrant(),
+            &roles,
+            &recipes
+        ),
+        Err(PlanError::InvalidProducer { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// loop → shaper, never a cycle (D76)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn loop_lowers_to_topology_decision_not_a_cycle() {
+    let (_roles, recipes) = standard_registries();
+    let proposal = LoopProposal {
+        next_steps: vec![
+            PlanStep {
+                role: "reader".into(),
+                intent: "again".into(),
+                kind: PlanStepKind::Plain,
+                producer: None,
+            },
+            PlanStep {
+                role: "summarizer".into(),
+                intent: "again".into(),
+                kind: PlanStepKind::Plain,
+                producer: None,
+            },
+        ],
+    };
+    let td = lower_loop_to_topology_decision(&proposal, &recipes).expect("lowers");
+    assert_eq!(td.children.len(), 2);
+    assert_eq!(&td.children[0].role_id.0, "reader");
+    // Deterministic content address (the shaper commits this).
+    assert_eq!(td.hash(), td.hash());
+}
+
+#[test]
+fn a_plan_authored_as_a_cycle_is_refused_by_compile() {
+    let (roles, recipes) = standard_registries();
+    // An agentic loop expressed as a DAG back-edge (0→1, 1→0) must be refused —
+    // loops belong to a shaper (above), never a cycle.
+    let bytes = json(
+        r#"{"plan":{"version":1,"steps":[{"role":"reader","intent":"a"},{"role":"summarizer","intent":"b"}],"edges":[{"parent":0,"child":1},{"parent":1,"child":0}]}}"#,
+    );
+    let plan = decode_plan(&bytes, 8192).unwrap();
+    assert!(matches!(
+        compile_plan(&plan, 1, &parent_warrant(), &roles, &recipes),
+        Err(PlanError::Compile(kx_workflow::CompileError::Cycle(_)))
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// never-widen warrant property (D75) — proptest over arbitrary role grants
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// For ANY role tool-grant subset of a fixed universe, lowering either
+    /// succeeds with a warrant whose grants ⊆ parent's, or (when the role
+    /// proposes an ungranted tool) refuses with `Ungrantable` — NEVER a step
+    /// with authority wider than the parent. The recipe declares no tools (so
+    /// the UngrantableTool check is inert and we isolate the warrant intersect).
+    #[test]
+    fn role_selection_never_widens_parent_warrant(
+        grants in proptest::collection::vec(
+            proptest::sample::select(vec!["t1", "t2", "t3", "t4"]),
+            0..5,
+        )
+    ) {
+        let parent = parent_warrant(); // grants t1,t2
+        let grant_pairs: Vec<(&str, &str)> = grants.iter().map(|t| (*t, "1")).collect();
+        let roles = InMemoryRoleRegistry::new();
+        roles.register(RoleId("x".into()), role_with_tools("x", &grant_pairs));
+        let recipes = InMemoryRoleRecipes::new();
+        recipes.register(RoleId("x".into()), recipe(NdClass::Pure, "kx-model", &[], None));
+
+        let bytes = json(r#"{"plan":{"version":1,"steps":[{"role":"x","intent":"i"}]}}"#);
+        let plan = decode_plan(&bytes, 8192).unwrap();
+        let within = grant_pairs.iter().all(|(id, _)| *id == "t1" || *id == "t2");
+
+        match compile_plan(&plan, 1, &parent, &roles, &recipes) {
+            Ok(cw) => {
+                prop_assert!(within, "a wider role must never compile to a warrant");
+                for m in &cw.motes {
+                    prop_assert!(m.warrant.tool_grants.is_subset(&parent.tool_grants));
+                }
+            }
+            Err(PlanError::Ungrantable { .. }) => {
+                prop_assert!(!within, "a within-parent role must not be refused");
+            }
+            Err(other) => prop_assert!(false, "unexpected error: {other:?}"),
+        }
+    }
+}

--- a/crates/kx-projection/src/lib.rs
+++ b/crates/kx-projection/src/lib.rs
@@ -128,6 +128,7 @@ mod mote_def_registry;
 mod projection;
 pub mod promotion;
 mod register;
+mod run_metadata;
 mod snapshot;
 mod state;
 
@@ -143,6 +144,7 @@ pub use mote_def_registry::{InMemoryMoteDefRegistry, MoteDefRegistry};
 pub use projection::Projection;
 pub use promotion::{ContentStoreVerdicts, VerdictLookup};
 pub use register::RegisterMote;
+pub use run_metadata::{fold_run_metadata, RunMetadata, RunMetadataFold};
 pub use snapshot::Snapshot;
 pub use state::RunResolvedVersions;
 

--- a/crates/kx-projection/src/run_metadata.rs
+++ b/crates/kx-projection/src/run_metadata.rs
@@ -1,0 +1,205 @@
+//! M6.2 (D78) — **run metadata as a fold over the journal**: observability for
+//! the planner, derived purely from journaled facts.
+//!
+//! When the planner proposes a plan, it benefits from knowing what already ran —
+//! which runs were registered, which recipes were committed, how many committed /
+//! failed / were repudiated. [`fold_run_metadata`] derives exactly that from the
+//! journal in a **single, flat-per-entry pass** (reusing the incremental-fold
+//! discipline; no `O(n²)` rescan). It is an **additive read path**: it never
+//! touches the truth fold, the projection digest, or identity — so the canonical
+//! product digest is unchanged.
+//!
+//! **Only journaled facts** are surfaced — instance ids ([`JournalEntry::RunRegistered`]),
+//! recipe fingerprints (`recipe_fingerprint` + each committed `mote_def_hash`),
+//! and per-outcome counts. **No verdict `is_valid` and no confidence** are read
+//! here: a verdict needs the content store (a forward enrichment), and confidence
+//! does not exist as a journaled fact. When/if a non-authoritative rating signal
+//! is added, it is **steering-only — never the promotion gate** (D77).
+
+use std::collections::BTreeSet;
+
+use kx_journal::{Journal, JournalEntry, JournalError, INSTANCE_ID_LEN};
+
+/// A read-only, journal-derived summary of what a run (or a journal of runs) has
+/// done so far. Purely additive metadata — never an identity or gate input.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunMetadata {
+    /// Number of registered runs (`RunRegistered` facts).
+    pub runs: usize,
+    /// The registered run instance ids, in journal order.
+    pub instance_ids: Vec<[u8; INSTANCE_ID_LEN]>,
+    /// Distinct recipe fingerprints seen (`RunRegistered.recipe_fingerprint` +
+    /// each committed Mote's `mote_def_hash`). Sorted (a `BTreeSet`) so the
+    /// rendered summary is deterministic.
+    pub recipe_fingerprints: BTreeSet<[u8; 32]>,
+    /// Committed Motes.
+    pub committed: usize,
+    /// Terminal/failed attempts.
+    pub failed: usize,
+    /// Repudiated (invalidated) Motes.
+    pub repudiated: usize,
+}
+
+impl RunMetadata {
+    /// A deterministic, model-readable text rendering for the planner's context.
+    /// Same metadata ⇒ byte-identical bytes (the recipe set is sorted).
+    #[must_use]
+    pub fn summary_bytes(&self) -> Vec<u8> {
+        use std::fmt::Write as _;
+        let mut s = String::new();
+        // `write!` to a String is infallible; ignore the Result (no unwrap/expect).
+        let _ = writeln!(
+            s,
+            "runs={} committed={} failed={} repudiated={} distinct_recipes={}",
+            self.runs,
+            self.committed,
+            self.failed,
+            self.repudiated,
+            self.recipe_fingerprints.len()
+        );
+        for fp in &self.recipe_fingerprints {
+            s.push_str("recipe ");
+            for b in fp {
+                let _ = write!(s, "{b:02x}");
+            }
+            s.push('\n');
+        }
+        s.into_bytes()
+    }
+}
+
+/// Incremental run-metadata accumulator — apply one [`JournalEntry`] at a time
+/// (so a caller already folding the journal can piggy-back), then [`finish`].
+///
+/// [`finish`]: RunMetadataFold::finish
+#[derive(Debug, Default)]
+pub struct RunMetadataFold {
+    md: RunMetadata,
+}
+
+impl RunMetadataFold {
+    /// A fresh, empty accumulator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one journal entry into the running metadata. Constant work per entry
+    /// (a counter bump + at most one set insert) — flat-per-entry by construction.
+    pub fn apply(&mut self, entry: &JournalEntry) {
+        match entry {
+            JournalEntry::RunRegistered {
+                instance_id,
+                recipe_fingerprint,
+                ..
+            } => {
+                self.md.runs += 1;
+                self.md.instance_ids.push(*instance_id);
+                self.md.recipe_fingerprints.insert(*recipe_fingerprint);
+            }
+            JournalEntry::Committed { mote_def_hash, .. } => {
+                self.md.committed += 1;
+                self.md
+                    .recipe_fingerprints
+                    .insert(*mote_def_hash.as_bytes());
+            }
+            JournalEntry::Failed { .. } => self.md.failed += 1,
+            JournalEntry::Repudiated { .. } => self.md.repudiated += 1,
+            // Proposed / EffectStaged / RunVersionsResolved / DigestSealed carry no
+            // planner-relevant metadata for M6.2.
+            _ => {}
+        }
+    }
+
+    /// Consume the accumulator, yielding the [`RunMetadata`].
+    #[must_use]
+    pub fn finish(self) -> RunMetadata {
+        self.md
+    }
+}
+
+/// Fold a whole journal into [`RunMetadata`] in one flat-per-entry pass.
+///
+/// # Errors
+///
+/// Propagates any [`JournalError`] from reading the journal.
+pub fn fold_run_metadata(journal: &dyn Journal) -> Result<RunMetadata, JournalError> {
+    let current = journal.current_seq()?;
+    let mut fold = RunMetadataFold::new();
+    for entry in journal.read_entries_by_seq(1..(current + 1))? {
+        fold.apply(&entry);
+    }
+    Ok(fold.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_journal::InMemoryJournal;
+    use kx_mote::MoteDefHash;
+    use smallvec::SmallVec;
+
+    fn run_registered(instance: u8, recipe: u8) -> JournalEntry {
+        JournalEntry::RunRegistered {
+            instance_id: [instance; INSTANCE_ID_LEN],
+            recipe_fingerprint: [recipe; 32],
+            ts: 0,
+            seq: 0,
+        }
+    }
+
+    fn committed(mote: u8, def: u8) -> JournalEntry {
+        JournalEntry::Committed {
+            mote_id: kx_mote::MoteId::from_bytes([mote; 32]),
+            idempotency_key: [mote; 32],
+            seq: 0,
+            nondeterminism: kx_mote::NdClass::Pure,
+            result_ref: kx_content::ContentRef::from_bytes([mote; 32]),
+            parents: SmallVec::new(),
+            warrant_ref: kx_content::ContentRef::from_bytes([0; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([def; 32]),
+        }
+    }
+
+    #[test]
+    fn folds_runs_recipes_and_outcomes() {
+        let j = InMemoryJournal::new();
+        j.append(run_registered(0x01, 0xAA)).unwrap();
+        j.append(committed(0x10, 0xAA)).unwrap(); // same recipe as the run
+        j.append(committed(0x11, 0xBB)).unwrap(); // distinct recipe
+        let md = fold_run_metadata(&j).unwrap();
+        assert_eq!(md.runs, 1);
+        assert_eq!(md.committed, 2);
+        assert_eq!(md.failed, 0);
+        assert_eq!(md.instance_ids, vec![[0x01; INSTANCE_ID_LEN]]);
+        // {0xAA (run + commit), 0xBB (commit)} = 2 distinct recipes.
+        assert_eq!(md.recipe_fingerprints.len(), 2);
+    }
+
+    #[test]
+    fn summary_is_deterministic_and_sorted() {
+        let mut a = RunMetadataFold::new();
+        a.apply(&committed(0x10, 0xBB));
+        a.apply(&committed(0x11, 0xAA));
+        let mut b = RunMetadataFold::new();
+        b.apply(&committed(0x21, 0xAA));
+        b.apply(&committed(0x20, 0xBB));
+        // Different insertion order, same recipe set ⇒ identical sorted summary
+        // lines (the `recipe …` lines are sorted; the count lines match).
+        let sa = a.finish().summary_bytes();
+        let sb = b.finish().summary_bytes();
+        assert_eq!(sa, sb);
+        // The 0xAA recipe sorts before 0xBB in the rendering.
+        let text = String::from_utf8(sa).unwrap();
+        let aa = text.find("recipe aaaa").unwrap();
+        let bb = text.find("recipe bbbb").unwrap();
+        assert!(aa < bb, "recipes render in sorted order");
+    }
+
+    #[test]
+    fn empty_journal_is_empty_metadata() {
+        let j = InMemoryJournal::new();
+        let md = fold_run_metadata(&j).unwrap();
+        assert_eq!(md, RunMetadata::default());
+    }
+}

--- a/crates/kx-projection/tests/run_metadata_scale.rs
+++ b/crates/kx-projection/tests/run_metadata_scale.rs
@@ -1,0 +1,85 @@
+//! M6.2 scale gate — the run-metadata fold (D78) must stay **O(entries)** (flat
+//! per entry), so feeding the planner observability over a large journal never
+//! becomes a super-linear tax. Mirrors `kx-journal`'s `migrate_25k_is_linear`
+//! ratio-gate style.
+//!
+//! Run via `scale-smoke`:
+//! `cargo test -p kx-projection --release --test run_metadata_scale -- --ignored --nocapture`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::time::Instant;
+
+use kx_journal::{InMemoryJournal, Journal, JournalEntry, INSTANCE_ID_LEN};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use kx_projection::fold_run_metadata;
+use smallvec::SmallVec;
+
+fn build_journal(n: u32) -> InMemoryJournal {
+    let j = InMemoryJournal::new();
+    j.append(JournalEntry::RunRegistered {
+        instance_id: [0x01; INSTANCE_ID_LEN],
+        recipe_fingerprint: [0x02; 32],
+        ts: 0,
+        seq: 0,
+    })
+    .unwrap();
+    for i in 0..n {
+        // Distinct id + idempotency_key per entry (the journal dedups by key), so
+        // all n Committed entries are stored. The def hash varies over a smaller
+        // domain so the recipe BTreeSet grows — the realistic worst case for the
+        // fold's per-entry cost.
+        let mut id = [0u8; 32];
+        id[0..4].copy_from_slice(&i.to_le_bytes());
+        let mut def = [0u8; 32];
+        def[0..4].copy_from_slice(&(i % 4096).to_le_bytes());
+        j.append(JournalEntry::Committed {
+            mote_id: MoteId::from_bytes(id),
+            idempotency_key: id,
+            seq: 0,
+            nondeterminism: NdClass::Pure,
+            result_ref: kx_content::ContentRef::from_bytes(id),
+            parents: SmallVec::new(),
+            warrant_ref: kx_content::ContentRef::from_bytes([0; 32]),
+            mote_def_hash: MoteDefHash::from_bytes(def),
+        })
+        .unwrap();
+    }
+    j
+}
+
+#[test]
+#[ignore = "scale: run --release --test run_metadata_scale -- --ignored --nocapture"]
+fn metadata_fold_scale_is_linear() {
+    const SIZES: &[u32] = &[1_000, 5_000, 10_000, 25_000];
+    let mut per_entry_us: Vec<f64> = Vec::with_capacity(SIZES.len());
+
+    for &n in SIZES {
+        let j = build_journal(n);
+        let start = Instant::now();
+        let md = fold_run_metadata(&j).unwrap();
+        let elapsed = start.elapsed();
+        assert_eq!(md.committed as u32, n, "every committed entry folded");
+        assert_eq!(md.runs, 1);
+        let us = elapsed.as_secs_f64() * 1e6;
+        let per = us / f64::from(n);
+        per_entry_us.push(per);
+        eprintln!(
+            "n={n:>6}  fold={:>9.2}ms  per_entry={per:>7.3}us  distinct_recipes={}",
+            us / 1e3,
+            md.recipe_fingerprints.len()
+        );
+    }
+
+    let ratio = per_entry_us.last().unwrap() / per_entry_us.first().unwrap();
+    eprintln!(
+        "per-entry metadata-fold cost ratio (25k/1k) = {ratio:.2}  (quadratic would be ~25x)"
+    );
+    if !cfg!(debug_assertions) {
+        assert!(
+            ratio < 8.0,
+            "fold_run_metadata per-entry cost grew {ratio:.1}x (1k->25k) — super-linear; \
+             the planner observability fold must stay O(entries)"
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -125,6 +125,7 @@ smoke-test-with-model:
 scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-projection --release --test run_metadata_scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
     cargo test -p kx-capture --release --test scale -- --ignored --nocapture --test-threads=1
 


### PR DESCRIPTION
## M6 — `kx-planner`: the agentic surface (IMP-1 / IMP-3, the next KILLER)

Turns an untrusted model **proposal** into a **registered Mote DAG**:
**prompt → committed plan FACT → decode → lower → `kx_workflow::compile` → run.** Additive, +2,335 lines, **30→31 crates**.

### What shipped
- **NEW `crates/kx-planner`** (pure lowering library):
  - `decode.rs` (**IMP-5**) — `decode_plan`: total/panic-free, size-checked **before** parse, strict `deny_unknown_fields` envelope, refuses unknown version / zero / over-cap steps. Mirrors `parse_tool_call` / `decode_tool_result`. Proptested.
  - `role.rs` (**D75**) — vetted crate-private role→recipe seam; the model names a *role*, the recipe supplies every identity/capability axis (never model output).
  - `lower.rs` (**D74/D75/D76**) — `lower_plan`→`WorkflowDef` (warrant = `intersect(parent, role)`, the **only** warrant path, narrowing-only); `compile_plan` (compile is the structural gate); `lower_loop_to_topology_decision` (a loop → a ROND shaper's `TopologyDecision`, never a DAG back-edge); replay-stable `blake3(plan)` seed.
- **`kx-model-harness`** — `workflows::planner_mote` + `from_compiled`; `planner_e2e` (plan commits as a fact, **replays without re-running the model**, ROND resamples), `replan_e2e` (planner-produced `TopologyDecision` drives the shipped materializer; re-plan **appends, never mutates** round-1), `planner_invariants` (prompt-key drift guard + the **D73 dependency-ban** test). All GGUF-free (recording-stub backend).
- **`kx-projection`** — **M6.2** `fold_run_metadata` (**D78**): additive read-only journal fold for planner observability (instance ids, recipe fingerprints, outcome counts); flat-per-entry (scale-smoke ratio **0.67**, sub-linear at 25k).

### D73 resolution (flagged)
D73's stated deps (`+kx-context-assembler +kx-inference`) both transitively pull `kx-projection` — the crate D73 *bans*. Resolved by making kx-planner a **pure lowering library** (deps = `kx-workflow + kx-mote + kx-warrant + kx-critic-types` only); the model-runs-once + read-the-plan-back wiring lives in `kx-model-harness`. A dependency-ban test enforces it.

### Golden Rule 8 (both passes)
- **Breaks-if-live:** frozen trio `kx-scheduler`/`kx-executor`/`kx-inference` source **diff EMPTY**; product digest `a6b5c679…` **unchanged** (`a0_guard`); compile is the sole structural gate (a cyclic plan ⇒ `CompileError::Cycle`).
- **Security:** fail-closed decode (proptested incl. deep-nest/oversize/truncation); exact-`RoleId` resolution (no fuzzy WM selection, D70); `intersect`-only authority, proptested never-widens (D75); confidence structurally absent from the promotion gate (D77); DoS step/edge/byte caps.
- **Perf:** model runs once off the hot journal/fold path; lowering O(steps+edges) bounded; metadata fold sub-linear.

### Gate (local, green)
`fmt` · `clippy --workspace --all-targets -D warnings` · `cargo test --workspace` (**0 failed**) · `cargo-deny` · `doc -D warnings` · `ffi-link` · `scale-smoke`. Thesis diff EMPTY; `a0_guard` `a6b5c679…` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)