### PR TITLE
feat(catalog): M7.3 (PR-A) — catalog discovery (fuzzy-in/exact-out) + advisory metadata (D84/D87)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ version = "0.0.1"
 dependencies = [
  "bincode",
  "blake3",
+ "kx-content",
  "kx-dataset",
  "kx-mote",
  "kx-warrant",

--- a/crates/kx-catalog/Cargo.toml
+++ b/crates/kx-catalog/Cargo.toml
@@ -18,8 +18,14 @@ path = "src/lib.rs"
 kx-mote     = { workspace = true }
 # ManifestId — the recipe-as-product identity a SignatureEntry pins.
 kx-workflow = { workspace = true }
-# DatasetId — the optional pinned corpus on a RecipeSnapshot.
+# DatasetId — the optional pinned corpus on a RecipeSnapshot. M7.3 also consumes
+# its RetrievalIndex/Hit similarity seam (SN-8-confined fuzzy discovery, D87).
 kx-dataset  = { workspace = true }
+# ContentRef — the content-addressed identity of an M7.3 SelectionFact (the
+# exact-out artifact of fuzzy-in/exact-out discovery, D87). A foundational
+# primitive (already transitive via kx-dataset); strictly BELOW the SN-8 wall
+# (kx-content cannot depend on kx-catalog), so the dependency direction holds.
+kx-content  = { workspace = true }
 # Role / WarrantSpec / intersect / NarrowingError (M7.2, D86): a grant's runtime
 # scope REUSES the frozen monotonic-narrowing seam verbatim — the catalog never
 # re-implements narrowing and never modifies kx-warrant. This is a dependency ON

--- a/crates/kx-catalog/src/discovery.rs
+++ b/crates/kx-catalog/src/discovery.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Catalog discovery (M7.3, D87) — **fuzzy-in, exact-out**.
+//!
+//! Two strictly-separated tiers:
+//!
+//! - **(a) EXACT metadata lookup** — deterministic, registry/index-backed:
+//!   [`CatalogDiscovery::by_namespace`] / `by_collection` / `by_path_prefix` (via
+//!   the [`DiscoveryIndex`]), `by_tag` (via the [`AdvisoryMetadataStore`]), and
+//!   `by_signature` (the registry's exact hash lookup).
+//! - **(b) FUZZY vector discovery** — [`FuzzyDiscovery`], a thin wrapper over a
+//!   `kx_dataset::RetrievalIndex` confined to `ReadOnlyNondet` semantics (the same
+//!   SN-8 boundary `kx_workflow::retrieval` documents). Embeddings are OPAQUE,
+//!   caller-supplied vectors; the catalog never computes them.
+//!
+//! # The hard SN-8 boundary
+//!
+//! The ONLY thing that becomes a committed selection is the chosen EXACT
+//! [`AssetRef`] — a [`SelectionFact`] has **no score field**, and
+//! [`commit_selection`] never reads a [`Hit`]'s score. Two index states returning
+//! the same neighbours produce a byte-identical `SelectionFact` regardless of the
+//! float scores, so similarity can never reach the identity / commit path. This is
+//! the narrowed SN-8 (D70) applied to the catalog, mirroring
+//! `kx_workflow::encode_retrieval_fact`.
+
+use kx_content::ContentRef;
+use kx_dataset::{Hit, RetrievalIndex};
+use serde::{Deserialize, Serialize};
+
+use crate::discovery_index::DiscoveryIndex;
+use crate::entry::SignatureEntry;
+use crate::metadata::{AdvisoryMetadataStore, Tag};
+use crate::path::AssetRef;
+use crate::registry::CatalogRegistry;
+use crate::signature::{canonical_config, TaskSignatureHash};
+
+/// The exact-lookup discovery facade: composes a [`CatalogRegistry`] (exact hash
+/// lookup) with a [`DiscoveryIndex`] (namespace / collection / prefix), without
+/// coupling either backend (the `GovernedCatalog` composition pattern). Tag lookup
+/// borrows an [`AdvisoryMetadataStore`] explicitly — advisory metadata is mutable
+/// and lives independently of the immutable registry.
+pub struct CatalogDiscovery<R: CatalogRegistry, D: DiscoveryIndex> {
+    registry: R,
+    index: D,
+}
+
+impl<R: CatalogRegistry, D: DiscoveryIndex> CatalogDiscovery<R, D> {
+    /// Compose a registry and a discovery index into the exact-lookup facade.
+    pub fn new(registry: R, index: D) -> Self {
+        Self { registry, index }
+    }
+
+    /// Borrow the underlying registry.
+    pub fn registry(&self) -> &R {
+        &self.registry
+    }
+
+    /// Borrow the underlying discovery index.
+    pub fn index(&self) -> &D {
+        &self.index
+    }
+
+    /// Every asset whose namespace equals `ns` (segment-exact), [`AssetRef`] order.
+    pub fn by_namespace(&self, ns: &str) -> Vec<AssetRef> {
+        self.index.by_namespace(ns)
+    }
+
+    /// Every asset whose `namespace/collection` equals `(ns, col)` (segment-exact).
+    pub fn by_collection(&self, ns: &str, col: &str) -> Vec<AssetRef> {
+        self.index.by_collection(ns, col)
+    }
+
+    /// Every asset whose path begins with the literal `prefix` (type-ahead).
+    pub fn by_path_prefix(&self, prefix: &str) -> Vec<AssetRef> {
+        self.index.by_path_prefix(prefix)
+    }
+
+    /// Every asset carrying `tag`, from the advisory metadata store (`O(log n + result)`).
+    pub fn by_tag<'m>(&self, store: &'m AdvisoryMetadataStore, tag: &Tag) -> Vec<&'m AssetRef> {
+        store.assets_with_tag(tag).collect()
+    }
+
+    /// The exact registry entry for a recipe signature hash, if registered.
+    pub fn by_signature(&self, hash: &TaskSignatureHash) -> Option<SignatureEntry> {
+        self.registry.lookup(hash)
+    }
+}
+
+/// The fuzzy discovery surface — discovery-only, `ReadOnlyNondet` semantics. Holds
+/// a `kx_dataset::RetrievalIndex` of OPAQUE caller-supplied embeddings keyed by
+/// [`ContentRef`]. A [`Hit`]'s score lives entirely INSIDE this surface (for
+/// ranking display only); it never crosses into a [`SelectionFact`].
+pub struct FuzzyDiscovery<I: RetrievalIndex> {
+    index: I,
+}
+
+impl<I: RetrievalIndex> FuzzyDiscovery<I> {
+    /// Wrap a retrieval index.
+    pub fn new(index: I) -> Self {
+        Self { index }
+    }
+
+    /// Insert (or overwrite) an opaque embedding for a content ref. The catalog
+    /// does NOT compute embeddings — the caller supplies the vector.
+    pub fn embed(&mut self, id: ContentRef, vector: Vec<f32>) {
+        self.index.insert(id, vector);
+    }
+
+    /// Top-`k` nearest candidates to `query`, highest score first (deterministic
+    /// order — the retrieval index tiebreaks by content ref). Scores are included
+    /// HERE, inside the boundary; promote to a committed selection via
+    /// [`commit_selection`], which drops them.
+    pub fn query(&self, query: &[f32], k: usize) -> Vec<Hit> {
+        self.index.query(query, k)
+    }
+
+    /// Borrow the underlying retrieval index.
+    pub fn index(&self) -> &I {
+        &self.index
+    }
+
+    /// Number of indexed embeddings.
+    pub fn len(&self) -> usize {
+        self.index.len()
+    }
+
+    /// `true` if nothing is embedded.
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
+}
+
+/// A committed catalog selection: the EXACT chosen asset ref(s), in canonical
+/// order. Scores are **structurally absent** — there is no score field, so
+/// similarity can never reach a committed output (SN-8 / D87 "fuzzy-in,
+/// exact-out"). The content-addressed identity is a pure function of the ref set
+/// ONLY.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+pub struct SelectionFact {
+    chosen: Vec<AssetRef>,
+}
+
+impl SelectionFact {
+    /// The chosen exact asset refs, canonical (sorted, deduped) order.
+    #[must_use]
+    pub fn chosen(&self) -> &[AssetRef] {
+        &self.chosen
+    }
+
+    /// `true` if no asset was selected (every candidate was unresolvable).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.chosen.is_empty()
+    }
+
+    /// Canonical bytes of the selection — the chosen ref set ONLY (scores absent),
+    /// via the catalog's canonical bincode. The one place "fuzzy in, exact out" is
+    /// enforced in code (mirrors `kx_workflow::encode_retrieval_fact`).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        bincode::serde::encode_to_vec(&self.chosen, canonical_config())
+            .expect("canonical bincode of a float-free Vec<AssetRef> is infallible")
+    }
+
+    /// The content-addressed identity of the selection — what a caller commits /
+    /// consumes by exact hash. Pure over the chosen ref set (scores excluded).
+    #[must_use]
+    pub fn selection_ref(&self) -> ContentRef {
+        ContentRef::of(&self.encode())
+    }
+}
+
+/// Turn a fuzzy discovery result into a committed [`SelectionFact`]: resolve each
+/// candidate [`Hit`]'s content ref → the EXACT [`AssetRef`] it stands for (via the
+/// caller's `resolve` map), DROPPING scores at this boundary. Unresolvable hits
+/// are filtered out (only an exact, resolvable ref can become a selection). Pure +
+/// total; the result is canonical (sorted + deduped) so it is independent of the
+/// score-driven hit order.
+///
+/// **This is the single chokepoint where fuzzy becomes exact** — `h.score` is
+/// never read, and [`SelectionFact`] has no score field, so the SN-8 boundary is
+/// structural.
+pub fn commit_selection(
+    hits: &[Hit],
+    resolve: impl Fn(&ContentRef) -> Option<AssetRef>,
+) -> SelectionFact {
+    let mut chosen: Vec<AssetRef> = hits.iter().filter_map(|h| resolve(&h.id)).collect();
+    chosen.sort();
+    chosen.dedup();
+    SelectionFact { chosen }
+}

