### PR TITLE
feat(catalog): M7.2 — namespacing + grants/RBAC + revocation (kx-catalog GrantLedger, D86)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "blake3",
  "kx-dataset",
  "kx-mote",
+ "kx-warrant",
  "kx-workflow",
  "proptest",
  "serde",

--- a/crates/kx-catalog/Cargo.toml
+++ b/crates/kx-catalog/Cargo.toml
@@ -20,6 +20,12 @@ kx-mote     = { workspace = true }
 kx-workflow = { workspace = true }
 # DatasetId — the optional pinned corpus on a RecipeSnapshot.
 kx-dataset  = { workspace = true }
+# Role / WarrantSpec / intersect / NarrowingError (M7.2, D86): a grant's runtime
+# scope REUSES the frozen monotonic-narrowing seam verbatim — the catalog never
+# re-implements narrowing and never modifies kx-warrant. This is a dependency ON
+# kx-warrant, NOT a dependency BY the guarantee path, so the SN-8 wall is intact
+# (no guarantee-path crate depends on kx-catalog; asserted by the m7_2 exit-gate).
+kx-warrant  = { workspace = true }
 # The frozen canonical content-addressed encoding (bincode v2, LE + fixed-int —
 # byte-identical to kx_mote::canonical_config; replicated to keep the hash
 # discipline self-contained, mirroring kx-critic-types).

--- a/crates/kx-catalog/src/action.rs
+++ b/crates/kx-catalog/src/action.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Catalog permissions (M7.2, D86): the closed [`CatalogAction`] vocabulary and
+//! the fail-closed, narrowing-only [`CatalogActionSet`].
+//!
+//! These are the catalog-governance actions, ORTHOGONAL to a `WarrantSpec`'s
+//! runtime capabilities (a grant carries BOTH: which catalog actions the grantee
+//! may perform, and the runtime warrant a `Use` runs under). [`CatalogActionSet`]
+//! mirrors `kx_warrant::SecretScope` — `None` is the fail-closed default and
+//! [`CatalogActionSet::narrow`] is set-intersection, so a delegated grant can
+//! never name an action the delegator did not hold (laundering is impossible by
+//! construction).
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// A single catalog-governance action. A closed `#[repr(u8)]` enum — growing it
+/// is a deliberate [`crate::GRANT_SCHEMA_VERSION`] bump (the variant set folds
+/// into a grant's content hash).
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub enum CatalogAction {
+    /// May read the asset's catalog metadata / discover it.
+    Read = 0,
+    /// May invoke the asset (a fresh registered run inherits the grant warrant).
+    Use = 1,
+    /// May register / publish a new version under the asset's namespace.
+    Register = 2,
+    /// May delegate a (narrowed) sub-grant of this asset to another party.
+    Delegate = 3,
+}
+
+impl CatalogAction {
+    /// The canonical full set of every action — the owner's complete authority.
+    /// MUST enumerate every variant (a drift guard in the proptests fails to
+    /// compile if a variant is added without being listed here).
+    #[must_use]
+    pub fn all() -> BTreeSet<Self> {
+        [Self::Read, Self::Use, Self::Register, Self::Delegate]
+            .into_iter()
+            .collect()
+    }
+}
+
+/// The set of catalog actions a grant conveys.
+///
+/// `None` is the fail-closed default (conveys nothing). `AllowList(S)` conveys
+/// exactly `S`. There is ONE canonical deny representation: [`CatalogActionSet::allow`]
+/// normalizes an empty allow-list to `None`, so `None` and `AllowList({})` can
+/// never both occur (illegal duplicate-state unrepresentable).
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default, Serialize, Deserialize)]
+pub enum CatalogActionSet {
+    /// Conveys no action (fail-closed default).
+    #[default]
+    None,
+    /// Conveys exactly the listed actions (never empty — see [`CatalogActionSet::allow`]).
+    AllowList(BTreeSet<CatalogAction>),
+}
+
+impl CatalogActionSet {
+    /// The full-authority set (every [`CatalogAction`]).
+    #[must_use]
+    pub fn all() -> Self {
+        Self::AllowList(CatalogAction::all())
+    }
+
+    /// Build from an iterator of actions. An empty set normalizes to [`Self::None`]
+    /// (the single canonical deny representation).
+    #[must_use]
+    pub fn allow(actions: impl IntoIterator<Item = CatalogAction>) -> Self {
+        let set: BTreeSet<CatalogAction> = actions.into_iter().collect();
+        if set.is_empty() {
+            Self::None
+        } else {
+            Self::AllowList(set)
+        }
+    }
+
+    /// `true` iff `self` conveys no more than `parent`: `None ⊆ anything`;
+    /// `AllowList(_) ⊄ None`; `AllowList(c) ⊆ AllowList(p)` iff `c ⊆ p`.
+    #[must_use]
+    pub fn is_subset_of(&self, parent: &Self) -> bool {
+        match (self, parent) {
+            (Self::None, _) => true,
+            (Self::AllowList(_), Self::None) => false,
+            (Self::AllowList(c), Self::AllowList(p)) => c.is_subset(p),
+        }
+    }
+
+    /// Set-intersection narrowing: the actions a delegate may convey are bounded
+    /// by what the delegator held. Monotone — the result is `⊆` both operands,
+    /// so an action absent from either is unrepresentable in the result.
+    #[must_use]
+    pub fn narrow(&self, cap: &Self) -> Self {
+        match (self, cap) {
+            (Self::None, _) | (_, Self::None) => Self::None,
+            (Self::AllowList(a), Self::AllowList(b)) => Self::allow(a.intersection(b).copied()),
+        }
+    }
+
+    /// Set-union: combine the actions conveyed by two grants the same party
+    /// holds on one asset (authorization is additive across grants).
+    #[must_use]
+    pub fn union(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::None, x) | (x, Self::None) => x.clone(),
+            (Self::AllowList(a), Self::AllowList(b)) => Self::allow(a.union(b).copied()),
+        }
+    }
+
+    /// `true` iff `action` is conveyed.
+    #[must_use]
+    pub fn contains(&self, action: CatalogAction) -> bool {
+        match self {
+            Self::None => false,
+            Self::AllowList(s) => s.contains(&action),
+        }
+    }
+
+    /// `true` iff this set conveys nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}

