### PR TITLE
M5.3a — warrant secret_scope/cost_ceiling/tls_required axes + deny-all Default (D110.3/D115/D118.5)

### DIFF
--- a/crates/kx-capability/src/local.rs
+++ b/crates/kx-capability/src/local.rs
@@ -182,6 +182,17 @@ impl<S: ContentStore + Send + Sync> LocalCapabilityBroker<S> {
             });
         }
 
+        // (5) request.secret_scope ⊆ warrant.secret_scope (D110.3) — the broker
+        //     is the single authorization gate for secret resolution; the
+        //     transport (kx-mcp `SecretStore`) only resolves what is granted
+        //     here. `cost_ceiling` (D115) enforcement is M11 (the spend fold);
+        //     no precheck consults it at M5.3.
+        if !request.secret_scope.is_subset_of(&warrant.secret_scope) {
+            return Err(BrokerError::CapabilityExceedsWarrant {
+                axis: WarrantField::SecretScope,
+            });
+        }
+
         Ok(&**capability)
     }
 

--- a/crates/kx-capability/src/request.rs
+++ b/crates/kx-capability/src/request.rs
@@ -4,7 +4,7 @@
 
 use kx_content::ContentRef;
 use kx_mote::{EffectPattern, ToolName, ToolVersion};
-use kx_warrant::{FsScope, NetScope};
+use kx_warrant::{FsScope, NetScope, SecretScope};
 use serde::{Deserialize, Serialize};
 
 /// The opaque payload the broker passes through to a capability.
@@ -40,6 +40,12 @@ pub struct EffectRequest {
     /// [`crate::BrokerError::CapabilityExceedsWarrant`] on
     /// [`kx_warrant::WarrantField::FsScope`].
     pub fs_scope: FsScope,
+    /// The secret references this dispatch requires resolution of (D110.3).
+    /// Must be a subset of `warrant.secret_scope`; otherwise the broker refuses
+    /// with [`crate::BrokerError::CapabilityExceedsWarrant`] on
+    /// [`kx_warrant::WarrantField::SecretScope`]. Defaults to
+    /// [`SecretScope::None`] (a dispatch that needs no secret).
+    pub secret_scope: SecretScope,
 }
 
 /// The broker's commit-ready artifact for a dispatched effect.

--- a/crates/kx-capability/src/tests.rs
+++ b/crates/kx-capability/src/tests.rs
@@ -139,6 +139,7 @@ fn permissive_warrant_with_grant(grant: ToolGrant) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -175,6 +176,7 @@ fn empty_request_with_pattern(pattern: EffectPattern, payload: Vec<u8>) -> Effec
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 
@@ -394,6 +396,7 @@ fn cap_7a_capability_exceeds_warrant_on_net_scope() {
         idempotency_key: None,
         net_scope: NetScope::EgressAllowlist(BTreeSet::from([Host("evil.example.com:443".into())])),
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     };
     let err = broker.dispatch(&mote, &warrant, &name, req).unwrap_err();
     assert!(matches!(
@@ -431,12 +434,53 @@ fn cap_7b_capability_exceeds_warrant_on_fs_scope() {
         fs_scope: FsScope {
             mounts: BTreeMap::from([(PathBuf::from("/etc"), FsMode::ReadWrite)]),
         },
+        secret_scope: kx_warrant::SecretScope::None,
     };
     let err = broker.dispatch(&mote, &warrant, &name, req).unwrap_err();
     assert!(matches!(
         err,
         BrokerError::CapabilityExceedsWarrant {
             axis: WarrantField::FsScope
+        }
+    ));
+}
+
+// -- CAP-7c — request.secret_scope ⊄ warrant.secret_scope is refused (D110.3)
+
+#[test]
+fn cap_7c_capability_exceeds_warrant_on_secret_scope() {
+    let name = tool_name("rev");
+    let version = tool_version("1");
+    let mote = mote_with_tool(&name, &version);
+    // The permissive fixture warrant carries `secret_scope: None` (deny-all) by
+    // default, so ANY requested secret exceeds it.
+    let warrant = permissive_warrant_with_grant(ToolGrant {
+        tool_id: name.clone(),
+        tool_version: version.clone(),
+    });
+    let broker = LocalCapabilityBroker::new(InMemoryContentStore::new());
+    broker.register_capability(Box::new(ReverseCapability::new(
+        "rev",
+        "1",
+        vec![EffectPattern::StageThenCommit],
+    )));
+
+    // Request needs a secret the warrant does not grant.
+    let req = EffectRequest {
+        payload: vec![],
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::AllowList(BTreeSet::from([kx_warrant::SecretRef(
+            "STRIPE_SK".into(),
+        )])),
+    };
+    let err = broker.dispatch(&mote, &warrant, &name, req).unwrap_err();
+    assert!(matches!(
+        err,
+        BrokerError::CapabilityExceedsWarrant {
+            axis: WarrantField::SecretScope
         }
     ));
 }

--- a/crates/kx-capability/tests/concurrency.rs
+++ b/crates/kx-capability/tests/concurrency.rs
@@ -110,6 +110,7 @@ fn permissive_warrant_with_grant(grant: ToolGrant) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -145,6 +146,7 @@ fn request(payload: Vec<u8>) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-capability/tests/proptest_broker.rs
+++ b/crates/kx-capability/tests/proptest_broker.rs
@@ -94,6 +94,7 @@ fn permissive_warrant_with_grant(grant: ToolGrant) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -143,6 +144,7 @@ fn request_with(payload: Vec<u8>) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-capability/tests/stress_policy.rs
+++ b/crates/kx-capability/tests/stress_policy.rs
@@ -107,6 +107,7 @@ fn warrant_with_grant(grant: ToolGrant) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -155,6 +156,7 @@ fn request_with(payload: Vec<u8>) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-chaos/src/cluster.rs
+++ b/crates/kx-chaos/src/cluster.rs
@@ -179,6 +179,7 @@ impl Cluster {
             idempotency_key: Some(idempotency_token_for(mote)),
             net_scope: NetScope::None,
             fs_scope: FsScope::empty(),
+            secret_scope: kx_warrant::SecretScope::None,
         };
         let handle = self
             .broker

--- a/crates/kx-chaos/src/workflow.rs
+++ b/crates/kx-chaos/src/workflow.rs
@@ -197,6 +197,7 @@ pub(crate) fn pure_warrant() -> WarrantSpec {
         },
         environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
         executor_class: WORKER_CLASS,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-context-assembler/src/tests.rs
+++ b/crates/kx-context-assembler/src/tests.rs
@@ -54,6 +54,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-context-assembler/tests/concurrency.rs
+++ b/crates/kx-context-assembler/tests/concurrency.rs
@@ -74,6 +74,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-context-assembler/tests/proptest_assembler.rs
+++ b/crates/kx-context-assembler/tests/proptest_assembler.rs
@@ -83,6 +83,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-coordinator/benches/commit_throughput.rs
+++ b/crates/kx-coordinator/benches/commit_throughput.rs
@@ -68,6 +68,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-coordinator/tests/common/mod.rs
+++ b/crates/kx-coordinator/tests/common/mod.rs
@@ -203,6 +203,7 @@ pub fn sample_warrant() -> WarrantSpec {
         },
         environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-coordinator/tests/m1_exit_gate.rs
+++ b/crates/kx-coordinator/tests/m1_exit_gate.rs
@@ -94,6 +94,7 @@ fn warrant_granting(tools: &[(&str, &str)], model_id: &str) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-coordinator/tests/run_versions.rs
+++ b/crates/kx-coordinator/tests/run_versions.rs
@@ -135,6 +135,7 @@ fn warrant_granting(tools: &[(&str, &str)], model_id: &str) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-coordinator/tests/submission_refusal.rs
+++ b/crates/kx-coordinator/tests/submission_refusal.rs
@@ -123,6 +123,7 @@ fn warrant_granting(tools: &[(&str, &str)], model_id: &str) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-executor/src/backends/macos_sandbox.rs
+++ b/crates/kx-executor/src/backends/macos_sandbox.rs
@@ -411,6 +411,7 @@ const DENY_DEFAULT_TEMPLATE: &[u8] = b"(version 1)\n(import \"system.sb\")\n(den
 ///     },
 ///     environment_ref: None,
 ///     executor_class: ExecutorClass::MacOsSandbox,
+///     ..Default::default()
 /// };
 ///
 /// // Pure / total / deterministic: same input → byte-identical output.

--- a/crates/kx-executor/src/lib.rs
+++ b/crates/kx-executor/src/lib.rs
@@ -107,6 +107,7 @@
 //! #         },
 //! #         environment_ref: None,
 //! #         executor_class: kx_warrant::ExecutorClass::Bwrap,
+//! #         ..Default::default()
 //! #     }
 //! # }
 //! ```
@@ -150,6 +151,7 @@
 //! #         },
 //! #         environment_ref: None,
 //! #         executor_class: kx_warrant::ExecutorClass::Bwrap,
+//! #         ..Default::default()
 //! #     }
 //! # }
 //! ```
@@ -215,6 +217,7 @@
 //! #         },
 //! #         environment_ref: None,
 //! #         executor_class: kx_warrant::ExecutorClass::Bwrap,
+//! #         ..Default::default()
 //! #     }
 //! # }
 //! ```

--- a/crates/kx-executor/tests/concurrency.rs
+++ b/crates/kx-executor/tests/concurrency.rs
@@ -258,6 +258,7 @@ fn example_warrant() -> kx_warrant::WarrantSpec {
         },
         environment_ref: None,
         executor_class: kx_warrant::ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-executor/tests/integration_body_resolver.rs
+++ b/crates/kx-executor/tests/integration_body_resolver.rs
@@ -169,6 +169,7 @@ mod macos {
             },
             environment_ref: None,
             executor_class: ExecutorClass::MacOsSandbox,
+            ..Default::default()
         }
     }
 

