### PR TITLE
feat(catalog): M7.2 — content-versioning handles + provenance/lineage fold (kx-catalog VersionLedger/GovernedCatalog; D82/D88/D-LOCK-4)

### DIFF
--- a/crates/kx-catalog/src/governed.rs
+++ b/crates/kx-catalog/src/governed.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`GovernedCatalog`] (M7.2) — the production governed surface over the
+//! [`crate::VersionLedger`], composed with the [`crate::GrantLedger`].
+//!
+//! The raw [`crate::VersionLedger::publish`] is the ungoverned mechanism (authority
+//! is the fold's business, exactly like [`crate::GrantLedger::append_grant`]).
+//! `GovernedCatalog` is the surface production code uses: **publishing a new
+//! version requires a [`CatalogAction::Register`] grant on the handle**, and the
+//! governed reads require [`CatalogAction::Read`]. The two ledgers are composed
+//! WITHOUT coupling their impls (Rule 1): neither references the other's concrete
+//! type — the facade holds both and gates one against the other.
+//!
+//! ## What gates what (D84 / SN-8)
+//!
+//! The ONLY thing that gates a publish is the live `Register` grant fold. A
+//! version's provenance/lineage is ADVISORY and NEVER gates a publish or any
+//! runtime action — the `Read` gate on the governed read methods is plain
+//! access-control on *viewing* the catalog, a distinct concern from "advisory
+//! data never gates an action". Because the gate consults the LIVE grant ledger,
+//! revoking a party's `Register` (a new [`crate::Revocation`] fact) immediately
+//! blocks their future publishes; already-published versions are retained forever
+//! (D-LOCK-4).
+
+use crate::action::CatalogAction;
+use crate::ledger::GrantLedger;
+use crate::party::PartyId;
+use crate::path::{AssetPath, AssetRef};
+use crate::version::{AssetVersion, VersionId, VersionedContent};
+use crate::version_ledger::{PublishOutcome, VersionLedger, VersionLedgerError};
+
+/// A governed-catalog operation failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum GovernedError {
+    /// The party lacks the required [`CatalogAction`] on the asset (fail-closed).
+    #[error("unauthorized {action:?} on {asset}")]
+    Unauthorized {
+        /// The action that was required.
+        action: CatalogAction,
+        /// The asset it was required on (display form).
+        asset: String,
+    },
+    /// The underlying version ledger refused the publish.
+    #[error(transparent)]
+    Ledger(#[from] VersionLedgerError),
+}
+
+/// The governed catalog surface: a [`GrantLedger`] + a [`VersionLedger`], composed
+/// so that publishing requires `Register` and viewing requires `Read`.
+///
+/// Generic over both backends (zero-cost); pass `Arc<InMemoryGrantLedger>` /
+/// `Arc<InMemoryVersionLedger>` (both impl their trait for `Arc<L>`) when the
+/// underlying ledgers must be shared with other holders.
+#[derive(Debug, Default)]
+pub struct GovernedCatalog<G: GrantLedger, V: VersionLedger> {
+    grants: G,
+    versions: V,
+}
+
+impl<G: GrantLedger, V: VersionLedger> GovernedCatalog<G, V> {
+    /// Compose a grant ledger and a version ledger into a governed surface.
+    #[must_use]
+    pub fn new(grants: G, versions: V) -> Self {
+        Self { grants, versions }
+    }
+
+    /// Borrow the underlying grant ledger (e.g. to seed bindings/grants, or to
+    /// query authorization directly).
+    #[inline]
+    #[must_use]
+    pub fn grants(&self) -> &G {
+        &self.grants
+    }
+
+    /// Borrow the underlying version ledger (e.g. for ungated discovery reads,
+    /// which are off the commit/audit path).
+    #[inline]
+    #[must_use]
+    pub fn versions(&self) -> &V {
+        &self.versions
+    }
+
+    /// Publish a new version, **requiring `Register`** on the version's handle.
+    ///
+    /// # Errors
+    ///
+    /// [`GovernedError::Unauthorized`] if the publisher lacks `Register` on the
+    /// handle (nothing is appended); [`GovernedError::Ledger`] on the version
+    /// ledger's immutability tripwire.
+    pub fn publish(&self, version: AssetVersion) -> Result<PublishOutcome, GovernedError> {
+        let asset = AssetRef::Path(version.handle().clone());
+        if !self
+            .grants
+            .is_authorized(version.publisher(), &asset, CatalogAction::Register)
+        {
+            return Err(GovernedError::Unauthorized {
+                action: CatalogAction::Register,
+                asset: asset.to_string(),
+            });
+        }
+        Ok(self.versions.publish(version)?)
+    }
+
+    /// Resolve a handle to its current content, **requiring `Read`**.
+    ///
+    /// # Errors
+    ///
+    /// [`GovernedError::Unauthorized`] if `party` lacks `Read` on the handle.
+    pub fn resolve(
+        &self,
+        party: &PartyId,
+        handle: &AssetPath,
+    ) -> Result<Option<(VersionedContent, VersionId)>, GovernedError> {
+        self.require_read(party, handle)?;
+        Ok(self.versions.resolve(handle))
+    }
+
+    /// The version history of a handle, **requiring `Read`**.
+    ///
+    /// # Errors
+    ///
+    /// [`GovernedError::Unauthorized`] if `party` lacks `Read` on the handle.
+    pub fn history(
+        &self,
+        party: &PartyId,
+        handle: &AssetPath,
+    ) -> Result<Vec<AssetVersion>, GovernedError> {
+        self.require_read(party, handle)?;
+        Ok(self.versions.history(handle))
+    }
+
+    /// The ancestor lineage of a version, **requiring `Read`** on that version's
+    /// handle. An absent version returns `Ok([])` (it gates nothing — there is no
+    /// handle to gate on, and lineage is advisory).
+    ///
+    /// # Errors
+    ///
+    /// [`GovernedError::Unauthorized`] if `party` lacks `Read` on the version's
+    /// handle.
+    pub fn lineage(
+        &self,
+        party: &PartyId,
+        id: &VersionId,
+    ) -> Result<Vec<AssetVersion>, GovernedError> {
+        let Some(v) = self.versions.get_version(id) else {
+            return Ok(Vec::new());
+        };
+        self.require_read(party, v.handle())?;
+        Ok(self.versions.lineage(id))
+    }
+
+    /// The forward descendants of a version, **requiring `Read`** on that version's
+    /// handle (symmetry with [`Self::lineage`]). An absent version returns
+    /// `Ok([])`. NOTE: an absent vs. present-but-unauthorized version is
+    /// distinguishable (an existence signal); acceptable because a `VersionId` is a
+    /// content hash — not enumerable/guessable — and the data is advisory (D84).
+    ///
+    /// # Errors
+    ///
+    /// [`GovernedError::Unauthorized`] if `party` lacks `Read` on the version's
+    /// handle.
+    pub fn descendants(
+        &self,
+        party: &PartyId,
+        id: &VersionId,
+    ) -> Result<Vec<VersionId>, GovernedError> {
+        let Some(v) = self.versions.get_version(id) else {
+            return Ok(Vec::new());
+        };
+        self.require_read(party, v.handle())?;
+        Ok(self.versions.descendants(id))
+    }
+
+    /// `Read`-gate helper.
+    fn require_read(&self, party: &PartyId, handle: &AssetPath) -> Result<(), GovernedError> {
+        let asset = AssetRef::Path(handle.clone());
+        if self
+            .grants
+            .is_authorized(party, &asset, CatalogAction::Read)
+        {
+            Ok(())
+        } else {
+            Err(GovernedError::Unauthorized {
+                action: CatalogAction::Read,
+                asset: asset.to_string(),
+            })
+        }
+    }
+}