--- a/crates/kx-catalog/src/grant.rs
+++ b/crates/kx-catalog/src/grant.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Grants + revocations (M7.2, D86) — content-addressed, narrowing-only,
+//! revoke-by-new-fact.
+//!
+//! A [`Grant`] issues a grantee a set of [`CatalogActionSet`] catalog actions on
+//! an [`AssetRef`], plus a runtime scope ([`Role`]) the grantee's runs narrow
+//! under. A grant is either a **root** grant (issued by the asset owner, `prior =
+//! None`) or a **delegated** sub-grant (`prior = Some(parent)`). It is
+//! content-addressed by [`GrantId`] (`blake3(domain-tag ‖ canonical_bincode)`),
+//! exactly the [`crate::TaskSignatureHash`] discipline — two byte-identical
+//! grants share an id.
+//!
+//! Narrowing is NOT re-implemented here: the runtime warrant a grant chain
+//! conveys is computed through the FROZEN `kx_warrant::intersect` seam
+//! ([`effective_runtime_warrant`] / the ledger fold), so a grant can never widen
+//! the granting party's own capability (a widen surfaces as
+//! [`NarrowingError`](kx_warrant::NarrowingError), never a silently-wider warrant).
+//!
+//! A [`Revocation`] is a NEW fact (D-LOCK-4: revoke by new fact, never edit). It
+//! is recorded MINIMALLY — append does not check the revoker's authority; the
+//! ledger fold honors a revocation ONLY when the revoker is the grant's grantor
+//! (you may revoke what you granted) or the asset owner (an owner may revoke any
+//! grant on their asset). An unauthorized revocation is a recorded-but-inert
+//! fact, exactly as an unauthorized grant conveys nothing.
+
+use kx_warrant::{intersect, NarrowingError, Role, WarrantSpec};
+use serde::{Deserialize, Serialize};
+
+use crate::action::CatalogActionSet;
+use crate::party::PartyId;
+use crate::path::AssetRef;
+use crate::signature::canonical_config;
+
+/// A 32-byte BLAKE3 hash — the catalog's identity substrate.
+type Hash32 = [u8; 32];
+
+/// Canonical-encoding schema version of a [`Grant`]. Bumped on ANY change to the
+/// canonical bytes (the version is a struct field, so it folds into [`GrantId`]).
+/// Mirrors [`crate::TASK_SIGNATURE_SCHEMA_VERSION`].
+pub const GRANT_SCHEMA_VERSION: u16 = 1;
+
+/// The content-addressed identity of a [`Grant`]:
+/// `blake3(b"kx-catalog/grant/v1" ‖ canonical_bincode(grant))`. The domain tag
+/// prevents cross-type preimage aliasing.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct GrantId(pub Hash32);
+
+impl GrantId {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for GrantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GrantId({})", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+impl std::fmt::Display for GrantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// A capability grant on a catalog asset.
+///
+/// All fields are private; the only constructors are [`Grant::root`] and
+/// [`Grant::delegated`], so `schema_version` is never caller-set and a grant's
+/// root/delegated shape is structurally honest (`prior` matches the constructor).
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct Grant {
+    /// Canonical-encoding schema version (constructor-set, never caller-set).
+    schema_version: u16,
+    /// The asset this grant is on.
+    asset: AssetRef,
+    /// Who issued the grant: the asset owner (root) or a delegator (delegated).
+    grantor: PartyId,
+    /// Who receives it.
+    grantee: PartyId,
+    /// The catalog actions conveyed (bounded by the grantor's own, via the fold).
+    actions: CatalogActionSet,
+    /// The runtime scope a `Use` runs under — narrowed through `kx_warrant::intersect`.
+    runtime_scope: Role,
+    /// `None` for a root grant; `Some(parent)` for a delegated sub-grant.
+    prior: Option<GrantId>,
+}
+
+impl Grant {
+    /// A **root** grant issued by an asset owner (`prior = None`). It conveys
+    /// authority only when the grantor is in fact the asset's bound owner (the
+    /// ledger fold checks this — an off-owner root grant is recorded-but-inert).
+    #[must_use]
+    pub fn root(
+        asset: AssetRef,
+        grantor: PartyId,
+        grantee: PartyId,
+        actions: CatalogActionSet,
+        runtime_scope: Role,
+    ) -> Self {
+        Self {
+            schema_version: GRANT_SCHEMA_VERSION,
+            asset,
+            grantor,
+            grantee,
+            actions,
+            runtime_scope,
+            prior: None,
+        }
+    }
+
+    /// A **delegated** sub-grant (`prior = Some(parent)`). It conveys authority
+    /// only when the parent grant conveys `Delegate`, the parent's grantee is
+    /// this grant's grantor, and both are on the same asset (the fold checks all
+    /// three — a broken chain is recorded-but-inert).
+    #[must_use]
+    pub fn delegated(
+        prior: GrantId,
+        asset: AssetRef,
+        grantor: PartyId,
+        grantee: PartyId,
+        actions: CatalogActionSet,
+        runtime_scope: Role,
+    ) -> Self {
+        Self {
+            schema_version: GRANT_SCHEMA_VERSION,
+            asset,
+            grantor,
+            grantee,
+            actions,
+            runtime_scope,
+            prior: Some(prior),
+        }
+    }
+
+    /// The asset this grant is on.
+    #[inline]
+    #[must_use]
+    pub fn asset(&self) -> &AssetRef {
+        &self.asset
+    }
+
+    /// The grantor (owner for root; delegator for delegated).
+    #[inline]
+    #[must_use]
+    pub fn grantor(&self) -> &PartyId {
+        &self.grantor
+    }
+
+    /// The grantee.
+    #[inline]
+    #[must_use]
+    pub fn grantee(&self) -> &PartyId {
+        &self.grantee
+    }
+
+    /// The conveyed catalog actions (before the fold's chain-narrowing).
+    #[inline]
+    #[must_use]
+    pub fn actions(&self) -> &CatalogActionSet {
+        &self.actions
+    }
+
+    /// The runtime scope (`Role`) a `Use` narrows under.
+    #[inline]
+    #[must_use]
+    pub fn runtime_scope(&self) -> &Role {
+        &self.runtime_scope
+    }
+
+    /// The parent grant id (`None` for a root grant).
+    #[inline]
+    #[must_use]
+    pub fn prior(&self) -> Option<GrantId> {
+        self.prior
+    }
+
+    /// The canonical-encoding schema version this grant was built under.
+    #[inline]
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// The content-addressed identity: `blake3(b"kx-catalog/grant/v1" ‖
+    /// canonical_bincode(self))`. Pure; two byte-identical grants share an id.
+    #[must_use]
+    pub fn grant_id(&self) -> GrantId {
+        let mut h = blake3::Hasher::new();
+        h.update(b"kx-catalog/grant/v1");
+        // SAFETY (expect): a Grant composes AssetRef (strings + [u8;32]), PartyId
+        // (string), CatalogActionSet (u8-discriminant enum set), a kx_warrant::Role
+        // (strings + u32 + WarrantSpec — integer/bytes only, NO float), u16, and
+        // Option<GrantId> ([u8;32]) — none of which carry a float or a
+        // non-encodable variant, so canonical bincode encoding is infallible.
+        // Mirrors the documented `TaskSignature::task_signature_hash`.
+        let body = bincode::serde::encode_to_vec(self, canonical_config())
+            .expect("Grant canonical encoding is infallible (no floats, no non-encodable types)");
+        h.update(&body);
+        GrantId(*h.finalize().as_bytes())
+    }
+}
+
+/// The content-addressed identity of a [`Revocation`] — equal to
+/// [`revocation_idempotency_key`], so two identical revocations dedupe.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct RevocationId(pub Hash32);
+
+impl RevocationId {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for RevocationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RevocationId({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+/// The idempotency key (and content id) of a revocation of `grant_id` by
+/// `revoker`: `blake3(b"kx-catalog/revocation/v1" ‖ grant_id(32B) ‖ revoker)`.
+///
+/// The fixed-length `grant_id` precedes the variable-length `revoker` so the
+/// byte boundary is unambiguous (no length-extension aliasing). Two identical
+/// `(grant_id, revoker)` revocations collapse to one fact.
+#[must_use]
+pub fn revocation_idempotency_key(grant_id: &GrantId, revoker: &PartyId) -> RevocationId {
+    let mut h = blake3::Hasher::new();
+    h.update(b"kx-catalog/revocation/v1");
+    h.update(grant_id.as_bytes());
+    h.update(revoker.as_str().as_bytes());
+    RevocationId(*h.finalize().as_bytes())
+}
+
+/// A revocation of a grant (D-LOCK-4: revoke by new fact, never edit).
+///
+/// Private fields; built via [`Revocation::new`]. The schema is pinned by the
+/// domain tag in [`revocation_idempotency_key`], so no struct version field is
+/// needed.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct Revocation {
+    grant_id: GrantId,
+    revoker: PartyId,
+}
+
+impl Revocation {
+    /// Record an intent to revoke `grant_id` by `revoker`. Authority is decided
+    /// by the ledger fold, not here.
+    #[must_use]
+    pub fn new(grant_id: GrantId, revoker: PartyId) -> Self {
+        Self { grant_id, revoker }
+    }
+
+    /// The grant being revoked.
+    #[inline]
+    #[must_use]
+    pub fn grant_id(&self) -> GrantId {
+        self.grant_id
+    }
+
+    /// Who is attempting the revocation.
+    #[inline]
+    #[must_use]
+    pub fn revoker(&self) -> &PartyId {
+        &self.revoker
+    }
+
+    /// The content-addressed identity (= [`revocation_idempotency_key`]).
+    #[must_use]
+    pub fn revocation_id(&self) -> RevocationId {
+        revocation_idempotency_key(&self.grant_id, &self.revoker)
+    }
+}
+
+/// One-hop effective warrant: narrow `grantor_effective` (the granting party's
+/// own effective warrant) by `grant`'s runtime scope, via the FROZEN
+/// `kx_warrant::intersect` seam. The ledger fold applies this at every chain hop.
+///
+/// # Errors
+///
+/// Propagates [`NarrowingError`](kx_warrant::NarrowingError) when the grant's
+/// runtime scope proposes a widen on any qualitative axis — a grant can never
+/// authorize a wider runtime warrant than the granting party holds.
+pub fn effective_runtime_warrant(
+    grantor_effective: &WarrantSpec,
+    grant: &Grant,
+) -> Result<WarrantSpec, NarrowingError> {
+    intersect(grantor_effective, grant.runtime_scope())
+}

--- a/crates/kx-catalog/src/in_memory_ledger.rs
+++ b/crates/kx-catalog/src/in_memory_ledger.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`InMemoryGrantLedger`] — the reference [`GrantLedger`] backend.
+//!
+//! An append-only `Vec<LedgerFact>` truth + derived `BTreeMap` indices under a
+//! single [`RwLock`]: O(log n) append + per-query lookup, sub-linear at scale,
+//! deterministic. Process-local + rebuildable — not for production durability (a
+//! persistent backend implements the same trait, D94). It proves [`GrantLedger`]
+//! carries no storage-substrate assumption (the role `InMemoryCatalog` plays for
+//! [`crate::CatalogRegistry`]).
+//!
+//! ## The fold
+//!
+//! Authorization is an iterative, depth-bounded, single-pass fold over a grant's
+//! delegation chain ([`fold_chain`]): collect leaf→root bounded by
+//! [`MAX_DELEGATION_DEPTH`] (cycle / missing / over-depth → fail-closed), then
+//! fold root→leaf narrowing actions (set-intersection) and the runtime warrant
+//! (the FROZEN `kx_warrant::intersect`), honoring authorized revocations at every
+//! hop. No recursion ⇒ a pathologically deep chain caps WORK, never the stack.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::RwLock;
+
+use kx_warrant::{intersect, NarrowingError, WarrantSpec};
+
+use crate::action::CatalogActionSet;
+use crate::grant::{Grant, GrantId};
+use crate::ledger::{
+    AppendOutcome, AssetBinding, EffectiveGrants, GrantLedger, GrantWarrant, LedgerError,
+    LedgerFact, MAX_DELEGATION_DEPTH,
+};
+use crate::party::PartyId;
+use crate::path::AssetRef;
+
+/// The append-only truth + derived indices.
+#[derive(Debug, Default)]
+struct Inner {
+    /// The append-only fact log (the truth; everything else is a derived index).
+    facts: Vec<LedgerFact>,
+    /// Content id → position in `facts` (idempotency + immutability tripwire).
+    by_id: BTreeMap<crate::ledger::FactId, usize>,
+    /// Asset → owner (genesis bindings).
+    bindings: BTreeMap<AssetRef, PartyId>,
+    /// Grant id → position in `facts` (O(log n) grant lookup for the fold).
+    grants: BTreeMap<GrantId, usize>,
+    /// (grantee, asset) → the leaf grant ids that party holds on that asset.
+    grants_by_grantee_asset: BTreeMap<(PartyId, AssetRef), Vec<GrantId>>,
+    /// Grant id → the parties that have recorded a revocation of it. The fold
+    /// filters to AUTHORIZED revokers (grantor or owner); recording is unchecked.
+    revoked: BTreeMap<GrantId, BTreeSet<PartyId>>,
+}
+
+/// An ephemeral, process-local [`GrantLedger`]. Multiple readers, one writer.
+///
+/// # Examples
+///
+/// ```
+/// use kx_catalog::{
+///     AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant,
+///     GrantLedger, InMemoryGrantLedger, PartyId,
+/// };
+/// use kx_warrant::{Role, WarrantSpec};
+///
+/// let ledger = InMemoryGrantLedger::new();
+/// let asset = AssetRef::Path(AssetPath::new("acme", "research", "lit-review").unwrap());
+/// let owner = PartyId::new("admin@acme");
+/// let mate = PartyId::new("teammate@acme");
+///
+/// ledger.append_binding(AssetBinding::new(asset.clone(), owner.clone())).unwrap();
+/// assert_eq!(ledger.owner_of(&asset), Some(owner.clone()));
+///
+/// // The owner's base warrant; a role that does not widen it.
+/// let owner_root = WarrantSpec::default();
+/// let role = Role { name: "read-only".into(), version: 1, spec: WarrantSpec::default(), description: String::new() };
+/// let g = Grant::root(asset.clone(), owner, mate.clone(),
+///     CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]), role);
+/// ledger.append_grant(g).unwrap();
+///
+/// assert!(ledger.is_authorized(&mate, &asset, CatalogAction::Use));
+/// assert!(!ledger.is_authorized(&mate, &asset, CatalogAction::Delegate));
+/// ```
+#[derive(Debug, Default)]
+pub struct InMemoryGrantLedger {
+    inner: RwLock<Inner>,
+}
+
+impl InMemoryGrantLedger {
+    /// Construct an empty ledger.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Look up a grant by id, borrowing it from the fact log.
+fn grant_at<'a>(inner: &'a Inner, gid: &GrantId) -> Option<&'a Grant> {
+    inner
+        .grants
+        .get(gid)
+        .and_then(|&pos| match &inner.facts[pos] {
+            LedgerFact::Grant(g) => Some(g.as_ref()),
+            _ => None,
+        })
+}
+
+/// `true` iff `gid` has an AUTHORIZED revocation: a revoker that is the grant's
+/// grantor (you may revoke what you granted) or the asset owner (an owner may
+/// revoke any grant on their asset). An unauthorized party's recorded revocation
+/// conveys nothing.
+fn is_revoked(inner: &Inner, gid: &GrantId, grant: &Grant, owner: Option<&PartyId>) -> bool {
+    match inner.revoked.get(gid) {
+        None => false,
+        Some(revokers) => revokers
+            .iter()
+            .any(|r| r == grant.grantor() || owner == Some(r)),
+    }
+}
+
+/// The folded result of one delegation chain.
+struct ChainFold {
+    actions: CatalogActionSet,
+    /// `Some` iff `owner_root` was supplied (the warrant-bearing fold); `None`
+    /// for the actions-only fold (which never invokes warrant narrowing, so it
+    /// is total / infallible).
+    warrant: Option<WarrantSpec>,
+}
+
+/// Fold a single delegation chain identified by its `leaf` grant id.
+///
+/// `Ok(None)` = the chain conveys nothing (fail-closed: missing/cyclic/over-deep
+/// chain, an authorized revocation anywhere, a broken delegation link, a
+/// delegator lacking `Delegate`, or a root grant not from the asset owner).
+/// `Err` = a runtime-scope widen surfaced by `kx_warrant::intersect` (only
+/// possible when `owner_root` is `Some`).
+fn fold_chain(
+    inner: &Inner,
+    leaf: &GrantId,
+    owner: Option<&PartyId>,
+    owner_root: Option<&WarrantSpec>,
+) -> Result<Option<ChainFold>, NarrowingError> {
+    // Phase 1 — collect leaf→root, bounded + cycle/missing guarded (fail-closed).
+    let mut chain: Vec<&Grant> = Vec::new();
+    let mut seen: BTreeSet<GrantId> = BTreeSet::new();
+    let mut cur = Some(*leaf);
+    while let Some(id) = cur {
+        if chain.len() >= MAX_DELEGATION_DEPTH {
+            return Ok(None); // over-depth → fail-closed
+        }
+        if !seen.insert(id) {
+            return Ok(None); // cycle → fail-closed
+        }
+        let Some(g) = grant_at(inner, &id) else {
+            return Ok(None); // missing grant → fail-closed
+        };
+        chain.push(g);
+        cur = g.prior();
+    }
+
+    // Phase 2 — fold root→leaf, narrowing actions + warrant at each hop.
+    let mut parent_actions = CatalogActionSet::all(); // owner's full authority above the root
+    let mut parent_warrant = owner_root.cloned();
+    let mut parent: Option<&Grant> = None;
+    for g in chain.iter().rev() {
+        let gid = g.grant_id();
+        if is_revoked(inner, &gid, g, owner) {
+            return Ok(None); // an authorized revocation cascades to the whole subtree
+        }
+        match g.prior() {
+            Some(_) => {
+                // Delegated hop: the parent must convey Delegate, the parent's
+                // grantee must be this grant's grantor, and both on the same asset.
+                let Some(p) = parent else {
+                    return Ok(None); // dangling delegated grant (no in-chain parent)
+                };
+                if p.grantee() != g.grantor() || p.asset() != g.asset() {
+                    return Ok(None); // broken delegation link
+                }
+                if !parent_actions.contains(crate::action::CatalogAction::Delegate) {
+                    return Ok(None); // delegator did not hold Delegate
+                }
+            }
+            None => {
+                // Root hop: the grantor must be the asset's bound owner.
+                if owner != Some(g.grantor()) {
+                    return Ok(None);
+                }
+            }
+        }
+        parent_actions = g.actions().narrow(&parent_actions);
+        parent_warrant = match parent_warrant {
+            Some(pw) => Some(intersect(&pw, g.runtime_scope())?),
+            None => None,
+        };
+        parent = Some(g);
+    }
+
+    Ok(Some(ChainFold {
+        actions: parent_actions,
+        warrant: parent_warrant,
+    }))
+}
+
+impl GrantLedger for InMemoryGrantLedger {
+    fn append_binding(&self, binding: AssetBinding) -> Result<AppendOutcome, LedgerError> {
+        let fact = LedgerFact::Bind(binding.clone());
+        let fid = fact.fact_id();
+        let mut guard = self.inner.write().expect("poisoned lock");
+        // Owner conflict takes precedence: an asset has exactly one owner.
+        if let Some(existing) = guard.bindings.get(binding.asset()) {
+            if existing != binding.owner() {
+                return Err(LedgerError::OwnerConflict(format!(
+                    "asset {} already bound to a different owner",
+                    binding.asset()
+                )));
+            }
+            return Ok(AppendOutcome::AlreadyPresent(fid)); // same owner → idempotent
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        guard
+            .bindings
+            .insert(binding.asset().clone(), binding.owner().clone());
+        Ok(AppendOutcome::Appended(fid))
+    }
+
+    fn append_grant(&self, grant: Grant) -> Result<AppendOutcome, LedgerError> {
+        let gid = grant.grant_id();
+        let grantee = grant.grantee().clone();
+        let asset = grant.asset().clone();
+        let fact = LedgerFact::Grant(Box::new(grant));
+        let fid = fact.fact_id();
+        let mut guard = self.inner.write().expect("poisoned lock");
+        if let Some(&pos) = guard.by_id.get(&fid) {
+            return if guard.facts[pos] == fact {
+                Ok(AppendOutcome::AlreadyPresent(fid))
+            } else {
+                Err(LedgerError::ImmutabilityConflict(fid.to_hex()))
+            };
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        guard.grants.insert(gid, pos);
+        guard
+            .grants_by_grantee_asset
+            .entry((grantee, asset))
+            .or_default()
+            .push(gid);
+        Ok(AppendOutcome::Appended(fid))
+    }
+
+    fn append_revocation(
+        &self,
+        revocation: crate::grant::Revocation,
+    ) -> Result<AppendOutcome, LedgerError> {
+        let grant_id = revocation.grant_id();
+        let revoker = revocation.revoker().clone();
+        let fact = LedgerFact::Revoke(revocation);
+        let fid = fact.fact_id();
+        let mut guard = self.inner.write().expect("poisoned lock");
+        if let Some(&pos) = guard.by_id.get(&fid) {
+            return if guard.facts[pos] == fact {
+                Ok(AppendOutcome::AlreadyPresent(fid))
+            } else {
+                Err(LedgerError::ImmutabilityConflict(fid.to_hex()))
+            };
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        guard.revoked.entry(grant_id).or_default().insert(revoker);
+        Ok(AppendOutcome::Appended(fid))
+    }
+
+    fn owner_of(&self, asset: &AssetRef) -> Option<PartyId> {
+        self.inner
+            .read()
+            .expect("poisoned lock")
+            .bindings
+            .get(asset)
+            .cloned()
+    }
+
+    fn effective_grants(&self, party: &PartyId, asset: &AssetRef) -> EffectiveGrants {
+        let guard = self.inner.read().expect("poisoned lock");
+        let inner: &Inner = &guard;
+        let owner = inner.bindings.get(asset);
+        let Some(gids) = inner
+            .grants_by_grantee_asset
+            .get(&(party.clone(), asset.clone()))
+        else {
+            return EffectiveGrants::default();
+        };
+        let mut per_grant: Vec<(GrantId, CatalogActionSet)> = Vec::new();
+        for gid in gids {
+            // Actions-only fold (owner_root = None): never invokes warrant
+            // narrowing, so it cannot error — an Err is structurally impossible.
+            if let Ok(Some(cf)) = fold_chain(inner, gid, owner, None) {
+                if !cf.actions.is_empty() {
+                    per_grant.push((*gid, cf.actions));
+                }
+            }
+        }
+        EffectiveGrants::from_parts(per_grant)
+    }
+
+    fn effective_grant_warrants(
+        &self,
+        party: &PartyId,
+        asset: &AssetRef,
+        owner_root: &WarrantSpec,
+    ) -> Result<Vec<GrantWarrant>, NarrowingError> {
+        let guard = self.inner.read().expect("poisoned lock");
+        let inner: &Inner = &guard;
+        let owner = inner.bindings.get(asset);
+        let Some(gids) = inner
+            .grants_by_grantee_asset
+            .get(&(party.clone(), asset.clone()))
+        else {
+            return Ok(Vec::new());
+        };
+        let mut out: Vec<GrantWarrant> = Vec::new();
+        for gid in gids {
+            if let Some(cf) = fold_chain(inner, gid, owner, Some(owner_root))? {
+                // owner_root is Some ⇒ the fold always yields Some(warrant).
+                if let (false, Some(w)) = (cf.actions.is_empty(), cf.warrant) {
+                    out.push(GrantWarrant::new(*gid, cf.actions, w));
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn list_facts<'a>(&'a self) -> Box<dyn Iterator<Item = LedgerFact> + 'a> {
+        let guard = self.inner.read().expect("poisoned lock");
+        // Snapshot under the read lock (append order), then release before iterating.
+        let facts: Vec<LedgerFact> = guard.facts.clone();
+        Box::new(facts.into_iter())
+    }
+
+    fn len(&self) -> usize {
+        self.inner.read().expect("poisoned lock").facts.len()
+    }
+}
+
+// Compile-time proof the ledger is shareable across threads (so `Arc<…>` works
+// for the concurrency tests + a multi-threaded gateway).
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<InMemoryGrantLedger>();
+};

--- a/crates/kx-catalog/src/ledger.rs
+++ b/crates/kx-catalog/src/ledger.rs
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The grant-ledger seam (M7.2, D86): the backend-agnostic [`GrantLedger`]
+//! trait, its append-only fact vocabulary ([`LedgerFact`] / [`AssetBinding`]),
+//! the query result types ([`EffectiveGrants`] / [`GrantWarrant`]), and the
+//! [`AppendOutcome`] / [`LedgerError`] outcomes. The in-memory reference backend
+//! is [`crate::InMemoryGrantLedger`].
+//!
+//! ## "Journaled" = the D-LOCK-4 discipline, applied HERE
+//!
+//! Like the M7.1 [`crate::CatalogRegistry`], this is a **separate truth**: it is
+//! authoritative for *what grants exist*, and does NOT depend on `kx-journal`
+//! (the dependency direction is the wall). D86's "journaled fact" is realized as
+//! the DISCIPLINE — append-only, content-addressed, immutable, idempotent,
+//! revoke-by-new-fact — inside the ledger. A durable / cloud backend (D94)
+//! implements the SAME trait; the in-memory backend is rebuildable, not durable.
+//!
+//! ## Authorization is the fold, never the fact
+//!
+//! Appends are minimal and unchecked: a grant or revocation is recorded as a
+//! fact regardless of whether it conveys anything. Authority is computed by the
+//! fail-closed fold ([`GrantLedger::effective_grants`] /
+//! [`GrantLedger::resolve_effective_warrant_for`]) — a forged, widening,
+//! laundering, off-owner, or over-deep grant conveys nothing. The fold reuses
+//! the FROZEN `kx_warrant::intersect`, so a runtime warrant can never widen.
+
+use std::sync::Arc;
+
+use kx_warrant::{NarrowingError, WarrantSpec};
+use serde::{Deserialize, Serialize};
+
+use crate::action::{CatalogAction, CatalogActionSet};
+use crate::grant::{Grant, GrantId, Revocation};
+use crate::party::PartyId;
+use crate::path::AssetRef;
+use crate::signature::canonical_config;
+
+/// A 32-byte BLAKE3 hash.
+type Hash32 = [u8; 32];
+
+/// The maximum delegation-chain depth the fold will walk. A chain deeper than
+/// this fails closed (conveys nothing) rather than walking unbounded — a hard
+/// DoS / stack-growth bound. The fold is iterative, so this caps work, never the
+/// call stack.
+pub const MAX_DELEGATION_DEPTH: usize = 64;
+
+/// The content-addressed identity of a [`LedgerFact`] — equal to the content id
+/// of the fact's payload (a binding's `binding_id`, a grant's `GrantId`, a
+/// revocation's `RevocationId`). The ledger dedups + enforces immutability by
+/// this id.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct FactId(pub Hash32);
+
+impl FactId {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for FactId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FactId({})", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// The genesis fact binding an asset to its owning party. The owner is the only
+/// party whose ROOT grant on the asset conveys authority.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct AssetBinding {
+    asset: AssetRef,
+    owner: PartyId,
+}
+
+impl AssetBinding {
+    /// Bind `asset` to `owner`.
+    #[must_use]
+    pub fn new(asset: AssetRef, owner: PartyId) -> Self {
+        Self { asset, owner }
+    }
+
+    /// The bound asset.
+    #[inline]
+    #[must_use]
+    pub fn asset(&self) -> &AssetRef {
+        &self.asset
+    }
+
+    /// The owning party.
+    #[inline]
+    #[must_use]
+    pub fn owner(&self) -> &PartyId {
+        &self.owner
+    }
+
+    /// The content-addressed identity:
+    /// `blake3(b"kx-catalog/asset-binding/v1" ‖ canonical_bincode(self))`.
+    #[must_use]
+    pub fn binding_id(&self) -> FactId {
+        let mut h = blake3::Hasher::new();
+        h.update(b"kx-catalog/asset-binding/v1");
+        // SAFETY (expect): AssetBinding is AssetRef (strings + [u8;32]) + PartyId
+        // (string) — no floats, no non-encodable variant; bincode encode is
+        // infallible (mirrors `Grant::grant_id`).
+        let body = bincode::serde::encode_to_vec(self, canonical_config()).expect(
+            "AssetBinding canonical encoding is infallible (no floats, no non-encodable types)",
+        );
+        h.update(&body);
+        FactId(*h.finalize().as_bytes())
+    }
+}
+
+/// An append-only ledger fact. A closed enum — there is no untyped fact. `Grant`
+/// is boxed so the enum stays pointer-sized (the grant is the large variant).
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum LedgerFact {
+    /// An asset → owner binding.
+    Bind(AssetBinding),
+    /// A capability grant.
+    Grant(Box<Grant>),
+    /// A revocation (revoke by new fact, D-LOCK-4).
+    Revoke(Revocation),
+}
+
+impl LedgerFact {
+    /// The content-addressed id of this fact (= the payload's content id). The
+    /// per-payload domain tags (`asset-binding` / `grant` / `revocation`) keep
+    /// cross-kind ids distinct.
+    #[must_use]
+    pub fn fact_id(&self) -> FactId {
+        match self {
+            Self::Bind(b) => b.binding_id(),
+            Self::Grant(g) => FactId(*g.grant_id().as_bytes()),
+            Self::Revoke(r) => FactId(*r.revocation_id().as_bytes()),
+        }
+    }
+}
+
+/// The outcome of an append: a fresh insert vs. an idempotent no-op (the fact
+/// was byte-identically present).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AppendOutcome {
+    /// First append of this fact.
+    Appended(FactId),
+    /// A byte-identical fact was already present — no-op (idempotent).
+    AlreadyPresent(FactId),
+}
+
+impl AppendOutcome {
+    /// The fact id this outcome refers to.
+    #[inline]
+    #[must_use]
+    pub const fn fact_id(&self) -> FactId {
+        match self {
+            Self::Appended(f) | Self::AlreadyPresent(f) => *f,
+        }
+    }
+
+    /// `true` iff this was a fresh append (not an idempotent no-op).
+    #[inline]
+    #[must_use]
+    pub const fn is_appended(&self) -> bool {
+        matches!(self, Self::Appended(_))
+    }
+}
+
+/// A grant-ledger append failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LedgerError {
+    /// A DIFFERENT fact already exists at this [`FactId`]. Facts are
+    /// content-addressed, so the same id MUST mean the same bytes — a mismatch
+    /// is a hash-collision tripwire (cryptographically unreachable): refuse
+    /// loudly rather than overwrite. Carries the conflicting id (hex).
+    #[error("immutable ledger conflict at fact_id {0}")]
+    ImmutabilityConflict(String),
+    /// An asset is already bound to a DIFFERENT owner. An asset has exactly one
+    /// owner; re-binding to a new owner is refused (the binding is genesis).
+    #[error("asset ownership conflict: {0}")]
+    OwnerConflict(String),
+}
+
+/// One active grant chain a party holds on an asset, paired with the catalog
+/// actions it conveys AND the runtime warrant a `Use` under THOSE actions runs
+/// with. The `actions` and `warrant` come from the SAME folded chain — there is
+/// no constructor that pairs a warrant from one chain with actions from another,
+/// so the action/warrant decoupling that an earlier draft suffered is
+/// **unrepresentable**.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GrantWarrant {
+    leaf: GrantId,
+    actions: CatalogActionSet,
+    warrant: WarrantSpec,
+}
+
+impl GrantWarrant {
+    /// Internal constructor — only the ledger fold builds these, guaranteeing
+    /// `actions` + `warrant` originate from one chain.
+    pub(crate) fn new(leaf: GrantId, actions: CatalogActionSet, warrant: WarrantSpec) -> Self {
+        Self {
+            leaf,
+            actions,
+            warrant,
+        }
+    }
+
+    /// The leaf grant id identifying this chain.
+    #[inline]
+    #[must_use]
+    pub fn leaf(&self) -> GrantId {
+        self.leaf
+    }
+
+    /// The effective catalog actions this chain conveys (post chain-narrowing).
+    #[inline]
+    #[must_use]
+    pub fn actions(&self) -> &CatalogActionSet {
+        &self.actions
+    }
+
+    /// The chain's effective runtime warrant.
+    #[inline]
+    #[must_use]
+    pub fn warrant(&self) -> &WarrantSpec {
+        &self.warrant
+    }
+
+    /// `true` iff this chain conveys `action`.
+    #[inline]
+    #[must_use]
+    pub fn conveys(&self, action: CatalogAction) -> bool {
+        self.actions.contains(action)
+    }
+}
+
+/// The catalog actions a party effectively holds on an asset — the union across
+/// all of their active grant chains, plus the per-chain action breakdown. The
+/// actions-only view (no warrant): warrant resolution is action-aligned and
+/// lives in [`GrantLedger::resolve_effective_warrant_for`].
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct EffectiveGrants {
+    per_grant: Vec<(GrantId, CatalogActionSet)>,
+    actions: CatalogActionSet,
+}
+
+impl EffectiveGrants {
+    /// Build from the folded per-chain `(leaf, actions)` pairs.
+    pub(crate) fn from_parts(per_grant: Vec<(GrantId, CatalogActionSet)>) -> Self {
+        let mut actions = CatalogActionSet::None;
+        for (_, a) in &per_grant {
+            actions = actions.union(a);
+        }
+        Self { per_grant, actions }
+    }
+
+    /// The union of actions across every active chain (the `is_authorized` view).
+    #[inline]
+    #[must_use]
+    pub fn actions(&self) -> &CatalogActionSet {
+        &self.actions
+    }
+
+    /// The leaf grant ids of every active chain.
+    pub fn active(&self) -> impl Iterator<Item = GrantId> + '_ {
+        self.per_grant.iter().map(|(g, _)| *g)
+    }
+
+    /// The leaf grant ids of the active chains that convey `action`.
+    pub fn grants_conveying(&self, action: CatalogAction) -> impl Iterator<Item = GrantId> + '_ {
+        self.per_grant
+            .iter()
+            .filter(move |(_, a)| a.contains(action))
+            .map(|(g, _)| *g)
+    }
+
+    /// `true` iff the party holds no active grant on the asset.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.per_grant.is_empty()
+    }
+}
+
+/// `true` iff warrant `a` conveys NO MORE capability than `b` on every axis
+/// (`a ⊆ b`). Reuses the frozen per-axis `is_subset_of` / `is_within`
+/// primitives; never synthesizes. Qualitative axes use subset; quantitative axes
+/// use `≤`; `tls_required` is restrictive-when-true (so `a ⊆ b` requires `a` at
+/// least as restrictive, i.e. `a.tls_required || !b.tls_required`); the
+/// child-set axes (class / executor / environment / syscall profile) require
+/// EQUALITY — a difference there makes the two warrants incomparable, never one
+/// "within" the other.
+pub(crate) fn warrant_within(a: &WarrantSpec, b: &WarrantSpec) -> bool {
+    // The destructure below is the drift guard: adding a `WarrantSpec` axis
+    // fails to compile here, forcing this comparison (and `most_permissive`) to
+    // be revisited rather than silently ignoring the new axis.
+    let WarrantSpec {
+        mote_class,
+        nd_class,
+        fs_scope,
+        net_scope,
+        syscall_profile_ref,
+        tool_grants,
+        model_route,
+        resource_ceiling,
+        environment_ref,
+        executor_class,
+        secret_scope,
+        cost_ceiling,
+        tls_required,
+    } = a;
+
+    // Qualitative (subset) axes.
+    fs_scope.is_subset_of(&b.fs_scope)
+        && net_scope.is_subset_of(&b.net_scope)
+        && secret_scope.is_subset_of(&b.secret_scope)
+        && tool_grants.is_subset(&b.tool_grants)
+        // Quantitative axes (per-axis ≤).
+        && model_route.is_within(&b.model_route)
+        && resource_ceiling.cpu_milli <= b.resource_ceiling.cpu_milli
+        && resource_ceiling.mem_bytes <= b.resource_ceiling.mem_bytes
+        && resource_ceiling.wall_clock_ms <= b.resource_ceiling.wall_clock_ms
+        && resource_ceiling.fd_count <= b.resource_ceiling.fd_count
+        && resource_ceiling.disk_bytes <= b.resource_ceiling.disk_bytes
+        && cost_ceiling.micro_usd <= b.cost_ceiling.micro_usd
+        // tls_required: a no more permissive than b ⇔ a at least as restrictive.
+        && (*tls_required || !b.tls_required)
+        // Child-set / opaque axes: equality (difference ⇒ incomparable).
+        && *mote_class == b.mote_class
+        && *nd_class == b.nd_class
+        && *syscall_profile_ref == b.syscall_profile_ref
+        && *environment_ref == b.environment_ref
+        && *executor_class == b.executor_class
+}
+
+/// Select the MOST-PERMISSIVE real warrant among `candidates`, breaking ties /
+/// incomparable maxima by the lexicographically-smallest leaf [`GrantId`] (a
+/// stable, content-addressed order). Never synthesizes a warrant — the result is
+/// always one a single grant chain actually conveyed (each is itself
+/// `intersect(owner_root, …chain…)`, hence `⊆ owner_root`), so this can neither
+/// escalate past the owner nor compose axes across grants the grantors did not
+/// jointly authorize. `None` when there are no candidates.
+pub(crate) fn most_permissive(mut candidates: Vec<GrantWarrant>) -> Option<WarrantSpec> {
+    candidates.sort_by(|x, y| x.leaf.as_bytes().cmp(y.leaf.as_bytes()));
+    let mut best: Option<&GrantWarrant> = None;
+    for c in &candidates {
+        best = match best {
+            None => Some(c),
+            // `best ⊆ c` ⇒ c is at least as permissive ⇒ prefer c. Otherwise keep
+            // best (it has the smaller GrantId, since `candidates` is sorted).
+            Some(b) if warrant_within(b.warrant(), c.warrant()) => Some(c),
+            Some(b) => Some(b),
+        };
+    }
+    best.map(|gw| gw.warrant.clone())
+}
+
+/// The grant-ledger seam — backend-agnostic (in-memory now; durable / cloud
+/// behind the same trait, D94). A SEPARATE TRUTH from the journal; it never
+/// writes the journal. Authorization is computed by the fold, never trusted from
+/// a fact.
+pub trait GrantLedger {
+    /// Bind an asset to an owner (genesis). Idempotent on an identical binding;
+    /// [`LedgerError::OwnerConflict`] if the asset is already bound to a
+    /// different owner.
+    ///
+    /// # Errors
+    ///
+    /// [`LedgerError::OwnerConflict`] on a rebind to a different owner.
+    fn append_binding(&self, binding: AssetBinding) -> Result<AppendOutcome, LedgerError>;
+
+    /// Append a grant. Minimal + idempotent (authority is the fold's business).
+    ///
+    /// # Errors
+    ///
+    /// [`LedgerError::ImmutabilityConflict`] only on the cryptographically
+    /// unreachable same-id-different-bytes tripwire.
+    fn append_grant(&self, grant: Grant) -> Result<AppendOutcome, LedgerError>;
+
+    /// Append a revocation (revoke by new fact). Minimal + idempotent; the
+    /// revoker's authority is decided by the fold.
+    ///
+    /// # Errors
+    ///
+    /// [`LedgerError::ImmutabilityConflict`] only on the same tripwire.
+    fn append_revocation(&self, revocation: Revocation) -> Result<AppendOutcome, LedgerError>;
+
+    /// The bound owner of `asset`, if any.
+    fn owner_of(&self, asset: &AssetRef) -> Option<PartyId>;
+
+    /// The catalog actions `party` effectively holds on `asset` (the fail-closed,
+    /// chain-narrowed, revocation-honoring fold). Total — never errors (the
+    /// actions-only fold never invokes warrant narrowing).
+    fn effective_grants(&self, party: &PartyId, asset: &AssetRef) -> EffectiveGrants;
+
+    /// Every active grant chain `party` holds on `asset`, each bundling the
+    /// actions it conveys WITH the runtime warrant under that chain (folded
+    /// against `owner_root`, the owner's base warrant). The transparency API a
+    /// dispatch layer (M7.3) inspects.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`NarrowingError`] if any active chain proposes a runtime-scope
+    /// widen (a grant can never widen the granting party's warrant).
+    fn effective_grant_warrants(
+        &self,
+        party: &PartyId,
+        asset: &AssetRef,
+        owner_root: &WarrantSpec,
+    ) -> Result<Vec<GrantWarrant>, NarrowingError>;
+
+    /// `true` iff `party` holds `action` on `asset` (the union of all active
+    /// chains). The default consults [`GrantLedger::effective_grants`].
+    fn is_authorized(&self, party: &PartyId, asset: &AssetRef, action: CatalogAction) -> bool {
+        self.effective_grants(party, asset)
+            .actions()
+            .contains(action)
+    }
+
+    /// The runtime warrant a `Use`-style invocation of `action` runs under — the
+    /// most-permissive REAL warrant among the active chains that ACTUALLY convey
+    /// `action`. `Ok(None)` if no active chain conveys `action` (even when other
+    /// chains convey other actions) — fail-closed + action-aligned.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`NarrowingError`] from the chain fold.
+    fn resolve_effective_warrant_for(
+        &self,
+        party: &PartyId,
+        asset: &AssetRef,
+        action: CatalogAction,
+        owner_root: &WarrantSpec,
+    ) -> Result<Option<WarrantSpec>, NarrowingError> {
+        let candidates: Vec<GrantWarrant> = self
+            .effective_grant_warrants(party, asset, owner_root)?
+            .into_iter()
+            .filter(|gw| gw.conveys(action))
+            .collect();
+        Ok(most_permissive(candidates))
+    }
+
+    /// The most-permissive REAL warrant across ALL active chains, action-agnostic
+    /// (a convenience for callers that do not key on an action). Prefer
+    /// [`GrantLedger::resolve_effective_warrant_for`] when the action matters.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`NarrowingError`] from the chain fold.
+    fn resolve_effective_warrant(
+        &self,
+        party: &PartyId,
+        asset: &AssetRef,
+        owner_root: &WarrantSpec,
+    ) -> Result<Option<WarrantSpec>, NarrowingError> {
+        Ok(most_permissive(
+            self.effective_grant_warrants(party, asset, owner_root)?,
+        ))
+    }
+
+    /// Enumerate every appended fact in append order.
+    fn list_facts<'a>(&'a self) -> Box<dyn Iterator<Item = LedgerFact> + 'a>;
+
+    /// Count of appended facts.
+    fn len(&self) -> usize;
+
+    /// `true` when no facts are appended.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<L: GrantLedger + ?Sized> GrantLedger for Arc<L> {
+    fn append_binding(&self, binding: AssetBinding) -> Result<AppendOutcome, LedgerError> {
+        (**self).append_binding(binding)
+    }
+
+    fn append_grant(&self, grant: Grant) -> Result<AppendOutcome, LedgerError> {
+        (**self).append_grant(grant)
+    }
+
+    fn append_revocation(&self, revocation: Revocation) -> Result<AppendOutcome, LedgerError> {
+        (**self).append_revocation(revocation)
+    }
+
+    fn owner_of(&self, asset: &AssetRef) -> Option<PartyId> {
+        (**self).owner_of(asset)
+    }
+
+    fn effective_grants(&self, party: &PartyId, asset: &AssetRef) -> EffectiveGrants {
+        (**self).effective_grants(party, asset)
+    }
+
+    fn effective_grant_warrants(
+        &self,
+        party: &PartyId,
+        asset: &AssetRef,
+        owner_root: &WarrantSpec,
+    ) -> Result<Vec<GrantWarrant>, NarrowingError> {
+        (**self).effective_grant_warrants(party, asset, owner_root)
+    }
+
+    fn list_facts<'a>(&'a self) -> Box<dyn Iterator<Item = LedgerFact> + 'a> {
+        (**self).list_facts()
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+}