--- a/crates/kx-executor/tests/integration_bwrap.rs
+++ b/crates/kx-executor/tests/integration_bwrap.rs
@@ -152,6 +152,7 @@ mod linux {
             },
             environment_ref: None,
             executor_class: ExecutorClass::Bwrap,
+            ..Default::default()
         }
     }
 

--- a/crates/kx-executor/tests/integration_commit_protocol.rs
+++ b/crates/kx-executor/tests/integration_commit_protocol.rs
@@ -54,6 +54,7 @@ fn pure_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -87,6 +88,7 @@ fn empty_effect_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_compensate_quarantine.rs
+++ b/crates/kx-executor/tests/integration_compensate_quarantine.rs
@@ -62,6 +62,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -95,6 +96,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_cross_product_recovery.rs
+++ b/crates/kx-executor/tests/integration_cross_product_recovery.rs
@@ -88,6 +88,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -121,6 +122,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_idempotent_commit.rs
+++ b/crates/kx-executor/tests/integration_idempotent_commit.rs
@@ -52,6 +52,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -85,6 +86,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_p04_gate.rs
+++ b/crates/kx-executor/tests/integration_p04_gate.rs
@@ -50,6 +50,7 @@ fn warrant(class: MoteClass) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -83,6 +84,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_pure.rs
+++ b/crates/kx-executor/tests/integration_pure.rs
@@ -47,6 +47,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-executor/tests/integration_real_spawn.rs
+++ b/crates/kx-executor/tests/integration_real_spawn.rs
@@ -80,6 +80,7 @@ mod macos {
             },
             environment_ref: None,
             executor_class: ExecutorClass::MacOsSandbox,
+            ..Default::default()
         }
     }
 

--- a/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
+++ b/crates/kx-executor/tests/integration_redispatch_wm_mote.rs
@@ -58,6 +58,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -91,6 +92,7 @@ fn empty_request(pattern: EffectPattern) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_refusal.rs
+++ b/crates/kx-executor/tests/integration_refusal.rs
@@ -43,6 +43,7 @@ fn warrant() -> kx_warrant::WarrantSpec {
         },
         environment_ref: None,
         executor_class: kx_warrant::ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-executor/tests/integration_run_wm_mote.rs
