### PR TITLE
feat(inference): Step 1.1 — feature-gate the llama.cpp FFI (OSS Adoption & Trust)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,53 @@ jobs:
             | sort | xargs -I {} sh -c 'printf "%10s  %s\n" "$(stat -c%s "{}")" "{}"'
 
   # ---------------------------------------------------------------------------
+  # build-no-inference — the OSS Adoption & Trust install gate (Step 1.1).
+  #
+  # Proves `cargo install kx-runtime` needs NO C++ toolchain: this job
+  # deliberately checks out WITHOUT submodules and installs NO native build
+  # deps (no libclang/clang/cmake). If the runtime's dependency closure ever
+  # pulls the llama.cpp FFI back in, the build fails here (CMake/submodule
+  # absent) — and the explicit `cargo tree` assertion fails first with a clear
+  # message. Also builds kx-inference --no-default-features (the
+  # bring-your-own-`InferenceBackend` path) to keep the feature-off gate honest.
+  # ---------------------------------------------------------------------------
+  build-no-inference:
+    name: build-no-inference (kx-runtime installs without a C++ toolchain)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (NO submodules — the FFI must not be needed)
+        uses: actions/checkout@v6
+        # Deliberately NO submodules and NO C++ toolchain install below.
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: |
+          rustup show active-toolchain
+          rustc --version
+          cargo --version
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-noinfer-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-noinfer-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Configure RUSTFLAGS for path-stripping
+        run: |
+          echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}= -Cmetadata=kortecx-v0" >> $GITHUB_ENV
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: just build-no-inference
+        run: just build-no-inference
+
+  # ---------------------------------------------------------------------------
   # reproducible — byte-determinism check (I1.c). Runs `just check-reproducible`
   # which performs two clean release builds and diffs the output. Expensive
   # (~6+ minutes) but the load-bearing reproducibility gate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,14 @@ kx-tool-registry     = { path = "crates/kx-tool-registry",     version = "0.0.1"
 kx-context-assembler = { path = "crates/kx-context-assembler", version = "0.0.1" }
 kx-memoizer          = { path = "crates/kx-memoizer",          version = "0.0.1" }
 kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.0.1" }
-kx-inference         = { path = "crates/kx-inference",         version = "0.0.1" }
+# `default-features = false` (no llama.cpp FFI) is the WORKSPACE default for every
+# crate that depends on kx-inference, so the runtime's closure builds with no C++
+# toolchain (`cargo install kx-runtime`). It must live here, not on a member edge —
+# Cargo ignores member-level `default-features` on an inherited workspace dep. The
+# one crate that needs the in-process backend, kx-model-harness, opts back in with
+# `features = ["llamacpp"]`. kx-inference's own `default = ["llamacpp"]` keeps its
+# own build/test/doctests on the FFI when it is itself the target.
+kx-inference         = { path = "crates/kx-inference",         version = "0.0.1", default-features = false }
 kx-capability        = { path = "crates/kx-capability",        version = "0.0.1" }
 kx-executor          = { path = "crates/kx-executor",          version = "0.0.1" }
 kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.0.1" }

--- a/crates/kx-inference/Cargo.toml
+++ b/crates/kx-inference/Cargo.toml
@@ -19,11 +19,30 @@ kx-model-validator   = { workspace = true }
 kx-memoizer          = { workspace = true }
 kx-projection        = { workspace = true }
 kx-context-assembler = { workspace = true }
-kx-llamacpp          = { workspace = true }
+# The in-process llama.cpp backend is the ONLY part of this crate that needs the
+# native FFI (C++ toolchain + CMake + the kx-llamacpp-sys submodule). It is an
+# OPTIONAL dependency behind the `llamacpp` feature so a consumer can use the
+# `Dispatcher` + `InferenceBackend` trait (bring-your-own backend) with NO native
+# toolchain. See the [features] section below.
+kx-llamacpp          = { workspace = true, optional = true }
 serde                = { workspace = true }
 thiserror            = { workspace = true }
 tracing              = { workspace = true }
 smallvec             = { workspace = true }