--- a/crates/kx-catalog/src/in_memory_version_ledger.rs
+++ b/crates/kx-catalog/src/in_memory_version_ledger.rs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`InMemoryVersionLedger`] — the reference [`VersionLedger`] backend.
+//!
+//! An append-only `Vec<AssetVersion>` truth + derived `BTreeMap` indices under a
+//! single [`RwLock`]: O(log n) publish + resolve, O(depth) lineage, O(subtree)
+//! descendants — sub-linear at scale, deterministic. Process-local + rebuildable —
+//! not for production durability (a persistent backend implements the same trait,
+//! D94). It proves [`VersionLedger`] carries no storage-substrate assumption (the
+//! role [`crate::InMemoryGrantLedger`] plays for [`crate::GrantLedger`]).
+//!
+//! ## The handle move (D-LOCK-4 "update")
+//!
+//! Publishing a version pushes an immutable fact and, iff it ranks ahead of the
+//! current latest, MOVES the handle (`by_path_latest`). `rank = (revision,
+//! version_id-bytes)` is a total, deterministic, insertion-order-independent order,
+//! so a rebuild from the append-only log yields the same resolution regardless of
+//! append order — and a rollback (a higher-revision publish pinning OLDER content)
+//! correctly moves the handle while retaining every prior version.
+//!
+//! ## The folds
+//!
+//! Lineage is an iterative, depth-bounded, cycle-safe, **integrity-checked** walk
+//! of the `prior` edges ([`fold_lineage`]); forward lineage is a bounded BFS
+//! ([`fold_descendants`], the `kx_projection::transitive_consumers` pattern,
+//! replicated WITHOUT the dependency). Both are COMPUTED not stored and ADVISORY
+//! (D84) — they never gate. No recursion ⇒ a pathological chain caps WORK, never
+//! the stack.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::RwLock;
+
+use crate::path::AssetPath;
+use crate::version::{AssetVersion, VersionId, VersionedContent};
+use crate::version_ledger::{
+    PublishOutcome, VersionLedger, VersionLedgerError, MAX_VERSION_CHAIN_DEPTH,
+    MAX_VERSION_DESCENDANTS,
+};
+
+/// A 32-byte BLAKE3 hash.
+type Hash32 = [u8; 32];
+
+/// The append-only truth + derived indices.
+#[derive(Debug, Default)]
+struct Inner {
+    /// The append-only version log (the truth; everything else is a derived index).
+    versions: Vec<AssetVersion>,
+    /// Content id → position in `versions` (idempotency + immutability tripwire).
+    by_id: BTreeMap<VersionId, usize>,
+    /// THE MUTABLE HANDLE: path → the latest (highest-rank) version published on it.
+    by_path_latest: BTreeMap<AssetPath, VersionId>,
+    /// Reverse adjacency for forward lineage: version → its direct children (those
+    /// whose `prior` == it). Built incrementally on publish — `descendants` is then
+    /// O(subtree), never an O(n) scan.
+    children: BTreeMap<VersionId, Vec<VersionId>>,
+}
+
+/// An ephemeral, process-local [`VersionLedger`]. Multiple readers, one writer.
+///
+/// # Examples
+///
+/// ```
+/// use kx_catalog::{
+///     AssetPath, AssetVersion, InMemoryVersionLedger, PartyId, Provenance,
+///     TaskSignatureHash, VersionLedger, VersionedContent,
+/// };
+///
+/// let ledger = InMemoryVersionLedger::new();
+/// let handle = AssetPath::new("acme", "recipes", "summarize").unwrap();
+/// let alice = PartyId::new("alice@acme");
+///
+/// // v1 — first publish of the handle.
+/// let v1 = AssetVersion::root(
+///     handle.clone(),
+///     VersionedContent::Recipe(TaskSignatureHash::from_bytes([1u8; 32])),
+///     alice.clone(),
+///     Provenance::from_recipe([1u8; 32]),
+/// );
+/// let v1_id = ledger.publish(v1).unwrap().version_id();
+/// assert_eq!(ledger.resolve(&handle).unwrap().1, v1_id);
+///
+/// // v2 — "update" = publish a NEW version + move the handle (D-LOCK-4).
+/// let v2 = AssetVersion::successor(
+///     v1_id, 0, handle.clone(),
+///     VersionedContent::Recipe(TaskSignatureHash::from_bytes([2u8; 32])),
+///     alice, Provenance::from_recipe([2u8; 32]),
+/// );
+/// let v2_id = ledger.publish(v2).unwrap().version_id();
+/// assert_eq!(ledger.resolve(&handle).unwrap().1, v2_id); // handle moved to v2
+/// assert!(ledger.get_version(&v1_id).is_some());          // v1 retained forever
+/// assert_eq!(ledger.lineage(&v2_id).len(), 2);            // v2 -> v1
+/// ```
+#[derive(Debug, Default)]
+pub struct InMemoryVersionLedger {
+    inner: RwLock<Inner>,
+}
+
+impl InMemoryVersionLedger {
+    /// Construct an empty ledger.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Look up a version by id, borrowing it from the log.
+fn version_at<'a>(inner: &'a Inner, id: &VersionId) -> Option<&'a AssetVersion> {
+    inner.by_id.get(id).map(|&pos| &inner.versions[pos])
+}
+
+/// `true` iff `child`'s `prior` edge to `parent` is a valid lineage edge: the
+/// child names `parent` as its prior, both are on the SAME handle, and the child's
+/// revision strictly advances the parent's. The publish path enforces this at
+/// write time (so a stored chain is always well-formed); the folds re-apply it as
+/// defense-in-depth, so even a corrupt / non-validating backend cannot make the
+/// advisory forward (descendants) and backward (lineage) views disagree.
+fn is_valid_edge(child: &AssetVersion, parent: &AssetVersion, parent_id: VersionId) -> bool {
+    child.prior() == Some(parent_id)
+        && child.handle() == parent.handle()
+        && child.revision() > parent.revision()
+}
+
+/// Walk a version's ancestor chain (latest → oldest), bounded + cycle/missing
+/// guarded + lineage-integrity-checked. A node whose `prior` references a missing
+/// version, a DIFFERENT handle, or a non-decreasing revision is INCLUDED (it is a
+/// real published fact) but the walk STOPS there (a forged/foreign graft conveys
+/// no further ancestry — the provenance analog of "a forged grant conveys
+/// nothing"). Over-depth returns the bounded prefix (ADVISORY → cannot escalate).
+fn fold_lineage(inner: &Inner, start: VersionId) -> Vec<AssetVersion> {
+    let mut chain: Vec<AssetVersion> = Vec::new();
+    let mut seen: BTreeSet<VersionId> = BTreeSet::new();
+    let mut cur = Some(start);
+    while let Some(id) = cur {
+        if chain.len() >= MAX_VERSION_CHAIN_DEPTH {
+            break; // depth cap → bounded prefix
+        }
+        if !seen.insert(id) {
+            break; // cycle → fail-closed (stop)
+        }
+        let Some(v) = version_at(inner, &id) else {
+            break; // missing → fail-closed (stop)
+        };
+        // Lineage integrity decides whether the walk continues PAST this node
+        // (defense-in-depth: publish already refuses a malformed edge, so on the
+        // in-memory backend this only ever stops at a root).
+        let continue_to = match v.prior() {
+            None => None, // root: the chain ends here
+            Some(parent_id) => match version_at(inner, &parent_id) {
+                Some(p) if is_valid_edge(v, p, parent_id) => Some(parent_id),
+                // missing parent / foreign graft / revision inversion → stop here.
+                _ => None,
+            },
+        };
+        chain.push(v.clone());
+        cur = continue_to;
+    }
+    chain
+}
+
+/// Forward-lineage BFS: every version transitively descending from `root` via the
+/// `children` index, applying the SAME [`is_valid_edge`] integrity check as
+/// [`fold_lineage`] so the forward and backward views agree on what edges are real.
+/// `visited` makes it cycle-safe; [`MAX_VERSION_DESCENDANTS`] bounds the work.
+/// `root` itself is not a descendant. The emit order is BFS-over-publish-order and
+/// is NOT a stable guarantee (it is advisory, never hashed).
+fn fold_descendants(inner: &Inner, root: VersionId) -> Vec<VersionId> {
+    let mut visited: BTreeSet<VersionId> = BTreeSet::new();
+    let mut order: Vec<VersionId> = Vec::new();
+    let mut queue: VecDeque<VersionId> = VecDeque::new();
+    visited.insert(root); // mark (not emitted) so a cycle back to root terminates
+    queue.push_back(root);
+    while let Some(cur) = queue.pop_front() {
+        if order.len() >= MAX_VERSION_DESCENDANTS {
+            break; // work/output bound
+        }
+        let Some(cur_v) = version_at(inner, &cur) else {
+            continue;
+        };
+        if let Some(kids) = inner.children.get(&cur) {
+            for &child in kids {
+                // Only follow a child that is a valid same-handle, strictly-
+                // advancing successor of `cur` (so a forged cross-handle graft is
+                // excluded forward, exactly as fold_lineage excludes it backward).
+                let valid = version_at(inner, &child).is_some_and(|c| is_valid_edge(c, cur_v, cur));
+                if valid && visited.insert(child) {
+                    order.push(child);
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+    order
+}
+
+impl VersionLedger for InMemoryVersionLedger {
+    fn publish(&self, version: AssetVersion) -> Result<PublishOutcome, VersionLedgerError> {
+        let vid = version.version_id();
+        let mut guard = self.inner.write().expect("poisoned lock");
+        if let Some(&pos) = guard.by_id.get(&vid) {
+            return if guard.versions[pos] == version {
+                Ok(PublishOutcome::AlreadyPresent(vid))
+            } else {
+                Err(VersionLedgerError::ImmutabilityConflict(vid.to_hex()))
+            };
+        }
+        // Lineage validation (fail-closed at the door): a successor's prior must be
+        // present, on the SAME handle, and exactly one revision below. This keeps
+        // the stored chain well-formed — a forged cross-handle graft or an inflated
+        // `revision` can never land, so the handle-move rank cannot be gamed and the
+        // forward/backward folds always agree.
+        if let Some(pid) = version.prior() {
+            let Some(parent) = version_at(&guard, &pid) else {
+                return Err(VersionLedgerError::PriorNotFound(pid.to_hex()));
+            };
+            if parent.handle() != version.handle() {
+                return Err(VersionLedgerError::InvalidLineage {
+                    version_id: vid.to_hex(),
+                    reason: format!("prior {pid} is on a different handle"),
+                });
+            }
+            if parent.revision().checked_add(1) != Some(version.revision()) {
+                return Err(VersionLedgerError::InvalidLineage {
+                    version_id: vid.to_hex(),
+                    reason: format!(
+                        "revision {} is not prior.revision ({}) + 1",
+                        version.revision(),
+                        parent.revision()
+                    ),
+                });
+            }
+        }
+        // Decide the handle move from a READ of current state (before any mutation).
+        // rank = (revision, id-bytes): a total, deterministic, order-independent order.
+        let new_rank = (version.revision(), *vid.as_bytes());
+        let move_handle = match guard.by_path_latest.get(version.handle()) {
+            None => true,
+            Some(cur_vid) => {
+                let cur_rank: (u32, Hash32) =
+                    guard.by_id.get(cur_vid).map_or((0u32, [0u8; 32]), |&cpos| {
+                        (guard.versions[cpos].revision(), *cur_vid.as_bytes())
+                    });
+                new_rank > cur_rank
+            }
+        };
+        let handle = version.handle().clone();
+        let parent = version.prior();
+        let pos = guard.versions.len();
+        guard.versions.push(version);
+        guard.by_id.insert(vid, pos);
+        if let Some(parent) = parent {
+            guard.children.entry(parent).or_default().push(vid);
+        }
+        if move_handle {
+            guard.by_path_latest.insert(handle, vid);
+        }
+        Ok(PublishOutcome::Published(vid))
+    }
+
+    fn resolve(&self, handle: &AssetPath) -> Option<(VersionedContent, VersionId)> {
+        let guard = self.inner.read().expect("poisoned lock");
+        let vid = *guard.by_path_latest.get(handle)?;
+        let v = version_at(&guard, &vid)?;
+        Some((*v.content(), vid))
+    }
+
+    fn get_version(&self, id: &VersionId) -> Option<AssetVersion> {
+        let guard = self.inner.read().expect("poisoned lock");
+        version_at(&guard, id).cloned()
+    }
+
+    fn lineage(&self, id: &VersionId) -> Vec<AssetVersion> {
+        let guard = self.inner.read().expect("poisoned lock");
+        fold_lineage(&guard, *id)
+    }
+
+    fn descendants(&self, id: &VersionId) -> Vec<VersionId> {
+        let guard = self.inner.read().expect("poisoned lock");
+        fold_descendants(&guard, *id)
+    }
+
+    fn list_versions<'a>(&'a self) -> Box<dyn Iterator<Item = AssetVersion> + 'a> {
+        let guard = self.inner.read().expect("poisoned lock");
+        // Snapshot under the read lock (append order), then release before iterating.
+        let versions: Vec<AssetVersion> = guard.versions.clone();
+        Box::new(versions.into_iter())
+    }
+
+    fn len(&self) -> usize {
+        self.inner.read().expect("poisoned lock").versions.len()
+    }
+}
+
+// Compile-time proof the ledger is shareable across threads (so `Arc<…>` works
+// for the concurrency tests + a multi-threaded gateway).
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<InMemoryVersionLedger>();
+};

--- a/crates/kx-catalog/src/lib.rs
+++ b/crates/kx-catalog/src/lib.rs
@@ -31,6 +31,18 @@
 //!   `kx-journal`**. Authorization is the fail-closed [`GrantLedger::effective_grants`]
 //!   fold, never trusted from a fact; the runtime warrant a `Use` runs under is
 //!   action-aligned ([`GrantLedger::resolve_effective_warrant_for`]).
+//! - **M7.2 — content-versioning + provenance/lineage** (`version` /
+//!   `version_ledger` / `in_memory_version_ledger` / `governed`, D82/D88 +
+//!   D-LOCK-4): an [`AssetPath`] is a **mutable handle** that resolves to an
+//!   immutable, content-addressed [`VersionedContent`]; "update" is never a
+//!   mutation — you **publish a new [`AssetVersion`]** and the [`VersionLedger`]
+//!   moves the handle (prior versions retained forever; rollback is a new fact).
+//!   Lineage is a **computed-not-stored** fold over the `prior` edges (the
+//!   `kx_projection::transitive_consumers` pattern, without the dependency) and is
+//!   ADVISORY (D84) — it never gates. [`GovernedCatalog`] is the production
+//!   surface: publishing requires a [`CatalogAction::Register`] grant, viewing
+//!   requires `Read` — composing the [`GrantLedger`] with the [`VersionLedger`]
+//!   without coupling either impl.
 //!
 //! ## A separate truth (R4 — NOT a journal-as-truth violation)
 //!
@@ -83,14 +95,18 @@
 
 mod action;
 mod entry;
+mod governed;
 mod grant;
 mod in_memory;
 mod in_memory_ledger;
+mod in_memory_version_ledger;
 mod ledger;
 mod party;
 mod path;
 mod registry;
 mod signature;
+mod version;
+mod version_ledger;
 
 #[cfg(test)]
 mod tests;
@@ -116,6 +132,18 @@ pub use ledger::{
 };
 pub use party::PartyId;
 pub use path::{AssetPath, AssetPathError, AssetRef, MAX_SEGMENT_LEN};
+
+// M7.2 (D82/D88 + D-LOCK-4) — content-versioning handles + provenance/lineage.
+pub use governed::{GovernedCatalog, GovernedError};
+pub use in_memory_version_ledger::InMemoryVersionLedger;
+pub use version::{
+    AssetVersion, Provenance, VersionError, VersionId, VersionedContent,
+    CATALOG_VERSION_SCHEMA_VERSION, MAX_PROVENANCE_LINEAGE,
+};
+pub use version_ledger::{
+    PublishOutcome, VersionLedger, VersionLedgerError, MAX_VERSION_CHAIN_DEPTH,
+    MAX_VERSION_DESCENDANTS,
+};
 
 // REUSE (never modify) the frozen monotonic-narrowing seam — one import surface
 // for catalog callers building grant runtime scopes (M7.2 consumes `intersect`;

--- a/crates/kx-catalog/src/tests.rs
+++ b/crates/kx-catalog/src/tests.rs
@@ -574,3 +574,375 @@ mod m7_2 {
             .is_err());
     }
 }
