### PR TITLE
feat(catalog): M7.3 (PR-B) — Mote-as-MCP advertisement (descriptor only) (D85/D86)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "kx-content",
  "kx-dataset",
  "kx-mote",
+ "kx-tool-registry",
  "kx-warrant",
  "kx-workflow",
  "proptest",

--- a/crates/kx-catalog/Cargo.toml
+++ b/crates/kx-catalog/Cargo.toml
@@ -26,6 +26,12 @@ kx-dataset  = { workspace = true }
 # primitive (already transitive via kx-dataset); strictly BELOW the SN-8 wall
 # (kx-content cannot depend on kx-catalog), so the dependency direction holds.
 kx-content  = { workspace = true }
+# M7.3 (D85): reuse the M5.3 closed, no-float typed-arg schema (InputSchema /
+# ParamType / validate_args) for the Mote-as-MCP tool descriptor — the SAME schema
+# M8's inbound path will pass to validate_args. NOT a guarantee-path edge
+# (kx-tool-registry does not depend on kx-catalog → no cycle), so the SN-8 wall
+# holds; the MCP JSON-RPC wire is M8's inbound server (we do NOT pull kx-mcp).
+kx-tool-registry = { workspace = true }
 # Role / WarrantSpec / intersect / NarrowingError (M7.2, D86): a grant's runtime
 # scope REUSES the frozen monotonic-narrowing seam verbatim — the catalog never
 # re-implements narrowing and never modifies kx-warrant. This is a dependency ON