--- a/crates/kx-catalog/src/discovery_index.rs
+++ b/crates/kx-catalog/src/discovery_index.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The sub-linear catalog discovery index (M7.3, D87) — exact metadata lookup by
+//! namespace / collection / path-prefix in `O(log n + result)`.
+//!
+//! The registry ([`crate::CatalogRegistry`]) and version ledger
+//! ([`crate::VersionLedger`]) answer EXACT-hash / EXACT-handle queries only; a
+//! "list everything in namespace `acme`" against them is an O(n) scan. This index
+//! is the secondary structure that keeps namespace/collection/prefix discovery
+//! sub-linear.
+//!
+//! # A rebuildable projection, never a source of truth
+//!
+//! The index is a **projection**: it can be rebuilt by replaying every
+//! `index_path` from the registry/ledger, exactly as lineage is "computed, never
+//! stored". A stale index degrades *discoverability* only — a miss can never gate
+//! a committed selection (discovery is fuzzy-in / exact-out, D87), so it is
+//! advisory in the SN-8 sense.
+//!
+//! # How the range scan works
+//!
+//! Every path is stored under one composite ordered key —
+//! `"namespace/collection/name"` (the [`crate::AssetPath`] `Display`). Because
+//! `/` is outside the legal segment class, the separator is unambiguous. A
+//! namespace / collection query is then a half-open range scan over the keys that
+//! begin with `"ns/"` / `"ns/col/"` (the trailing `/` makes it segment-exact, so
+//! `"acme"` never matches `"acmecorp"`); a path-prefix query is a character-prefix
+//! scan for type-ahead. Each is `O(log n)` to seek + `O(result)` to walk (the
+//! `take_while` stops at the first non-matching key), bounded by
+//! [`MAX_DISCOVERY_RESULT`].
+
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use crate::path::{AssetPath, AssetRef};
+
+/// A hard upper bound on a single discovery result. A discovery result is
+/// advisory (it never gates), so truncating it cannot escalate anything — it only
+/// bounds the response of a pathologically large namespace. Mirrors
+/// [`crate::MAX_VERSION_DESCENDANTS`].
+pub const MAX_DISCOVERY_RESULT: usize = 65_536;
+
+/// A backend-agnostic secondary index over catalog asset paths that answers
+/// namespace / collection / path-prefix queries in `O(log n + result)`.
+///
+/// A rebuildable PROJECTION (not a source of truth), advisory in the SN-8 sense:
+/// it never gates a committed selection. A durable / cloud backend (D94) is a
+/// later impl behind this same trait, exactly as [`crate::CatalogRegistry`] and
+/// `kx_dataset::RetrievalIndex`.
+pub trait DiscoveryIndex {
+    /// Add a path-addressed asset to the index. Idempotent (re-indexing the same
+    /// path is a no-op).
+    fn index_path(&self, path: &AssetPath);
+
+    /// Every asset whose namespace equals `ns` (segment-exact), in [`AssetRef`]
+    /// order. `O(log n + result)`.
+    fn by_namespace(&self, ns: &str) -> Vec<AssetRef>;
+
+    /// Every asset whose `namespace/collection` equals `(ns, col)` (segment-exact),
+    /// in [`AssetRef`] order. `O(log n + result)`.
+    fn by_collection(&self, ns: &str, col: &str) -> Vec<AssetRef>;
+
+    /// Every asset whose full `namespace/collection/name` begins with the literal
+    /// `prefix` (character-prefix, for type-ahead), in [`AssetRef`] order.
+    /// `O(log n + result)`.
+    fn by_path_prefix(&self, prefix: &str) -> Vec<AssetRef>;
+
+    /// Number of indexed paths.
+    fn len(&self) -> usize;
+
+    /// `true` if nothing is indexed.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// The in-memory reference [`DiscoveryIndex`]: a `BTreeMap` keyed by the composite
+/// `"namespace/collection/name"` string, answering every query shape by a
+/// half-open range scan.
+#[derive(Debug, Default)]
+pub struct InMemoryDiscoveryIndex {
+    by_path: RwLock<BTreeMap<String, AssetRef>>,
+}
+
+impl InMemoryDiscoveryIndex {
+    /// Create an empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Range-scan every entry whose composite key begins with `prefix`. Seeks to
+    /// the first key `>= prefix` (`O(log n)`), then walks while the prefix holds
+    /// (stopping at the first non-match), bounded by [`MAX_DISCOVERY_RESULT`].
+    ///
+    /// The bounded result is re-sorted into [`AssetRef`] order before return:
+    /// composite-String order is *not* identical to `AssetRef` (tuple) order
+    /// (`-`/`.` byte-sort before the `/` separator), so the range scan finds the
+    /// correct SET but in String order; the sort restores the documented
+    /// `AssetRef`-ordered, deterministic contract. The sort is `O(result log
+    /// result)` over a bounded result — sub-linear in the catalog size `n`.
+    fn scan(&self, prefix: &str) -> Vec<AssetRef> {
+        let guard = self.by_path.read().expect("poisoned lock");
+        let mut out: Vec<AssetRef> = guard
+            .range(prefix.to_owned()..)
+            .take_while(|(k, _)| k.starts_with(prefix))
+            .map(|(_, v)| v.clone())
+            .take(MAX_DISCOVERY_RESULT)
+            .collect();
+        drop(guard);
+        out.sort();
+        out
+    }
+}
+
+impl DiscoveryIndex for InMemoryDiscoveryIndex {
+    fn index_path(&self, path: &AssetPath) {
+        let key = path.to_string();
+        self.by_path
+            .write()
+            .expect("poisoned lock")
+            .insert(key, AssetRef::Path(path.clone()));
+    }
+
+    fn by_namespace(&self, ns: &str) -> Vec<AssetRef> {
+        // Trailing `/` → segment-exact: "acme/" can never be a prefix of
+        // "acmecorp/...".
+        self.scan(&format!("{ns}/"))
+    }
+
+    fn by_collection(&self, ns: &str, col: &str) -> Vec<AssetRef> {
+        self.scan(&format!("{ns}/{col}/"))
+    }
+
+    fn by_path_prefix(&self, prefix: &str) -> Vec<AssetRef> {
+        self.scan(prefix)
+    }
+
+    fn len(&self) -> usize {
+        self.by_path.read().expect("poisoned lock").len()
+    }
+}

--- a/crates/kx-catalog/src/lib.rs
+++ b/crates/kx-catalog/src/lib.rs
@@ -94,6 +94,8 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod action;
+mod discovery;
+mod discovery_index;
 mod entry;
 mod governed;
 mod grant;
@@ -101,6 +103,7 @@ mod in_memory;
 mod in_memory_ledger;
 mod in_memory_version_ledger;
 mod ledger;
+mod metadata;
 mod party;
 mod path;
 mod registry;
@@ -143,6 +146,18 @@ pub use version::{
 pub use version_ledger::{
     PublishOutcome, VersionLedger, VersionLedgerError, MAX_VERSION_CHAIN_DEPTH,
     MAX_VERSION_DESCENDANTS,
+};
+
+// M7.3 (D87/D84) — discovery (fuzzy-in, exact-out) + advisory metadata.
+pub use discovery::{commit_selection, CatalogDiscovery, FuzzyDiscovery, SelectionFact};
+// One import surface for catalog callers building discovery: the content-address
+// type (in `SelectionFact`/`commit_selection`) and the similarity seam the fuzzy
+// surface wraps (`kx_dataset`, already a dependency; the SN-8-confined ANN seam).
+pub use discovery_index::{DiscoveryIndex, InMemoryDiscoveryIndex, MAX_DISCOVERY_RESULT};
+pub use kx_content::ContentRef;
+pub use kx_dataset::{Hit, InMemoryRetrievalIndex, RetrievalIndex};
+pub use metadata::{
+    AdvisoryMetadata, AdvisoryMetadataStore, Tag, TagError, MAX_TAGS_PER_ASSET, MAX_TAG_LEN,
 };
 
 // REUSE (never modify) the frozen monotonic-narrowing seam — one import surface

--- a/crates/kx-catalog/src/metadata.rs
+++ b/crates/kx-catalog/src/metadata.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Advisory catalog metadata (M7.3, D84) — discovery [`Tag`]s + an integer-scaled
+//! confidence, modelled on `kx_dataset::AnnotationStore`.
+//!
+//! # The wall (SN-8, load-bearing)
+//!
+//! This projection is **off the trust path**. It is NEVER journaled, NEVER on the
+//! identity / commit / memoization path, and it NEVER gates selection, eviction,
+//! or promotion. Its sole job is to feed an advisory signal into a model's
+//! *catalog* context (tags to discover by, a confidence to rank a *proposal* by) —
+//! curation, not a fact. The boundary is enforced by the dependency graph (the
+//! guarantee-path crates do not depend on `kx-catalog`), exactly as
+//! `kx_dataset::AnnotationStore` documents; this module re-keys that same shape
+//! from `ContentRef` to the catalog's [`AssetRef`] and adds a tag index.
+//!
+//! # No floats
+//!
+//! Confidence is **integer-scaled** ([`AdvisoryMetadata::confidence_scaled`] is
+//! `i64`, e.g. basis points). No float ever touches this projection, so even a
+//! future mistake that wired it toward a decision path would carry none onto a
+//! canonical hash.
+//!
+//! # A rebuildable projection
+//!
+//! Iteration is in [`AssetRef`] order (`BTreeMap`), so a rebuild is deterministic.
+//! The inverted tag index is kept in lock-step with the forward map by every
+//! mutating method, so [`AdvisoryMetadataStore::assets_with_tag`] is
+//! `O(log n + result)` — never an O(n) scan.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::path::AssetRef;
+
+/// Maximum length, in bytes, of one discovery [`Tag`]. A bound keeps the inverted
+/// index key small and rejects pathological input (mirrors [`crate::MAX_SEGMENT_LEN`]).
+pub const MAX_TAG_LEN: usize = 64;
+
+/// Maximum number of distinct tags one asset may carry — a hard fan-out bound on
+/// the inverted index. Exceeding it is a loud, fail-closed refusal (never a silent
+/// truncation).
+pub const MAX_TAGS_PER_ASSET: usize = 256;
+
+/// A canonical, validated discovery tag. Construction ([`Tag::new`]) is the SOLE
+/// validation gate, so an illegal tag is **unrepresentable** downstream — the same
+/// discipline as [`crate::AssetPath`]'s segments.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub struct Tag(String);
+
+/// Why a tag (or a tag set) was rejected. Loud, typed refusal — never a silently
+/// coerced or truncated tag.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum TagError {
+    /// The tag was empty.
+    #[error("tag must not be empty")]
+    Empty,
+    /// The tag exceeded [`MAX_TAG_LEN`] bytes.
+    #[error("tag is {0} bytes (max {MAX_TAG_LEN})")]
+    TooLong(usize),
+    /// The tag carried a character outside the canonical `[a-z0-9._-]` class.
+    #[error("tag contains illegal character {0:?} (allowed: [a-z0-9._-])")]
+    IllegalChar(char),
+    /// An asset's tag set exceeded [`MAX_TAGS_PER_ASSET`].
+    #[error("asset carries {0} tags (max {MAX_TAGS_PER_ASSET})")]
+    TooManyTags(usize),
+}
+
+impl Tag {
+    /// Construct + validate. The ONLY way to build a `Tag`, so any `Tag` value is
+    /// canonical: non-empty, at most [`MAX_TAG_LEN`] bytes, drawn from the
+    /// lowercase class `[a-z0-9._-]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`TagError`] encountered.
+    pub fn new(s: impl Into<String>) -> Result<Self, TagError> {
+        let s = s.into();
+        if s.is_empty() {
+            return Err(TagError::Empty);
+        }
+        if s.len() > MAX_TAG_LEN {
+            return Err(TagError::TooLong(s.len()));
+        }
+        for ch in s.chars() {
+            if !(ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '_' | '-')) {
+                return Err(TagError::IllegalChar(ch));
+            }
+        }
+        Ok(Self(s))
+    }
+
+    /// Borrow the tag's canonical string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Tag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One advisory curation record for a catalog asset. Integer-scaled, mutable,
+/// rebuildable; NEVER journaled, NEVER an identity input, NEVER gates anything.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+pub struct AdvisoryMetadata {
+    /// Confidence, **integer-scaled** (e.g. basis points, `0..=10_000`). Never a
+    /// float — advisory ranking input for a *proposal*, never a gate.
+    pub confidence_scaled: i64,
+    /// The canonical discovery tag set (`BTreeSet` → deterministic iteration).
+    pub tags: BTreeSet<Tag>,
+    /// Opaque curator identity (free-form; advisory only).
+    pub curated_by: String,
+    /// Free-form curator notes (advisory only).
+    pub notes: String,
+}
+
+/// A mutable, rebuildable advisory projection keyed by [`AssetRef`], with an
+/// inverted `tag → assets` index for tag-based discovery.
+///
+/// Advisory only — see the module-level wall. Iteration is in [`AssetRef`] order
+/// (`BTreeMap`), so a rebuild is deterministic. The inverted index is kept in sync
+/// with the forward map by [`AdvisoryMetadataStore::set`] /
+/// [`AdvisoryMetadataStore::remove`].
+#[derive(Clone, Debug, Default)]
+pub struct AdvisoryMetadataStore {
+    by_ref: BTreeMap<AssetRef, AdvisoryMetadata>,
+    by_tag: BTreeMap<Tag, BTreeSet<AssetRef>>,
+}
+
+impl AdvisoryMetadataStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or overwrite the advisory metadata for `asset`, keeping the inverted
+    /// tag index in sync.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TagError::TooManyTags`] (fail-closed, no partial write) if the
+    /// record carries more than [`MAX_TAGS_PER_ASSET`] tags.
+    pub fn set(&mut self, asset: AssetRef, meta: AdvisoryMetadata) -> Result<(), TagError> {
+        if meta.tags.len() > MAX_TAGS_PER_ASSET {
+            return Err(TagError::TooManyTags(meta.tags.len()));
+        }
+        // Purge the prior record's inverted-index entries (clone the prior tag set
+        // first so the forward map is not borrowed while the inverted map mutates).
+        if let Some(old_tags) = self.by_ref.get(&asset).map(|m| m.tags.clone()) {
+            for t in &old_tags {
+                self.unindex_tag(t, &asset);
+            }
+        }
+        for t in &meta.tags {
+            self.by_tag
+                .entry(t.clone())
+                .or_default()
+                .insert(asset.clone());
+        }
+        self.by_ref.insert(asset, meta);
+        Ok(())
+    }
+
+    /// Read the advisory metadata for `asset`, if any.
+    #[must_use]
+    pub fn get(&self, asset: &AssetRef) -> Option<&AdvisoryMetadata> {
+        self.by_ref.get(asset)
+    }
+
+    /// Remove and return the advisory metadata for `asset`, purging its inverted
+    /// tag index entries.
+    pub fn remove(&mut self, asset: &AssetRef) -> Option<AdvisoryMetadata> {
+        let removed = self.by_ref.remove(asset)?;
+        for t in &removed.tags {
+            self.unindex_tag(t, asset);
+        }
+        Some(removed)
+    }
+
+    /// Drop `asset` from `tag`'s inverted-index bucket, removing the bucket when it
+    /// empties (so iteration never sees a dangling tag).
+    fn unindex_tag(&mut self, tag: &Tag, asset: &AssetRef) {
+        if let Some(set) = self.by_tag.get_mut(tag) {
+            set.remove(asset);
+            if set.is_empty() {
+                self.by_tag.remove(tag);
+            }
+        }
+    }
+
+    /// Every asset carrying `tag`, in [`AssetRef`] order. `O(log n + result)` via
+    /// the inverted index — never an O(n) scan.
+    pub fn assets_with_tag<'a>(&'a self, tag: &Tag) -> impl Iterator<Item = &'a AssetRef> + 'a {
+        self.by_tag.get(tag).into_iter().flat_map(BTreeSet::iter)
+    }
+
+    /// Number of assets with advisory metadata.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_ref.len()
+    }
+
+    /// `true` if no asset has advisory metadata.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_ref.is_empty()
+    }
+
+    /// Iterate `(asset, metadata)` in [`AssetRef`] order (deterministic rebuild).
+    pub fn iter(&self) -> impl Iterator<Item = (&AssetRef, &AdvisoryMetadata)> {
+        self.by_ref.iter()
+    }
+}

