### PR TITLE
feat(fleet): M7 — fleet/team (D112): NEW kx-fleet crate (membership facts + composed warrant resolution)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-fleet"
+version = "0.0.1"
+dependencies = [
+ "bincode",
+ "blake3",
+ "kx-catalog",
+ "kx-mote",
+ "kx-warrant",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kx-inference"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/kx-mcp",
     "crates/kx-planner",
     "crates/kx-catalog",
+    "crates/kx-fleet",
     "crates/kx-model-harness",
 ]
 exclude = [
@@ -145,6 +146,12 @@ kx-planner           = { path = "crates/kx-planner",           version = "0.0.1"
 # path (composes kx-mote/kx-workflow identities, never bumps MoteDef). Depends
 # only on kx-mote/kx-workflow/kx-dataset — NEVER the journal or the frozen trio.
 kx-catalog           = { path = "crates/kx-catalog",           version = "0.0.1" }
+# Teams / fleets (M7, D112) — journaled membership facts + a fail-closed fold +
+# composed warrant resolution. Membership is one-level-up delegation
+# (intersect(team_warrant, member_role)); nested fleet-of-teams = a bounded multi-hop
+# narrow. A SEPARATE TRUTH (off-journal, off the trust path, SN-8). Depends ONLY on
+# kx-catalog/kx-warrant; the journal + frozen trio NEVER depend on it (one-way edge).
+kx-fleet             = { path = "crates/kx-fleet",             version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-fleet/Cargo.toml
+++ b/crates/kx-fleet/Cargo.toml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-fleet"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx teams/fleets (M7, D112): journaled membership facts + a fail-closed fold + composed warrant resolution. A SEPARATE TRUTH (authoritative for WHO is in a team), realized as the D-LOCK-4 discipline (append-only, content-addressed, immutable, idempotent, revoke-by-new-fact) — off-journal and off the trust path (SN-8). Membership is one-level-up delegation: a member's effective warrant on a recipe = intersect(team_grant_warrant, member_role) via the FROZEN kx_warrant::intersect, so a member can NEVER exceed the team's grant; nested fleet-of-teams generalizes it to a bounded multi-hop narrow. Depends only on kx-catalog/kx-warrant; the frozen trio and the journal NEVER depend on it."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# PartyId / AssetRef / CatalogAction(Set) / GrantLedger / resolve_effective_warrant_for
+# (M7.2, D86): a team is a PartyId, "team T may Use recipe A under warrant W" is an
+# ordinary catalog grant, and the team's effective warrant is resolved through the
+# EXISTING grant fold — kx-fleet adds no grant logic. Also reuses kx_catalog::canonical_config
+# so the membership content-hash discipline is byte-identical to the catalog's.
+kx-catalog  = { workspace = true }
+# Role / WarrantSpec / intersect / NarrowingError: a membership's runtime scope REUSES
+# the frozen monotonic-narrowing seam verbatim — kx-fleet never re-implements narrowing
+# and never modifies kx-warrant (a STRICT seam; its own PR by Rule 1). This is a
+# dependency ON kx-warrant, NOT a dependency BY the guarantee path, so the SN-8 wall holds.
+kx-warrant  = { workspace = true }
+# The frozen canonical content-addressed encoding (bincode v2, LE + fixed-int), used via
+# kx_catalog::canonical_config for the Team / Admit / Removal / Disband content ids.
+bincode     = { workspace = true }
+# Content-addressing (domain-tagged blake3) for membership fact ids.
+blake3      = { workspace = true }
+# Stack-inline small vecs (membership edges / role chains) without per-entry heap churn.
+smallvec    = { workspace = true }
+# serde derives across all public fact types (persistence-friendly, sharable bundles).
+serde       = { workspace = true }
+# Typed MembershipLedgerError / GovernedFleetError.
+thiserror   = { workspace = true }
+# Append observability (debug-level only; never on the truth path).
+tracing     = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+# TEST-ONLY: kx_mote::ModelId to build a positive `ModelRoute` (kx_warrant::intersect
+# rejects a zero model_route). Production depends ONLY on kx-catalog/kx-warrant; a
+# dev-dep does not widen the dependency wall (and kx-mote sits below everything).
+kx-mote  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-fleet/examples/author_a_fleet.rs
+++ b/crates/kx-fleet/examples/author_a_fleet.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Author a team / fleet and resolve a member's effective warrant (M7, D112).
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run -p kx-fleet --example author_a_fleet
+//! ```
+//!
+//! This is the fleet analogue of `kx-workflow`'s `author_a_workflow`: zero model, zero
+//! network, fully deterministic. It shows the whole D112 story end to end —
+//!
+//! 1. an org admin **founds a team** and **grants the team** `Use` on a catalog recipe
+//!    (an ordinary `kx-catalog` grant — a team is just a `PartyId`);
+//! 2. the admin **admits two members** under different runtime roles;
+//! 3. each member's effective warrant on the recipe is resolved as
+//!    `intersect(team_grant_warrant, member_role)` — structurally `⊆` the team's grant
+//!    (a member can never exceed the team);
+//! 4. a **nested fleet** (a team admitted into a fleet that holds the grant) resolves
+//!    the same way, narrowed at every hop;
+//! 5. **removing** a member makes their access vanish immediately (revoke-by-new-fact).
+//!
+//! See ARCHITECTURE.md / GLOSSARY.md for how this sits OFF the trust path (SN-8): the
+//! fleet layer never gates selection/promotion and never touches the journal.
+
+// Example code: `.unwrap()` on the ledger appends is the right "fail loud in a demo"
+// behavior, and the linear narrative reads better as one `main` than split helpers.
+#![allow(clippy::unwrap_used, clippy::too_many_lines)]
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantLedger,
+    InMemoryGrantLedger, PartyId,
+};
+use kx_fleet::{Admit, GovernedFleet, InMemoryMembershipLedger, MembershipLedger, Removal, Team};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
+
+/// A warrant capping inference calls at `max_calls` (positive model route, since
+/// `kx_warrant::intersect` rejects a zero route).
+fn warrant(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("gemma".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 1_024,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 2_000,
+            mem_bytes: 512 << 20,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 30,
+        },
+        ..Default::default()
+    }
+}
+
+fn role(name: &str, max_calls: u32) -> Role {
+    Role {
+        name: name.into(),
+        version: 1,
+        spec: warrant(max_calls),
+        description: String::new(),
+    }
+}
+
+fn main() {
+    // The principals. A team is a group `PartyId`, exactly like a user.
+    let admin = PartyId::new("admin@acme");
+    let sre = PartyId::new("team:sre@acme");
+    let platform = PartyId::new("fleet:platform@acme");
+    let alice = PartyId::new("alice@acme");
+    let bob = PartyId::new("bob@acme");
+    let frank = PartyId::new("frank@acme");
+
+    // The shared catalog recipe + the org's base warrant (the ceiling everything
+    // narrows under).
+    let recipe = AssetRef::Path(AssetPath::new("acme", "runbooks", "restart-service").unwrap());
+    let owner_root = warrant(100);
+
+    // ---- Step 1: grant the TEAM `Use` on the recipe (an ordinary catalog grant) ----
+    let grants = InMemoryGrantLedger::new();
+    grants
+        .append_binding(AssetBinding::new(recipe.clone(), admin.clone()))
+        .unwrap();
+    grants
+        .append_grant(Grant::root(
+            recipe.clone(),
+            admin.clone(),
+            sre.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role("sre-team", 50),
+        ))
+        .unwrap();
+
+    // ---- Step 2: found the team + admit two members under different roles ----------
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE on-call"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            alice.clone(),
+            admin.clone(),
+            role("oncall-senior", 30),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            bob.clone(),
+            admin.clone(),
+            role("oncall-junior", 5),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // ---- Step 3: resolve each member's effective warrant (narrowed, never wider) ---
+    let team_eff = gov
+        .grants()
+        .resolve_effective_warrant_for(&sre, &recipe, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    let alice_w = gov
+        .resolve_member_warrant(&alice, &recipe, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    let bob_w = gov
+        .resolve_member_warrant(&bob, &recipe, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+
+    println!("recipe: {recipe}");
+    println!(
+        "team SRE effective max_calls = {} (= min(owner 100, team 50))",
+        team_eff.model_route.max_calls
+    );
+    println!(
+        "  alice (oncall-senior, 30) -> max_calls = {} (= min(team 50, 30))",
+        alice_w.model_route.max_calls
+    );
+    println!(
+        "  bob   (oncall-junior,  5) -> max_calls = {} (= min(team 50, 5))",
+        bob_w.model_route.max_calls
+    );
+    assert_eq!(alice_w.model_route.max_calls, 30);
+    assert_eq!(bob_w.model_route.max_calls, 5);
+    assert!(alice_w.model_route.max_calls <= team_eff.model_route.max_calls);
+
+    // ---- Step 4: a NESTED fleet resolves the same way, narrowed at every hop -------
+    // A separate recipe the FLEET (not the team) holds; team:sre is a member of it.
+    let deploy = AssetRef::Path(AssetPath::new("acme", "runbooks", "deploy").unwrap());
+    gov.grants()
+        .append_binding(AssetBinding::new(deploy.clone(), admin.clone()))
+        .unwrap();
+    gov.grants()
+        .append_grant(Grant::root(
+            deploy.clone(),
+            admin.clone(),
+            platform.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]),
+            role("platform-fleet", 80),
+        ))
+        .unwrap();
+    gov.members()
+        .append_founding(Team::found(
+            platform.clone(),
+            admin.clone(),
+            "Platform fleet",
+        ))
+        .unwrap();
+    gov.members()
+        .append_admit(Admit::new(
+            platform.clone(),
+            sre.clone(),
+            admin.clone(),
+            role("sre-in-platform", 40),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    gov.members()
+        .append_admit(Admit::new(
+            sre.clone(),
+            frank.clone(),
+            admin.clone(),
+            role("frank", 25),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let frank_w = gov
+        .resolve_member_warrant(&frank, &deploy, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    println!(
+        "  frank via fleet:platform -> max_calls = {} (= min(owner 100, fleet 80, sre-in-platform 40, frank 25))",
+        frank_w.model_route.max_calls
+    );
+    assert_eq!(frank_w.model_route.max_calls, 25);
+
+    // ---- Step 5: remove a member -> access vanishes immediately ---------------------
+    assert!(gov.is_member_authorized(&bob, &recipe, CatalogAction::Use));
+    gov.members()
+        .append_remove(Removal::new(sre.clone(), bob.clone(), admin.clone()))
+        .unwrap();
+    assert!(!gov.is_member_authorized(&bob, &recipe, CatalogAction::Use));
+    println!(
+        "removed bob from team:sre -> bob authorized for Use? {}",
+        gov.is_member_authorized(&bob, &recipe, CatalogAction::Use)
+    );
+
+    println!(
+        "\nOK: a member's warrant is always the team's grant narrowed by their role — never wider."
+    );
+}

--- a/crates/kx-fleet/src/error.rs
+++ b/crates/kx-fleet/src/error.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed fleet errors (M7, D112): [`MembershipLedgerError`] (append failures) and
+//! [`GovernedFleetError`] (composed-resolution failures). Mirrors
+//! `kx_catalog::LedgerError` / `kx_catalog::GovernedError`.
+
+use kx_catalog::CatalogAction;
+use kx_warrant::NarrowingError;
+
+/// A membership-ledger append failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MembershipLedgerError {
+    /// A DIFFERENT fact already exists at this `MembershipId`. Facts are
+    /// content-addressed, so the same id MUST mean the same bytes — a mismatch is a
+    /// hash-collision tripwire (cryptographically unreachable): refuse loudly rather
+    /// than overwrite. Carries the conflicting id (hex).
+    #[error("immutable membership ledger conflict at membership_id {0}")]
+    ImmutabilityConflict(String),
+    /// A team is already founded with a DIFFERENT owner. A team has exactly one
+    /// owner; re-founding to a new owner is refused (the founding is genesis).
+    #[error("team ownership conflict: {0}")]
+    OwnerConflict(String),
+}
+
+/// A composed [`crate::GovernedFleet`] resolution failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum GovernedFleetError {
+    /// The member is not authorized for `action` on `asset` through any active
+    /// (possibly nested) team membership (fail-closed). Returned only by the strict
+    /// `require_*` resolver; the non-strict resolver returns `Ok(None)` instead.
+    #[error("member {member} not authorized for {action:?} on {asset} via any team")]
+    Unauthorized {
+        /// The member (display form).
+        member: String,
+        /// The action that was required.
+        action: CatalogAction,
+        /// The asset it was required on (display form).
+        asset: String,
+    },
+    /// A membership role proposed a runtime-scope widen at some hop — surfaced by
+    /// the FROZEN `kx_warrant::intersect`, never a silently-wider warrant.
+    #[error(transparent)]
+    Narrowing(#[from] NarrowingError),
+}

--- a/crates/kx-fleet/src/governed.rs
+++ b/crates/kx-fleet/src/governed.rs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`GovernedFleet`] (M7, D112) — the composed resolution over a
+//! [`MembershipLedger`] + a [`kx_catalog::GrantLedger`].
+//!
+//! A team is a `PartyId`, and "team `T` may `Use` recipe `A` under warrant `W`" is an
+//! ordinary catalog grant. `GovernedFleet` answers the question the fleet layer
+//! exists for: **what warrant does member `M` get when invoking recipe `A`, through
+//! their (possibly nested) team membership?** It walks the membership edges upward
+//! from `M` (bounded, cycle-guarded), and at every reachable team `T` that holds the
+//! action on `A` it narrows `T`'s grant warrant by the chain of membership roles via
+//! the FROZEN [`kx_warrant::intersect`] — so the result is structurally `⊆` the
+//! team's grant (a member can never exceed the team), and `⊆` `owner_root` (the
+//! grant fold already guarantees that). The two ledgers are composed WITHOUT coupling
+//! their impls (Rule 1, exactly `kx_catalog::GovernedCatalog`).
+
+use std::collections::BTreeSet;
+
+use kx_catalog::{canonical_config, CatalogAction, CatalogActionSet, GrantLedger, PartyId};
+use kx_warrant::{intersect, Role, WarrantSpec};
+
+use crate::error::GovernedFleetError;
+use crate::ledger::{MembershipLedger, MAX_TEAM_MEMBERS_WALK};
+use kx_catalog::AssetRef;
+
+/// A hard cap on the number of membership edges a single resolution will expand — a
+/// DoS backstop for a pathologically dense membership DAG (where the count of simple
+/// paths could otherwise be exponential in the depth bound). Generous: a real fleet
+/// is shallow + narrow and never approaches it. Hitting it yields a fail-closed
+/// partial result (the most-permissive warrant found within budget). `MAX² ` so a
+/// full `MAX`-deep, `MAX`-wide frontier is still covered.
+const MAX_RESOLUTION_STEPS: usize = MAX_TEAM_MEMBERS_WALK * MAX_TEAM_MEMBERS_WALK;
+
+/// The composed governed-fleet surface: a [`MembershipLedger`] + a
+/// [`kx_catalog::GrantLedger`], composed so a member's effective warrant on a recipe
+/// is resolved through their team membership.
+///
+/// Generic over both backends (zero-cost); pass `Arc<InMemory…>` (both impl their
+/// trait for `Arc<L>`) when the underlying ledgers must be shared with other holders.
+#[derive(Debug, Default)]
+pub struct GovernedFleet<M: MembershipLedger, G: GrantLedger> {
+    members: M,
+    grants: G,
+}
+
+impl<M: MembershipLedger, G: GrantLedger> GovernedFleet<M, G> {
+    /// Compose a membership ledger and a grant ledger into a governed surface.
+    #[must_use]
+    pub fn new(members: M, grants: G) -> Self {
+        Self { members, grants }
+    }
+
+    /// Borrow the underlying membership ledger (e.g. to seed teams/admits, or to
+    /// query membership directly).
+    #[inline]
+    #[must_use]
+    pub fn members(&self) -> &M {
+        &self.members
+    }
+
+    /// Borrow the underlying grant ledger (e.g. to seed bindings/team grants).
+    #[inline]
+    #[must_use]
+    pub fn grants(&self) -> &G {
+        &self.grants
+    }
+
+    /// The runtime warrant `member` gets when invoking `action` on `asset` through
+    /// their (possibly nested) team membership: the MOST-PERMISSIVE
+    /// `intersect(team_warrant, …membership roles…)` among all active membership
+    /// paths whose cap conveys `action` and whose top team holds `action` on `asset`.
+    /// `Ok(None)` if no such path exists (fail-closed + action-aligned).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`GovernedFleetError::Narrowing`] if a membership role proposes a
+    /// runtime-scope widen at any hop (a member can never widen the team's warrant).
+    pub fn resolve_member_warrant(
+        &self,
+        member: &PartyId,
+        asset: &AssetRef,
+        action: CatalogAction,
+        owner_root: &WarrantSpec,
+    ) -> Result<Option<WarrantSpec>, GovernedFleetError> {
+        // Collect every path-candidate warrant, then select the most-permissive with a
+        // stable, content-addressed tie-break (order-independent — mirrors
+        // `kx_catalog`'s `most_permissive`).
+        let mut candidates: Vec<([u8; 32], WarrantSpec)> = Vec::new();
+        // DFS frame: (principal, role-chain member→here, accumulated cap, seen teams).
+        let mut stack: Vec<(PartyId, Vec<Role>, CatalogActionSet, BTreeSet<PartyId>)> = vec![(
+            member.clone(),
+            Vec::new(),
+            CatalogActionSet::all(),
+            BTreeSet::new(),
+        )];
+        let mut steps = 0usize;
+        while let Some((principal, roles, cap, seen)) = stack.pop() {
+            if roles.len() >= MAX_TEAM_MEMBERS_WALK {
+                continue; // depth bound → fail-closed (stop deepening this path)
+            }
+            for edge in self.members.member_edges(&principal) {
+                if steps >= MAX_RESOLUTION_STEPS {
+                    break; // DoS budget exhausted → fail-closed partial result
+                }
+                steps += 1;
+                let team = edge.team();
+                if seen.contains(team) {
+                    continue; // cycle guard
+                }
+                let new_cap = cap.narrow(edge.action_cap());
+                let mut new_roles = roles.clone();
+                new_roles.push(edge.role().clone());
+
+                // Candidate: does this team hold `action` on `asset`, and does the
+                // path cap still convey it?
+                if new_cap.contains(action) {
+                    if let Some(team_warrant) = self
+                        .grants
+                        .resolve_effective_warrant_for(team, asset, action, owner_root)?
+                    {
+                        // Narrow the team's warrant by the role chain, outermost edge
+                        // first (reverse of member→top), via the FROZEN seam.
+                        let mut w = team_warrant;
+                        for r in new_roles.iter().rev() {
+                            w = intersect(&w, r)?;
+                        }
+                        candidates.push((path_anchor(team, &new_roles), w));
+                    }
+                }
+
+                // Continue upward (this team may itself be a member of a fleet).
+                let mut seen2 = seen.clone();
+                seen2.insert(team.clone());
+                stack.push((team.clone(), new_roles, new_cap, seen2));
+            }
+            if steps >= MAX_RESOLUTION_STEPS {
+                break;
+            }
+        }
+        Ok(most_permissive(candidates))
+    }
+
+    /// Like [`GovernedFleet::resolve_member_warrant`] but fail-closed to a typed
+    /// [`GovernedFleetError::Unauthorized`] instead of `Ok(None)`.
+    ///
+    /// # Errors
+    ///
+    /// [`GovernedFleetError::Unauthorized`] if no active membership path conveys
+    /// `action` on `asset`; [`GovernedFleetError::Narrowing`] on a role widen.
+    pub fn require_member_warrant(
+        &self,
+        member: &PartyId,
+        asset: &AssetRef,
+        action: CatalogAction,
+        owner_root: &WarrantSpec,
+    ) -> Result<WarrantSpec, GovernedFleetError> {
+        match self.resolve_member_warrant(member, asset, action, owner_root)? {
+            Some(w) => Ok(w),
+            None => Err(GovernedFleetError::Unauthorized {
+                member: member.to_string(),
+                action,
+                asset: asset.to_string(),
+            }),
+        }
+    }
+
+    /// `true` iff `member` may perform `action` on `asset` through some active
+    /// (possibly nested) team membership — the team holds `action` AND the membership
+    /// path's cap conveys it. Pure boolean, fail-closed; does not require an
+    /// `owner_root` (no warrant is resolved).
+    #[must_use]
+    pub fn is_member_authorized(
+        &self,
+        member: &PartyId,
+        asset: &AssetRef,
+        action: CatalogAction,
+    ) -> bool {
+        let mut stack: Vec<(PartyId, CatalogActionSet, BTreeSet<PartyId>)> =
+            vec![(member.clone(), CatalogActionSet::all(), BTreeSet::new())];
+        let mut steps = 0usize;
+        while let Some((principal, cap, seen)) = stack.pop() {
+            if seen.len() >= MAX_TEAM_MEMBERS_WALK {
+                continue;
+            }
+            for edge in self.members.member_edges(&principal) {
+                if steps >= MAX_RESOLUTION_STEPS {
+                    return false;
+                }
+                steps += 1;
+                let team = edge.team();
+                if seen.contains(team) {
+                    continue;
+                }
+                let new_cap = cap.narrow(edge.action_cap());
+                if new_cap.contains(action) && self.grants.is_authorized(team, asset, action) {
+                    return true;
+                }
+                let mut seen2 = seen.clone();
+                seen2.insert(team.clone());
+                stack.push((team.clone(), new_cap, seen2));
+            }
+        }
+        false
+    }
+}
+
+/// A stable, content-addressed tie-break key for a membership path:
+/// `blake3(b"kx-fleet/path/v1" ‖ canonical_bincode((team, roles)))`. The `(team,
+/// roles)` tuple is encoded as ONE canonical bincode value so the team string is
+/// length-delimited from the role chain (no concatenation-boundary aliasing).
+fn path_anchor(team: &PartyId, roles: &[Role]) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(b"kx-fleet/path/v1");
+    // SAFETY (expect): PartyId is a string and a Role is strings + u32 + WarrantSpec
+    // (integer/bytes/bools, NO float) — canonical bincode encode is infallible
+    // (mirrors the fact content ids).
+    let body = bincode::serde::encode_to_vec((team, roles), canonical_config())
+        .expect("path anchor canonical encoding is infallible (no floats, no non-encodable types)");
+    h.update(&body);
+    *h.finalize().as_bytes()
+}
+
+/// Select the MOST-PERMISSIVE warrant among `candidates`, breaking ties / incomparable
+/// maxima by the lexicographically-smallest path anchor (stable, content-addressed).
+/// Never synthesizes a warrant — each candidate is already
+/// `intersect(team_warrant, …roles…) ⊆ team_warrant ⊆ owner_root`, so this can neither
+/// escalate past the team nor compose axes across paths. `None` when empty. Mirrors
+/// `kx_catalog`'s `most_permissive`.
+fn most_permissive(mut candidates: Vec<([u8; 32], WarrantSpec)>) -> Option<WarrantSpec> {
+    candidates.sort_by(|x, y| x.0.cmp(&y.0));
+    let mut best: Option<&([u8; 32], WarrantSpec)> = None;
+    for c in &candidates {
+        best = match best {
+            None => Some(c),
+            // `best ⊆ c` ⇒ c is at least as permissive ⇒ prefer c. Otherwise keep best
+            // (smaller anchor, since `candidates` is sorted).
+            Some(b) if warrant_within(&b.1, &c.1) => Some(c),
+            Some(b) => Some(b),
+        };
+    }
+    best.map(|(_, w)| w.clone())
+}
+
+/// `true` iff warrant `a` conveys NO MORE capability than `b` on every axis
+/// (`a ⊆ b`). A local mirror of `kx_catalog`'s `pub(crate) warrant_within` (which is
+/// not exported); the destructure of `a` is the drift guard — adding a `WarrantSpec`
+/// axis fails to compile here, forcing this comparison to be revisited rather than
+/// silently ignoring the new axis. (Promoting `warrant_within` to a public
+/// `kx_warrant` primitive is a parked refactor — a STRICT-seam change, its own PR.)
+fn warrant_within(a: &WarrantSpec, b: &WarrantSpec) -> bool {
+    let WarrantSpec {
+        mote_class,
+        nd_class,
+        fs_scope,
+        net_scope,
+        syscall_profile_ref,
+        tool_grants,
+        model_route,
+        resource_ceiling,
+        environment_ref,
+        executor_class,
+        secret_scope,
+        cost_ceiling,
+        tls_required,
+    } = a;
+
+    fs_scope.is_subset_of(&b.fs_scope)
+        && net_scope.is_subset_of(&b.net_scope)
+        && secret_scope.is_subset_of(&b.secret_scope)
+        && tool_grants.is_subset(&b.tool_grants)
+        && model_route.is_within(&b.model_route)
+        && resource_ceiling.cpu_milli <= b.resource_ceiling.cpu_milli
+        && resource_ceiling.mem_bytes <= b.resource_ceiling.mem_bytes
+        && resource_ceiling.wall_clock_ms <= b.resource_ceiling.wall_clock_ms
+        && resource_ceiling.fd_count <= b.resource_ceiling.fd_count
+        && resource_ceiling.disk_bytes <= b.resource_ceiling.disk_bytes
+        && cost_ceiling.micro_usd <= b.cost_ceiling.micro_usd
+        && (*tls_required || !b.tls_required)
+        && *mote_class == b.mote_class
+        && *nd_class == b.nd_class
+        && *syscall_profile_ref == b.syscall_profile_ref
+        && *environment_ref == b.environment_ref
+        && *executor_class == b.executor_class
+}

--- a/crates/kx-fleet/src/in_memory.rs
+++ b/crates/kx-fleet/src/in_memory.rs
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`InMemoryMembershipLedger`] — the reference [`MembershipLedger`] backend.
+//!
+//! An append-only `Vec<MembershipFact>` truth + derived `BTreeMap` indices under a
+//! single [`RwLock`]: O(log n) append + per-query lookup, sub-linear at scale,
+//! deterministic. Process-local + rebuildable — not for production durability (a
+//! persistent backend implements the same trait, D94). It proves
+//! [`MembershipLedger`] carries no storage-substrate assumption (the role
+//! `kx_catalog::InMemoryGrantLedger` plays for `kx_catalog::GrantLedger`).
+//!
+//! ## The fold ([`edges_of`])
+//!
+//! A member's active edges are computed by an iterative, depth-bounded,
+//! cycle-guarded fold: for each team the member is admitted to that is not
+//! disbanded (by the owner) and from which the member is not removed (by the owner
+//! or an admitter), every admit whose admitter has admit-authority (the owner, or an
+//! active `Delegate`-holding member — checked recursively, bounded by
+//! [`MAX_TEAM_MEMBERS_WALK`] + a `visiting` cycle-guard) becomes a [`TeamEdge`]. A
+//! pathologically deep admit-delegation chain caps WORK, never the stack (fail-closed
+//! beyond the bound). Mirrors `kx_catalog`'s `fold_chain`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::RwLock;
+
+use kx_catalog::{CatalogAction, CatalogActionSet, PartyId};
+
+use crate::error::MembershipLedgerError;
+use crate::ledger::{
+    MemberRole, MembershipLedger, MembershipOutcome, TeamEdge, MAX_TEAM_MEMBERS_WALK,
+};
+use crate::membership::{Admit, Disband, MembershipFact, MembershipId, Removal};
+use crate::team::Team;
+
+/// The append-only truth + derived indices.
+#[derive(Debug, Default)]
+struct Inner {
+    /// The append-only fact log (the truth; everything else is a derived index).
+    facts: Vec<MembershipFact>,
+    /// Content id → position in `facts` (idempotency + immutability tripwire).
+    by_id: BTreeMap<MembershipId, usize>,
+    /// Team principal → owner (genesis foundings).
+    owners: BTreeMap<PartyId, PartyId>,
+    /// Team principal → its canonical (first) founding id. Genesis is set once; a
+    /// re-founding by the same owner is idempotent (first display name wins).
+    foundings: BTreeMap<PartyId, MembershipId>,
+    /// (team, member) → the positions of `Admit` facts for that edge.
+    admits_by_team_member: BTreeMap<(PartyId, PartyId), Vec<usize>>,
+    /// Member → the teams it has been admitted to (for `member_edges` / `teams_of`).
+    teams_by_member: BTreeMap<PartyId, BTreeSet<PartyId>>,
+    /// Team → the members admitted to it (for `effective_members`).
+    members_by_team: BTreeMap<PartyId, BTreeSet<PartyId>>,
+    /// (team, member) → the `facts` positions of `Removal` facts for that edge. The
+    /// fold honors a removal at position `Pr` for an admit at `Pa` only when
+    /// `Pr > Pa` (time-ordered: a removal cancels only PRIOR admits, so a fresh
+    /// re-admit restores access) AND the remover is AUTHORIZED (owner or an admitter).
+    removed: BTreeMap<(PartyId, PartyId), Vec<usize>>,
+    /// Team → the parties that have recorded a disband. The fold filters to the owner;
+    /// an owner disband is TERMINAL (position-independent — re-founding cannot resurrect).
+    disbanded: BTreeMap<PartyId, BTreeSet<PartyId>>,
+}
+
+/// An ephemeral, process-local [`MembershipLedger`]. Multiple readers, one writer.
+///
+/// # Examples
+///
+/// ```
+/// use kx_fleet::{InMemoryMembershipLedger, MembershipLedger, Team, Admit};
+/// use kx_catalog::{CatalogAction, CatalogActionSet, PartyId};
+/// use kx_warrant::{Role, WarrantSpec};
+///
+/// let fleet = InMemoryMembershipLedger::new();
+/// let team = PartyId::new("team:sre@acme");
+/// let owner = PartyId::new("admin@acme");
+/// let alice = PartyId::new("alice@acme");
+///
+/// fleet.append_founding(Team::found(team.clone(), owner.clone(), "SRE")).unwrap();
+/// let role = Role { name: "oncall".into(), version: 1, spec: WarrantSpec::default(), description: String::new() };
+/// fleet.append_admit(Admit::new(
+///     team.clone(), alice.clone(), owner.clone(), role,
+///     CatalogActionSet::allow([CatalogAction::Use]),
+/// )).unwrap();
+///
+/// assert!(fleet.is_member(&alice, &team));
+/// assert!(!fleet.is_member(&PartyId::new("mallory"), &team));
+/// ```
+#[derive(Debug, Default)]
+pub struct InMemoryMembershipLedger {
+    inner: RwLock<Inner>,
+}
+
+impl InMemoryMembershipLedger {
+    /// Construct an empty ledger.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// `true` iff `team` has an AUTHORIZED disband: a disbander that is the team owner.
+fn disbanded_authorized(inner: &Inner, team: &PartyId) -> bool {
+    match inner.disbanded.get(team) {
+        None => false,
+        Some(disbanders) => {
+            let owner = inner.owners.get(team);
+            disbanders.iter().any(|d| Some(d) == owner)
+        }
+    }
+}
+
+/// `true` iff the admit at `admit_pos` for `(team, member)` is cancelled by a LATER
+/// AUTHORIZED removal — a remover that is the team owner OR a party who admitted
+/// `member` to `team` (you may undo what you granted). Append-only + time-ordered: a
+/// removal at position `Pr` cancels an admit at `Pa` only when `Pr > Pa`, so a fresh
+/// re-admit appended AFTER the removal restores access (revoke-by-new-fact,
+/// re-admit-by-new-fact — exactly the grant-ledger discipline).
+fn admit_is_removed(inner: &Inner, team: &PartyId, member: &PartyId, admit_pos: usize) -> bool {
+    let key = (team.clone(), member.clone());
+    let Some(removals) = inner.removed.get(&key) else {
+        return false;
+    };
+    let owner = inner.owners.get(team);
+    // The admitters of this edge (the parties who issued an admit for it).
+    let admitters: BTreeSet<&PartyId> = inner
+        .admits_by_team_member
+        .get(&key)
+        .into_iter()
+        .flatten()
+        .filter_map(|&pos| match &inner.facts[pos] {
+            MembershipFact::Admit(a) => Some(a.admitter()),
+            _ => None,
+        })
+        .collect();
+    removals.iter().any(|&rpos| {
+        rpos > admit_pos
+            && match &inner.facts[rpos] {
+                MembershipFact::Remove(r) => {
+                    Some(r.remover()) == owner || admitters.contains(r.remover())
+                }
+                _ => false,
+            }
+    })
+}
+
+/// `true` iff `admitter` has admit-authority on `team`: the team owner, OR an active
+/// member of `team` whose cap holds [`CatalogAction::Delegate`]. The recursive arm
+/// is depth-bounded + `visiting`-guarded (cycle / over-depth → fail-closed).
+fn admitter_authorized(
+    inner: &Inner,
+    team: &PartyId,
+    admitter: &PartyId,
+    depth: usize,
+    visiting: &BTreeSet<PartyId>,
+    member: &PartyId,
+) -> bool {
+    if Some(admitter) == inner.owners.get(team) {
+        return true;
+    }
+    // The admitter must be an active member of `team` with Delegate. Recurse, adding
+    // the member currently being resolved to the visiting set to break cycles.
+    let mut visiting2 = visiting.clone();
+    visiting2.insert(member.clone());
+    edges_of(inner, admitter, depth + 1, &visiting2)
+        .iter()
+        .any(|e| e.team() == team && e.action_cap().contains(CatalogAction::Delegate))
+}
+
+/// The authority-checked active membership edges `member` holds as a CHILD. Iterative
+/// over the member's teams; the only recursion is the bounded admit-authority check.
+fn edges_of(
+    inner: &Inner,
+    member: &PartyId,
+    depth: usize,
+    visiting: &BTreeSet<PartyId>,
+) -> Vec<TeamEdge> {
+    if depth > MAX_TEAM_MEMBERS_WALK || visiting.contains(member) {
+        return Vec::new(); // over-depth / cycle → fail-closed
+    }
+    let Some(teams) = inner.teams_by_member.get(member) else {
+        return Vec::new();
+    };
+    let mut out: Vec<TeamEdge> = Vec::new();
+    for team in teams {
+        if disbanded_authorized(inner, team) {
+            continue; // an owner disband is terminal for the whole team
+        }
+        let key = (team.clone(), member.clone());
+        let Some(positions) = inner.admits_by_team_member.get(&key) else {
+            continue;
+        };
+        for &pos in positions {
+            // Time-ordered removal: a later authorized removal cancels this admit,
+            // but a re-admit appended after the removal survives.
+            if admit_is_removed(inner, team, member, pos) {
+                continue;
+            }
+            let MembershipFact::Admit(admit) = &inner.facts[pos] else {
+                continue;
+            };
+            if !admitter_authorized(inner, team, admit.admitter(), depth, visiting, member) {
+                continue;
+            }
+            out.push(TeamEdge::new(
+                team.clone(),
+                admit.role().clone(),
+                admit.action_cap().clone(),
+                admit.admit_id(),
+            ));
+        }
+    }
+    // Deterministic order: (team, admit_id).
+    out.sort_by(|a, b| {
+        (a.team(), a.admit_id().as_bytes()).cmp(&(b.team(), b.admit_id().as_bytes()))
+    });
+    out
+}
+
+/// Merge a member's surviving edges in ONE team into the additive [`MemberRole`]
+/// view: cap = union, role = from the smallest `admit_id`. `edges` MUST be the
+/// member's edges already filtered to that team and be non-empty.
+fn merge_member_role(member: &PartyId, mut edges: Vec<TeamEdge>) -> MemberRole {
+    edges.sort_by(|a, b| a.admit_id().as_bytes().cmp(b.admit_id().as_bytes()));
+    let mut cap = CatalogActionSet::None;
+    for e in &edges {
+        cap = cap.union(e.action_cap());
+    }
+    let role = edges[0].role().clone();
+    MemberRole::new(member.clone(), role, cap)
+}
+
+impl MembershipLedger for InMemoryMembershipLedger {
+    fn append_founding(&self, team: Team) -> Result<MembershipOutcome, MembershipLedgerError> {
+        let fid = MembershipId::from_bytes(*team.team_id().as_bytes());
+        let team_principal = team.team().clone();
+        let owner = team.owner().clone();
+        let fact = MembershipFact::Found(Box::new(team));
+        let mut guard = self.inner.write().expect("poisoned lock");
+        // Genesis is set ONCE per team principal. A re-founding by the SAME owner is
+        // idempotent — the FIRST founding is canonical, and a differing display_name is
+        // ignored rather than appended as a second genesis fact. A DIFFERENT owner is an
+        // OwnerConflict. (Byte-identical re-foundings naturally collapse here too.)
+        if let Some(existing_owner) = guard.owners.get(&team_principal) {
+            if existing_owner != &owner {
+                return Err(MembershipLedgerError::OwnerConflict(format!(
+                    "team {team_principal} already founded with a different owner"
+                )));
+            }
+            let canonical = guard.foundings.get(&team_principal).copied().unwrap_or(fid);
+            return Ok(MembershipOutcome::AlreadyPresent(canonical));
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        guard.owners.insert(team_principal.clone(), owner);
+        guard.foundings.insert(team_principal, fid);
+        Ok(MembershipOutcome::Appended(fid))
+    }
+
+    fn append_admit(&self, admit: Admit) -> Result<MembershipOutcome, MembershipLedgerError> {
+        let fid = admit.admit_id();
+        let team = admit.team().clone();
+        let member = admit.member().clone();
+        let fact = MembershipFact::Admit(Box::new(admit));
+        let mut guard = self.inner.write().expect("poisoned lock");
+        if let Some(&pos) = guard.by_id.get(&fid) {
+            return if guard.facts[pos] == fact {
+                Ok(MembershipOutcome::AlreadyPresent(fid))
+            } else {
+                Err(MembershipLedgerError::ImmutabilityConflict(fid.to_hex()))
+            };
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        guard
+            .admits_by_team_member
+            .entry((team.clone(), member.clone()))
+            .or_default()
+            .push(pos);
+        guard
+            .teams_by_member
+            .entry(member.clone())
+            .or_default()
+            .insert(team.clone());
+        guard
+            .members_by_team
+            .entry(team)
+            .or_default()
+            .insert(member);
+        Ok(MembershipOutcome::Appended(fid))
+    }
+
+    fn append_remove(&self, removal: Removal) -> Result<MembershipOutcome, MembershipLedgerError> {
+        let fid = removal.removal_id();
+        let team = removal.team().clone();
+        let member = removal.member().clone();
+        let fact = MembershipFact::Remove(Box::new(removal));
+        let mut guard = self.inner.write().expect("poisoned lock");
+        if let Some(&pos) = guard.by_id.get(&fid) {
+            return if guard.facts[pos] == fact {
+                Ok(MembershipOutcome::AlreadyPresent(fid))
+            } else {
+                Err(MembershipLedgerError::ImmutabilityConflict(fid.to_hex()))
+            };
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        // Record the removal POSITION; the fold honors it only for admits at an
+        // earlier position (time-ordered — a later re-admit survives).
+        guard.removed.entry((team, member)).or_default().push(pos);
+        Ok(MembershipOutcome::Appended(fid))
+    }
+
+    fn append_disband(&self, disband: Disband) -> Result<MembershipOutcome, MembershipLedgerError> {
+        let fid = disband.disband_id();
+        let team = disband.team().clone();
+        let by = disband.by().clone();
+        let fact = MembershipFact::Disband(Box::new(disband));
+        let mut guard = self.inner.write().expect("poisoned lock");
+        if let Some(&pos) = guard.by_id.get(&fid) {
+            return if guard.facts[pos] == fact {
+                Ok(MembershipOutcome::AlreadyPresent(fid))
+            } else {
+                Err(MembershipLedgerError::ImmutabilityConflict(fid.to_hex()))
+            };
+        }
+        let pos = guard.facts.len();
+        guard.facts.push(fact);
+        guard.by_id.insert(fid, pos);
+        guard.disbanded.entry(team).or_default().insert(by);
+        Ok(MembershipOutcome::Appended(fid))
+    }
+
+    fn owner_of_team(&self, team: &PartyId) -> Option<PartyId> {
+        self.inner
+            .read()
+            .expect("poisoned lock")
+            .owners
+            .get(team)
+            .cloned()
+    }
+
+    fn member_edges(&self, member: &PartyId) -> Vec<TeamEdge> {
+        let guard = self.inner.read().expect("poisoned lock");
+        edges_of(&guard, member, 0, &BTreeSet::new())
+    }
+
+    fn effective_members(&self, team: &PartyId) -> Vec<MemberRole> {
+        let guard = self.inner.read().expect("poisoned lock");
+        let inner: &Inner = &guard;
+        let Some(members) = inner.members_by_team.get(team) else {
+            return Vec::new();
+        };
+        let mut out: Vec<MemberRole> = Vec::new();
+        for m in members {
+            let edges: Vec<TeamEdge> = edges_of(inner, m, 0, &BTreeSet::new())
+                .into_iter()
+                .filter(|e| e.team() == team)
+                .collect();
+            if !edges.is_empty() {
+                out.push(merge_member_role(m, edges));
+            }
+        }
+        out
+    }
+
+    fn list_facts<'a>(&'a self) -> Box<dyn Iterator<Item = MembershipFact> + 'a> {
+        let guard = self.inner.read().expect("poisoned lock");
+        // Snapshot under the read lock (append order), then release before iterating.
+        let facts: Vec<MembershipFact> = guard.facts.clone();
+        Box::new(facts.into_iter())
+    }
+
+    fn len(&self) -> usize {
+        self.inner.read().expect("poisoned lock").facts.len()
+    }
+}
+
+// Compile-time proof the ledger is shareable across threads (so `Arc<…>` works for
+// the concurrency tests + a multi-threaded gateway).
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<InMemoryMembershipLedger>();
+};

--- a/crates/kx-fleet/src/ledger.rs
+++ b/crates/kx-fleet/src/ledger.rs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The membership-ledger seam (M7, D112): the backend-agnostic [`MembershipLedger`]
+//! trait, its query result types ([`TeamEdge`] / [`MemberRole`]), and the
+//! [`MembershipOutcome`] append result. The in-memory reference backend is
+//! [`crate::InMemoryMembershipLedger`].
+//!
+//! Like `kx_catalog::GrantLedger`, this is a **separate truth**: authoritative for
+//! *who is in a team*, never depending on `kx-journal`. Authorization (admit
+//! authority, removal/disband honoring) is computed by the fail-closed fold, never
+//! trusted from a fact. The single core query is [`MembershipLedger::member_edges`]
+//! — the authority-checked active edges a principal holds as a *member* (child);
+//! everything else (membership tests, nested warrant resolution in
+//! [`crate::GovernedFleet`]) derives from it.
+
+use std::sync::Arc;
+
+use kx_catalog::{CatalogActionSet, PartyId};
+use kx_warrant::Role;
+
+use crate::error::MembershipLedgerError;
+use crate::membership::{Admit, Disband, MembershipFact, MembershipId, Removal};
+use crate::team::Team;
+
+/// The maximum membership-chain depth the fold / the nested resolution will walk. A
+/// chain (admit-delegation OR fleet-of-teams nesting) deeper than this fails closed
+/// (conveys nothing) rather than walking unbounded — a hard DoS / stack-growth
+/// bound. The walks are iterative + `seen`-guarded, so this caps WORK, never the
+/// call stack. Mirrors `kx_catalog::MAX_DELEGATION_DEPTH`.
+pub const MAX_TEAM_MEMBERS_WALK: usize = 64;
+
+/// One authority-checked active membership edge: `member ∈ team` under `role` +
+/// `action_cap`, established by the admit `admit_id`. The role + cap come from the
+/// SAME admit fact — there is no constructor pairing a cap from one admit with a
+/// role from another, so the action/warrant decoupling is unrepresentable (mirrors
+/// `kx_catalog::GrantWarrant`).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TeamEdge {
+    team: PartyId,
+    role: Role,
+    action_cap: CatalogActionSet,
+    admit_id: MembershipId,
+}
+
+impl TeamEdge {
+    /// Internal constructor — only the ledger fold builds these.
+    pub(crate) fn new(
+        team: PartyId,
+        role: Role,
+        action_cap: CatalogActionSet,
+        admit_id: MembershipId,
+    ) -> Self {
+        Self {
+            team,
+            role,
+            action_cap,
+            admit_id,
+        }
+    }
+
+    /// The team this edge admits the member into.
+    #[inline]
+    #[must_use]
+    pub fn team(&self) -> &PartyId {
+        &self.team
+    }
+
+    /// The runtime scope a `Use` along this edge narrows under.
+    #[inline]
+    #[must_use]
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+
+    /// The catalog actions this edge conveys.
+    #[inline]
+    #[must_use]
+    pub fn action_cap(&self) -> &CatalogActionSet {
+        &self.action_cap
+    }
+
+    /// The id of the admit fact establishing this edge (the stable, content-addressed
+    /// tie-break key).
+    #[inline]
+    #[must_use]
+    pub fn admit_id(&self) -> MembershipId {
+        self.admit_id
+    }
+}
+
+/// A member's merged effective role in a team — the additive view across all their
+/// parallel active admits: `action_cap` is the UNION of conveyed actions (the
+/// user-chosen additive model), and `role` is the one from the lexicographically
+/// smallest `admit_id` (a stable, content-addressed pick). For sound, action-aligned
+/// WARRANT resolution use [`crate::GovernedFleet`], which pairs each action with its
+/// own admit's role rather than this merged view.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MemberRole {
+    member: PartyId,
+    role: Role,
+    action_cap: CatalogActionSet,
+}
+
+impl MemberRole {
+    /// Internal constructor — only the ledger fold builds these.
+    pub(crate) fn new(member: PartyId, role: Role, action_cap: CatalogActionSet) -> Self {
+        Self {
+            member,
+            role,
+            action_cap,
+        }
+    }
+
+    /// The member.
+    #[inline]
+    #[must_use]
+    pub fn member(&self) -> &PartyId {
+        &self.member
+    }
+
+    /// The merged runtime scope (from the smallest `admit_id`).
+    #[inline]
+    #[must_use]
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+
+    /// The union of catalog actions conveyed across the member's parallel admits.
+    #[inline]
+    #[must_use]
+    pub fn action_cap(&self) -> &CatalogActionSet {
+        &self.action_cap
+    }
+}
+
+/// The outcome of an append: a fresh insert vs. an idempotent no-op (the fact was
+/// byte-identically present). Mirrors `kx_catalog::AppendOutcome`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MembershipOutcome {
+    /// First append of this fact.
+    Appended(MembershipId),
+    /// A byte-identical fact was already present — no-op (idempotent).
+    AlreadyPresent(MembershipId),
+}
+
+impl MembershipOutcome {
+    /// The membership id this outcome refers to.
+    #[inline]
+    #[must_use]
+    pub const fn membership_id(&self) -> MembershipId {
+        match self {
+            Self::Appended(f) | Self::AlreadyPresent(f) => *f,
+        }
+    }
+
+    /// `true` iff this was a fresh append (not an idempotent no-op).
+    #[inline]
+    #[must_use]
+    pub const fn is_appended(&self) -> bool {
+        matches!(self, Self::Appended(_))
+    }
+}
+
+/// The membership-ledger seam — backend-agnostic (in-memory now; durable / cloud
+/// behind the same trait, D94). A SEPARATE TRUTH from the journal; it never writes
+/// the journal. Authorization is computed by the fold, never trusted from a fact.
+pub trait MembershipLedger {
+    /// Found a team (genesis). Idempotent on an identical founding;
+    /// [`MembershipLedgerError::OwnerConflict`] if the team is already founded with
+    /// a different owner.
+    fn append_founding(&self, team: Team) -> Result<MembershipOutcome, MembershipLedgerError>;
+
+    /// Append an admission. Minimal + idempotent (authority is the fold's business).
+    fn append_admit(&self, admit: Admit) -> Result<MembershipOutcome, MembershipLedgerError>;
+
+    /// Append a removal (revoke by new fact). Minimal + idempotent; the remover's
+    /// authority is decided by the fold.
+    fn append_remove(&self, removal: Removal) -> Result<MembershipOutcome, MembershipLedgerError>;
+
+    /// Append a disband (revoke the team). Minimal + idempotent; the disbander's
+    /// authority is decided by the fold.
+    fn append_disband(&self, disband: Disband) -> Result<MembershipOutcome, MembershipLedgerError>;
+
+    /// The founded owner of `team`, if any.
+    fn owner_of_team(&self, team: &PartyId) -> Option<PartyId>;
+
+    /// The authority-checked active membership edges `member` holds as a CHILD — one
+    /// per surviving admit (admitter authorized, not removed, team not disbanded),
+    /// sorted by `(team, admit_id)` for determinism. The core query everything else
+    /// derives from; nested resolution in [`crate::GovernedFleet`] walks these edges
+    /// upward.
+    fn member_edges(&self, member: &PartyId) -> Vec<TeamEdge>;
+
+    /// The authority-checked active members of `team` (the additive merged view per
+    /// member), sorted by member id. The team-keyed dual of
+    /// [`MembershipLedger::member_edges`].
+    fn effective_members(&self, team: &PartyId) -> Vec<MemberRole>;
+
+    /// Enumerate every appended fact in append order.
+    fn list_facts<'a>(&'a self) -> Box<dyn Iterator<Item = MembershipFact> + 'a>;
+
+    /// Count of appended facts.
+    fn len(&self) -> usize;
+
+    /// `true` when no facts are appended.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// `true` iff `member` is a DIRECT active member of `team`. (Transitive
+    /// reachability through nested teams is resolved by [`crate::GovernedFleet`].)
+    fn is_member(&self, member: &PartyId, team: &PartyId) -> bool {
+        self.member_edges(member).iter().any(|e| e.team() == team)
+    }
+
+    /// The member's merged effective role in `team` (additive caps; role from the
+    /// smallest `admit_id`), or `None` if not an active member.
+    fn member_role(&self, member: &PartyId, team: &PartyId) -> Option<MemberRole> {
+        let mut edges: Vec<TeamEdge> = self
+            .member_edges(member)
+            .into_iter()
+            .filter(|e| e.team() == team)
+            .collect();
+        if edges.is_empty() {
+            return None;
+        }
+        // Deterministic: role from the smallest admit_id; cap = union of all.
+        edges.sort_by(|a, b| a.admit_id().as_bytes().cmp(b.admit_id().as_bytes()));
+        let mut cap = CatalogActionSet::None;
+        for e in &edges {
+            cap = cap.union(e.action_cap());
+        }
+        let role = edges[0].role().clone();
+        Some(MemberRole::new(member.clone(), role, cap))
+    }
+
+    /// The teams `member` is a DIRECT active member of, sorted + de-duplicated.
+    fn teams_of(&self, member: &PartyId) -> Vec<PartyId> {
+        let mut teams: Vec<PartyId> = self
+            .member_edges(member)
+            .into_iter()
+            .map(|e| e.team().clone())
+            .collect();
+        teams.sort();
+        teams.dedup();
+        teams
+    }
+}
+
+impl<L: MembershipLedger + ?Sized> MembershipLedger for Arc<L> {
+    fn append_founding(&self, team: Team) -> Result<MembershipOutcome, MembershipLedgerError> {
+        (**self).append_founding(team)
+    }
+    fn append_admit(&self, admit: Admit) -> Result<MembershipOutcome, MembershipLedgerError> {
+        (**self).append_admit(admit)
+    }
+    fn append_remove(&self, removal: Removal) -> Result<MembershipOutcome, MembershipLedgerError> {
+        (**self).append_remove(removal)
+    }
+    fn append_disband(&self, disband: Disband) -> Result<MembershipOutcome, MembershipLedgerError> {
+        (**self).append_disband(disband)
+    }
+    fn owner_of_team(&self, team: &PartyId) -> Option<PartyId> {
+        (**self).owner_of_team(team)
+    }
+    fn member_edges(&self, member: &PartyId) -> Vec<TeamEdge> {
+        (**self).member_edges(member)
+    }
+    fn effective_members(&self, team: &PartyId) -> Vec<MemberRole> {
+        (**self).effective_members(team)
+    }
+    fn list_facts<'a>(&'a self) -> Box<dyn Iterator<Item = MembershipFact> + 'a> {
+        (**self).list_facts()
+    }
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+    fn is_member(&self, member: &PartyId, team: &PartyId) -> bool {
+        (**self).is_member(member, team)
+    }
+    fn member_role(&self, member: &PartyId, team: &PartyId) -> Option<MemberRole> {
+        (**self).member_role(member, team)
+    }
+    fn teams_of(&self, member: &PartyId) -> Vec<PartyId> {
+        (**self).teams_of(member)
+    }
+}

