### PR TITLE
M7.0+M7.1 — kx-catalog: TaskSignature foundation + content-addressed signature registry (D82/D83)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-catalog"
+version = "0.0.1"
+dependencies = [
+ "bincode",
+ "blake3",
+ "kx-dataset",
+ "kx-mote",
+ "kx-workflow",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kx-chaos"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/kx-refusal",
     "crates/kx-mcp",
     "crates/kx-planner",
+    "crates/kx-catalog",
     "crates/kx-model-harness",
 ]
 exclude = [
@@ -138,6 +139,12 @@ kx-mcp               = { path = "crates/kx-mcp",               version = "0.0.1"
 # kx-workflow/kx-mote/kx-warrant/kx-critic-types (NEVER scheduler/projection/
 # executor/inference — the thesis dependency-ban, asserted in kx-model-harness).
 kx-planner           = { path = "crates/kx-planner",           version = "0.0.1" }
+# The sharable catalog (M7, D82/D83) — the TaskSignature verdict-reuse foundation
+# + a content-addressed, idempotent, immutable signature registry. A SEPARATE
+# TRUTH (authoritative for WHAT recipes exist); off-journal + off the identity
+# path (composes kx-mote/kx-workflow identities, never bumps MoteDef). Depends
+# only on kx-mote/kx-workflow/kx-dataset — NEVER the journal or the frozen trio.
+kx-catalog           = { path = "crates/kx-catalog",           version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-catalog/Cargo.toml
+++ b/crates/kx-catalog/Cargo.toml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-catalog"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx snapshot registry + sharable catalog (M7, D82/D83): the TaskSignature verdict-reuse foundation (M7.0) + a content-addressed, idempotent, immutable signature registry (M7.1). A SEPARATE TRUTH — authoritative for WHAT recipes exist; the journal stays authoritative for what runs DID. Off-journal and off the identity path: it composes kx-mote/kx-workflow/kx-content identities and never bumps MoteDef. SN-8: discovery/stats never gate selection; reuse is exact crypto-equality only."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Identity primitives COMPOSED into TaskSignature / SignatureEntry / VerdictScope:
+# MoteDefHash (the pinned critic + skill hashes) and MoteId (the citee).
+kx-mote     = { workspace = true }
+# ManifestId — the recipe-as-product identity a SignatureEntry pins.
+kx-workflow = { workspace = true }
+# DatasetId — the optional pinned corpus on a RecipeSnapshot.
+kx-dataset  = { workspace = true }
+# The frozen canonical content-addressed encoding (bincode v2, LE + fixed-int —
+# byte-identical to kx_mote::canonical_config; replicated to keep the hash
+# discipline self-contained, mirroring kx-critic-types).
+bincode     = { workspace = true }
+# task_signature_hash + content-addressing.
+blake3      = { workspace = true }
+# Stack-inline pinned-skill vec without per-entry heap churn at scale.
+smallvec    = { workspace = true }
+# serde derives across all public types (persistence-friendly, sharable bundles).
+serde       = { workspace = true }
+# Typed CatalogError.
+thiserror   = { workspace = true }
+# Registration observability (debug-level only; never on the truth path).
+tracing     = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-catalog/src/entry.rs
+++ b/crates/kx-catalog/src/entry.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`SignatureEntry`] (M7.1, D83) — the registry's value type — plus the
+//! snapshot/recipe descriptor ([`RecipeSnapshot`]) and the typed free-param
+//! contract ([`FreeParamContract`]).
+//!
+//! A "snapshot" (D83) is a *recipe fingerprint + free-param contract*: invoking
+//! it (later milestones) is always a FRESH registered run, never a replayed
+//! result. The `variable_slots` machinery lives OUTSIDE [`TaskSignature`] so the
+//! author's variable-vs-fixed declaration never bumps
+//! [`crate::TASK_SIGNATURE_SCHEMA_VERSION`].
+
+use std::collections::BTreeMap;
+
+use kx_dataset::DatasetId;
+use kx_mote::MoteDefHash;
+use kx_workflow::ManifestId;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+use crate::signature::{TaskSignature, TaskSignatureHash, VerdictScope};
+
+/// Whether a snapshot input is fixed (part of the recipe) or varies per
+/// invocation. Default authoring rule (D101.6): external inputs are
+/// [`SlotBinding::Variable`], Mote-produced inputs are [`SlotBinding::Constant`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub enum SlotBinding {
+    /// Fixed by the recipe (Mote-produced).
+    Constant,
+    /// Supplied per invocation (an external free param).
+    Variable,
+}
+
+/// A typed free-param slot a snapshot declares. The `schema_ref` is the
+/// integration hook to the M5.3 MCP `inputSchema` `validate_args`: it is an
+/// opaque content-ref of the declared schema bytes here; the gateway / form
+/// layer validates submitted args against it (later FE work). No float ever
+/// touches this type (`schema_ref` is bytes, never a parsed value).
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct FreeParamSlot {
+    /// Fixed vs varies-per-invocation.
+    pub binding: SlotBinding,
+    /// Content-ref (`blake3`) of the slot's declared input schema, or `None` for
+    /// an untyped/opaque slot.
+    pub schema_ref: Option<[u8; 32]>,
+}
+
+impl FreeParamSlot {
+    /// A variable slot, optionally typed by a schema content-ref.
+    #[must_use]
+    pub const fn variable(schema_ref: Option<[u8; 32]>) -> Self {
+        Self {
+            binding: SlotBinding::Variable,
+            schema_ref,
+        }
+    }
+
+    /// A constant slot (fixed by the recipe).
+    #[must_use]
+    pub const fn constant() -> Self {
+        Self {
+            binding: SlotBinding::Constant,
+            schema_ref: None,
+        }
+    }
+}
+
+/// The typed free-param contract a snapshot publishes. Reuse passes dynamic
+/// params (validated against each slot's `schema_ref` at the gateway) → fresh
+/// `input_data_id` → fresh run, same recipe. Slots are keyed by name in a
+/// `BTreeMap`, so duplicate names are structurally impossible and iteration is
+/// canonical.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+pub struct FreeParamContract {
+    /// The declared slots, keyed by name (canonical order).
+    pub slots: BTreeMap<String, FreeParamSlot>,
+}
+
+impl FreeParamContract {
+    /// An empty contract.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare a slot (builder). Re-declaring a name overwrites it (the
+    /// `BTreeMap` cannot hold a duplicate key).
+    #[must_use]
+    pub fn with_slot(mut self, name: impl Into<String>, slot: FreeParamSlot) -> Self {
+        self.slots.insert(name.into(), slot);
+        self
+    }
+
+    /// Number of declared slots.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// `true` if no slots are declared.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+}
+
+/// The snapshot / recipe descriptor (D83): a recipe fingerprint + the free-param
+/// contract + an optional pinned corpus. Carries NO cached result — a snapshot
+/// invocation is always a fresh registered run (`WorldMutating` work re-runs by
+/// default).
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct RecipeSnapshot {
+    /// The recipe fingerprint carried on the `RunRegistered` journal fact
+    /// (discovery/dedup hash). Held as raw bytes so this crate stays off the
+    /// `kx-journal` dependency; equals the value the submission layer records.
+    pub recipe_fingerprint: [u8; 32],
+    /// The free-param contract for this snapshot.
+    pub free_params: FreeParamContract,
+    /// The produced corpus, if the snapshot pins a concrete result alongside the
+    /// recipe (mirrors `kx_workflow::Manifest::with_dataset`).
+    pub dataset_id: Option<DatasetId>,
+}
+
+impl RecipeSnapshot {
+    /// A snapshot of a recipe fingerprint with an empty free-param contract and
+    /// no pinned corpus.
+    #[must_use]
+    pub fn new(recipe_fingerprint: [u8; 32]) -> Self {
+        Self {
+            recipe_fingerprint,
+            free_params: FreeParamContract::new(),
+            dataset_id: None,
+        }
+    }
+
+    /// Attach a free-param contract (builder).
+    #[must_use]
+    pub fn with_free_params(mut self, free_params: FreeParamContract) -> Self {
+        self.free_params = free_params;
+        self
+    }
+
+    /// Pin a produced corpus (builder).
+    #[must_use]
+    pub fn with_dataset(mut self, dataset_id: DatasetId) -> Self {
+        self.dataset_id = Some(dataset_id);
+        self
+    }
+}
+
+/// The registry's value: a fully-described signature entry. Content-addressed by
+/// its [`TaskSignature`]'s hash ([`SignatureEntry::hash`]); immutable once
+/// registered.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct SignatureEntry {
+    /// The verdict-reuse identity foundation.
+    pub task_signature: TaskSignature,
+    /// The skills (MoteDefs) pinned constant for this signature, by hash. A
+    /// `SmallVec` avoids per-entry heap allocation for the common small DAG.
+    pub pinned_skill_hashes: SmallVec<[MoteDefHash; 8]>,
+    /// Which named inputs vary vs are fixed — OUTSIDE [`TaskSignature`] (no
+    /// schema bump). Canonical order.
+    pub variable_slots: BTreeMap<String, SlotBinding>,
+    /// The recipe-as-product reference this signature is published against.
+    pub manifest_ref: ManifestId,
+    /// The snapshot/recipe descriptor (recipe fingerprint + free-param contract).
+    pub snapshot: RecipeSnapshot,
+    /// The verdict-reuse association, recorded HERE (off `MoteDef`) so the
+    /// canonical digest stays invariant. The promotion gate still decides on the
+    /// exact `CriticVerdict::is_valid` check; this is reuse bookkeeping only.
+    pub verdict_scope: Option<VerdictScope>,
+}
+
+impl SignatureEntry {
+    /// A minimal entry: a signature published against a manifest + snapshot, with
+    /// no pinned skills, no variable slots, and no verdict scope. Use the
+    /// builders to add the rest.
+    #[must_use]
+    pub fn new(
+        task_signature: TaskSignature,
+        manifest_ref: ManifestId,
+        snapshot: RecipeSnapshot,
+    ) -> Self {
+        Self {
+            task_signature,
+            pinned_skill_hashes: SmallVec::new(),
+            variable_slots: BTreeMap::new(),
+            manifest_ref,
+            snapshot,
+            verdict_scope: None,
+        }
+    }
+
+    /// Pin the subgraph's skill hashes (builder).
+    #[must_use]
+    pub fn with_pinned_skills(
+        mut self,
+        pinned_skill_hashes: impl IntoIterator<Item = MoteDefHash>,
+    ) -> Self {
+        self.pinned_skill_hashes = pinned_skill_hashes.into_iter().collect();
+        self
+    }
+
+    /// Declare which named inputs vary vs are fixed (builder).
+    #[must_use]
+    pub fn with_variable_slots(
+        mut self,
+        variable_slots: impl IntoIterator<Item = (String, SlotBinding)>,
+    ) -> Self {
+        self.variable_slots = variable_slots.into_iter().collect();
+        self
+    }
+
+    /// Record the verdict-reuse scope (builder).
+    #[must_use]
+    pub fn with_verdict_scope(mut self, verdict_scope: VerdictScope) -> Self {
+        self.verdict_scope = Some(verdict_scope);
+        self
+    }
+
+    /// The content-addressed registry key — the entry's signature hash.
+    #[must_use]
+    pub fn hash(&self) -> TaskSignatureHash {
+        self.task_signature.task_signature_hash()
+    }
+}