+
+// ---- M7.2: content-versioning + provenance/lineage (D82/D88 + D-LOCK-4) ------
+
+mod m7_2_versioning {
+    use kx_dataset::DatasetId;
+    use kx_mote::MoteId;
+    use kx_workflow::ManifestId;
+
+    use crate::{
+        AssetPath, AssetVersion, InMemoryVersionLedger, PartyId, Provenance, TaskSignatureHash,
+        VersionError, VersionLedger, VersionLedgerError, VersionedContent,
+        CATALOG_VERSION_SCHEMA_VERSION, MAX_PROVENANCE_LINEAGE,
+    };
+
+    fn apath(name: &str) -> AssetPath {
+        AssetPath::new("acme", "recipes", name).unwrap()
+    }
+
+    fn recipe(byte: u8) -> VersionedContent {
+        VersionedContent::Recipe(TaskSignatureHash::from_bytes([byte; 32]))
+    }
+
+    fn prov(byte: u8) -> Provenance {
+        Provenance::from_recipe([byte; 32])
+    }
+
+    fn alice() -> PartyId {
+        PartyId::new("alice@acme")
+    }
+
+    // -- content addressing ----------------------------------------------------
+
+    #[test]
+    fn version_id_is_stable_and_deterministic() {
+        let v = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        assert_eq!(v.version_id(), v.version_id(), "deterministic");
+        let same = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        assert_eq!(v.version_id(), same.version_id(), "same bytes ⇒ same id");
+    }
+
+    #[test]
+    fn version_id_distinct_on_content() {
+        let a = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        let b = AssetVersion::root(apath("summarize"), recipe(2), alice(), prov(1));
+        assert_ne!(a.version_id(), b.version_id());
+    }
+
+    #[test]
+    fn version_id_distinct_on_handle() {
+        let a = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        let b = AssetVersion::root(apath("classify"), recipe(1), alice(), prov(1));
+        assert_ne!(a.version_id(), b.version_id());
+    }
+
+    #[test]
+    fn version_id_distinct_on_provenance() {
+        // Provenance folds into the id ⇒ a forged provenance is tamper-evident.
+        let a = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        let b = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(9));
+        assert_ne!(a.version_id(), b.version_id());
+    }
+
+    #[test]
+    fn version_id_distinct_on_content_kind() {
+        // Recipe vs Workflow vs Dataset are distinct even on coincident bytes.
+        let r = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let w = AssetVersion::root(
+            apath("x"),
+            VersionedContent::Workflow(ManifestId([1u8; 32])),
+            alice(),
+            prov(1),
+        );
+        let d = AssetVersion::root(
+            apath("x"),
+            VersionedContent::Dataset(DatasetId([1u8; 32])),
+            alice(),
+            prov(1),
+        );
+        assert_ne!(r.version_id(), w.version_id());
+        assert_ne!(r.version_id(), d.version_id());
+        assert_ne!(w.version_id(), d.version_id());
+    }
+
+    #[test]
+    fn version_id_hex_is_64_chars() {
+        let id = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1)).version_id();
+        assert_eq!(id.to_hex().len(), 64);
+        assert_eq!(format!("{id}").len(), 64);
+    }
+
+    #[test]
+    fn schema_version_is_pinned() {
+        let v = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        assert_eq!(v.schema_version(), CATALOG_VERSION_SCHEMA_VERSION);
+        assert_eq!(CATALOG_VERSION_SCHEMA_VERSION, 1);
+    }
+
+    // -- root / successor shape ------------------------------------------------
+
+    #[test]
+    fn root_has_no_prior_revision_zero() {
+        let v = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        assert!(v.prior().is_none());
+        assert_eq!(v.revision(), 0);
+    }
+
+    #[test]
+    fn successor_increments_revision() {
+        let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let v1_id = v1.version_id();
+        let v2 = AssetVersion::successor(v1_id, 0, apath("x"), recipe(2), alice(), prov(2));
+        assert_eq!(v2.prior(), Some(v1_id));
+        assert_eq!(v2.revision(), 1);
+    }
+
+    // -- publish / resolve / move handle ---------------------------------------
+
+    #[test]
+    fn publish_then_resolve_returns_content() {
+        let ledger = InMemoryVersionLedger::new();
+        let v = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        let id = ledger.publish(v).unwrap().version_id();
+        let (content, vid) = ledger.resolve(&apath("summarize")).unwrap();
+        assert_eq!(vid, id);
+        assert_eq!(content, recipe(1));
+    }
+
+    #[test]
+    fn publish_successor_moves_handle() {
+        let ledger = InMemoryVersionLedger::new();
+        let v1 = AssetVersion::root(apath("summarize"), recipe(1), alice(), prov(1));
+        let v1_id = ledger.publish(v1).unwrap().version_id();
+        let v2 = AssetVersion::successor(v1_id, 0, apath("summarize"), recipe(2), alice(), prov(2));
+        let v2_id = ledger.publish(v2).unwrap().version_id();
+        let (content, vid) = ledger.resolve(&apath("summarize")).unwrap();
+        assert_eq!(vid, v2_id, "handle moved to the latest");
+        assert_eq!(content, recipe(2));
+        assert!(ledger.get_version(&v1_id).is_some(), "v1 retained");
+    }
+
+    #[test]
+    fn rollback_moves_handle_keeps_all() {
+        let ledger = InMemoryVersionLedger::new();
+        let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let v1_id = ledger.publish(v1).unwrap().version_id();
+        let v2 = AssetVersion::successor(v1_id, 0, apath("x"), recipe(2), alice(), prov(2));
+        let v2_id = ledger.publish(v2).unwrap().version_id();
+        // Rollback = a NEW version (revision 2) pinning v1's OLDER content.
+        let v3 = AssetVersion::successor(v2_id, 1, apath("x"), recipe(1), alice(), prov(3));
+        let v3_id = ledger.publish(v3).unwrap().version_id();
+        let (content, vid) = ledger.resolve(&apath("x")).unwrap();
+        assert_eq!(vid, v3_id);
+        assert_eq!(content, recipe(1), "rolled back to v1's content");
+        assert_eq!(ledger.len(), 3, "all three versions retained (D-LOCK-4)");
+        assert!(ledger.get_version(&v1_id).is_some());
+        assert!(ledger.get_version(&v2_id).is_some());
+    }
+
+    #[test]
+    fn publish_is_idempotent() {
+        // Re-publishing a byte-identical version is AlreadyPresent (the same-id
+        // tripwire's ImmutabilityConflict branch is cryptographically unreachable
+        // because version_id hashes the WHOLE fact — same id ⟺ same bytes).
+        let ledger = InMemoryVersionLedger::new();
+        let v = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        assert!(ledger.publish(v.clone()).unwrap().is_published());
+        for _ in 0..5 {
+            assert!(!ledger.publish(v.clone()).unwrap().is_published());
+        }
+        assert_eq!(ledger.len(), 1);
+    }
+
+    // -- history / lineage / descendants ---------------------------------------
+
+    #[test]
+    fn history_walks_latest_to_oldest() {
+        let ledger = InMemoryVersionLedger::new();
+        let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let v1_id = ledger.publish(v1).unwrap().version_id();
+        let v2 = AssetVersion::successor(v1_id, 0, apath("x"), recipe(2), alice(), prov(2));
+        let v2_id = ledger.publish(v2).unwrap().version_id();
+        let v3 = AssetVersion::successor(v2_id, 1, apath("x"), recipe(3), alice(), prov(3));
+        let v3_id = ledger.publish(v3).unwrap().version_id();
+
+        let hist = ledger.history(&apath("x"));
+        let ids: Vec<_> = hist.iter().map(AssetVersion::version_id).collect();
+        assert_eq!(ids, vec![v3_id, v2_id, v1_id], "latest → oldest");
+
+        let lin = ledger.lineage(&v3_id);
+        assert_eq!(lin.len(), 3);
+        assert_eq!(lin.first().unwrap().version_id(), v3_id);
+        assert_eq!(lin.last().unwrap().version_id(), v1_id);
+    }
+
+    #[test]
+    fn descendants_covers_forward_chain() {
+        let ledger = InMemoryVersionLedger::new();
+        let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let v1_id = ledger.publish(v1).unwrap().version_id();
+        let v2 = AssetVersion::successor(v1_id, 0, apath("x"), recipe(2), alice(), prov(2));
+        let v2_id = ledger.publish(v2).unwrap().version_id();
+        let v3 = AssetVersion::successor(v2_id, 1, apath("x"), recipe(3), alice(), prov(3));
+        let v3_id = ledger.publish(v3).unwrap().version_id();
+
+        let desc = ledger.descendants(&v1_id);
+        assert_eq!(desc.len(), 2, "v1's descendants are v2, v3 (not v1 itself)");
+        assert!(desc.contains(&v2_id) && desc.contains(&v3_id));
+        assert!(ledger.descendants(&v3_id).is_empty(), "leaf has none");
+    }
+
+    #[test]
+    fn missing_prior_publish_is_refused() {
+        // A successor whose `prior` was never published is refused fail-closed at
+        // the door (publish is causally ordered).
+        let ledger = InMemoryVersionLedger::new();
+        let phantom = AssetVersion::root(apath("ghost"), recipe(9), alice(), prov(9)).version_id();
+        let orphan = AssetVersion::successor(phantom, 0, apath("x"), recipe(1), alice(), prov(1));
+        assert!(matches!(
+            ledger.publish(orphan).unwrap_err(),
+            VersionLedgerError::PriorNotFound(_)
+        ));
+        assert_eq!(ledger.len(), 0, "nothing landed");
+    }
+
+    #[test]
+    fn foreign_prior_publish_is_refused() {
+        // A successor grafting a DIFFERENT handle's version as its prior is refused
+        // (the stored chain can never carry a cross-handle graft).
+        let ledger = InMemoryVersionLedger::new();
+        let vy = AssetVersion::root(apath("other"), recipe(2), alice(), prov(2));
+        let vy_id = ledger.publish(vy).unwrap().version_id();
+        let forged = AssetVersion::successor(vy_id, 0, apath("x"), recipe(1), alice(), prov(1));
+        assert!(matches!(
+            ledger.publish(forged).unwrap_err(),
+            VersionLedgerError::InvalidLineage { .. }
+        ));
+        assert_eq!(ledger.len(), 1, "only the legitimate root landed");
+    }
+
+    #[test]
+    fn wrong_prior_revision_publish_is_refused() {
+        // Declaring an inflated `prior_revision` (the griefing vector) is refused:
+        // the revision must be exactly real_prior.revision + 1.
+        let ledger = InMemoryVersionLedger::new();
+        let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let v1_id = ledger.publish(v1).unwrap().version_id();
+        // prior is v1 (revision 0) but we LIE that prior_revision = u32::MAX-1 ⇒
+        // revision = u32::MAX, which does not equal 0 + 1.
+        let inflated =
+            AssetVersion::successor(v1_id, u32::MAX - 1, apath("x"), recipe(2), alice(), prov(2));
+        assert_eq!(inflated.revision(), u32::MAX);
+        assert!(matches!(
+            ledger.publish(inflated).unwrap_err(),
+            VersionLedgerError::InvalidLineage { .. }
+        ));
+        assert_eq!(
+            ledger.resolve(&apath("x")).unwrap().1,
+            v1_id,
+            "handle unmoved"
+        );
+    }
+
+    #[test]
+    fn fork_two_successors_same_prior() {
+        // Two distinct successors of the SAME prior on the SAME handle (a fork):
+        // both publish; descendants(v1) = {both}; resolve tie-breaks by version-id
+        // bytes deterministically + order-independently; each branch's lineage is
+        // [branch, v1]; history is the rank-winner's lineage.
+        let publish_order = |a_first: bool| {
+            let ledger = InMemoryVersionLedger::new();
+            let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+            let v1_id = ledger.publish(v1).unwrap().version_id();
+            let a =
+                AssetVersion::successor(v1_id, 0, apath("x"), recipe(0xA0), alice(), prov(0xA0));
+            let b =
+                AssetVersion::successor(v1_id, 0, apath("x"), recipe(0xB0), alice(), prov(0xB0));
+            let (a_id, b_id) = (a.version_id(), b.version_id());
+            if a_first {
+                ledger.publish(a).unwrap();
+                ledger.publish(b).unwrap();
+            } else {
+                ledger.publish(b).unwrap();
+                ledger.publish(a).unwrap();
+            }
+            (ledger, v1_id, a_id, b_id)
+        };
+
+        let (ledger, v1_id, a_id, b_id) = publish_order(true);
+        // descendants(v1) = exactly {a, b}.
+        let mut desc = ledger.descendants(&v1_id);
+        desc.sort_unstable_by_key(|v| *v.as_bytes());
+        let mut want = vec![a_id, b_id];
+        want.sort_unstable_by_key(|v| *v.as_bytes());
+        assert_eq!(desc, want, "both fork branches are descendants of v1");
+        // each branch's lineage is [branch, v1].
+        assert_eq!(
+            ledger
+                .lineage(&a_id)
+                .iter()
+                .map(AssetVersion::version_id)
+                .collect::<Vec<_>>(),
+            vec![a_id, v1_id]
+        );
+        // resolve tie-breaks by version-id bytes (both revision 1): the larger wins.
+        let winner = if *a_id.as_bytes() > *b_id.as_bytes() {
+            a_id
+        } else {
+            b_id
+        };
+        assert_eq!(ledger.resolve(&apath("x")).unwrap().1, winner);
+        // history is the winner's lineage; publish order does not change the winner.
+        let (ledger2, _, _, _) = publish_order(false);
+        assert_eq!(
+            ledger2.resolve(&apath("x")).unwrap().1,
+            winner,
+            "tie-break is publish-order-independent"
+        );
+        assert_eq!(ledger.history(&apath("x"))[0].version_id(), winner);
+    }
+
+    #[test]
+    fn lineage_of_absent_version_is_empty() {
+        let ledger = InMemoryVersionLedger::new();
+        let nobody = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1)).version_id();
+        assert!(ledger.lineage(&nobody).is_empty());
+        assert!(ledger.resolve(&apath("x")).is_none());
+    }
+
+    // -- Provenance ------------------------------------------------------------
+
+    #[test]
+    fn provenance_builders_and_accessors() {
+        let p = Provenance::from_recipe([7u8; 32])
+            .with_run([3u8; 16])
+            .with_dataset(DatasetId([4u8; 32]))
+            .with_corpus_lineage([MoteId::from_bytes([5u8; 32])])
+            .unwrap();
+        assert_eq!(p.recipe_fingerprint(), &[7u8; 32]);
+        assert_eq!(p.generating_run(), Some([3u8; 16]));
+        assert_eq!(p.dataset_id(), Some(DatasetId([4u8; 32])));
+        assert_eq!(p.corpus_lineage().len(), 1);
+    }
+
+    #[test]
+    fn provenance_too_large_is_refused() {
+        // Build MAX+1 distinct MoteIds (distinct by their leading 8 bytes).
+        let lineage: Vec<MoteId> = (0..=MAX_PROVENANCE_LINEAGE as u64)
+            .map(|i| {
+                let mut b = [0u8; 32];
+                b[..8].copy_from_slice(&i.to_le_bytes());
+                MoteId::from_bytes(b)
+            })
+            .collect();
+        assert!(lineage.len() > MAX_PROVENANCE_LINEAGE);
+        let err = Provenance::from_recipe([0u8; 32])
+            .with_corpus_lineage(lineage)
+            .unwrap_err();
+        assert!(matches!(err, VersionError::ProvenanceTooLarge { .. }));
+    }
+
+    #[test]
+    fn provenance_serde_round_trips() {
+        let p = Provenance::from_recipe([1u8; 32])
+            .with_run([2u8; 16])
+            .with_dataset(DatasetId([3u8; 32]));
+        let bytes = bincode::serde::encode_to_vec(&p, crate::canonical_config()).unwrap();
+        let (back, _) =
+            bincode::serde::decode_from_slice::<Provenance, _>(&bytes, crate::canonical_config())
+                .unwrap();
+        assert_eq!(p, back);
+    }
+}