+++ b/crates/kx-executor/tests/integration_run_wm_mote.rs
@@ -48,6 +48,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -81,6 +82,7 @@ fn empty_request(pattern: EffectPattern) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_sbpl.rs
+++ b/crates/kx-executor/tests/integration_sbpl.rs
@@ -38,6 +38,7 @@ fn permissive_warrant_with(fs_scope: FsScope, net_scope: NetScope) -> WarrantSpe
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-executor/tests/integration_stage_then_commit.rs
+++ b/crates/kx-executor/tests/integration_stage_then_commit.rs
@@ -51,6 +51,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -84,6 +85,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_test_b_commit_trust.rs
+++ b/crates/kx-executor/tests/integration_test_b_commit_trust.rs
@@ -205,6 +205,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -238,6 +239,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_validate_then_commit.rs
+++ b/crates/kx-executor/tests/integration_validate_then_commit.rs
@@ -52,6 +52,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -85,6 +86,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/integration_wall_clock.rs
+++ b/crates/kx-executor/tests/integration_wall_clock.rs
@@ -77,6 +77,7 @@ mod macos {
             },
             environment_ref: None,
             executor_class: ExecutorClass::MacOsSandbox,
+            ..Default::default()
         }
     }
 
@@ -257,6 +258,7 @@ mod linux {
             },
             environment_ref: None,
             executor_class: ExecutorClass::Bwrap,
+            ..Default::default()
         }
     }
 

--- a/crates/kx-executor/tests/integration_wm_crash_recovery_e2e.rs
+++ b/crates/kx-executor/tests/integration_wm_crash_recovery_e2e.rs
@@ -163,6 +163,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -196,6 +197,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/native_critic.rs
+++ b/crates/kx-executor/tests/native_critic.rs
@@ -48,6 +48,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-executor/tests/proptest_idempotent_commit.rs
+++ b/crates/kx-executor/tests/proptest_idempotent_commit.rs
@@ -54,6 +54,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -87,6 +88,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/proptest_refusal.rs
+++ b/crates/kx-executor/tests/proptest_refusal.rs
@@ -116,6 +116,7 @@ fn arb_warrant() -> impl Strategy<Value = WarrantSpec> {
         },
         environment_ref: None,
         executor_class: ec,
+        ..Default::default()
     })
 }
 

--- a/crates/kx-executor/tests/proptest_stage_then_commit.rs
+++ b/crates/kx-executor/tests/proptest_stage_then_commit.rs
@@ -57,6 +57,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -90,6 +91,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/proptest_validate_then_commit.rs
+++ b/crates/kx-executor/tests/proptest_validate_then_commit.rs
@@ -53,6 +53,7 @@ fn warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -86,6 +87,7 @@ fn empty_request() -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-executor/tests/verify_rerun.rs
+++ b/crates/kx-executor/tests/verify_rerun.rs
@@ -45,6 +45,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-inference/tests/batching.rs
+++ b/crates/kx-inference/tests/batching.rs
@@ -43,6 +43,7 @@ fn dummy_warrant(model_id: ModelId) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-inference/tests/concurrency.rs
+++ b/crates/kx-inference/tests/concurrency.rs
@@ -75,6 +75,7 @@ fn dummy_warrant(model_id: ModelId) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-inference/tests/d50_from_mote.rs
+++ b/crates/kx-inference/tests/d50_from_mote.rs
@@ -70,6 +70,7 @@ fn warrant_with_ceiling(max_output_tokens: u32) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-inference/tests/proptest_dispatch.rs
+++ b/crates/kx-inference/tests/proptest_dispatch.rs
@@ -57,6 +57,7 @@ fn warrant_with_route(model_id: ModelId, max_output_tokens: u32) -> WarrantSpec 
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-inference/tests/trait_seam.rs
+++ b/crates/kx-inference/tests/trait_seam.rs
@@ -129,6 +129,7 @@ fn dummy_warrant(model_id: ModelId) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-mcp/tests/common/mod.rs
+++ b/crates/kx-mcp/tests/common/mod.rs
@@ -104,6 +104,7 @@ pub fn warrant_granting(tool_name: &ToolName, tool_version: &ToolVersion) -> War
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 
@@ -117,6 +118,7 @@ pub fn effect(args_json: &str) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 
@@ -375,5 +377,6 @@ pub fn effect_egress(args_json: &str) -> EffectRequest {
         idempotency_key: Some([0x11; 32]),
         net_scope: NetScope::EgressAllowlist([Host("127.0.0.1".to_string())].into_iter().collect()),
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }

--- a/crates/kx-mcp/tests/http_security.rs
+++ b/crates/kx-mcp/tests/http_security.rs
@@ -130,6 +130,7 @@ fn unscoped_egress_request_under_none_warrant_never_dials() {
             [Host("example.com".to_string())].into_iter().collect(),
         ),
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     };
     let err = broker
         .dispatch(&mote, &warrant, &name, req)

--- a/crates/kx-model-harness/src/broker.rs
+++ b/crates/kx-model-harness/src/broker.rs
@@ -246,6 +246,7 @@ where
                         idempotency_key: Some(run_scoped_token(&self.instance_id, mote)),
                         net_scope,
                         fs_scope: FsScope::empty(),
+                        secret_scope: kx_warrant::SecretScope::None,
                     };
                     let handle = self
                         .tool_broker

--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -132,6 +132,7 @@ pub fn harness_warrant(
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-model-harness/src/toolcall.rs
+++ b/crates/kx-model-harness/src/toolcall.rs
@@ -185,6 +185,7 @@ mod tests {
             },
             environment_ref: None,
             executor_class: ExecutorClass::Bwrap,
+            ..Default::default()
         }
     }
 

--- a/crates/kx-model-harness/tests/planner_e2e.rs
+++ b/crates/kx-model-harness/tests/planner_e2e.rs
@@ -124,6 +124,7 @@ fn parent_warrant(model_id: &ModelId) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-model-harness/tests/replan_e2e.rs
+++ b/crates/kx-model-harness/tests/replan_e2e.rs
@@ -64,6 +64,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-planner/src/tests.rs
+++ b/crates/kx-planner/src/tests.rs
@@ -57,6 +57,7 @@ fn parent_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-projection/tests/cold_refold_topology.rs
+++ b/crates/kx-projection/tests/cold_refold_topology.rs
@@ -131,6 +131,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-projection/tests/integration_planner_worker_shaper_e2e.rs
+++ b/crates/kx-projection/tests/integration_planner_worker_shaper_e2e.rs
@@ -120,6 +120,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-projection/tests/integration_topology_classes.rs
+++ b/crates/kx-projection/tests/integration_topology_classes.rs
@@ -92,6 +92,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-proto/src/convert.rs
+++ b/crates/kx-proto/src/convert.rs
@@ -599,6 +599,11 @@ impl TryFrom<proto::WarrantSpec> for WarrantSpec {
                 p.executor_class,
                 "ExecutorClass",
             )?,