--- a/crates/kx-catalog/src/in_memory.rs
+++ b/crates/kx-catalog/src/in_memory.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`InMemoryCatalog`] — the reference [`CatalogRegistry`] backend.
+//!
+//! A `BTreeMap<TaskSignatureHash, SignatureEntry>` under an [`RwLock`]: O(log n)
+//! `lookup` / `get`, sub-linear amortized `register`, deterministic (hash-order)
+//! enumeration. Process-local and rebuildable — not for production durability
+//! (a persistent backend implements the same trait). Exists primarily to prove
+//! [`CatalogRegistry`] carries no storage-substrate assumption (the role
+//! `kx_content::InMemoryContentStore` plays for `ContentStore`).
+
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use crate::entry::SignatureEntry;
+use crate::registry::{CatalogError, CatalogRegistry, RegistrationOutcome};
+use crate::signature::TaskSignatureHash;
+
+/// An ephemeral, process-local [`CatalogRegistry`]. Multiple readers, one writer.
+///
+/// # Examples
+///
+/// ```
+/// use kx_catalog::{CatalogRegistry, InMemoryCatalog, RecipeSnapshot, SignatureEntry, TaskSignature};
+/// use kx_mote::MoteDefHash;
+/// use kx_workflow::ManifestId;
+///
+/// let catalog = InMemoryCatalog::new();
+/// assert!(catalog.is_empty());
+///
+/// let sig = TaskSignature::model_invariant(MoteDefHash::from_bytes([7u8; 32]));
+/// let entry = SignatureEntry::new(sig, ManifestId([1u8; 32]), RecipeSnapshot::new([2u8; 32]));
+/// let hash = entry.hash();
+///
+/// let outcome = catalog.register_signature(entry.clone()).unwrap();
+/// assert!(outcome.is_inserted());
+/// assert_eq!(catalog.len(), 1);
+///
+/// // Idempotent: re-registering the same entry is a no-op.
+/// let again = catalog.register_signature(entry).unwrap();
+/// assert!(!again.is_inserted());
+/// assert_eq!(catalog.len(), 1);
+///
+/// assert_eq!(catalog.get_signature(&hash).unwrap().hash(), hash);
+/// ```
+#[derive(Debug, Default)]
+pub struct InMemoryCatalog {
+    by_hash: RwLock<BTreeMap<TaskSignatureHash, SignatureEntry>>,
+}
+
+impl InMemoryCatalog {
+    /// Construct an empty catalog.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CatalogRegistry for InMemoryCatalog {
+    fn register_signature(
+        &self,
+        entry: SignatureEntry,
+    ) -> Result<RegistrationOutcome, CatalogError> {
+        let hash = entry.hash();
+        // The Entry API avoids holding a borrow across the insert (no double-borrow).
+        let mut guard = self.by_hash.write().expect("poisoned lock");
+        match guard.entry(hash) {
+            Entry::Occupied(occupied) => {
+                if *occupied.get() == entry {
+                    Ok(RegistrationOutcome::AlreadyPresent(hash))
+                } else {
+                    // Same hash, different bytes: refuse (immutability).
+                    Err(CatalogError::ImmutabilityConflict(hash.to_hex()))
+                }
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(entry);
+                tracing::debug!(task_signature_hash = %hash, "registered catalog signature");
+                Ok(RegistrationOutcome::Inserted(hash))
+            }
+        }
+    }
+
+    fn lookup(&self, hash: &TaskSignatureHash) -> Option<SignatureEntry> {
+        self.by_hash
+            .read()
+            .expect("poisoned lock")
+            .get(hash)
+            .cloned()
+    }
+
+    fn list_signatures<'a>(&'a self) -> Box<dyn Iterator<Item = SignatureEntry> + 'a> {
+        let guard = self.by_hash.read().expect("poisoned lock");
+        // Snapshot under the read lock (hash order), then release before iterating.
+        let entries: Vec<SignatureEntry> = guard.values().cloned().collect();
+        Box::new(entries.into_iter())
+    }
+
+    fn len(&self) -> usize {
+        self.by_hash.read().expect("poisoned lock").len()
+    }
+}