--- a/crates/kx-catalog/src/version.rs
+++ b/crates/kx-catalog/src/version.rs
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Content-versioning facts (M7.2, D82/D88 + D-LOCK-4) — an [`AssetVersion`] is
+//! the immutable, content-addressed "publish a new version" fact that the
+//! [`crate::VersionLedger`] folds into a *mutable-handle → immutable-content*
+//! mapping plus a *computed-not-stored* provenance/lineage chain.
+//!
+//! ## "Update" is never a mutation (D-LOCK-4)
+//!
+//! Versioning is by content: a new recipe → a new [`crate::TaskSignatureHash`], a
+//! new workflow → a new `kx_workflow::ManifestId`. There is no edit-in-place. To
+//! "update" the asset at a catalog path you **publish a new [`AssetVersion`]** (a
+//! new immutable fact) and the ledger **moves the handle** ([`AssetPath`] →
+//! latest). Prior versions are retained forever — a rollback is itself a new
+//! `AssetVersion` whose `content` pins an OLDER [`VersionedContent`]. The
+//! `prior` edge forms the append-only version chain; lineage is a fold over it.
+//!
+//! ## Provenance is advisory (D84), but tamper-evident
+//!
+//! [`Provenance`] (which recipe/run/corpus produced this content) is **advisory**
+//! — it NEVER gates a runtime decision (only a [`crate::CatalogAction::Register`]
+//! grant gates a publish, in [`crate::GovernedCatalog`]). But it folds into the
+//! [`VersionId`], so a version's claimed provenance is content-addressed: a forged
+//! provenance produces a different id, and a forged `prior` edge is caught by the
+//! ledger's lineage-integrity fold. No float, no wall-clock touches any field —
+//! ordering is the chain-derived `revision`, not a timestamp — so the canonical
+//! bytes stay byte-deterministic (I1.c).
+
+use kx_dataset::DatasetId;
+use kx_mote::MoteId;
+use kx_workflow::ManifestId;
+use serde::{Deserialize, Serialize};
+
+use crate::path::AssetPath;
+use crate::signature::{canonical_config, TaskSignatureHash};
+
+/// A 32-byte BLAKE3 hash — the catalog's identity substrate.
+type Hash32 = [u8; 32];
+
+/// Canonical-encoding schema version of an [`AssetVersion`]. Bumped on ANY change
+/// to the canonical bytes (the version is a struct field, so it folds into the
+/// [`VersionId`]). Mirrors [`crate::GRANT_SCHEMA_VERSION`].
+pub const CATALOG_VERSION_SCHEMA_VERSION: u16 = 1;
+
+/// The maximum number of `MoteId`s a [`Provenance`] may echo in `corpus_lineage`.
+/// A hard bound on the hash-input size (the full corpus lineage is dereferenced
+/// from `kx-dataset` via `dataset_id` when needed). Exceeding it is a loud,
+/// fail-closed refusal — never a silent truncation.
+pub const MAX_PROVENANCE_LINEAGE: usize = 4096;
+
+/// The content-addressed identity of an [`AssetVersion`]:
+/// `blake3(b"kx-catalog/asset-version/v1" ‖ canonical_bincode(version))`. The
+/// domain tag prevents cross-type preimage aliasing — exactly the [`crate::GrantId`]
+/// / [`crate::TaskSignatureHash`] discipline.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct VersionId(pub Hash32);
+
+impl VersionId {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for VersionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "VersionId({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+impl std::fmt::Display for VersionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// The IMMUTABLE content a version pins. A closed enum — each variant is an
+/// already-content-addressed identity from another crate, so "version content" is
+/// always immutable (unlike an [`crate::AssetRef::Path`], which is a *mutable*
+/// handle and is therefore deliberately NOT a valid version content). Growing the
+/// set (e.g. a script or context-file variant for D88 bundles) is an additive,
+/// deliberate [`CATALOG_VERSION_SCHEMA_VERSION`] bump — append new variants only,
+/// so existing version ids never move.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub enum VersionedContent {
+    /// A registered recipe (M7.0/M7.1), by its content hash.
+    Recipe(TaskSignatureHash),
+    /// A workflow recipe-as-product (`kx_workflow::Manifest`), by its id.
+    Workflow(ManifestId),
+    /// A produced corpus (`kx_dataset::Dataset`), by its id.
+    Dataset(DatasetId),
+}
+
+/// Why a [`Provenance`] was rejected. Loud, typed refusal — never a silently
+/// truncated lineage echo.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum VersionError {
+    /// `corpus_lineage` exceeded [`MAX_PROVENANCE_LINEAGE`] entries.
+    #[error("provenance corpus_lineage is {len} entries (max {MAX_PROVENANCE_LINEAGE})")]
+    ProvenanceTooLarge {
+        /// The over-large length.
+        len: usize,
+    },
+}
+
+/// Advisory provenance for a published version (D84): which recipe / run / corpus
+/// produced this content. NEVER gates a runtime decision; recorded for audit and
+/// lineage only. All fields are bytes/integers — NO float, NO wall-clock — and the
+/// whole record folds into the [`VersionId`], so a forged provenance is
+/// tamper-evident. Fields are private; built via [`Provenance::from_recipe`] + the
+/// fallible/builder methods, so the [`MAX_PROVENANCE_LINEAGE`] bound cannot be
+/// bypassed.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct Provenance {
+    /// The recipe fingerprint that produced this content — equal to the value the
+    /// submission layer records on the `RunRegistered` journal fact. Held as raw
+    /// bytes so this crate stays off the `kx-journal` dependency (mirrors
+    /// [`crate::RecipeSnapshot::recipe_fingerprint`]).
+    recipe_fingerprint: [u8; 32],
+    /// The generating run's `instance_id` (16-byte run nonce), raw + advisory —
+    /// NOT a `kx-journal` dependency, NOT identity.
+    generating_run: Option<[u8; 16]>,
+    /// The pinned corpus this content was derived from / is, if any.
+    dataset_id: Option<DatasetId>,
+    /// An optional echo of the producing run's `Dataset.lineage` Motes (advisory;
+    /// bounded by [`MAX_PROVENANCE_LINEAGE`]).
+    corpus_lineage: Vec<MoteId>,
+}
+
+impl Provenance {
+    /// Minimal provenance: just the recipe fingerprint that produced the content.
+    #[must_use]
+    pub fn from_recipe(recipe_fingerprint: [u8; 32]) -> Self {
+        Self {
+            recipe_fingerprint,
+            generating_run: None,
+            dataset_id: None,
+            corpus_lineage: Vec::new(),
+        }
+    }
+
+    /// Attach the generating run's `instance_id` (builder, advisory).
+    #[must_use]
+    pub fn with_run(mut self, instance_id: [u8; 16]) -> Self {
+        self.generating_run = Some(instance_id);
+        self
+    }
+
+    /// Pin the corpus this content was derived from (builder, advisory).
+    #[must_use]
+    pub fn with_dataset(mut self, dataset_id: DatasetId) -> Self {
+        self.dataset_id = Some(dataset_id);
+        self
+    }
+
+    /// Echo the producing run's corpus lineage (builder).
+    ///
+    /// # Errors
+    ///
+    /// [`VersionError::ProvenanceTooLarge`] if `lineage` exceeds
+    /// [`MAX_PROVENANCE_LINEAGE`] — a loud, fail-closed refusal rather than a
+    /// silent truncation (the full lineage is dereferenced from `kx-dataset`).
+    pub fn with_corpus_lineage(
+        mut self,
+        lineage: impl IntoIterator<Item = MoteId>,
+    ) -> Result<Self, VersionError> {
+        let lineage: Vec<MoteId> = lineage.into_iter().collect();
+        if lineage.len() > MAX_PROVENANCE_LINEAGE {
+            return Err(VersionError::ProvenanceTooLarge { len: lineage.len() });
+        }
+        self.corpus_lineage = lineage;
+        Ok(self)
+    }
+
+    /// The recipe fingerprint that produced this content.
+    #[inline]
+    #[must_use]
+    pub const fn recipe_fingerprint(&self) -> &[u8; 32] {
+        &self.recipe_fingerprint
+    }
+
+    /// The generating run's `instance_id`, if recorded.
+    #[inline]
+    #[must_use]
+    pub const fn generating_run(&self) -> Option<[u8; 16]> {
+        self.generating_run
+    }
+
+    /// The pinned corpus this content was derived from, if any.
+    #[inline]
+    #[must_use]
+    pub const fn dataset_id(&self) -> Option<DatasetId> {
+        self.dataset_id
+    }
+
+    /// The (bounded) echo of the producing run's corpus lineage.
+    #[inline]
+    #[must_use]
+    pub fn corpus_lineage(&self) -> &[MoteId] {
+        &self.corpus_lineage
+    }
+}
+
+/// A content-versioning publish fact: the mutable-handle → immutable-content
+/// mapping (D82, D88), with an append-only `prior` edge to this handle's previous
+/// version (the lineage chain) and advisory [`Provenance`].
+///
+/// All fields are private; the only constructors are [`AssetVersion::root`] and
+/// [`AssetVersion::successor`], so `schema_version` is never caller-set and the
+/// `revision` is always chain-derived (never a forged or wall-clock value).
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct AssetVersion {
+    /// Canonical-encoding schema version (constructor-set, never caller-set).
+    schema_version: u16,
+    /// The MUTABLE human handle this publish moves.
+    handle: AssetPath,
+    /// The IMMUTABLE content this version pins.
+    content: VersionedContent,
+    /// `None` for the first version of this handle; `Some(prior)` = the previous
+    /// version of THIS SAME handle (the append-only lineage edge).
+    prior: Option<VersionId>,
+    /// Monotonic chain position: root = 0, successor = `prior_revision + 1`
+    /// (saturating). Derived from the chain, NOT a clock — two byte-identical
+    /// publishes share a [`VersionId`].
+    revision: u32,
+    /// Who published (the governance subject; `Register` is checked in
+    /// [`crate::GovernedCatalog`], never here — authority is the fold's business).
+    publisher: crate::PartyId,
+    /// Advisory provenance (D84) — never gates.
+    provenance: Provenance,
+}
+
+impl AssetVersion {
+    /// The FIRST version of a handle (`prior = None`, `revision = 0`).
+    #[must_use]
+    pub fn root(
+        handle: AssetPath,
+        content: VersionedContent,
+        publisher: crate::PartyId,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            schema_version: CATALOG_VERSION_SCHEMA_VERSION,
+            handle,
+            content,
+            prior: None,
+            revision: 0,
+            publisher,
+            provenance,
+        }
+    }
+
+    /// "Update" a handle by publishing a NEW version pinning `content` (D-LOCK-4 —
+    /// the prior version is retained; the handle is moved by the ledger). The
+    /// `prior` and `prior_revision` args name the version this one supersedes. The
+    /// ledger's `publish` RE-VERIFIES them against the real chain — the prior must
+    /// be present, on the SAME handle, and `revision == prior.revision + 1` — and
+    /// refuses a mismatch (so a forged `prior` or an inflated `prior_revision` can
+    /// never land). `revision` here is the chain-derived `prior_revision + 1`
+    /// (saturating), folded into the id; it is never trusted for authority.
+    #[must_use]
+    pub fn successor(
+        prior: VersionId,
+        prior_revision: u32,
+        handle: AssetPath,
+        content: VersionedContent,
+        publisher: crate::PartyId,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            schema_version: CATALOG_VERSION_SCHEMA_VERSION,
+            handle,
+            content,
+            prior: Some(prior),
+            revision: prior_revision.saturating_add(1),
+            publisher,
+            provenance,
+        }
+    }
+
+    /// The mutable handle this version was published at.
+    #[inline]
+    #[must_use]
+    pub fn handle(&self) -> &AssetPath {
+        &self.handle
+    }
+
+    /// The immutable content this version pins.
+    #[inline]
+    #[must_use]
+    pub fn content(&self) -> &VersionedContent {
+        &self.content
+    }
+
+    /// The prior version of this handle (`None` for the root).
+    #[inline]
+    #[must_use]
+    pub fn prior(&self) -> Option<VersionId> {
+        self.prior
+    }
+
+    /// The chain-derived revision number (root = 0).
+    #[inline]
+    #[must_use]
+    pub const fn revision(&self) -> u32 {
+        self.revision
+    }
+
+    /// Who published this version.
+    #[inline]
+    #[must_use]
+    pub fn publisher(&self) -> &crate::PartyId {
+        &self.publisher
+    }
+
+    /// The advisory provenance.
+    #[inline]
+    #[must_use]
+    pub fn provenance(&self) -> &Provenance {
+        &self.provenance
+    }
+
+    /// The canonical-encoding schema version this version was built under.
+    #[inline]
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// The content-addressed identity: `blake3(b"kx-catalog/asset-version/v1" ‖
+    /// canonical_bincode(self))`. Pure; two byte-identical versions share an id.
+    #[must_use]
+    pub fn version_id(&self) -> VersionId {
+        let mut h = blake3::Hasher::new();
+        h.update(b"kx-catalog/asset-version/v1");
+        // SAFETY (expect): an AssetVersion composes a u16, an AssetPath (strings),
+        // a VersionedContent ([u8;32]-bearing newtypes), Option<VersionId> ([u8;32]),
+        // a u32, a PartyId (string), and a Provenance ([u8;32] / [u8;16] /
+        // Option<DatasetId> / Vec<MoteId> — all bytes) — none of which carry a float
+        // or a non-encodable variant, so canonical bincode encoding is infallible.
+        // Mirrors the documented `Grant::grant_id` / `TaskSignature::task_signature_hash`.
+        let body = bincode::serde::encode_to_vec(self, canonical_config()).expect(
+            "AssetVersion canonical encoding is infallible (no floats, no non-encodable types)",
+        );
+        h.update(&body);
+        VersionId(*h.finalize().as_bytes())
+    }
+}