--- a/crates/kx-fleet/src/lib.rs
+++ b/crates/kx-fleet/src/lib.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+//! # kx-fleet — teams / fleets (M7, D112)
+//!
+//! The kortecx **fleet** layer is "the unit users actually want": a **team** that
+//! owns and shares catalog recipes, and a **fleet** that nests teams. It is the
+//! last M7-era capability before the SDK (M8), and it is built on — never beside —
+//! the M7.2 governance machinery (`kx-catalog`).
+//!
+//! ## What a team IS (and is not)
+//!
+//! A team is just a group [`PartyId`]: "team `T` may `Use` recipe `A` under warrant
+//! `W`" is an ordinary [`kx_catalog::Grant`] on the existing [`GrantLedger`]. The
+//! ONLY new truth this crate adds is **who is in a team, under what role** — a set
+//! of append-only [`MembershipFact`]s ([`Team`] founding, [`Admit`], [`Removal`],
+//! [`Disband`]) folded by a fail-closed [`MembershipLedger`]. A team is **never a
+//! stateful in-memory actor** (adheres D109.1 / journal-as-truth): its membership
+//! is derived by folding immutable facts, exactly like [`GrantLedger`] derives
+//! authority by folding grants.
+//!
+//! ## "Journaled" = the D-LOCK-4 discipline (NOT a `kx-journal` dependency)
+//!
+//! Like [`GrantLedger`], the membership ledger is a **separate truth**: append-only,
+//! content-addressed, immutable, idempotent, **revoke-by-new-fact**. It is
+//! authoritative for *who is in a team*; the journal stays authoritative for *what
+//! runs did*. This crate therefore **never depends on `kx-journal`** — the
+//! dependency direction is the wall. A durable / cloud backend (D94) implements the
+//! same trait; the in-memory backend is rebuildable, not durable.
+//!
+//! ## Membership is one-level-up delegation (the core insight)
+//!
+//! A member's effective warrant on a recipe is
+//! `intersect(team_grant_warrant, member_role)` via the **FROZEN**
+//! [`kx_warrant::intersect`] seam — structurally `⊆` the team's grant, so a member
+//! can **never** exceed the team. With **nested fleet-of-teams** it generalizes to a
+//! bounded *multi-hop* narrow (member → team → fleet → …), one `intersect` per hop;
+//! the fold mirrors `kx-catalog`'s grant-chain fold over membership edges. The
+//! composition surface is [`GovernedFleet`] (a [`MembershipLedger`] + a
+//! [`GrantLedger`], composed without coupling either impl — Rule 1, exactly
+//! `kx_catalog::GovernedCatalog`).
+//!
+//! ## The SN-8 wall (load-bearing)
+//!
+//! Like `kx-catalog`, the fleet layer is **off the trust path**: it never gates
+//! selection, eviction, or promotion, and carries **no floats** (so even a future
+//! mistake could carry none onto a canonical hash). The wall is enforced by the
+//! dependency graph — the guarantee-path crates (`kx-scheduler` / `kx-executor` /
+//! `kx-projection` / `kx-inference` / `kx-mote` / `kx-journal`) do NOT depend on
+//! `kx-fleet`, and neither does `kx-catalog` (the edge is one-way,
+//! `kx-fleet → kx-catalog`). Asserted from the manifests in
+//! `tests/security_governance.rs`.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+// `.expect()` on canonical-bincode encode of a type WITHOUT floats and WITHOUT
+// non-encodable variants IS infallible (the membership/team content-id sites), and
+// `.expect("poisoned lock")` on the `InMemoryMembershipLedger` RwLock is the correct
+// propagate-on-catastrophe behavior. Both site classes carry an inline justification;
+// this crate-level allow suppresses the workspace `clippy::expect_used = "deny"`
+// policy for those documented uses (mirrors kx-catalog / kx-mote / kx-content).
+#![allow(clippy::expect_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+mod error;
+mod governed;
+mod in_memory;
+mod ledger;
+mod membership;
+mod team;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::{GovernedFleetError, MembershipLedgerError};
+pub use governed::GovernedFleet;
+pub use in_memory::InMemoryMembershipLedger;
+pub use ledger::{
+    MemberRole, MembershipLedger, MembershipOutcome, TeamEdge, MAX_TEAM_MEMBERS_WALK,
+};
+pub use membership::{Admit, Disband, MembershipFact, MembershipId, Removal};
+pub use team::{Team, TeamId, FLEET_SCHEMA_VERSION};
+
+// REUSE (never modify) the M7.2 governance + frozen narrowing seams — one import
+// surface for fleet callers. A team is a `PartyId`, a team grant is a `Grant` on the
+// `GrantLedger`, and a membership's runtime scope is a `Role` narrowed via `intersect`.
+pub use kx_catalog::{
+    AssetRef, CatalogAction, CatalogActionSet, GrantLedger, InMemoryGrantLedger, PartyId,
+};
+pub use kx_warrant::{intersect, NarrowingError, Role, WarrantSpec};