+            // The proto schema does not yet carry the M5.3 axes (secret_scope /
+            // cost_ceiling / tls_required); they decode to the fail-closed
+            // deny-all default. Distributed enforcement of these axes extends
+            // the proto wire format in M10 (single-node M5.3 does not use proto).
+            ..Default::default()
         })
     }
 }

--- a/crates/kx-proto/tests/common/mod.rs
+++ b/crates/kx-proto/tests/common/mod.rs
@@ -128,5 +128,6 @@ pub fn sample_warrant() -> WarrantSpec {
         },
         environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }

--- a/crates/kx-proto/tests/proptest_messages.rs
+++ b/crates/kx-proto/tests/proptest_messages.rs
@@ -242,6 +242,7 @@ fn arb_warrant() -> impl Strategy<Value = WarrantSpec> {
                 resource_ceiling: rc,
                 environment_ref: env.map(ContentRef::from_bytes),
                 executor_class: exec,
+                ..Default::default()
             },
         )
 }

--- a/crates/kx-refusal/src/refusal.rs
+++ b/crates/kx-refusal/src/refusal.rs
@@ -402,6 +402,7 @@ pub fn validate_submission(submission: &WorkflowSubmission) -> Result<(), Submis
 ///     },
 ///     environment_ref: None,
 ///     executor_class: ExecutorClass::Bwrap,
+///     ..Default::default()
 /// };
 /// let submission = WorkflowSubmission {
 ///     run_id: [0u8; 32],