--- a/crates/kx-catalog/src/lib.rs
+++ b/crates/kx-catalog/src/lib.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+//! # kx-catalog — the snapshot registry + sharable catalog (M7, D82/D83)
+//!
+//! The kortecx **catalog** is the Unity-Catalog-class registry of reusable
+//! assets. This crate lands its foundation in two layers:
+//!
+//! - **M7.0 — [`TaskSignature`]** (`signature`): the verdict-reuse identity
+//!   foundation. A `TaskSignature` pins the deterministic critic terminating a
+//!   chain plus the closed set of [`SignatureAxis`] a reuse must additionally
+//!   match. It is built ONLY via [`TaskSignature::model_invariant`] /
+//!   [`TaskSignature::scoped`] and content-addressed by [`TaskSignatureHash`]
+//!   (`blake3` over a domain-tagged canonical bincode encoding, exactly the
+//!   `kx_workflow::ManifestId` / `kx_mote::MoteDef::hash` discipline). The
+//!   [`VerdictScope`] expresses "this critic's `Valid` verdict is reusable for
+//!   runs matching this signature".
+//! - **M7.1 — the registry** (`registry` / `in_memory`): a content-addressed,
+//!   **idempotent + immutable** store of [`SignatureEntry`] keyed by
+//!   `TaskSignatureHash`. [`CatalogRegistry`] is backend-agnostic (in-memory now;
+//!   a persistent / cloud backend is a later impl behind the same trait, exactly
+//!   as `kx_content::ContentStore` and `kx_dataset::RetrievalIndex`).
+//!
+//! ## A separate truth (R4 — NOT a journal-as-truth violation)
+//!
+//! The catalog is authoritative for **what recipes exist** (immutable,
+//! content-addressed, idempotent registration); the journal stays authoritative
+//! for **what runs did**. This crate therefore **never** writes the journal and
+//! **does not depend on `kx-journal`** — the dependency direction is the wall.
+//! Registering a signature creates no run and mutates no committed fact; a
+//! snapshot invocation (later milestones) is always a FRESH registered run
+//! (`WorldMutating` work re-runs by default — D83), never a replayed result.
+//!
+//! ## The SN-8 wall (load-bearing)
+//!
+//! Like `kx_dataset::AnnotationStore`, the catalog is **off the trust path**: it
+//! never gates selection, eviction, or promotion. The promotion decision stays
+//! `kx_projection::promotion`'s fail-closed exact `CriticVerdict::is_valid`
+//! check. A [`VerdictScope`] is *recorded* here for reuse bookkeeping; it never
+//! short-circuits that gate. The wall is enforced by the dependency graph: the
+//! guarantee-path crates (`kx-scheduler` / `kx-executor` / `kx-projection`) do
+//! NOT depend on `kx-catalog`, so the compiler rejects wiring catalog data onto
+//! the identity / commit / selection path. **No floats** touch any type here, so
+//! even a future mistake could carry none onto a canonical hash.
+//!
+//! ## Verdict-reuse lives HERE, not on `MoteDef`
+//!
+//! A [`VerdictScope`] is stored in [`SignatureEntry`], **not** as a
+//! `MoteDef.verdict_for` field. This keeps `kx-mote` byte-unchanged and the
+//! canonical projection digest invariant (a `MoteDef` schema bump would move it).
+//! It mirrors the established pattern of keeping reuse / advisory metadata off
+//! the identity path (`AnnotationStore`, `kx-memoizer`).
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+// `.expect()` on canonical-bincode encode of a type WITHOUT floats and WITHOUT
+// non-encodable variants IS infallible (the single site is
+// `TaskSignature::task_signature_hash`), and `.expect("poisoned lock")` on the
+// `InMemoryCatalog` RwLock is the correct propagate-on-catastrophe behavior.
+// Both sites carry an inline justification; this crate-level allow suppresses
+// the workspace `clippy::expect_used = "deny"` policy for those documented uses
+// (mirrors kx-mote / kx-critic-types / kx-content).
+#![allow(clippy::expect_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+mod entry;
+mod in_memory;
+mod registry;
+mod signature;
+
+#[cfg(test)]
+mod tests;
+
+pub use entry::{FreeParamContract, FreeParamSlot, RecipeSnapshot, SignatureEntry, SlotBinding};
+pub use in_memory::InMemoryCatalog;
+pub use registry::{CatalogError, CatalogRegistry, RegistrationOutcome};
+pub use signature::{
+    canonical_config, SignatureAxis, TaskSignature, TaskSignatureHash, VerdictScope,
+    TASK_SIGNATURE_SCHEMA_VERSION,
+};

--- a/crates/kx-catalog/src/registry.rs
+++ b/crates/kx-catalog/src/registry.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The catalog seam (M7.1): the backend-agnostic [`CatalogRegistry`] trait, its
+//! [`RegistrationOutcome`] / [`CatalogError`] vocabulary, and an `Arc` blanket
+//! impl. The in-memory reference backend is [`crate::InMemoryCatalog`].
+//!
+//! Registration is **content-addressed, idempotent, and immutable**: keyed by
+//! the entry's [`TaskSignatureHash`], a re-register of a byte-identical entry is
+//! a no-op, and a re-register of a *different* entry at the same hash is refused
+//! ([`CatalogError::ImmutabilityConflict`]) rather than silently overwritten
+//! (asymmetric strictness). The trait carries no storage-substrate assumption —
+//! a persistent / cloud backend is a later impl behind it, exactly as
+//! `kx_content::ContentStore`.
+
+use std::sync::Arc;
+
+use crate::entry::SignatureEntry;
+use crate::signature::TaskSignatureHash;
+
+/// The result of [`CatalogRegistry::register_signature`] — distinguishes a fresh
+/// insert from an idempotent no-op so callers observe idempotency without a
+/// second lookup.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RegistrationOutcome {
+    /// First registration of this signature hash.
+    Inserted(TaskSignatureHash),
+    /// A byte-identical entry was already present — no-op (idempotent).
+    AlreadyPresent(TaskSignatureHash),
+}
+
+impl RegistrationOutcome {
+    /// The signature hash this outcome refers to.
+    #[must_use]
+    pub const fn hash(&self) -> TaskSignatureHash {
+        match self {
+            Self::Inserted(h) | Self::AlreadyPresent(h) => *h,
+        }
+    }
+
+    /// `true` iff this was a fresh insert (not an idempotent no-op).
+    #[must_use]
+    pub const fn is_inserted(&self) -> bool {
+        matches!(self, Self::Inserted(_))
+    }
+}
+
+/// A catalog registration failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CatalogError {
+    /// A DIFFERENT entry already exists at this signature hash. Registration is
+    /// immutable: the same hash MUST mean the same bytes. A mismatch is a caller
+    /// bug (or a hash-collision attack surface) — refuse loudly rather than
+    /// overwrite a registered fact. Carries the conflicting hash (hex).
+    #[error("immutable catalog conflict at task_signature_hash {0}")]
+    ImmutabilityConflict(String),
+}
+
+/// The catalog seam — backend-agnostic (in-memory now; SQLite / cloud later
+/// behind the same trait). Authoritative for WHAT recipes exist (a separate
+/// truth from the journal); it never writes the journal.
+pub trait CatalogRegistry {
+    /// Register a signature entry, content-addressed by its
+    /// [`TaskSignatureHash`]. Idempotent + immutable:
+    /// - hash absent → insert, return [`RegistrationOutcome::Inserted`];
+    /// - present and byte-identical → no-op, [`RegistrationOutcome::AlreadyPresent`];
+    /// - present but different bytes → [`CatalogError::ImmutabilityConflict`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::ImmutabilityConflict`] when a different entry is
+    /// already registered under the same signature hash.
+    fn register_signature(
+        &self,
+        entry: SignatureEntry,
+    ) -> Result<RegistrationOutcome, CatalogError>;
+
+    /// Exact lookup by content hash; `None` if absent. O(log n).
+    fn lookup(&self, hash: &TaskSignatureHash) -> Option<SignatureEntry>;
+
+    /// Get by hash (alias of [`CatalogRegistry::lookup`], named per the
+    /// `GetSignature` API surface).
+    fn get_signature(&self, hash: &TaskSignatureHash) -> Option<SignatureEntry> {
+        self.lookup(hash)
+    }
+
+    /// Enumerate every registered entry in deterministic (hash) order.
+    fn list_signatures<'a>(&'a self) -> Box<dyn Iterator<Item = SignatureEntry> + 'a>;
+
+    /// Count of registered entries.
+    fn len(&self) -> usize;
+
+    /// `true` when no signatures are registered.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<R: CatalogRegistry + ?Sized> CatalogRegistry for Arc<R> {
+    fn register_signature(
+        &self,
+        entry: SignatureEntry,
+    ) -> Result<RegistrationOutcome, CatalogError> {
+        (**self).register_signature(entry)
+    }
+
+    fn lookup(&self, hash: &TaskSignatureHash) -> Option<SignatureEntry> {
+        (**self).lookup(hash)
+    }
+
+    fn list_signatures<'a>(&'a self) -> Box<dyn Iterator<Item = SignatureEntry> + 'a> {
+        (**self).list_signatures()
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+}