--- a/crates/kx-fleet/src/membership.rs
+++ b/crates/kx-fleet/src/membership.rs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The append-only membership fact vocabulary (M7, D112): [`Admit`], [`Removal`],
+//! [`Disband`], and the [`MembershipFact`] union — content-addressed,
+//! narrowing-only, revoke-by-new-fact.
+//!
+//! Each fact is content-addressed by [`MembershipId`] (`blake3(domain-tag ‖
+//! canonical_bincode(payload))`), exactly the [`kx_catalog::Grant`] /
+//! `Revocation` discipline. Two byte-identical facts share an id (idempotent
+//! append); a same-id-different-bytes append is a hash-collision tripwire refused
+//! loudly. Canonical bincode length-prefixes every string, so concatenating two
+//! [`PartyId`]s in a key can never alias (the catalog's manual
+//! fixed-length-before-variable rule is unnecessary here — the encoding is
+//! self-delimiting).
+//!
+//! An [`Admit`] carries BOTH a [`CatalogActionSet`] action-cap (which catalog
+//! actions the membership conveys) AND a [`Role`] runtime scope (the warrant a
+//! `Use` narrows under) — EXACTLY a delegated [`kx_catalog::Grant`], which carries
+//! both `actions` + `runtime_scope`. The cap + role are paired on the SAME fact, so
+//! action/warrant decoupling is unrepresentable.
+
+use kx_catalog::{canonical_config, CatalogActionSet, PartyId};
+use kx_warrant::Role;
+use serde::{Deserialize, Serialize};
+
+use crate::team::{Team, FLEET_SCHEMA_VERSION};
+
+/// A 32-byte BLAKE3 hash.
+type Hash32 = [u8; 32];
+
+/// Domain-tagged content id of a fleet fact payload:
+/// `blake3(domain_tag ‖ canonical_bincode(value))`. Pure + infallible (the payload
+/// types carry no floats and no non-encodable variants).
+fn content_id<T: Serialize>(domain_tag: &[u8], value: &T) -> Hash32 {
+    let mut h = blake3::Hasher::new();
+    h.update(domain_tag);
+    // SAFETY (expect): every fleet fact payload composes PartyId (string),
+    // CatalogActionSet (u8-discriminant enum set), kx_warrant::Role (strings + u32 +
+    // WarrantSpec — integer/bytes/bools only, NO float), and u16 — none of which
+    // carry a float or a non-encodable variant, so canonical bincode encode is
+    // infallible (mirrors `kx_catalog::Grant::grant_id`).
+    let body = bincode::serde::encode_to_vec(value, canonical_config())
+        .expect("fleet fact canonical encoding is infallible (no floats, no non-encodable types)");
+    h.update(&body);
+    *h.finalize().as_bytes()
+}
+
+/// The content-addressed identity of a [`MembershipFact`] — equal to the content id
+/// of the fact's payload. The per-payload domain tags (`team` / `admit` / `removal`
+/// / `disband`) keep cross-kind ids distinct. The ledger dedups + enforces
+/// immutability by this id.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct MembershipId(pub Hash32);
+
+impl MembershipId {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for MembershipId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MembershipId({})",
+            blake3::Hash::from_bytes(self.0).to_hex()
+        )
+    }
+}
+
+/// Admit `member` to `team` under a runtime `role` + catalog `action_cap`, issued by
+/// `admitter`.
+///
+/// Conveys membership ONLY when the fold finds `admitter` is the team owner OR an
+/// active member of `team` whose cap holds [`kx_catalog::CatalogAction::Delegate`]
+/// (an off-authority admit is recorded-but-inert, mirroring an off-owner root
+/// grant). Private fields; built via [`Admit::new`].
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Admit {
+    schema_version: u16,
+    team: PartyId,
+    member: PartyId,
+    admitter: PartyId,
+    role: Role,
+    action_cap: CatalogActionSet,
+}
+
+impl Admit {
+    /// Record an admission of `member` to `team` by `admitter`, under `role` +
+    /// `action_cap`. Authority is decided by the ledger fold, not here.
+    #[must_use]
+    pub fn new(
+        team: PartyId,
+        member: PartyId,
+        admitter: PartyId,
+        role: Role,
+        action_cap: CatalogActionSet,
+    ) -> Self {
+        Self {
+            schema_version: FLEET_SCHEMA_VERSION,
+            team,
+            member,
+            admitter,
+            role,
+            action_cap,
+        }
+    }
+
+    /// The team admitted into.
+    #[inline]
+    #[must_use]
+    pub fn team(&self) -> &PartyId {
+        &self.team
+    }
+
+    /// The admitted member (may itself be a team principal — nesting).
+    #[inline]
+    #[must_use]
+    pub fn member(&self) -> &PartyId {
+        &self.member
+    }
+
+    /// Who issued the admission.
+    #[inline]
+    #[must_use]
+    pub fn admitter(&self) -> &PartyId {
+        &self.admitter
+    }
+
+    /// The runtime scope a member's `Use` narrows under.
+    #[inline]
+    #[must_use]
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+
+    /// The catalog actions this membership conveys.
+    #[inline]
+    #[must_use]
+    pub fn action_cap(&self) -> &CatalogActionSet {
+        &self.action_cap
+    }
+
+    /// The canonical-encoding schema version this admit was built under.
+    #[inline]
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// The content-addressed identity:
+    /// `blake3(b"kx-fleet/admit/v1" ‖ canonical_bincode(self))`.
+    #[must_use]
+    pub fn admit_id(&self) -> MembershipId {
+        MembershipId(content_id(b"kx-fleet/admit/v1", self))
+    }
+}
+
+/// Remove `member` from `team` (revoke-by-new-fact, D-LOCK-4), recorded by
+/// `remover`.
+///
+/// A removal is **member-level + time-ordered**: it cancels every active admit of
+/// `(team, member)` that PRECEDES it in the log (so a fresh re-admit appended AFTER
+/// the removal restores access — revoke-by-new-fact, re-admit-by-new-fact, exactly
+/// the grant-ledger discipline). It is honored by the fold ONLY when `remover` is the
+/// team owner OR a party who admitted `member` to `team` (you may undo what you, or a
+/// fellow admitter, granted). An unauthorized remover's fact is recorded-but-inert.
+/// Removal only ever REDUCES access (it can never escalate), so the owner-or-admitter
+/// authority is intentionally permissive. Private fields; built via [`Removal::new`].
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Removal {
+    schema_version: u16,
+    team: PartyId,
+    member: PartyId,
+    remover: PartyId,
+}
+
+impl Removal {
+    /// Record an intent to remove `member` from `team` by `remover`. Authority is
+    /// decided by the ledger fold, not here.
+    #[must_use]
+    pub fn new(team: PartyId, member: PartyId, remover: PartyId) -> Self {
+        Self {
+            schema_version: FLEET_SCHEMA_VERSION,
+            team,
+            member,
+            remover,
+        }
+    }
+
+    /// The team the member is removed from.
+    #[inline]
+    #[must_use]
+    pub fn team(&self) -> &PartyId {
+        &self.team
+    }
+
+    /// The member being removed.
+    #[inline]
+    #[must_use]
+    pub fn member(&self) -> &PartyId {
+        &self.member
+    }
+
+    /// Who is attempting the removal.
+    #[inline]
+    #[must_use]
+    pub fn remover(&self) -> &PartyId {
+        &self.remover
+    }
+
+    /// The content-addressed identity:
+    /// `blake3(b"kx-fleet/removal/v1" ‖ canonical_bincode(self))`.
+    #[must_use]
+    pub fn removal_id(&self) -> MembershipId {
+        MembershipId(content_id(b"kx-fleet/removal/v1", self))
+    }
+}
+
+/// Disband `team` (revoke-the-team), recorded by `by`.
+///
+/// Honored by the fold ONLY when `by` is the team owner — every membership in a
+/// disbanded team goes inert. Private fields; built via [`Disband::new`].
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Disband {
+    schema_version: u16,
+    team: PartyId,
+    by: PartyId,
+}
+
+impl Disband {
+    /// Record an intent to disband `team` by `by`. Authority is decided by the
+    /// ledger fold, not here.
+    #[must_use]
+    pub fn new(team: PartyId, by: PartyId) -> Self {
+        Self {
+            schema_version: FLEET_SCHEMA_VERSION,
+            team,
+            by,
+        }
+    }
+
+    /// The team being disbanded.
+    #[inline]
+    #[must_use]
+    pub fn team(&self) -> &PartyId {
+        &self.team
+    }
+
+    /// Who is attempting the disband.
+    #[inline]
+    #[must_use]
+    pub fn by(&self) -> &PartyId {
+        &self.by
+    }
+
+    /// The content-addressed identity:
+    /// `blake3(b"kx-fleet/disband/v1" ‖ canonical_bincode(self))`.
+    #[must_use]
+    pub fn disband_id(&self) -> MembershipId {
+        MembershipId(content_id(b"kx-fleet/disband/v1", self))
+    }
+}
+
+/// An append-only membership fact. A closed enum — there is no untyped fact. The
+/// large variants are boxed so the enum stays pointer-sized.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum MembershipFact {
+    /// A team founding record (genesis: establishes the team owner).
+    Found(Box<Team>),
+    /// An admission of a member to a team under a role + cap.
+    Admit(Box<Admit>),
+    /// A removal of a member from a team (revoke by new fact, D-LOCK-4).
+    Remove(Box<Removal>),
+    /// A disband of a team (revoke the team).
+    Disband(Box<Disband>),
+}
+
+impl MembershipFact {
+    /// The content-addressed id of this fact (= the payload's content id). The
+    /// per-payload domain tags keep cross-kind ids distinct.
+    #[must_use]
+    pub fn fact_id(&self) -> MembershipId {
+        match self {
+            Self::Found(t) => MembershipId(*t.team_id().as_bytes()),
+            Self::Admit(a) => a.admit_id(),
+            Self::Remove(r) => r.removal_id(),
+            Self::Disband(d) => d.disband_id(),
+        }
+    }
+}