--- a/crates/kx-catalog/src/lib.rs
+++ b/crates/kx-catalog/src/lib.rs
@@ -18,6 +18,19 @@
 //!   `TaskSignatureHash`. [`CatalogRegistry`] is backend-agnostic (in-memory now;
 //!   a persistent / cloud backend is a later impl behind the same trait, exactly
 //!   as `kx_content::ContentStore` and `kx_dataset::RetrievalIndex`).
+//! - **M7.2 — namespacing + grants/RBAC + revocation** (`path` / `party` /
+//!   `action` / `grant` / `ledger` / `in_memory_ledger`, D86): an asset lives at
+//!   an [`AssetPath`] (`namespace/collection/name`) bound to an owner; a
+//!   content-addressed [`Grant`] issues a grantee [`CatalogActionSet`] catalog
+//!   actions plus a runtime scope, **narrowing-only** through the FROZEN
+//!   `kx_warrant::intersect` (the model can never authorize a widen). A
+//!   [`Revocation`] is a NEW fact (D-LOCK-4) honored only for an authorized
+//!   revoker. [`GrantLedger`] is backend-agnostic (in-memory now; durable / cloud
+//!   later, D94); "journaled" is realized as the append-only, content-addressed,
+//!   immutable, idempotent discipline — this crate still **never depends on
+//!   `kx-journal`**. Authorization is the fail-closed [`GrantLedger::effective_grants`]
+//!   fold, never trusted from a fact; the runtime warrant a `Use` runs under is
+//!   action-aligned ([`GrantLedger::resolve_effective_warrant_for`]).
 //!
 //! ## A separate truth (R4 — NOT a journal-as-truth violation)
 //!