--- a/crates/kx-catalog/src/signature.rs
+++ b/crates/kx-catalog/src/signature.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`TaskSignature`] (M7.0, D82) — the verdict-reuse identity foundation: the
+//! closed [`SignatureAxis`] vocabulary, the content-addressed
+//! [`TaskSignatureHash`], and the [`VerdictScope`] reuse association.
+//!
+//! A `TaskSignature` is built ONLY via [`TaskSignature::model_invariant`] or
+//! [`TaskSignature::scoped`]; its fields are private, so a malformed signature
+//! (e.g. a caller-forged `schema_version`, or an axis outside the closed set) is
+//! **unrepresentable**. Identity is `blake3` over a domain-tagged canonical
+//! bincode encoding — the same discipline as `kx_workflow::ManifestId` and
+//! `kx_mote::MoteDef::hash`, so two byte-identical signatures share a hash and a
+//! shared signature is verifiable by reference.
+
+use std::collections::BTreeSet;
+
+use kx_mote::{MoteDefHash, MoteId};
+use serde::{Deserialize, Serialize};
+
+/// Schema version of the canonical [`TaskSignature`] encoding. Bumped on ANY
+/// change to the canonical bytes (a `TaskSignature` folds into a
+/// [`TaskSignatureHash`] that scopes verdict reuse). Stored as a struct field
+/// (mirroring `kx_mote::MOTE_DEF_SCHEMA_VERSION` on `MoteDef`) so it is bound
+/// into the hash, and pinned in the hash's domain tag.
+pub const TASK_SIGNATURE_SCHEMA_VERSION: u16 = 1;
+
+/// A 32-byte BLAKE3 hash — the common substrate of the catalog's identity types.
+type Hash32 = [u8; 32];
+
+/// The 32-byte content-addressed identity of a [`TaskSignature`].
+///
+/// `blake3(b"kx-catalog/task-signature/v1" ‖ canonical_bincode(signature))`.
+/// The domain tag prevents cross-type preimage aliasing (a `TaskSignatureHash`
+/// can never collide with a `ManifestId` / `MoteDefHash` preimage). The newtype
+/// mirrors `kx_mote::MoteDefHash` / `kx_workflow::ManifestId`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TaskSignatureHash(pub Hash32);
+
+impl TaskSignatureHash {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for TaskSignatureHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TaskSignatureHash({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+impl std::fmt::Display for TaskSignatureHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// The closed set of `MoteDef` axes a [`TaskSignature::scoped`] signature may
+/// narrow on — EXACTLY the five behavior-determining `MoteDef` identity fields.
+///
+/// Illegal states unrepresentable: a caller cannot name an axis that is not a
+/// pinned `MoteDef` input. Growing this enum is a [`TASK_SIGNATURE_SCHEMA_VERSION`]
+/// bump (the variant set folds into the canonical bytes).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub enum SignatureAxis {
+    /// The citer Mote's `model_id`.
+    CiterModelId,
+    /// The citer Mote's `prompt_template_hash`.
+    CiterPromptTemplateHash,
+    /// An entry of the citer Mote's `tool_contract`.
+    CiterToolContractEntry,
+    /// The citer Mote's `inference_params`.
+    CiterInferenceParams,
+    /// A key of the citer Mote's `config_subset`.
+    CiterConfigKey,
+}
+
+/// The reuse scope of a deterministic critic's `Valid` verdict: "this critic's
+/// `Valid` verdict is reusable for runs whose task matches this signature".
+///
+/// Recorded in the CATALOG ([`crate::SignatureEntry`]), **never** on `MoteDef` —
+/// keeping `kx-mote` byte-unchanged and the canonical digest invariant. The
+/// promotion gate itself stays the exact, fail-closed
+/// `kx_projection::promotion` check; a `VerdictScope` is reuse bookkeeping, not
+/// a gate bypass (SN-8).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub struct VerdictScope {
+    /// The critic-bearing Mote whose `Valid` verdict the scope makes reusable.
+    pub citee_mote_id: MoteId,
+    /// The signature the reuse is scoped to (raw bytes of a [`TaskSignatureHash`]).
+    pub task_signature_hash: Hash32,
+}
+
+/// The verdict-reuse identity foundation (M7.0, D82).
+///
+/// Built ONLY via [`TaskSignature::model_invariant`] (empty narrowing) or
+/// [`TaskSignature::scoped`]. `narrowing` is the set of `MoteDef` axes whose
+/// value must additionally match for reuse; an empty set IS model-invariance.
+/// The terminating deterministic critic is pinned by its `MoteDefHash`. All
+/// fields are private — the constructors are the only construction path, so
+/// `schema_version` is never caller-set.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct TaskSignature {
+    /// Canonical-encoding schema version (constructor-set, never caller-set).
+    schema_version: u16,
+    /// The `MoteDefHash` of the deterministic critic terminating the chain.
+    critic_mote_def_hash: MoteDefHash,
+    /// The closed, canonical (`BTreeSet`-ordered) set of narrowed axes. Empty
+    /// <=> model-invariant.
+    narrowing: BTreeSet<SignatureAxis>,
+}
+
+impl TaskSignature {
+    /// A model-invariant signature: empty narrowing. Reuse matches any citer
+    /// differing only in axes NOT pinned here (i.e. all of them).
+    #[must_use]
+    pub fn model_invariant(critic_mote_def_hash: MoteDefHash) -> Self {
+        Self {
+            schema_version: TASK_SIGNATURE_SCHEMA_VERSION,
+            critic_mote_def_hash,
+            narrowing: BTreeSet::new(),
+        }
+    }
+
+    /// A scoped signature: reuse additionally requires every named axis to
+    /// match. Pure + total + infallible — a `BTreeSet` is canonical by
+    /// construction and every [`SignatureAxis`] is a legal value, so there is no
+    /// malformed-narrowing state to reject. `scoped(h, <empty>)` is byte-identical
+    /// to `model_invariant(h)` (an empty narrowing IS model-invariance).
+    #[must_use]
+    pub fn scoped(critic_mote_def_hash: MoteDefHash, narrowing: BTreeSet<SignatureAxis>) -> Self {
+        Self {
+            schema_version: TASK_SIGNATURE_SCHEMA_VERSION,
+            critic_mote_def_hash,
+            narrowing,
+        }
+    }
+
+    /// The canonical-encoding schema version this signature was built under.
+    #[inline]
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// The pinned terminating-critic `MoteDefHash`.
+    #[inline]
+    #[must_use]
+    pub const fn critic_mote_def_hash(&self) -> &MoteDefHash {
+        &self.critic_mote_def_hash
+    }
+
+    /// The narrowed axes, in canonical (`Ord`) order.
+    #[inline]
+    #[must_use]
+    pub const fn narrowing(&self) -> &BTreeSet<SignatureAxis> {
+        &self.narrowing
+    }
+
+    /// `true` iff this is a model-invariant signature (empty narrowing).
+    #[must_use]
+    pub fn is_model_invariant(&self) -> bool {
+        self.narrowing.is_empty()
+    }
+
+    /// The content-addressed identity: `blake3(domain-tag ‖
+    /// canonical_bincode(self))`. A **pure** function of the signature's bytes;
+    /// the `schema_version` field is encoded in the body, so a version change
+    /// re-derives the hash. The narrowing is a `BTreeSet`, so insertion order
+    /// does not affect the hash.
+    #[must_use]
+    pub fn task_signature_hash(&self) -> TaskSignatureHash {
+        let mut h = blake3::Hasher::new();
+        h.update(b"kx-catalog/task-signature/v1");
+        // SAFETY (expect): TaskSignature has no floats and no non-encodable
+        // variants (MoteDefHash = [u8;32], BTreeSet<u8-discriminant enum>, u16),
+        // so canonical bincode encoding is infallible — mirrors the documented
+        // `kx_mote::MoteDef::hash` / `kx_critic_types::CriticVerdict::encode`.
+        let body = bincode::serde::encode_to_vec(self, canonical_config()).expect(
+            "TaskSignature canonical encoding is infallible (no floats, no non-encodable types)",
+        );
+        h.update(&body);
+        TaskSignatureHash(*h.finalize().as_bytes())
+    }
+}
+
+/// The canonical bincode configuration for catalog content-addressing: bincode
+/// v2, little-endian, fixed-int. **Byte-identical to `kx_mote::canonical_config`**
+/// — replicated here so this crate stays `kx-mote`-internals-free (mirrors
+/// `kx_critic_types::canonical_config`). Any change to these flags is a
+/// [`TASK_SIGNATURE_SCHEMA_VERSION`] bump.
+#[must_use]
+pub fn canonical_config(
+) -> bincode::config::Configuration<bincode::config::LittleEndian, bincode::config::Fixint> {
+    bincode::config::standard()
+        .with_little_endian()
+        .with_fixed_int_encoding()
+}