--- a/crates/kx-catalog/src/advertise.rs
+++ b/crates/kx-catalog/src/advertise.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Mote-as-MCP advertisement (M7.3, D85) — **DESCRIPTOR ONLY**.
+//!
+//! Publishing a snapshot to the catalog's MCP surface makes it an MCP-callable
+//! tool. This module produces the tool DESCRIPTOR `{name, description,
+//! input_schema}` for a PUBLISHED, GRANTED snapshot. The inbound EXECUTION
+//! endpoint (resolve → bind args → `RegisterRun` → `StageThenCommit` →
+//! `Committed`) is **M8** (D121) — it is deliberately NOT built here, so the
+//! catalog stays off the coordinator / journal and a half-built inbound path can
+//! never leak authority.
+//!
+//! # The schema is the M8 contract
+//!
+//! The descriptor's [`InputSchema`] reuses the M5.3 closed, **no-float**
+//! `kx_tool_registry::{InputSchema, ParamType}` — the SAME schema M8's inbound
+//! path will hand to `kx_tool_registry::validate_args`, so validation is
+//! forward-compatible by construction. A snapshot's free params are typed by
+//! content-ref ([`crate::FreeParamSlot::schema_ref`]); the agreed payload format
+//! is the **canonical bincode of a [`ParamType`]** ([`encode_param_schema`]),
+//! resolved here via a caller-supplied [`SchemaResolver`] so kx-catalog needs no
+//! content-store dependency.
+//!
+//! # Governance (D86)
+//!
+//! [`advertise_snapshot`] is gated on the LIVE [`crate::GrantLedger`]: only a
+//! snapshot the querying party holds `Use` (or `Read`) on is advertised. A
+//! revoked grant immediately stops advertisement; an ungranted party learns only
+//! "unauthorized", never publication state (the gate is checked first).
+
+use kx_tool_registry::{InputSchema, ParamSpec, ParamType};
+use serde::{Deserialize, Serialize};
+
+use crate::action::CatalogAction;
+use crate::entry::{FreeParamContract, RecipeSnapshot, SlotBinding};
+use crate::governed::GovernedCatalog;
+use crate::ledger::GrantLedger;
+use crate::party::PartyId;
+use crate::path::{AssetPath, AssetRef};
+use crate::signature::canonical_config;
+use crate::version_ledger::VersionLedger;
+
+/// Canonical-bincode bytes of a [`ParamType`] — the agreed
+/// [`crate::FreeParamSlot::schema_ref`] payload format. M8's inbound path decodes
+/// the SAME bytes for `validate_args`, so a snapshot published today advertises
+/// and validates identically when execution lands. Float-free → infallible encode.
+#[must_use]
+pub fn encode_param_schema(ty: &ParamType) -> Vec<u8> {
+    bincode::serde::encode_to_vec(ty, canonical_config())
+        .expect("canonical bincode of a float-free ParamType is infallible")
+}
+
+/// Resolves a free-param slot's `schema_ref` → the canonical bincode bytes of a
+/// [`ParamType`] (see [`encode_param_schema`]). Caller-supplied so kx-catalog
+/// needs no content-store dependency — a `&dyn kx_dataset::DataStore` /
+/// `kx_content::ContentStore` adapter is a one-line closure.
+pub trait SchemaResolver {
+    /// The canonical-bincode([`ParamType`]) bytes for `schema_ref`, or `None` if
+    /// unknown.
+    fn resolve_schema(&self, schema_ref: &[u8; 32]) -> Option<Vec<u8>>;
+}
+
+/// Any `Fn(&[u8; 32]) -> Option<Vec<u8>>` is a [`SchemaResolver`].
+impl<F> SchemaResolver for F
+where
+    F: Fn(&[u8; 32]) -> Option<Vec<u8>>,
+{
+    fn resolve_schema(&self, schema_ref: &[u8; 32]) -> Option<Vec<u8>> {
+        self(schema_ref)
+    }
+}
+
+/// An MCP tool descriptor produced from a published, granted snapshot. DESCRIPTOR
+/// ONLY (D85) — it carries NO execution endpoint; the inbound resolve→bind→
+/// `RegisterRun`→`StageThenCommit` path is M8 (D121). This is exactly what M8's
+/// server will expose (in `tools/list`) and validate proposed args against.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct SnapshotAdvertisement {
+    /// The MCP tool name (the snapshot's handle, `namespace/collection/name`).
+    pub name: String,
+    /// Human description (advisory; e.g. drawn from advisory metadata, D84).
+    pub description: String,
+    /// The typed input schema — the snapshot's `Variable` free-param slots, each
+    /// `schema_ref` resolved to a [`ParamType`]. The SAME `InputSchema` M8 will
+    /// pass to `validate_args`.
+    pub input_schema: InputSchema,
+    /// The exact asset this advertises (the exact-out anchor; not a fuzzy hit).
+    pub asset: AssetRef,
+}
+
+/// Why [`advertise_snapshot`] refused. All fail-closed; no panics.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum AdvertiseError {
+    /// The party holds neither `Use` nor `Read` on the asset (checked first, so no
+    /// publication state leaks to an unauthorized party).
+    #[error("party not authorized to {action:?} {asset}")]
+    Unauthorized {
+        /// The action whose absence blocked advertisement.
+        action: CatalogAction,
+        /// The asset it was required on (display form).
+        asset: String,
+    },
+    /// No version is published at the handle.
+    #[error("snapshot not published at handle {0}")]
+    NotPublished(String),
+    /// A `Variable` slot carries no `schema_ref`, so its MCP param cannot be typed.
+    #[error("variable slot `{slot}` has no schema_ref (cannot type the MCP param)")]
+    UntypedVariableSlot {
+        /// The offending slot name.
+        slot: String,
+    },
+    /// A `Variable` slot's `schema_ref` did not resolve to bytes.
+    #[error("schema_ref for slot `{slot}` did not resolve")]
+    SchemaUnresolved {
+        /// The offending slot name.
+        slot: String,
+    },
+    /// A slot's resolved bytes are not a valid canonical [`ParamType`] (fail-closed).
+    #[error("schema bytes for slot `{slot}` are not a valid ParamType")]
+    SchemaDecode {
+        /// The offending slot name.
+        slot: String,
+    },
+}
+
+/// Produce an MCP tool descriptor from a published, granted snapshot.
+///
+/// Governance-gated (D86): the querying party MUST hold `Use` (or `Read`) on the
+/// asset, checked against the LIVE [`GrantLedger`] via [`GovernedCatalog`] — an
+/// ungranted snapshot is NEVER advertised. DESCRIPTOR ONLY (D85 / D121): it builds
+/// `{name, description, input_schema}`; it does NOT execute and does NOT touch the
+/// coordinator / journal.
+///
+/// # Errors
+///
+/// [`AdvertiseError::Unauthorized`] (gate fails), [`AdvertiseError::NotPublished`]
+/// (handle resolves to nothing), or a `Schema*` error if a `Variable` slot's type
+/// cannot be resolved/decoded.
+pub fn advertise_snapshot<G: GrantLedger, V: VersionLedger>(
+    governed: &GovernedCatalog<G, V>,
+    party: &PartyId,
+    handle: &AssetPath,
+    snapshot: &RecipeSnapshot,
+    description: &str,
+    resolver: &impl SchemaResolver,
+) -> Result<SnapshotAdvertisement, AdvertiseError> {
+    let asset = AssetRef::Path(handle.clone());
+
+    // (1) Governance gate FIRST, against the LIVE grant ledger — `Use` (the action
+    // M8's inbound call will require) preferred, `Read` accepted (D86). Gate-first
+    // ordering means an unauthorized party cannot probe publication state.
+    let authorized = governed
+        .grants()
+        .is_authorized(party, &asset, CatalogAction::Use)
+        || governed
+            .grants()
+            .is_authorized(party, &asset, CatalogAction::Read);
+    if !authorized {
+        return Err(AdvertiseError::Unauthorized {
+            action: CatalogAction::Use,
+            asset: asset.to_string(),
+        });
+    }
+
+    // (2) Must be PUBLISHED (resolves on the version ledger).
+    if governed.versions().resolve(handle).is_none() {
+        return Err(AdvertiseError::NotPublished(handle.to_string()));
+    }
+
+    // (3) FreeParamContract → InputSchema (Variable slots only).
+    let input_schema = free_params_to_input_schema(&snapshot.free_params, resolver)?;
+
+    Ok(SnapshotAdvertisement {
+        name: handle.to_string(),
+        description: description.to_string(),
+        input_schema,
+        asset,
+    })
+}
+
+/// Map a [`FreeParamContract`] to an [`InputSchema`]. Only `Variable` slots become
+/// MCP params (a `Constant` slot is fixed by the recipe — not a free argument);
+/// each `Variable` slot's `schema_ref` is resolved → canonical bincode → a
+/// [`ParamType`]. Every `Variable` param is `required: true` and the schema is
+/// `deny_unknown: true` (fail-closed against smuggled args, matching `validate_args`
+/// strict mode). `BTreeMap` iteration gives a canonical param order.
+fn free_params_to_input_schema(
+    contract: &FreeParamContract,
+    resolver: &impl SchemaResolver,
+) -> Result<InputSchema, AdvertiseError> {
+    let mut params = Vec::new();
+    for (name, slot) in &contract.slots {
+        if slot.binding != SlotBinding::Variable {
+            continue; // Constant slots are fixed by the recipe — not free args.
+        }
+        let schema_ref = slot
+            .schema_ref
+            .ok_or_else(|| AdvertiseError::UntypedVariableSlot { slot: name.clone() })?;
+        let bytes = resolver
+            .resolve_schema(&schema_ref)
+            .ok_or_else(|| AdvertiseError::SchemaUnresolved { slot: name.clone() })?;
+        let (ty, _) = bincode::serde::decode_from_slice::<ParamType, _>(&bytes, canonical_config())
+            .map_err(|_| AdvertiseError::SchemaDecode { slot: name.clone() })?;
+        params.push(ParamSpec {
+            name: name.clone(),
+            ty,
+            required: true,
+        });
+    }
+    Ok(InputSchema {
+        params,
+        deny_unknown: true,
+    })
+}