@@ -68,8 +81,14 @@
 #![allow(clippy::expect_used)]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
+mod action;
 mod entry;
+mod grant;
 mod in_memory;
+mod in_memory_ledger;
+mod ledger;
+mod party;
+mod path;
 mod registry;
 mod signature;
 
@@ -83,3 +102,23 @@ pub use signature::{
     canonical_config, SignatureAxis, TaskSignature, TaskSignatureHash, VerdictScope,
     TASK_SIGNATURE_SCHEMA_VERSION,
 };
+
+// M7.2 (D86) — namespacing + grants/RBAC + revocation.
+pub use action::{CatalogAction, CatalogActionSet};
+pub use grant::{
+    effective_runtime_warrant, revocation_idempotency_key, Grant, GrantId, Revocation,
+    RevocationId, GRANT_SCHEMA_VERSION,
+};
+pub use in_memory_ledger::InMemoryGrantLedger;
+pub use ledger::{
+    AppendOutcome, AssetBinding, EffectiveGrants, FactId, GrantLedger, GrantWarrant, LedgerError,
+    LedgerFact, MAX_DELEGATION_DEPTH,
+};
+pub use party::PartyId;
+pub use path::{AssetPath, AssetPathError, AssetRef, MAX_SEGMENT_LEN};
+
+// REUSE (never modify) the frozen monotonic-narrowing seam — one import surface
+// for catalog callers building grant runtime scopes (M7.2 consumes `intersect`;
+// it adds no warrant axis — `secret_scope`/`cost_ceiling`/`tls_required` landed
+// in M5.3a).
+pub use kx_warrant::{intersect, NarrowingError, Role, WarrantSpec};

--- a/crates/kx-catalog/src/party.rs
+++ b/crates/kx-catalog/src/party.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`PartyId`] — the opaque identity a grant is issued to / by (M7.2, D86).
+//!
+//! A `PartyId` is an opaque handle the catalog **never parses**: authorization
+//! is decided by byte-equality of the handle against the grant facts, never by
+//! interpreting its structure. Real principal resolution (a user, a service, a
+//! team, a tenant) lives BEHIND the trait in the cloud identity layer
+//! (`PrincipalResolver`, D94) — keeping it a plain string lets the cloud map it
+//! without reshaping this type, and keeps this crate off `kx-content`.
+
+use serde::{Deserialize, Serialize};
+
+/// The opaque identity of a grantor or grantee. Equality-only; never parsed.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub struct PartyId(String);
+
+impl PartyId {
+    /// Wrap an opaque identity handle.
+    #[inline]
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Borrow the underlying handle bytes.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PartyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/crates/kx-catalog/src/path.rs
+++ b/crates/kx-catalog/src/path.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Catalog namespacing (M7.2, D86) — an asset lives at `namespace/collection/name`.
+//!
+//! [`AssetPath`] is the Unity-Catalog analog (`catalog → schema → object`). Its
+//! three segments are validated to one canonical lowercase byte-representation,
+//! so two logically-equal paths share a hash and an authorization key. An
+//! [`AssetRef`] addresses a governed asset either by its human path or by a
+//! content-addressed [`TaskSignatureHash`] (a recipe), so a grant can name a
+//! recipe directly without a path indirection.
+//!
+//! Construction is the SOLE validation gate ([`AssetPath::new`]): an illegal
+//! path is **unrepresentable** downstream — there is no other way to build one.
+
+use serde::{Deserialize, Serialize};
+
+use crate::signature::TaskSignatureHash;
+
+/// Maximum length, in bytes, of any single path segment. A bound keeps a path
+/// (and its content-addressed key) small and rejects pathological input.
+pub const MAX_SEGMENT_LEN: usize = 128;
+
+/// A namespaced catalog path: `namespace/collection/name`.
+///
+/// Each segment is non-empty, at most [`MAX_SEGMENT_LEN`] bytes, drawn from the
+/// canonical class `[a-z0-9._-]` (lowercase only — one byte-representation per
+/// logical path), and may not begin or end with `.` or `-` (so a segment can
+/// never be read as a relative-path token). Fields are private; the only
+/// constructor is [`AssetPath::new`].
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub struct AssetPath {
+    namespace: String,
+    collection: String,
+    name: String,
+}
+
+/// Why an [`AssetPath`] segment was rejected. Loud, typed refusal — never a
+/// silently-coerced path.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum AssetPathError {
+    /// A segment was empty.
+    #[error("catalog path segment `{which}` must not be empty")]
+    EmptySegment {
+        /// Which segment (`namespace` / `collection` / `name`).
+        which: &'static str,
+    },
+    /// A segment carried a character outside the canonical `[a-z0-9._-]` class.
+    #[error(
+        "catalog path segment `{which}` contains illegal character {ch:?} (allowed: [a-z0-9._-])"
+    )]
+    IllegalChar {
+        /// Which segment.
+        which: &'static str,
+        /// The offending character.
+        ch: char,
+    },
+    /// A segment exceeded [`MAX_SEGMENT_LEN`] bytes.
+    #[error("catalog path segment `{which}` is {len} bytes (max {MAX_SEGMENT_LEN})")]
+    SegmentTooLong {
+        /// Which segment.
+        which: &'static str,
+        /// The over-long length in bytes.
+        len: usize,
+    },
+    /// A segment began or ended with `.` or `-`.
+    #[error("catalog path segment `{which}` must not begin or end with `.` or `-`")]
+    LeadingOrTrailingPunct {
+        /// Which segment.
+        which: &'static str,
+    },
+}
+
+/// Validate one path segment against the canonical class + bounds.
+fn validate_segment(which: &'static str, seg: &str) -> Result<(), AssetPathError> {
+    if seg.is_empty() {
+        return Err(AssetPathError::EmptySegment { which });
+    }
+    if seg.len() > MAX_SEGMENT_LEN {
+        return Err(AssetPathError::SegmentTooLong {
+            which,
+            len: seg.len(),
+        });
+    }
+    for ch in seg.chars() {
+        if !(ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '_' | '-')) {
+            return Err(AssetPathError::IllegalChar { which, ch });
+        }
+    }
+    // `unwrap` here cannot panic: the segment is non-empty (checked above).
+    let first = seg.chars().next().unwrap_or(' ');
+    let last = seg.chars().next_back().unwrap_or(' ');
+    if matches!(first, '.' | '-') || matches!(last, '.' | '-') {
+        return Err(AssetPathError::LeadingOrTrailingPunct { which });
+    }
+    Ok(())
+}
+
+impl AssetPath {
+    /// Construct + validate. The ONLY way to build an `AssetPath`, so any
+    /// `AssetPath` value is guaranteed canonical.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`AssetPathError`] encountered (segments validated
+    /// `namespace`, then `collection`, then `name`).
+    pub fn new(
+        namespace: impl Into<String>,
+        collection: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Result<Self, AssetPathError> {
+        let namespace = namespace.into();
+        let collection = collection.into();
+        let name = name.into();
+        validate_segment("namespace", &namespace)?;
+        validate_segment("collection", &collection)?;
+        validate_segment("name", &name)?;
+        Ok(Self {
+            namespace,
+            collection,
+            name,
+        })
+    }
+
+    /// The namespace segment.
+    #[inline]
+    #[must_use]
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// The collection segment.
+    #[inline]
+    #[must_use]
+    pub fn collection(&self) -> &str {
+        &self.collection
+    }
+
+    /// The name segment.
+    #[inline]
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl std::fmt::Display for AssetPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}/{}", self.namespace, self.collection, self.name)
+    }
+}
+
+/// A reference to a governed asset: a human [`AssetPath`] or a content-addressed
+/// recipe [`TaskSignatureHash`]. A closed enum — a grant can be issued on either
+/// without a third, untyped addressing mode.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub enum AssetRef {
+    /// Addressed by its namespaced path.
+    Path(AssetPath),
+    /// Addressed by the content hash of a registered recipe (M7.1).
+    Signature(TaskSignatureHash),
+}
+
+impl std::fmt::Display for AssetRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(p) => write!(f, "{p}"),
+            Self::Signature(h) => write!(f, "sig:{h}"),
+        }
+    }
+}