--- a/crates/kx-catalog/src/tests.rs
+++ b/crates/kx-catalog/src/tests.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Unit tests for the catalog foundation (M7.0 + M7.1).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_mote::{MoteDefHash, MoteId};
+use kx_workflow::ManifestId;
+
+use crate::{
+    CatalogError, CatalogRegistry, FreeParamContract, FreeParamSlot, InMemoryCatalog,
+    RecipeSnapshot, SignatureAxis, SignatureEntry, SlotBinding, TaskSignature, VerdictScope,
+};
+
+fn critic(byte: u8) -> MoteDefHash {
+    MoteDefHash::from_bytes([byte; 32])
+}
+
+fn entry_for(sig: TaskSignature) -> SignatureEntry {
+    SignatureEntry::new(sig, ManifestId([9u8; 32]), RecipeSnapshot::new([8u8; 32]))
+}
+
+// ---- M7.0: TaskSignature ----------------------------------------------------
+
+#[test]
+fn model_invariant_has_empty_narrowing() {
+    let sig = TaskSignature::model_invariant(critic(1));
+    assert!(sig.is_model_invariant());
+    assert!(sig.narrowing().is_empty());
+    assert_eq!(sig.schema_version(), crate::TASK_SIGNATURE_SCHEMA_VERSION);
+    assert_eq!(sig.critic_mote_def_hash(), &critic(1));
+}
+
+#[test]
+fn scoped_with_empty_equals_model_invariant() {
+    let mi = TaskSignature::model_invariant(critic(2));
+    let scoped_empty = TaskSignature::scoped(critic(2), BTreeSet::new());
+    assert_eq!(mi, scoped_empty, "empty narrowing IS model-invariance");
+    assert_eq!(
+        mi.task_signature_hash(),
+        scoped_empty.task_signature_hash(),
+        "hashes must match"
+    );
+}
+
+#[test]
+fn scoped_narrowing_is_order_independent() {
+    let mut a = BTreeSet::new();
+    a.insert(SignatureAxis::CiterModelId);
+    a.insert(SignatureAxis::CiterConfigKey);
+
+    let mut b = BTreeSet::new();
+    b.insert(SignatureAxis::CiterConfigKey);
+    b.insert(SignatureAxis::CiterModelId);
+
+    let sa = TaskSignature::scoped(critic(3), a);
+    let sb = TaskSignature::scoped(critic(3), b);
+    assert_eq!(sa.task_signature_hash(), sb.task_signature_hash());
+    assert!(!sa.is_model_invariant());
+}
+
+#[test]
+fn hash_is_stable_and_distinct() {
+    let sig = TaskSignature::scoped(
+        critic(4),
+        BTreeSet::from([SignatureAxis::CiterInferenceParams]),
+    );
+    assert_eq!(
+        sig.task_signature_hash(),
+        sig.task_signature_hash(),
+        "deterministic"
+    );
+
+    // Distinct critic hash → distinct signature hash.
+    let other = TaskSignature::scoped(
+        critic(5),
+        BTreeSet::from([SignatureAxis::CiterInferenceParams]),
+    );
+    assert_ne!(sig.task_signature_hash(), other.task_signature_hash());
+
+    // Distinct narrowing → distinct signature hash.
+    let wider = TaskSignature::scoped(
+        critic(4),
+        BTreeSet::from([
+            SignatureAxis::CiterInferenceParams,
+            SignatureAxis::CiterModelId,
+        ]),
+    );
+    assert_ne!(sig.task_signature_hash(), wider.task_signature_hash());
+}
+
+#[test]
+fn hash_hex_is_64_chars() {
+    let h = TaskSignature::model_invariant(critic(6)).task_signature_hash();
+    assert_eq!(h.to_hex().len(), 64);
+    assert_eq!(format!("{h}").len(), 64);
+}
+
+#[test]
+fn verdict_scope_serde_round_trips() {
+    let vs = VerdictScope {
+        citee_mote_id: MoteId::from_bytes([3u8; 32]),
+        task_signature_hash: [4u8; 32],
+    };
+    let bytes = bincode::serde::encode_to_vec(vs, crate::canonical_config()).unwrap();
+    let (back, _) =
+        bincode::serde::decode_from_slice::<VerdictScope, _>(&bytes, crate::canonical_config())
+            .unwrap();
+    assert_eq!(vs, back);
+}
+
+// ---- M7.1: entry / contract -------------------------------------------------
+
+#[test]
+fn free_param_contract_dedups_by_name() {
+    let c = FreeParamContract::new()
+        .with_slot("to", FreeParamSlot::variable(Some([1u8; 32])))
+        .with_slot("to", FreeParamSlot::constant());
+    assert_eq!(c.len(), 1, "same name overwrites");
+    assert_eq!(c.slots["to"].binding, SlotBinding::Constant);
+}
+
+#[test]
+fn entry_hash_matches_signature_hash() {
+    let sig = TaskSignature::model_invariant(critic(7));
+    let want = sig.task_signature_hash();
+    let entry = entry_for(sig)
+        .with_pinned_skills([critic(10), critic(11)])
+        .with_variable_slots([("subject".to_string(), SlotBinding::Variable)])
+        .with_verdict_scope(VerdictScope {
+            citee_mote_id: MoteId::from_bytes([12u8; 32]),
+            task_signature_hash: *want.as_bytes(),
+        });
+    assert_eq!(entry.hash(), want, "entry key is its signature hash");
+    assert_eq!(entry.pinned_skill_hashes.len(), 2);
+}
+
+// ---- M7.1: registry ---------------------------------------------------------
+
+#[test]
+fn register_then_get() {
+    let catalog = InMemoryCatalog::new();
+    assert!(catalog.is_empty());
+
+    let sig = TaskSignature::model_invariant(critic(20));
+    let entry = entry_for(sig);
+    let hash = entry.hash();
+
+    let outcome = catalog.register_signature(entry.clone()).unwrap();
+    assert!(outcome.is_inserted());
+    assert_eq!(outcome.hash(), hash);
+    assert_eq!(catalog.len(), 1);
+    assert_eq!(catalog.get_signature(&hash), Some(entry.clone()));
+    assert_eq!(catalog.lookup(&hash), Some(entry));
+}
+
+#[test]
+fn lookup_absent_is_none() {
+    let catalog = InMemoryCatalog::new();
+    let missing = TaskSignature::model_invariant(critic(21)).task_signature_hash();
+    assert_eq!(catalog.lookup(&missing), None);
+}
+
+#[test]
+fn registration_is_idempotent() {
+    let catalog = InMemoryCatalog::new();
+    let entry = entry_for(TaskSignature::model_invariant(critic(22)));
+
+    assert!(catalog
+        .register_signature(entry.clone())
+        .unwrap()
+        .is_inserted());
+    for _ in 0..5 {
+        let again = catalog.register_signature(entry.clone()).unwrap();
+        assert!(!again.is_inserted(), "re-register is AlreadyPresent");
+    }
+    assert_eq!(catalog.len(), 1, "exactly one stored entry");
+}
+
+#[test]
+fn registration_is_immutable_on_collision() {
+    let catalog = InMemoryCatalog::new();
+    let sig = TaskSignature::model_invariant(critic(23));
+
+    // Two entries with the SAME signature (same hash) but DIFFERENT bodies.
+    let a = entry_for(sig.clone());
+    let b = entry_for(sig).with_pinned_skills([critic(99)]);
+    assert_eq!(a.hash(), b.hash(), "same signature → same key");
+    assert_ne!(a, b, "different bodies");
+
+    catalog.register_signature(a).unwrap();
+    let err = catalog.register_signature(b).unwrap_err();
+    assert!(matches!(err, CatalogError::ImmutabilityConflict(_)));
+    assert_eq!(catalog.len(), 1, "the conflicting write did not land");
+}
+
+#[test]
+fn list_is_deterministic_hash_order() {
+    let catalog = InMemoryCatalog::new();
+    let mut expected: Vec<_> = (30u8..40)
+        .map(|b| {
+            let e = entry_for(TaskSignature::model_invariant(critic(b)));
+            catalog.register_signature(e.clone()).unwrap();
+            e
+        })
+        .collect();
+    expected.sort_by_key(SignatureEntry::hash);
+
+    let got: Vec<_> = catalog.list_signatures().collect();
+    let got_hashes: Vec<_> = got.iter().map(SignatureEntry::hash).collect();
+    let want_hashes: Vec<_> = expected.iter().map(SignatureEntry::hash).collect();
+    assert_eq!(got_hashes, want_hashes, "enumeration is hash-ordered");
+}
+
+#[test]
+fn arc_blanket_impl_forwards() {
+    use std::sync::Arc;
+    let catalog: Arc<InMemoryCatalog> = Arc::new(InMemoryCatalog::new());
+    let entry = entry_for(TaskSignature::model_invariant(critic(41)));
+    let hash = entry.hash();
+    // Call through the Arc (exercises the blanket impl).
+    CatalogRegistry::register_signature(&catalog, entry).unwrap();
+    assert_eq!(catalog.len(), 1);
+    assert!(catalog.lookup(&hash).is_some());
+}
+
+#[test]
+fn slot_binding_default_authoring_shapes() {
+    // A sanity check that the variable/constant constructors set the binding.
+    assert_eq!(FreeParamSlot::variable(None).binding, SlotBinding::Variable);
+    assert_eq!(FreeParamSlot::constant().binding, SlotBinding::Constant);
+    let _ = BTreeMap::<String, SlotBinding>::new();
+}