--- a/crates/kx-catalog/tests/action_selection_safety.rs
+++ b/crates/kx-catalog/tests/action_selection_safety.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//! M7.3 action-selection-safety (SN-8 / D70 / D87): fuzzy discovery scores NEVER
+//! leak into the committed selection. The catalog analog of
+//! `kx-workflow/tests/retrieval_mote.rs::similarity_scores_do_not_leak_into_the_committed_fact`.
+//!
+//! The boundary is structural: [`SelectionFact`] has no score field and
+//! [`commit_selection`] never reads a [`Hit`]'s score, so two index states that
+//! return the same neighbours produce a byte-identical selection regardless of the
+//! float scores. Similarity is "fuzzy in, exact out" — only the chosen EXACT
+//! [`AssetRef`] is ever committed.
+
+#![allow(clippy::unwrap_used)]
+
+use kx_catalog::{commit_selection, AssetPath, AssetRef, ContentRef, Hit, SelectionFact};
+use proptest::prelude::*;
+
+fn cref(b: u8) -> ContentRef {
+    ContentRef::from_bytes([b; 32])
+}
+
+/// The exact asset a hit's content ref (byte `b`) stands for.
+fn asset(b: u8) -> AssetRef {
+    AssetRef::Path(AssetPath::new("ns", "col", format!("n{b}")).unwrap())
+}
+
+/// The caller's content-ref → exact-asset resolver (the fuzzy→exact bridge).
+/// Total here by construction; `commit_selection` requires the `Option` signature
+/// (a real resolver returns `None` for an unmappable ref — see `unresolvable_hits_are_dropped`).
+#[allow(clippy::unnecessary_wraps)]
+fn resolver(c: &ContentRef) -> Option<AssetRef> {
+    Some(asset(c.as_bytes()[0]))
+}
+
+#[test]
+fn similarity_scores_do_not_leak_into_the_committed_selection() {
+    let high = [
+        Hit {
+            id: cref(1),
+            score: 0.99,
+        },
+        Hit {
+            id: cref(2),
+            score: 0.50,
+        },
+    ];
+    let low = [
+        Hit {
+            id: cref(1),
+            score: 0.11,
+        },
+        Hit {
+            id: cref(2),
+            score: 0.02,
+        },
+    ];
+    let fa = commit_selection(&high, resolver);
+    let fb = commit_selection(&low, resolver);
+    assert_eq!(
+        fa.encode(),
+        fb.encode(),
+        "scores must be excluded from the committed selection"
+    );
+    assert_eq!(fa.selection_ref(), fb.selection_ref());
+    assert_eq!(fa, fb);
+}
+
+#[test]
+fn different_neighbours_yield_different_selection() {
+    let s1 = [Hit {
+        id: cref(1),
+        score: 0.9,
+    }];
+    let s2 = [Hit {
+        id: cref(2),
+        score: 0.9,
+    }];
+    assert_ne!(
+        commit_selection(&s1, resolver).selection_ref(),
+        commit_selection(&s2, resolver).selection_ref(),
+    );
+}
+
+#[test]
+fn selection_is_canonical_and_order_independent() {
+    // Same neighbours, opposite (score-driven) order → identical selection.
+    let a = [
+        Hit {
+            id: cref(1),
+            score: 0.9,
+        },
+        Hit {
+            id: cref(2),
+            score: 0.1,
+        },
+    ];
+    let b = [
+        Hit {
+            id: cref(2),
+            score: 0.9,
+        },
+        Hit {
+            id: cref(1),
+            score: 0.1,
+        },
+    ];
+    assert_eq!(
+        commit_selection(&a, resolver),
+        commit_selection(&b, resolver)
+    );
+}
+
+#[test]
+fn duplicate_neighbours_dedup() {
+    let hits = [
+        Hit {
+            id: cref(1),
+            score: 0.9,
+        },
+        Hit {
+            id: cref(1),
+            score: 0.4,
+        },
+    ];
+    assert_eq!(commit_selection(&hits, resolver).chosen(), &[asset(1)]);
+}
+
+#[test]
+fn unresolvable_hits_are_dropped() {
+    let hits = [
+        Hit {
+            id: cref(1),
+            score: 0.9,
+        },
+        Hit {
+            id: cref(2),
+            score: 0.8,
+        },
+    ];
+    // Only content-ref byte 1 resolves to an exact asset.
+    let only_one = |c: &ContentRef| (c.as_bytes()[0] == 1).then(|| asset(1));
+    assert_eq!(commit_selection(&hits, only_one).chosen(), &[asset(1)]);
+}
+
+#[test]
+fn empty_hits_yield_empty_selection() {
+    let fact = commit_selection(&[], resolver);
+    assert!(fact.is_empty());
+    assert_eq!(fact, SelectionFact::default());
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// For an arbitrary neighbour set, perturbing every score (including NaN /
+    /// infinities) leaves the committed selection byte-identical.
+    #[test]
+    fn selection_ref_is_score_invariant(
+        ids in prop::collection::vec(0u8..32, 0..16),
+        perturb in prop::collection::vec(any::<f32>(), 16),
+    ) {
+        let base: Vec<Hit> = ids.iter().map(|&b| Hit { id: cref(b), score: 1.0 }).collect();
+        let perturbed: Vec<Hit> = ids
+            .iter()
+            .enumerate()
+            .map(|(k, &b)| Hit { id: cref(b), score: perturb[k % perturb.len()] })
+            .collect();
+        let fa = commit_selection(&base, resolver);
+        let fb = commit_selection(&perturbed, resolver);
+        prop_assert_eq!(fa.encode(), fb.encode());
+        prop_assert_eq!(fa.selection_ref(), fb.selection_ref());
+    }
+}