--- a/crates/kx-catalog/src/tests.rs
+++ b/crates/kx-catalog/src/tests.rs
@@ -230,3 +230,347 @@ fn slot_binding_default_authoring_shapes() {
     assert_eq!(FreeParamSlot::constant().binding, SlotBinding::Constant);
     let _ = BTreeMap::<String, SlotBinding>::new();
 }
+
+// ---- M7.2: namespacing + grants + revocation (D86) --------------------------
+
+mod m7_2 {
+    use kx_mote::ModelId;
+    use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
+
+    use crate::ledger::{most_permissive, warrant_within, GrantWarrant};
+    use crate::{
+        revocation_idempotency_key, AssetBinding, AssetPath, AssetPathError, AssetRef,
+        CatalogAction, CatalogActionSet, Grant, GrantId, GrantLedger, InMemoryGrantLedger, PartyId,
+        Revocation, TaskSignatureHash,
+    };
+
+    fn path(ns: &str, col: &str, name: &str) -> AssetRef {
+        AssetRef::Path(AssetPath::new(ns, col, name).unwrap())
+    }
+
+    /// A warrant whose only non-default axes are positive quantitative ceilings
+    /// (so `intersect` accepts it; its qualitative axes are the empty defaults,
+    /// hence ⊆ any parent). `max_calls` distinguishes "wide" from "tight".
+    fn warrant_calls(max_calls: u32) -> WarrantSpec {
+        WarrantSpec {
+            model_route: ModelRoute {
+                model_id: ModelId("m".into()),
+                max_input_tokens: 1_000,
+                max_output_tokens: 1_000,
+                max_calls,
+            },
+            resource_ceiling: ResourceCeiling {
+                cpu_milli: 1_000,
+                mem_bytes: 1 << 20,
+                wall_clock_ms: 1_000,
+                fd_count: 16,
+                disk_bytes: 1 << 20,
+            },
+            ..Default::default()
+        }
+    }
+
+    fn role(name: &str, max_calls: u32) -> Role {
+        Role {
+            name: name.into(),
+            version: 1,
+            spec: warrant_calls(max_calls),
+            description: String::new(),
+        }
+    }
+
+    // -- AssetPath validation --------------------------------------------------
+
+    #[test]
+    fn asset_path_accepts_canonical_and_displays() {
+        let p = AssetPath::new("acme", "research", "lit-review").unwrap();
+        assert_eq!(p.namespace(), "acme");
+        assert_eq!(p.collection(), "research");
+        assert_eq!(p.name(), "lit-review");
+        assert_eq!(p.to_string(), "acme/research/lit-review");
+    }
+
+    #[test]
+    fn asset_path_rejects_malformed() {
+        assert!(matches!(
+            AssetPath::new("", "c", "n"),
+            Err(AssetPathError::EmptySegment { which: "namespace" })
+        ));
+        assert!(matches!(
+            AssetPath::new("ns", "Col", "n"), // uppercase not in [a-z0-9._-]
+            Err(AssetPathError::IllegalChar { .. })
+        ));
+        assert!(matches!(
+            AssetPath::new("ns", "c", "a/b"), // '/' is illegal inside a segment
+            Err(AssetPathError::IllegalChar { ch: '/', .. })
+        ));
+        assert!(matches!(
+            AssetPath::new("ns", "c", "x".repeat(crate::MAX_SEGMENT_LEN + 1)),
+            Err(AssetPathError::SegmentTooLong { .. })
+        ));
+        assert!(matches!(
+            AssetPath::new("ns", "c", "-lead"),
+            Err(AssetPathError::LeadingOrTrailingPunct { .. })
+        ));
+        assert!(matches!(
+            AssetPath::new("ns", "c", "trail."),
+            Err(AssetPathError::LeadingOrTrailingPunct { .. })
+        ));
+    }
+
+    #[test]
+    fn asset_ref_path_and_signature_are_distinct() {
+        let by_path = path("ns", "c", "n");
+        let by_sig = AssetRef::Signature(TaskSignatureHash::from_bytes([7u8; 32]));
+        assert_ne!(by_path, by_sig);
+        assert!(by_sig.to_string().starts_with("sig:"));
+    }
+
+    // -- PartyId ---------------------------------------------------------------
+
+    #[test]
+    fn party_id_is_opaque_equality() {
+        let a = PartyId::new("user@x");
+        assert_eq!(a.as_str(), "user@x");
+        assert_eq!(a.to_string(), "user@x");
+        assert_eq!(a, PartyId::new("user@x"));
+        assert_ne!(a, PartyId::new("user@y"));
+    }
+
+    // -- CatalogActionSet ------------------------------------------------------
+
+    #[test]
+    fn action_set_truth_table() {
+        assert_eq!(CatalogActionSet::default(), CatalogActionSet::None);
+        // empty allow-list normalizes to the single canonical deny.
+        assert_eq!(CatalogActionSet::allow([]), CatalogActionSet::None);
+        assert_eq!(CatalogAction::all().len(), 4);
+
+        let ru = CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]);
+        assert!(ru.contains(CatalogAction::Read));
+        assert!(!ru.contains(CatalogAction::Delegate));
+        assert!(!ru.is_empty());
+
+        // narrow = intersection; union = combine.
+        let r = CatalogActionSet::allow([CatalogAction::Read]);
+        assert_eq!(ru.narrow(&r), r);
+        assert!(CatalogActionSet::None.narrow(&ru).is_empty());
+        assert_eq!(r.union(&CatalogActionSet::allow([CatalogAction::Use])), ru);
+        // subset.
+        assert!(r.is_subset_of(&ru));
+        assert!(!ru.is_subset_of(&r));
+        assert!(CatalogActionSet::None.is_subset_of(&r));
+    }
+
+    // -- Content addressing ----------------------------------------------------
+
+    #[test]
+    fn grant_id_is_deterministic_and_root_differs_from_delegated() {
+        let a = path("ns", "c", "n");
+        let owner = PartyId::new("o");
+        let mate = PartyId::new("m");
+        let actions = CatalogActionSet::allow([CatalogAction::Use]);
+        let r = role("r", 5);
+
+        let g1 = Grant::root(
+            a.clone(),
+            owner.clone(),
+            mate.clone(),
+            actions.clone(),
+            r.clone(),
+        );
+        let g2 = Grant::root(
+            a.clone(),
+            owner.clone(),
+            mate.clone(),
+            actions.clone(),
+            r.clone(),
+        );
+        assert_eq!(g1.grant_id(), g2.grant_id(), "same bytes ⇒ same id");
+        assert_eq!(g1.grant_id().to_hex().len(), 64);
+
+        let del = Grant::delegated(g1.grant_id(), a, owner, mate, actions, r);
+        assert_ne!(g1.grant_id(), del.grant_id(), "prior changes the id");
+        assert!(del.prior().is_some());
+        assert!(g1.prior().is_none());
+    }
+
+    #[test]
+    fn revocation_key_is_deterministic_and_equals_id() {
+        let gid = GrantId::from_bytes([3u8; 32]);
+        let revoker = PartyId::new("o");
+        let k1 = revocation_idempotency_key(&gid, &revoker);
+        let k2 = revocation_idempotency_key(&gid, &revoker);
+        assert_eq!(k1, k2);
+        assert_eq!(Revocation::new(gid, revoker.clone()).revocation_id(), k1);
+        // a different revoker ⇒ a different key.
+        assert_ne!(revocation_idempotency_key(&gid, &PartyId::new("p")), k1);
+    }
+
+    #[test]
+    fn binding_id_distinct_from_grant_id_for_coincident_bytes() {
+        // Distinct domain tags keep a binding's FactId off a grant's id space.
+        let a = path("ns", "c", "n");
+        let b = AssetBinding::new(a, PartyId::new("o"));
+        assert_eq!(b.binding_id().to_hex().len(), 64);
+    }
+
+    // -- warrant_within / most_permissive --------------------------------------
+
+    #[test]
+    fn warrant_within_is_reflexive_and_orders_by_ceiling() {
+        let tight = warrant_calls(2);
+        let wide = warrant_calls(50);
+        assert!(warrant_within(&tight, &tight), "reflexive");
+        assert!(warrant_within(&tight, &wide), "tight ⊆ wide");
+        assert!(!warrant_within(&wide, &tight), "wide ⊄ tight");
+    }
+
+    #[test]
+    fn warrant_within_incomparable_on_child_set_axis() {
+        let mut a = warrant_calls(5);
+        let mut b = warrant_calls(5);
+        a.executor_class = kx_warrant::ExecutorClass::Bwrap;
+        b.executor_class = kx_warrant::ExecutorClass::OciDaemon;
+        // Differ only on a child-set axis ⇒ neither is "within" the other.
+        assert!(!warrant_within(&a, &b));
+        assert!(!warrant_within(&b, &a));
+    }
+
+    #[test]
+    fn most_permissive_selects_widest_real_warrant() {
+        assert!(most_permissive(Vec::new()).is_none());
+
+        let tight = GrantWarrant::new(
+            GrantId::from_bytes([1u8; 32]),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            warrant_calls(2),
+        );
+        let wide = GrantWarrant::new(
+            GrantId::from_bytes([2u8; 32]),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            warrant_calls(50),
+        );
+        // Either input order selects the wider (real, never synthesized) warrant.
+        let w1 = most_permissive(vec![tight.clone(), wide.clone()]).unwrap();
+        let w2 = most_permissive(vec![wide, tight]).unwrap();
+        assert_eq!(w1.model_route.max_calls, 50);
+        assert_eq!(w1, w2, "selection is order-independent");
+    }
+
+    // -- A small end-to-end + the multi-grant regression -----------------------
+
+    #[test]
+    fn bind_grant_authorize_revoke_roundtrip() {
+        let ledger = InMemoryGrantLedger::new();
+        let asset = path("acme", "research", "lit-review");
+        let owner = PartyId::new("admin@acme");
+        let mate = PartyId::new("teammate@acme");
+        let owner_root = warrant_calls(100);
+
+        ledger
+            .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+            .unwrap();
+        ledger
+            .append_grant(Grant::root(
+                asset.clone(),
+                owner.clone(),
+                mate.clone(),
+                CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
+                role("read-use", 10),
+            ))
+            .unwrap();
+
+        assert!(ledger.is_authorized(&mate, &asset, CatalogAction::Use));
+        let w = ledger
+            .resolve_effective_warrant_for(&mate, &asset, CatalogAction::Use, &owner_root)
+            .unwrap()
+            .expect("Use is granted");
+        assert_eq!(w.model_route.max_calls, 10, "min(10,100)");
+
+        // Owner revokes; authority drops but the grant fact survives (append-only).
+        let gid_before: Vec<GrantId> = ledger.effective_grants(&mate, &asset).active().collect();
+        let gid = gid_before[0];
+        ledger
+            .append_revocation(Revocation::new(gid, owner))
+            .unwrap();
+        assert!(!ledger.is_authorized(&mate, &asset, CatalogAction::Use));
+        assert!(ledger.list_facts().count() >= 3, "facts are append-only");
+    }
+
+    #[test]
+    fn multi_grant_warrant_is_action_aligned() {
+        // The regression test for the fixed bug: a party holds two grants on one
+        // asset — Use under a TIGHT warrant, Read under a WIDE one. The warrant
+        // for Use MUST be the tight (Use-conveying) one, never the wide Read one.
+        let ledger = InMemoryGrantLedger::new();
+        let asset = path("acme", "models", "summarizer");
+        let owner = PartyId::new("owner");
+        let ds = PartyId::new("data-scientist");
+        let owner_root = warrant_calls(100);
+
+        ledger
+            .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+            .unwrap();
+        ledger
+            .append_grant(Grant::root(
+                asset.clone(),
+                owner.clone(),
+                ds.clone(),
+                CatalogActionSet::allow([CatalogAction::Use]),
+                role("tight-use", 2),
+            ))
+            .unwrap();
+        ledger
+            .append_grant(Grant::root(
+                asset.clone(),
+                owner,
+                ds.clone(),
+                CatalogActionSet::allow([CatalogAction::Read]),
+                role("wide-read", 50),
+            ))
+            .unwrap();
+
+        let use_w = ledger
+            .resolve_effective_warrant_for(&ds, &asset, CatalogAction::Use, &owner_root)
+            .unwrap()
+            .expect("Use is granted");
+        assert_eq!(
+            use_w.model_route.max_calls, 2,
+            "Use runs under the tight warrant"
+        );
+
+        let read_w = ledger
+            .resolve_effective_warrant_for(&ds, &asset, CatalogAction::Read, &owner_root)
+            .unwrap()
+            .expect("Read is granted");
+        assert_eq!(
+            read_w.model_route.max_calls, 50,
+            "Read runs under the wide warrant"
+        );
+
+        // A never-granted action resolves to None (fail-closed, action-aligned).
+        assert!(ledger
+            .resolve_effective_warrant_for(&ds, &asset, CatalogAction::Delegate, &owner_root)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn rebind_to_different_owner_is_refused() {
+        let ledger = InMemoryGrantLedger::new();
+        let asset = path("ns", "c", "n");
+        ledger
+            .append_binding(AssetBinding::new(asset.clone(), PartyId::new("o1")))
+            .unwrap();
+        // Same owner → idempotent no-op.
+        let again = ledger
+            .append_binding(AssetBinding::new(asset.clone(), PartyId::new("o1")))
+            .unwrap();
+        assert!(!again.is_appended());
+        // Different owner → OwnerConflict.
+        assert!(ledger
+            .append_binding(AssetBinding::new(asset, PartyId::new("o2")))
+            .is_err());
+    }
+}

--- a/crates/kx-catalog/tests/proptest_grants.rs
+++ b/crates/kx-catalog/tests/proptest_grants.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property tests for M7.2 grants/RBAC + revocation (D86).
+//!
+//! Integration-test file: compiled as a separate crate, so it carries its own
+//! lint allowances for fixture `unwrap`s and pedantic test idioms.
+//!
+//! Properties (each over randomized grants/roles/parties):
+//! 1. A grant chain's effective runtime warrant NEVER widens past the owner root
+//!    (quantitative axes are min-narrowed; a qualitative widen is a typed error).
+//! 2. A delegated grant's actions are a SUBSET of the delegator's — laundering
+//!    an action the delegator lacked is impossible.
+//! 3. The fold is order-independent (append order of facts does not change the
+//!    resolution).
+//! 4. Revoke-by-new-fact: an authorized revocation drops authority while the
+//!    grant fact survives (append-only).
+//! 5. Only the grantor or the asset owner can revoke (a stranger's revocation is
+//!    recorded-but-inert).
+//! 6. Appending a grant is idempotent (N appends ⇒ one stored fact).
+//! 7. The effective warrant for an action is ACTION-ALIGNED: it equals the
+//!    most-permissive fold among the chains that ACTUALLY convey that action.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantLedger,
+    InMemoryGrantLedger, PartyId, Revocation,
+};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, SecretRef, SecretScope, WarrantSpec};
+use proptest::prelude::*;
+
+fn asset() -> AssetRef {
+    AssetRef::Path(AssetPath::new("ns", "col", "asset").unwrap())
+}
+
+/// A warrant whose only non-default axes are positive quantitative ceilings
+/// (qualitative axes are the empty defaults ⇒ ⊆ any parent).
+fn warrant_calls(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1_000,
+            max_output_tokens: 1_000,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 1_000,
+            fd_count: 16,
+            disk_bytes: 1 << 20,
+        },
+        ..Default::default()
+    }
+}
+
+fn role_calls(max_calls: u32) -> Role {
+    Role {
+        name: "r".into(),
+        version: 1,
+        spec: warrant_calls(max_calls),
+        description: String::new(),
+    }
+}
+
+/// Each catalog action independently present/absent.
+fn arb_actions() -> impl Strategy<Value = CatalogActionSet> {
+    (any::<bool>(), any::<bool>(), any::<bool>(), any::<bool>()).prop_map(|(r, u, reg, d)| {
+        let mut v = Vec::new();
+        if r {
+            v.push(CatalogAction::Read);
+        }
+        if u {
+            v.push(CatalogAction::Use);
+        }
+        if reg {
+            v.push(CatalogAction::Register);
+        }
+        if d {
+            v.push(CatalogAction::Delegate);
+        }
+        CatalogActionSet::allow(v)
+    })
+}
+
+const ACTIONS: [CatalogAction; 4] = [
+    CatalogAction::Read,
+    CatalogAction::Use,
+    CatalogAction::Register,
+    CatalogAction::Delegate,
+];
+
+proptest! {
+    /// (1) quantitative narrowing: the resolved warrant never exceeds owner root.
+    #[test]
+    fn grant_runtime_warrant_never_widens(parent in 1u32..=1000, child in 1u32..=2000) {
+        let ledger = InMemoryGrantLedger::new();
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let mate = PartyId::new("mate");
+        let owner_root = warrant_calls(parent);
+        ledger.append_binding(AssetBinding::new(a.clone(), owner.clone())).unwrap();
+        ledger.append_grant(Grant::root(
+            a.clone(), owner, mate.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]), role_calls(child),
+        )).unwrap();
+
+        let w = ledger
+            .resolve_effective_warrant_for(&mate, &a, CatalogAction::Use, &owner_root)
+            .unwrap()
+            .expect("Use is granted");
+        prop_assert!(w.model_route.max_calls <= parent, "never widens past owner root");
+        prop_assert_eq!(w.model_route.max_calls, child.min(parent), "min-narrowed");
+    }
+
+    /// (1b) a qualitative widen (a secret the owner cannot resolve) is a typed error.
+    #[test]
+    fn qualitative_widen_is_refused(parent in 1u32..=1000) {
+        let ledger = InMemoryGrantLedger::new();
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let mate = PartyId::new("mate");
+        let owner_root = warrant_calls(parent); // secret_scope = None (default)
+        let mut wide = warrant_calls(parent);
+        wide.secret_scope = SecretScope::AllowList([SecretRef("s".into())].into_iter().collect());
+        let role = Role { name: "wide".into(), version: 1, spec: wide, description: String::new() };
+        ledger.append_binding(AssetBinding::new(a.clone(), owner.clone())).unwrap();
+        ledger.append_grant(Grant::root(
+            a.clone(), owner, mate.clone(), CatalogActionSet::allow([CatalogAction::Use]), role,
+        )).unwrap();
+
+        prop_assert!(ledger
+            .resolve_effective_warrant_for(&mate, &a, CatalogAction::Use, &owner_root)
+            .is_err());
+    }
+
+    /// (2) a delegated grant's effective actions ⊆ the delegator's; no laundering.
+    #[test]
+    fn delegated_actions_subset_of_delegator(as_a in arb_actions(), as_b in arb_actions()) {
+        let ledger = InMemoryGrantLedger::new();
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let lead = PartyId::new("lead");
+        let intern = PartyId::new("intern");
+        ledger.append_binding(AssetBinding::new(a.clone(), owner.clone())).unwrap();
+        let root = Grant::root(a.clone(), owner, lead.clone(), as_a, role_calls(50));
+        let root_id = root.grant_id();
+        ledger.append_grant(root).unwrap();
+        ledger.append_grant(Grant::delegated(
+            root_id, a.clone(), lead.clone(), intern.clone(), as_b, role_calls(50),
+        )).unwrap();
+
+        let lead_acts = ledger.effective_grants(&lead, &a);
+        let intern_acts = ledger.effective_grants(&intern, &a);
+        for x in ACTIONS {
+            if intern_acts.actions().contains(x) {
+                // Anything the intern conveys, the lead conveyed (no laundering).
+                prop_assert!(lead_acts.actions().contains(x), "no action laundered via delegation");
+            }
+        }
+    }
+
+    /// (3) the fold is independent of fact append order.
+    #[test]
+    fn fold_is_order_independent(acts in arb_actions()) {
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let mate = PartyId::new("mate");
+        let bind = AssetBinding::new(a.clone(), owner.clone());
+        let grant = Grant::root(a.clone(), owner, mate.clone(), acts, role_calls(10));
+
+        let l1 = InMemoryGrantLedger::new();
+        l1.append_binding(bind.clone()).unwrap();
+        l1.append_grant(grant.clone()).unwrap();
+
+        let l2 = InMemoryGrantLedger::new();
+        l2.append_grant(grant).unwrap(); // grant BEFORE the binding
+        l2.append_binding(bind).unwrap();
+
+        for x in ACTIONS {
+            prop_assert_eq!(
+                l1.is_authorized(&mate, &a, x),
+                l2.is_authorized(&mate, &a, x),
+                "resolution is order-independent"
+            );
+        }
+    }
+
+    /// (4)+(5) revoke-by-new-fact + only grantor/owner can revoke. For a ROOT
+    /// grant the grantor IS the owner, so a revocation takes effect iff the
+    /// revoker is the owner.
+    #[test]
+    fn revocation_authority(revoker_pick in 0u8..3) {
+        let ledger = InMemoryGrantLedger::new();
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let mate = PartyId::new("mate");
+        let stranger = PartyId::new("stranger");
+        ledger.append_binding(AssetBinding::new(a.clone(), owner.clone())).unwrap();
+        let g = Grant::root(a.clone(), owner.clone(), mate.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]), role_calls(10));
+        let gid = g.grant_id();
+        ledger.append_grant(g).unwrap();
+        prop_assert!(ledger.is_authorized(&mate, &a, CatalogAction::Use));
+
+        let facts_before = ledger.list_facts().count();
+        let revoker = [owner.clone(), mate.clone(), stranger][revoker_pick as usize].clone();
+        let authorized = revoker == owner; // grantor == owner for a root grant
+        ledger.append_revocation(Revocation::new(gid, revoker)).unwrap();
+
+        prop_assert_eq!(
+            ledger.is_authorized(&mate, &a, CatalogAction::Use),
+            !authorized,
+            "authority drops iff the revoker is authorized"
+        );
+        // The grant fact survives regardless (append-only; revoke is a new fact).
+        prop_assert!(ledger.list_facts().count() > facts_before, "revoke is a new fact");
+        prop_assert!(
+            ledger.list_facts().filter(|f| matches!(f, kx_catalog::LedgerFact::Grant(_))).count() == 1,
+            "the grant fact is never mutated/removed"
+        );
+    }
+
+    /// (6) appending a grant is idempotent.
+    #[test]
+    fn append_grant_is_idempotent(reps in 1usize..6) {
+        let ledger = InMemoryGrantLedger::new();
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let mate = PartyId::new("mate");
+        ledger.append_binding(AssetBinding::new(a.clone(), owner.clone())).unwrap();
+        let g = Grant::root(a.clone(), owner, mate, CatalogActionSet::allow([CatalogAction::Use]), role_calls(10));
+        let mut appended = 0;
+        for _ in 0..reps {
+            if ledger.append_grant(g.clone()).unwrap().is_appended() {
+                appended += 1;
+            }
+        }
+        prop_assert_eq!(appended, 1, "only the first append lands");
+        prop_assert_eq!(
+            ledger.list_facts().filter(|f| matches!(f, kx_catalog::LedgerFact::Grant(_))).count(),
+            1
+        );
+    }
+
+    /// (7) the warrant for an action equals the most-permissive fold among the
+    /// chains that ACTUALLY convey it (the multi-grant regression, randomized).
+    #[test]
+    fn per_grant_warrant_aligned_with_action(
+        as1 in arb_actions(), as2 in arb_actions(), c1 in 1u32..=100, c2 in 1u32..=100,
+    ) {
+        let ledger = InMemoryGrantLedger::new();
+        let a = asset();
+        let owner = PartyId::new("owner");
+        let party = PartyId::new("party");
+        let owner_root = warrant_calls(100); // ≥ c1,c2 ⇒ min(ci,100)=ci
+        ledger.append_binding(AssetBinding::new(a.clone(), owner.clone())).unwrap();
+        ledger.append_grant(Grant::root(a.clone(), owner.clone(), party.clone(), as1.clone(), role_calls(c1))).unwrap();
+        ledger.append_grant(Grant::root(a.clone(), owner, party.clone(), as2.clone(), role_calls(c2))).unwrap();
+
+        for x in ACTIONS {
+            let resolved = ledger
+                .resolve_effective_warrant_for(&party, &a, x, &owner_root)
+                .unwrap();
+            // The expected max_calls = max over the chains that convey x.
+            let mut expected: Option<u32> = None;
+            if as1.contains(x) { expected = Some(expected.map_or(c1, |e| e.max(c1))); }
+            if as2.contains(x) { expected = Some(expected.map_or(c2, |e| e.max(c2))); }
+            match (resolved, expected) {
+                (Some(w), Some(e)) => {
+                    prop_assert_eq!(w.model_route.max_calls, e, "warrant comes from a conveying chain");
+                    prop_assert!(w.model_route.max_calls <= 100, "never widens past owner root");
+                }
+                (None, None) => {} // action conveyed by neither ⇒ fail-closed None
+                (r, e) => prop_assert!(false, "mismatch: resolved={:?} expected_calls={:?}", r.is_some(), e),
+            }
+        }
+    }
+}
+
+/// Closed-enum drift guard: adding a `CatalogAction` variant fails to compile
+/// here (and `ACTIONS` above would be incomplete), forcing the proptests + the
+/// `CatalogAction::all()` set to be revisited.
+#[allow(dead_code)]
+fn exhaustive_action_match(a: CatalogAction) {
+    match a {
+        CatalogAction::Read
+        | CatalogAction::Use
+        | CatalogAction::Register
+        | CatalogAction::Delegate => {}
+    }
+}
+
+#[test]
+fn action_vocabulary_is_pinned() {
+    assert_eq!(
+        CatalogAction::all().len(),
+        ACTIONS.len(),
+        "closed action vocabulary"
+    );
+}