--- a/crates/kx-catalog/src/version_ledger.rs
+++ b/crates/kx-catalog/src/version_ledger.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The version-ledger seam (M7.2, D82/D88): the backend-agnostic [`VersionLedger`]
+//! trait — content-versioning handles + the provenance/lineage fold. The
+//! in-memory reference backend is [`crate::InMemoryVersionLedger`]; the production
+//! governed surface (publish requires `Register`) is [`crate::GovernedCatalog`].
+//!
+//! ## A separate truth, the same D-LOCK-4 discipline
+//!
+//! Like the M7.1 [`crate::CatalogRegistry`] and the M7.2 [`crate::GrantLedger`],
+//! this is authoritative for *what versions exist* and does NOT depend on
+//! `kx-journal` (the dependency direction is the wall). D88's "journaled fact" is
+//! realized as the DISCIPLINE — append-only, content-addressed, immutable,
+//! idempotent — inside the ledger. A durable / cloud backend (D94) implements the
+//! SAME trait; the in-memory backend is rebuildable, not durable.
+//!
+//! ## Lineage is computed, never stored; advisory, never gating
+//!
+//! [`VersionLedger::lineage`] / [`VersionLedger::descendants`] are pure folds over
+//! the `prior` edges — re-derived on every query, never materialized (the
+//! `kx_projection::transitive_consumers` pattern, replicated WITHOUT a
+//! `kx-projection` dependency). They are advisory (D84): they never gate a publish
+//! or any runtime action. The ONLY publish gate is the `Register` grant check in
+//! [`crate::GovernedCatalog`]; the raw [`VersionLedger::publish`] here is the
+//! minimal mechanism (authority is the facade's business).
+
+use std::sync::Arc;
+
+use crate::path::AssetPath;
+use crate::version::{AssetVersion, VersionId, VersionedContent};
+
+/// The maximum version-chain depth the lineage/history fold will walk. A chain
+/// deeper than this is depth-capped (the fold returns the bounded prefix actually
+/// walked — lineage is ADVISORY, so a depth cap cannot escalate anything, unlike
+/// the grant fold which returns "conveys nothing" because it gates). A hard
+/// DoS / stack-growth bound; the fold is iterative, so this caps work, not the
+/// stack. Larger than [`crate::MAX_DELEGATION_DEPTH`] because a long-lived asset's
+/// publish history legitimately grows far deeper than a delegation chain.
+pub const MAX_VERSION_CHAIN_DEPTH: usize = 1024;
+
+/// The maximum number of forward descendants [`VersionLedger::descendants`] will
+/// enumerate. A hard bound on the BFS work / output size; reaching it stops the
+/// walk (a fail-safe DoS bound, never the stack — the walk is iterative).
+pub const MAX_VERSION_DESCENDANTS: usize = 65_536;
+
+/// The outcome of a publish: a fresh insert vs. an idempotent no-op (the version
+/// fact was byte-identically present).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PublishOutcome {
+    /// First publish of this version fact.
+    Published(VersionId),
+    /// A byte-identical version was already present — no-op (idempotent).
+    AlreadyPresent(VersionId),
+}
+
+impl PublishOutcome {
+    /// The version id this outcome refers to.
+    #[inline]
+    #[must_use]
+    pub const fn version_id(&self) -> VersionId {
+        match self {
+            Self::Published(v) | Self::AlreadyPresent(v) => *v,
+        }
+    }
+
+    /// `true` iff this was a fresh publish (not an idempotent no-op).
+    #[inline]
+    #[must_use]
+    pub const fn is_published(&self) -> bool {
+        matches!(self, Self::Published(_))
+    }
+}
+
+/// A version-ledger publish failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum VersionLedgerError {
+    /// A DIFFERENT version already exists at this [`VersionId`]. Versions are
+    /// content-addressed, so the same id MUST mean the same bytes — a mismatch is
+    /// a hash-collision tripwire (cryptographically unreachable): refuse loudly
+    /// rather than overwrite. Carries the conflicting id (hex).
+    #[error("immutable version conflict at version_id {0}")]
+    ImmutabilityConflict(String),
+    /// A successor's `prior` version is not present. Publishing is causally
+    /// ordered — a version's prior must already be published (in practice a
+    /// successor's `prior` id is only obtainable by first publishing the prior).
+    /// Carries the missing prior id (hex).
+    #[error("prior version {0} not found (publish the prior first)")]
+    PriorNotFound(String),
+    /// A successor's declared lineage is inconsistent with its REAL prior: the
+    /// prior is on a DIFFERENT handle, or the revision is not exactly
+    /// `prior.revision + 1`. Refused fail-closed so the stored chain is always
+    /// well-formed — a forged cross-handle graft or an inflated revision can never
+    /// land, which keeps the handle-move rank ungameable and the forward
+    /// (descendants) and backward (lineage) folds in agreement.
+    #[error("invalid lineage for version {version_id}: {reason}")]
+    InvalidLineage {
+        /// The offending version id (hex).
+        version_id: String,
+        /// Why the lineage was refused.
+        reason: String,
+    },
+}
+
+/// The backend-agnostic content-versioning + lineage ledger.
+///
+/// Publishing is intentionally MINIMAL + ungoverned here (idempotent + immutable);
+/// the `Register`-gated production surface is [`crate::GovernedCatalog`]. Resolving
+/// a handle returns its CURRENT immutable content (the mutable handle → immutable
+/// version mapping); lineage/descendants are advisory folds.
+pub trait VersionLedger {
+    /// Append a publish fact (the mechanism). MINIMAL governance-wise — the
+    /// `Register` gate is [`crate::GovernedCatalog`]'s business (mirroring how
+    /// [`crate::GrantLedger::append_grant`] is minimal) — but lineage-strict: a
+    /// successor's `prior` must be present, on the SAME handle, and exactly one
+    /// revision below, so the stored chain is always well-formed. Idempotent +
+    /// immutable on the content id. Moves the handle to this version iff it ranks
+    /// ahead of the current latest (higher `revision`, ties broken by `version_id`
+    /// bytes — a total, deterministic, insertion-order-independent order; because
+    /// `revision` is validated against the real prior it cannot be inflated to game
+    /// the move).
+    ///
+    /// # Errors
+    ///
+    /// [`VersionLedgerError::ImmutabilityConflict`] on the cryptographically
+    /// unreachable same-id-different-bytes tripwire;
+    /// [`VersionLedgerError::PriorNotFound`] if a successor's prior is not yet
+    /// published; [`VersionLedgerError::InvalidLineage`] if the prior is on a
+    /// different handle or the revision is not `prior.revision + 1`.
+    fn publish(&self, version: AssetVersion) -> Result<PublishOutcome, VersionLedgerError>;
+
+    /// Resolve a handle to its CURRENT immutable content + the resolving version
+    /// id (the latest publish on that path). `None` if never published. This IS
+    /// "the mutable handle resolving to an immutable content-addressed version".
+    fn resolve(&self, handle: &AssetPath) -> Option<(VersionedContent, VersionId)>;
+
+    /// Fetch one version by its content id (the EXACT-selection pin, D87 — a
+    /// recipient pins an immutable version, never a fuzzy match). `None` if absent.
+    fn get_version(&self, id: &VersionId) -> Option<AssetVersion>;
+
+    /// The ancestor provenance chain of a version (walk `prior`, latest → oldest),
+    /// depth-bounded + cycle-safe + lineage-integrity-checked, fail-closed.
+    /// COMPUTED, never stored. ADVISORY (D84) — never gates.
+    ///
+    /// Cost note: returns owned [`AssetVersion`]s, so it clones up to
+    /// [`MAX_VERSION_CHAIN_DEPTH`] nodes (each carrying a [`crate::Provenance`]
+    /// whose `corpus_lineage` is bounded by [`crate::MAX_PROVENANCE_LINEAGE`]).
+    /// Both bounds are hard, so the cost is bounded; a future ids-only / borrowed
+    /// view is a seam-level optimization (its own PR, Rule 1).
+    fn lineage(&self, id: &VersionId) -> Vec<AssetVersion>;
+
+    /// Forward lineage: every version that (transitively) descends from `id` via
+    /// `prior`. BFS-with-visited, bounded by [`MAX_VERSION_DESCENDANTS`]. COMPUTED,
+    /// never stored. ADVISORY (D84) — never gates.
+    fn descendants(&self, id: &VersionId) -> Vec<VersionId>;
+
+    /// The full version chain of a handle (latest → oldest). Default: resolve the
+    /// handle, then walk its lineage (each version's `prior` is the same handle's
+    /// previous version, so the lineage of the latest IS the handle's history).
+    fn history(&self, handle: &AssetPath) -> Vec<AssetVersion> {
+        match self.resolve(handle) {
+            Some((_, vid)) => self.lineage(&vid),
+            None => Vec::new(),
+        }
+    }
+
+    /// Enumerate every published version in append order.
+    fn list_versions<'a>(&'a self) -> Box<dyn Iterator<Item = AssetVersion> + 'a>;
+
+    /// Count of published versions.
+    fn len(&self) -> usize;
+
+    /// `true` when no versions are published.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<L: VersionLedger + ?Sized> VersionLedger for Arc<L> {
+    fn publish(&self, version: AssetVersion) -> Result<PublishOutcome, VersionLedgerError> {
+        (**self).publish(version)
+    }
+
+    fn resolve(&self, handle: &AssetPath) -> Option<(VersionedContent, VersionId)> {
+        (**self).resolve(handle)
+    }
+
+    fn get_version(&self, id: &VersionId) -> Option<AssetVersion> {
+        (**self).get_version(id)
+    }
+
+    fn lineage(&self, id: &VersionId) -> Vec<AssetVersion> {
+        (**self).lineage(id)
+    }
+
+    fn descendants(&self, id: &VersionId) -> Vec<VersionId> {
+        (**self).descendants(id)
+    }
+
+    fn list_versions<'a>(&'a self) -> Box<dyn Iterator<Item = AssetVersion> + 'a> {
+        (**self).list_versions()
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+}