--- a/crates/kx-refusal/tests/mote_submission.rs
+++ b/crates/kx-refusal/tests/mote_submission.rs
@@ -42,6 +42,7 @@ fn warrant() -> kx_warrant::WarrantSpec {
         },
         environment_ref: None,
         executor_class: kx_warrant::ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -630,6 +630,7 @@ fn effect_request_for(w: &WorkflowMote) -> EffectRequest {
         idempotency_key: None,
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-runtime/src/workflow.rs
+++ b/crates/kx-runtime/src/workflow.rs
@@ -177,6 +177,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-runtime/tests/stress_throughput.rs
+++ b/crates/kx-runtime/tests/stress_throughput.rs
@@ -118,6 +118,7 @@ fn pure_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-scheduler/tests/common/mod.rs
+++ b/crates/kx-scheduler/tests/common/mod.rs
@@ -100,6 +100,7 @@ pub(crate) fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-tool-registry/src/registry.rs
+++ b/crates/kx-tool-registry/src/registry.rs
@@ -76,6 +76,7 @@ pub trait ToolRegistry: Send + Sync {
     ///         fd_count: 16, disk_bytes: 1 << 20,
     ///     },
     ///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+    ///     ..Default::default()
     /// };
     /// let resolved = reg.resolve(&grant, &warrant).expect("builtin fs-read fits");
     /// assert_eq!(resolved.def.tool_id.0, "fs-read");
@@ -147,6 +148,7 @@ pub trait ToolRegistry: Send + Sync {
     ///         fd_count: 16, disk_bytes: 1 << 20,
     ///     },
     ///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+    ///     ..Default::default()
     /// };
     ///
     /// let mut reg = InMemoryToolRegistry::new();

--- a/crates/kx-tool-registry/src/tests.rs
+++ b/crates/kx-tool-registry/src/tests.rs
@@ -41,6 +41,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-tool-registry/tests/concurrency.rs
+++ b/crates/kx-tool-registry/tests/concurrency.rs
@@ -93,6 +93,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-tool-registry/tests/proptest_registry.rs
+++ b/crates/kx-tool-registry/tests/proptest_registry.rs
@@ -128,6 +128,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-warrant/src/check.rs
+++ b/crates/kx-warrant/src/check.rs
@@ -44,6 +44,7 @@ use crate::spec::{ToolRequirement, WarrantSpec};
 ///         fd_count: 64, disk_bytes: 1 << 28,
 ///     },
 ///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+///     ..Default::default()
 /// };
 ///
 /// // A tool requiring more memory than the warrant permits → ToolDenied.

--- a/crates/kx-warrant/src/fields.rs
+++ b/crates/kx-warrant/src/fields.rs
@@ -23,6 +23,12 @@ pub enum WarrantField {
     ExecutorClass,
     /// Environment rootfs.
     EnvironmentRef,
+    /// Secret-resolution scope (D110.3).
+    SecretScope,
+    /// Cost ceiling (D115).
+    CostCeiling,
+    /// TLS-required flag (D118.5).
+    TlsRequired,
 }
 
 /// A host:port pair in the egress allowlist of

--- a/crates/kx-warrant/src/lib.rs
+++ b/crates/kx-warrant/src/lib.rs
@@ -20,7 +20,7 @@
 //!   output. No I/O, no clock, no journal access. Recovery re-derives warrants
 //!   bit-for-bit (machine-independent).
 //!
-//! # Six narrowable axes (qualitative — widening rejected as typed error)
+//! # Seven narrowable axes (qualitative — widening rejected as typed error)
 //!
 //! | Axis                  | Semantics                                              |
 //! |-----------------------|--------------------------------------------------------|
@@ -28,6 +28,7 @@
 //! | `net_scope`           | egress allowlist subset; `None` blocks all egress      |
 //! | `syscall_profile_ref` | opaque content-ref; subset check deferred to compiler  |
 //! | `tool_grants`         | set subset on `(ToolName, ToolVersion)`                |
+//! | `secret_scope`        | secret-ref allowlist subset; `None` authorizes none (D110.3) |
 //! | `executor_class`      | set by child's role; not narrowed from parent          |
 //! | `environment_ref`     | set by child's role; not narrowed from parent          |
 //!
@@ -35,6 +36,12 @@
 //!
 //! - `resource_ceiling.*` — cpu_milli, mem_bytes, wall_clock_ms, fd_count, disk_bytes.
 //! - `model_route.max_input_tokens` / `max_output_tokens` / `max_calls`.
+//! - `cost_ceiling.micro_usd` — dollar ceiling (D115; axis reserved at M5.3,
+//!   spend enforcement at M11).
+//!
+//! # `tls_required` is tighten-only (narrowed via `||`)
+//!
+//! A child can add a TLS requirement but never relax a parent's (D118.5).
 //!
 //! # `mote_class` and `nd_class` are set by child's role (NOT inherited).
 //!
@@ -87,6 +94,7 @@ mod narrow;
 mod refs;
 mod registry;
 mod scope;
+mod secret;
 mod spec;
 
 pub use check::check_tool_requirement;
@@ -97,7 +105,10 @@ pub use narrow::{intersect, narrow};
 pub use refs::{role_id_of, warrant_ref_of};
 pub use registry::{InMemoryRoleRegistry, RoleRegistry};
 pub use scope::{FsScope, NetScope};
-pub use spec::{ModelRoute, ResourceCeiling, Role, ToolGrant, ToolRequirement, WarrantSpec};
+pub use secret::{SecretRef, SecretScope};
+pub use spec::{
+    CostCeiling, ModelRoute, ResourceCeiling, Role, ToolGrant, ToolRequirement, WarrantSpec,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/kx-warrant/src/narrow.rs
+++ b/crates/kx-warrant/src/narrow.rs
@@ -64,6 +64,7 @@ use crate::spec::{Role, WarrantSpec};
 ///     // narrowing inherits the AXES, not the VALUES); the macOS sibling
 ///     // variant `MacOsSandbox` is a sibling default on macOS hosts.
 ///     executor_class: ExecutorClass::Bwrap,
+///     ..Default::default()
 /// };
 ///
 /// // A child role that strictly tightens (max_calls 10 → 5) AND selects
@@ -124,6 +125,16 @@ pub fn intersect(parent: &WarrantSpec, role: &Role) -> Result<WarrantSpec, Narro
         });
     }
 
+    // secret_scope: None authorizes nothing; allowlist must be subset of
+    // parent's (the D110.3 authorization axis; mirrors net_scope).
+    if !proposed.secret_scope.is_subset_of(&parent.secret_scope) {
+        return Err(NarrowingError::AttemptedWiden {
+            field: WarrantField::SecretScope,
+            parent: format!("{:?}", parent.secret_scope),
+            proposed: format!("{:?}", proposed.secret_scope),
+        });
+    }
+
     // model_route: child names its own model; quantitative ceilings narrow.
     // Reject zero ceilings as structurally invalid (a route with zero tokens
     // is useless; surface loudly).
@@ -142,6 +153,16 @@ pub fn intersect(parent: &WarrantSpec, role: &Role) -> Result<WarrantSpec, Narro
     // resource_ceiling: per-axis min.
     let resource_ceiling = proposed.resource_ceiling.narrow(&parent.resource_ceiling);
 
+    // cost_ceiling: per-axis min — a child can only lower the dollar ceiling
+    // (D115; mirrors resource_ceiling). Axis reserved; enforcement is M11.
+    let cost_ceiling = proposed.cost_ceiling.narrow(&parent.cost_ceiling);
+
+    // tls_required: tighten-only. A child can add TLS but never remove a
+    // parent's requirement — the boolean dual of the quantitative `min()` axes
+    // (safe value = true), so a relaxation is structurally impossible rather
+    // than a loud error (D118.5).
+    let tls_required = proposed.tls_required || parent.tls_required;
+
     // mote_class / nd_class: set by child's role (NOT inherited).
     // executor_class: set by child's role (orthogonal to narrowing).
     // environment_ref: set by child's role (orthogonal to narrowing).
@@ -157,6 +178,9 @@ pub fn intersect(parent: &WarrantSpec, role: &Role) -> Result<WarrantSpec, Narro
         resource_ceiling,
         environment_ref: proposed.environment_ref,
         executor_class: proposed.executor_class,
+        secret_scope: proposed.secret_scope.clone(),
+        cost_ceiling,
+        tls_required,
     })
 }
 

--- a/crates/kx-warrant/src/refs.rs
+++ b/crates/kx-warrant/src/refs.rs
@@ -43,6 +43,7 @@ use crate::spec::{Role, WarrantSpec};
 ///         fd_count: 0, disk_bytes: 0,
 ///     },
 ///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+///     ..Default::default()
 /// };
 /// // Same spec → same ref (idempotent).
 /// assert_eq!(warrant_ref_of(&spec), warrant_ref_of(&spec));

--- a/crates/kx-warrant/src/registry.rs
+++ b/crates/kx-warrant/src/registry.rs
@@ -81,6 +81,7 @@ pub trait RoleRegistry: Send + Sync {
 ///         fd_count: 1, disk_bytes: 1,
 ///     },
 ///     environment_ref: None, executor_class: ExecutorClass::Bwrap,
+///     ..Default::default()
 /// };
 /// let role = Role {
 ///     name: "worker".into(), version: 1, spec,
@@ -180,6 +181,7 @@ mod tests {
             },
             environment_ref: None,
             executor_class: ExecutorClass::Bwrap,
+            ..Default::default()
         };
         Role {
             name: name.into(),

--- a/crates/kx-warrant/src/secret.rs
+++ b/crates/kx-warrant/src/secret.rs
@@ -1,0 +1,45 @@
+//! [`SecretRef`] (opaque secret identifier) + [`SecretScope`] (the warrant axis
+//! authorizing which secrets a role may resolve, D110.3). Mirrors
+//! [`crate::NetScope`]: the warrant carries *identifiers*, never *values* — the
+//! resolver (`SecretStore`, at the transport, M5.3 PR-B) is the only thing that
+//! turns a `SecretRef` into a secret. `is_subset_of` gives monotonic narrowing.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// An opaque secret identifier the warrant may authorize resolution of.
+///
+/// Stored as an opaque string so the warrant layer never reimplements secret
+/// naming or holds a secret value (the resolver interprets it — D81/D110). The
+/// same ref-not-value discipline as [`crate::NetScope`]'s [`crate::Host`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SecretRef(pub String);
+
+/// Which secret references a role/warrant may resolve (D110.3).
+///
+/// Qualitative, subset-narrowed — the exact shape of [`crate::NetScope`].
+/// `None` authorizes **no** secret resolution at all (the fail-closed default).
+/// `AllowList(S)` authorizes exactly the refs in `S`. Narrowing respects
+/// monotonic subset: `None ⊆ anything`; `AllowList(C) ⊆ None` is false;
+/// `AllowList(C) ⊆ AllowList(P)` iff `C ⊆ P`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SecretScope {
+    /// No secret may be resolved under this warrant (fail-closed default).
+    #[default]
+    None,
+    /// Exactly the listed secret references may be resolved.
+    AllowList(BTreeSet<SecretRef>),
+}
+
+impl SecretScope {
+    /// `true` iff `self` authorizes no more secrets than `parent`.
+    #[must_use]
+    pub fn is_subset_of(&self, parent: &Self) -> bool {
+        match (self, parent) {
+            (Self::None, _) => true,
+            (Self::AllowList(_), Self::None) => false,
+            (Self::AllowList(child), Self::AllowList(parent)) => child.is_subset(parent),
+        }
+    }
+}