--- a/crates/kx-catalog/tests/proptest_discovery.rs
+++ b/crates/kx-catalog/tests/proptest_discovery.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property + scenario tests for M7.3 exact discovery (D87): the range-scan index
+//! matches a brute-force scan for namespace / collection / path-prefix, results
+//! are deterministic [`AssetRef`]-ordered, namespace/collection matching is
+//! segment-exact, and `by_signature` is the exact registry lookup.
+
+#![allow(clippy::unwrap_used)]
+
+use kx_catalog::{
+    AssetPath, AssetRef, CatalogDiscovery, CatalogRegistry, DiscoveryIndex, InMemoryCatalog,
+    InMemoryDiscoveryIndex, RecipeSnapshot, SignatureEntry, TaskSignature, TaskSignatureHash,
+};
+use kx_mote::MoteDefHash;
+use kx_workflow::ManifestId;
+use proptest::prelude::*;
+
+// Small alphabets so collisions + prefix overlaps actually occur.
+fn path(i: usize) -> AssetPath {
+    AssetPath::new(
+        format!("ns{}", i % 3),
+        format!("col{}", i % 4),
+        format!("n{i}"),
+    )
+    .unwrap()
+}
+
+fn pref(p: &AssetPath) -> AssetRef {
+    AssetRef::Path(p.clone())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    #[test]
+    fn by_namespace_matches_linear_scan(ids in prop::collection::vec(0usize..60, 0..40)) {
+        let index = InMemoryDiscoveryIndex::new();
+        let mut all: Vec<AssetPath> = Vec::new();
+        for i in &ids {
+            let p = path(*i);
+            index.index_path(&p);
+            all.push(p);
+        }
+        for nsk in 0..3 {
+            let ns = format!("ns{nsk}");
+            let via_index = index.by_namespace(&ns);
+            let mut via_scan: Vec<AssetRef> = all
+                .iter()
+                .filter(|p| p.namespace() == ns)
+                .map(pref)
+                .collect();
+            via_scan.sort();
+            via_scan.dedup();
+            prop_assert_eq!(via_index, via_scan);
+        }
+    }
+
+    #[test]
+    fn by_collection_matches_linear_scan(ids in prop::collection::vec(0usize..60, 0..40)) {
+        let index = InMemoryDiscoveryIndex::new();
+        let mut all: Vec<AssetPath> = Vec::new();
+        for i in &ids {
+            let p = path(*i);
+            index.index_path(&p);
+            all.push(p);
+        }
+        for nsk in 0..3 {
+            for colk in 0..4 {
+                let (ns, col) = (format!("ns{nsk}"), format!("col{colk}"));
+                let via_index = index.by_collection(&ns, &col);
+                let mut via_scan: Vec<AssetRef> = all
+                    .iter()
+                    .filter(|p| p.namespace() == ns && p.collection() == col)
+                    .map(pref)
+                    .collect();
+                via_scan.sort();
+                via_scan.dedup();
+                prop_assert_eq!(via_index, via_scan);
+            }
+        }
+    }
+
+    #[test]
+    fn by_path_prefix_matches_linear_scan(
+        ids in prop::collection::vec(0usize..60, 0..40),
+        plen in 1usize..6,
+    ) {
+        let index = InMemoryDiscoveryIndex::new();
+        let mut all: Vec<AssetPath> = Vec::new();
+        for i in &ids {
+            let p = path(*i);
+            index.index_path(&p);
+            all.push(p);
+        }
+        // Derive a prefix from a stable key (all chars ASCII → any byte split ok).
+        let prefix: String = path(0).to_string().chars().take(plen).collect();
+        let via_index = index.by_path_prefix(&prefix);
+        let mut via_scan: Vec<AssetRef> = all
+            .iter()
+            .filter(|p| p.to_string().starts_with(&prefix))
+            .map(pref)
+            .collect();
+        via_scan.sort();
+        via_scan.dedup();
+        prop_assert_eq!(via_index, via_scan);
+    }
+
+    /// Re-indexing the same path is idempotent (no duplicate result).
+    #[test]
+    fn index_path_is_idempotent(i in 0usize..50, reps in 1usize..5) {
+        let index = InMemoryDiscoveryIndex::new();
+        let p = path(i);
+        for _ in 0..reps {
+            index.index_path(&p);
+        }
+        prop_assert_eq!(index.len(), 1);
+        prop_assert_eq!(index.by_namespace(p.namespace()), vec![pref(&p)]);
+    }
+}
+
+#[test]
+fn namespace_match_is_segment_exact() {
+    let index = InMemoryDiscoveryIndex::new();
+    let inside = AssetPath::new("ns", "c", "x").unwrap();
+    let sibling = AssetPath::new("nsx", "c", "y").unwrap(); // "nsx" must NOT match "ns"
+    index.index_path(&inside);
+    index.index_path(&sibling);
+    assert_eq!(index.by_namespace("ns"), vec![pref(&inside)]);
+    assert_eq!(index.by_namespace("nsx"), vec![pref(&sibling)]);
+}
+
+#[test]
+fn collection_match_is_segment_exact() {
+    let index = InMemoryDiscoveryIndex::new();
+    let inside = AssetPath::new("ns", "col", "x").unwrap();
+    let sibling = AssetPath::new("ns", "colx", "y").unwrap(); // "colx" must NOT match "col"
+    index.index_path(&inside);
+    index.index_path(&sibling);
+    assert_eq!(index.by_collection("ns", "col"), vec![pref(&inside)]);
+}
+
+/// The String-vs-tuple ordering edge: `-` and `.` byte-sort before the `/`
+/// separator, so the composite-key scan order differs from `AssetRef` order. The
+/// scan re-sorts to `AssetRef` order — assert it directly.
+#[test]
+fn results_are_assetref_ordered_across_separator_edge() {
+    let index = InMemoryDiscoveryIndex::new();
+    let plain = AssetPath::new("ns", "b", "z").unwrap(); // "ns/b/z"
+    let dashed = AssetPath::new("ns", "b-c", "a").unwrap(); // "ns/b-c/a" (String-sorts FIRST)
+    index.index_path(&plain);
+    index.index_path(&dashed);
+    let got = index.by_namespace("ns");
+    let mut expect = vec![pref(&plain), pref(&dashed)];
+    expect.sort(); // AssetRef (tuple) order: "b" < "b-c" → plain first
+    assert_eq!(got, expect);
+    assert_eq!(
+        got[0],
+        pref(&plain),
+        "AssetRef order, not composite-String order"
+    );
+}
+
+#[test]
+fn empty_prefix_returns_all() {
+    let index = InMemoryDiscoveryIndex::new();
+    for i in 0..5 {
+        index.index_path(&path(i));
+    }
+    assert_eq!(index.by_path_prefix("").len(), 5);
+}
+
+#[test]
+fn by_signature_is_exact_registry_lookup() {
+    let registry = InMemoryCatalog::new();
+    let index = InMemoryDiscoveryIndex::new();
+    let sig = TaskSignature::model_invariant(MoteDefHash::from_bytes([7u8; 32]));
+    let entry = SignatureEntry::new(sig, ManifestId([1u8; 32]), RecipeSnapshot::new([2u8; 32]));
+    let h = entry.hash();
+    registry.register_signature(entry.clone()).unwrap();
+    let disc = CatalogDiscovery::new(registry, index);
+    assert_eq!(disc.by_signature(&h), Some(entry));
+    assert!(disc
+        .by_signature(&TaskSignatureHash::from_bytes([9u8; 32]))
+        .is_none());
+}