--- a/crates/kx-fleet/src/team.rs
+++ b/crates/kx-fleet/src/team.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The [`Team`] founding record + its content-addressed [`TeamId`] (M7, D112).
+//!
+//! A team is a group [`PartyId`]; [`Team`] is the genesis fact that establishes a
+//! team's **owner** (the only party whose admit conveys root authority). It is
+//! content-addressed by [`TeamId`] (`blake3(b"kx-fleet/team/v1" ‖
+//! canonical_bincode(team))`), exactly the [`kx_catalog::Grant`] / `AssetBinding`
+//! discipline — two byte-identical teams share an id. All fields are private; the
+//! only constructor is [`Team::found`], so `schema_version` is never caller-set.
+
+use kx_catalog::{canonical_config, PartyId};
+use serde::{Deserialize, Serialize};
+
+/// A 32-byte BLAKE3 hash — the fleet layer's identity substrate.
+type Hash32 = [u8; 32];
+
+/// Canonical-encoding schema version of a [`Team`] / membership fact. Bumped on ANY
+/// change to the canonical bytes (the version is a struct field, so it folds into a
+/// fact's content id). Mirrors [`kx_catalog::GRANT_SCHEMA_VERSION`].
+pub const FLEET_SCHEMA_VERSION: u16 = 1;
+
+/// The content-addressed identity of a [`Team`]:
+/// `blake3(b"kx-fleet/team/v1" ‖ canonical_bincode(team))`. The domain tag prevents
+/// cross-type preimage aliasing.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TeamId(pub Hash32);
+
+impl TeamId {
+    /// Construct from raw 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: Hash32) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the underlying 32 bytes.
+    #[inline]
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Hash32 {
+        &self.0
+    }
+
+    /// Lowercase 64-char hex.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        blake3::Hash::from_bytes(self.0).to_hex().to_string()
+    }
+}
+
+impl std::fmt::Debug for TeamId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TeamId({})", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+impl std::fmt::Display for TeamId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", blake3::Hash::from_bytes(self.0).to_hex())
+    }
+}
+
+/// A team founding record — the genesis fact binding a team's principal to its
+/// owner.
+///
+/// All fields are private; the only constructor is [`Team::found`], so
+/// `schema_version` is never caller-set. The `team` principal is the group
+/// [`PartyId`] grants are issued to (a team that owns/uses a recipe); `owner` is the
+/// founding admin whose admit conveys root authority (the fold checks this — an
+/// off-owner admit is recorded-but-inert).
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Team {
+    /// Canonical-encoding schema version (constructor-set, never caller-set).
+    schema_version: u16,
+    /// The team's own group principal (the grantee of a team grant).
+    principal: PartyId,
+    /// The founding admin — the only party whose ROOT admit conveys authority.
+    owner: PartyId,
+    /// Free-form human handle. NEVER parsed for enforcement.
+    display_name: String,
+}
+
+impl Team {
+    /// Found a team named by the group principal `team`, owned by `owner`.
+    #[must_use]
+    pub fn found(principal: PartyId, owner: PartyId, display_name: impl Into<String>) -> Self {
+        Self {
+            schema_version: FLEET_SCHEMA_VERSION,
+            principal,
+            owner,
+            display_name: display_name.into(),
+        }
+    }
+
+    /// The team's group principal.
+    #[inline]
+    #[must_use]
+    pub fn team(&self) -> &PartyId {
+        &self.principal
+    }
+
+    /// The founding owner.
+    #[inline]
+    #[must_use]
+    pub fn owner(&self) -> &PartyId {
+        &self.owner
+    }
+
+    /// The human display name (advisory; never parsed).
+    #[inline]
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    /// The canonical-encoding schema version this team was built under.
+    #[inline]
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// The content-addressed identity: `blake3(b"kx-fleet/team/v1" ‖
+    /// canonical_bincode(self))`. Pure; two byte-identical teams share an id.
+    #[must_use]
+    pub fn team_id(&self) -> TeamId {
+        let mut h = blake3::Hasher::new();
+        h.update(b"kx-fleet/team/v1");
+        // SAFETY (expect): a Team is PartyId (string) + PartyId (string) + String +
+        // u16 — no floats, no non-encodable variant; canonical bincode encoding is
+        // infallible (mirrors `kx_catalog::Grant::grant_id`).
+        let body = bincode::serde::encode_to_vec(self, canonical_config())
+            .expect("Team canonical encoding is infallible (no floats, no non-encodable types)");
+        h.update(&body);
+        TeamId(*h.finalize().as_bytes())
+    }
+}