+
+[features]
+# `llamacpp` (DEFAULT-ON, preserves existing behavior): compile the in-process
+# `LlamaInferenceBackend` and pull the kx-llamacpp FFI. Turning it OFF
+# (`default-features = false`) drops the native build entirely — the dispatcher,
+# the `InferenceBackend` trait, and the inference types remain, so a downstream
+# crate can bind its own backend and build/install with no C++ toolchain. The
+# runtime takes exactly this path: the workspace sets `default-features = false`
+# for kx-inference (root Cargo.toml [workspace.dependencies]), so
+# `cargo install kx-runtime` needs no native build. `cargo {build,test}
+# --workspace` keep the FFI ON because kx-model-harness (the only consumer of the
+# concrete backend) opts back in with `features = ["llamacpp"]`.
+default  = ["llamacpp"]
+llamacpp = ["dep:kx-llamacpp"]
 
 [dev-dependencies]
 kx-journal         = { workspace = true }

--- a/crates/kx-inference/src/lib.rs
+++ b/crates/kx-inference/src/lib.rs
@@ -40,11 +40,16 @@
 
 mod backend;
 mod dispatcher;
+// The llama.cpp-backed `LlamaInferenceBackend` lives behind the `llamacpp`
+// feature (default-on). Gating the module — not just the dep — is what lets the
+// crate compile with `--no-default-features` (no native FFI). See Cargo.toml.
+#[cfg(feature = "llamacpp")]
 mod llama;
 mod types;
 
 pub use backend::{BatchItem, InferenceBackend};
 pub use dispatcher::{DispatchOutcome, Dispatcher, DispatcherConfig};