--- a/crates/kx-catalog/tests/scale.rs
+++ b/crates/kx-catalog/tests/scale.rs
@@ -11,13 +11,44 @@
 use std::time::Instant;
 
 use kx_catalog::{
-    CatalogRegistry, InMemoryCatalog, RecipeSnapshot, SignatureEntry, TaskSignature,
-    TaskSignatureHash,
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, CatalogRegistry, Grant,
+    GrantLedger, InMemoryCatalog, InMemoryGrantLedger, PartyId, RecipeSnapshot, SignatureEntry,
+    TaskSignature, TaskSignatureHash,
 };
-use kx_mote::MoteDefHash;
+use kx_mote::{ModelId, MoteDefHash};
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
 use kx_workflow::ManifestId;
 
 const SIZES: &[usize] = &[1_000, 5_000, 10_000, 25_000];
+
+/// A non-default-quantitative warrant (qualitative axes are empty defaults).
+fn warrant_calls(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1_000,
+            max_output_tokens: 1_000,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 1_000,
+            fd_count: 16,
+            disk_bytes: 1 << 20,
+        },
+        ..Default::default()
+    }
+}
+
+fn role_calls(max_calls: u32) -> Role {
+    Role {
+        name: "r".into(),
+        version: 1,
+        spec: warrant_calls(max_calls),
+        description: String::new(),
+    }
+}
 
 /// A distinct entry for index `i` (the index encoded into the critic hash bytes,
 /// so every signature — and thus every key — is unique).
