### PR TITLE
perf(journal),test: IMP-4 single-writer scale spike + O(n²)→O(n log n) journal dedup fix (D116/D117)

### DIFF
--- a/crates/kx-coordinator/tests/ceiling_e2e.rs
+++ b/crates/kx-coordinator/tests/ceiling_e2e.rs
@@ -1,0 +1,145 @@
+// Integration-test file: compiled as a separate crate from the host lib; tests
+// legitimately use `.unwrap()` for fixture construction.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! IMP-4 (D116) — single-writer **realistic end-to-end** commit ceiling (number iii).
+//!
+//! `kx-journal/tests/ceiling_throughput.rs` measures the raw `Journal` write floor/ceiling
+//! in isolation. This file measures the number the roadmap actually cares about: the
+//! coordinator's sole-writer path under maximum simultaneous fan-out — many workers
+//! reporting commits at once, all funneling through the single owner thread. That path
+//! already does **group commit** (the corpus contingency "design group-commit if too low"
+//! is already built): `core_loop` drains up to `MAX_DRAIN=256` `Command`s per wake from the
+//! bounded `mpsc` channel (`COMMAND_BUFFER=1024`) and `flush_commits`/`apply_batch` coalesce
+//! consecutive `Commit`s into ONE atomic `journal.append_batch()` + fold. So the on-disk
+//! number here is the group-commit ceiling end-to-end, including the channel + `oneshot`
+//! reply + fold overhead a real worker pays.
+//!
+//! **Non-gating** (testing doctrine §Load/throughput): `#[ignore]`, prints commits/s, asserts
+//! only a loose catastrophic-regression floor + the exactly-once correctness count
+//! (`committed_count == n`) — never an absolute-time threshold.
+//!
+//! Run via `just bench-ceiling` (or directly):
+//! `cargo test -p kx-coordinator --release --test ceiling_e2e -- --ignored --nocapture --test-threads=1`
+//! `KX_CEILING_HUGE=1` adds the 10^6 in-memory tier (local only).
+//!
+//! Caveats for the published number: it includes tokio multi-thread scheduling + the channel
+//! hops, so present it *beside* the raw `append_batch` ceiling (ii) to see how much of the gap
+//! is fsync-amortization vs runtime overhead. On-disk numbers are platform-sensitive (macOS
+//! `fsync` is weaker than Linux) — label them with their environment.
+
+mod common;
+
+use std::time::Instant;
+
+use kx_coordinator::proto;
+use kx_coordinator::proto::coordinator_server::Coordinator;
+use kx_coordinator::CoordinatorService;
+use kx_journal::SqliteJournal;
+use kx_mote::{Mote, NdClass};
+use kx_warrant::WarrantSpec;
+use tempfile::tempdir;
+use tonic::Request;
+
+/// Register the run once, then submit all `motes` (untimed setup). Avoids the
+/// per-call re-registration `common::submit` does so setup of 10^5 Motes stays cheap.
+async fn submit_all(svc: &CoordinatorService, motes: &[Mote], warrant: &WarrantSpec) {
+    common::register_run(svc, common::TEST_RECIPE_FINGERPRINT).await;
+    for m in motes {
+        svc.submit_mote(Request::new(proto::SubmitMoteRequest {
+            mote: Some(m.clone().into()),
+            warrant: Some(warrant.clone().into()),
+            accept_at_least_once: false,
+        }))
+        .await
+        .unwrap();
+    }
+}
+
+/// Fan out a `report_commit` per Mote across concurrent tasks (the owner thread
+/// coalesces them into group commits), join all, and return the timed wall clock
+/// of just the commit phase.
+async fn time_concurrent_commits(svc: &CoordinatorService, motes: &[Mote], worker: u64) -> f64 {
+    let start = Instant::now();
+    let mut handles = Vec::with_capacity(motes.len());
+    for m in motes {
+        let s = svc.clone();
+        let req = common::report_commit_request(m, worker);
+        handles.push(tokio::spawn(async move {
+            s.report_commit(Request::new(req)).await
+        }));
+    }
+    for h in handles {
+        h.await.unwrap().unwrap();
+    }
+    start.elapsed().as_secs_f64()
+}
+
+fn sizes(include_huge: bool) -> Vec<u64> {
+    if include_huge && std::env::var_os("KX_CEILING_HUGE").is_some() {
+        vec![10_000, 100_000, 1_000_000]
+    } else {
+        vec![10_000, 100_000]
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "scale: just bench-ceiling (cargo test -p kx-coordinator --release --test ceiling_e2e -- --ignored --nocapture)"]
+async fn coordinator_concurrent_ceiling_on_disk() {
+    eprintln!(
+        "=== (iii) coordinator concurrent commit ceiling — on-disk (group-commit, fsync/batch) ==="
+    );
+    let warrant = common::sample_warrant();
+    // On-disk capped at 10^5 (a 10^6 on-disk journal is hundreds of MB on disk + WAL).
+    for &n in &sizes(false) {
+        let dir = tempdir().unwrap();
+        let svc = CoordinatorService::new(SqliteJournal::open(dir.path().join("e2e.db")).unwrap());
+        let worker = common::register(&svc, "w").await;
+        let motes: Vec<Mote> = (0..n)
+            .map(|i| common::mote_indexed(i, NdClass::Pure))
+            .collect();
+        submit_all(&svc, &motes, &warrant).await;
+
+        let secs = time_concurrent_commits(&svc, &motes, worker).await;
+
+        assert_eq!(
+            svc.committed_count().await.unwrap(),
+            n as usize,
+            "every distinct Mote committed exactly once"
+        );
+        let rate = n as f64 / secs;
+        eprintln!("  n={n:>9}  {secs:>10.3}s  {rate:>12.0} commits/s");
+        assert!(
+            rate > 100.0,
+            "e2e on-disk below 100 commits/s ({rate:.0}) — catastrophic regression"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "scale: just bench-ceiling (cargo test -p kx-coordinator --release --test ceiling_e2e -- --ignored --nocapture)"]
+async fn coordinator_concurrent_ceiling_in_memory() {
+    eprintln!("=== (iii) coordinator concurrent commit ceiling — in-memory (no fsync; channel + fold only) ===");
+    let warrant = common::sample_warrant();
+    for &n in &sizes(true) {
+        let svc = CoordinatorService::new(SqliteJournal::open_in_memory().unwrap());
+        let worker = common::register(&svc, "w").await;
+        let motes: Vec<Mote> = (0..n)
+            .map(|i| common::mote_indexed(i, NdClass::Pure))
+            .collect();
+        submit_all(&svc, &motes, &warrant).await;
+
+        let secs = time_concurrent_commits(&svc, &motes, worker).await;
+
+        assert_eq!(
+            svc.committed_count().await.unwrap(),
+            n as usize,
+            "exactly-once"
+        );
+        let rate = n as f64 / secs;
+        eprintln!("  n={n:>9}  {secs:>10.3}s  {rate:>12.0} commits/s");
+        assert!(
+            rate > 100.0,
+            "e2e in-memory below 100 commits/s ({rate:.0}) — catastrophic regression"
+        );
+    }
+}

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -394,11 +394,22 @@ fn append_one(
     let kind = entry.kind();
     if kind == KIND_COMMITTED || kind == KIND_REPUDIATED || kind == KIND_EFFECT_STAGED {
         let key = *entry.idempotency_key();
+        // The dedupe lookup MUST use the partial `idx_entries_dedupe` index
+        // (`... WHERE kind IN (1, 2, 4)`). SQLite only applies a partial index when
+        // the query's WHERE clause provably implies the index's predicate — and a
+        // *bound* `kind = ?2` parameter cannot be proven to imply `kind IN (1,2,4)`
+        // at plan time, so without the explicit `AND kind IN (1, 2, 4)` below SQLite
+        // falls back to a FULL TABLE SCAN, making every append O(n) and the journal
+        // O(n²) over its life (IMP-4 / D116 — measured + EXPLAIN-confirmed). The added
+        // predicate is always TRUE here (the enclosing guard restricts `kind` to
+        // exactly {1, 2, 4}), so it changes nothing semantically — it only lets the
+        // planner use the index, restoring O(log n) per append.
         let existing = txn
             .query_row(
                 "SELECT entry_bytes, mote_def_hash
                    FROM entries
-                  WHERE idempotency_key = ?1 AND kind = ?2",
+                  WHERE idempotency_key = ?1 AND kind = ?2
+                    AND kind IN (1, 2, 4)",
                 params![&key[..], kind as i64],
                 |r| {
                     let bytes: Vec<u8> = r.get(0)?;

--- a/crates/kx-journal/tests/ceiling_throughput.rs
+++ b/crates/kx-journal/tests/ceiling_throughput.rs
@@ -1,0 +1,186 @@
+// Integration-test file: compiled as a separate crate from the host lib; tests
+// legitimately use `.unwrap()` for fixture construction.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! IMP-4 (D116) — single-writer journal throughput **measurement spike**.
+//!
+//! The single-writer journal is the runtime's exactly-once moat *and* its hard
+//! scale wall. This file measures the raw `Journal`-trait write ceiling so a real
+//! number can be published (HANDOFF §3.9 §A) instead of the standing "qualitatively
+//! true, quantitatively unproven" placeholder. It is a **non-gating** characterization
+//! (testing doctrine `04-testing-and-gates.md` §Load/throughput): every test is
+//! `#[ignore]` (the green suite never runs it), prints commits/s, and asserts only a
+//! loose catastrophic-regression floor + a correctness count — never an absolute-time
+//! threshold (those flake across machines).
+//!
+//! Run via `just bench-ceiling` (or directly):
+//! `cargo test -p kx-journal --release --test ceiling_throughput -- --ignored --nocapture --test-threads=1`
+//! `--release` is essential — an unoptimized SQLite/encode path understates the ceiling.
+//! Set `KX_CEILING_HUGE=1` to add the 10^6 tier (hundreds of MB RAM + on-disk WAL — local only).
+//!
+//! Four numbers, deliberately separated so the published curve attributes the cost:
+//!
+//! - (i) `SqliteJournal::append` sequential on-disk — one `BEGIN IMMEDIATE` + fsync per
+//!   commit = the **pessimistic floor** (and the realistic per-commit floor: it already
+//!   pays the per-entry dedup `SELECT` + `MAX(seq)+1` index probes).
+//! - (ii) `SqliteJournal::append_batch` on-disk, swept over batch size — one fsync per
+//!   batch = the **group-commit ceiling** (and how batch size moves it; 256 = the
+//!   coordinator's `MAX_DRAIN`).
+//! - (iv) `InMemoryJournal::append` — no fsync, `RwLock<Vec>` push = the **CPU-bound upper
+//!   bound**; plus a `SqliteJournal::open_in_memory()` row that isolates the
+//!   SQLite-transaction cost from the fsync cost.
+//!
+//! (Numbers i/ii/iv here; the realistic end-to-end coordinator number (iii) lives in
+//! `kx-coordinator/tests/ceiling_e2e.rs` — it adds the channel + drain + group-commit.)
+//!
+//! Platform caveat for the published numbers: macOS `fsync` does not force a drive-cache
+//! flush (no `F_FULLFSYNC`), so on-disk commits/s on Apple-Silicon is **optimistic**
+//! relative to a Linux runner. Always label on-disk numbers with their environment; the
+//! in-memory numbers are platform-comparable.
+
+use std::time::Instant;
+
+use kx_content::ContentRef;
+use kx_journal::{InMemoryJournal, Journal, JournalEntry, SqliteJournal};
+use kx_mote::{MoteDefHash, MoteId, NdClass};
+use smallvec::SmallVec;
+use tempfile::tempdir;
+
+/// A distinct, dedup-storable `Committed` entry per index (the journal dedups by
+/// `idempotency_key`, so distinct keys mean all N are stored). Mirrors the
+/// `run_metadata_scale.rs` fixture shape.
+fn committed_at(i: u64) -> JournalEntry {
+    let mut id = [0u8; 32];
+    id[..8].copy_from_slice(&i.to_le_bytes());
+    JournalEntry::Committed {
+        mote_id: MoteId::from_bytes(id),
+        idempotency_key: id,
+        seq: 0, // assigned by the journal at append time
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes(id),
+        parents: SmallVec::new(),
+        warrant_ref: ContentRef::from_bytes([0u8; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+/// The size tiers. `KX_CEILING_HUGE=1` adds 10^6 (local only — RAM + disk heavy).
+fn sizes() -> Vec<u64> {
+    if std::env::var_os("KX_CEILING_HUGE").is_some() {
+        vec![10_000, 100_000, 1_000_000]
+    } else {
+        vec![10_000, 100_000]
+    }
+}
+
+/// commits/s from a count + elapsed wall time.
+fn cps(n: u64, secs: f64) -> f64 {
+    n as f64 / secs
+}
+
+// ---------------------------------------------------------------------------
+// (i) raw SqliteJournal::append — sequential, on-disk, one fsync per commit.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "scale: just bench-ceiling (cargo test -p kx-journal --release --test ceiling_throughput -- --ignored --nocapture)"]
+fn append_sequential_ceiling() {
+    eprintln!("=== (i) SqliteJournal::append — sequential on-disk (one fsync/commit) ===");
+    for &n in &sizes() {
+        let dir = tempdir().unwrap();
+        let j = SqliteJournal::open(dir.path().join("ceiling.kxjournal")).unwrap();
+        let entries: Vec<JournalEntry> = (0..n).map(committed_at).collect();
+
+        let start = Instant::now();
+        for e in entries {
+            j.append(e).unwrap();
+        }
+        let elapsed = start.elapsed();
+
+        assert_eq!(j.count_entries().unwrap(), n, "all {n} entries durable");
+        let rate = cps(n, elapsed.as_secs_f64());
+        eprintln!("  n={n:>9}  {elapsed:>12?}  {rate:>12.0} commits/s");
+        assert!(
+            rate > 100.0,
+            "sequential append fell below 100 commits/s ({rate:.0}) — catastrophic regression"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (ii) raw SqliteJournal::append_batch — on-disk, one fsync per batch.
+//      Swept over batch size to show how group-commit moves the ceiling.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "scale: just bench-ceiling (cargo test -p kx-journal --release --test ceiling_throughput -- --ignored --nocapture)"]
+fn append_batch_ceiling() {
+    // 256 == the coordinator's MAX_DRAIN (one drain → one append_batch → one fsync).
+    const BATCH_SIZES: &[usize] = &[1, 64, 256];
+    eprintln!("=== (ii) SqliteJournal::append_batch — on-disk (one fsync/batch) ===");
+    for &n in &sizes() {
+        for &batch in BATCH_SIZES {
+            let dir = tempdir().unwrap();
+            let j = SqliteJournal::open(dir.path().join("ceiling.kxjournal")).unwrap();
+            let entries: Vec<JournalEntry> = (0..n).map(committed_at).collect();
+
+            let start = Instant::now();
+            for chunk in entries.chunks(batch) {
+                j.append_batch(chunk.to_vec()).unwrap();
+            }
+            let elapsed = start.elapsed();
+
+            assert_eq!(j.count_entries().unwrap(), n, "all {n} entries durable");
+            let rate = cps(n, elapsed.as_secs_f64());
+            eprintln!("  n={n:>9}  batch={batch:>4}  {elapsed:>12?}  {rate:>12.0} commits/s");
+            assert!(
+                rate > 100.0,
+                "batch append fell below 100 commits/s ({rate:.0}) — catastrophic regression"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (iv) in-memory ceilings — the CPU-bound upper bound (no fsync). Two rows:
+//      InMemoryJournal (RwLock<Vec> push) and SqliteJournal in-memory (SQLite
+//      txn machinery, no fsync) — the gap isolates SQLite cost from fsync cost.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "scale: just bench-ceiling (cargo test -p kx-journal --release --test ceiling_throughput -- --ignored --nocapture)"]
+fn in_memory_append_ceiling() {
+    eprintln!("=== (iv) in-memory append — CPU-bound upper bound (no fsync) ===");
+    for &n in &sizes() {
+        // InMemoryJournal: pure RwLock<Vec> push + dedup probe.
+        {
+            let j = InMemoryJournal::new();
+            let entries: Vec<JournalEntry> = (0..n).map(committed_at).collect();
+            let start = Instant::now();
+            for e in entries {
+                j.append(e).unwrap();
+            }
+            let elapsed = start.elapsed();
+            assert_eq!(j.count_entries().unwrap(), n);
+            let rate = cps(n, elapsed.as_secs_f64());
+            eprintln!("  InMemoryJournal   n={n:>9}  {elapsed:>12?}  {rate:>12.0} commits/s");
+            assert!(
+                rate > 100.0,
+                "in-memory append below 100 commits/s ({rate:.0})"
+            );
+        }
+        // SqliteJournal in-memory: SQLite txn machinery, no fsync.
+        {
+            let j = SqliteJournal::open_in_memory().unwrap();
+            let entries: Vec<JournalEntry> = (0..n).map(committed_at).collect();
+            let start = Instant::now();
+            for e in entries {
+                j.append(e).unwrap();
+            }
+            let elapsed = start.elapsed();
+            assert_eq!(j.count_entries().unwrap(), n);
+            let rate = cps(n, elapsed.as_secs_f64());
+            eprintln!("  Sqlite in-memory  n={n:>9}  {elapsed:>12?}  {rate:>12.0} commits/s");
+            assert!(
+                rate > 100.0,
+                "sqlite in-memory append below 100 commits/s ({rate:.0})"
+            );
+        }
+    }
+}

--- a/crates/kx-projection/tests/fold_curve_scale.rs
+++ b/crates/kx-projection/tests/fold_curve_scale.rs
@@ -1,0 +1,122 @@
+// Integration-test file: compiled as a separate crate from the host lib; tests
+// legitimately use `.unwrap()` for fixture construction.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! IMP-4 (D116) — the **projection-fold curve** (number v): the read/recovery side of
+//! the single-writer ceiling. Cold recovery folds the committed log into projection
+//! state, so the per-entry fold cost is the resume-availability ceiling; a super-linear
+//! fold turns a large-log resume into an outage. This publishes the µs/entry curve at
+//! 10^3 → 10^5 (10^6 local) the dossier asks for.
+//!
+//! Unlike the throughput numbers (which are non-gating prints), this carries a **ratio
+//! gate** — `per_entry[100k] / per_entry[1k] < 8.0` — identical in spirit to the existing
+//! `incremental_children_index` / `run_metadata_scale` / `migrate_25k_is_linear` gates: a
+//! *ratio* (never absolute time) so it cannot flake across CI-ubuntu vs local-Apple-Silicon,
+//! while a quadratic fold (≈100× across this 100× span) is caught with wide headroom. This is
+//! the ONE line this spike adds to the required `scale-smoke` gate.
+//!
+//! Run via `scale-smoke` / `just bench-ceiling`:
+//! `cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1`
+//! `--release` is required (the debug differential oracle makes the fold O(n²); ratio skipped in debug).
+//! `KX_CEILING_HUGE=1` adds the 10^6 tier (hundreds of MB RAM — local only, kept OUT of the gate).
+
+use std::time::Instant;
+
+use kx_content::ContentRef;
+use kx_journal::{JournalEntry, ParentEntry};
+use kx_mote::{EdgeMeta, MoteDefHash, MoteId, NdClass, ParentRef};
+use kx_projection::Projection;
+use smallvec::SmallVec;
+
+/// A distinct `MoteId` per `u32` (first 4 bytes carry `i`).
+fn mid_n(i: u32) -> MoteId {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&i.to_le_bytes());
+    MoteId::from_bytes(bytes)
+}
+
+fn pref(id: MoteId, edge: EdgeMeta) -> ParentRef {
+    ParentRef {
+        parent_id: id,
+        edge,
+    }
+}
+
+fn committed_with(id: MoteId, seq: u64, parents: &[ParentRef]) -> JournalEntry {
+    let pe: SmallVec<[ParentEntry; 4]> = parents.iter().map(ParentEntry::from_parent_ref).collect();
+    JournalEntry::Committed {
+        mote_id: id,
+        idempotency_key: *id.as_bytes(),
+        seq,
+        nondeterminism: NdClass::Pure,
+        result_ref: ContentRef::from_bytes([7u8; 32]),
+        parents: pe,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+/// A wide-but-HUBLESS DAG (mote i ← i-1 data, i-2 control; fan-in/out ≤ 2), so a
+/// correct incremental fold is O(n) — the common-case resume shape. (Built before
+/// the timed region.)
+fn hubless_chain(n: u32) -> Vec<JournalEntry> {
+    let mut entries: Vec<JournalEntry> = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        let mut ps: Vec<ParentRef> = Vec::new();
+        if i >= 1 {
+            ps.push(pref(mid_n(i - 1), EdgeMeta::data()));
+        }
+        if i >= 2 {
+            ps.push(pref(mid_n(i - 2), EdgeMeta::control()));
+        }
+        entries.push(committed_with(mid_n(i), u64::from(i) + 1, &ps));
+    }
+    entries
+}
+
+#[test]
+#[ignore = "scale: scale-smoke / just bench-ceiling (cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture)"]
+fn fold_curve_is_linear() {
+    // The gated span is always [1k, 10k, 100k]; the 100k/1k ratio (indices 2/0) is the
+    // gate and is stable regardless of the optional 10^6 tier appended below.
+    let mut sizes: Vec<u32> = vec![1_000, 10_000, 100_000];
+    if std::env::var_os("KX_CEILING_HUGE").is_some() {
+        sizes.push(1_000_000);
+    }
+
+    let mut per_entry_us: Vec<f64> = Vec::with_capacity(sizes.len());
+    for &n in &sizes {
+        let entries = hubless_chain(n);
+        let start = Instant::now();
+        let mut p = Projection::new();
+        for e in &entries {
+            p.fold(e).unwrap();
+        }
+        let elapsed = start.elapsed();
+        assert_eq!(p.committed_count(), n as usize, "all {n} motes folded");
+
+        let us = elapsed.as_secs_f64() * 1e6;
+        let per = us / f64::from(n);
+        per_entry_us.push(per);
+        eprintln!(
+            "  n={n:>9}  fold={:>10.2}ms  per_entry={per:>7.3}us",
+            us / 1e3
+        );
+    }
+
+    // Gate on the fixed 100k/1k pair (indices 2/0), independent of the 10^6 tier.
+    let ratio = per_entry_us[2] / per_entry_us[0];
+    eprintln!("per-entry fold cost ratio (100k/1k) = {ratio:.2}  (quadratic would be ~100x)");
+
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "NOTE: debug build — the differential oracle makes the fold O(n^2); ratio \
+             assertion skipped. Re-run with --release for the real gate."
+        );
+    } else {
+        assert!(
+            ratio < 8.0,
+            "fold per-entry cost grew {ratio:.1}x (1k->100k) — super-linear; the IMP-4 \
+             resume-availability ceiling (cold recovery folds the whole log) is violated"
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -117,17 +117,35 @@ smoke-test-with-model:
 # churn (not by journal length), (M2.2b) the SAME bound holds end-to-end over a real
 # disk-backed SQLite journal + an on-disk checkpoint sidecar, and (M2.x-E / IMP-2)
 # offline schema migration (`migrate_to`) stays O(entries) so resume-after-upgrade
-# is not an outage. The first three cases live in `kx-projection`; the migration
-# case in `kx-journal` (both llamacpp-free — no C++ FFI in this lean job). A
-# super-linear resume is an outage, and resume IS the product. `--release` is
-# REQUIRED — in a debug build the differential oracle re-imposes the O(n^2) full
-# rebuild on every fold and the ratio assertions are skipped.
+# is not an outage, and (IMP-4 / D116) the cold-recovery projection fold stays
+# O(entries) at 10^5 — the read side of the single-writer ceiling (cold resume folds
+# the whole log; a super-linear fold turns a large-log resume into an outage). The
+# fold cases live in `kx-projection`; the migration case in `kx-journal` (both
+# llamacpp-free — no C++ FFI in this lean job). A super-linear resume is an outage,
+# and resume IS the product. `--release` is REQUIRED — in a debug build the
+# differential oracle re-imposes the O(n^2) full rebuild on every fold and the ratio
+# assertions are skipped.
 scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test run_metadata_scale -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
     cargo test -p kx-capture --release --test scale -- --ignored --nocapture --test-threads=1
+
+# IMP-4 (D116) single-writer scale-readiness measurement spike — publish the
+# single-writer journal commit ceiling + the projection-fold curve so a real number
+# replaces the "qualitatively true, quantitatively unproven" placeholder (HANDOFF
+# §3.9 §A). NON-GATING (not part of `just ci`): every test is `#[ignore]`, prints
+# commits/s + µs/entry, and asserts only a loose catastrophic-regression floor (the
+# fold-curve linearity ratio is the only gated piece, run by `scale-smoke` above).
+# `--release` is REQUIRED. `KX_CEILING_HUGE=1 just bench-ceiling` adds the 10^6 tier
+# (hundreds of MB RAM + on-disk WAL — local only). On-disk commits/s is platform-
+# sensitive (macOS fsync is weaker than Linux) — label numbers with their environment.
+bench-ceiling:
+    cargo test -p kx-journal --release --test ceiling_throughput -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-coordinator --release --test ceiling_e2e -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1
 
 # ============================================================================
 # Preflight diagnostic


### PR DESCRIPTION
## What & why

**IMP-4** (the #3 project-killer; orchestration dossier D116, roadmap row 1): the single-writer journal throughput ceiling is the runtime's exactly-once moat **and** its hard scale wall, and it was **UNMEASURED** — no external scale figure could be quoted. This PR measures it (single-writer commit/s + the projection-fold curve at 10⁵–10⁶) and, in doing so, **finds and fixes an O(n²) full-table-scan in the production journal's per-commit dedup path.**

## The finding (the headline)

The measurement immediately surfaced a super-linear wall: per-commit cost grew ~10× from 10k→100k Motes (≈O(n²)), and group-commit batching barely helped at 100k — proving fsync was **not** the bottleneck.

**Root cause (EXPLAIN-confirmed):** the dedup `SELECT … WHERE idempotency_key=? AND kind=?` could **not** use the partial unique index `idx_entries_dedupe (… WHERE kind IN (1,2,4))` — SQLite only applies a partial index when the query provably implies the index predicate, and a *bound* `kind` parameter can't be proven to imply `kind IN (1,2,4)` at plan time → **full table scan per append → O(n²) over the journal's life.**

```
EXPLAIN QUERY PLAN … WHERE idempotency_key=? AND kind=?               → SCAN entries
EXPLAIN QUERY PLAN … WHERE idempotency_key=? AND kind=? AND kind IN (1,2,4) → SEARCH USING INDEX idx_entries_dedupe
```

**Fix:** add `AND kind IN (1,2,4)` to the query. It is **always true at the call site** (the enclosing guard restricts `kind` to exactly `{1,2,4}`), so it is **zero semantic change** — it only lets the planner use the index, restoring **O(log n)** per append.

## Measured impact (Apple-Silicon; on-disk, 100k Motes)

| metric | before (O(n²)) | after (O(n log n)) | speedup |
|---|---|---|---|
| `append_batch(256)` | 227 cps | **18,692 cps** | **82×** |
| `append` sequential | 208 cps | 10,048 cps | 48× |
| coordinator e2e (group-commit) | — | **~21,200 cps** | — |
| projection fold (cold recovery) | — | **O(n), 1M Motes in 1.22s** | — |

The "single-writer ceiling" the corpus feared was **largely an indexing bug, not a fundamental limit.** Post-fix the single SQLite writer sustains ~10k–50k commits/s (group-commit dependent), with the M10 partitioned-journal seam still available for horizontal scale-out.

> On-disk numbers are platform-caveated (macOS `fsync` ≠ Linux `F_FULLFSYNC`); in-memory/CPU-bound numbers are platform-comparable. The published `append` floor already includes the per-entry dedup `SELECT` + `MAX(seq)+1` index probes (the realistic floor).

## What's in the PR

- **`crates/kx-journal/src/sqlite.rs`** — the 1-line dedup-index fix (+ a comment so it's never "simplified" away).
- **`crates/kx-journal/tests/ceiling_throughput.rs`** *(new, `#[ignore]`)* — raw `append` / `append_batch` (batch-size sweep) / in-memory ceilings.
- **`crates/kx-coordinator/tests/ceiling_e2e.rs`** *(new, `#[ignore]`)* — realistic concurrent group-commit ceiling end-to-end.
- **`crates/kx-projection/tests/fold_curve_scale.rs`** *(new, `#[ignore]`)* — the fold curve; the **one ratio gate** added to `scale-smoke` (100k/1k = 0.91, sub-linear).
- **`justfile`** — `bench-ceiling` recipe (manual numbers capture) + one `scale-smoke` line. CI job name unchanged (branch-protection context preserved).

Throughput tests are **non-gating** (testing doctrine §Load/throughput): `#[ignore]`, print-only, with only a loose catastrophic-regression floor. Only the **O(n) fold-curve linearity ratio** gates (a super-linear cold recovery is an outage).

## Golden Rule 8

**Pass A (defensive):** the only production change is a crate-private, semantics-preserving query rewrite → **frozen trio `kx-scheduler`/`kx-executor`/`kx-inference` byte-unchanged**, **canonical digest `a6b5c679…` invariant** (`a0_guard` green), **no schema bump**, all 133 kx-journal tests green. No new untrusted input / egress / secrets. 10⁶ tiers env-gated (`KX_CEILING_HUGE=1`) to avoid CI RAM/disk pressure.

**Pass B (forward):** flips IMP-4 from unmeasured→published, removing the "no external scale claim" block; surfaces that group-commit already exists (D117.1) and the generic `Journal` seam already enables the M10 partitioned escape hatch (D116.1); leaves repeatable measurement infra (`just bench-ceiling`).

**Deferred follow-ons (own PRs, Rule 1):** `InMemoryJournal` dedup O(n²) (`.iter().find()`, dev/non-durable backend); `list_committed_by_mote_def_hash` cold-path same-class scan.

## Verification

`fmt-check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (1277 passed / 0 failed, incl. `a0_guard`), `deny`, `doc -D warnings`, `ffi-link`, `scale-smoke` (6/6, fold-curve green twice) all pass locally; `check-reproducible` (I1.c) in progress. `git diff` confirms the frozen trio is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)