--- a/crates/kx-catalog/tests/proptest_registry.rs
+++ b/crates/kx-catalog/tests/proptest_registry.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property tests for the M7.1 registry: idempotency, immutability,
+//! lookup totality, and deterministic hash-ordered enumeration.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use kx_catalog::{
+    CatalogError, CatalogRegistry, InMemoryCatalog, RecipeSnapshot, SignatureAxis, SignatureEntry,
+    TaskSignature,
+};
+use kx_mote::MoteDefHash;
+use kx_workflow::ManifestId;
+use proptest::prelude::*;
+
+fn axis_strategy() -> impl Strategy<Value = SignatureAxis> {
+    prop_oneof![
+        Just(SignatureAxis::CiterModelId),
+        Just(SignatureAxis::CiterPromptTemplateHash),
+        Just(SignatureAxis::CiterToolContractEntry),
+        Just(SignatureAxis::CiterInferenceParams),
+        Just(SignatureAxis::CiterConfigKey),
+    ]
+}
+
+fn sig_strategy() -> impl Strategy<Value = TaskSignature> {
+    (
+        any::<[u8; 32]>(),
+        prop::collection::btree_set(axis_strategy(), 0..=5),
+    )
+        .prop_map(|(h, axes)| TaskSignature::scoped(MoteDefHash::from_bytes(h), axes))
+}
+
+fn entry_strategy() -> impl Strategy<Value = SignatureEntry> {
+    (
+        sig_strategy(),
+        any::<[u8; 32]>(),
+        any::<[u8; 32]>(),
+        prop::collection::vec(any::<[u8; 32]>(), 0..=4),
+    )
+        .prop_map(|(sig, manifest, fingerprint, skills)| {
+            SignatureEntry::new(sig, ManifestId(manifest), RecipeSnapshot::new(fingerprint))
+                .with_pinned_skills(skills.into_iter().map(MoteDefHash::from_bytes))
+        })
+}
+
+proptest! {
+    /// Registering the same entry any number of times stores exactly one copy;
+    /// only the first is an insert.
+    #[test]
+    fn registration_is_idempotent(entry in entry_strategy(), reps in 1usize..6) {
+        let catalog = InMemoryCatalog::new();
+        prop_assert!(catalog.register_signature(entry.clone()).unwrap().is_inserted());
+        for _ in 0..reps {
+            let again = catalog.register_signature(entry.clone()).unwrap();
+            prop_assert!(!again.is_inserted());
+        }
+        prop_assert_eq!(catalog.len(), 1);
+    }
+
+    /// get(absent) is None; get(register(e)) is Some(e).
+    #[test]
+    fn lookup_is_total(entry in entry_strategy()) {
+        let catalog = InMemoryCatalog::new();
+        let hash = entry.hash();
+        prop_assert_eq!(catalog.lookup(&hash), None);
+        catalog.register_signature(entry.clone()).unwrap();
+        prop_assert_eq!(catalog.lookup(&hash), Some(entry));
+    }
+
+    /// Two entries with the SAME signature but DIFFERENT bodies collide on the
+    /// key; the second registration is refused and does not land.
+    #[test]
+    fn registration_is_immutable(
+        sig in sig_strategy(),
+        skills_a in prop::collection::vec(any::<[u8; 32]>(), 0..=3),
+        skills_b in prop::collection::vec(any::<[u8; 32]>(), 0..=3),
+    ) {
+        let a = SignatureEntry::new(sig.clone(), ManifestId([0u8; 32]), RecipeSnapshot::new([0u8; 32]))
+            .with_pinned_skills(skills_a.into_iter().map(MoteDefHash::from_bytes));
+        let b = SignatureEntry::new(sig, ManifestId([0u8; 32]), RecipeSnapshot::new([0u8; 32]))
+            .with_pinned_skills(skills_b.into_iter().map(MoteDefHash::from_bytes));
+        prop_assume!(a != b);
+        prop_assert_eq!(a.hash(), b.hash());
+
+        let catalog = InMemoryCatalog::new();
+        catalog.register_signature(a).unwrap();
+        let err = catalog.register_signature(b).unwrap_err();
+        prop_assert!(matches!(err, CatalogError::ImmutabilityConflict(_)));
+        prop_assert_eq!(catalog.len(), 1);
+    }
+
+    /// Enumeration is in hash order regardless of insertion order.
+    #[test]
+    fn list_is_hash_ordered(entries in prop::collection::vec(entry_strategy(), 0..12)) {
+        let catalog = InMemoryCatalog::new();
+        for e in &entries {
+            // A duplicate-signature collision returns Err and is intentionally skipped.
+            let _ = catalog.register_signature(e.clone());
+        }
+        let listed: Vec<_> = catalog.list_signatures().map(|e| e.hash()).collect();
+        let mut sorted = listed.clone();
+        sorted.sort_unstable();
+        prop_assert_eq!(listed, sorted);
+    }
+}