--- a/crates/kx-fleet/src/tests.rs
+++ b/crates/kx-fleet/src/tests.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+//! In-crate smoke tests: identity stability, schema-version honesty, and the
+//! content-id no-aliasing property. The end-to-end governance + scale behavior lives
+//! in `tests/*.rs` (separate-crate integration tests).
+
+use kx_catalog::{CatalogAction, CatalogActionSet, PartyId};
+use kx_warrant::{Role, WarrantSpec};
+
+use crate::membership::{Admit, Removal};
+use crate::team::{Team, FLEET_SCHEMA_VERSION};
+
+fn role(name: &str) -> Role {
+    Role {
+        name: name.into(),
+        version: 1,
+        spec: WarrantSpec::default(),
+        description: String::new(),
+    }
+}
+
+#[test]
+fn team_id_is_stable_and_content_addressed() {
+    let a = Team::found(PartyId::new("team:x"), PartyId::new("owner"), "X");
+    let b = Team::found(PartyId::new("team:x"), PartyId::new("owner"), "X");
+    let c = Team::found(PartyId::new("team:x"), PartyId::new("owner"), "Y");
+    assert_eq!(a.team_id(), b.team_id(), "byte-identical teams share an id");
+    assert_ne!(
+        a.team_id(),
+        c.team_id(),
+        "a display-name change is a new id"
+    );
+}
+
+#[test]
+fn schema_version_is_constructor_set() {
+    let t = Team::found(PartyId::new("t"), PartyId::new("o"), "d");
+    assert_eq!(t.schema_version(), FLEET_SCHEMA_VERSION);
+    let a = Admit::new(
+        PartyId::new("t"),
+        PartyId::new("m"),
+        PartyId::new("o"),
+        role("r"),
+        CatalogActionSet::allow([CatalogAction::Use]),
+    );
+    assert_eq!(a.schema_version(), FLEET_SCHEMA_VERSION);
+}
+
+#[test]
+fn admit_id_folds_role_and_cap() {
+    // Two admits differing ONLY in role are distinct facts (so a re-admit under a new
+    // role is recorded, not silently deduped).
+    let mk = |r: Role, cap: CatalogActionSet| {
+        Admit::new(
+            PartyId::new("t"),
+            PartyId::new("m"),
+            PartyId::new("o"),
+            r,
+            cap,
+        )
+        .admit_id()
+    };
+    let cap = CatalogActionSet::allow([CatalogAction::Use]);
+    assert_eq!(mk(role("r"), cap.clone()), mk(role("r"), cap.clone()));
+    assert_ne!(mk(role("r"), cap.clone()), mk(role("r2"), cap.clone()));
+    assert_ne!(
+        mk(role("r"), cap),
+        mk(role("r"), CatalogActionSet::allow([CatalogAction::Read]))
+    );
+}
+
+#[test]
+fn content_ids_do_not_alias_across_party_concatenation() {
+    // ("ab","c") vs ("a","bc") must not collide — canonical bincode length-prefixes
+    // each string, so the boundary is unambiguous (no length-extension aliasing).
+    let x = Removal::new(PartyId::new("ab"), PartyId::new("c"), PartyId::new("o")).removal_id();
+    let y = Removal::new(PartyId::new("a"), PartyId::new("bc"), PartyId::new("o")).removal_id();
+    assert_ne!(x, y);
+}
+
+#[test]
+fn removal_and_admit_ids_are_domain_separated() {
+    // Same parties, different fact kinds ⇒ different ids (per-variant domain tags).
+    let admit = Admit::new(
+        PartyId::new("t"),
+        PartyId::new("m"),
+        PartyId::new("o"),
+        role("r"),
+        CatalogActionSet::all(),
+    )
+    .admit_id();
+    let removal =
+        Removal::new(PartyId::new("t"), PartyId::new("m"), PartyId::new("o")).removal_id();
+    assert_ne!(admit, removal);
+}