--- a/crates/kx-warrant/src/spec.rs
+++ b/crates/kx-warrant/src/spec.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::classes::{ExecutorClass, MoteClass};
 use crate::scope::{FsScope, NetScope};
+use crate::secret::SecretScope;
 
 /// A reference to a tool in the shared registry (per D32).
 ///
@@ -98,11 +99,43 @@ impl ResourceCeiling {
     }
 }
 
+/// A quantitative cost ceiling, in micro-dollars (D115).
+///
+/// `micro_usd` is the MAXIMUM spend permitted under this warrant. Integer
+/// fixed-point — **no float on the identity path** (SN-8). `0` = no spend
+/// permitted (the fail-closed default); [`u64::MAX`] = effectively unlimited.
+/// Narrowed silently via `min()` like [`ResourceCeiling`] (a child can never
+/// raise the ceiling).
+///
+/// **M5.3 reserves the axis only** (D115.1): the field + `min()`-narrowing exist
+/// here; the spend FOLD (accumulating cost) and the `spent ≤ cost_ceiling`
+/// enforcement land in M11 (`kx-trace`). At M5.3 the ceiling is recorded +
+/// narrowed but never consulted (no cost accounting is built).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CostCeiling {
+    /// Maximum spend in micro-dollars (USD × 1_000_000).
+    pub micro_usd: u64,
+}
+
+impl CostCeiling {
+    /// Per-axis `min` narrowing (a child can only lower the ceiling).
+    #[inline]
+    #[must_use]
+    pub fn narrow(&self, parent: &Self) -> Self {
+        Self {
+            micro_usd: self.micro_usd.min(parent.micro_usd),
+        }
+    }
+}
+
 /// The complete capability envelope a Mote attempts under.
 ///
 /// Computed via [`crate::intersect`] of the parent's warrant and the child's
 /// role. Content-addressed via [`crate::warrant_ref_of`]; recovery re-derives
-/// bit-for-bit.
+/// bit-for-bit. [`WarrantSpec::default`] is a fail-closed **deny-all** envelope
+/// (no tools, no egress, no filesystem, zero resource/cost ceilings, TLS
+/// required, `Pure`) — the safe base every fixture and future axis builds on via
+/// `..Default::default()`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct WarrantSpec {
     /// Non-determinism class. Set by child's role; NOT inherited.
@@ -128,6 +161,50 @@ pub struct WarrantSpec {
     pub environment_ref: Option<ContentRef>,
     /// Executor backend selection. Set by child's role.
     pub executor_class: ExecutorClass,
+    /// Which secret references this warrant may resolve (D110.3). Narrowable via
+    /// subset; widening → `AttemptedWiden`. `None` authorizes no secret.
+    pub secret_scope: SecretScope,
+    /// Quantitative cost ceiling (D115). Narrowed silently via `min()`. Axis
+    /// reserved at M5.3; spend enforcement is M11 (see [`CostCeiling`]).
+    pub cost_ceiling: CostCeiling,
+    /// Force TLS on remote MCP egress (D118.5). Tighten-only: a parent requiring
+    /// TLS forces every child to require it too (narrow = `||`). Consumed by the
+    /// HTTP transport (`https_only`) in M5.3 PR-B.
+    pub tls_required: bool,
+}
+
+impl Default for WarrantSpec {
+    /// A fail-closed **deny-all** warrant: no tools, no egress, no filesystem,
+    /// zero resource + cost ceilings, TLS required, `Pure` class, the default
+    /// executor backend. The least-privilege base for `..Default::default()`.
+    fn default() -> Self {
+        Self {
+            mote_class: MoteClass::Pure,
+            nd_class: MoteClass::Pure,
+            fs_scope: FsScope::empty(),
+            net_scope: NetScope::None,
+            syscall_profile_ref: ContentRef::from_bytes([0u8; 32]),
+            tool_grants: BTreeSet::new(),
+            model_route: ModelRoute {
+                model_id: ModelId(String::new()),
+                max_input_tokens: 0,
+                max_output_tokens: 0,
+                max_calls: 0,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+            environment_ref: None,
+            executor_class: ExecutorClass::Bwrap,
+            secret_scope: SecretScope::None,
+            cost_ceiling: CostCeiling { micro_usd: 0 },
+            tls_required: true,
+        }
+    }
 }
 
 /// A `(name, version, spec, description)` tuple identifying a named, versioned

--- a/crates/kx-warrant/src/tests.rs
+++ b/crates/kx-warrant/src/tests.rs
@@ -50,6 +50,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-warrant/tests/concurrency.rs
+++ b/crates/kx-warrant/tests/concurrency.rs
@@ -96,6 +96,7 @@ fn permissive_warrant() -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-warrant/tests/proptest_warrant.rs
+++ b/crates/kx-warrant/tests/proptest_warrant.rs
@@ -29,9 +29,9 @@ use std::path::PathBuf;
 use kx_content::ContentRef;
 use kx_mote::{ModelId, ToolName, ToolVersion};
 use kx_warrant::{
-    check_tool_requirement, intersect, narrow, warrant_ref_of, ExecutorClass, FsMode, FsScope,
-    Host, ModelRoute, MoteClass, NarrowingError, NetScope, ResourceCeiling, Role, ToolGrant,
-    ToolRequirement, WarrantField, WarrantSpec,
+    check_tool_requirement, intersect, narrow, warrant_ref_of, CostCeiling, ExecutorClass, FsMode,
+    FsScope, Host, ModelRoute, MoteClass, NarrowingError, NetScope, ResourceCeiling, Role,
+    SecretRef, SecretScope, ToolGrant, ToolRequirement, WarrantField, WarrantSpec,
 };
 use proptest::prelude::*;
 
@@ -174,8 +174,27 @@ fn arb_resource_ceiling() -> impl Strategy<Value = ResourceCeiling> {
         )
 }
 