--- a/crates/kx-catalog/tests/proptest_metadata.rs
+++ b/crates/kx-catalog/tests/proptest_metadata.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property tests for the M7.3 advisory metadata sidecar (D84): set/get/remove,
+//! deterministic [`AssetRef`]-ordered iteration, the inverted tag index matches a
+//! brute-force scan, the per-asset tag bound is fail-closed, and `Tag` validation.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+
+use kx_catalog::{
+    AdvisoryMetadata, AdvisoryMetadataStore, AssetPath, AssetRef, Tag, TagError, MAX_TAGS_PER_ASSET,
+};
+use proptest::prelude::*;
+
+/// A distinct path-addressed asset for index `i`.
+fn asset(i: usize) -> AssetRef {
+    AssetRef::Path(AssetPath::new("ns", "col", format!("n{i}")).unwrap())
+}
+
+/// Advisory metadata carrying a tag set.
+fn meta_with(tags: BTreeSet<Tag>) -> AdvisoryMetadata {
+    AdvisoryMetadata {
+        confidence_scaled: 0,
+        tags,
+        curated_by: "curator".into(),
+        notes: String::new(),
+    }
+}
+
+#[test]
+fn tag_new_rejects_empty() {
+    assert!(matches!(Tag::new(""), Err(TagError::Empty)));
+}
+
+#[test]
+fn tag_new_rejects_too_long() {
+    let s = "a".repeat(kx_catalog::MAX_TAG_LEN + 1);
+    assert!(matches!(Tag::new(s), Err(TagError::TooLong(_))));
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// Canonical-class strings (lowercase `[a-z0-9._-]`, bounded) always construct.
+    #[test]
+    fn tag_new_accepts_canonical(s in "[a-z0-9._-]{1,64}") {
+        prop_assert!(Tag::new(s).is_ok());
+    }
+
+    /// Uppercase characters are outside the canonical class — fail-closed.
+    #[test]
+    fn tag_new_rejects_illegal_char(s in "[A-Z]{1,8}") {
+        prop_assert!(matches!(Tag::new(s), Err(TagError::IllegalChar(_))));
+    }
+
+    #[test]
+    fn set_get_roundtrip(i in 0usize..200, conf in any::<i64>(), tagn in 0usize..5) {
+        let mut store = AdvisoryMetadataStore::new();
+        let a = asset(i);
+        let tags: BTreeSet<Tag> = (0..tagn).map(|t| Tag::new(format!("t{t}")).unwrap()).collect();
+        let mut meta = meta_with(tags);
+        meta.confidence_scaled = conf;
+        store.set(a.clone(), meta.clone()).unwrap();
+        prop_assert_eq!(store.get(&a), Some(&meta));
+        prop_assert_eq!(store.len(), 1);
+        prop_assert!(store.get(&asset(i + 1)).is_none());
+    }
+
+    /// Overwriting an asset's record re-indexes its tags: the prior tag no longer
+    /// points at the asset, the new one does.
+    #[test]
+    fn set_overwrites_and_reindexes(i in 0usize..50) {
+        let mut store = AdvisoryMetadataStore::new();
+        let a = asset(i);
+        let t_old = Tag::new("old").unwrap();
+        let t_new = Tag::new("new").unwrap();
+        store.set(a.clone(), meta_with(BTreeSet::from([t_old.clone()]))).unwrap();
+        store.set(a.clone(), meta_with(BTreeSet::from([t_new.clone()]))).unwrap();
+        prop_assert!(store.assets_with_tag(&t_old).next().is_none());
+        let via_new: Vec<&AssetRef> = store.assets_with_tag(&t_new).collect();
+        prop_assert_eq!(via_new, vec![&a]);
+        prop_assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn remove_returns_and_clears_index(i in 0usize..50) {
+        let mut store = AdvisoryMetadataStore::new();
+        let a = asset(i);
+        let t = Tag::new("x").unwrap();
+        store.set(a.clone(), meta_with(BTreeSet::from([t.clone()]))).unwrap();
+        prop_assert!(store.remove(&a).is_some());
+        prop_assert!(store.remove(&a).is_none());
+        prop_assert!(store.assets_with_tag(&t).next().is_none());
+        prop_assert!(store.is_empty());
+    }
+
+    /// The load-bearing property: the inverted tag index equals a brute-force scan
+    /// over the forward map, for every tag.
+    #[test]
+    fn tag_index_matches_linear_scan(
+        entries in prop::collection::vec((0usize..40, 0usize..6), 0..30)
+    ) {
+        let mut store = AdvisoryMetadataStore::new();
+        let all_tags: Vec<Tag> = (0..6).map(|t| Tag::new(format!("t{t}")).unwrap()).collect();
+        for (i, tagn) in entries {
+            let tags: BTreeSet<Tag> = all_tags.iter().take(tagn).cloned().collect();
+            store.set(asset(i), meta_with(tags)).unwrap();
+        }
+        for tag in &all_tags {
+            let via_index: Vec<&AssetRef> = store.assets_with_tag(tag).collect();
+            let via_scan: Vec<&AssetRef> = store
+                .iter()
+                .filter(|(_, m)| m.tags.contains(tag))
+                .map(|(a, _)| a)
+                .collect();
+            // Both are AssetRef-ordered (BTreeSet bucket / BTreeMap iteration).
+            prop_assert_eq!(via_index, via_scan);
+        }
+    }
+
+    #[test]
+    fn iter_is_assetref_ordered(ids in prop::collection::vec(0usize..100, 0..30)) {
+        let mut store = AdvisoryMetadataStore::new();
+        for i in &ids {
+            store.set(asset(*i), AdvisoryMetadata::default()).unwrap();
+        }
+        let keys: Vec<AssetRef> = store.iter().map(|(a, _)| a.clone()).collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        prop_assert_eq!(keys, sorted);
+    }
+
+    /// Exceeding the per-asset tag bound is a loud, fail-closed refusal — no
+    /// partial write.
+    #[test]
+    fn over_tag_limit_is_refused(extra in 1usize..8) {
+        let mut store = AdvisoryMetadataStore::new();
+        let n = MAX_TAGS_PER_ASSET + extra;
+        let tags: BTreeSet<Tag> = (0..n).map(|t| Tag::new(format!("t{t}")).unwrap()).collect();
+        prop_assert_eq!(tags.len(), n);
+        let err = store.set(asset(1), meta_with(tags)).unwrap_err();
+        prop_assert!(matches!(err, TagError::TooManyTags(_)));
+        prop_assert!(store.is_empty(), "fail-closed: no partial write on refusal");
+    }
+}

--- a/crates/kx-catalog/tests/scale.rs
+++ b/crates/kx-catalog/tests/scale.rs
@@ -476,3 +476,111 @@ fn version_chains_publish_resolve_history_stay_sublinear() {
     assert_sublinear("version-chains-resolve", &resolve_ns);
     assert_sublinear("version-chains-history", &history_ns);
 }
+
+/// M7.3 (D87): exact discovery by namespace / collection stays `O(log n + result)`
+/// — NOT an O(n) `list` scan. Each namespace holds a CONSTANT number of entries
+/// (`PER_NS`) and the namespace COUNT grows with `n`, so every query returns a
+/// fixed-size result and the measured cost isolates the `O(log n)` range-scan seek.
+/// A full-table scan would be ~25× at 25k vs 1k; the index keeps it flat.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn discovery_exact_lookup_stays_sublinear() {
+    use kx_catalog::{DiscoveryIndex, InMemoryDiscoveryIndex};
+
+    const PER_NS: usize = 4; // constant result size per namespace
+    let mut by_ns: Vec<(usize, f64)> = Vec::new();
+    let mut by_col: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let index = InMemoryDiscoveryIndex::new();
+        let ns_count = n / PER_NS;
+        for i in 0..n {
+            let p = AssetPath::new(format!("ns{}", i / PER_NS), "c", format!("n{i}")).unwrap();
+            index.index_path(&p);
+        }
+        assert_eq!(index.len(), n);
+
+        // Precompute query keys OUTSIDE the timed region (mirrors the registry
+        // test convention) so the measurement isolates the lookup, not `format!`.
+        let q = 500;
+        let ns_queries: Vec<String> = (0..q)
+            .map(|j| format!("ns{}", (j * 7) % ns_count))
+            .collect();
+
+        let start = Instant::now();
+        for ns in &ns_queries {
+            assert_eq!(index.by_namespace(ns).len(), PER_NS);
+        }
+        let ns_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for ns in &ns_queries {
+            assert_eq!(index.by_collection(ns, "c").len(), PER_NS);
+        }
+        let col_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = |d: std::time::Duration| d.as_nanos() as f64 / q as f64;
+        println!(
+            "discovery-exact: n={n} ns_count={ns_count} by_ns_per_ns={:.1} by_col_per_ns={:.1}",
+            per(ns_elapsed),
+            per(col_elapsed)
+        );
+        by_ns.push((n, per(ns_elapsed)));
+        by_col.push((n, per(col_elapsed)));
+    }
+
+    assert_sublinear("discovery-by-namespace", &by_ns);
+    assert_sublinear("discovery-by-collection", &by_col);
+}
+
+/// M7.3 (D84/D87): tag-based discovery stays `O(log n + result)` via the inverted
+/// tag index — never an O(n) scan over all advisory records. Each tag holds a
+/// CONSTANT number of assets (`PER_TAG`); the tag COUNT grows with `n`.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn discovery_tag_lookup_stays_sublinear() {
+    use std::collections::BTreeSet;
+
+    use kx_catalog::{AdvisoryMetadata, AdvisoryMetadataStore, Tag};
+
+    const PER_TAG: usize = 4;
+    let mut series: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let mut store = AdvisoryMetadataStore::new();
+        let tag_count = n / PER_TAG;
+        for i in 0..n {
+            let tag = Tag::new(format!("t{}", i / PER_TAG)).unwrap();
+            let asset = AssetRef::Path(AssetPath::new("ns", "c", format!("n{i}")).unwrap());
+            let meta = AdvisoryMetadata {
+                tags: BTreeSet::from([tag]),
+                ..Default::default()
+            };
+            store.set(asset, meta).unwrap();
+        }
+        assert_eq!(store.len(), n);
+
+        // Precompute query tags OUTSIDE the timed region; materialize each result
+        // into a Vec (what a real discovery caller does) so the measured cost is
+        // the realistic get + collect, not a bare iterator `count`.
+        let q = 500;
+        let query_tags: Vec<Tag> = (0..q)
+            .map(|j| Tag::new(format!("t{}", (j * 7) % tag_count)).unwrap())
+            .collect();
+
+        let start = Instant::now();
+        for tag in &query_tags {
+            let hits: Vec<AssetRef> = store.assets_with_tag(tag).cloned().collect();
+            assert_eq!(hits.len(), PER_TAG);
+        }
+        let elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = elapsed.as_nanos() as f64 / q as f64;
+        println!("discovery-tag: n={n} tag_count={tag_count} per_query_ns={per:.1}");
+        series.push((n, per));
+    }
+
+    assert_sublinear("discovery-by-tag", &series);
+}