--- a/crates/kx-catalog/tests/proptest_signature.rs
+++ b/crates/kx-catalog/tests/proptest_signature.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property tests for the M7.0 [`TaskSignature`] foundation: canonical
+//! round-trip, hash determinism + order-independence, schema-version pinning,
+//! and a collision-resistance sanity check.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::BTreeSet;
+
+use kx_catalog::{canonical_config, SignatureAxis, TaskSignature, TASK_SIGNATURE_SCHEMA_VERSION};
+use kx_mote::MoteDefHash;
+use proptest::prelude::*;
+
+fn axis_strategy() -> impl Strategy<Value = SignatureAxis> {
+    prop_oneof![
+        Just(SignatureAxis::CiterModelId),
+        Just(SignatureAxis::CiterPromptTemplateHash),
+        Just(SignatureAxis::CiterToolContractEntry),
+        Just(SignatureAxis::CiterInferenceParams),
+        Just(SignatureAxis::CiterConfigKey),
+    ]
+}
+
+fn sig_strategy() -> impl Strategy<Value = TaskSignature> {
+    (
+        any::<[u8; 32]>(),
+        prop::collection::btree_set(axis_strategy(), 0..=5),
+    )
+        .prop_map(|(h, axes)| TaskSignature::scoped(MoteDefHash::from_bytes(h), axes))
+}
+
+proptest! {
+    /// Canonical bincode is an exact, lossless round-trip (no trailing garbage).
+    #[test]
+    fn bincode_round_trip(sig in sig_strategy()) {
+        let bytes = bincode::serde::encode_to_vec(&sig, canonical_config()).unwrap();
+        let (back, consumed) =
+            bincode::serde::decode_from_slice::<TaskSignature, _>(&bytes, canonical_config())
+                .unwrap();
+        prop_assert_eq!(consumed, bytes.len());
+        prop_assert_eq!(sig, back);
+    }
+
+    /// The signature hash is a deterministic pure function of the value.
+    #[test]
+    fn hash_is_deterministic(sig in sig_strategy()) {
+        prop_assert_eq!(sig.task_signature_hash(), sig.task_signature_hash());
+    }
+
+    /// The narrowing is a set: the order axes are inserted never affects the hash.
+    #[test]
+    fn hash_is_order_independent(
+        h in any::<[u8; 32]>(),
+        axes in prop::collection::vec(axis_strategy(), 0..=8),
+    ) {
+        let forward: BTreeSet<SignatureAxis> = axes.iter().copied().collect();
+        let backward: BTreeSet<SignatureAxis> = axes.into_iter().rev().collect();
+        let a = TaskSignature::scoped(MoteDefHash::from_bytes(h), forward);
+        let b = TaskSignature::scoped(MoteDefHash::from_bytes(h), backward);
+        prop_assert_eq!(a.task_signature_hash(), b.task_signature_hash());
+    }
+
+    /// Every constructed signature carries the current schema version.
+    #[test]
+    fn schema_version_is_pinned(sig in sig_strategy()) {
+        prop_assert_eq!(sig.schema_version(), TASK_SIGNATURE_SCHEMA_VERSION);
+    }
+
+    /// Distinct signatures hash to distinct ids (collision-resistance sanity).
+    #[test]
+    fn distinct_signatures_have_distinct_hashes(a in sig_strategy(), b in sig_strategy()) {
+        prop_assume!(a != b);
+        prop_assert_ne!(a.task_signature_hash(), b.task_signature_hash());
+    }
+}