--- a/crates/kx-fleet/tests/proptest_membership.rs
+++ b/crates/kx-fleet/tests/proptest_membership.rs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Property tests for the membership ledger + the composed fleet resolution (M7,
+//! D112): idempotency, content-id distinctness, fold determinism + order-independence,
+//! the **no-widen** safety invariant (a member never exceeds the team), revoke /
+//! disband honoring + authority, and the additive-cap model. Mirrors
+//! `kx-catalog/tests/proptest_grants.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantLedger,
+    InMemoryGrantLedger, PartyId,
+};
+use kx_fleet::{
+    Admit, Disband, GovernedFleet, InMemoryMembershipLedger, MembershipLedger, Removal, Team,
+};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
+use proptest::prelude::*;
+
+// ---- fixtures ---------------------------------------------------------------
+
+fn asset() -> AssetRef {
+    AssetRef::Path(AssetPath::new("acme", "runbooks", "restart").unwrap())
+}
+
+/// A FIXED positive model route shared by every warrant — `kx_warrant::intersect`
+/// rejects a zero model route, and a constant route makes its per-axis `min()` a
+/// no-op so the narrowing chain isolates `cpu_milli`.
+fn model_route() -> ModelRoute {
+    ModelRoute {
+        model_id: ModelId("m".into()),
+        max_input_tokens: 1_000,
+        max_output_tokens: 1_000,
+        max_calls: 1_000,
+    }
+}
+
+/// A warrant whose ONLY varying quantitative axis is `cpu_milli` (so a narrowing chain
+/// is exactly a `min()` over `cpu_milli` — qualitative axes stay default-empty, so
+/// `intersect` never errors on a widen).
+fn warrant_cpu(cpu: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: model_route(),
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: cpu,
+            mem_bytes: 0,
+            wall_clock_ms: 0,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        ..Default::default()
+    }
+}
+
+fn role_cpu(name: &str, cpu: u32) -> Role {
+    Role {
+        name: name.into(),
+        version: 1,
+        spec: warrant_cpu(cpu),
+        description: String::new(),
+    }
+}
+
+fn role(name: &str) -> Role {
+    role_cpu(name, 0)
+}
+
+// ---- properties -------------------------------------------------------------
+
+proptest! {
+    /// Appending the same admit any number of times stores exactly one fact.
+    #[test]
+    fn admit_append_is_idempotent(reps in 1usize..6) {
+        let fleet = InMemoryMembershipLedger::new();
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+        let admit = Admit::new(team.clone(), PartyId::new("m"), owner, role("r"),
+            CatalogActionSet::allow([CatalogAction::Use]));
+        prop_assert!(fleet.append_admit(admit.clone()).unwrap().is_appended());
+        for _ in 0..reps {
+            prop_assert!(!fleet.append_admit(admit.clone()).unwrap().is_appended());
+        }
+        // founding + one admit.
+        prop_assert_eq!(fleet.len(), 2);
+    }
+
+    /// Distinct admits (differing in any field) get distinct content ids.
+    #[test]
+    fn distinct_admits_have_distinct_ids(a in 0u8..4, b in 0u8..4) {
+        prop_assume!(a != b);
+        let mk = |i: u8| Admit::new(
+            PartyId::new("t"), PartyId::new(format!("m{i}")), PartyId::new("o"),
+            role("r"), CatalogActionSet::all()).admit_id();
+        prop_assert_ne!(mk(a), mk(b));
+    }
+
+    /// The fold is order-independent: appending a member-set in any order yields the
+    /// same effective membership.
+    #[test]
+    fn effective_members_are_order_independent(n in 1usize..8) {
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        let members: Vec<PartyId> = (0..n).map(|i| PartyId::new(format!("m{i}"))).collect();
+
+        let build = |order: Box<dyn Iterator<Item = usize>>| {
+            let fleet = InMemoryMembershipLedger::new();
+            fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+            for i in order {
+                fleet.append_admit(Admit::new(team.clone(), members[i].clone(), owner.clone(),
+                    role("r"), CatalogActionSet::allow([CatalogAction::Use]))).unwrap();
+            }
+            fleet.effective_members(&team)
+        };
+        let forward = build(Box::new(0..n));
+        let reverse = build(Box::new((0..n).rev()));
+        prop_assert_eq!(forward.len(), n);
+        // Effective members are sorted by member id ⇒ identical regardless of order.
+        prop_assert!(forward.iter().map(|m| m.member().clone())
+            .eq(reverse.iter().map(|m| m.member().clone())));
+    }
+
+    /// THE core safety invariant: a member's resolved warrant never exceeds the team
+    /// grant. With single-axis (`cpu_milli`) warrants the resolved value is EXACTLY
+    /// the chain `min` — and therefore `≤` the team's own effective warrant.
+    #[test]
+    fn member_warrant_never_exceeds_team(c0 in 0u32..50_000, c1 in 0u32..50_000, c2 in 0u32..50_000) {
+        let owner = PartyId::new("asset-owner");
+        let team = PartyId::new("team:eng");
+        let member = PartyId::new("alice");
+        let owner_root = warrant_cpu(c0);
+
+        let grants = InMemoryGrantLedger::new();
+        grants.append_binding(AssetBinding::new(asset(), owner.clone())).unwrap();
+        grants.append_grant(Grant::root(asset(), owner.clone(), team.clone(),
+            CatalogActionSet::allow([CatalogAction::Use]), role_cpu("team", c1))).unwrap();
+
+        let fleet = InMemoryMembershipLedger::new();
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "Eng")).unwrap();
+        fleet.append_admit(Admit::new(team.clone(), member.clone(), owner.clone(),
+            role_cpu("member", c2), CatalogActionSet::allow([CatalogAction::Use]))).unwrap();
+
+        let team_eff = grants
+            .resolve_effective_warrant_for(&team, &asset(), CatalogAction::Use, &owner_root)
+            .unwrap().unwrap();
+        let gov = GovernedFleet::new(fleet, grants);
+        let resolved = gov
+            .resolve_member_warrant(&member, &asset(), CatalogAction::Use, &owner_root)
+            .unwrap().unwrap();
+
+        prop_assert_eq!(resolved.resource_ceiling.cpu_milli, c0.min(c1).min(c2));
+        prop_assert!(resolved.resource_ceiling.cpu_milli <= team_eff.resource_ceiling.cpu_milli);
+    }
+
+    /// An authorized removal (by the owner) drops the member; the admit fact survives.
+    #[test]
+    fn authorized_remove_drops_member(_seed in 0u8..4) {
+        let fleet = InMemoryMembershipLedger::new();
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        let member = PartyId::new("m");
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+        fleet.append_admit(Admit::new(team.clone(), member.clone(), owner.clone(),
+            role("r"), CatalogActionSet::allow([CatalogAction::Use]))).unwrap();
+        prop_assert!(fleet.is_member(&member, &team));
+        fleet.append_remove(Removal::new(team.clone(), member.clone(), owner.clone())).unwrap();
+        prop_assert!(!fleet.is_member(&member, &team));
+        // The admit fact is retained (append-only) — founding + admit + removal.
+        prop_assert_eq!(fleet.len(), 3);
+    }
+
+    /// A stranger's removal is recorded-but-inert (the member stays).
+    #[test]
+    fn stranger_remove_is_inert(_seed in 0u8..4) {
+        let fleet = InMemoryMembershipLedger::new();
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        let member = PartyId::new("m");
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+        fleet.append_admit(Admit::new(team.clone(), member.clone(), owner.clone(),
+            role("r"), CatalogActionSet::allow([CatalogAction::Use]))).unwrap();
+        fleet.append_remove(Removal::new(team.clone(), member.clone(), PartyId::new("mallory"))).unwrap();
+        prop_assert!(fleet.is_member(&member, &team));
+    }
+
+    /// An owner disband makes every member inert (cascade).
+    #[test]
+    fn owner_disband_cascades(n in 1usize..6) {
+        let fleet = InMemoryMembershipLedger::new();
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+        for i in 0..n {
+            fleet.append_admit(Admit::new(team.clone(), PartyId::new(format!("m{i}")),
+                owner.clone(), role("r"), CatalogActionSet::all())).unwrap();
+        }
+        prop_assert_eq!(fleet.effective_members(&team).len(), n);
+        fleet.append_disband(Disband::new(team.clone(), owner.clone())).unwrap();
+        prop_assert!(fleet.effective_members(&team).is_empty());
+    }
+
+    /// An admit by a non-owner without Delegate conveys nothing.
+    #[test]
+    fn non_admin_admit_is_inert(_seed in 0u8..4) {
+        let fleet = InMemoryMembershipLedger::new();
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        // Dave is a plain member (cap {Use}, no Delegate).
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+        fleet.append_admit(Admit::new(team.clone(), PartyId::new("dave"), owner.clone(),
+            role("r"), CatalogActionSet::allow([CatalogAction::Use]))).unwrap();
+        // Dave admits Eve — inert (Dave lacks Delegate).
+        fleet.append_admit(Admit::new(team.clone(), PartyId::new("eve"), PartyId::new("dave"),
+            role("r"), CatalogActionSet::all())).unwrap();
+        prop_assert!(!fleet.is_member(&PartyId::new("eve"), &team));
+    }
+
+    /// Additive caps: multiple parallel admits of one member union their action caps.
+    #[test]
+    fn parallel_admits_union_caps(_seed in 0u8..4) {
+        let fleet = InMemoryMembershipLedger::new();
+        let team = PartyId::new("t");
+        let owner = PartyId::new("o");
+        let member = PartyId::new("grace");
+        fleet.append_founding(Team::found(team.clone(), owner.clone(), "T")).unwrap();
+        // Two admits under different roles + disjoint caps.
+        fleet.append_admit(Admit::new(team.clone(), member.clone(), owner.clone(),
+            role("a"), CatalogActionSet::allow([CatalogAction::Use]))).unwrap();
+        fleet.append_admit(Admit::new(team.clone(), member.clone(), owner.clone(),
+            role("b"), CatalogActionSet::allow([CatalogAction::Read]))).unwrap();
+        let mr = fleet.member_role(&member, &team).unwrap();
+        prop_assert!(mr.action_cap().contains(CatalogAction::Use));
+        prop_assert!(mr.action_cap().contains(CatalogAction::Read));
+    }
+}

--- a/crates/kx-fleet/tests/scale.rs
+++ b/crates/kx-fleet/tests/scale.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scale-smoke: the membership ledger + the composed fleet resolution stay
+//! sub-linear / depth-bounded at scale (M7, D112).
+//!
+//! `#[ignore]`d — run in `--release` via the `scale-smoke` recipe. Append + membership
+//! queries are `BTreeMap` insert/get keyed by `(team, member)`, so both are O(log n);
+//! a nested resolution walks at most `MAX_TEAM_MEMBERS_WALK` hops, so its cost is
+//! bounded by the depth cap, NOT by how deep the fleet nests. Mirrors
+//! `kx-catalog/tests/scale.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Instant;
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantLedger,
+    InMemoryGrantLedger, PartyId,
+};
+use kx_fleet::{
+    Admit, GovernedFleet, InMemoryMembershipLedger, MembershipLedger, Team, MAX_TEAM_MEMBERS_WALK,
+};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, WarrantSpec};
+
+const SIZES: &[usize] = &[1_000, 5_000, 10_000, 25_000];
+
+fn warrant_calls(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1_000,
+            max_output_tokens: 1_000,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 1_000,
+            fd_count: 16,
+            disk_bytes: 1 << 20,
+        },
+        ..Default::default()
+    }
+}
+
+fn role_calls(max_calls: u32) -> Role {
+    Role {
+        name: "r".into(),
+        version: 1,
+        spec: warrant_calls(max_calls),
+        description: String::new(),
+    }
+}
+
+fn assert_sublinear(label: &str, series: &[(usize, f64)]) {
+    let first = series.first().unwrap().1;
+    let last = series.last().unwrap().1;
+    assert!(
+        last <= first * 4.0,
+        "{label} must stay sub-linear (n=1k {first:.1}ns vs n=25k {last:.1}ns)"
+    );
+}
+
+/// Membership append + per-member query (`is_member` / `member_edges`) stay O(log n)
+/// in the number of distinct (team, member) edges — the `BTreeMap` indices keep
+/// governance sub-linear at fleet scale.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn membership_append_and_query_stay_sublinear() {
+    let owner = PartyId::new("owner");
+    let mut admit_ns: Vec<(usize, f64)> = Vec::new();
+    let mut is_member_ns: Vec<(usize, f64)> = Vec::new();
+    let mut edges_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let fleet = InMemoryMembershipLedger::new();
+        // n distinct teams, each with one member (a distinct (team, member) edge).
+        let teams: Vec<PartyId> = (0..n).map(|i| PartyId::new(format!("t{i}"))).collect();
+        let members: Vec<PartyId> = (0..n).map(|i| PartyId::new(format!("m{i}"))).collect();
+        for t in &teams {
+            fleet
+                .append_founding(Team::found(t.clone(), owner.clone(), "T"))
+                .unwrap();
+        }
+
+        let start = Instant::now();
+        for (t, m) in teams.iter().zip(&members) {
+            fleet
+                .append_admit(Admit::new(
+                    t.clone(),
+                    m.clone(),
+                    owner.clone(),
+                    role_calls(10),
+                    CatalogActionSet::allow([CatalogAction::Use]),
+                ))
+                .unwrap();
+        }
+        let admit_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for (t, m) in teams.iter().zip(&members) {
+            assert!(fleet.is_member(m, t));
+        }
+        let is_member_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for m in &members {
+            assert_eq!(fleet.member_edges(m).len(), 1);
+        }
+        let edges_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = |d: std::time::Duration| d.as_nanos() as f64 / n as f64;
+        println!(
+            "fleet-membership: n={n} admit_per_ns={:.1} is_member_per_ns={:.1} edges_per_ns={:.1}",
+            per(admit_elapsed),
+            per(is_member_elapsed),
+            per(edges_elapsed)
+        );
+        admit_ns.push((n, per(admit_elapsed)));
+        is_member_ns.push((n, per(is_member_elapsed)));
+        edges_ns.push((n, per(edges_elapsed)));
+    }
+
+    assert_sublinear("membership-admit", &admit_ns);
+    assert_sublinear("membership-is-member", &is_member_ns);
+    assert_sublinear("membership-edges", &edges_ns);
+}
+
+/// The full composed resolution (`resolve_member_warrant`: membership fold + grant
+/// fold + intersect) stays flat per-op as the fleet grows — n distinct
+/// (team, member, asset) triples, each a one-hop resolution.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn governed_resolve_member_warrant_stays_sublinear() {
+    let admin = PartyId::new("admin");
+    let owner_root = warrant_calls(100);
+    let mut resolve_ns: Vec<(usize, f64)> = Vec::new();
+    let mut authz_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &n in SIZES {
+        let grants = InMemoryGrantLedger::new();
+        let fleet = InMemoryMembershipLedger::new();
+        let teams: Vec<PartyId> = (0..n).map(|i| PartyId::new(format!("t{i}"))).collect();
+        let members: Vec<PartyId> = (0..n).map(|i| PartyId::new(format!("m{i}"))).collect();
+        let assets: Vec<AssetRef> = (0..n)
+            .map(|i| AssetRef::Path(AssetPath::new("ns", "c", format!("a{i}")).unwrap()))
+            .collect();
+        for ((t, m), a) in teams.iter().zip(&members).zip(&assets) {
+            grants
+                .append_binding(AssetBinding::new(a.clone(), admin.clone()))
+                .unwrap();
+            grants
+                .append_grant(Grant::root(
+                    a.clone(),
+                    admin.clone(),
+                    t.clone(),
+                    CatalogActionSet::allow([CatalogAction::Use]),
+                    role_calls(50),
+                ))
+                .unwrap();
+            fleet
+                .append_founding(Team::found(t.clone(), admin.clone(), "T"))
+                .unwrap();
+            fleet
+                .append_admit(Admit::new(
+                    t.clone(),
+                    m.clone(),
+                    admin.clone(),
+                    role_calls(25),
+                    CatalogActionSet::allow([CatalogAction::Use]),
+                ))
+                .unwrap();
+        }
+        let gov = GovernedFleet::new(fleet, grants);
+
+        let start = Instant::now();
+        for (m, a) in members.iter().zip(&assets) {
+            assert!(gov
+                .resolve_member_warrant(m, a, CatalogAction::Use, &owner_root)
+                .unwrap()
+                .is_some());
+        }
+        let resolve_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        for (m, a) in members.iter().zip(&assets) {
+            assert!(gov.is_member_authorized(m, a, CatalogAction::Use));
+        }
+        let authz_elapsed = start.elapsed();
+
+        #[allow(clippy::cast_precision_loss)]
+        let per = |d: std::time::Duration| d.as_nanos() as f64 / n as f64;
+        println!(
+            "fleet-resolve: n={n} resolve_per_ns={:.1} authz_per_ns={:.1}",
+            per(resolve_elapsed),
+            per(authz_elapsed)
+        );
+        resolve_ns.push((n, per(resolve_elapsed)));
+        authz_ns.push((n, per(authz_elapsed)));
+    }
+
+    assert_sublinear("fleet-resolve-warrant", &resolve_ns);
+    assert_sublinear("fleet-authorize", &authz_ns);
+}
+
+/// A nested resolution is BOUNDED by `MAX_TEAM_MEMBERS_WALK` (64), independent of how
+/// deeply the fleet actually nests — the `DoS` / stack guard. A 50k-deep nesting chain
+/// queries no slower than a 1k-deep one (both walk at most 64 hops, then fail closed),
+/// so cost stays flat as depth grows. Mirrors `kx-catalog`'s `deep_chain_query_is_bounded`.
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn deep_nested_chain_query_is_bounded() {
+    const DEPTHS: &[usize] = &[1_000, 10_000, 50_000];
+    const ITERS: usize = 2_000;
+    let admin = PartyId::new("admin");
+    let mut query_ns: Vec<(usize, f64)> = Vec::new();
+
+    for &depth in DEPTHS {
+        let grants = InMemoryGrantLedger::new();
+        let fleet = InMemoryMembershipLedger::new();
+        let asset = AssetRef::Path(AssetPath::new("ns", "c", "deep").unwrap());
+        let team = |i: usize| PartyId::new(format!("t{i}"));
+        for i in 0..=depth {
+            fleet
+                .append_founding(Team::found(team(i), admin.clone(), "T"))
+                .unwrap();
+        }
+        // t{i} ∈ t{i+1}; the leaf member is in t0; the TOP team holds the grant.
+        for i in 0..depth {
+            fleet
+                .append_admit(Admit::new(
+                    team(i + 1),
+                    team(i),
+                    admin.clone(),
+                    role_calls(50),
+                    CatalogActionSet::all(),
+                ))
+                .unwrap();
+        }
+        let member = PartyId::new("leaf");
+        fleet
+            .append_admit(Admit::new(
+                team(0),
+                member.clone(),
+                admin.clone(),
+                role_calls(50),
+                CatalogActionSet::all(),
+            ))
+            .unwrap();
+        grants
+            .append_binding(AssetBinding::new(asset.clone(), admin.clone()))
+            .unwrap();
+        grants
+            .append_grant(Grant::root(
+                asset.clone(),
+                admin.clone(),
+                team(depth),
+                CatalogActionSet::allow([CatalogAction::Use]),
+                role_calls(50),
+            ))
+            .unwrap();
+        let gov = GovernedFleet::new(fleet, grants);
+
+        // The grant is beyond MAX hops ⇒ the walk caps at MAX, independent of `depth`.
+        let start = Instant::now();
+        for _ in 0..ITERS {
+            let _ = gov.is_member_authorized(&member, &asset, CatalogAction::Use);
+        }
+        let elapsed = start.elapsed();
+        #[allow(clippy::cast_precision_loss)]
+        let per = elapsed.as_nanos() as f64 / ITERS as f64;
+        println!("fleet-deep-nest: depth={depth} query_per_ns={per:.1}");
+        query_ns.push((depth, per));
+
+        // Sanity: unreachable beyond the bound (the top grant is `depth` > MAX hops up).
+        assert!(
+            depth <= MAX_TEAM_MEMBERS_WALK
+                || !gov.is_member_authorized(&member, &asset, CatalogAction::Use)
+        );
+    }
+
+    let first = query_ns.first().unwrap().1;
+    let last = query_ns.last().unwrap().1;
+    assert!(
+        last <= first * 4.0,
+        "deep-nest query must be depth-bounded (depth 1k {first:.1}ns vs 50k {last:.1}ns)"
+    );
+}