### PR DESCRIPTION
## What

First of two M7.3 PRs (Rule 1 granularity). Adds the **discovery surface** to `kx-catalog` — the last slice of the M7 exit gate (*"discovery vector-backed, selection exact-ref"*) — **without moving one byte onto the trust path** (SN-8 / D70 / D87: *fuzzy in, exact out*).

- **`metadata` (D84)** — `Tag` (validated, sole-gate construction), `AdvisoryMetadata` (`i64`-scaled confidence, **no float**), `AdvisoryMetadataStore` (forward map + inverted `tag → assets` index kept in lock-step; fail-closed `MAX_TAGS_PER_ASSET` bound). Modelled on `kx_dataset::AnnotationStore`; off the trust path, **never gates**.
- **`discovery_index` (D87)** — `DiscoveryIndex` trait + `InMemoryDiscoveryIndex`: one composite-key (`"ns/col/name"`) `BTreeMap` range scan answering namespace / collection / path-prefix in **O(log n + result)** (segment-exact via a trailing `/`), re-sorted to `AssetRef` order. A **rebuildable projection**, never a source of truth.
- **`discovery` (D87)** — `CatalogDiscovery` (exact lookups), `FuzzyDiscovery` (vector via `kx_dataset::RetrievalIndex`, `ReadOnlyNondet`-confined), and the load-bearing **`SelectionFact` + `commit_selection` chokepoint**: scores are **structurally absent** (no score field; `commit_selection` never reads `Hit.score`), so similarity can never reach a committed selection.