+fn arb_secret_ref() -> impl Strategy<Value = SecretRef> {
+    prop_oneof!["API_KEY", "DB_URL", "TOKEN", "SLACK_HOOK", "STRIPE_SK"]
+        .prop_map(|s: String| SecretRef(s))
+}
+
+fn arb_secret_scope() -> impl Strategy<Value = SecretScope> {
+    prop_oneof![
+        Just(SecretScope::None),
+        proptest::collection::btree_set(arb_secret_ref(), 0..4).prop_map(SecretScope::AllowList),
+    ]
+}
+
+fn arb_cost_ceiling() -> impl Strategy<Value = CostCeiling> {
+    (0u64..=10_000_000_000).prop_map(|micro_usd| CostCeiling { micro_usd })
+}
+
 fn arb_warrant_spec() -> impl Strategy<Value = WarrantSpec> {
-    (
+    // Base 9-axis warrant (new M5.3 axes default-filled), then overlay the three
+    // M5.3 axes (secret_scope / cost_ceiling / tls_required) so every property
+    // exercises them. Two-stage compose keeps each tuple within proptest's arity.
+    let base = (
         arb_mote_class(),
         arb_fs_scope(),
         arb_net_scope(),
@@ -208,8 +227,17 @@ fn arb_warrant_spec() -> impl Strategy<Value = WarrantSpec> {
                 resource_ceiling,
                 environment_ref,
                 executor_class,
+                ..Default::default()
             },
-        )
+        );
+    (base, arb_secret_scope(), arb_cost_ceiling(), any::<bool>()).prop_map(
+        |(base, secret_scope, cost_ceiling, tls_required)| WarrantSpec {
+            secret_scope,
+            cost_ceiling,
+            tls_required,
+            ..base
+        },
+    )
 }
 
 fn arb_role(spec_strategy: impl Strategy<Value = WarrantSpec>) -> impl Strategy<Value = Role> {
@@ -401,6 +429,84 @@ proptest! {
         prop_assert!(child2.resource_ceiling.fd_count <= child1.resource_ceiling.fd_count);
         prop_assert!(child2.resource_ceiling.disk_bytes <= child1.resource_ceiling.disk_bytes);
     }
+
+    /// Property 8 (D110.3): `cost_ceiling` narrows to the per-axis `min`.
+    /// Mirrors property 5 for the new quantitative axis.
+    #[test]
+    fn prop_cost_ceiling_narrows_to_min(
+        parent in arb_warrant_spec(),
+        child_cost in arb_cost_ceiling(),
+    ) {
+        // Inherit every other axis from the parent so no widen trips; vary only cost.
+        let mut child_spec = parent.clone();
+        child_spec.cost_ceiling = child_cost;
+        let role = Role { name: "cc".into(), version: 1, spec: child_spec, description: String::new() };
+        if let Ok(r) = intersect(&parent, &role) {
+            prop_assert_eq!(
+                r.cost_ceiling.micro_usd,
+                parent.cost_ceiling.micro_usd.min(child_cost.micro_usd)
+            );
+        }
+    }
+
+    /// Property 9 (D118.5): `tls_required` is TIGHTEN-ONLY (`parent || child`).
+    /// A parent requiring TLS forces the result to require it; a relaxation is
+    /// structurally impossible (never an error, always the safe value).
+    #[test]
+    fn prop_tls_required_tighten_only(
+        parent in arb_warrant_spec(),
+        child_tls in any::<bool>(),
+    ) {
+        let mut child_spec = parent.clone();
+        child_spec.tls_required = child_tls;
+        let role = Role { name: "tls".into(), version: 1, spec: child_spec, description: String::new() };
+        if let Ok(r) = intersect(&parent, &role) {
+            prop_assert_eq!(r.tls_required, parent.tls_required || child_tls);
+            // Never relaxes: if the parent required TLS, the result requires it.
+            if parent.tls_required {
+                prop_assert!(r.tls_required);
+            }
+        }
+    }
+
+    /// Property 10 (D110.3): a `secret_scope` ⊆ the parent's NARROWS (Ok, value
+    /// = child's). Mirrors the qualitative subset axes.
+    #[test]
+    fn prop_secret_scope_subset_narrows(parent in arb_warrant_spec()) {
+        // A child whose secret_scope is `None` is always ⊆ any parent.
+        let mut child_spec = parent.clone();
+        child_spec.secret_scope = SecretScope::None;
+        let role = Role { name: "ss".into(), version: 1, spec: child_spec, description: String::new() };
+        if let Ok(r) = intersect(&parent, &role) {
+            prop_assert_eq!(r.secret_scope, SecretScope::None);
+        }
+    }
+
+    /// Property 11 (D110.3): WIDENING `secret_scope` is REFUSED with
+    /// `AttemptedWiden { field: SecretScope }`. Mirrors property 6.
+    #[test]
+    fn prop_secret_scope_widening_is_refused(
+        parent in arb_warrant_spec(),
+        extra in arb_secret_ref(),
+    ) {
+        // Build a child scope that is a strict SUPERSET of the parent's (so it
+        // can never be ⊆): parent's refs ∪ {extra}, with `extra` not already in.
+        let mut child_set: std::collections::BTreeSet<SecretRef> = match &parent.secret_scope {
+            SecretScope::None => std::collections::BTreeSet::new(),
+            SecretScope::AllowList(s) => s.clone(),
+        };
+        if child_set.contains(&extra) {
+            return Ok(()); // degenerate: already present, not a widen
+        }
+        child_set.insert(extra);
+        let mut child_spec = parent.clone();
+        child_spec.secret_scope = SecretScope::AllowList(child_set);
+        let role = Role { name: "ssw".into(), version: 1, spec: child_spec, description: String::new() };
+        match intersect(&parent, &role) {
+            Err(NarrowingError::AttemptedWiden { field: WarrantField::SecretScope, .. }) => {}
+            other => prop_assert!(false, "expected SecretScope AttemptedWiden, got {:?}", other),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -450,6 +556,7 @@ fn check_tool_requirement_smoke() {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     };
 
     // Permissive req: ok.

--- a/crates/kx-worker/src/run_wm.rs
+++ b/crates/kx-worker/src/run_wm.rs
@@ -100,6 +100,7 @@ fn effect_request_for(mote: &Mote, instance_id: Option<[u8; INSTANCE_ID_LEN]>) -
         idempotency_key: Some(idempotency_key),
         net_scope: NetScope::None,
         fs_scope: FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     }
 }
 

--- a/crates/kx-worker/tests/common/mod.rs
+++ b/crates/kx-worker/tests/common/mod.rs
@@ -111,6 +111,7 @@ pub fn pure_warrant() -> WarrantSpec {
         },
         environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
         executor_class: WORKER_CLASS,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-worker/tests/thesis_verbatim.rs
+++ b/crates/kx-worker/tests/thesis_verbatim.rs
@@ -109,5 +109,6 @@ fn sample_warrant() -> kx_warrant::WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::MacOsSandbox,
+        ..Default::default()
     }
 }

