### PR TITLE
M5.3b — SecretStore seam + secret_scope gating + MCP inputSchema validation (D110.1/.2/.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "kx-warrant",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/crates/kx-capability/src/capability.rs
+++ b/crates/kx-capability/src/capability.rs
@@ -3,6 +3,7 @@
 //! integration.
 
 use kx_mote::{EffectPattern, ToolName, ToolVersion};
+use kx_warrant::SecretScope;
 
 use crate::errors::CapabilityFailureReason;
 use crate::request::EffectRequest;
@@ -40,6 +41,16 @@ pub trait Capability: Send + Sync {
     /// `StageThenCommit`; an MCP server call may honor
     /// `ValidateThenCommit`.
     fn supported_patterns(&self) -> &[EffectPattern];
+
+    /// The secret references this capability will actually resolve when invoked
+    /// (its configured credentials, D110.3). The broker's `precheck` gates this
+    /// `⊆ warrant.secret_scope`, so a run whose role does not grant a secret the
+    /// capability needs is refused at dispatch — data-minimization enforced by the
+    /// runtime, not just the registrant. Default: [`SecretScope::None`] (the
+    /// capability resolves no secret).
+    fn required_secret_scope(&self) -> SecretScope {
+        SecretScope::None
+    }
 
     /// Invoke the capability with the given request, producing the
     /// response bytes that the broker will stage into the content store.

--- a/crates/kx-capability/src/local.rs
+++ b/crates/kx-capability/src/local.rs
@@ -182,12 +182,19 @@ impl<S: ContentStore + Send + Sync> LocalCapabilityBroker<S> {
             });
         }
 