--- a/crates/kx-catalog/tests/proptest_versions.rs
+++ b/crates/kx-catalog/tests/proptest_versions.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property tests for M7.2 content-versioning + provenance/lineage (D82/D88).
+//!
+//! Integration-test file: compiled as a separate crate, so it carries its own
+//! lint allowances for fixture `unwrap`s and pedantic test idioms.
+//!
+//! Properties (each over randomized chains/orders/actions):
+//! 1. Publishing a version is idempotent (N publishes ⇒ one stored fact).
+//! 2. A handle resolves to its max-rank version, and `history` is identical
+//!    regardless of the order the versions were published (the handle move + the
+//!    fold are pure functions of the fact set, not of append order).
+//! 3. Lineage walks the full chain when under the depth cap.
+//! 4. `descendants(root)` covers every forward node exactly once.
+//! 5. The governed publish succeeds IFF the publisher holds `Register`.
+//! 6. A foreign-`prior` graft (a different handle's version) truncates lineage —
+//!    forged provenance conveys no further ancestry (fail-closed).
+//! 7. A missing-`prior` (phantom) reference truncates lineage (fail-closed).
+//! 8. A published version round-trips through `get_version` by its exact id.
+//!
+//! NOTE (structural unreachability): a `VersionId` is `blake3` over the WHOLE
+//! `AssetVersion` INCLUDING `prior`, so (a) two versions with the same id are
+//! byte-identical (the `ImmutabilityConflict` branch is a cryptographic tripwire,
+//! not a reachable state), and (b) a `prior` cycle is impossible to construct (a
+//! version's id depends on its prior's id). The `seen`/immutability guards are
+//! defense-in-depth for a corrupt backend; the reachable fail-closed paths
+//! (foreign/missing `prior`) are what these properties exercise.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, AssetVersion, CatalogAction, CatalogActionSet,
+    GovernedCatalog, GovernedError, Grant, GrantLedger, InMemoryGrantLedger, InMemoryVersionLedger,
+    PartyId, Provenance, TaskSignatureHash, VersionLedger, VersionLedgerError, VersionedContent,
+    MAX_VERSION_CHAIN_DEPTH,
+};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
+use proptest::prelude::*;
+
+fn apath(name: &str) -> AssetPath {
+    AssetPath::new("acme", "recipes", name).unwrap()
+}
+
+fn recipe(byte: u8) -> VersionedContent {
+    VersionedContent::Recipe(TaskSignatureHash::from_bytes([byte; 32]))
+}
+
+fn prov(byte: u8) -> Provenance {
+    Provenance::from_recipe([byte; 32])
+}
+
+fn alice() -> PartyId {
+    PartyId::new("alice@acme")
+}
+
+fn warrant_calls(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1_000,
+            max_output_tokens: 1_000,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 1_000,
+            fd_count: 16,
+            disk_bytes: 1 << 20,
+        },
+        ..Default::default()
+    }
+}
+
+fn role_calls(max_calls: u32) -> Role {
+    Role {
+        name: "r".into(),
+        version: 1,
+        spec: warrant_calls(max_calls),
+        description: String::new(),
+    }
+}
+
+fn arb_actions() -> impl Strategy<Value = CatalogActionSet> {
+    (any::<bool>(), any::<bool>(), any::<bool>(), any::<bool>()).prop_map(|(r, u, reg, d)| {
+        let mut v = Vec::new();
+        if r {
+            v.push(CatalogAction::Read);
+        }
+        if u {
+            v.push(CatalogAction::Use);
+        }
+        if reg {
+            v.push(CatalogAction::Register);
+        }
+        if d {
+            v.push(CatalogAction::Delegate);
+        }
+        CatalogActionSet::allow(v)
+    })
+}
+
+/// Build the linear version chain `v0 → v1 → … → v(n-1)` of one handle.
+fn build_chain(handle: &AssetPath, n: usize) -> Vec<AssetVersion> {
+    let mut chain = Vec::with_capacity(n);
+    let v0 = AssetVersion::root(handle.clone(), recipe(0), alice(), prov(0));
+    let mut prev_id = v0.version_id();
+    let mut prev_rev = v0.revision();
+    chain.push(v0);
+    for k in 1..n {
+        let v = AssetVersion::successor(
+            prev_id,
+            prev_rev,
+            handle.clone(),
+            recipe(u8::try_from(k % 250).unwrap()),
+            alice(),
+            prov(u8::try_from((k * 3) % 250).unwrap()),
+        );
+        prev_id = v.version_id();
+        prev_rev = v.revision();
+        chain.push(v);
+    }
+    chain
+}
+
+/// A count of independent roots + a random publish order over their indices
+/// (roots have no prior, so any publish order is valid — genuine order-independence).
+fn roots_and_order() -> impl Strategy<Value = (usize, Vec<usize>)> {
+    (2usize..10).prop_flat_map(|n| (Just(n), Just((0..n).collect::<Vec<usize>>()).prop_shuffle()))
+}
+
+proptest! {
+    /// (1) publish is idempotent.
+    #[test]
+    fn publish_is_idempotent(reps in 1usize..6) {
+        let ledger = InMemoryVersionLedger::new();
+        let v = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let mut published = 0;
+        for _ in 0..reps {
+            if ledger.publish(v.clone()).unwrap().is_published() {
+                published += 1;
+            }
+        }
+        prop_assert_eq!(published, 1, "only the first publish lands");
+        prop_assert_eq!(ledger.len(), 1);
+    }
+
+    /// (2a) a chain published in causal order resolves to its latest; history is
+    /// the full latest → oldest walk.
+    #[test]
+    fn chain_resolves_to_latest(n in 2usize..10) {
+        let handle = apath("x");
+        let chain = build_chain(&handle, n);
+        let ledger = InMemoryVersionLedger::new();
+        for v in &chain {
+            ledger.publish(v.clone()).unwrap();
+        }
+        let latest = chain[n - 1].version_id();
+        prop_assert_eq!(ledger.resolve(&handle).unwrap().1, latest);
+        let got: Vec<_> = ledger.history(&handle).iter().map(AssetVersion::version_id).collect();
+        let want: Vec<_> = (0..n).rev().map(|k| chain[k].version_id()).collect();
+        prop_assert_eq!(got, want);
+    }
+
+    /// (2b) independent roots (distinct handles, no prior) publish in ANY order and
+    /// each handle resolves to its own root — genuine order-independence across
+    /// independent facts (the per-chain order is fixed by causality).
+    #[test]
+    fn independent_roots_order_independent((n, order) in roots_and_order()) {
+        let ledger = InMemoryVersionLedger::new();
+        let roots: Vec<AssetVersion> = (0..n)
+            .map(|i| AssetVersion::root(apath(&format!("h{i}")), recipe(u8::try_from(i).unwrap()), alice(), prov(1)))
+            .collect();
+        for &k in &order {
+            ledger.publish(roots[k].clone()).unwrap();
+        }
+        for (i, r) in roots.iter().enumerate() {
+            prop_assert_eq!(ledger.resolve(&apath(&format!("h{i}"))).unwrap().1, r.version_id());
+        }
+    }
+
+    /// (3) lineage walks the full chain when under the depth cap.
+    #[test]
+    fn lineage_length_equals_chain_depth(n in 1usize..50) {
+        let handle = apath("x");
+        let chain = build_chain(&handle, n);
+        let ledger = InMemoryVersionLedger::new();
+        for v in &chain {
+            ledger.publish(v.clone()).unwrap();
+        }
+        let leaf = chain[n - 1].version_id();
+        let lin = ledger.lineage(&leaf);
+        prop_assert_eq!(lin.len(), n.min(MAX_VERSION_CHAIN_DEPTH));
+        prop_assert_eq!(lin.first().unwrap().version_id(), leaf);
+    }
+
+    /// (4) descendants(root) covers every forward node exactly once.
+    #[test]
+    fn descendants_cover_forward_chain_once(n in 1usize..50) {
+        let handle = apath("x");
+        let chain = build_chain(&handle, n);
+        let ledger = InMemoryVersionLedger::new();
+        for v in &chain {
+            ledger.publish(v.clone()).unwrap();
+        }
+        let root = chain[0].version_id();
+        let desc = ledger.descendants(&root);
+        prop_assert_eq!(desc.len(), n - 1, "every non-root node, once");
+        // unique
+        let mut sorted = desc.clone();
+        sorted.sort_unstable_by_key(|v| *v.as_bytes());
+        sorted.dedup();
+        prop_assert_eq!(sorted.len(), desc.len(), "no duplicates");
+    }
+
+    /// (5) governed publish succeeds IFF the publisher holds Register.
+    #[test]
+    fn governed_publish_iff_register(acts in arb_actions()) {
+        let asset = AssetRef::Path(apath("x"));
+        let owner = PartyId::new("owner");
+        let grants = InMemoryGrantLedger::new();
+        grants.append_binding(AssetBinding::new(asset.clone(), owner.clone())).unwrap();
+        grants.append_grant(Grant::root(
+            asset, owner, alice(), acts.clone(), role_calls(10),
+        )).unwrap();
+
+        let catalog = GovernedCatalog::new(grants, InMemoryVersionLedger::new());
+        let v = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let result = catalog.publish(v);
+
+        if acts.contains(CatalogAction::Register) {
+            prop_assert!(result.is_ok(), "Register-holder may publish");
+        } else {
+            prop_assert!(
+                matches!(result, Err(GovernedError::Unauthorized { action: CatalogAction::Register, .. })),
+                "without Register the publish is refused"
+            );
+            prop_assert_eq!(catalog.versions().len(), 0, "nothing appended on refusal");
+        }
+    }
+
+    /// (6) a foreign-`prior` graft is refused at publish (cross-handle chain).
+    #[test]
+    fn foreign_prior_publish_is_refused(b in 0u8..200) {
+        let ledger = InMemoryVersionLedger::new();
+        // A real version on a DIFFERENT handle Y.
+        let vy = AssetVersion::root(apath("y"), recipe(b), alice(), prov(b));
+        let vy_id = ledger.publish(vy).unwrap().version_id();
+        // A "successor" on handle X grafting Y's version as its prior.
+        let forged = AssetVersion::successor(
+            vy_id, 0, apath("x"), recipe(b.wrapping_add(1)), alice(), prov(b),
+        );
+        let is_invalid = matches!(
+            ledger.publish(forged).unwrap_err(),
+            VersionLedgerError::InvalidLineage { .. }
+        );
+        prop_assert!(is_invalid);
+        prop_assert_eq!(ledger.len(), 1);
+    }
+
+    /// (7) a missing-`prior` (phantom) reference is refused at publish.
+    #[test]
+    fn missing_prior_publish_is_refused(b in 0u8..200) {
+        let ledger = InMemoryVersionLedger::new();
+        let phantom = AssetVersion::root(apath("ghost"), recipe(b), alice(), prov(b)).version_id();
+        let orphan = AssetVersion::successor(
+            phantom, 0, apath("x"), recipe(b.wrapping_add(7)), alice(), prov(b),
+        );
+        prop_assert!(matches!(
+            ledger.publish(orphan).unwrap_err(),
+            VersionLedgerError::PriorNotFound(_)
+        ));
+        prop_assert_eq!(ledger.len(), 0);
+    }
+
+    /// (7b) an inflated `prior_revision` (the handle-grief vector) is refused — the
+    /// revision must be exactly real_prior.revision + 1, so the rank can't be gamed.
+    #[test]
+    fn inflated_prior_revision_publish_is_refused(inflate in 1u32..u32::MAX) {
+        let ledger = InMemoryVersionLedger::new();
+        let v1 = AssetVersion::root(apath("x"), recipe(1), alice(), prov(1));
+        let v1_id = ledger.publish(v1).unwrap().version_id(); // real revision 0
+        // Lie that prior_revision = inflate (>0) ⇒ declared revision = inflate+1 ≠ 1.
+        let forged = AssetVersion::successor(v1_id, inflate, apath("x"), recipe(2), alice(), prov(2));
+        let is_invalid = matches!(
+            ledger.publish(forged).unwrap_err(),
+            VersionLedgerError::InvalidLineage { .. }
+        );
+        prop_assert!(is_invalid);
+        // The handle stays at the legitimate v1.
+        prop_assert_eq!(ledger.resolve(&apath("x")).unwrap().1, v1_id);
+    }
+
+    /// (8) a published version round-trips through get_version by its exact id.
+    #[test]
+    fn get_version_roundtrips(n in 1usize..20) {
+        let handle = apath("x");
+        let chain = build_chain(&handle, n);
+        let ledger = InMemoryVersionLedger::new();
+        for v in &chain {
+            ledger.publish(v.clone()).unwrap();
+        }
+        for v in &chain {
+            let got = ledger.get_version(&v.version_id()).expect("present");
+            prop_assert_eq!(&got, v, "exact-id pin returns the same version");
+        }
+    }
+}

--- a/crates/kx-catalog/tests/scale.rs
+++ b/crates/kx-catalog/tests/scale.rs
@@ -11,9 +11,10 @@
 use std::time::Instant;
 
 use kx_catalog::{
-    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, CatalogRegistry, Grant,
-    GrantLedger, InMemoryCatalog, InMemoryGrantLedger, PartyId, RecipeSnapshot, SignatureEntry,
-    TaskSignature, TaskSignatureHash,
+    AssetBinding, AssetPath, AssetRef, AssetVersion, CatalogAction, CatalogActionSet,
+    CatalogRegistry, Grant, GrantLedger, InMemoryCatalog, InMemoryGrantLedger,
+    InMemoryVersionLedger, PartyId, Provenance, RecipeSnapshot, SignatureEntry, TaskSignature,
+    TaskSignatureHash, VersionLedger, VersionedContent, MAX_VERSION_CHAIN_DEPTH,
 };
 use kx_mote::{ModelId, MoteDefHash};
 use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
@@ -258,4 +259,220 @@ fn deep_chain_query_is_bounded() {
         last <= first * 4.0,
         "deep-chain query must be depth-bounded (depth 1k {first:.1}ns vs 50k {last:.1}ns)"
     );
+}
+
+/// M7.2 versioning: publish + handle-resolve + history stay O(log n) in the
+/// number of distinct handles — the `BTreeMap` indices keep the
+/// mutable-handle → immutable-content mapping sub-linear at catalog scale.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn version_ledger_publish_resolve_history_stay_sublinear() {
+    let mut publish_ns: Vec<(usize, f64)> = Vec::new();
+    let mut resolve_ns: Vec<(usize, f64)> = Vec::new();
+    let mut history_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let ledger = InMemoryVersionLedger::new();
+        let handles: Vec<AssetPath> = (0..n)
+            .map(|i| AssetPath::new("ns", "c", format!("a{i}")).unwrap())
+            .collect();
+        // Build the (distinct-handle) root versions OUTSIDE the timed region.
+        let versions: Vec<AssetVersion> = handles
+            .iter()
+            .map(|h| {
+                AssetVersion::root(
+                    h.clone(),
+                    VersionedContent::Recipe(TaskSignatureHash::from_bytes([1u8; 32])),
+                    PartyId::new("p"),
+                    Provenance::from_recipe([2u8; 32]),
+                )
+            })
+            .collect();
+
+        let start = Instant::now();
+        for v in versions {
+            ledger.publish(v).unwrap();
+        }
+        let publish_elapsed = start.elapsed();
+        assert_eq!(ledger.len(), n, "one version per handle at n={n}");
+
+        let start = Instant::now();
+        for h in &handles {
+            assert!(ledger.resolve(h).is_some(), "published handle must resolve");
+        }
+        let resolve_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for h in &handles {
+            assert_eq!(ledger.history(h).len(), 1, "single-version history");
+        }
+        let history_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = |d: std::time::Duration| d.as_nanos() as f64 / n as f64;
+        println!(
+            "version-ledger: n={n} publish_per_ns={:.1} resolve_per_ns={:.1} history_per_ns={:.1}",
+            per(publish_elapsed),
+            per(resolve_elapsed),
+            per(history_elapsed)
+        );
+        publish_ns.push((n, per(publish_elapsed)));
+        resolve_ns.push((n, per(resolve_elapsed)));
+        history_ns.push((n, per(history_elapsed)));
+    }
+
+    assert_sublinear("version-publish", &publish_ns);
+    assert_sublinear("version-resolve", &resolve_ns);
+    assert_sublinear("version-history", &history_ns);
+}
+
+/// M7.2 versioning: a lineage query is BOUNDED by `MAX_VERSION_CHAIN_DEPTH`
+/// (1024), independent of how deep the version chain actually is. A 50k-deep
+/// chain's lineage walks at most 1024 hops — without the cap it would walk 50k
+/// (≈50× slower), so flatness across a 50× depth increase proves the bound.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn deep_version_chain_lineage_is_bounded() {
+    const DEPTHS: &[usize] = &[1_000, 10_000, 50_000];
+    const ITERS: usize = 500;
+    let mut query_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &depth in DEPTHS {
+        let ledger = InMemoryVersionLedger::new();
+        let handle = AssetPath::new("ns", "c", "deep").unwrap();
+        let v0 = AssetVersion::root(
+            handle.clone(),
+            VersionedContent::Recipe(TaskSignatureHash::from_bytes([0u8; 32])),
+            PartyId::new("p"),
+            Provenance::from_recipe([0u8; 32]),
+        );
+        let mut prev_id = v0.version_id();
+        let mut prev_rev = v0.revision();
+        ledger.publish(v0).unwrap();
+        for i in 1..depth {
+            let v = AssetVersion::successor(
+                prev_id,
+                prev_rev,
+                handle.clone(),
+                VersionedContent::Recipe(TaskSignatureHash::from_bytes(
+                    [u8::try_from(i % 256).unwrap(); 32],
+                )),
+                PartyId::new("p"),
+                Provenance::from_recipe([0u8; 32]),
+            );
+            prev_id = v.version_id();
+            prev_rev = v.revision();
+            ledger.publish(v).unwrap();
+        }
+        let leaf = prev_id;
+
+        // Query the leaf's lineage many times; the walk caps at MAX_VERSION_CHAIN_DEPTH.
+        // Tight length check: EXACTLY min(depth, cap) — catches an early-truncation
+        // regression that a loose `<= cap` would pass trivially.
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            let lin = ledger.lineage(&leaf);
+            assert_eq!(lin.len(), depth.min(MAX_VERSION_CHAIN_DEPTH));
+        }
+        let elapsed = start.elapsed();
+        #[allow(clippy::cast_precision_loss)]
+        let per = elapsed.as_nanos() as f64 / ITERS as f64;
+        println!("deep-version-chain: depth={depth} lineage_per_ns={per:.1}");
+        query_ns.push((depth, per));
+    }
+
+    let first = query_ns.first().unwrap().1;
+    let last = query_ns.last().unwrap().1;
+    assert!(
+        last <= first * 4.0,
+        "deep version-chain lineage must be depth-bounded (depth 1k {first:.1}ns vs 50k {last:.1}ns)"
+    );
+}
+
+/// M7.2 versioning: the realistic enterprise shape — MANY handles each with a
+/// fixed-depth version history — keeps publish (the rank-comparison handle-move
+/// `Some` branch), resolve, and multi-version history sub-linear as the catalog
+/// (handle count) grows. Chain depth is held CONSTANT (`DEPTH`) and the handle
+/// count grows with `n`, so each op stays `O(log n)` in the `BTreeMap` indices.
+/// Complements `version_ledger_publish_resolve_history_stay_sublinear` (which
+/// only times distinct single-version roots and never exercises the handle move).
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn version_chains_publish_resolve_history_stay_sublinear() {
+    const DEPTH: usize = 4; // fixed per-handle chain depth (exercises the Some-branch move)
+    let mut publish_ns: Vec<(usize, f64)> = Vec::new();
+    let mut resolve_ns: Vec<(usize, f64)> = Vec::new();
+    let mut history_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let ledger = InMemoryVersionLedger::new();
+        let handle_count = n / DEPTH;
+        let handles: Vec<AssetPath> = (0..handle_count)
+            .map(|i| AssetPath::new("ns", "c", format!("h{i}")).unwrap())
+            .collect();
+
+        // Build all DEPTH-deep chains (causal order) OUTSIDE the timed region.
+        let mut versions: Vec<AssetVersion> = Vec::with_capacity(handle_count * DEPTH);
+        for h in &handles {
+            let v0 = AssetVersion::root(
+                h.clone(),
+                VersionedContent::Recipe(TaskSignatureHash::from_bytes([0u8; 32])),
+                PartyId::new("p"),
+                Provenance::from_recipe([0u8; 32]),
+            );
+            let mut prev_id = v0.version_id();
+            let mut prev_rev = v0.revision();
+            versions.push(v0);
+            for k in 1..DEPTH {
+                let v = AssetVersion::successor(
+                    prev_id,
+                    prev_rev,
+                    h.clone(),
+                    VersionedContent::Recipe(TaskSignatureHash::from_bytes(
+                        [u8::try_from(k).unwrap(); 32],
+                    )),
+                    PartyId::new("p"),
+                    Provenance::from_recipe([0u8; 32]),
+                );
+                prev_id = v.version_id();
+                prev_rev = v.revision();
+                versions.push(v);
+            }
+        }
+
+        let total = versions.len();
+        let start = Instant::now();
+        for v in versions {
+            ledger.publish(v).unwrap(); // exercises the rank-comparison handle move
+        }
+        let publish_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for h in &handles {
+            assert!(ledger.resolve(h).is_some());
+        }
+        let resolve_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for h in &handles {
+            assert_eq!(ledger.history(h).len(), DEPTH, "full multi-version history");
+        }
+        let history_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = |d: std::time::Duration, by: usize| d.as_nanos() as f64 / by as f64;
+        println!(
+            "version-chains: n={n} handles={handle_count} depth={DEPTH} publish_per_ns={:.1} resolve_per_ns={:.1} history_per_ns={:.1}",
+            per(publish_elapsed, total),
+            per(resolve_elapsed, handle_count),
+            per(history_elapsed, handle_count)
+        );
+        publish_ns.push((n, per(publish_elapsed, total)));
+        resolve_ns.push((n, per(resolve_elapsed, handle_count)));
+        history_ns.push((n, per(history_elapsed, handle_count)));
+    }
+
+    assert_sublinear("version-chains-publish", &publish_ns);
+    assert_sublinear("version-chains-resolve", &resolve_ns);
+    assert_sublinear("version-chains-history", &history_ns);
 }