--- a/crates/kx-worker/tests/wm_dispatch.rs
+++ b/crates/kx-worker/tests/wm_dispatch.rs
@@ -478,6 +478,7 @@ async fn w3_worker_death_after_stage_is_exactly_once() {
         idempotency_key: Some(run_scoped_token(&iid, &wm)),
         net_scope: kx_warrant::NetScope::None,
         fs_scope: kx_warrant::FsScope::empty(),
+        secret_scope: kx_warrant::SecretScope::None,
     };
     broker.dispatch(&wm, &warrant, &cap, req).unwrap();
     assert_eq!(broker.net_effects.load(Ordering::SeqCst), 1);
@@ -627,6 +628,7 @@ async fn w5_dead_workers_late_commit_dedupes() {
                 idempotency_key: Some(idempotency_token_for(&wm)),
                 net_scope: kx_warrant::NetScope::None,
                 fs_scope: kx_warrant::FsScope::empty(),
+                secret_scope: kx_warrant::SecretScope::None,
             },
         )
         .unwrap();

--- a/crates/kx-workflow/src/synthesis.rs
+++ b/crates/kx-workflow/src/synthesis.rs
@@ -54,6 +54,7 @@ pub fn permissive_warrant(model_id: ModelId) -> WarrantSpec {
         },
         environment_ref: None,
         executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## M5.3a — the kx-warrant STRICT seam (Rule 1: the warrant churns once)

First of two PRs for **M5.3 (secure integrations)**. Adds three additive, narrowing-only warrant axes; PR-B (SecretStore + MCP inputSchema) rides on top.

### What
- **`secret_scope: SecretScope`** (D110.3) — which `SecretRef`s a role may resolve. Subset-narrowed like `net_scope`. **Broker precheck step 7** enforces `request.secret_scope ⊆ warrant.secret_scope` → `CapabilityExceedsWarrant{SecretScope}` (the single authorization gate; the transport resolver in PR-B only resolves what is granted here).
- **`cost_ceiling: CostCeiling`** (D115) — micro-USD **integer** (no float, SN-8), min-narrowed like `resource_ceiling`. **Axis reserved only** — the spend fold + `spent ≤ ceiling` enforcement is M11 (`kx-trace`); no accounting is built here.
- **`tls_required: bool`** (D118.5) — **tighten-only** (`parent || child`): a child can add a TLS requirement but never relax a parent's. Consumed by the HTTP transport (`https_only`) in PR-B.
- New `kx-warrant/src/secret.rs` (`SecretRef`, `SecretScope`), `CostCeiling` in `spec.rs`, 3 `WarrantField` variants; `EffectRequest` gains `secret_scope`.
- **Fail-closed deny-all `WarrantSpec::Default`** so this and every future warrant-axis addition stops churning fixtures: ~98 full literals migrate to `..Default::default()` (the 10 pre-existing fields stay byte-identical; only the 3 new axes default-fill).

### Pre-flight (Golden Rule 8)
- **Identity invariant:** `warrant_ref` is not on the product-digest path, so `a6b5c679…` (`a0_guard`) and `6bf5b52d…` (`schema_evolution` product identity) are **byte-unchanged**. The resume/state digest folds `warrant_ref` → version-local → self-heals (the D107 pattern). **No journal schema bump** (`warrant_ref` stays a fixed 32-byte slot).
- **Thesis:** frozen-trio **engine logic is byte-unchanged** — `kx-scheduler`/`kx-inference` `src` untouched; `kx-executor` `src` changes are **4 doc-comment `WarrantSpec` examples only** (the non-doc-comment trio-src diff is empty). The literal trio diff is non-empty only because test fixtures + doc examples track the evolved warrant shape.
- **Perf:** `intersect`/precheck add one `BTreeSet::is_subset` + one `u64::min` + one `bool ||` — same class as existing axes; precheck stays O(log n) (scale-smoke green).
- **Security:** `secret_scope` is the data-minimization authorization gate; deny-all defaults are fail-closed.

### Tests
4 new kx-warrant proptests (cost-min narrows, tls tighten-only, secret-subset narrows, secret-widen refused) + broker `cap_7c` secret_scope refusal.

### Gate (local, all green)
fmt · clippy `--workspace --all-targets -D warnings` · `cargo test --workspace` **1282/0** · cargo-deny · doc `-D warnings` · ffi-link · **I1.c byte-determinism PASS** · scale-smoke (gated ratios) · doc-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)