-        // (5) request.secret_scope ⊆ warrant.secret_scope (D110.3) — the broker
-        //     is the single authorization gate for secret resolution; the
-        //     transport (kx-mcp `SecretStore`) only resolves what is granted
-        //     here. `cost_ceiling` (D115) enforcement is M11 (the spend fold);
-        //     no precheck consults it at M5.3.
-        if !request.secret_scope.is_subset_of(&warrant.secret_scope) {
+        // (5) secret_scope ⊆ warrant.secret_scope (D110.3) — the broker is the
+        //     single authorization gate for secret resolution; the transport
+        //     (kx-mcp `SecretStore`) only resolves what is granted here. Two
+        //     subset checks: the dispatch's DECLARED need (`request.secret_scope`)
+        //     and the capability's ACTUAL need (its configured credentials,
+        //     `required_secret_scope`) — a run whose role grants neither the
+        //     declared nor the capability's secrets is refused. `cost_ceiling`
+        //     (D115) enforcement is M11 (the spend fold); no precheck consults it.
+        if !request.secret_scope.is_subset_of(&warrant.secret_scope)
+            || !capability
+                .required_secret_scope()
+                .is_subset_of(&warrant.secret_scope)
+        {
             return Err(BrokerError::CapabilityExceedsWarrant {
                 axis: WarrantField::SecretScope,
             });

--- a/crates/kx-context-assembler/src/tests.rs
+++ b/crates/kx-context-assembler/src/tests.rs
@@ -158,6 +158,7 @@ fn assemble_two_parents_one_tool() {
         required_capability: permissive_req(),
         description: "reads files".into(),
         idempotency_class: kx_tool_registry::IdempotencyClass::Readback,
+        input_schema: None,
     };
     let _ = registry
         .register(

--- a/crates/kx-context-assembler/tests/proptest_assembler.rs
+++ b/crates/kx-context-assembler/tests/proptest_assembler.rs
@@ -344,6 +344,7 @@ fn register_tool_for_test(
         },
         description: description.into(),
         idempotency_class: IdempotencyClass::Readback,
+        input_schema: None,
     };
     let prov = ToolProvenance::HumanAuthored {
         author: "h2-test".into(),

--- a/crates/kx-coordinator/tests/run_versions.rs
+++ b/crates/kx-coordinator/tests/run_versions.rs
@@ -350,6 +350,7 @@ async fn capability_exceeds_warrant_skips_capture() {
                 },
                 description: "needs egress the warrant lacks".into(),
                 idempotency_class: IdempotencyClass::Token,
+                input_schema: None,
             },
             ToolProvenance::HumanAuthored {
                 author: "ops".into(),

--- a/crates/kx-coordinator/tests/submission_refusal.rs
+++ b/crates/kx-coordinator/tests/submission_refusal.rs
@@ -149,6 +149,7 @@ fn registry_with_at_least_once() -> Arc<dyn ToolRegistry> {
             },
             description: "sends an email; no closing mechanism (at-least-once)".into(),
             idempotency_class: IdempotencyClass::AtLeastOnce,
+            input_schema: None,
         },
         ToolProvenance::HumanAuthored {
             author: "ops".into(),
@@ -242,6 +243,7 @@ async fn d66_security_refuses_capability_exceeding_warrant() {
             },
             description: "needs egress the warrant lacks".into(),
             idempotency_class: IdempotencyClass::Token,
+            input_schema: None,
         },
         ToolProvenance::HumanAuthored {
             author: "ops".into(),

--- a/crates/kx-coordinator/tests/wm_reschedule.rs
+++ b/crates/kx-coordinator/tests/wm_reschedule.rs
@@ -76,6 +76,7 @@ fn coordinator_with_alo_tool(clock: Arc<FakeClock>) -> CoordinatorService {
                 },
                 description: "a token-less, no-readback effect (at-most-once)".into(),
                 idempotency_class: IdempotencyClass::AtLeastOnce,
+                input_schema: None,
             },
             ToolProvenance::HumanAuthored {
                 author: "ops".into(),

--- a/crates/kx-mcp/src/capability.rs
+++ b/crates/kx-mcp/src/capability.rs
@@ -112,6 +112,14 @@ impl Capability for McpCapability {
         &SUPPORTED_PATTERNS
     }
 
+    fn required_secret_scope(&self) -> kx_warrant::SecretScope {
+        // The secrets this capability will actually resolve = its transport's
+        // configured credentials. The broker gates this ⊆ warrant.secret_scope
+        // (D110.3), so a run whose role does not grant the tool's credentials is
+        // refused at dispatch (data-minimization), and the model never sees them.
+        self.transport.declared_secret_scope()
+    }
+
     fn invoke(&self, request: &EffectRequest) -> Result<Vec<u8>, CapabilityFailureReason> {
         // The args are the validated `EffectRequest.payload`, carried VERBATIM as an
         // opaque RawValue (never decoded into a dynamic Value / floats). An empty

--- a/crates/kx-mcp/src/credential.rs
+++ b/crates/kx-mcp/src/credential.rs
@@ -1,65 +1,89 @@
 //! [`CredentialRef`] — a reference to a secret, never the secret itself (D81).
 //!
 //! Auth for an MCP server (API keys, OAuth tokens) is supplied **out-of-band**: a
-//! `CredentialRef` names a host environment variable (or, later, a cloud
-//! secret-broker key); the secret *value* is read transiently at transport-setup
-//! time and handed to the child process's environment. The value is never stored on
-//! any struct, never placed in an `EffectRequest`, a `BrokerHandle`, the journal, a
-//! `MoteId`, or a `StepRecord`. `Debug`/`Display` print only the *identity* (the
-//! variable name), so a logged credential ref never leaks the secret.
+//! `CredentialRef` names a [`SecretRef`] (the env-var name, or — via the cloud
+//! [`SecretStore`] — a vault key); the secret *value* is read transiently at
+//! transport-setup time through the transport's [`SecretStore`] and handed to the
+//! child process's environment (stdio) or a request header (HTTP). The value is
+//! never stored on any struct, never placed in an `EffectRequest`, a
+//! `BrokerHandle`, the journal, a `MoteId`, or a `StepRecord`. `Debug`/`Display`
+//! print only the *identity* (the ref name), so a logged credential ref never
+//! leaks the secret.
 
 use std::process::Command;
 
-/// A reference to a credential by the name of the host environment variable that
-/// holds it. The secret value is read on demand at injection time and never stored.
+use kx_warrant::SecretRef;
+
+use crate::secret_store::SecretStore;
+
+/// A reference to a credential by its [`SecretRef`] (the env-var name, or a cloud
+/// vault key). The secret value is read on demand at injection time through a
+/// [`SecretStore`] and never stored.
 ///
-/// `Debug`/`Display` deliberately print only the variable name (the identity that
+/// `Debug`/`Display` deliberately print only the ref name (the identity that
 /// acted), never the secret — D81's "records *which* credential identity acted,
 /// never the secret".
 #[derive(Clone, PartialEq, Eq)]
-pub struct CredentialRef(String);
+pub struct CredentialRef {
+    secret_ref: SecretRef,
+}
 
 impl CredentialRef {
     /// Construct a credential reference from the host environment-variable name
-    /// that holds the secret.
+    /// that holds the secret (resolved by the OSS [`crate::EnvSecretStore`]).
     #[must_use]
     pub fn from_env_var(var_name: impl Into<String>) -> Self {
-        Self(var_name.into())
-    }
-
-    /// The credential's identity (the env-var name). Safe to log — never the secret.
-    #[must_use]
-    pub fn identity(&self) -> &str {
-        &self.0
-    }
-
-    /// Inject the referenced secret into `cmd`'s environment, reading it from the
-    /// host environment transiently. If the variable is unset, no env entry is
-    /// added (the server then fails its own auth — the runtime never fabricates a
-    /// credential). The secret value is dropped at the end of this call; it is
-    /// never returned or stored.
-    pub fn inject_into(&self, cmd: &mut Command) {
-        if let Ok(secret) = std::env::var(&self.0) {
-            cmd.env(&self.0, secret);
+        Self {
+            secret_ref: SecretRef(var_name.into()),
         }
     }
 
-    /// Read the referenced secret transiently from the host environment, for
-    /// injection as an HTTP request header (the M5.2b [`crate::HttpTransport`]
-    /// path — stdio injects into the child env instead, [`inject_into`]).
+    /// Construct a credential reference from an explicit [`SecretRef`] (e.g. a
+    /// cloud vault key resolved by a `kx-cloud` [`SecretStore`]).
+    #[must_use]
+    pub fn from_secret_ref(secret_ref: SecretRef) -> Self {
+        Self { secret_ref }
+    }
+
+    /// The underlying [`SecretRef`] — used by the transport to check the dispatch's
+    /// authorized `secret_scope` before resolving (defense-in-depth).
+    #[must_use]
+    pub fn secret_ref(&self) -> &SecretRef {
+        &self.secret_ref
+    }
+
+    /// The credential's identity (the ref name). Safe to log — never the secret.
+    #[must_use]
+    pub fn identity(&self) -> &str {
+        &self.secret_ref.0
+    }
+
+    /// Inject the referenced secret into `cmd`'s environment, reading it through
+    /// `store` transiently. If the ref is unresolvable, no env entry is added (the
+    /// server then fails its own auth — the runtime never fabricates a credential).
+    /// The secret value is dropped at the end of this call; it is never returned or
+    /// stored.
+    pub fn inject_into(&self, store: &dyn SecretStore, cmd: &mut Command) {
+        if let Some(secret) = store.resolve(&self.secret_ref) {
+            cmd.env(&self.secret_ref.0, secret);
+        }
+    }
+
+    /// Read the referenced secret transiently through `store`, for injection as an
+    /// HTTP request header (the M5.2b [`crate::HttpTransport`] path — stdio injects
+    /// into the child env instead, [`inject_into`]).
     ///
-    /// Returns `None` when the variable is unset (the server then fails its own
+    /// Returns `None` when the ref is unresolvable (the server then fails its own
     /// auth — the runtime never fabricates a credential). The returned `String` is
     /// the ONLY place the secret materializes: the caller injects it into a header
     /// and drops it; it is never stored on this struct, an `EffectRequest`, a
-    /// `BrokerHandle`, the journal, a `MoteId`, or a `StepRecord` (D81). Because
-    /// the type still holds only the variable name, `Debug`/`Display` redaction is
-    /// unaffected.
+    /// `BrokerHandle`, the journal, a `MoteId`, or a `StepRecord` (D81). Because the
+    /// type still holds only the ref name, `Debug`/`Display` redaction is unaffected.
     ///
     /// [`inject_into`]: Self::inject_into
     #[must_use]
-    pub fn read_secret(&self) -> Option<String> {
-        std::env::var(&self.0).ok()
+    pub fn read_secret(&self, store: &dyn SecretStore) -> Option<String> {
+        store.resolve(&self.secret_ref)
     }
 }
 
@@ -68,13 +92,13 @@ impl CredentialRef {
 impl std::fmt::Debug for CredentialRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CredentialRef")
-            .field("identity", &self.0)
+            .field("identity", &self.secret_ref.0)
             .finish()
     }
 }
 
 impl std::fmt::Display for CredentialRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "credential:{}", self.0)
+        write!(f, "credential:{}", self.secret_ref.0)
     }
 }

--- a/crates/kx-mcp/src/http_transport.rs
+++ b/crates/kx-mcp/src/http_transport.rs
@@ -388,15 +388,23 @@ mod tests {
 
     #[test]
     fn new_refuses_non_http_scheme() {
-        let err = HttpTransport::new("ftp://api.example.com/mcp", &scope(&["api.example.com"]), false)
-            .expect_err("non-http scheme must refuse");
+        let err = HttpTransport::new(
+            "ftp://api.example.com/mcp",
+            &scope(&["api.example.com"]),
+            false,
+        )
+        .expect_err("non-http scheme must refuse");
         assert!(matches!(err, TransportError::Unreachable(_)));
     }
 
     #[test]
     fn new_accepts_allowlisted_endpoint() {
-        let t = HttpTransport::new("https://api.example.com/mcp", &scope(&["api.example.com"]), true)
-            .expect("allowlisted endpoint builds (tls_required does not fail at build)");
+        let t = HttpTransport::new(
+            "https://api.example.com/mcp",
+            &scope(&["api.example.com"]),
+            true,
+        )
+        .expect("allowlisted endpoint builds (tls_required does not fail at build)");
         let _ = t;
     }
 

--- a/crates/kx-mcp/src/http_transport.rs
+++ b/crates/kx-mcp/src/http_transport.rs
@@ -177,6 +177,10 @@ impl HttpTransport {
 }
 
 impl McpTransport for HttpTransport {
+    fn declared_secret_scope(&self) -> kx_warrant::SecretScope {
+        crate::transport::scope_of_credentials(self.credentials.iter().map(|(_, c)| c))
+    }
+
     fn round_trip(
         &self,
         request: &[u8],

--- a/crates/kx-mcp/src/http_transport.rs
+++ b/crates/kx-mcp/src/http_transport.rs
@@ -33,6 +33,7 @@
 use std::io::Read;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::Arc;
 use std::time::Duration;
 
 use url::Url;
@@ -40,6 +41,7 @@ use url::Url;
 use crate::credential::CredentialRef;
 use crate::egress::{vet_resolved_addr, EgressPolicy};
 use crate::errors::TransportError;
+use crate::secret_store::{EnvSecretStore, SecretStore};
 use crate::transport::{McpTransport, DEFAULT_WALL_CLOCK_MS};
 
 /// Slack added to the per-call budget for ureq's own request timeout, so a worker
@@ -66,12 +68,16 @@ pub struct HttpTransport {
     endpoint: Url,
     /// `header-name → credential` pairs injected transiently at dispatch (D81).
     credentials: Vec<(String, CredentialRef)>,
+    /// Resolves a `CredentialRef`'s `SecretRef` → value at dispatch (D110.2).
+    /// Defaults to [`EnvSecretStore`]; a cloud vault swaps in via
+    /// [`HttpTransport::with_secret_store`].
+    secret_store: Arc<dyn SecretStore>,
 }
 
 impl std::fmt::Debug for HttpTransport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Print only header NAMES + the credential identities (never a secret);
-        // elide the agent (not `Debug`-meaningful).
+        // elide the agent + the secret store (not `Debug`-meaningful / secret-bearing).
         f.debug_struct("HttpTransport")
             .field("endpoint", &self.endpoint.as_str())
             .field("credentials", &self.credentials)
@@ -83,6 +89,11 @@ impl HttpTransport {
     /// Build an HTTP transport that POSTs to `endpoint_url`, permitted to dial only
     /// hosts in `net_scope` (the resolved tool's warrant-validated egress).
     ///
+    /// When `tls_required` is `true` (the warrant's `tls_required` axis, D118.5),
+    /// the agent is built with `https_only(true)` and refuses any plaintext
+    /// `http://` dial at request time — closing the plaintext-credential gap. The
+    /// hermetic loopback path passes `false` (it serves plaintext `http://127.0.0.1`).
+    ///
     /// # Errors
     ///
     /// [`TransportError::Unreachable`] if `endpoint_url` is not a valid `http(s)`
@@ -92,6 +103,7 @@ impl HttpTransport {
     pub fn new(
         endpoint_url: &str,
         net_scope: &kx_warrant::NetScope,
+        tls_required: bool,
     ) -> Result<Self, TransportError> {
         let endpoint = Url::parse(endpoint_url)
             .map_err(|e| TransportError::Unreachable(format!("invalid endpoint URL: {e}")))?;
@@ -122,10 +134,11 @@ impl HttpTransport {
             // Refuse ALL redirects: a 3xx surfaces as an Ok response we reject in
             // `round_trip`, so a cross-host redirect can never smuggle egress.
             .redirects(0)
-            // Safety is the host-allowlist + the vetting resolver, NOT the scheme:
-            // the hermetic test server is plaintext `http://127.0.0.1`. A
-            // TLS-required policy is a forward warrant axis (M5.3+).
-            .https_only(false)
+            // The host-allowlist + vetting resolver bind WHERE we dial; `https_only`
+            // binds the SCHEME. The warrant's `tls_required` axis (D118.5) drives it:
+            // `true` refuses plaintext `http://`; `false` permits the hermetic
+            // loopback `http://127.0.0.1`.
+            .https_only(tls_required)
             // No FIXED agent-wide timeout: a per-call ureq timeout (set in
             // `round_trip`, derived from the warrant budget) is the worker backstop,
             // so a large legitimate budget is never pre-empted by a shared ceiling.
@@ -135,7 +148,17 @@ impl HttpTransport {
             agent,
             endpoint,
             credentials: Vec::new(),
+            secret_store: Arc::new(EnvSecretStore),
         })
+    }
+
+    /// Swap the [`SecretStore`] used to resolve credential secrets (the cloud KMS/HSM
+    /// vault swaps in here behind the same trait, D110.2). Defaults to
+    /// [`EnvSecretStore`].
+    #[must_use]
+    pub fn with_secret_store(mut self, store: Arc<dyn SecretStore>) -> Self {
+        self.secret_store = store;
+        self
     }
 
     /// Register a credential to inject as the `header_name` request header,
@@ -179,7 +202,10 @@ impl McpTransport for HttpTransport {
         let headers: Vec<(String, String)> = self
             .credentials
             .iter()
-            .filter_map(|(name, cred)| cred.read_secret().map(|val| (name.clone(), val)))
+            .filter_map(|(name, cred)| {
+                cred.read_secret(&*self.secret_store)
+                    .map(|val| (name.clone(), val))
+            })
             .collect();
         let idempotency_header = idempotency_key.map(hex32);
 
@@ -344,29 +370,29 @@ mod tests {
 
     #[test]
     fn new_refuses_endpoint_host_outside_allowlist() {
-        let err = HttpTransport::new("https://evil.com/mcp", &scope(&["api.example.com"]))
+        let err = HttpTransport::new("https://evil.com/mcp", &scope(&["api.example.com"]), false)
             .expect_err("host not allowlisted must refuse");
         assert!(matches!(err, TransportError::Unreachable(_)));
     }
 
     #[test]
     fn new_refuses_none_scope() {
-        let err = HttpTransport::new("https://api.example.com/mcp", &NetScope::None)
+        let err = HttpTransport::new("https://api.example.com/mcp", &NetScope::None, false)
             .expect_err("None egress must refuse every host");
         assert!(matches!(err, TransportError::Unreachable(_)));
     }
 
     #[test]
     fn new_refuses_non_http_scheme() {
-        let err = HttpTransport::new("ftp://api.example.com/mcp", &scope(&["api.example.com"]))
+        let err = HttpTransport::new("ftp://api.example.com/mcp", &scope(&["api.example.com"]), false)
             .expect_err("non-http scheme must refuse");
         assert!(matches!(err, TransportError::Unreachable(_)));
     }
 
     #[test]
     fn new_accepts_allowlisted_endpoint() {
-        let t = HttpTransport::new("https://api.example.com/mcp", &scope(&["api.example.com"]))
-            .expect("allowlisted endpoint builds");
+        let t = HttpTransport::new("https://api.example.com/mcp", &scope(&["api.example.com"]), true)
+            .expect("allowlisted endpoint builds (tls_required does not fail at build)");
         let _ = t;
     }
 

--- a/crates/kx-mcp/src/lib.rs
+++ b/crates/kx-mcp/src/lib.rs
@@ -62,6 +62,7 @@ mod egress;
 mod errors;
 mod http_transport;
 mod jsonrpc;
+mod secret_store;
 mod transport;
 
 pub use capability::McpCapability;
@@ -70,4 +71,8 @@ pub use decode::{decode_tool_result, MAX_TOOL_RESULT_BYTES_DEFAULT};
 pub use egress::{classify_ip, vet_resolved_addr, EgressDenied, EgressPolicy, IpClass};
 pub use errors::{DecodeError, TransportError};
 pub use http_transport::HttpTransport;
+pub use secret_store::{EnvSecretStore, SecretStore};
 pub use transport::{McpTransport, StdioTransport};
+// Re-export the warrant's `SecretRef` (the scope identifier) so callers can build
+// a `CredentialRef::from_secret_ref` without a direct `kx-warrant` dependency.
+pub use kx_warrant::SecretRef;

--- a/crates/kx-mcp/src/secret_store.rs
+++ b/crates/kx-mcp/src/secret_store.rs
@@ -1,0 +1,40 @@
+//! [`SecretStore`] — the resolver seam that turns an authorized [`SecretRef`]
+//! into its secret value, transiently, at the transport (D110.2).
+//!
+//! The warrant (`secret_scope`, D110.3) AUTHORIZES which refs may resolve; the
+//! broker precheck (`secret_scope ⊆ warrant`) is the single authorization gate.
+//! This trait is the MECHANISM consumed *after* that gate — it makes no
+//! authorization decision. The returned value is the ONLY place a secret
+//! materializes; the caller injects it into a header / child env and drops it.
+//! It is never stored on any struct, `EffectRequest`, `BrokerHandle`, the
+//! journal, a `MoteId`, a `StepRecord`, or the model's context (D81/D110).
+//!
+//! OSS ships [`EnvSecretStore`] (host-environment passthrough). The hardened
+//! per-tenant KMS/HSM vault (envelope encryption, rotation, mTLS, audit) is a
+//! `kx-cloud/*` impl behind this same trait — the deployment boundary is the
+//! trait seam (D28/D94). OSS makes no "best-cryptography vault" claim.
+
+use kx_warrant::SecretRef;
+
+/// Resolves a [`SecretRef`] to its secret value, transiently, at the transport.
+///
+/// Object-safe (`Send + Sync`) so a `Box<dyn McpTransport>` can hold an
+/// `Arc<dyn SecretStore>`. Implementations MUST be pure-read (no mutation) and
+/// MUST NOT log or persist the value.
+pub trait SecretStore: Send + Sync {
+    /// Resolve `secret_ref` to its value, or `None` if absent (the runtime then
+    /// never fabricates a credential — the server fails its own auth).
+    fn resolve(&self, secret_ref: &SecretRef) -> Option<String>;
+}
+
+/// The OSS simple impl: resolve a [`SecretRef`] as the name of a host
+/// environment variable. `SecretRef("API_KEY")` → `std::env::var("API_KEY")`.
+/// This is the pre-M5.3 `CredentialRef` behavior, now behind the seam.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EnvSecretStore;
+
+impl SecretStore for EnvSecretStore {
+    fn resolve(&self, secret_ref: &SecretRef) -> Option<String> {
+        std::env::var(&secret_ref.0).ok()
+    }
+}

--- a/crates/kx-mcp/src/transport.rs
+++ b/crates/kx-mcp/src/transport.rs
@@ -11,10 +11,12 @@ use std::ffi::OsString;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::credential::CredentialRef;
 use crate::errors::TransportError;
+use crate::secret_store::{EnvSecretStore, SecretStore};
 
 /// Fallback wall-clock budget when the warrant supplies none (`0`): 30 s. Keeps a
 /// hung or chatty server from blocking a dispatch indefinitely while not failing a
@@ -61,12 +63,27 @@ pub trait McpTransport: Send + Sync {
 /// M5.2a is **single-shot**: write one `tools/call` request, read one response.
 /// The `initialize`/`initialized` handshake a stateful MCP server expects is a
 /// documented forward seam (M5.2b); the bundled test server is handshake-free.
-#[derive(Debug, Default)]
 pub struct StdioTransport {
     program: OsString,
     args: Vec<OsString>,
     envs: Vec<(OsString, OsString)>,
     credentials: Vec<CredentialRef>,
+    /// Resolves a `CredentialRef`'s `SecretRef` → value at spawn (D110.2).
+    /// Defaults to [`EnvSecretStore`]; swap a cloud vault via
+    /// [`StdioTransport::with_secret_store`].
+    secret_store: Arc<dyn SecretStore>,
+}
+
+impl std::fmt::Debug for StdioTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Elide the secret store (not `Debug`-meaningful); credential identities
+        // are already redaction-safe.
+        f.debug_struct("StdioTransport")
+            .field("program", &self.program)
+            .field("args", &self.args)
+            .field("credentials", &self.credentials)
+            .finish_non_exhaustive()
+    }
 }
 
 impl StdioTransport {
@@ -78,7 +95,16 @@ impl StdioTransport {
             args: Vec::new(),
             envs: Vec::new(),
             credentials: Vec::new(),
+            secret_store: Arc::new(EnvSecretStore),
         }
+    }
+
+    /// Swap the [`SecretStore`] used to resolve credential secrets (D110.2).
+    /// Defaults to [`EnvSecretStore`].
+    #[must_use]
+    pub fn with_secret_store(mut self, store: Arc<dyn SecretStore>) -> Self {
+        self.secret_store = store;
+        self
     }
 
     /// Append a command-line argument for the server subprocess.
@@ -125,10 +151,10 @@ impl McpTransport for StdioTransport {
         for (key, value) in &self.envs {
             cmd.env(key, value);
         }
-        // Out-of-band secret injection (D81): read from the host env into the child
-        // env; the secret never transits an EffectRequest / handle / journal.
+        // Out-of-band secret injection (D81): resolve through the SecretStore into
+        // the child env; the secret never transits an EffectRequest / handle / journal.
         for credential in &self.credentials {
-            credential.inject_into(&mut cmd);
+            credential.inject_into(&*self.secret_store, &mut cmd);
         }
 
         let mut child = cmd

--- a/crates/kx-mcp/src/transport.rs
+++ b/crates/kx-mcp/src/transport.rs
@@ -14,6 +14,8 @@ use std::sync::mpsc::{self, RecvTimeoutError};
 use std::sync::Arc;
 use std::time::Duration;
 
+use kx_warrant::SecretScope;
+
 use crate::credential::CredentialRef;
 use crate::errors::TransportError;
 use crate::secret_store::{EnvSecretStore, SecretStore};
@@ -55,6 +57,29 @@ pub trait McpTransport: Send + Sync {
         wall_clock_ms: u64,
         idempotency_key: Option<&[u8; 32]>,
     ) -> Result<Vec<u8>, TransportError>;
+
+    /// The [`SecretScope`] this transport will actually resolve at dispatch — the
+    /// union of its configured credentials' [`SecretRef`](kx_warrant::SecretRef)s
+    /// (D110.3). [`crate::McpCapability`] surfaces this as its
+    /// `required_secret_scope`, which the broker gates `⊆ warrant.secret_scope`.
+    /// Default: [`SecretScope::None`] (no credentials configured).
+    fn declared_secret_scope(&self) -> SecretScope {
+        SecretScope::None
+    }
+}
+
+/// Build a [`SecretScope`] from an iterator of credential refs: `None` when empty,
+/// else an `AllowList` of their [`SecretRef`](kx_warrant::SecretRef)s.
+pub(crate) fn scope_of_credentials<'a>(
+    creds: impl Iterator<Item = &'a CredentialRef>,
+) -> SecretScope {
+    let set: std::collections::BTreeSet<kx_warrant::SecretRef> =
+        creds.map(|c| c.secret_ref().clone()).collect();
+    if set.is_empty() {
+        SecretScope::None
+    } else {
+        SecretScope::AllowList(set)
+    }
 }
 
 /// A subprocess MCP transport: newline-delimited JSON-RPC over the child's
@@ -132,6 +157,10 @@ impl StdioTransport {
 }
 
 impl McpTransport for StdioTransport {
+    fn declared_secret_scope(&self) -> SecretScope {
+        scope_of_credentials(self.credentials.iter())
+    }
+
     fn round_trip(
         &self,
         request: &[u8],

--- a/crates/kx-mcp/tests/common/mod.rs
+++ b/crates/kx-mcp/tests/common/mod.rs
@@ -348,7 +348,7 @@ pub fn http_capability(
     version: ToolVersion,
     server: &MockHttpServer,
 ) -> McpCapability {
-    let transport = HttpTransport::new(&server.url(), &server.net_scope())
+    let transport = HttpTransport::new(&server.url(), &server.net_scope(), false)
         .expect("http transport builds for the loopback mock");
     McpCapability::new(
         name,

--- a/crates/kx-mcp/tests/http_chaos.rs
+++ b/crates/kx-mcp/tests/http_chaos.rs
@@ -27,7 +27,7 @@ fn broker_with(
 ) -> LocalCapabilityBroker<Arc<InMemoryContentStore>> {
     let store = Arc::new(InMemoryContentStore::new());
     let broker = LocalCapabilityBroker::new(store);
-    let transport = HttpTransport::new(&server.url(), &server.net_scope()).unwrap();
+    let transport = HttpTransport::new(&server.url(), &server.net_scope(), false).unwrap();
     let cap = McpCapability::new(
         name.clone(),
         version.clone(),

--- a/crates/kx-mcp/tests/http_secret_sweep.rs
+++ b/crates/kx-mcp/tests/http_secret_sweep.rs
@@ -59,7 +59,8 @@ fn http_secret_reaches_no_runtime_sink() {
     let mote = sample_mote(&name, &version);
     // The role grants the secret the header credential needs (D110.3).
     let mut warrant = warrant_granting_egress(&name, &version);
-    warrant.secret_scope = SecretScope::AllowList(BTreeSet::from([SecretRef(CRED_VAR.to_string())]));
+    warrant.secret_scope =
+        SecretScope::AllowList(BTreeSet::from([SecretRef(CRED_VAR.to_string())]));
     let req = effect_egress(r#"{"q":"hello"}"#);
     assert!(
         !contains(&req.payload, SECRET.as_bytes()),

--- a/crates/kx-mcp/tests/http_secret_sweep.rs
+++ b/crates/kx-mcp/tests/http_secret_sweep.rs
@@ -40,7 +40,7 @@ fn http_secret_reaches_no_runtime_sink() {
     let store = Arc::new(InMemoryContentStore::new());
     let broker = LocalCapabilityBroker::new(store.clone());
 
-    let transport = HttpTransport::new(&server.url(), &server.net_scope())
+    let transport = HttpTransport::new(&server.url(), &server.net_scope(), false)
         .unwrap()
         .header_credential("Authorization", CredentialRef::from_env_var(CRED_VAR));
     let cap = McpCapability::new(

--- a/crates/kx-mcp/tests/http_secret_sweep.rs
+++ b/crates/kx-mcp/tests/http_secret_sweep.rs
@@ -9,13 +9,15 @@
 
 mod common;
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use common::{effect_egress, sample_mote, tool, warrant_granting_egress, HttpMode, MockHttpServer};
 use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
 use kx_content::{ContentStore, InMemoryContentStore};
-use kx_mcp::{CredentialRef, HttpTransport, McpCapability};
+use kx_mcp::{CredentialRef, HttpTransport, McpCapability, SecretRef};
 use kx_tool_registry::McpEndpointId;
+use kx_warrant::SecretScope;
 
 const SECRET: &str = "SUPER_SECRET_sk-HTTP-DEADBEEF-do-not-leak-0123456789";
 const CRED_VAR: &str = "KX_MCP_TEST_CRED_HTTP_SECRETS_LEAK";
@@ -55,7 +57,9 @@ fn http_secret_reaches_no_runtime_sink() {
     broker.register_capability(Box::new(cap));
 
     let mote = sample_mote(&name, &version);
-    let warrant = warrant_granting_egress(&name, &version);
+    // The role grants the secret the header credential needs (D110.3).
+    let mut warrant = warrant_granting_egress(&name, &version);
+    warrant.secret_scope = SecretScope::AllowList(BTreeSet::from([SecretRef(CRED_VAR.to_string())]));
     let req = effect_egress(r#"{"q":"hello"}"#);
     assert!(
         !contains(&req.payload, SECRET.as_bytes()),

--- a/crates/kx-mcp/tests/http_security.rs
+++ b/crates/kx-mcp/tests/http_security.rs
@@ -39,7 +39,7 @@ fn allowlisted_name_resolving_to_loopback_is_refused() {
     let store = Arc::new(InMemoryContentStore::new());
     let broker = LocalCapabilityBroker::new(store);
     let endpoint = format!("http://localhost:{}/mcp", server.addr.port());
-    let transport = HttpTransport::new(&endpoint, &localhost_scope)
+    let transport = HttpTransport::new(&endpoint, &localhost_scope, false)
         .expect("transport builds (localhost is allowlisted by name)");
     broker.register_capability(Box::new(McpCapability::new(
         name.clone(),

--- a/crates/kx-mcp/tests/secrets_never_leak.rs
+++ b/crates/kx-mcp/tests/secrets_never_leak.rs
@@ -7,13 +7,15 @@
 
 mod common;
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use common::{effect, sample_mote, tool, warrant_granting, MOCK_SERVER};
-use kx_capability::{CapabilityBroker, LocalCapabilityBroker};
+use kx_capability::{BrokerError, CapabilityBroker, LocalCapabilityBroker};
 use kx_content::{ContentStore, InMemoryContentStore};
-use kx_mcp::{CredentialRef, McpCapability, StdioTransport};
+use kx_mcp::{CredentialRef, McpCapability, SecretRef, StdioTransport};
 use kx_tool_registry::McpEndpointId;
+use kx_warrant::{SecretScope, WarrantField};
 
 /// Distinctive secret value that must never appear in any runtime sink.
 const SECRET: &str = "SUPER_SECRET_sk-DEADBEEF-do-not-leak-0123456789";
@@ -22,6 +24,11 @@ const CRED_VAR: &str = "KX_MCP_TEST_CRED_SECRETS_LEAK";
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// A `secret_scope` granting exactly the test credential (D110.3).
+fn grants_secret() -> SecretScope {
+    SecretScope::AllowList(BTreeSet::from([SecretRef(CRED_VAR.to_string())]))
 }
 
 #[test]
@@ -56,7 +63,10 @@ fn secret_reaches_no_runtime_sink() {
     broker.register_capability(Box::new(cap));
 
     let mote = sample_mote(&name, &version);
-    let warrant = warrant_granting(&name, &version);
+    // The role grants the secret the capability needs (D110.3); without this the
+    // broker would refuse the dispatch (see the gate test below).
+    let mut warrant = warrant_granting(&name, &version);
+    warrant.secret_scope = grants_secret();
     let req = effect(r#"{"q":"hi"}"#);
     let payload = req.payload.clone();
 
@@ -86,4 +96,42 @@ fn secret_reaches_no_runtime_sink() {
     );
 
     std::env::remove_var(CRED_VAR);
+}
+
+/// D110.3 — data minimization: a role that does NOT grant the capability's
+/// secret is refused at dispatch (the capability declares `required_secret_scope`
+/// = its configured credential; the broker gates it `⊆ warrant.secret_scope`).
+/// The secret is never resolved, and the model never sees it.
+#[test]
+fn dispatch_refused_when_warrant_does_not_grant_the_secret() {
+    let (name, version) = tool();
+    let transport = Box::new(
+        StdioTransport::new(MOCK_SERVER).credential(CredentialRef::from_env_var(CRED_VAR)),
+    );
+    let cap = McpCapability::new(
+        name.clone(),
+        version.clone(),
+        McpEndpointId("stdio://mock".into()),
+        "echo",
+        transport,
+    );
+
+    let store = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(store);
+    broker.register_capability(Box::new(cap));
+
+    let mote = sample_mote(&name, &version);
+    // The role grants the tool but NOT the secret (`secret_scope: None`).
+    let warrant = warrant_granting(&name, &version);
+    assert_eq!(warrant.secret_scope, SecretScope::None);
+
+    let err = broker
+        .dispatch(&mote, &warrant, &name, effect(r#"{"q":"hi"}"#))
+        .expect_err("a role that does not grant the secret must be refused");
+    assert!(matches!(
+        err,
+        BrokerError::CapabilityExceedsWarrant {
+            axis: WarrantField::SecretScope
+        }
+    ));
 }

--- a/crates/kx-model-harness/src/broker.rs
+++ b/crates/kx-model-harness/src/broker.rs
@@ -222,18 +222,32 @@ where
                     // byte-identical to M5.2a); an HTTP tool declares its host
                     // allowlist. A tool that does not resolve is refused fail-closed
                     // (no effect fires).
-                    let net_scope = match self.registry.lookup(&call.name, &call.version) {
-                        Some(def) => def.required_capability.net_scope_required,
-                        None => {
+                    let Some(def) = self.registry.lookup(&call.name, &call.version) else {
+                        return Err(BrokerError::StageWriteFailed {
+                            capability: capability.clone(),
+                            diagnostic: format!(
+                                "tool {:?}@{:?} not resolvable for egress derivation",
+                                call.name, call.version
+                            ),
+                        });
+                    };
+                    // M5.3 (D110.4) — validate the model's proposed args against the
+                    // tool's declared typed `inputSchema`, FAIL-CLOSED, BEFORE any
+                    // effect fires. A tool with no schema (`None`) is dispatched as
+                    // before (byte-identical). The model proposes; the runtime enforces.
+                    if let Some(schema) = &def.input_schema {
+                        if let Err(reason) =
+                            kx_tool_registry::validate_args(schema, &call.args_bytes)
+                        {
                             return Err(BrokerError::StageWriteFailed {
                                 capability: capability.clone(),
                                 diagnostic: format!(
-                                    "tool {:?}@{:?} not resolvable for egress derivation",
-                                    call.name, call.version
+                                    "model-proposed args failed inputSchema: {reason:?}"
                                 ),
                             });
                         }
-                    };
+                    }
+                    let net_scope = def.required_capability.net_scope_required;
                     let effect = EffectRequest {
                         payload: call.args_bytes,
                         // MCP effects are world-mutating by default → StageThenCommit (D66).

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -263,6 +263,7 @@ fn drive(
     let transport = HttpTransport::new(
         &server.url(),
         &NetScope::EgressAllowlist([Host("127.0.0.1".to_string())].into_iter().collect()),
+        false,
     )
     .expect("http transport builds for loopback");
     tool_broker_concrete.register_capability(Box::new(McpCapability::new(

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -199,6 +199,7 @@ fn registry_with_http_tool(
             },
             description: "HTTP MCP echo tool (M5.2b e2e).".into(),
             idempotency_class: IdempotencyClass::Staged,
+            input_schema: None,
         },
         ToolProvenance::HumanAuthored {
             author: "test".into(),

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -62,6 +62,7 @@ fn registry_with_mcp(tool: &ToolName, version: &ToolVersion) -> InMemoryToolRegi
             },
             description: "MCP echo tool (M5.2 test).".into(),
             idempotency_class: IdempotencyClass::Staged,
+            input_schema: None,
         },
         ToolProvenance::HumanAuthored {
             author: "test".into(),

--- a/crates/kx-tool-registry/Cargo.toml
+++ b/crates/kx-tool-registry/Cargo.toml
@@ -18,6 +18,7 @@ kx-warrant = { workspace = true }
 bincode    = { workspace = true }
 blake3     = { workspace = true }
 serde      = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror  = { workspace = true }
 tracing    = { workspace = true }
 

--- a/crates/kx-tool-registry/src/lib.rs
+++ b/crates/kx-tool-registry/src/lib.rs
@@ -92,6 +92,7 @@
 mod errors;
 mod idempotency_class;
 mod ids;
+mod param_schema;
 mod provenance;
 mod registry;
 mod token;
@@ -101,6 +102,7 @@ mod tool_kind;
 pub use errors::{RegistrationError, ResolutionError};
 pub use idempotency_class::IdempotencyClass;
 pub use ids::{McpEndpointId, RegistrationToken, ReviewerId};
+pub use param_schema::{validate_args, InputSchema, ParamSpec, ParamType, SchemaError};
 pub use provenance::{RegistrationStatus, ToolProvenance};
 pub use registry::{resolve_run_versions, InMemoryToolRegistry, ToolRegistry};
 pub use token::registration_token_of;

--- a/crates/kx-tool-registry/src/param_schema.rs
+++ b/crates/kx-tool-registry/src/param_schema.rs
@@ -1,0 +1,333 @@
+//! [`InputSchema`] — a tool's declared, typed parameter contract, and
+//! [`validate_args`], the fail-closed validator for a model's proposed tool-call
+//! arguments (D110.4; meets D83's `free_param_schema`).
+//!
+//! Adopts the MCP `inputSchema` idea but as a **closed, integer-/bytes-typed**
+//! schema — there is **no `Float` variant**, so no float ever reaches the action
+//! path (SN-8). A model-proposed argument bag is untrusted JSON; it is validated
+//! against the tool's declared schema **before** dispatch, mirroring the
+//! fail-closed, total, panic-free decode discipline of `kx_planner::decode` and
+//! `kx_mcp::decode` (size-cap is already applied upstream by
+//! `kx_model_harness::toolcall::parse_tool_call`, IMP-16). A tool with no schema
+//! (`input_schema: None`) is dispatched exactly as before (no validation).
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+/// A tool parameter's declared type. A CLOSED set with **no float** (SN-8 / D83):
+/// integers are exact, bytes/strings are length-bounded, enums are exact-match.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum ParamType {
+    /// A signed 64-bit integer, with optional inclusive `[min, max]` bounds.
+    /// Decoding rejects any non-integer JSON token (a float like `1.5` fails).
+    Int {
+        /// Inclusive lower bound, if any.
+        min: Option<i64>,
+        /// Inclusive upper bound, if any.
+        max: Option<i64>,
+    },
+    /// A JSON string treated as opaque bytes, bounded to `max_len` UTF-8 bytes.
+    Bytes {
+        /// Maximum length in bytes.
+        max_len: usize,
+    },
+    /// A UTF-8 string, bounded to `max_len` bytes.
+    Str {
+        /// Maximum length in bytes.
+        max_len: usize,
+    },
+    /// A boolean.
+    Bool,
+    /// An exact-match against a fixed set of allowed string values.
+    Enum {
+        /// The permitted values (exact equality; no fuzzy match, SN-8).
+        allowed: BTreeSet<String>,
+    },
+}
+
+/// A single declared parameter: its name, type, and whether it is required.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParamSpec {
+    /// The argument key the model must use.
+    pub name: String,
+    /// The declared type the argument's value must satisfy.
+    pub ty: ParamType,
+    /// Whether the argument must be present.
+    pub required: bool,
+}
+
+/// A tool's declared typed parameter schema (the MCP `inputSchema` analogue).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InputSchema {
+    /// The declared parameters (canonical order — part of the tool's identity).
+    pub params: Vec<ParamSpec>,
+    /// If `true`, an argument key not in `params` is refused (fail-closed against
+    /// smuggled fields). If `false`, unknown keys are ignored.
+    pub deny_unknown: bool,
+}
+
+/// Why a model-proposed argument bag failed [`validate_args`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaError {
+    /// The args were not a JSON object.
+    NotAnObject,
+    /// A required parameter was absent.
+    MissingRequired {
+        /// The missing parameter's name.
+        name: String,
+    },
+    /// An argument key is not a declared parameter and `deny_unknown` is set.
+    UnknownParam {
+        /// The offending key.
+        name: String,
+    },
+    /// A parameter's value did not match its declared type.
+    TypeMismatch {
+        /// The parameter's name.
+        name: String,
+        /// The declared type, for diagnostics.
+        expected: &'static str,
+    },
+    /// An integer parameter's value was outside its declared `[min, max]`.
+    OutOfRange {
+        /// The parameter's name.
+        name: String,
+    },
+    /// A bytes/string parameter exceeded its declared `max_len`.
+    TooLong {
+        /// The parameter's name.
+        name: String,
+        /// The declared maximum.
+        max: usize,
+    },
+    /// An enum parameter's value was not in the allowed set.
+    NotAllowed {
+        /// The parameter's name.
+        name: String,
+    },
+    /// The args bytes were not well-formed JSON.
+    Malformed {
+        /// A short, non-secret diagnostic.
+        diagnostic: String,
+    },
+}
+
+/// Validate a model's proposed tool-call `args_bytes` against `schema`,
+/// **fail-closed**. Total + panic-free over arbitrary bytes: the args are parsed
+/// as a SHALLOW one-level map of raw values (never a recursive dynamic `Value`,
+/// so no float / NaN / unbounded-recursion ever reaches the action path), then
+/// each declared parameter is checked by deserializing its raw value into the
+/// EXACT Rust type for its [`ParamType`].
+///
+/// # Errors
+///
+/// [`SchemaError`] on any structural or type mismatch — the dispatch is then
+/// refused before any effect fires.
+pub fn validate_args(schema: &InputSchema, args_bytes: &[u8]) -> Result<(), SchemaError> {
+    // Empty args == `{}` (the no-arguments case), mirroring the MCP capability.
+    let map: BTreeMap<String, &RawValue> = if args_bytes.is_empty() {
+        BTreeMap::new()
+    } else {
+        serde_json::from_slice(args_bytes).map_err(|e| {
+            // A non-object (array, scalar) or malformed body: classify NotAnObject
+            // for the common "not an object" case, else Malformed.
+            if e.is_data() {
+                SchemaError::NotAnObject
+            } else {
+                SchemaError::Malformed {
+                    diagnostic: e.to_string(),
+                }
+            }
+        })?
+    };
+
+    if schema.deny_unknown {
+        let declared: BTreeSet<&str> = schema.params.iter().map(|p| p.name.as_str()).collect();
+        for key in map.keys() {
+            if !declared.contains(key.as_str()) {
+                return Err(SchemaError::UnknownParam { name: key.clone() });
+            }
+        }
+    }
+
+    for spec in &schema.params {
+        match map.get(&spec.name) {
+            None => {
+                if spec.required {
+                    return Err(SchemaError::MissingRequired {
+                        name: spec.name.clone(),
+                    });
+                }
+            }
+            Some(raw) => check_value(&spec.name, &spec.ty, raw)?,
+        }
+    }
+    Ok(())
+}
+
+/// Check one raw JSON value against a declared [`ParamType`] by deserializing into
+/// the exact Rust type — never `serde_json::Value` (no float/recursion path).
+fn check_value(name: &str, ty: &ParamType, raw: &RawValue) -> Result<(), SchemaError> {
+    let s = raw.get();
+    match ty {
+        ParamType::Int { min, max } => {
+            // `i64` deserialize rejects float tokens (`1.5`), strings, etc.
+            let v: i64 = serde_json::from_str(s).map_err(|_| SchemaError::TypeMismatch {
+                name: name.to_string(),
+                expected: "integer",
+            })?;
+            if min.is_some_and(|lo| v < lo) || max.is_some_and(|hi| v > hi) {
+                return Err(SchemaError::OutOfRange {
+                    name: name.to_string(),
+                });
+            }
+            Ok(())
+        }
+        ParamType::Bytes { max_len } | ParamType::Str { max_len } => {
+            let v: String = serde_json::from_str(s).map_err(|_| SchemaError::TypeMismatch {
+                name: name.to_string(),
+                expected: "string",
+            })?;
+            if v.len() > *max_len {
+                return Err(SchemaError::TooLong {
+                    name: name.to_string(),
+                    max: *max_len,
+                });
+            }
+            Ok(())
+        }
+        ParamType::Bool => {
+            let _: bool = serde_json::from_str(s).map_err(|_| SchemaError::TypeMismatch {
+                name: name.to_string(),
+                expected: "bool",
+            })?;
+            Ok(())
+        }
+        ParamType::Enum { allowed } => {
+            let v: String = serde_json::from_str(s).map_err(|_| SchemaError::TypeMismatch {
+                name: name.to_string(),
+                expected: "string",
+            })?;
+            if allowed.contains(&v) {
+                Ok(())
+            } else {
+                Err(SchemaError::NotAllowed {
+                    name: name.to_string(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> InputSchema {
+        InputSchema {
+            params: vec![
+                ParamSpec {
+                    name: "count".into(),
+                    ty: ParamType::Int {
+                        min: Some(0),
+                        max: Some(100),
+                    },
+                    required: true,
+                },
+                ParamSpec {
+                    name: "label".into(),
+                    ty: ParamType::Str { max_len: 8 },
+                    required: false,
+                },
+                ParamSpec {
+                    name: "mode".into(),
+                    ty: ParamType::Enum {
+                        allowed: BTreeSet::from(["fast".to_string(), "slow".to_string()]),
+                    },
+                    required: false,
+                },
+            ],
+            deny_unknown: true,
+        }
+    }
+
+    #[test]
+    fn accepts_valid_args() {
+        assert!(validate_args(&schema(), br#"{"count":5,"label":"hi","mode":"fast"}"#).is_ok());
+    }
+
+    #[test]
+    fn required_missing_is_refused() {
+        assert_eq!(
+            validate_args(&schema(), br#"{"label":"hi"}"#),
+            Err(SchemaError::MissingRequired {
+                name: "count".into()
+            })
+        );
+    }
+
+    #[test]
+    fn float_for_int_is_refused() {
+        assert_eq!(
+            validate_args(&schema(), br#"{"count":1.5}"#),
+            Err(SchemaError::TypeMismatch {
+                name: "count".into(),
+                expected: "integer"
+            })
+        );
+    }
+
+    #[test]
+    fn out_of_range_int_is_refused() {
+        assert!(matches!(
+            validate_args(&schema(), br#"{"count":999}"#),
+            Err(SchemaError::OutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn over_long_string_is_refused() {
+        assert!(matches!(
+            validate_args(&schema(), br#"{"count":1,"label":"way-too-long"}"#),
+            Err(SchemaError::TooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_key_is_refused_when_deny_unknown() {
+        assert!(matches!(
+            validate_args(&schema(), br#"{"count":1,"smuggled":7}"#),
+            Err(SchemaError::UnknownParam { .. })
+        ));
+    }
+
+    #[test]
+    fn enum_outside_set_is_refused() {
+        assert!(matches!(
+            validate_args(&schema(), br#"{"count":1,"mode":"turbo"}"#),
+            Err(SchemaError::NotAllowed { .. })
+        ));
+    }
+
+    #[test]
+    fn non_object_is_refused() {
+        assert_eq!(
+            validate_args(&schema(), b"[1,2,3]"),
+            Err(SchemaError::NotAnObject)
+        );
+    }
+
+    #[test]
+    fn empty_args_with_required_is_refused() {
+        assert!(matches!(
+            validate_args(&schema(), b""),
+            Err(SchemaError::MissingRequired { .. })
+        ));
+    }
+}

--- a/crates/kx-tool-registry/src/registry.rs
+++ b/crates/kx-tool-registry/src/registry.rs
@@ -167,6 +167,7 @@ pub trait ToolRegistry: Send + Sync {
     ///     },
     ///     description: String::new(),
     ///     idempotency_class: IdempotencyClass::Token,
+    ///     input_schema: None,
     /// };
     /// let token = reg.register(
     ///     def.clone(),
@@ -263,6 +264,7 @@ struct RegistrationRecord {
 ///     },
 ///     description: "Read files from /input".into(),
 ///     idempotency_class: IdempotencyClass::Readback,
+///     input_schema: None,
 /// };
 ///
 /// let token = reg.register(
@@ -323,6 +325,7 @@ impl InMemoryToolRegistry {
                 },
                 description: "Read bytes from a path declared in the warrant's fs_scope. Read-only; naturally idempotent.".into(),
                 idempotency_class: IdempotencyClass::Readback,
+                input_schema: None,
             },
             ToolProvenance::HumanAuthored {
                 author: author.clone(),
@@ -364,6 +367,7 @@ impl InMemoryToolRegistry {
                 },
                 description: "Write the complete intended file content to a path declared in the warrant's fs_scope (overwrite-only; no append; staged-intent dispatch).".into(),
                 idempotency_class: IdempotencyClass::Staged,
+                input_schema: None,
             },
             ToolProvenance::HumanAuthored {
                 author: author.clone(),
@@ -390,6 +394,7 @@ impl InMemoryToolRegistry {
                 },
                 description: "Deterministic text summarization heuristic. Pure transformation; naturally idempotent.".into(),
                 idempotency_class: IdempotencyClass::Readback,
+                input_schema: None,
             },
             ToolProvenance::HumanAuthored { author },
         );

--- a/crates/kx-tool-registry/src/tests.rs
+++ b/crates/kx-tool-registry/src/tests.rs
@@ -58,6 +58,7 @@ fn sample_def(id: &str, version: &str, kind: ToolKind, req: ToolRequirement) -> 
         required_capability: req,
         description: format!("test tool {id}@{version}"),
         idempotency_class: IdempotencyClass::Token,
+        input_schema: None,
     }
 }
 

--- a/crates/kx-tool-registry/src/token.rs
+++ b/crates/kx-tool-registry/src/token.rs
@@ -44,6 +44,7 @@ use crate::tool_def::ToolDef;
 ///     },
 ///     description: String::new(),
 ///     idempotency_class: IdempotencyClass::Token,
+///     input_schema: None,
 /// };
 /// let prov = ToolProvenance::HumanAuthored { author: "ops".into() };
 ///

--- a/crates/kx-tool-registry/src/tool_def.rs
+++ b/crates/kx-tool-registry/src/tool_def.rs
@@ -56,6 +56,14 @@ pub struct ToolDef {
     /// Per-tool declared idempotency mechanism (D38 §2). Required field;
     /// no default. See [`IdempotencyClass`] for variant semantics.
     pub idempotency_class: IdempotencyClass,
+    /// Optional typed parameter schema (the MCP `inputSchema` analogue, D110.4).
+    /// When `Some`, the runtime validates a model's proposed tool-call args against
+    /// it **fail-closed** before dispatch ([`crate::validate_args`]); `None`
+    /// preserves the pre-M5.3 unvalidated behavior. Like any `ToolDef` field it
+    /// participates in `resolved_def_hash` — a tool that gains a schema is a new
+    /// tool version (the canonical-bytes shift is the intended content-addressing
+    /// behavior, bounded to in-test fixtures + built-ins; the PR-4.6/D38 precedent).
+    pub input_schema: Option<crate::InputSchema>,
 }
 
 /// The content-addressed fact that "tool X version Y was resolved as kind Z

--- a/crates/kx-tool-registry/tests/concurrency.rs
+++ b/crates/kx-tool-registry/tests/concurrency.rs
@@ -119,6 +119,7 @@ fn resolve_is_thread_independent() {
         },
         description: "thread test".into(),
         idempotency_class: IdempotencyClass::Token,
+        input_schema: None,
     };
     let _ = reg
         .register(
@@ -184,6 +185,7 @@ fn registration_token_of_is_thread_independent() {
         },
         description: "test".into(),
         idempotency_class: IdempotencyClass::Token,
+        input_schema: None,
     };
     let prov = ToolProvenance::SelfGenerated {
         generating_lineage_warrant: permissive_warrant(),

--- a/crates/kx-tool-registry/tests/proptest_registry.rs
+++ b/crates/kx-tool-registry/tests/proptest_registry.rs
@@ -162,6 +162,7 @@ prop_compose! {
             required_capability: req,
             description: "arb tool".into(),
             idempotency_class,
+            input_schema: None,
         }
     }
 }
@@ -255,6 +256,7 @@ proptest! {
             required_capability: permissive_req(),
             description: "needs lots of memory".into(),
             idempotency_class: IdempotencyClass::Token,
+            input_schema: None,
         };
         def.required_capability.min_resource_ceiling.mem_bytes = mem_req;
         let mut reg = InMemoryToolRegistry::new();
@@ -307,6 +309,7 @@ proptest! {
             required_capability: permissive_req(),
             description: "subset-check parity".into(),
             idempotency_class: IdempotencyClass::Token,
+            input_schema: None,
         };
         def.required_capability.min_resource_ceiling.mem_bytes = mem_req;
         let warrant = permissive_warrant();
@@ -358,6 +361,7 @@ fn self_gen_lifecycle_smoke() {
         required_capability: permissive_req(),
         description: "self-emitted".into(),
         idempotency_class: IdempotencyClass::Token,
+        input_schema: None,
     };
     let token = reg
         .register(

--- a/crates/kx-tool-registry/tests/validate_args_proptest.rs
+++ b/crates/kx-tool-registry/tests/validate_args_proptest.rs
@@ -1,0 +1,108 @@
+//! D110.4 / IMP-5 — `validate_args` is TOTAL + panic-free over arbitrary bytes
+//! and never ACCEPTS a value that violates the declared typed schema (no float
+//! reaches an `Int` param, no over-long string, no smuggled key under
+//! `deny_unknown`). Mirrors the fail-closed decode proptests of `kx-planner`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeSet;
+
+use kx_tool_registry::{validate_args, InputSchema, ParamSpec, ParamType};
+use proptest::prelude::*;
+
+fn arb_param_type() -> impl Strategy<Value = ParamType> {
+    prop_oneof![
+        (
+            proptest::option::of(any::<i64>()),
+            proptest::option::of(any::<i64>())
+        )
+            .prop_map(|(min, max)| ParamType::Int { min, max }),
+        (0usize..32).prop_map(|max_len| ParamType::Bytes { max_len }),
+        (0usize..32).prop_map(|max_len| ParamType::Str { max_len }),
+        Just(ParamType::Bool),
+        proptest::collection::btree_set("[a-z]{1,5}", 1..4)
+            .prop_map(|allowed| ParamType::Enum { allowed }),
+    ]
+}
+
+fn arb_schema() -> impl Strategy<Value = InputSchema> {
+    (
+        proptest::collection::vec(
+            ("[a-z]{1,6}", arb_param_type(), any::<bool>())
+                .prop_map(|(name, ty, required)| ParamSpec { name, ty, required }),
+            0..5,
+        ),
+        any::<bool>(),
+    )
+        .prop_map(|(params, deny_unknown)| InputSchema {
+            params,
+            deny_unknown,
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// TOTAL: never panics on arbitrary bytes against an arbitrary schema.
+    #[test]
+    fn prop_validate_args_is_total(schema in arb_schema(), bytes in proptest::collection::vec(any::<u8>(), 0..256)) {
+        let _ = validate_args(&schema, &bytes); // reaching here proves no panic
+    }
+
+    /// TOTAL over arbitrary UTF-8 JSON-ish strings too (denser coverage of the
+    /// parse path than raw bytes, which are mostly invalid JSON).
+    #[test]
+    fn prop_validate_args_is_total_over_json_ish(schema in arb_schema(), s in "\\{.*\\}") {
+        let _ = validate_args(&schema, s.as_bytes());
+    }
+
+    /// A required `Int` param NEVER accepts a NON-INTEGER JSON number (no float on
+    /// the action path, SN-8). Built as `<int>.5` so the JSON token always has a
+    /// fractional part — an `i64` deserialize must reject it.
+    #[test]
+    fn prop_int_never_accepts_float(base in any::<i32>()) {
+        let schema = InputSchema {
+            params: vec![ParamSpec {
+                name: "n".into(),
+                ty: ParamType::Int { min: None, max: None },
+                required: true,
+            }],
+            deny_unknown: true,
+        };
+        let args = format!("{{\"n\":{base}.5}}");
+        prop_assert!(validate_args(&schema, args.as_bytes()).is_err());
+    }
+}
+
+/// An unknown key under `deny_unknown` is refused; under `!deny_unknown` ignored.
+#[test]
+fn unknown_key_policy() {
+    let mk = |deny_unknown| InputSchema {
+        params: vec![ParamSpec {
+            name: "a".into(),
+            ty: ParamType::Bool,
+            required: false,
+        }],
+        deny_unknown,
+    };
+    assert!(validate_args(&mk(true), br#"{"a":true,"x":1}"#).is_err());
+    assert!(validate_args(&mk(false), br#"{"a":true,"x":1}"#).is_ok());
+}
+
+/// An enum value outside the allowed set is refused (exact match, no fuzzy, SN-8).
+#[test]
+fn enum_exact_match_only() {
+    let schema = InputSchema {
+        params: vec![ParamSpec {
+            name: "mode".into(),
+            ty: ParamType::Enum {
+                allowed: BTreeSet::from(["fast".to_string()]),
+            },
+            required: true,
+        }],
+        deny_unknown: true,
+    };
+    assert!(validate_args(&schema, br#"{"mode":"fast"}"#).is_ok());
+    assert!(validate_args(&schema, br#"{"mode":"Fast"}"#).is_err()); // near-miss refused
+    assert!(validate_args(&schema, br#"{"mode":"slow"}"#).is_err());
+}


### PR DESCRIPTION
## M5.3b — the secure-integration consumer layer (rides M5.3a #114)

Completes **M5.3**. Three commits, each green.

### B1 — SecretStore seam + transport wiring + TLS axis (D110.2/D118.5)
- NEW `kx-mcp/src/secret_store.rs`: object-safe `SecretStore` trait (resolves a `SecretRef` → value, transiently, never stored/journaled/in-context) + `EnvSecretStore` OSS impl (host-env passthrough). The cloud KMS/HSM vault swaps in behind the same trait (D94).
- `CredentialRef` re-expressed over `kx_warrant::SecretRef`; resolves through a `SecretStore`. Both transports hold an `Arc<dyn SecretStore>` (default `EnvSecretStore`, swappable).
- `HttpTransport::new` gains `tls_required` → `https_only(tls_required)`, closing the **D118.5** plaintext-credential gap (a TLS-required transport refuses `http://`).
- **D110.2 resolved:** SecretStore is a broker-consumed resolver (mechanism), NOT a 7th seam — the broker stays the single authorization gate.

### B2 — secret_scope gating (D110.3)
- `Capability` gains a defaulted `required_secret_scope()`; `McpCapability` returns its transport's configured-credential `SecretRef`s (new defaulted `McpTransport::declared_secret_scope`). The broker precheck refuses a dispatch whose capability needs a secret the role's `warrant.secret_scope` doesn't grant — **data-minimization enforced by the runtime**, and the model never sees an ungranted secret.

### B3 — MCP inputSchema typed validation (D110.4)
- NEW `kx-tool-registry/src/param_schema.rs`: a CLOSED, integer-/bytes-typed `ParamType` (Int/Bytes/Str/Bool/Enum — **no Float**, SN-8) + `validate_args`, total + panic-free over arbitrary bytes (shallow `RawValue` map, no recursive `Value`). Hand-rolled, **not** the `jsonschema` crate (Rule 6 + the M5.2a precedent).
- `ToolDef` gains `input_schema: Option<InputSchema>`; the harness broker validates a model's proposed args against it **fail-closed before dispatch**. `None` = byte-identical pre-M5.3 behavior. `resolved_def_hash` changing for a tool that gains a schema is the intended content-addressing (PR-4.6/D38 precedent).

### Invariants
- **Product digest `a6b5c679…` unaffected** — none of B1/B2/B3 touches the `mote_def_hash`/`MoteId` path. Frozen-trio engine logic byte-unchanged (additive defaulted trait methods only; no `McpTransport`/`Capability` narrowing).
- All defaulted trait methods → zero churn for existing Capability impls.

### Tests
`secrets_never_leak` extended (vault path via `EnvSecretStore` across all sinks + a `dispatch_refused_when_warrant_does_not_grant_the_secret` gate test); 9 `param_schema` unit + 5 `validate_args` proptests (TOTAL over arbitrary bytes; Int never accepts a non-integer; enum exact-match-only; deny_unknown). Full workspace **1297/0**; clippy/fmt/doc/deny clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)