--- a/crates/kx-fleet/tests/security_governance.rs
+++ b/crates/kx-fleet/tests/security_governance.rs
@@ -1,0 +1,1111 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration + security + exit-gate tests for fleet/team governance (M7, D112).
+//!
+//! Drives the real-life enterprise use cases end to end — an org admin founds a team,
+//! grants it a recipe, admits members under narrowed roles, a member invokes the
+//! recipe under their team's grant narrowed by their role; an SRE team nested inside
+//! a platform fleet; removal / disband cascades — and proves the security invariants
+//! (no escalation past the team, action-aligned per-team resolution, admit-authority,
+//! revoke-by-new-fact, fail-closed default, bounded cycle/depth). Also asserts the
+//! compiler-enforced wall keeping fleet governance OFF the guarantee path (no
+//! guarantee-path crate, and not even kx-catalog, may import `kx-fleet`).
+//!
+//! `Kind 4 (chaos)` scoping (honest, mirrors kx-catalog): an in-memory ledger has no
+//! process kill/replay — durable crash-recovery is a future persistent backend (D94).
+//! The analogue here is idempotent-replay-of-appends + fail-closed folds.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeSet;
+
+use kx_catalog::{
+    AssetBinding, AssetPath, AssetRef, CatalogAction, CatalogActionSet, Grant, GrantLedger,
+    InMemoryGrantLedger, PartyId,
+};
+use kx_fleet::{
+    Admit, Disband, GovernedFleet, GovernedFleetError, InMemoryMembershipLedger, MembershipFact,
+    MembershipLedger, MembershipLedgerError, MembershipOutcome, Removal, Team,
+    MAX_TEAM_MEMBERS_WALK,
+};
+use kx_mote::ModelId;
+use kx_warrant::{ModelRoute, ResourceCeiling, Role, SecretRef, SecretScope, WarrantSpec};
+
+// ---- fixtures ---------------------------------------------------------------
+
+fn path(ns: &str, col: &str, name: &str) -> AssetRef {
+    AssetRef::Path(AssetPath::new(ns, col, name).unwrap())
+}
+
+fn warrant_calls(max_calls: u32) -> WarrantSpec {
+    WarrantSpec {
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1_000,
+            max_output_tokens: 1_000,
+            max_calls,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 20,
+            wall_clock_ms: 1_000,
+            fd_count: 16,
+            disk_bytes: 1 << 20,
+        },
+        ..Default::default()
+    }
+}
+
+fn role(name: &str, max_calls: u32) -> Role {
+    Role {
+        name: name.into(),
+        version: 1,
+        spec: warrant_calls(max_calls),
+        description: String::new(),
+    }
+}
+
+/// Bind `asset` to `owner` and grant `team` the `actions` under `role`.
+fn grant_team(
+    grants: &InMemoryGrantLedger,
+    asset: &AssetRef,
+    owner: &PartyId,
+    team: &PartyId,
+    actions: CatalogActionSet,
+    role: Role,
+) {
+    // Idempotent binding (one owner per asset).
+    let _ = grants.append_binding(AssetBinding::new(asset.clone(), owner.clone()));
+    grants
+        .append_grant(Grant::root(
+            asset.clone(),
+            owner.clone(),
+            team.clone(),
+            actions,
+            role,
+        ))
+        .unwrap();
+}
+
+// ---- Scenario 1: the happy path ---------------------------------------------
+
+#[test]
+fn org_admin_grants_team_then_member_uses_under_narrowed_role() {
+    let admin = PartyId::new("admin@acme");
+    let sre = PartyId::new("team:sre@acme");
+    let alice = PartyId::new("alice@acme");
+    let asset = path("acme", "runbooks", "restart");
+    let owner_root = warrant_calls(100);
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 50),
+    );
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            alice.clone(),
+            admin.clone(),
+            role("oncall", 20),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+
+    let team_eff = grants
+        .resolve_effective_warrant_for(&sre, &asset, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    assert!(gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+    let w = gov
+        .resolve_member_warrant(&alice, &asset, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    // min(owner 100, team 50, member 20) = 20, and ≤ the team's own 50 (no escalation).
+    assert_eq!(w.model_route.max_calls, 20);
+    assert!(w.model_route.max_calls <= team_eff.model_route.max_calls);
+}
+
+// ---- Scenario 2: removal is immediate ---------------------------------------
+
+#[test]
+fn removed_member_loses_access_immediately() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let alice = PartyId::new("alice");
+    let asset = path("acme", "runbooks", "restart");
+    let owner_root = warrant_calls(100);
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 50),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            alice.clone(),
+            admin.clone(),
+            role("oncall", 20),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+    assert!(gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+
+    // The owner removes Alice — a NEW fact; the live fold reflects it at once.
+    gov.members()
+        .append_remove(Removal::new(sre.clone(), alice.clone(), admin.clone()))
+        .unwrap();
+    assert!(!gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+    assert_eq!(
+        gov.resolve_member_warrant(&alice, &asset, CatalogAction::Use, &owner_root)
+            .unwrap(),
+        None
+    );
+}
+
+// ---- Scenario 3: no escalation past the team --------------------------------
+
+#[test]
+fn member_role_cannot_widen_the_team_grant() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let bob = PartyId::new("bob");
+    let asset = path("acme", "runbooks", "restart");
+    let owner_root = warrant_calls(10); // secret_scope = None
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 10), // secret_scope = None
+    );
+
+    // Bob's membership role proposes a secret the team's warrant cannot resolve.
+    let mut wide = warrant_calls(10);
+    wide.secret_scope =
+        SecretScope::AllowList([SecretRef("db-password".into())].into_iter().collect());
+    let wide_role = Role {
+        name: "wide".into(),
+        version: 1,
+        spec: wide,
+        description: String::new(),
+    };
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            bob.clone(),
+            admin.clone(),
+            wide_role,
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // The widen surfaces loudly as a typed error — never a silently-wider warrant.
+    let err = gov
+        .resolve_member_warrant(&bob, &asset, CatalogAction::Use, &owner_root)
+        .unwrap_err();
+    assert!(matches!(err, GovernedFleetError::Narrowing(_)));
+}
+
+// ---- Scenario 4: action-aligned, no confused-deputy union -------------------
+
+#[test]
+fn multi_team_membership_is_action_aligned() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let dev = PartyId::new("team:dev");
+    let carol = PartyId::new("carol");
+    let shared = path("acme", "runbooks", "restart");
+    let dev_only = path("acme", "data", "etl");
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &shared,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("sre", 50),
+    );
+    grant_team(
+        &grants,
+        &shared,
+        &admin,
+        &dev,
+        CatalogActionSet::allow([CatalogAction::Read]),
+        role("dev", 50),
+    );
+    grant_team(
+        &grants,
+        &dev_only,
+        &admin,
+        &dev,
+        CatalogActionSet::allow([CatalogAction::Read]),
+        role("dev", 50),
+    );
+
+    let fleet = InMemoryMembershipLedger::new();
+    for (team, name) in [(&sre, "SRE"), (&dev, "Dev")] {
+        fleet
+            .append_founding(Team::found(team.clone(), admin.clone(), name))
+            .unwrap();
+    }
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            carol.clone(),
+            admin.clone(),
+            role("c-sre", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            dev.clone(),
+            carol.clone(),
+            admin.clone(),
+            role("c-dev", 50),
+            CatalogActionSet::allow([CatalogAction::Read]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // Use comes ONLY via SRE; Read ONLY via Dev.
+    assert!(gov.is_member_authorized(&carol, &shared, CatalogAction::Use));
+    assert!(gov.is_member_authorized(&carol, &shared, CatalogAction::Read));
+    // No confused-deputy synthesis: on dev-only (Dev holds only Read), Carol cannot Use.
+    assert!(gov.is_member_authorized(&carol, &dev_only, CatalogAction::Read));
+    assert!(!gov.is_member_authorized(&carol, &dev_only, CatalogAction::Use));
+}
+
+// ---- Scenario 5: admit-authority is a fold property -------------------------
+
+#[test]
+fn non_delegate_member_cannot_admit() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let dave = PartyId::new("dave");
+    let eve = PartyId::new("eve");
+    let asset = path("acme", "runbooks", "restart");
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 50),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    // Dave: plain member, cap {Use}, NO Delegate.
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            dave.clone(),
+            admin.clone(),
+            role("dave", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    // Dave tries to admit Eve — inert.
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            eve.clone(),
+            dave.clone(),
+            role("eve", 50),
+            CatalogActionSet::all(),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    assert!(gov.members().is_member(&dave, &sre));
+    assert!(!gov.members().is_member(&eve, &sre));
+    assert!(!gov.is_member_authorized(&eve, &asset, CatalogAction::Use));
+
+    // A Delegate-holding member CAN admit (the positive control).
+    let frank = PartyId::new("frank");
+    let lead = PartyId::new("lead");
+    gov.members()
+        .append_admit(Admit::new(
+            sre.clone(),
+            lead.clone(),
+            admin.clone(),
+            role("lead", 50),
+            CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]),
+        ))
+        .unwrap();
+    gov.members()
+        .append_admit(Admit::new(
+            sre.clone(),
+            frank.clone(),
+            lead.clone(),
+            role("frank", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    assert!(gov.members().is_member(&frank, &sre));
+    assert!(gov.is_member_authorized(&frank, &asset, CatalogAction::Use));
+}
+
+// ---- Scenario 6: nested fleet-of-teams + cycle/depth fail-closed ------------
+
+#[test]
+fn member_resolves_through_a_nested_fleet() {
+    let admin = PartyId::new("admin");
+    let org = PartyId::new("fleet:platform");
+    let sre = PartyId::new("team:sre");
+    let frank = PartyId::new("frank");
+    let asset = path("acme", "fleet", "deploy");
+    let owner_root = warrant_calls(100);
+
+    let grants = InMemoryGrantLedger::new();
+    // The FLEET holds the grant (not the team directly).
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &org,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("fleet", 80),
+    );
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(org.clone(), admin.clone(), "Platform"))
+        .unwrap();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    // team:sre is a MEMBER of fleet:platform (admitted by the fleet owner).
+    fleet
+        .append_admit(Admit::new(
+            org.clone(),
+            sre.clone(),
+            admin.clone(),
+            role("sre-in-org", 40),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    // Frank is a member of team:sre.
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            frank.clone(),
+            admin.clone(),
+            role("frank", 20),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // Frank reaches the asset THROUGH the fleet; the warrant narrows at BOTH hops.
+    let w = gov
+        .resolve_member_warrant(&frank, &asset, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    assert_eq!(w.model_route.max_calls, 20); // min(100, 80, 40, 20)
+    assert!(gov.is_member_authorized(&frank, &asset, CatalogAction::Use));
+}
+
+#[test]
+fn membership_cycle_is_bounded_and_fail_closed() {
+    let admin = PartyId::new("admin");
+    let t1 = PartyId::new("team:1");
+    let t2 = PartyId::new("team:2");
+    let m = PartyId::new("m");
+    let asset = path("acme", "x", "y");
+    let owner_root = warrant_calls(100);
+
+    let grants = InMemoryGrantLedger::new(); // NO team holds a grant on `asset`.
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(t1.clone(), admin.clone(), "T1"))
+        .unwrap();
+    fleet
+        .append_founding(Team::found(t2.clone(), admin.clone(), "T2"))
+        .unwrap();
+    // A membership cycle: t1 ∈ t2 and t2 ∈ t1 (both admitted by their owner).
+    fleet
+        .append_admit(Admit::new(
+            t2.clone(),
+            t1.clone(),
+            admin.clone(),
+            role("a", 50),
+            CatalogActionSet::all(),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            t1.clone(),
+            t2.clone(),
+            admin.clone(),
+            role("b", 50),
+            CatalogActionSet::all(),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            t1.clone(),
+            m.clone(),
+            admin.clone(),
+            role("m", 50),
+            CatalogActionSet::all(),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // Terminates (cycle-guarded) and fails closed (no grant anywhere).
+    assert!(!gov.is_member_authorized(&m, &asset, CatalogAction::Use));
+    assert_eq!(
+        gov.resolve_member_warrant(&m, &asset, CatalogAction::Use, &owner_root)
+            .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn over_max_nesting_depth_fails_closed() {
+    let admin = PartyId::new("admin");
+    let asset = path("acme", "deep", "z");
+    let owner_root = warrant_calls(100);
+    let depth = MAX_TEAM_MEMBERS_WALK + 6; // beyond the bound
+
+    let grants = InMemoryGrantLedger::new();
+    let fleet = InMemoryMembershipLedger::new();
+    // Chain: t0 ∈ t1 ∈ … ∈ t{depth}. The TOP team holds the only grant.
+    let team = |i: usize| PartyId::new(format!("t{i}"));
+    for i in 0..=depth {
+        fleet
+            .append_founding(Team::found(team(i), admin.clone(), "T"))
+            .unwrap();
+    }
+    for i in 0..depth {
+        // t{i} is a member of t{i+1}.
+        fleet
+            .append_admit(Admit::new(
+                team(i + 1),
+                team(i),
+                admin.clone(),
+                role("r", 50),
+                CatalogActionSet::all(),
+            ))
+            .unwrap();
+    }
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &team(depth),
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("top", 50),
+    );
+    let member = PartyId::new("leaf-user");
+    fleet
+        .append_admit(Admit::new(
+            team(0),
+            member.clone(),
+            admin.clone(),
+            role("u", 50),
+            CatalogActionSet::all(),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // The top grant is beyond MAX_TEAM_MEMBERS_WALK hops ⇒ unreachable ⇒ fail-closed.
+    assert!(!gov.is_member_authorized(&member, &asset, CatalogAction::Use));
+    assert_eq!(
+        gov.resolve_member_warrant(&member, &asset, CatalogAction::Use, &owner_root)
+            .unwrap(),
+        None
+    );
+}
+
+// ---- Scenario 7: fail-closed default ----------------------------------------
+
+#[test]
+fn unknown_member_or_team_resolves_to_nothing() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let asset = path("acme", "runbooks", "restart");
+    let owner_root = warrant_calls(100);
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 50),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    assert!(!gov.is_member_authorized(&PartyId::new("nobody"), &asset, CatalogAction::Use));
+    assert_eq!(
+        gov.resolve_member_warrant(
+            &PartyId::new("nobody"),
+            &asset,
+            CatalogAction::Use,
+            &owner_root
+        )
+        .unwrap(),
+        None
+    );
+    // `require_*` surfaces the typed Unauthorized.
+    let err = gov
+        .require_member_warrant(
+            &PartyId::new("nobody"),
+            &asset,
+            CatalogAction::Use,
+            &owner_root,
+        )
+        .unwrap_err();
+    assert!(matches!(err, GovernedFleetError::Unauthorized { .. }));
+}
+
+// ---- Scenario 8: additive caps across parallel admits -----------------------
+
+#[test]
+fn parallel_admits_are_additive() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let grace = PartyId::new("grace");
+    let asset = path("acme", "runbooks", "restart");
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Read]),
+        role("team", 50),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    // Two admits with disjoint caps.
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            grace.clone(),
+            admin.clone(),
+            role("a", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            grace.clone(),
+            admin.clone(),
+            role("b", 50),
+            CatalogActionSet::allow([CatalogAction::Read]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // Grace effectively holds the union {Use, Read}.
+    assert!(gov.is_member_authorized(&grace, &asset, CatalogAction::Use));
+    assert!(gov.is_member_authorized(&grace, &asset, CatalogAction::Read));
+    let mr = gov.members().member_role(&grace, &sre).unwrap();
+    assert!(mr.action_cap().contains(CatalogAction::Use));
+    assert!(mr.action_cap().contains(CatalogAction::Read));
+}
+
+// ---- ORACLE: the fold equals a brute-force recompute ------------------------
+
+#[test]
+fn effective_members_equals_brute_force_oracle() {
+    let admin = PartyId::new("admin");
+    let team = PartyId::new("team:t");
+    let members: Vec<PartyId> = (0..8).map(|i| PartyId::new(format!("m{i}"))).collect();
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(team.clone(), admin.clone(), "T"))
+        .unwrap();
+    // Owner-issued admits for everyone, then the owner removes a few.
+    for m in &members {
+        fleet
+            .append_admit(Admit::new(
+                team.clone(),
+                m.clone(),
+                admin.clone(),
+                role("r", 50),
+                CatalogActionSet::all(),
+            ))
+            .unwrap();
+    }
+    let removed: BTreeSet<PartyId> = [members[1].clone(), members[4].clone()]
+        .into_iter()
+        .collect();
+    for m in &removed {
+        fleet
+            .append_remove(Removal::new(team.clone(), m.clone(), admin.clone()))
+            .unwrap();
+    }
+
+    // Brute force from the fact log: owner-admitted AND not owner-removed.
+    let mut admitted: BTreeSet<PartyId> = BTreeSet::new();
+    let mut owner_removed: BTreeSet<PartyId> = BTreeSet::new();
+    for fact in fleet.list_facts() {
+        match fact {
+            MembershipFact::Admit(a) if a.admitter() == &admin && a.team() == &team => {
+                admitted.insert(a.member().clone());
+            }
+            MembershipFact::Remove(r) if r.remover() == &admin && r.team() == &team => {
+                owner_removed.insert(r.member().clone());
+            }
+            _ => {}
+        }
+    }
+    let expected: BTreeSet<PartyId> = admitted.difference(&owner_removed).cloned().collect();
+
+    let got: BTreeSet<PartyId> = fleet
+        .effective_members(&team)
+        .into_iter()
+        .map(|mr| mr.member().clone())
+        .collect();
+    assert_eq!(got, expected);
+    assert_eq!(got.len(), members.len() - removed.len());
+}
+
+// ---- The SN-8 wall ----------------------------------------------------------
+
+/// The structural wall: NO guarantee-path crate — and not even `kx-catalog` — may
+/// depend on `kx-fleet`, so the compiler can never wire fleet governance onto the
+/// identity / commit / selection path (SN-8 / D70). The dependency direction is
+/// one-way (`kx-fleet → kx-catalog`). Read the manifests directly — a future
+/// `kx-fleet` edge into any of these is a compile-independent regression this catches.
+#[test]
+fn guarantee_path_does_not_depend_on_fleet() {
+    let crates = [
+        "kx-scheduler",
+        "kx-executor",
+        "kx-projection",
+        "kx-inference",
+        "kx-mote",
+        "kx-journal",
+        // The one-way edge: the catalog must not depend back on the fleet.
+        "kx-catalog",
+    ];
+    for c in crates {
+        let manifest = format!("{}/../{c}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+        let toml =
+            std::fs::read_to_string(&manifest).unwrap_or_else(|e| panic!("read {manifest}: {e}"));
+        assert!(
+            !toml.contains("kx-fleet"),
+            "{c} must NOT depend on kx-fleet (the SN-8 governance wall)"
+        );
+    }
+}
+
+// ---- The D112 exit gate (composite) -----------------------------------------
+
+#[test]
+fn d112_exit_gate() {
+    // A composite proof of the milestone: a team grant is shared, a member uses it
+    // narrowed by their role (no escalation), removal is immediate, a nested fleet
+    // resolves, and an unknown principal gets nothing — all on the off-trust-path,
+    // off-journal separate truth.
+    let admin = PartyId::new("admin");
+    let org = PartyId::new("fleet:platform");
+    let sre = PartyId::new("team:sre");
+    let alice = PartyId::new("alice");
+    let asset = path("acme", "runbooks", "restart");
+    let owner_root = warrant_calls(100);
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &org,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("fleet", 60),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(org.clone(), admin.clone(), "Platform"))
+        .unwrap();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            org.clone(),
+            sre.clone(),
+            admin.clone(),
+            role("sre-in-org", 40),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            alice.clone(),
+            admin.clone(),
+            role("alice", 25),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    // (1) nested resolution, narrowed at every hop (no escalation).
+    let w = gov
+        .resolve_member_warrant(&alice, &asset, CatalogAction::Use, &owner_root)
+        .unwrap()
+        .unwrap();
+    assert_eq!(w.model_route.max_calls, 25); // min(100, 60, 40, 25)
+
+    // (2) the disband cascade is immediate (owner disbands the whole SRE team).
+    gov.members()
+        .append_disband(Disband::new(sre.clone(), admin.clone()))
+        .unwrap();
+    assert!(!gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+
+    // (3) the in-memory ledger is shareable (the Arc path a multi-threaded gateway uses).
+    let shared = std::sync::Arc::new(InMemoryMembershipLedger::new());
+    let _: &dyn MembershipLedger = &shared;
+}
+
+// ---- Lifecycle edge cases (post-review hardening) ---------------------------
+
+/// Re-admission after removal RESTORES access — the time-ordered append-only model:
+/// a removal cancels only the admits that precede it; a fresh re-admit survives.
+#[test]
+fn re_admission_after_removal_restores_access() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let alice = PartyId::new("alice");
+    let asset = path("acme", "runbooks", "restart");
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 50),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    let admit = |cap_role: &str| {
+        Admit::new(
+            sre.clone(),
+            alice.clone(),
+            admin.clone(),
+            role(cap_role, 20),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        )
+    };
+    fleet.append_admit(admit("v1")).unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+    assert!(gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+
+    // Remove → access gone.
+    gov.members()
+        .append_remove(Removal::new(sre.clone(), alice.clone(), admin.clone()))
+        .unwrap();
+    assert!(!gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+
+    // Re-admit (a NEW admit, appended AFTER the removal) → access restored.
+    gov.members().append_admit(admit("v2")).unwrap();
+    assert!(gov.members().is_member(&alice, &sre));
+    assert!(gov.is_member_authorized(&alice, &asset, CatalogAction::Use));
+}
+
+/// Founding is genesis: a re-founding by the SAME owner is idempotent (no second
+/// founding fact, first display name wins); a DIFFERENT owner is an OwnerConflict.
+#[test]
+fn re_founding_is_idempotent_per_owner() {
+    let fleet = InMemoryMembershipLedger::new();
+    let team = PartyId::new("team:x");
+    let admin = PartyId::new("admin");
+
+    let first = fleet
+        .append_founding(Team::found(team.clone(), admin.clone(), "Name1"))
+        .unwrap();
+    assert!(first.is_appended());
+
+    // Same owner, DIFFERENT display name → idempotent (no second genesis fact).
+    let again = fleet
+        .append_founding(Team::found(team.clone(), admin.clone(), "Name2"))
+        .unwrap();
+    assert!(!again.is_appended());
+    assert_eq!(again.membership_id(), first.membership_id());
+    assert_eq!(
+        fleet.len(),
+        1,
+        "exactly one founding fact per team principal"
+    );
+    assert_eq!(fleet.owner_of_team(&team), Some(admin.clone()));
+
+    // Different owner → OwnerConflict.
+    let err = fleet
+        .append_founding(Team::found(team, PartyId::new("usurper"), "Name3"))
+        .unwrap_err();
+    assert!(matches!(err, MembershipLedgerError::OwnerConflict(_)));
+    assert_eq!(fleet.len(), 1);
+}
+
+/// Revoking a delegate cascades: members the delegate admitted go inert once the
+/// delegate's own (authority-bearing) membership is removed.
+#[test]
+fn revoking_a_delegate_cascades_to_their_admits() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let lead = PartyId::new("lead");
+    let carol = PartyId::new("carol");
+    let asset = path("acme", "runbooks", "restart");
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &sre,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("team", 50),
+    );
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    // Owner admits lead WITH Delegate; lead admits carol.
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            lead.clone(),
+            admin.clone(),
+            role("lead", 50),
+            CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            carol.clone(),
+            lead.clone(),
+            role("carol", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+    assert!(gov.members().is_member(&carol, &sre));
+    assert!(gov.is_member_authorized(&carol, &asset, CatalogAction::Use));
+
+    // The owner removes the lead → carol's admit (by the now-inert lead) cascades off.
+    gov.members()
+        .append_remove(Removal::new(sre.clone(), lead.clone(), admin.clone()))
+        .unwrap();
+    assert!(!gov.members().is_member(&lead, &sre));
+    assert!(
+        !gov.members().is_member(&carol, &sre),
+        "carol's admit by the de-authorized lead is now inert (cascade)"
+    );
+    assert!(!gov.is_member_authorized(&carol, &asset, CatalogAction::Use));
+}
+
+/// A role widen ANYWHERE in a NESTED chain surfaces as a typed NarrowingError —
+/// never a silently-wider warrant through the fleet.
+#[test]
+fn nested_chain_widen_is_refused() {
+    let admin = PartyId::new("admin");
+    let org = PartyId::new("fleet:platform");
+    let sre = PartyId::new("team:sre");
+    let frank = PartyId::new("frank");
+    let asset = path("acme", "fleet", "deploy");
+    let owner_root = warrant_calls(10); // secret_scope = None
+
+    let grants = InMemoryGrantLedger::new();
+    grant_team(
+        &grants,
+        &asset,
+        &admin,
+        &org,
+        CatalogActionSet::allow([CatalogAction::Use]),
+        role("fleet", 10),
+    );
+
+    // The INNER hop (sre-in-org) proposes a secret the fleet's warrant cannot resolve.
+    let mut wide = warrant_calls(10);
+    wide.secret_scope =
+        SecretScope::AllowList([SecretRef("prod-key".into())].into_iter().collect());
+    let wide_role = Role {
+        name: "wide".into(),
+        version: 1,
+        spec: wide,
+        description: String::new(),
+    };
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(org.clone(), admin.clone(), "Platform"))
+        .unwrap();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            org.clone(),
+            sre.clone(),
+            admin.clone(),
+            wide_role,
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            frank.clone(),
+            admin.clone(),
+            role("frank", 10),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    let gov = GovernedFleet::new(fleet, grants);
+
+    let err = gov
+        .resolve_member_warrant(&frank, &asset, CatalogAction::Use, &owner_root)
+        .unwrap_err();
+    assert!(matches!(err, GovernedFleetError::Narrowing(_)));
+}
+
+/// An admitter may remove a member they admitted EVEN after losing their own
+/// membership — removal only ever REDUCES access (safe-direction), so the
+/// owner-or-admitter authority is intentionally permissive.
+#[test]
+fn admitter_can_remove_what_they_admitted_even_after_losing_membership() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let bob = PartyId::new("bob");
+    let carol = PartyId::new("carol");
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    // Bob is admitted WITH Delegate; Bob admits Carol.
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            bob.clone(),
+            admin.clone(),
+            role("bob", 50),
+            CatalogActionSet::allow([CatalogAction::Use, CatalogAction::Delegate]),
+        ))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            carol.clone(),
+            bob.clone(),
+            role("carol", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    // The owner removes Bob; Carol cascades off (Bob no longer authorizes her).
+    fleet
+        .append_remove(Removal::new(sre.clone(), bob.clone(), admin.clone()))
+        .unwrap();
+    assert!(!fleet.is_member(&carol, &sre));
+
+    // Re-admit Carol directly by the OWNER (so she's active again).
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            carol.clone(),
+            admin.clone(),
+            role("carol2", 50),
+            CatalogActionSet::allow([CatalogAction::Use]),
+        ))
+        .unwrap();
+    assert!(fleet.is_member(&carol, &sre));
+    // Bob (a former admitter of Carol, now de-authorized) records a removal — honored
+    // (safe-direction: it only removes access).
+    fleet
+        .append_remove(Removal::new(sre.clone(), carol.clone(), bob.clone()))
+        .unwrap();
+    assert!(!fleet.is_member(&carol, &sre));
+}
+
+/// An owner disband is TERMINAL: re-founding the same team principal cannot
+/// resurrect it (genesis is idempotent; the disband persists in the fold).
+#[test]
+fn disband_is_terminal_across_refounding() {
+    let admin = PartyId::new("admin");
+    let sre = PartyId::new("team:sre");
+    let alice = PartyId::new("alice");
+
+    let fleet = InMemoryMembershipLedger::new();
+    fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE"))
+        .unwrap();
+    fleet
+        .append_admit(Admit::new(
+            sre.clone(),
+            alice.clone(),
+            admin.clone(),
+            role("a", 50),
+            CatalogActionSet::all(),
+        ))
+        .unwrap();
+    fleet
+        .append_disband(Disband::new(sre.clone(), admin.clone()))
+        .unwrap();
+    assert!(!fleet.is_member(&alice, &sre));
+
+    // Re-founding is idempotent (no new genesis) and does NOT clear the disband.
+    let out = fleet
+        .append_founding(Team::found(sre.clone(), admin.clone(), "SRE-again"))
+        .unwrap();
+    assert!(matches!(out, MembershipOutcome::AlreadyPresent(_)));
+    assert!(
+        !fleet.is_member(&alice, &sre),
+        "a disbanded team stays disbanded — re-founding cannot resurrect it"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -135,6 +135,7 @@ scale-smoke:
     cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
     cargo test -p kx-capture --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-catalog --release --test scale -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-fleet --release --test scale -- --ignored --nocapture --test-threads=1
 
 # IMP-4 (D116) single-writer scale-readiness measurement spike — publish the
 # single-writer journal commit ceiling + the projection-fold curve so a real number


### PR DESCRIPTION
## What

The final M7-era capability before M8: **teams** — the unit users actually want. A new leaf crate **`kx-fleet`** (32 → **33 crates**, no new external dep).

A team is a group `PartyId`; *"team T may `Use` recipe A under warrant W"* is an ordinary `kx-catalog` grant (M7.2). The only new truth `kx-fleet` adds is **who is in a team, under what role** — append-only `MembershipFact`s (`Team` founding / `Admit` / `Removal` / `Disband`) folded by a fail-closed `MembershipLedger`.

**The core insight — membership is one-level-up delegation:** a member's effective warrant on a recipe = `intersect(team_grant_warrant, member_role)` via the **frozen** `kx_warrant::intersect`, so a member can **never** exceed the team. With **nested fleet-of-teams** it generalizes to a bounded *multi-hop* narrow (`member → team → fleet`), one `intersect` per hop. `GovernedFleet<M, G>` composes the membership ledger with the grant ledger without coupling impls (Rule 1, exactly `GovernedCatalog<G, V>`).

A **SEPARATE TRUTH** (D-LOCK-4 discipline: append-only · content-addressed · immutable · idempotent · revoke-by-new-fact); **off-journal** (no `kx-journal` dep) and **off the trust path** (SN-8). Depends ONLY on `kx-catalog` + `kx-warrant`; the edge is one-way.

## Invariants held (additive — Golden Rule 1)

- **Frozen trio** (`kx-scheduler`/`kx-executor`/`kx-inference`) + `kx-mote`/`kx-journal`/`kx-projection` source diff is **EMPTY** (diff-proven).
- Canonical **product digest `a6b5c679…` unchanged**; **no `JOURNAL_SCHEMA_VERSION` bump**.
- **SN-8 wall** asserted in-crate: no guarantee-path crate — and not even `kx-catalog` — may import `kx-fleet`.
- **No floats** on any content/identity path; content-addressed (domain-tagged blake3 over canonical bincode).

## Golden Rule 8 — Pass A (defensive)

**(a) Breaks if live** — member escalation → monotonic `intersect` (no-widen proptest + scenarios); stale access after removal → revoke-by-new-fact + live fold; forged/off-authority admit → fail-closed fold; identity/digest drift → off-journal/off-trust-path, diff-proven.
**(b) Perf degrades** — deep/cyclic membership → `MAX_TEAM_MEMBERS_WALK=64` + `visiting` cycle-guard + a `MAX_RESOLUTION_STEPS` budget (all fail-closed); `BTreeMap` indices keep append/query/resolve sub-linear (scale-smoke 25k; deep-nest flat across 50×).
**(c) Security hole** — SN-8 dependency wall (manifest test); no floats; content-addressed immutability tripwire.

## Hardened after an adversarial multi-agent review

- **Genesis is idempotent per owner** — a re-founding by the same owner is a no-op (no duplicate founding fact); a different owner is `OwnerConflict`.
- **Removal is time-ordered** — a removal cancels only *prior* admits, so a fresh re-admit after a removal **restores access** (append-only revoke / re-admit discipline).
- **Disband is terminal** — re-founding the same team principal cannot resurrect it.
- **Path-anchor tie-break is length-delimited** (no concatenation-boundary aliasing).

## Tests

5 in-crate + **9 proptest** (idempotency / immutability / order-independence / **no-widen** / revoke / disband / non-admin-inert / additive-caps) + **19 enterprise scenarios** (happy path, removal, no-escalation, action-alignment, admit-authority, **nested fleet**, cycle / over-depth fail-closed, fail-closed default, additive caps, **re-admission**, **delegate cascade**, **nested-widen-refused**, **disband-terminal**) + a brute-force **oracle** + the **SN-8 wall** + **scale-smoke** (sub-linear / depth-bounded at 25k–50k) + a runnable `author_a_fleet` example.

Local gate green: `fmt` · `clippy --workspace --all-targets -D warnings` · `test --workspace` · `deny` · `doc -D warnings` · `scale-smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)