## Scope (confirmed)

- **Mote-as-MCP advertisement → PR-B** (own PR per Rule 1; isolates the `kx-catalog → kx-tool-registry` edge for a focused dependency-wall review).
- **Inbound execution endpoint → M8** (D121 — browse + retrigger work without it).

## Golden Rule 8 — pre-flight (both passes)

**Pass A (breaks / degrades / opens a hole):**
- *Correctness:* the composite-String order ≠ `AssetRef` (tuple) order (`-`/`.` byte-sort before the `/` separator) — the range scan finds the correct SET in String order, then re-sorts to `AssetRef` order (proptest vs brute-force oracle + a dedicated separator-edge test). The `DiscoveryIndex`/`AdvisoryMetadataStore` are rebuildable projections; a stale index degrades *discoverability* only, never a committed selection.
- *Performance:* super-linear discovery (the named risk) is eliminated by the range scan + inverted tag index — proven by 2 scale-smoke gates over `[1k..25k]`. Results are bounded by `MAX_DISCOVERY_RESULT`.
- *Security:* **score-leak onto the commit path = the central threat → eliminated structurally** (proven by `action_selection_safety`). Embeddings are opaque, `RetrievalIndex`-confined (skew ranking at worst). Tags are validated/bounded; confidence is `i64` (no float).