+#[cfg(feature = "llamacpp")]
 pub use llama::LlamaInferenceBackend;
 pub use types::{
     inference_params_from_mote, Grammar, InferenceError, InferenceInput, InferenceOutput,

--- a/crates/kx-inference/src/types.rs
+++ b/crates/kx-inference/src/types.rs
@@ -125,6 +125,12 @@ pub fn inference_params_from_mote(
 ///
 /// Backends call this from their `dispatch` impl to enforce D30's
 /// monotonic-narrowing rule on a quantitative axis.
+///
+/// Gated on `llamacpp`: the only caller today is the in-process
+/// `LlamaInferenceBackend`. A bring-your-own backend (built without the FFI
+/// feature) re-uses it once it is wired; the gate just keeps the
+/// `--no-default-features` build warning-free until then.
+#[cfg(feature = "llamacpp")]
 pub(crate) fn check_within(
     params: &InferenceParams,
     warrant: &WarrantSpec,

--- a/crates/kx-model-harness/Cargo.toml
+++ b/crates/kx-model-harness/Cargo.toml
@@ -16,7 +16,12 @@ kx-projection.workspace = true
 kx-executor.workspace = true
 kx-capability.workspace = true
 kx-warrant.workspace = true
-kx-inference.workspace = true
+# The harness is the only crate that constructs the concrete in-process
+# `LlamaInferenceBackend`, so it opts back into the FFI (the workspace default is
+# `default-features = false` / no llama.cpp, to keep `cargo install kx-runtime`
+# toolchain-free). This is what keeps `cargo {build,test} --workspace` exercising
+# the real model path.
+kx-inference = { workspace = true, features = ["llamacpp"] }
 kx-context-assembler.workspace = true
 kx-tool-registry.workspace = true
 kx-memoizer.workspace = true

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ check: fmt-check clippy test
 # Exact mirror of the CI workflow's gates (in dependency order). Runs every
 # job .github/workflows/ci.yml runs in parallel, here sequentially. Modify
 # this recipe in lock-step with ci.yml.
-ci: fmt-check clippy test deny doc ffi-link check-reproducible scale-smoke
+ci: fmt-check clippy test deny doc ffi-link build-no-inference check-reproducible scale-smoke
 
 # Verify code is formatted per rustfmt.toml. Fails on any drift.
 fmt-check:
@@ -70,6 +70,27 @@ deny:
 ffi-link:
     cargo build -p kx-llamacpp-sys --release
     cargo build -p kx-llamacpp --release
+
+# Prove the runtime installs/builds with NO native FFI in its dependency closure
+# (no C++ toolchain, no llama.cpp submodule). Step 1.1 of the OSS Adoption & Trust
+# track: `cargo install kx-runtime` must not require a C++ build. Asserts
+# kx-llamacpp{,-sys} is absent from the runtime's normal dependency tree, then
+# builds the runtime + the feature-off inference lib (the bring-your-own-backend
+# path). CI runs this on a runner WITHOUT a C++ toolchain or submodule, so a
+# regression that leaks the FFI back into the runtime closure fails loudly.
+build-no-inference:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Asserting kx-runtime's dependency closure is FFI-free..."
+    if cargo tree -p kx-runtime -e normal | grep -qE 'kx-llamacpp'; then
+        echo " ✗ FAIL: kx-llamacpp is in kx-runtime's dependency closure (the FFI leaked into the runtime)"
+        cargo tree -p kx-runtime -e normal | grep -E 'kx-llamacpp' || true
+        exit 1
+    fi
+    echo " ✓ no kx-llamacpp in kx-runtime closure"
+    cargo build -p kx-runtime
+    cargo build -p kx-inference --no-default-features
+    echo " ✓ build-no-inference: PASS"
 
 # Byte-determinism check (I1.c). Two consecutive release builds must produce
 # bit-identical artifacts. Failure indicates the build is nondeterministic and


### PR DESCRIPTION
## What & why

OSS **Adoption & Trust** track, **Step 1.1** — the highest-leverage install fix.

Until now **every** build pulled the llama.cpp FFI (C++ toolchain + CMake + libclang + the pinned `llama.cpp` submodule), even `kx-runtime` — which uses no inference directly but pulled it transitively via `kx-executor → kx-inference`. That made `cargo install kx-runtime` require a native toolchain: the #1 barrier to adopting the runtime.

This makes the in-process llama backend **optional** so the runtime's dependency closure builds **FFI-free** (bring-your-own `InferenceBackend`).

## How

- **`kx-inference`**: `kx-llamacpp` is now an **optional** dep behind a default-on `llamacpp` feature. `mod llama` + the `LlamaInferenceBackend` re-export are `#[cfg(feature = "llamacpp")]`; `check_within` (sole caller is the gated backend) is gated too, keeping the feature-off build warning-free. These are the **only** `kx-inference/src` changes — all `#[cfg]`, zero logic.
- **Workspace**: `[workspace.dependencies].kx-inference` sets `default-features = false`, so every dependent (incl. the runtime via the executor) builds FFI-free by default. *(Member-level `default-features` is ignored on inherited workspace deps — it must live in `[workspace.dependencies]`.)*
- **`kx-model-harness`** — the only crate that constructs the concrete `LlamaInferenceBackend` — opts back in with `features = ["llamacpp"]`, so `cargo {build,test} --workspace` still exercises the real-model path and `ffi-link` / `smoke-test-with-model` are unaffected (they build the FFI crates directly).
- **CI + justfile**: new **`build-no-inference`** gate — checks out with **no submodule** and installs **no C++ toolchain**, builds `-p kx-runtime` (a leaked FFI fails the build), asserts `kx-llamacpp` is absent from the runtime's dependency tree, and builds `kx-inference --no-default-features`.

## Thesis test (frozen trio)

`kx-scheduler/src` and `kx-executor/src` are **diff-EMPTY**; the only `kx-inference/src` changes are 3 `#[cfg]` attributes (logic diff-empty). Only manifests + cfg attrs changed. Canonical digest path unaffected (no behavior change).

## Golden Rule 8

- **(a) Breaks live:** a regression re-introducing an FFI edge into the runtime closure → caught by `build-no-inference` (no-toolchain runner). Default `--workspace` behavior preserved (harness keeps `llamacpp` on).
- **(b) Perf:** none; minimal installs compile *less* (no native code).
- **(c) Security:** reduces attack surface (no native code in the minimal install).
- **Better:** removes the #1 adoption barrier and enables bring-your-own-backend on a toolchain-free install.

## Verification

`fmt` · `clippy --workspace --all-targets -D warnings` · `cargo deny` · `test --workspace` (251 binaries ok, 0 fail) · `doc -D warnings` · `build-no-inference` (`cargo tree -p kx-runtime` FFI-free + feature-off build clean) · `Cargo.lock` unchanged. Byte-determinism (I1.c) running; ffi-link/smoke/scale-smoke run fresh in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)