--- a/crates/kx-catalog/tests/security_governance.rs
+++ b/crates/kx-catalog/tests/security_governance.rs
@@ -21,10 +21,13 @@
 use std::sync::Arc;
 
 use kx_catalog::{
-    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantId,
-    GrantLedger, InMemoryGrantLedger, LedgerFact, PartyId, Revocation,
+    AssetBinding, AssetPath, AssetRef, AssetVersion, CatalogAction, CatalogActionSet,
+    GovernedCatalog, GovernedError, Grant, GrantId, GrantLedger, InMemoryGrantLedger,
+    InMemoryVersionLedger, LedgerFact, PartyId, Provenance, Revocation, TaskSignatureHash,
+    VersionLedger, VersionLedgerError, VersionedContent,
 };
-use kx_mote::ModelId;
+use kx_dataset::DatasetId;
+use kx_mote::{ModelId, MoteId};
 use kx_warrant::{ModelRoute, ResourceCeiling, Role, SecretRef, SecretScope, WarrantSpec};
 
 // ---- fixtures ---------------------------------------------------------------
@@ -578,6 +581,10 @@ fn guarantee_path_does_not_depend_on_catalog() {
         "kx-executor",
         "kx-projection",
         "kx-inference",
+        // The journal/identity core must also stay off kx-catalog (the new
+        // versioning/lineage modules add no edge back into the frozen spine).
+        "kx-mote",
+        "kx-journal",
     ];
     for c in crates {
         let manifest = format!("{}/../{c}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
@@ -666,4 +673,579 @@ fn m7_2_exit_gate() {
         ledger.is_authorized(&ds, &asset, CatalogAction::Read),
         "unaffected action stands"
     );
+}
+
+// ============================================================================
+// M7.2 — content-versioning + provenance/lineage (D82/D88 + D-LOCK-4)
+// ============================================================================
+
+fn vpath(name: &str) -> AssetPath {
+    AssetPath::new("acme", "recipes", name).unwrap()
+}
+
+fn recipe(byte: u8) -> VersionedContent {
+    VersionedContent::Recipe(TaskSignatureHash::from_bytes([byte; 32]))
+}
+
+/// A governed catalog where `owner` owns `handle` and `publisher` holds the given
+/// actions on it.
+fn governed_with(
+    handle: &AssetPath,
+    owner: &PartyId,
+    publisher: &PartyId,
+    actions: CatalogActionSet,
+) -> GovernedCatalog<InMemoryGrantLedger, InMemoryVersionLedger> {
+    let grants = InMemoryGrantLedger::new();
+    let asset = AssetRef::Path(handle.clone());
+    grants
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    grants
+        .append_grant(Grant::root(
+            asset,
+            owner.clone(),
+            publisher.clone(),
+            actions,
+            role("publisher", 10),
+        ))
+        .unwrap();
+    GovernedCatalog::new(grants, InMemoryVersionLedger::new())
+}
+
+// ---- governance (publish gated by Register; reads gated by Read) -------------
+
+#[test]
+fn unauthorized_publish_is_refused() {
+    let handle = vpath("summarize");
+    let owner = PartyId::new("owner@acme");
+    let mate = PartyId::new("mate@acme");
+    // mate holds Read+Use but NOT Register.
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &mate,
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
+    );
+    let v = AssetVersion::root(handle, recipe(1), mate, Provenance::from_recipe([1u8; 32]));
+    let err = catalog.publish(v).unwrap_err();
+    assert!(matches!(
+        err,
+        GovernedError::Unauthorized {
+            action: CatalogAction::Register,
+            ..
+        }
+    ));
+    assert_eq!(catalog.versions().len(), 0, "nothing appended on refusal");
+}
+
+#[test]
+fn register_granted_party_can_publish() {
+    let handle = vpath("summarize");
+    let owner = PartyId::new("owner@acme");
+    let lead = PartyId::new("lead@acme");
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &lead,
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+    );
+    let v = AssetVersion::root(
+        handle.clone(),
+        recipe(1),
+        lead.clone(),
+        Provenance::from_recipe([1u8; 32]),
+    );
+    assert!(catalog.publish(v).unwrap().is_published());
+    // lead also holds Read → can resolve.
+    assert!(catalog.resolve(&lead, &handle).unwrap().is_some());
+}
+
+#[test]
+fn confused_deputy_publish_across_handles_is_refused() {
+    let handle_a = vpath("recipe-a");
+    let owner = PartyId::new("owner@acme");
+    let lead = PartyId::new("lead@acme");
+    // lead holds Register on handle A only.
+    let catalog = governed_with(
+        &handle_a,
+        &owner,
+        &lead,
+        CatalogActionSet::allow([CatalogAction::Register]),
+    );
+    // Publishing to a DIFFERENT handle B is refused (authority is asset-keyed).
+    let handle_b = vpath("recipe-b");
+    let v = AssetVersion::root(
+        handle_b,
+        recipe(2),
+        lead,
+        Provenance::from_recipe([2u8; 32]),
+    );
+    assert!(matches!(
+        catalog.publish(v).unwrap_err(),
+        GovernedError::Unauthorized { .. }
+    ));
+}
+
+#[test]
+fn revoked_register_cannot_publish_but_prior_versions_retained() {
+    let handle = vpath("summarize");
+    let owner = PartyId::new("owner@acme");
+    let lead = PartyId::new("lead@acme");
+    let grants = InMemoryGrantLedger::new();
+    let asset = AssetRef::Path(handle.clone());
+    grants
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    let reg_grant = Grant::root(
+        asset.clone(),
+        owner.clone(),
+        lead.clone(),
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+        role("publisher", 10),
+    );
+    let reg_gid = reg_grant.grant_id();
+    grants.append_grant(reg_grant).unwrap();
+    let catalog = GovernedCatalog::new(grants, InMemoryVersionLedger::new());
+
+    // v1 publishes fine.
+    let v1 = AssetVersion::root(
+        handle.clone(),
+        recipe(1),
+        lead.clone(),
+        Provenance::from_recipe([1u8; 32]),
+    );
+    let v1_id = catalog.publish(v1).unwrap().version_id();
+
+    // Owner revokes Register (a NEW fact). v2 is now refused.
+    catalog
+        .grants()
+        .append_revocation(Revocation::new(reg_gid, owner))
+        .unwrap();
+    let v2 = AssetVersion::successor(
+        v1_id,
+        0,
+        handle.clone(),
+        recipe(2),
+        lead.clone(),
+        Provenance::from_recipe([2u8; 32]),
+    );
+    assert!(matches!(
+        catalog.publish(v2).unwrap_err(),
+        GovernedError::Unauthorized { .. }
+    ));
+    // v1 is retained and still resolves (revocation stops FUTURE publishes only).
+    assert_eq!(catalog.versions().resolve(&handle).unwrap().1, v1_id);
+    assert!(catalog.versions().get_version(&v1_id).is_some());
+}
+
+#[test]
+fn governed_read_requires_read() {
+    let handle = vpath("summarize");
+    let owner = PartyId::new("owner@acme");
+    let lead = PartyId::new("lead@acme");
+    let stranger = PartyId::new("stranger@acme");
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &lead,
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+    );
+    let v = AssetVersion::root(
+        handle.clone(),
+        recipe(1),
+        lead.clone(),
+        Provenance::from_recipe([1u8; 32]),
+    );
+    catalog.publish(v).unwrap();
+    // lead has Read → ok; stranger has nothing → refused.
+    assert!(catalog.resolve(&lead, &handle).unwrap().is_some());
+    assert!(matches!(
+        catalog.resolve(&stranger, &handle).unwrap_err(),
+        GovernedError::Unauthorized {
+            action: CatalogAction::Read,
+            ..
+        }
+    ));
+}
+
+// ---- lineage integrity + advisory wall ---------------------------------------
+
+#[test]
+fn provenance_forgery_via_fake_prior_is_refused_at_publish() {
+    // A forged "successor" grafting a FOREIGN handle's version as its prior is
+    // refused fail-closed at publish — stronger than truncate-on-read: the forged
+    // edge never lands, so the forward (descendants) and backward (lineage) folds
+    // can never disagree about it (the review's consistency finding).
+    let ledger = InMemoryVersionLedger::new();
+    let foreign = AssetVersion::root(
+        vpath("other"),
+        recipe(9),
+        PartyId::new("x"),
+        Provenance::from_recipe([9u8; 32]),
+    );
+    let foreign_id = ledger.publish(foreign).unwrap().version_id();
+    let forged = AssetVersion::successor(
+        foreign_id,
+        0,
+        vpath("summarize"),
+        recipe(1),
+        PartyId::new("x"),
+        Provenance::from_recipe([1u8; 32]),
+    );
+    assert!(matches!(
+        ledger.publish(forged).unwrap_err(),
+        VersionLedgerError::InvalidLineage { .. }
+    ));
+    // The foreign version gained NO descendant (the graft never landed), and the
+    // target handle was never created.
+    assert!(ledger.descendants(&foreign_id).is_empty());
+    assert!(ledger.resolve(&vpath("summarize")).is_none());
+}
+
+#[test]
+fn lineage_never_gates_publish() {
+    // A version with empty/garbage provenance still publishes (D84: provenance is
+    // advisory; only the Register grant gates). Build it via the governed surface.
+    let handle = vpath("summarize");
+    let owner = PartyId::new("owner@acme");
+    let lead = PartyId::new("lead@acme");
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &lead,
+        CatalogActionSet::allow([CatalogAction::Register]),
+    );
+    // Provenance points at a recipe that was never run / does not exist — advisory.
+    let v = AssetVersion::root(handle, recipe(1), lead, Provenance::from_recipe([0xAB; 32]));
+    assert!(
+        catalog.publish(v).unwrap().is_published(),
+        "advisory provenance never blocks a Register-authorized publish"
+    );
+}
+
+#[test]
+fn version_fold_is_deterministic_on_refold() {
+    let ledger = InMemoryVersionLedger::new();
+    let handle = vpath("summarize");
+    let v1 = AssetVersion::root(
+        handle.clone(),
+        recipe(1),
+        PartyId::new("p"),
+        Provenance::from_recipe([1u8; 32]),
+    );
+    let v1_id = ledger.publish(v1).unwrap().version_id();
+    let v2 = AssetVersion::successor(
+        v1_id,
+        0,
+        handle,
+        recipe(2),
+        PartyId::new("p"),
+        Provenance::from_recipe([2u8; 32]),
+    );
+    let v2_id = ledger.publish(v2).unwrap().version_id();
+    let a: Vec<_> = ledger
+        .lineage(&v2_id)
+        .iter()
+        .map(AssetVersion::version_id)
+        .collect();
+    let b: Vec<_> = ledger
+        .lineage(&v2_id)
+        .iter()
+        .map(AssetVersion::version_id)
+        .collect();
+    assert_eq!(a, b, "lineage re-fold is byte-identical");
+    assert_eq!(a, vec![v2_id, v1_id]);
+}
+
+// ---- Kind 4 analogue: concurrency / poison-safety + idempotent replay --------
+
+#[test]
+fn concurrent_version_publishes_and_resolves_are_safe() {
+    let ledger = Arc::new(InMemoryVersionLedger::new());
+
+    // 8 threads each publish a DISTINCT handle + resolve concurrently.
+    let mut handles = Vec::new();
+    for i in 0..8u32 {
+        let l = Arc::clone(&ledger);
+        handles.push(std::thread::spawn(move || {
+            let h = AssetPath::new("acme", "recipes", format!("r{i}")).unwrap();
+            let v = AssetVersion::root(
+                h.clone(),
+                recipe(u8::try_from(i).unwrap()),
+                PartyId::new("p"),
+                Provenance::from_recipe([1u8; 32]),
+            );
+            l.publish(v).unwrap();
+            assert!(l.resolve(&h).is_some());
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Idempotent replay: a burst of the SAME version from many threads lands once.
+    let shared = AssetVersion::root(
+        vpath("shared"),
+        recipe(42),
+        PartyId::new("p"),
+        Provenance::from_recipe([2u8; 32]),
+    );
+    let mut bursts = Vec::new();
+    for _ in 0..8 {
+        let l = Arc::clone(&ledger);
+        let v = shared.clone();
+        bursts.push(std::thread::spawn(move || {
+            l.publish(v).unwrap().is_published()
+        }));
+    }
+    let published = bursts
+        .into_iter()
+        .map(|h| h.join().unwrap())
+        .filter(|&b| b)
+        .count();
+    assert_eq!(published, 1, "exactly one of the identical bursts lands");
+}
+
+// ---- Integration: real-life enterprise scenarios -----------------------------
+
+/// Scenario A — a platform team publishes a recipe v1, improves it, publishes v2;
+/// the handle resolves v2, v1 stays exact-pinnable (D87), lineage traces v2 → v1.
+#[test]
+fn platform_team_publishes_recipe_v1_then_v2() {
+    let handle = vpath("summarize");
+    let owner = PartyId::new("platform-team@acme");
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &owner, // the team owns and publishes
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+    );
+
+    let v1 = AssetVersion::root(
+        handle.clone(),
+        recipe(0x11),
+        owner.clone(),
+        Provenance::from_recipe([0x11; 32]),
+    );
+    let v1_id = catalog.publish(v1).unwrap().version_id();
+
+    // Improve the recipe → publish v2 (new fingerprint, prior = v1).
+    let v2 = AssetVersion::successor(
+        v1_id,
+        0,
+        handle.clone(),
+        recipe(0x22),
+        owner.clone(),
+        Provenance::from_recipe([0x22; 32]),
+    );
+    let v2_id = catalog.publish(v2).unwrap().version_id();
+
+    // The handle now resolves v2; v1 is still pinnable by its exact id (D87).
+    assert_eq!(catalog.resolve(&owner, &handle).unwrap().unwrap().1, v2_id);
+    assert!(catalog.versions().get_version(&v1_id).is_some());
+    // Lineage traces v2 → v1.
+    let lin: Vec<_> = catalog
+        .lineage(&owner, &v2_id)
+        .unwrap()
+        .iter()
+        .map(AssetVersion::version_id)
+        .collect();
+    assert_eq!(lin, vec![v2_id, v1_id]);
+    assert_eq!(catalog.history(&owner, &handle).unwrap().len(), 2);
+}
+
+/// Scenario B — governed publishing: a lead with `Register` may publish a new
+/// version; an intern with only `Use` is refused.
+#[test]
+fn governed_publishing_intern_with_use_is_refused() {
+    let handle = vpath("summarize");
+    let owner = PartyId::new("owner@acme");
+    let lead = PartyId::new("lead@acme");
+    let intern = PartyId::new("intern@acme");
+    let asset = AssetRef::Path(handle.clone());
+
+    let grants = InMemoryGrantLedger::new();
+    grants
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    grants
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner.clone(),
+            lead.clone(),
+            CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+            role("lead", 10),
+        ))
+        .unwrap();
+    grants
+        .append_grant(Grant::root(
+            asset,
+            owner,
+            intern.clone(),
+            CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
+            role("intern", 10),
+        ))
+        .unwrap();
+    let catalog = GovernedCatalog::new(grants, InMemoryVersionLedger::new());
+
+    // Lead publishes.
+    let v1 = AssetVersion::root(
+        handle.clone(),
+        recipe(1),
+        lead,
+        Provenance::from_recipe([1u8; 32]),
+    );
+    let v1_id = catalog.publish(v1).unwrap().version_id();
+
+    // Intern (Use, not Register) tries to publish a new version → refused.
+    let v2 = AssetVersion::successor(
+        v1_id,
+        0,
+        handle.clone(),
+        recipe(2),
+        intern,
+        Provenance::from_recipe([2u8; 32]),
+    );
+    assert!(matches!(
+        catalog.publish(v2).unwrap_err(),
+        GovernedError::Unauthorized {
+            action: CatalogAction::Register,
+            ..
+        }
+    ));
+    // The shared recipe is unchanged (still v1).
+    assert_eq!(catalog.versions().resolve(&handle).unwrap().1, v1_id);
+}
+
+/// Scenario C — provenance audit / M12 flywheel: a curated model is published as
+/// a new version carrying full provenance + a `prior` to the previous corpus
+/// version; an auditor traces the lineage and confirms it gated nothing.
+#[test]
+fn provenance_audit_m12_flywheel_traces_chain() {
+    let handle = vpath("curated-summarizer");
+    let owner = PartyId::new("ml-platform@acme");
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &owner,
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+    );
+
+    // v1 — the first curated corpus (a Dataset content).
+    let v1 = AssetVersion::root(
+        handle.clone(),
+        VersionedContent::Dataset(DatasetId([0x10; 32])),
+        owner.clone(),
+        Provenance::from_recipe([0x10; 32]),
+    );
+    let v1_id = catalog.publish(v1).unwrap().version_id();
+
+    // v2 — a re-curated corpus produced by a known run, derived from v1.
+    let prov_v2 = Provenance::from_recipe([0x20; 32])
+        .with_run([0x21; 16])
+        .with_dataset(DatasetId([0x22; 32]))
+        .with_corpus_lineage([
+            MoteId::from_bytes([0x23; 32]),
+            MoteId::from_bytes([0x24; 32]),
+        ])
+        .unwrap();
+    let v2 = AssetVersion::successor(
+        v1_id,
+        0,
+        handle.clone(),
+        VersionedContent::Dataset(DatasetId([0x25; 32])),
+        owner.clone(),
+        prov_v2,
+    );
+    let v2_id = catalog.publish(v2).unwrap().version_id();
+
+    // The auditor walks the lineage and reads each version's advisory provenance.
+    let lin = catalog.lineage(&owner, &v2_id).unwrap();
+    assert_eq!(lin.len(), 2, "v2 → v1");
+    let head = &lin[0];
+    assert_eq!(head.version_id(), v2_id);
+    assert_eq!(head.provenance().generating_run(), Some([0x21; 16]));
+    assert_eq!(head.provenance().corpus_lineage().len(), 2);
+    assert_eq!(head.provenance().recipe_fingerprint(), &[0x20; 32]);
+    // The advisory provenance gated nothing — the Register grant did.
+    assert_eq!(catalog.resolve(&owner, &handle).unwrap().unwrap().1, v2_id);
+}
+
+// ---- Exit gate (versioning) --------------------------------------------------
+
+/// The M7.2 versioning exit gate, composite: publish → resolve → move-handle →
+/// rollback round-trip; governed publish refused without `Register`; lineage is
+/// advisory (a forged-provenance publish still succeeds); the schema version is
+/// pinned; and the guarantee-path wall holds (asserted by
+/// `guarantee_path_does_not_depend_on_catalog`).
+#[test]
+fn m7_2_versioning_exit_gate() {
+    let handle = vpath("recipe");
+    let owner = PartyId::new("owner@acme");
+    let catalog = governed_with(
+        &handle,
+        &owner,
+        &owner,
+        CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Register]),
+    );
+
+    // (a) publish → resolve → move handle → rollback.
+    let v1 = AssetVersion::root(
+        handle.clone(),
+        recipe(1),
+        owner.clone(),
+        Provenance::from_recipe([1u8; 32]),
+    );
+    assert_eq!(
+        v1.schema_version(),
+        kx_catalog::CATALOG_VERSION_SCHEMA_VERSION
+    );
+    let v1_id = catalog.publish(v1).unwrap().version_id();
+    let v2 = AssetVersion::successor(
+        v1_id,
+        0,
+        handle.clone(),
+        recipe(2),
+        owner.clone(),
+        Provenance::from_recipe([2u8; 32]),
+    );
+    let v2_id = catalog.publish(v2).unwrap().version_id();
+    assert_eq!(catalog.resolve(&owner, &handle).unwrap().unwrap().1, v2_id);
+    // rollback to v1's content (a NEW version).
+    let v3 = AssetVersion::successor(
+        v2_id,
+        1,
+        handle.clone(),
+        recipe(1),
+        owner.clone(),
+        Provenance::from_recipe([3u8; 32]),
+    );
+    let v3_id = catalog.publish(v3).unwrap().version_id();
+    assert_eq!(catalog.resolve(&owner, &handle).unwrap().unwrap().1, v3_id);
+    assert_eq!(
+        catalog.resolve(&owner, &handle).unwrap().unwrap().0,
+        recipe(1),
+        "rolled back to v1 content"
+    );
+    assert_eq!(catalog.versions().len(), 3, "all versions retained");
+
+    // (b) without Register, a publish is refused.
+    let nobody = PartyId::new("nobody@acme");
+    let bad = AssetVersion::root(
+        handle,
+        recipe(9),
+        nobody,
+        Provenance::from_recipe([9u8; 32]),
+    );
+    assert!(matches!(
+        catalog.publish(bad).unwrap_err(),
+        GovernedError::Unauthorized {
+            action: CatalogAction::Register,
+            ..
+        }
+    ));
+
+    // (c) lineage is advisory: it traces the chain but never gated a publish.
+    let lin = catalog.lineage(&owner, &v3_id).unwrap();
+    assert_eq!(lin.len(), 3, "v3 → v2 → v1");
 }