**Pass B (forward + enterprise adoption gap → sequenced tickets):** turns the catalog discoverable with the trust path untouched. Roadmap: **(1) M8** inbound execution endpoint (D121); **(2) M9.3** real ANN backend behind the unchanged `RetrievalIndex` trait; **(3) D94-class** durable advisory-metadata / discovery-index backend + `rebuild_from`; **(4)** multi-tenant discovery-listing governance (`discover_visible_to`); **(5)** discovery audit (advisory, off-journal).

## Tests
`proptest_metadata` (tag-index == linear scan, fail-closed bound, ordered rebuild) · `proptest_discovery` (range scan == brute-force; segment-exact; separator-edge ordering; idempotent index) · `action_selection_safety` (the SN-8 scores-excluded proof + 256-case score-invariance proptest) · 2 new scale-smoke gates (discovery exact + tag lookup, sub-linear).

## Invariants
- Frozen-trio (`kx-scheduler`/`kx-executor`/`kx-inference`) **src diff EMPTY**.
- Canonical product digest `a6b5c679…` **invariant** (`a0_guard`).
- Dependency wall intact (`guarantee_path_does_not_depend_on_catalog`).
- Dependency: **+`kx-catalog → kx-content`** (`ContentRef` for `SelectionFact`; a foundational primitive, already transitive via kx-dataset, strictly **below** the SN-8 wall — no cycle). `Cargo.lock` +1 line, **no new external crate**.

## Local gate — all green
fmt · clippy `--workspace --all-targets -D warnings` · `cargo test --workspace` (**232 suites / 0 failed**) · cargo-deny · doc `-D warnings` · ffi-link · **I1.c byte-determinism PASS** · scale-smoke (8/8 sub-linear) · smoke-test-with-model (GGUF e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)