@@ -84,5 +115,147 @@ fn assert_sublinear(label: &str, series: &[(usize, f64)]) {
     assert!(
         last <= first * 4.0,
         "{label} must stay sub-linear (n=1k {first:.1}ns vs n=25k {last:.1}ns)"
+    );
+}
+
+/// M7.2: grant append + authorization query + warrant resolution stay O(log n)
+/// in the number of distinct (party, asset) grants — the index keeps governance
+/// sub-linear at catalog scale (a full-log scan would be ~25× at 25k vs 1k).
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn grant_ledger_fold_stays_sublinear() {
+    let mut append_ns: Vec<(usize, f64)> = Vec::new();
+    let mut auth_ns: Vec<(usize, f64)> = Vec::new();
+    let mut resolve_ns: Vec<(usize, f64)> = Vec::new();
+    let owner = PartyId::new("owner");
+    let owner_root = warrant_calls(100);
+
+    for &n in SIZES {
+        let ledger = InMemoryGrantLedger::new();
+
+        // n distinct (party, asset) pairs, each a single root grant of {Use}.
+        let assets: Vec<AssetRef> = (0..n)
+            .map(|i| AssetRef::Path(AssetPath::new("ns", "c", format!("a{i}")).unwrap()))
+            .collect();
+        let parties: Vec<PartyId> = (0..n).map(|i| PartyId::new(format!("p{i}"))).collect();
+        for a in &assets {
+            ledger
+                .append_binding(AssetBinding::new(a.clone(), owner.clone()))
+                .unwrap();
+        }
+
+        let start = Instant::now();
+        for (a, p) in assets.iter().zip(&parties) {
+            ledger
+                .append_grant(Grant::root(
+                    a.clone(),
+                    owner.clone(),
+                    p.clone(),
+                    CatalogActionSet::allow([CatalogAction::Use]),
+                    role_calls(10),
+                ))
+                .unwrap();
+        }
+        let append_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for (a, p) in assets.iter().zip(&parties) {
+            assert!(ledger.is_authorized(p, a, CatalogAction::Use));
+        }
+        let auth_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for (a, p) in assets.iter().zip(&parties) {
+            assert!(ledger
+                .resolve_effective_warrant_for(p, a, CatalogAction::Use, &owner_root)
+                .unwrap()
+                .is_some());
+        }
+        let resolve_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = |d: std::time::Duration| d.as_nanos() as f64 / n as f64;
+        println!(
+            "grant-ledger: n={n} append_per_ns={:.1} auth_per_ns={:.1} resolve_per_ns={:.1}",
+            per(append_elapsed),
+            per(auth_elapsed),
+            per(resolve_elapsed)
+        );
+        append_ns.push((n, per(append_elapsed)));
+        auth_ns.push((n, per(auth_elapsed)));
+        resolve_ns.push((n, per(resolve_elapsed)));
+    }
+
+    assert_sublinear("grant-append", &append_ns);
+    assert_sublinear("grant-authorize", &auth_ns);
+    assert_sublinear("grant-resolve-warrant", &resolve_ns);
+}
+
+/// M7.2: an authorization query is BOUNDED by `MAX_DELEGATION_DEPTH` (64),
+/// independent of how deep the delegation chain actually is — the `DoS` / stack
+/// guard. A 50k-deep chain queries no slower than a 1k-deep one (both walk at
+/// most 64 hops, then fail closed), so the cost stays flat as depth grows.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn deep_chain_query_is_bounded() {
+    const DEPTHS: &[usize] = &[1_000, 10_000, 50_000];
+    const ITERS: usize = 2_000;
+    let mut query_ns: Vec<(usize, f64)> = Vec::new();
+    let owner = PartyId::new("owner");
+    let acts = CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]);
+
+    for &depth in DEPTHS {
+        let ledger = InMemoryGrantLedger::new();
+        let asset = AssetRef::Path(AssetPath::new("ns", "c", "deep").unwrap());
+        ledger
+            .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+            .unwrap();
+
+        // owner → p0 → p1 → … → p(depth-1), each conveying {Use, Delegate}.
+        let leaf = PartyId::new(format!("p{}", depth - 1));
+        let root = Grant::root(
+            asset.clone(),
+            owner.clone(),
+            PartyId::new("p0"),
+            acts.clone(),
+            role_calls(50),
+        );
+        let mut prev_id = root.grant_id();
+        let mut prev_party = PartyId::new("p0");
+        ledger.append_grant(root).unwrap();
+        for i in 1..depth {
+            let p = PartyId::new(format!("p{i}"));
+            let g = Grant::delegated(
+                prev_id,
+                asset.clone(),
+                prev_party.clone(),
+                p.clone(),
+                acts.clone(),
+                role_calls(50),
+            );
+            prev_id = g.grant_id();
+            prev_party = p;
+            ledger.append_grant(g).unwrap();
+        }
+
+        // Query the leaf many times; the fold walks at most 64 hops (then fails
+        // closed for depth > 64), so cost is independent of `depth`.
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            let _ = ledger.is_authorized(&leaf, &asset, CatalogAction::Use);
+        }
+        let elapsed = start.elapsed();
+        #[allow(clippy::cast_precision_loss)]
+        let per = elapsed.as_nanos() as f64 / ITERS as f64;
+        println!("deep-chain: depth={depth} query_per_ns={per:.1}");
+        query_ns.push((depth, per));
+    }
+
+    // Flat within the 4× headband across a 50× depth increase.
+    let first = query_ns.first().unwrap().1;
+    let last = query_ns.last().unwrap().1;
+    assert!(
+        last <= first * 4.0,
+        "deep-chain query must be depth-bounded (depth 1k {first:.1}ns vs 50k {last:.1}ns)"
     );
 }