--- a/crates/kx-catalog/src/lib.rs
+++ b/crates/kx-catalog/src/lib.rs
@@ -94,6 +94,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod action;
+mod advertise;
 mod discovery;
 mod discovery_index;
 mod entry;
@@ -147,6 +148,14 @@ pub use version_ledger::{
     PublishOutcome, VersionLedger, VersionLedgerError, MAX_VERSION_CHAIN_DEPTH,
     MAX_VERSION_DESCENDANTS,
 };
+
+// M7.3 (D85) — Mote-as-MCP advertisement (descriptor only; execution is M8/D121).
+pub use advertise::{
+    advertise_snapshot, encode_param_schema, AdvertiseError, SchemaResolver, SnapshotAdvertisement,
+};
+// The M5.3 closed, no-float typed-arg schema, re-exported so an advertisement's
+// `input_schema` is one import surface (the SAME schema M8's `validate_args` uses).
+pub use kx_tool_registry::{validate_args, InputSchema, ParamSpec, ParamType, SchemaError};
 
 // M7.3 (D87/D84) — discovery (fuzzy-in, exact-out) + advisory metadata.
 pub use discovery::{commit_selection, CatalogDiscovery, FuzzyDiscovery, SelectionFact};

--- a/crates/kx-catalog/tests/advertise.rs
+++ b/crates/kx-catalog/tests/advertise.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+//! M7.3 Mote-as-MCP advertisement (D85/D86) — descriptor-only, governance-gated.
+//!
+//! Proves: a granted, published snapshot advertises a typed MCP descriptor whose
+//! `input_schema` round-trips through `validate_args` (the M8 contract); an
+//! ungranted / confused-deputy / unpublished snapshot is refused fail-closed;
+//! `Constant` slots are excluded; untyped/unresolved/garbage schemas are refused;
+//! and advertisement is a pure read (emits no run / appends no fact).
+
+#![allow(clippy::unwrap_used)]
+
+use kx_catalog::{
+    advertise_snapshot, encode_param_schema, validate_args, AdvertiseError, AssetBinding,
+    AssetPath, AssetRef, AssetVersion, CatalogAction, CatalogActionSet, FreeParamContract,
+    FreeParamSlot, GovernedCatalog, Grant, GrantLedger, InMemoryGrantLedger, InMemoryVersionLedger,
+    ParamType, PartyId, Provenance, RecipeSnapshot, Role, TaskSignatureHash, VersionLedger,
+    VersionedContent, WarrantSpec,
+};
+
+type Catalog = GovernedCatalog<InMemoryGrantLedger, InMemoryVersionLedger>;
+
+fn role() -> Role {
+    Role {
+        name: "r".into(),
+        version: 1,
+        spec: WarrantSpec::default(),
+        description: String::new(),
+    }
+}
+
+fn handle() -> AssetPath {
+    AssetPath::new("acme", "recipes", "summarize").unwrap()
+}
+
+/// The schema content-ref convention used by these tests.
+const LIMIT_SCHEMA_REF: [u8; 32] = [42u8; 32];
+
+/// A snapshot with one Variable typed slot (`limit`) + one Constant slot
+/// (`internal`, must be excluded from the descriptor).
+fn snapshot() -> RecipeSnapshot {
+    RecipeSnapshot::new([1u8; 32]).with_free_params(
+        FreeParamContract::new()
+            .with_slot("limit", FreeParamSlot::variable(Some(LIMIT_SCHEMA_REF)))
+            .with_slot("internal", FreeParamSlot::constant()),
+    )
+}
+
+/// Resolver: `LIMIT_SCHEMA_REF` → canonical bincode of `Int{1..=100}`.
+fn resolver(r: &[u8; 32]) -> Option<Vec<u8>> {
+    if *r == LIMIT_SCHEMA_REF {
+        Some(encode_param_schema(&ParamType::Int {
+            min: Some(1),
+            max: Some(100),
+        }))
+    } else {
+        None
+    }
+}
+
+/// Build a governed catalog: `owner` (full authority, can publish), `user` (Use),
+/// `reader` (Read). The snapshot's handle is published.
+fn setup() -> (Catalog, PartyId, PartyId) {
+    let owner = PartyId::new("owner");
+    let user = PartyId::new("user");
+    let reader = PartyId::new("reader");
+    let h = handle();
+    let asset = AssetRef::Path(h.clone());
+
+    let grants = InMemoryGrantLedger::new();
+    grants
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    // Owner self-grant (full authority) → owner may publish (Register).
+    grants
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner.clone(),
+            owner.clone(),
+            CatalogActionSet::all(),
+            role(),
+        ))
+        .unwrap();
+    grants
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner.clone(),
+            user.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role(),
+        ))
+        .unwrap();
+    grants
+        .append_grant(Grant::root(
+            asset,
+            owner.clone(),
+            reader.clone(),
+            CatalogActionSet::allow([CatalogAction::Read]),
+            role(),
+        ))
+        .unwrap();
+
+    let versions = InMemoryVersionLedger::new();
+    let governed = GovernedCatalog::new(grants, versions);
+    governed
+        .publish(AssetVersion::root(
+            h,
+            VersionedContent::Recipe(TaskSignatureHash::from_bytes([1u8; 32])),
+            owner,
+            Provenance::from_recipe([1u8; 32]),
+        ))
+        .unwrap();
+    (governed, user, reader)
+}
+
+#[test]
+fn granted_use_party_gets_a_descriptor_that_validates() {
+    let (cat, user, _) = setup();
+    let ad = advertise_snapshot(
+        &cat,
+        &user,
+        &handle(),
+        &snapshot(),
+        "summarize an incident",
+        &resolver,
+    )
+    .unwrap();
+
+    assert_eq!(ad.name, "acme/recipes/summarize");
+    assert_eq!(ad.description, "summarize an incident");
+    assert_eq!(ad.asset, AssetRef::Path(handle()));
+    // Only the Variable slot becomes a param; the Constant slot is excluded.
+    assert_eq!(ad.input_schema.params.len(), 1);
+    assert_eq!(ad.input_schema.params[0].name, "limit");
+    assert!(ad.input_schema.params[0].required);
+    assert!(ad.input_schema.deny_unknown);
+
+    // The descriptor's schema is the M8 contract — it round-trips through validate_args.
+    assert!(validate_args(&ad.input_schema, br#"{"limit": 50}"#).is_ok());
+    assert!(validate_args(&ad.input_schema, br#"{"limit": 999}"#).is_err()); // out of [1,100]
+    assert!(validate_args(&ad.input_schema, br#"{"limit": 1.5}"#).is_err()); // no float (SN-8)
+    assert!(validate_args(&ad.input_schema, br#"{"bogus": 1}"#).is_err()); // deny_unknown + missing
+}
+
+#[test]
+fn read_only_party_can_advertise() {
+    let (cat, _, reader) = setup();
+    assert!(advertise_snapshot(&cat, &reader, &handle(), &snapshot(), "d", &resolver).is_ok());
+}
+
+#[test]
+fn ungranted_party_is_refused() {
+    let (cat, _, _) = setup();
+    let intruder = PartyId::new("intruder");
+    let err =
+        advertise_snapshot(&cat, &intruder, &handle(), &snapshot(), "d", &resolver).unwrap_err();
+    assert!(matches!(err, AdvertiseError::Unauthorized { .. }));
+}
+
+#[test]
+fn confused_deputy_grant_on_other_asset_does_not_advertise() {
+    let (cat, _, _) = setup();
+    // `stranger` is granted Use on a DIFFERENT asset; it must not advertise `handle`.
+    let owner = PartyId::new("owner");
+    let stranger = PartyId::new("stranger");
+    let other = AssetRef::Path(AssetPath::new("acme", "recipes", "other").unwrap());
+    cat.grants()
+        .append_binding(AssetBinding::new(other.clone(), owner.clone()))
+        .unwrap();
+    cat.grants()
+        .append_grant(Grant::root(
+            other,
+            owner,
+            stranger.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role(),
+        ))
+        .unwrap();
+    let err =
+        advertise_snapshot(&cat, &stranger, &handle(), &snapshot(), "d", &resolver).unwrap_err();
+    assert!(matches!(err, AdvertiseError::Unauthorized { .. }));
+}
+
+#[test]
+fn unpublished_handle_is_refused() {
+    let (cat, _, _) = setup();
+    // A handle the user is granted Read on, but with no published version.
+    let owner = PartyId::new("owner");
+    let user = PartyId::new("user");
+    let unpub = AssetPath::new("acme", "recipes", "draft").unwrap();
+    let asset = AssetRef::Path(unpub.clone());
+    cat.grants()
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .unwrap();
+    cat.grants()
+        .append_grant(Grant::root(
+            asset,
+            owner,
+            user.clone(),
+            CatalogActionSet::allow([CatalogAction::Read]),
+            role(),
+        ))
+        .unwrap();
+    let err = advertise_snapshot(&cat, &user, &unpub, &snapshot(), "d", &resolver).unwrap_err();
+    assert!(matches!(err, AdvertiseError::NotPublished(_)));
+}
+
+#[test]
+fn untyped_variable_slot_is_refused() {
+    let (cat, user, _) = setup();
+    let snap = RecipeSnapshot::new([1u8; 32])
+        .with_free_params(FreeParamContract::new().with_slot("x", FreeParamSlot::variable(None)));
+    let err = advertise_snapshot(&cat, &user, &handle(), &snap, "d", &resolver).unwrap_err();
+    assert!(matches!(err, AdvertiseError::UntypedVariableSlot { slot } if slot == "x"));
+}
+
+#[test]
+fn unresolved_schema_ref_is_refused() {
+    let (cat, user, _) = setup();
+    let snap = RecipeSnapshot::new([1u8; 32]).with_free_params(
+        FreeParamContract::new().with_slot("x", FreeParamSlot::variable(Some([7u8; 32]))),
+    );
+    // resolver only knows LIMIT_SCHEMA_REF.
+    let err = advertise_snapshot(&cat, &user, &handle(), &snap, "d", &resolver).unwrap_err();
+    assert!(matches!(err, AdvertiseError::SchemaUnresolved { slot } if slot == "x"));
+}
+
+#[test]
+fn garbage_schema_bytes_are_refused() {
+    let (cat, user, _) = setup();
+    let bad_ref = [9u8; 32];
+    let snap = RecipeSnapshot::new([1u8; 32]).with_free_params(
+        FreeParamContract::new().with_slot("x", FreeParamSlot::variable(Some(bad_ref))),
+    );
+    let bad_resolver = |r: &[u8; 32]| (*r == bad_ref).then(|| vec![0xFFu8, 0x00, 0x01]);
+    let err = advertise_snapshot(&cat, &user, &handle(), &snap, "d", &bad_resolver).unwrap_err();
+    assert!(matches!(err, AdvertiseError::SchemaDecode { slot } if slot == "x"));
+}
+
+#[test]
+fn param_types_round_trip_through_the_descriptor() {
+    let (cat, user, _) = setup();
+    for ty in [
+        ParamType::Int {
+            min: None,
+            max: None,
+        },
+        ParamType::Str { max_len: 64 },
+        ParamType::Bytes { max_len: 8 },
+        ParamType::Bool,
+    ] {
+        let r = [200u8; 32];
+        let snap = RecipeSnapshot::new([1u8; 32]).with_free_params(
+            FreeParamContract::new().with_slot("p", FreeParamSlot::variable(Some(r))),
+        );
+        let ty2 = ty.clone();
+        let res = move |q: &[u8; 32]| (*q == r).then(|| encode_param_schema(&ty2));
+        let ad = advertise_snapshot(&cat, &user, &handle(), &snap, "d", &res).unwrap();
+        assert_eq!(ad.input_schema.params[0].ty, ty);
+    }
+}
+
+#[test]
+fn advertise_emits_no_run_and_appends_no_fact() {
+    let (cat, user, _) = setup();
+    let versions_before = cat.versions().len();
+    let grants_before = cat.grants().len();
+    let _ = advertise_snapshot(&cat, &user, &handle(), &snapshot(), "d", &resolver).unwrap();
+    // Descriptor-only: no coordinator/journal, no new fact in either ledger.
+    assert_eq!(cat.versions().len(), versions_before);
+    assert_eq!(cat.grants().len(), grants_before);
+}
+
+/// M7.3 (PR-B) exit gate: the new `kx-catalog → kx-tool-registry` edge must NOT
+/// create a cycle — kx-tool-registry and the crates it depends on must stay off
+/// kx-catalog, so the SN-8 wall and the dependency direction hold (complements
+/// `guarantee_path_does_not_depend_on_catalog` in `security_governance.rs`).
+#[test]
+fn advertisement_edge_introduces_no_cycle() {
+    for c in ["kx-tool-registry", "kx-mote", "kx-content", "kx-warrant"] {
+        let manifest = format!("{}/../{c}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+        let toml =
+            std::fs::read_to_string(&manifest).unwrap_or_else(|e| panic!("read {manifest}: {e}"));
+        assert!(
+            !toml.contains("kx-catalog"),
+            "{c} must NOT depend on kx-catalog (no cycle via the M7.3 advertise edge)"
+        );
+    }
+}

--- a/crates/kx-catalog/tests/scale.rs
+++ b/crates/kx-catalog/tests/scale.rs
@@ -584,3 +584,91 @@ fn discovery_tag_lookup_stays_sublinear() {
 
     assert_sublinear("discovery-by-tag", &series);
 }
+
+/// M7.3 (D85): Mote-as-MCP advertisement stays `O(log n)` in catalog size — the
+/// governance fold is depth-bounded, the version resolve is `O(log n)`, and the
+/// FreeParamContract→InputSchema map is `O(#slots)` (constant). A descriptor is
+/// produced per call; per-op cost stays flat as the catalog grows.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn advertisement_generation_stays_sublinear() {
+    use kx_catalog::{
+        advertise_snapshot, encode_param_schema, FreeParamContract, FreeParamSlot, GovernedCatalog,
+        ParamType,
+    };
+
+    const SCHEMA_REF: [u8; 32] = [55u8; 32];
+    let resolver = |r: &[u8; 32]| {
+        (*r == SCHEMA_REF).then(|| {
+            encode_param_schema(&ParamType::Int {
+                min: None,
+                max: None,
+            })
+        })
+    };
+    let snap = RecipeSnapshot::new([1u8; 32]).with_free_params(
+        FreeParamContract::new().with_slot("p", FreeParamSlot::variable(Some(SCHEMA_REF))),
+    );
+    let owner = PartyId::new("owner");
+    let user = PartyId::new("user");
+
+    let mut series: Vec<(usize, f64)> = Vec::new();
+    for &n in SIZES {
+        let grants = InMemoryGrantLedger::new();
+        let versions = InMemoryVersionLedger::new();
+        let handles: Vec<AssetPath> = (0..n)
+            .map(|i| AssetPath::new("ns", "c", format!("h{i}")).unwrap())
+            .collect();
+        for h in &handles {
+            let asset = AssetRef::Path(h.clone());
+            grants
+                .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+                .unwrap();
+            grants
+                .append_grant(Grant::root(
+                    asset.clone(),
+                    owner.clone(),
+                    owner.clone(),
+                    CatalogActionSet::all(),
+                    role_calls(10),
+                ))
+                .unwrap();
+            grants
+                .append_grant(Grant::root(
+                    asset,
+                    owner.clone(),
+                    user.clone(),
+                    CatalogActionSet::allow([CatalogAction::Use]),
+                    role_calls(10),
+                ))
+                .unwrap();
+        }
+        let governed = GovernedCatalog::new(grants, versions);
+        for h in &handles {
+            governed
+                .publish(AssetVersion::root(
+                    h.clone(),
+                    VersionedContent::Recipe(TaskSignatureHash::from_bytes([1u8; 32])),
+                    owner.clone(),
+                    Provenance::from_recipe([1u8; 32]),
+                ))
+                .unwrap();
+        }
+
+        let q = 500;
+        let start = Instant::now();
+        for j in 0..q {
+            let h = &handles[(j * 7) % n];
+            let ad = advertise_snapshot(&governed, &user, h, &snap, "d", &resolver).unwrap();
+            assert_eq!(ad.input_schema.params.len(), 1);
+        }
+        let elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = elapsed.as_nanos() as f64 / q as f64;
+        println!("advertise: n={n} per_op_ns={per:.1}");
+        series.push((n, per));
+    }
+
+    assert_sublinear("advertisement-generation", &series);
+}


### PR DESCRIPTION
## What

Second of two M7.3 PRs (Rule 1). Produces an **MCP tool descriptor** `{name, description, input_schema}` for a published, granted snapshot — the on-ramp to the M8 marketplace — **without** building the inbound execution endpoint and **without** coupling kx-catalog to the coordinator/journal.

- **`advertise` module (D85/D86):**
  - `SnapshotAdvertisement { name, description, input_schema, asset }` — descriptor only.
  - `advertise_snapshot(...)` — **governance-gated on the LIVE `GrantLedger`** via `GovernedCatalog` (`Use` preferred, `Read` accepted; **gate-first** so an unauthorized party can't probe publication state). An ungranted / revoked party is never advertised.
  - `free_params_to_input_schema(...)` — only `Variable` slots become params (a `Constant` slot is fixed by the recipe); each `schema_ref` → canonical `bincode(ParamType)` → `ParamType`, fail-closed on untyped/unresolved/garbage.
  - `SchemaResolver` seam + `encode_param_schema` — `schema_ref` bytes = canonical `bincode(ParamType)`. kx-catalog needs no content-store dep (callers adapt one in a closure).
- The descriptor's `input_schema` reuses the M5.3 closed, **no-float** `kx_tool_registry::{InputSchema, ParamType}` — the **SAME** schema M8's inbound path passes to `validate_args` (forward-compatible by construction).

## Scope (D121)
The inbound **execution** endpoint (resolve → bind args → `RegisterRun` → `StageThenCommit` → `Committed`) is **M8** — deliberately not here. The MCP JSON-RPC wire is M8's inbound server, so **`kx-mcp` is NOT pulled in** (avoids `ureq`/`url` in the catalog).

## Golden Rule 8 — pre-flight (both passes)
**Pass A:** *security* — advertising is gated on the live grant ledger (a revocation immediately stops it); authority is asset-keyed (no confused deputy — tested); schema bytes decode into the closed no-float `ParamType` fail-closed; gate-first ordering avoids a publication-existence oracle. *correctness* — `descriptor.input_schema` is the exact object M8 will `validate_args` against (round-trip tested). *performance* — advertisement is `O(log n)` (depth-bounded grant fold + `O(log n)` resolve + `O(#slots)` schema map), scale-smoke proven flat.
**Pass B → roadmap:** **M8** inbound execution endpoint (this descriptor is its contract); **M9.3** real-ANN discovery backend; durable catalog backend (D94); multi-tenant discovery-listing governance.

## Tests
`advertise.rs` — granted-validates-via-`validate_args`; ungranted / confused-deputy / unpublished refused; `Constant` excluded; untyped / unresolved / garbage schema refused; `ParamType` round-trip; **advertise-emits-no-run** (no fact appended); **`advertisement_edge_introduces_no_cycle`** (the new edge creates no cycle). + `advertisement_generation` scale-smoke (sub-linear).

## Invariants
- Frozen-trio src diff **EMPTY**; canonical digest `a6b5c679…` invariant.
- Dependency: **+`kx-catalog → kx-tool-registry`** (isolated to this PR per Rule 1). No cycle (kx-tool-registry + deps stay off kx-catalog); SN-8 wall intact. `Cargo.lock`: **no new external crate**.
- Local gate green: fmt, clippy `-D warnings`, `cargo test --workspace` (233 suites / 0 failed), deny, doc `-D warnings`, scale-smoke; byte-determinism/ffi/smoke via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)