### PR DESCRIPTION
## M7.2 — content-versioning handles + provenance/lineage fold

Closes the deferred M7.2 slice (**D122.3**): the catalog **path is a mutable handle** resolving to an **immutable content-addressed version**, plus the **computed-not-stored** provenance/lineage fold — governed by the just-merged M7.2 grant ledger. Purely additive in `kx-catalog`; the next step after this is **M7.3** (discovery + Mote-as-MCP, D85/D87).

### What

| File (new unless noted) | Contents |
|---|---|
| `version.rs` | `VersionId` (domain-tagged blake3); `VersionedContent` (`Recipe`\|`Workflow`\|`Dataset` — immutable ids, append-only enum); `Provenance` (advisory D84; `recipe_fingerprint`/`generating_run`/`dataset_id`/bounded `corpus_lineage`; **no float, no clock**); `AssetVersion` (`root`/`successor` smart ctors; `revision` chain-derived, folded into the id) |
| `version_ledger.rs` | `VersionLedger` trait (`publish`/`resolve`/`get_version`/`history`/`lineage`/`descendants`) + `Arc` impl; depth bounds; `PublishOutcome` + `VersionLedgerError` |
| `in_memory_version_ledger.rs` | append-only reference backend; handle move by a total `(revision, id)` rank; `fold_lineage` + `fold_descendants` (iterative, depth-bounded, cycle-safe, integrity-checked via shared `is_valid_edge`) |
| `governed.rs` | `GovernedCatalog` facade — **publish requires `Register`, reads require `Read`**; composes the `GrantLedger` without coupling the two impls (Rule 1) |
| `lib.rs` (mod) | additive `mod` + `pub use` + crate-doc bullet |

### Semantics (corpus-aligned)
- **D-LOCK-4:** "update" = publish a NEW version + move the handle; prior versions retained forever; **rollback is a new fact** pinning older content.
- **D84:** provenance/lineage is advisory and **never gates** a publish or any runtime action — only the `Register` grant gates a publish (**D86**). Selection is exact-by-id (**D87**).
- **Robustness (publish-time lineage validation):** a successor's `prior` must be **present, same-handle, and `revision == prior.revision + 1`**, else fail-closed. The stored chain is therefore always well-formed, so the handle-move rank can't be gamed and the forward (`descendants`) / backward (`lineage`) folds agree.

### Constraints held (merge gate)
- **NO `kx-journal` dep, NO `kx-warrant` change, no new external dep** — 32 crates, `Cargo.lock` 0-delta.
- **Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) + `kx-mote`/`kx-journal`/`kx-projection` `src/**` diff EMPTY**; product digest `a6b5c679…` **INVARIANT** (`a0_guard` green); **I1.c byte-determinism** PASS (no float / no wall-clock on the content path).

### Tests
52 unit + 27 proptest + 28 security/governance/scenario/exit-gate + 6 scale-smoke (version publish/resolve/history sub-linear; lineage depth-bounded; fork tie-break; forged/missing/inflated-`prior` refused). **3 named enterprise scenarios e2e:** platform team publishes recipe v1→v2 (handle resolves v2, v1 still pinnable, lineage v2→v1); governed publishing refuses an intern with only `Use`; M12-flywheel provenance audit traces the chain.

**Adversarially reviewed** (multi-agent, 6 dimensions + per-finding verification). No critical/high. All confirmed findings addressed in-PR: publish-time lineage validation (closes a handle-move griefing vector + the descendants/lineage asymmetry), `descendants`/`lineage` integrity symmetry, fork + revision-grief tests, tightened scale assertions, governed `descendants`.

### Golden Rule 8 — both passes

**Pass A (defensive).** *(a) breaks:* handle move is a pure function of the fact set (`rank=(revision,id)`, order-independent, proptest-locked); idempotency short-circuits before any move; immutability tripwire refuses same-id-different-bytes; **no float / no clock** → reproducible build green; existing hashes + `a6b5c679…` invariant (new types only). *(b) degrades:* publish/resolve/get O(log n); lineage O(depth≤1024); descendants O(subtree) via the incremental `children` index — no O(n) scan; the only steep path (`lineage` cloning bounded `Provenance`) is documented + a seam-level ids-only optimization is flagged as a Rule-1 follow-on. *(c) opens a hole:* only new untrusted input is `AssetVersion` (handle validated, all fields content-folded → tamper-evident); sole publish gate is the `Register` grant fold (fail-closed); provenance never gates; SN-8 wall preserved + tested (extended to `kx-mote`/`kx-journal`).

**Pass B (forward).** More correct (auditable, never-lossy "update"); more scalable (bounded BFS lineage); more durable (the `VersionLedger` trait carries no storage assumption → a cloud/D94 backend slots in). Flagged follow-ons (own PRs, Rule 1): ids-only `lineage` view; `VersionedContent` script/context variants for D88 bundles; durable backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