--- a/crates/kx-catalog/tests/security_governance.rs
+++ b/crates/kx-catalog/tests/security_governance.rs
@@ -1,0 +1,669 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration + security + exit-gate tests for M7.2 governance (D86).
+//!
+//! Drives the real-life enterprise use cases end to end (an org admin grants a
+//! recipe to a teammate under a narrowed role, then revokes; a consulting
+//! delegation chain narrows each hop and a parent revocation cascades; a data
+//! scientist holds two grants on one model under different warrants), proves the
+//! security invariants (no widening, no laundering, no revocation bypass, no
+//! confused deputy, deep-chain fail-closed, fail-closed default), and asserts the
+//! milestone exit gate — including the compiler-enforced wall keeping catalog
+//! governance OFF the guarantee path (no guarantee-path crate may import
+//! `kx-catalog`).
+//!
+//! `Kind 4 (chaos)` scoping (D95, honest): an in-memory ledger has no process
+//! kill/replay — durable crash-recovery is owned by a future persistent backend
+//! (D94). The analogue exercised here is concurrency/poison-safety +
+//! idempotent-replay-of-appends (`concurrent_appends_and_queries_are_safe`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::sync::Arc;
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantId,
+    GrantLedger, InMemoryGrantLedger, LedgerFact, PartyId, Revocation,
+};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, SecretRef, SecretScope, WarrantSpec};
+
+// ---- fixtures ---------------------------------------------------------------
+
+fn path(ns: &str, col: &str, name: &str) -> AssetRef {
+    AssetRef::Path(AssetPath::new(ns, col, name).unwrap())
+}
+
+fn warrant_calls(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1_000,
+            max_output_tokens: 1_000,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 1_000,
+            fd_count: 16,
+            disk_bytes: 1 << 20,
+        },
+        ..Default::default()
+    }
+}
+
+fn role(name: &str, max_calls: u32) -> Role {
+    Role {
+        name: name.into(),
+        version: 1,
+        spec: warrant_calls(max_calls),
+        description: String::new(),
+    }
+}
+
+// ---- Integration: real-life enterprise scenarios ----------------------------
+
+/// Scenario 1 — Acme Research: the org admin grants a teammate {Read,Use} on a
+/// recipe under a narrowed role, then revokes.
+#[test]
+fn org_admin_grants_then_revokes_end_to_end() {
+    let ledger = InMemoryGrantLedger::new();
+    let recipe = path("acme", "research", "lit-review");
+    let admin = PartyId::new("admin@acme");
+    let mate = PartyId::new("teammate@acme");
+    let owner_root = warrant_calls(100);
+
+    ledger
+        .append_binding(AssetBinding::new(recipe.clone(), admin.clone()))
+        .unwrap();
+    let g = Grant::root(
+        recipe.clone(),
+        admin.clone(),
+        mate.clone(),
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
+        role("read-only-research", 10),
+    );
+    let gid = g.grant_id();
+    ledger.append_grant(g).unwrap();
+
+    assert!(ledger.is_authorized(&mate, &recipe, CatalogAction::Read));
+    assert!(ledger.is_authorized(&mate, &recipe, CatalogAction::Use));
+    assert!(!ledger.is_authorized(&mate, &recipe, CatalogAction::Delegate));
+    let w = ledger
+        .resolve_effective_warrant_for(&mate, &recipe, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .expect("Use granted");
+    assert_eq!(w.model_route.max_calls, 10, "narrowed to min(10,100)");
+
+    ledger
+        .append_revocation(Revocation::new(gid, admin))
+        .unwrap();
+    assert!(!ledger.is_authorized(&mate, &recipe, CatalogAction::Use));
+}
+
+/// Scenario 2 — consulting delegation: owner → lead {Use,Delegate}@8 → intern
+/// {Use}@3. The runtime warrant narrows min(10,8,3)=3 at the leaf; revoking the
+/// parent cascades to the intern.
+#[test]
+fn delegation_chain_narrows_each_hop_and_parent_revoke_cascades() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("contoso", "tools", "summarize");
+    let owner = PartyId::new("owner");
+    let lead = PartyId::new("lead");
+    let intern = PartyId::new("intern");
+    let owner_root = warrant_calls(10);
+
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    let root = Grant::root(
+        asset.clone(),
+        owner.clone(),
+        lead.clone(),
+        CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]),
+        role("lead", 8),
+    );
+    let root_id = root.grant_id();
+    ledger.append_grant(root).unwrap();
+    ledger
+        .append_grant(Grant::delegated(
+            root_id,
+            asset.clone(),
+            lead.clone(),
+            intern.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role("intern", 3),
+        ))
+        .unwrap();
+
+    assert!(ledger.is_authorized(&intern, &asset, CatalogAction::Use));
+    assert!(!ledger.is_authorized(&intern, &asset, CatalogAction::Delegate));
+    let w = ledger
+        .resolve_effective_warrant_for(&intern, &asset, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .expect("intern may Use");
+    assert_eq!(w.model_route.max_calls, 3, "min(10,8,3) narrowed each hop");
+
+    // Owner revokes the ROOT (lead's) grant → cascades to the intern's chain.
+    ledger
+        .append_revocation(Revocation::new(root_id, owner))
+        .unwrap();
+    assert!(
+        !ledger.is_authorized(&intern, &asset, CatalogAction::Use),
+        "cascade"
+    );
+    assert!(!ledger.is_authorized(&lead, &asset, CatalogAction::Use));
+}
+
+/// Scenario 3 — multi-grant aligned warrant: a data scientist holds Use under a
+/// tight warrant and Read under a wide one on the SAME model; each action runs
+/// under the warrant of a chain that conveys it (the bug-fix regression).
+#[test]
+fn multi_grant_warrant_is_action_aligned() {
+    let ledger = InMemoryGrantLedger::new();
+    let model = path("acme", "models", "summarizer");
+    let owner = PartyId::new("owner");
+    let ds = PartyId::new("data-scientist");
+    let owner_root = warrant_calls(100);
+
+    ledger
+        .append_binding(AssetBinding::new(model.clone(), owner.clone()))
+        .unwrap();
+    ledger
+        .append_grant(Grant::root(
+            model.clone(),
+            owner.clone(),
+            ds.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role("tight-use", 2),
+        ))
+        .unwrap();
+    ledger
+        .append_grant(Grant::root(
+            model.clone(),
+            owner,
+            ds.clone(),
+            CatalogActionSet::allow([CatalogAction::Read]),
+            role("wide-read", 80),
+        ))
+        .unwrap();
+
+    let use_calls = ledger
+        .resolve_effective_warrant_for(&ds, &model, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap()
+        .model_route
+        .max_calls;
+    let read_calls = ledger
+        .resolve_effective_warrant_for(&ds, &model, CatalogAction::Read, &owner_root)
+        .unwrap()
+        .unwrap()
+        .model_route
+        .max_calls;
+    assert_eq!(use_calls, 2, "Use runs under the tight warrant");
+    assert_eq!(read_calls, 80, "Read runs under the wide warrant");
+}
+
+// ---- Security invariants ----------------------------------------------------
+
+#[test]
+fn widen_attempt_is_refused() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    let mate = PartyId::new("mate");
+    let owner_root = warrant_calls(10); // secret_scope = None
+
+    let mut wide = warrant_calls(10);
+    wide.secret_scope =
+        SecretScope::AllowList([SecretRef("db-password".into())].into_iter().collect());
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    ledger
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner,
+            mate.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            Role {
+                name: "wide".into(),
+                version: 1,
+                spec: wide,
+                description: String::new(),
+            },
+        ))
+        .unwrap();
+
+    // The widen surfaces loudly as a typed error — never a silently-wider warrant.
+    assert!(ledger
+        .resolve_effective_warrant_for(&mate, &asset, CatalogAction::Use, &owner_root)
+        .is_err());
+}
+
+#[test]
+fn delegation_laundering_is_refused() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    let lead = PartyId::new("lead");
+    let intern = PartyId::new("intern");
+
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    // Lead holds Use + Delegate but NOT Register.
+    let root = Grant::root(
+        asset.clone(),
+        owner,
+        lead.clone(),
+        CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]),
+        role("lead", 10),
+    );
+    let root_id = root.grant_id();
+    ledger.append_grant(root).unwrap();
+    // Lead tries to delegate Register (which it never held) to the intern.
+    ledger
+        .append_grant(Grant::delegated(
+            root_id,
+            asset.clone(),
+            lead,
+            intern.clone(),
+            CatalogActionSet::allow([CatalogAction::Register]),
+            role("intern", 10),
+        ))
+        .unwrap();
+
+    // Register was never the lead's to give: the intern gets nothing for it.
+    assert!(!ledger.is_authorized(&intern, &asset, CatalogAction::Register));
+    assert!(!ledger.is_authorized(&intern, &asset, CatalogAction::Use));
+}
+
+#[test]
+fn delegation_without_delegate_conveys_nothing() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    let lead = PartyId::new("lead");
+    let intern = PartyId::new("intern");
+
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    // Lead holds Use but NOT Delegate.
+    let root = Grant::root(
+        asset.clone(),
+        owner,
+        lead.clone(),
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("lead", 10),
+    );
+    let root_id = root.grant_id();
+    ledger.append_grant(root).unwrap();
+    ledger
+        .append_grant(Grant::delegated(
+            root_id,
+            asset.clone(),
+            lead,
+            intern.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role("intern", 10),
+        ))
+        .unwrap();
+
+    // A delegator without Delegate mints nothing.
+    assert!(!ledger.is_authorized(&intern, &asset, CatalogAction::Use));
+}
+
+#[test]
+fn revocation_bypass_is_impossible() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    let mate = PartyId::new("mate");
+
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    let g = Grant::root(
+        asset.clone(),
+        owner.clone(),
+        mate.clone(),
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("r", 10),
+    );
+    let gid = g.grant_id();
+    ledger.append_grant(g.clone()).unwrap();
+    ledger
+        .append_revocation(Revocation::new(gid, owner))
+        .unwrap();
+    assert!(!ledger.is_authorized(&mate, &asset, CatalogAction::Use));
+
+    // Re-appending the identical grant is an idempotent no-op — it does NOT
+    // resurrect authority (the revocation fact stands; the grant id is unchanged).
+    let outcome = ledger.append_grant(g).unwrap();
+    assert!(!outcome.is_appended(), "re-append is idempotent");
+    assert!(
+        !ledger.is_authorized(&mate, &asset, CatalogAction::Use),
+        "a revoked grant cannot be un-revoked by re-appending it"
+    );
+}
+
+#[test]
+fn confused_deputy_across_assets_is_refused() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset_a = path("acme", "research", "lit-review");
+    let asset_b = path("acme", "finance", "payroll");
+    let owner = PartyId::new("owner");
+    let mate = PartyId::new("mate");
+
+    ledger
+        .append_binding(AssetBinding::new(asset_a.clone(), owner.clone()))
+        .unwrap();
+    ledger
+        .append_binding(AssetBinding::new(asset_b.clone(), owner.clone()))
+        .unwrap();
+    ledger
+        .append_grant(Grant::root(
+            asset_a.clone(),
+            owner,
+            mate.clone(),
+            CatalogActionSet::all(),
+            role("r", 10),
+        ))
+        .unwrap();
+
+    // Full authority on A conveys NOTHING on B.
+    assert!(ledger.is_authorized(&mate, &asset_a, CatalogAction::Use));
+    assert!(!ledger.is_authorized(&mate, &asset_b, CatalogAction::Read));
+    assert!(!ledger.is_authorized(&mate, &asset_b, CatalogAction::Use));
+}
+
+#[test]
+fn only_grantor_or_owner_can_revoke() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    let mate = PartyId::new("mate");
+    let stranger = PartyId::new("stranger");
+
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    let g = Grant::root(
+        asset.clone(),
+        owner.clone(),
+        mate.clone(),
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("r", 10),
+    );
+    let gid = g.grant_id();
+    ledger.append_grant(g).unwrap();
+
+    // A stranger's revocation is recorded-but-inert.
+    ledger
+        .append_revocation(Revocation::new(gid, stranger))
+        .unwrap();
+    assert!(
+        ledger.is_authorized(&mate, &asset, CatalogAction::Use),
+        "stranger cannot revoke"
+    );
+
+    // The owner (== grantor of the root) can.
+    ledger
+        .append_revocation(Revocation::new(gid, owner))
+        .unwrap();
+    assert!(!ledger.is_authorized(&mate, &asset, CatalogAction::Use));
+}
+
+#[test]
+fn deep_delegation_chain_is_bounded_and_fail_closed() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+
+    // Build a chain of 66 grants: owner → p1 → p2 → … → p66, each conveying
+    // {Use, Delegate}. The fold caps at MAX_DELEGATION_DEPTH (64).
+    let parties: Vec<PartyId> = (1..=66).map(|i| PartyId::new(format!("p{i}"))).collect();
+    let acts = CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]);
+
+    let root = Grant::root(
+        asset.clone(),
+        owner.clone(),
+        parties[0].clone(),
+        acts.clone(),
+        role("r", 50),
+    );
+    let mut prev_id = root.grant_id();
+    let mut prev_party = parties[0].clone();
+    ledger.append_grant(root).unwrap();
+    for p in &parties[1..] {
+        let g = Grant::delegated(
+            prev_id,
+            asset.clone(),
+            prev_party.clone(),
+            p.clone(),
+            acts.clone(),
+            role("r", 50),
+        );
+        prev_id = g.grant_id();
+        prev_party = p.clone();
+        ledger.append_grant(g).unwrap();
+    }
+
+    // Depth 64 still resolves; depth 65+ fails closed (work-bounded, no overflow).
+    assert!(
+        ledger.is_authorized(&parties[63], &asset, CatalogAction::Use),
+        "depth 64 resolves"
+    );
+    assert!(
+        !ledger.is_authorized(&parties[64], &asset, CatalogAction::Use),
+        "depth 65 fails closed"
+    );
+    assert!(
+        !ledger.is_authorized(&parties[65], &asset, CatalogAction::Use),
+        "depth 66 fails closed"
+    );
+}
+
+#[test]
+fn grant_on_unbound_asset_fails_closed() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner"); // never bound as the asset's owner
+    let mate = PartyId::new("mate");
+    // A root grant whose grantor is not the (absent) owner conveys nothing.
+    ledger
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner,
+            mate.clone(),
+            CatalogActionSet::all(),
+            role("r", 10),
+        ))
+        .unwrap();
+    assert!(ledger.owner_of(&asset).is_none());
+    assert!(!ledger.is_authorized(&mate, &asset, CatalogAction::Use));
+}
+
+#[test]
+fn fail_closed_default_denies_all() {
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("ns", "c", "n");
+    let nobody = PartyId::new("nobody");
+    assert!(ledger.is_empty());
+    assert!(!ledger.is_authorized(&nobody, &asset, CatalogAction::Read));
+    assert!(ledger.effective_grants(&nobody, &asset).is_empty());
+    assert!(ledger
+        .resolve_effective_warrant_for(&nobody, &asset, CatalogAction::Use, &warrant_calls(10))
+        .unwrap()
+        .is_none());
+}
+
+// ---- Kind 4 analogue: concurrency / poison-safety + idempotent replay --------
+
+#[test]
+fn concurrent_appends_and_queries_are_safe() {
+    let ledger = Arc::new(InMemoryGrantLedger::new());
+    let asset = path("ns", "c", "n");
+    let owner = PartyId::new("owner");
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+
+    // 8 threads each append a DISTINCT grant + query concurrently.
+    let mut handles = Vec::new();
+    for i in 0..8u32 {
+        let l = Arc::clone(&ledger);
+        let a = asset.clone();
+        let o = owner.clone();
+        handles.push(std::thread::spawn(move || {
+            let mate = PartyId::new(format!("mate{i}"));
+            l.append_grant(Grant::root(
+                a.clone(),
+                o,
+                mate.clone(),
+                CatalogActionSet::allow([CatalogAction::Use]),
+                role("r", 10),
+            ))
+            .unwrap();
+            assert!(l.is_authorized(&mate, &a, CatalogAction::Use));
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Idempotent replay: a burst of the SAME grant from many threads lands once.
+    let shared = Grant::root(
+        asset.clone(),
+        owner,
+        PartyId::new("shared"),
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("r", 10),
+    );
+    let mut bursts = Vec::new();
+    for _ in 0..8 {
+        let l = Arc::clone(&ledger);
+        let g = shared.clone();
+        bursts.push(std::thread::spawn(move || {
+            l.append_grant(g).unwrap().is_appended()
+        }));
+    }
+    let appended_count = bursts
+        .into_iter()
+        .map(|h| h.join().unwrap())
+        .filter(|&b| b)
+        .count();
+    assert_eq!(
+        appended_count, 1,
+        "exactly one of the identical-grant bursts lands"
+    );
+}
+
+// ---- Exit gate --------------------------------------------------------------
+
+/// The structural wall: NO guarantee-path crate may depend on `kx-catalog`, so
+/// the compiler can never wire catalog governance onto the identity / commit /
+/// selection path (SN-8 / D70 / D87). Read the manifests directly — a future
+/// `kx-catalog` edge into any of these is a compile-independent regression this
+/// test catches.
+#[test]
+fn guarantee_path_does_not_depend_on_catalog() {
+    let crates = [
+        "kx-scheduler",
+        "kx-executor",
+        "kx-projection",
+        "kx-inference",
+    ];
+    for c in crates {
+        let manifest = format!("{}/../{c}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+        let toml =
+            std::fs::read_to_string(&manifest).unwrap_or_else(|e| panic!("read {manifest}: {e}"));
+        assert!(
+            !toml.contains("kx-catalog"),
+            "{c} must NOT depend on kx-catalog (the SN-8 governance wall)"
+        );
+    }
+}
+
+/// The M7.2 milestone exit gate, composite: grant-never-widens + revoke-by-new-
+/// fact + multi-grant action-aligned warrant + the closed action vocabulary +
+/// the guarantee-path wall.
+#[test]
+fn m7_2_exit_gate() {
+    // (a) closed action vocabulary.
+    assert_eq!(CatalogAction::all().len(), 4);
+
+    let ledger = InMemoryGrantLedger::new();
+    let asset = path("acme", "models", "summarizer");
+    let owner = PartyId::new("owner");
+    let ds = PartyId::new("ds");
+    let owner_root = warrant_calls(50);
+    ledger
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+
+    // (b) a grant never widens (resolved ≤ owner root) + multi-grant alignment.
+    ledger
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner.clone(),
+            ds.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role("use", 5),
+        ))
+        .unwrap();
+    ledger
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner.clone(),
+            ds.clone(),
+            CatalogActionSet::allow([CatalogAction::Read]),
+            role("read", 40),
+        ))
+        .unwrap();
+    let use_w = ledger
+        .resolve_effective_warrant_for(&ds, &asset, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    assert!(use_w.model_route.max_calls <= 50, "never widens");
+    assert_eq!(
+        use_w.model_route.max_calls, 5,
+        "Use is action-aligned to its chain"
+    );
+
+    // (c) revoke-by-new-fact: the grant fact survives a revocation.
+    let use_gid: GrantId = ledger
+        .effective_grants(&ds, &asset)
+        .grants_conveying(CatalogAction::Use)
+        .next()
+        .unwrap();
+    let facts_before = ledger.list_facts().count();
+    ledger
+        .append_revocation(Revocation::new(use_gid, owner))
+        .unwrap();
+    assert!(
+        ledger.list_facts().count() > facts_before,
+        "revoke is a NEW fact"
+    );
+    assert_eq!(
+        ledger
+            .list_facts()
+            .filter(|f| matches!(f, LedgerFact::Grant(_)))
+            .count(),
+        2,
+        "no grant fact is mutated or removed"
+    );
+    assert!(
+        !ledger.is_authorized(&ds, &asset, CatalogAction::Use),
+        "revoked"
+    );
+    assert!(
+        ledger.is_authorized(&ds, &asset, CatalogAction::Read),
+        "unaffected action stands"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -124,7 +124,9 @@ smoke-test-with-model:
 # llamacpp-free — no C++ FFI in this lean job). A super-linear resume is an outage,
 # and resume IS the product. `--release` is REQUIRED — in a debug build the
 # differential oracle re-imposes the O(n^2) full rebuild on every fold and the ratio
-# assertions are skipped.
+# assertions are skipped. Also gates (M7 / D86) the kx-catalog governance paths —
+# signature register/lookup, the grant-ledger authorization fold, and the
+# depth-bounded deep-chain query — all stay sub-linear / depth-bounded at 25k-50k.
 scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
@@ -132,6 +134,7 @@ scale-smoke:
     cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
     cargo test -p kx-capture --release --test scale -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-catalog --release --test scale -- --ignored --nocapture --test-threads=1
 
 # IMP-4 (D116) single-writer scale-readiness measurement spike — publish the
 # single-writer journal commit ceiling + the projection-fold curve so a real number


### PR DESCRIPTION
## M7.2 — catalog namespacing + grants/RBAC + revocation (D86)

Clean-room implementation of the **M7.2 grants slice** on the M7.1 `kx-catalog` foundation. (Provenance/lineage + versioning — the rest of corpus M7.2 — are deferred to a later slice per Rule 1.)

### What
- New modules `path` / `party` / `action` / `grant` / `ledger` / `in_memory_ledger` (thin `lib.rs`, module-split, private fields + smart constructors).
- **`GrantLedger` trait + `InMemoryGrantLedger`** — append-only, content-addressed, idempotent, **revoke-by-new-fact** (D-LOCK-4). "Journaled" (D86) is realized as that *discipline inside the catalog ledger*; the crate still **does not depend on `kx-journal`** (the M7.1 separation wall holds). A durable/cloud backend is a future impl behind the trait (D94).
- Narrowing **reuses the frozen `kx_warrant::intersect` verbatim** — no warrant axis added; `kx-warrant` source byte-unchanged.
- Authorization is an **iterative, depth-bounded (64), single-pass fold**: fail-closed on cycle/missing/over-depth; authorized-revoker (grantor|owner) cascade; Delegate-at-each-hop; root-grantor-is-owner.
- **Action-aligned warrant resolution** (`resolve_effective_warrant_for`): the warrant an action runs under is the most-permissive **real (never synthesized)** warrant among the chains that *actually convey* it — fixes a multi-grant action/warrant decoupling (a low-privilege action could otherwise run under an unrelated high-privilege warrant).

### Tests (D95)
13 unit + 8 proptest + 3 scale (wired into the `scale-smoke` required gate) + 15 security/governance/exit-gate. Real-life scenarios driven e2e: admin grant→revoke; consulting delegation→parent-revoke cascade; multi-grant aligned warrant. The exit-gate includes a **compiler-enforced wall test** asserting no guarantee-path crate (`kx-scheduler`/`kx-executor`/`kx-projection`/`kx-inference`) imports `kx-catalog`.

### Rule 8 pre-flight
- **(a) what breaks:** authorization is the fail-closed fold (never trusted from a fact); digest `a6b5c679…` **proven invariant** (runtime/harness guards green); frozen-trio + `kx-mote`/`kx-journal` `src/**` diff **EMPTY**; no `kx-journal` dep; no schema bump / no D107 migration.
- **(b) perf:** index-driven O(log n) queries; fold O(depth ≤ 64); `scale-smoke` proves sub-linear grant-fold (append/auth/resolve flat 1k→25k) and depth-bounded deep-chain (50k ≈ 1k).
- **(c) security:** opaque/unparsed `PartyId`; scope can only narrow; fail-closed default; no escalation/laundering/confused-deputy/revocation-bypass; the multi-grant fix closes a privilege-confusion gap.
- **Own-PR (not bundled):** durable `GrantLedger` backend + kill/replay chaos (D94); cloud `PrincipalResolver`/`OwnershipStore`; M7.3 Mote-as-MCP dispatch + real-model e2e. **kx-warrant is out of scope (seam reused verbatim).**

### Local gate
fmt ✓ · clippy `--workspace --all-targets -D warnings` ✓ · `cargo test --workspace` (228 binaries, 0 fail) ✓ · cargo-deny ✓ · doc `-D warnings` ✓ · scale-smoke ✓ · I1.c byte-determinism ✓ · digest `a6b5c679…` unmoved ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