--- a/crates/kx-catalog/tests/scale.rs
+++ b/crates/kx-catalog/tests/scale.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scale-smoke: the catalog registry stays sub-linear at scale.
+//!
+//! `#[ignore]`d — run in `--release` via the `scale-smoke` recipe. Registration
+//! and lookup are `BTreeMap` insert/get keyed by [`TaskSignatureHash`], so both
+//! are O(log n); this proves a large catalog cannot turn a registration or
+//! discovery path super-linear. Mirrors `kx-capture/tests/scale.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Instant;
+
+use kx_catalog::{
+    CatalogRegistry, InMemoryCatalog, RecipeSnapshot, SignatureEntry, TaskSignature,
+    TaskSignatureHash,
+};
+use kx_mote::MoteDefHash;
+use kx_workflow::ManifestId;
+
+const SIZES: &[usize] = &[1_000, 5_000, 10_000, 25_000];
+
+/// A distinct entry for index `i` (the index encoded into the critic hash bytes,
+/// so every signature — and thus every key — is unique).
+fn entry_at(i: usize) -> SignatureEntry {
+    let mut b = [0u8; 32];
+    b[..8].copy_from_slice(&(i as u64).to_le_bytes());
+    let sig = TaskSignature::model_invariant(MoteDefHash::from_bytes(b));
+    SignatureEntry::new(sig, ManifestId([1u8; 32]), RecipeSnapshot::new([2u8; 32]))
+}
+
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn registry_register_and_lookup_stay_sublinear() {
+    let mut register_ns: Vec<(usize, f64)> = Vec::new();
+    let mut lookup_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let catalog = InMemoryCatalog::new();
+
+        // Build entries + their hashes OUTSIDE the timed regions.
+        let mut hashes: Vec<TaskSignatureHash> = Vec::with_capacity(n);
+        let entries: Vec<SignatureEntry> = (0..n)
+            .map(|i| {
+                let e = entry_at(i);
+                hashes.push(e.hash());
+                e
+            })
+            .collect();
+
+        let start = Instant::now();
+        for e in entries {
+            catalog.register_signature(e).unwrap();
+        }
+        let register_elapsed = start.elapsed();
+
+        // Exactly-once: every distinct signature stored, none dropped.
+        assert_eq!(catalog.len(), n, "one entry per signature at n={n}");
+
+        let start = Instant::now();
+        for h in &hashes {
+            assert!(catalog.lookup(h).is_some(), "registered hash must resolve");
+        }
+        let lookup_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let register_per = register_elapsed.as_nanos() as f64 / n as f64;
+        #[allow(clippy::cast_precision_loss)]
+        let lookup_per = lookup_elapsed.as_nanos() as f64 / n as f64;
+        println!("catalog: n={n} register_per_ns={register_per:.1} lookup_per_ns={lookup_per:.1}");
+        register_ns.push((n, register_per));
+        lookup_ns.push((n, lookup_per));
+    }
+
+    // BTreeMap insert/get are O(log n): the 25k/1k ratio is ~log(25k)/log(1k)
+    // ≈ 1.47×. Allow 4× headroom for small-N timing noise while still catching a
+    // genuine super-linear regression (a quadratic path would be ≈ 25×).
+    assert_sublinear("register", &register_ns);
+    assert_sublinear("lookup", &lookup_ns);
+}
+
+fn assert_sublinear(label: &str, series: &[(usize, f64)]) {
+    let first = series.first().unwrap().1;
+    let last = series.last().unwrap().1;
+    assert!(
+        last <= first * 4.0,
+        "{label} must stay sub-linear (n=1k {first:.1}ns vs n=25k {last:.1}ns)"
+    );
+}


### PR DESCRIPTION
## What this is

The first slice of **M7** (the sharable catalog, D82). A NEW leaf crate **`kx-catalog`** combining **M7.0** (the `TaskSignature` verdict-reuse foundation, the M7.0 prerequisite per D102.5/R9 — spec-only until now) and **M7.1** (the content-addressed snapshot registry).

## What was implemented

- **M7.0 — `signature.rs`:** `TaskSignature` (private fields; built only via `model_invariant()`/`scoped()` → malformed signatures unrepresentable), the closed `SignatureAxis` enum (the 5 pinned `MoteDef` axes), `TaskSignatureHash` (domain-tagged `blake3` over canonical bincode — the same discipline as `kx_workflow::ManifestId` / `kx_mote::MoteDef::hash`), `VerdictScope`, `TASK_SIGNATURE_SCHEMA_VERSION = 1`.
- **M7.1 — `entry.rs`/`registry.rs`/`in_memory.rs`:** `SignatureEntry`, `RecipeSnapshot` (D83 recipe-fingerprint + free-param contract), `FreeParamContract`; the backend-agnostic **idempotent + immutable** `CatalogRegistry` trait (+ `Arc` blanket impl) and `InMemoryCatalog`. Same-hash/different-bytes registration is **refused** (`ImmutabilityConflict`), never silently overwritten.

## Design / boundary decisions

- **Verdict-reuse (`VerdictScope`) is recorded in `SignatureEntry`, NOT on `MoteDef`** → `kx-mote` byte-unchanged and the canonical digest `a6b5c679…` invariant. (This corrects a corpus claim that `MoteDef.verdict_for` is "the existing D52 field" — it does not exist; only `critic_for` does. Catalog-side reuse mirrors the `AnnotationStore`/`kx-memoizer` "off the identity path" pattern.)
- **A separate truth (R4):** authoritative for *what recipes exist*; **off-journal** (no `kx-journal` dep) — the journal stays authoritative for *what runs did*. No journal schema bump, no D107 migration.
- **SN-8 wall:** the catalog never gates selection/eviction/promotion; the dependency direction (the frozen trio + `kx-projection` do not depend on it) is the wall. **No floats** anywhere.

## How it helps / enables

Helps: gives the runtime an immutable, content-addressed, tamper-evident registry of reusable recipes cleanly separated from the journal. Enables: M7.2 (grants/RBAC via the `kx-warrant` seam — its own PR), M7.3 (vector discovery via `RetrievalIndex`; Mote-as-MCP *advertisement*), the FE promotion path (FE.4/FE.5), teams (D112), and the gateway surfaces — all build on this foundation.

## Golden Rule 8 — pre-flight

- **Pass A (defensive):** additive new crate; `MoteDef` untouched ⇒ digest cannot move; off-journal ⇒ no migration; idempotent+immutable registration refuses same-hash/different-body (no silent overwrite). `BTreeMap` get/insert is O(log n) (scale-smoke gate `ratio ≤ 4×`). Registration is a new untrusted surface but stores only hashes + small typed metadata — no secrets/credentials/weights; content-addressing is one-way + domain-tagged. SN-8/D70/D87 wall confirmed closed (catalog never gates).
- **Pass B (forward):** more correct/durable (recipes as a tamper-evident separate truth), scalable (O(log n) hash-keyed lookup is the base for discovery + bundles), reproducible-by-reference signatures enable cross-org sharing. Flagged (own PRs, Rule 1): `canonical_config()` is now triplicated (a future `kx-canonical` extraction); the `verdict_for`-on-`MoteDef` option remains a separately-gated v5→v6 bump if reuse must live on the identity path.

## Verification (local)

| Gate | Result |
|---|---|
| `cargo build -p kx-catalog` | ✅ |
| `cargo clippy --workspace --all-targets -D warnings` | ✅ clean |
| `cargo fmt --check` / `cargo doc -D warnings` | ✅ |
| kx-catalog tests | ✅ 15 unit + 5 sig-proptest + 4 reg-proptest + 1 doctest |
| scale-smoke `--release` | ✅ register ~0.6×, lookup ~1.38× over [1k..25k] (gate 4×) |
| `cargo test --workspace` | ✅ 0 failures |
| frozen-trio + `kx-mote`/`kx-journal` diff | ✅ EMPTY (only +7 lines `Cargo.toml`) |
| digest `a6b5c679…` | ✅ unmoved (kx-runtime `seals_do_not_change_product_digest` green) |
| `cargo deny check` | ✅ bans/licenses/sources; no new external dep |

CI runs the remaining gate: I1.c byte-determinism, ffi-link, and smoke-test-with-model.

## Scope / deferred (Rule 1)

Deferred to their own PRs: **M7.2** grants/RBAC (touches the `kx-warrant` strict seam) + portable bundle (D88) + namespacing/lineage; **M7.3** vector discovery + Mote-as-MCP advertisement (inbound serving = D121/M8); teams (D112); gateway FE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)