### PR TITLE
feat(inference): M4 — kx-model-store + loaded-model cache (OSS multi-modal track, PR-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "kx-journal",
  "kx-llamacpp",
  "kx-memoizer",
+ "kx-model-store",
  "kx-model-validator",
  "kx-mote",
  "kx-projection",
@@ -1386,6 +1387,20 @@ dependencies = [
  "tempfile",
  "tracing",
  "ureq",
+]
+
+[[package]]
+name = "kx-model-store"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "kx-content",
+ "kx-mote",
+ "serde",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "crates/kx-model-harness",
     "crates/kx-gateway-core",
     "crates/kx-invoke",
+    "crates/kx-model-store",
 ]
 exclude = [
     "kx-cloud",
@@ -169,6 +170,11 @@ kx-gateway-core      = { path = "crates/kx-gateway-core",      version = "0.0.1"
 # bind args, compile, and submit under intersect(use, step) via the gateway
 # RunSubmitter. A composition over the catalog + gateway; adds no new write path.
 kx-invoke            = { path = "crates/kx-invoke",            version = "0.0.1" }
+# M4 (D108.2) model lifecycle: backend-agnostic, FFI-FREE registry of model
+# identity + declared modalities + projector path + fail-closed GGUF validation.
+# An InferenceBackend resolves paths/capabilities through its ModelResolver seam;
+# the live loaded-model handle cache (kx-inference) keys on its identity_digest.
+kx-model-store       = { path = "crates/kx-model-store",       version = "0.0.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/kx-inference/Cargo.toml
+++ b/crates/kx-inference/Cargo.toml
@@ -25,6 +25,11 @@ kx-context-assembler = { workspace = true }
 # `Dispatcher` + `InferenceBackend` trait (bring-your-own backend) with NO native
 # toolchain. See the [features] section below.
 kx-llamacpp          = { workspace = true, optional = true }
+# Model lifecycle (M4): the ModelResolver / ModelDescriptor the concrete backend
+# resolves paths + modalities through. Optional + behind `llamacpp` because only
+# the in-process backend consumes it; a bring-your-own backend pulls it directly
+# if it wants the registry. FFI-free, so it never affects `build-no-inference`.
+kx-model-store       = { workspace = true, optional = true }
 serde                = { workspace = true }
 thiserror            = { workspace = true }
 tracing              = { workspace = true }
@@ -42,7 +47,7 @@ smallvec             = { workspace = true }
 # --workspace` keep the FFI ON because kx-model-harness (the only consumer of the
 # concrete backend) opts back in with `features = ["llamacpp"]`.
 default  = ["llamacpp"]
-llamacpp = ["dep:kx-llamacpp"]
+llamacpp = ["dep:kx-llamacpp", "dep:kx-model-store"]
 
 [dev-dependencies]
 kx-journal         = { workspace = true }

--- a/crates/kx-inference/src/cache.rs
+++ b/crates/kx-inference/src/cache.rs
@@ -1,0 +1,290 @@
+// A loaded-model handle cache for the in-process llama.cpp backend.
+//
+// WHY A DEDICATED OWNER THREAD (not a `Mutex<Model>` field):
+// `kx_llamacpp::LlamaBackend` is `!Send + !Sync` (it carries
+// `PhantomData<*const ()>` to pin llama.cpp's not-thread-safe global state to
+// one thread), and every `Model<'b>` borrows the backend. So the backend and
+// its loaded models cannot be stored in a `Send + Sync` backend struct, nor
+// behind a `Mutex` (a reference to a `!Sync` type is itself `!Send`). The clean
+// solution — the one the wrapper docs name — is a single owner thread that
+// creates the backend and keeps every loaded `Model` as a thread-local. The
+// only thing that crosses the thread boundary is the `mpsc` channel handle
+// (`Send + Sync` on Rust ≥ 1.72) and plain-data jobs/replies (`InferenceInput`,
+// `InferenceParams`, `InferenceOutput` are all `Send`).
+//
+// WHAT IT FIXES: the pre-cache backend called `Model::load(path)` on EVERY
+// dispatch (seconds for a 7B model; catastrophic for a multi-GB multimodal
+// model). The owner thread loads each model once, keyed by its
+// `kx_model_store` `identity_digest`, and reuses it. A small LRU bounds RAM.
+//
+// CONCURRENCY: dispatch is serialized by the single owner thread — exactly the
+// discipline `kx-llamacpp` mandates ("never `&Context` from two threads").
+// Concurrent callers queue on the channel; each blocks until its reply lands.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use kx_content::ContentRef;
+use kx_llamacpp::{Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, Sampler};
+use kx_mote::{InferenceParams, ModelId};
+
+use crate::llama::BACKEND_NAME;
+use crate::types::{InferenceError, InferenceOutput};
+
+/// Default number of distinct models kept loaded at once. Small because models
+/// are heavyweight; enough for one active model plus a swap.
+pub(crate) const DEFAULT_CACHE_CAPACITY: usize = 2;
+
+/// Convert a `kx_llamacpp::LlamaError` into the public error enum. Localised so
+/// the dispatcher's error surface stays stable as `kx-llamacpp`'s variants
+/// evolve.
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn map_llama_err(err: LlamaError) -> InferenceError {
+    InferenceError::BackendFailure {
+        backend: BACKEND_NAME,
+        message: format!("{err}"),
+    }
+}
+
+/// One inference request handed to the owner thread. All fields are `Send`.
+struct Job {
+    /// Loaded-model cache key (path+modality identity; NOT a weight hash).
+    identity: ContentRef,
+    /// Where to load the model from on a cache miss.
+    path: PathBuf,
+    /// Echoed back into `InferenceOutput.model_id`.
+    model_id: ModelId,
+    /// Text prompt (PR-1 is text-only; the multimodal branch is rejected on the
+    /// caller thread before a job is ever built).
+    prompt: String,
+    /// Decoding parameters (already validated against the warrant by the caller).
+    params: InferenceParams,
+    /// Context window for this dispatch.
+    n_ctx: u32,
+    /// Wall-clock ceiling in milliseconds (`warrant.resource_ceiling`).
+    wall_clock_ms: u64,
+    /// Where the owner thread sends the result.
+    reply: Sender<Result<InferenceOutput, InferenceError>>,
+}
+
+/// `Send + Sync` handle to the model-cache owner thread. Cheap to clone (clones
+/// share one worker + one load counter).
+#[derive(Clone, Debug)]
+pub(crate) struct ModelCache {
+    tx: Sender<Job>,
+    /// Number of cold `Model::load`s performed — the observable proof that a
+    /// cache hit did NOT reload (and the ops metric for "the reload is gone").
+    loads: Arc<AtomicU64>,
+}
+
+impl ModelCache {
+    /// Spawn the owner thread and return a handle to it. The thread lives until
+    /// every `ModelCache` clone (and thus every `Sender`) is dropped, at which
+    /// point `recv` errors and it exits cleanly.
+    pub(crate) fn spawn(capacity: usize) -> Self {
+        let (tx, rx) = mpsc::channel::<Job>();
+        let loads = Arc::new(AtomicU64::new(0));
+        let worker_loads = Arc::clone(&loads);
+        // `std::thread::spawn` panics on OS thread-exhaustion — an unrecoverable
+        // condition for which panic is the correct behavior (no Result to leak
+        // into the infallible backend constructors).
+        let _handle = std::thread::spawn(move || owner_loop(&rx, capacity.max(1), &worker_loads));
+        Self { tx, loads }
+    }
+
+    /// Number of cold model loads performed so far.
+    pub(crate) fn loads(&self) -> u64 {
+        self.loads.load(Ordering::Relaxed)
+    }
+
+    /// Submit a job and block until the owner thread replies.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn dispatch(
+        &self,
+        identity: ContentRef,
+        path: PathBuf,
+        model_id: ModelId,
+        prompt: String,
+        params: InferenceParams,
+        n_ctx: u32,
+        wall_clock_ms: u64,
+    ) -> Result<InferenceOutput, InferenceError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let job = Job {
+            identity,
+            path,
+            model_id,
+            prompt,
+            params,
+            n_ctx,
+            wall_clock_ms,
+            reply: reply_tx,
+        };
+        self.tx
+            .send(job)
+            .map_err(|_| InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: "model-cache owner thread is gone (send failed)".to_string(),
+            })?;
+        reply_rx
+            .recv()
+            .map_err(|_| InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: "model-cache owner thread died mid-job (recv failed)".to_string(),
+            })?
+    }
+}
+
+/// The owner thread's loop. Owns the (`!Send`) backend and the loaded-model LRU
+/// as thread-locals; serves jobs until the channel closes.
+fn owner_loop(rx: &Receiver<Job>, capacity: usize, loads: &AtomicU64) {
+    let backend = match LlamaBackend::new() {
+        Ok(b) => b,
+        Err(e) => {
+            // Backend init failed: reply the same error to every queued job so
+            // callers fail fast instead of hanging.
+            let err = map_llama_err(e);
+            while let Ok(job) = rx.recv() {
+                let _ = job.reply.send(Err(err.clone()));
+            }
+            return;
+        }
+    };
+
+    // LRU of loaded models. Each `Model<'_>` borrows `backend`; both are locals
+    // of this function, so the borrow is valid for the whole loop and `lru` is
+    // dropped before `backend`.
+    let mut lru: Vec<(ContentRef, Model<'_>)> = Vec::with_capacity(capacity);
+
+    while let Ok(job) = rx.recv() {
+        let result = run_job(&backend, &mut lru, capacity, loads, &job);
+        // A dropped reply receiver (caller gave up) is not our problem.
+        let _ = job.reply.send(result);
+    }
+}
+
+/// Resolve-or-load the model, then run text generation against it.
+fn run_job<'b>(
+    backend: &'b LlamaBackend,
+    lru: &mut Vec<(ContentRef, Model<'b>)>,
+    capacity: usize,
+    loads: &AtomicU64,
+    job: &Job,
+) -> Result<InferenceOutput, InferenceError> {
+    let start = Instant::now();
+    let timeout = Duration::from_millis(job.wall_clock_ms);
+    let model = get_or_load(backend, lru, capacity, loads, job.identity, &job.path)
+        .map_err(map_llama_err)?;
+    check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
+
+    let (bytes, output_tokens) = generate(backend, model, job, start, timeout)?;
+    Ok(InferenceOutput {
+        bytes,
+        output_tokens,
+        backend_name: BACKEND_NAME,
+        model_id: job.model_id.clone(),
+        elapsed: start.elapsed(),
+    })
+}
+
+/// Return a reference to the cached model for `identity`, loading + inserting it
+/// (and evicting the LRU front at capacity) on a miss. By construction the
+/// wanted model is the last LRU entry on return.
+fn get_or_load<'a, 'b>(
+    backend: &'b LlamaBackend,
+    lru: &'a mut Vec<(ContentRef, Model<'b>)>,
+    capacity: usize,
+    loads: &AtomicU64,
+    identity: ContentRef,
+    path: &Path,
+) -> Result<&'a Model<'b>, LlamaError> {
+    if let Some(pos) = lru.iter().position(|(id, _)| *id == identity) {
+        // Hit: move to the most-recently-used end.
+        let entry = lru.remove(pos);
+        lru.push(entry);
+    } else {
+        // Miss: evict LRU front if full, then load + insert.
+        if lru.len() >= capacity {
+            let _evicted = lru.remove(0);
+        }
+        let model = Model::load(backend, path)?;
+        loads.fetch_add(1, Ordering::Relaxed);
+        lru.push((identity, model));
+    }
+    // Non-empty by construction (a hit re-pushes; a miss pushes).
+    let idx = lru.len() - 1;
+    Ok(&lru[idx].1)
+}
+
+/// The text generation loop, lifted verbatim from the pre-cache dispatch path
+/// (greedy when `temperature_bps == 0`, else temp/top-k/top-p sampling).
+fn generate(
+    backend: &LlamaBackend,
+    model: &Model<'_>,
+    job: &Job,
+    start: Instant,
+    timeout: Duration,
+) -> Result<(Vec<u8>, u32), InferenceError> {
+    let ctx_params = ContextParams::new().with_n_ctx(job.n_ctx);
+    let mut ctx = Context::new_with_params(model, &ctx_params).map_err(map_llama_err)?;
+    let vocab = model.vocab();
+
+    let prompt_tokens = vocab
+        .tokenize(&job.prompt, true, false)
+        .map_err(map_llama_err)?;
+    check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
+
+    let params = &job.params;
+    let mut sampler = if params.temperature_bps == 0 {
+        Sampler::greedy(backend).map_err(map_llama_err)?
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        let temp = (params.temperature_bps as f32) / 10_000.0;
+        #[allow(clippy::cast_precision_loss)]
+        let top_p = (params.top_p_bps as f32) / 10_000.0;
+        #[allow(clippy::cast_possible_wrap)]
+        let top_k = params.top_k as i32;
+        Sampler::typical(backend, temp, top_k, top_p, params.seed).map_err(map_llama_err)?
+    };
+
+    let generator =
+        Generator::new(&mut ctx, &mut sampler, &vocab, prompt_tokens).map_err(map_llama_err)?;
+
+    let mut output_bytes: Vec<u8> = Vec::with_capacity(
+        usize::try_from(params.max_output_tokens.saturating_mul(4)).unwrap_or(2048),
+    );
+    let mut output_tokens: u32 = 0;
+
+    for token_result in generator {
+        check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
+        let token = token_result.map_err(map_llama_err)?;
+        vocab
+            .token_to_piece_into(token, 0, false, &mut output_bytes)
+            .map_err(map_llama_err)?;
+        output_tokens = output_tokens.saturating_add(1);
+        if output_tokens >= params.max_output_tokens {
+            break;
+        }
+        if vocab.is_eog(token) {
+            break;
+        }
+    }
+
+    Ok((output_bytes, output_tokens))
+}
+
+/// Timeout guard, identical in semantics to the pre-cache path.
+fn check_timeout(
+    elapsed: Duration,
+    timeout: Duration,
+    wall_clock_ms: u64,
+) -> Result<(), InferenceError> {
+    if elapsed >= timeout {
+        Err(InferenceError::Timeout { wall_clock_ms })
+    } else {
+        Ok(())
+    }
+}

--- a/crates/kx-inference/src/lib.rs
+++ b/crates/kx-inference/src/lib.rs
@@ -40,9 +40,12 @@
 
 mod backend;
 mod dispatcher;
-// The llama.cpp-backed `LlamaInferenceBackend` lives behind the `llamacpp`
-// feature (default-on). Gating the module — not just the dep — is what lets the
-// crate compile with `--no-default-features` (no native FFI). See Cargo.toml.
+// The llama.cpp-backed `LlamaInferenceBackend` + its loaded-model cache live
+// behind the `llamacpp` feature (default-on). Gating the modules — not just the
+// dep — is what lets the crate compile with `--no-default-features` (no native
+// FFI). See Cargo.toml.
+#[cfg(feature = "llamacpp")]
+mod cache;
 #[cfg(feature = "llamacpp")]
 mod llama;
 mod types;

--- a/crates/kx-inference/src/llama.rs
+++ b/crates/kx-inference/src/llama.rs
@@ -4,75 +4,66 @@
 // repo. Out-of-process backends (Triton, vLLM, remote APIs) ride the same
 // `InferenceBackend` trait but live in private `kx-cloud/*` crates.
 //
-// v0.1 design choices:
-//   - Model registry is a frozen-at-construction `HashMap<ModelId, PathBuf>`.
-//     Reloading a different model is a `kx-llamacpp` constructor reset; the
-//     runtime doesn't reload models per-dispatch (they're heavyweight).
-//   - LlamaBackend is RAII-ref-counted inside kx-llamacpp; we call ::new()
-//     per dispatch since the type is `!Send + !Sync` and we cannot hold it
-//     long-term in a Send + Sync backend struct. The internal mutex makes
-//     repeated `LlamaBackend::new()` calls cheap (subsequent calls just
-//     bump a ref-count; the actual `llama_backend_init` runs once).
-//   - The Model load IS expensive (seconds for a 7B GGUF). Future PRs may
-//     introduce a long-lived `LoadedModel` cache (via worker thread + mpsc
-//     channel to dodge the `!Send` constraint). v0.1 ships the simpler
-//     per-call path because the OSS critical-path goal is the seam,
-//     not throughput.
+// Design (post-M4, D108.2):
+//   - Model identity + paths + declared modalities come from a
+//     `kx_model_store::ModelResolver` (a `BTreeMap`-backed `ModelRegistry` by
+//     default), NOT a frozen `HashMap<ModelId, PathBuf>`. A future durable /
+//     remote registry implements the same trait without this backend changing.
+//   - Loaded `llama_model` handles are CACHED across dispatches by a dedicated
+//     owner thread (see `cache.rs`). The pre-M4 path reloaded the model from
+//     disk on EVERY dispatch (seconds for a 7B model; ruinous for a multi-GB
+//     multimodal model); the cache loads each model once, keyed by its
+//     `identity_digest`. `LlamaBackend`/`Model` are `!Send`/`!Sync`, so the
+//     owner thread (which holds only a `Send + Sync` channel handle) is what
+//     keeps this backend `Send + Sync`.
+//   - `with_model` / `with_models` are retained as thin shims that build a
+//     one-/multi-entry `ModelRegistry`, so existing callers are unchanged.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, OnceLock};
 
+use kx_model_store::{ModelDescriptor, ModelRegistry, ModelResolver};
 use kx_mote::ModelId;
 use kx_warrant::WarrantSpec;
 
 use crate::backend::InferenceBackend;
+use crate::cache::{ModelCache, DEFAULT_CACHE_CAPACITY};
 use crate::types::{
     check_within, InferenceError, InferenceInput, InferenceOutput, InferenceParams,
 };
 
 /// Backend name reported in `InferenceOutput.backend_name`.
-const BACKEND_NAME: &str = "kx-llamacpp";
+pub(crate) const BACKEND_NAME: &str = "kx-llamacpp";
 
 /// Default context window. Per llama.cpp convention, 0 means "use the
 /// model's own `n_ctx_train`". We pick a conservative cap so v0.1 doesn't
 /// silently allocate huge KV caches.
-const DEFAULT_N_CTX: u32 = 4096;
-
-/// Convert a `kx_llamacpp::LlamaError` into our public error enum.
-///
-/// Localised to one place so the dispatcher's error surface stays
-/// stable as `kx-llamacpp`'s error variants evolve. Takes the error
-/// by value so it can be used directly as `.map_err(map_llama_err)`
-/// in the dispatch path; the underlying error's `Display` is what
-/// we ultimately surface so consuming the original is fine.
-#[allow(clippy::needless_pass_by_value)]
-fn map_llama_err(err: kx_llamacpp::LlamaError) -> InferenceError {
-    InferenceError::BackendFailure {
-        backend: BACKEND_NAME,
-        message: format!("{err}"),
-    }
-}
+pub(crate) const DEFAULT_N_CTX: u32 = 4096;
 
 /// OSS v0.1 in-process inference backend wrapping `kx-llamacpp`.
 ///
 /// **What it implements**:
 ///   - `InferenceInput::Text(prompt)` — runs the prompt through the
-///     loaded model.
+///     loaded (and cached) model.
 ///   - `InferenceParams.grammar = None` — vanilla sampling (greedy when
 ///     `temperature_bps == 0`, otherwise temp + top-k + top-p).
 ///
 /// **What it returns `Err(Unsupported)` on** (deliberate seam):
-///   - `InferenceInput::Multimodal { .. }` — reserved for future PRs.
-///   - `InferenceParams.grammar = Some(_)` — reserved for future PRs.
-///
-/// See `roadmap-multimodal-synthesis-post-pr9` for the sequencing
-/// commitment.
-#[derive(Debug, Clone)]
+///   - `InferenceInput::Multimodal { .. }` — reserved for the multi-modal PRs.
+///   - `InferenceParams.grammar = Some(_)` — reserved for constrained generation.
+#[derive(Clone)]
 pub struct LlamaInferenceBackend {
-    model_paths: Arc<HashMap<ModelId, PathBuf>>,
+    /// The model registry / resolver this backend serves from.
+    resolver: Arc<dyn ModelResolver>,
+    /// Lazily-spawned loaded-model cache (owner thread). `OnceLock` so a backend
+    /// that never dispatches (e.g. a unit test expecting `ModelNotFound`) never
+    /// spawns a thread or touches the FFI. Shared across `Clone`s via `Arc`.
+    cache: Arc<OnceLock<ModelCache>>,
+    /// Context window passed to each dispatch.
     n_ctx: u32,
+    /// Number of distinct models the cache keeps loaded at once.
+    cache_capacity: usize,
 }
 
 impl LlamaInferenceBackend {
@@ -80,13 +71,22 @@ impl LlamaInferenceBackend {
     /// tests where every dispatch is expected to return `ModelNotFound`.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_resolver(Arc::new(ModelRegistry::new()))
+    }
+
+    /// Construct a backend that serves from an arbitrary [`ModelResolver`]
+    /// (e.g. a richly-populated `ModelRegistry`, or a future durable registry).
+    #[must_use]
+    pub fn with_resolver(resolver: Arc<dyn ModelResolver>) -> Self {
         Self {
-            model_paths: Arc::new(HashMap::new()),
+            resolver,
+            cache: Arc::new(OnceLock::new()),
             n_ctx: DEFAULT_N_CTX,
+            cache_capacity: DEFAULT_CACHE_CAPACITY,
         }
     }
 
-    /// Construct a backend with a single model registered.
+    /// Construct a backend with a single text model registered.
     ///
     /// # Examples
     ///
@@ -106,21 +106,13 @@ impl LlamaInferenceBackend {
     /// ```
     #[must_use]
     pub fn with_model(id: ModelId, path: PathBuf) -> Self {
-        let mut map = HashMap::new();
-        map.insert(id, path);
-        Self {
-            model_paths: Arc::new(map),
-            n_ctx: DEFAULT_N_CTX,
-        }
+        Self::with_resolver(Arc::new(registry_from_paths(std::iter::once((id, path)))))
     }
 
-    /// Construct a backend with multiple model ids registered.
+    /// Construct a backend with multiple text model ids registered.
     #[must_use]
     pub fn with_models(models: HashMap<ModelId, PathBuf>) -> Self {
-        Self {
-            model_paths: Arc::new(models),
-            n_ctx: DEFAULT_N_CTX,
-        }
+        Self::with_resolver(Arc::new(registry_from_paths(models)))
     }
 
     /// Override the default context window.
@@ -128,6 +120,45 @@ impl LlamaInferenceBackend {
     pub fn with_n_ctx(mut self, n_ctx: u32) -> Self {
         self.n_ctx = n_ctx;
         self
+    }
+
+    /// Override the loaded-model cache capacity (distinct models kept resident).
+    #[must_use]
+    pub fn with_cache_capacity(mut self, capacity: usize) -> Self {
+        self.cache_capacity = capacity.max(1);
+        self
+    }
+
+    /// Number of cold `Model::load`s performed so far (0 if no dispatch has
+    /// spawned the cache yet). The observable proof that cache hits do not
+    /// reload, and the ops metric for model-load pressure.
+    #[must_use]
+    pub fn loads_performed(&self) -> u64 {
+        self.cache.get().map_or(0, ModelCache::loads)
+    }
+}
+
+/// Build a [`ModelRegistry`] of text-only descriptors from `(ModelId, path)`
+/// pairs. Registration of a fresh, unique set is infallible; a duplicate or an
+/// over-capacity entry is logged and skipped rather than panicking in an
+/// infallible constructor (a `HashMap` source cannot contain duplicates).
+fn registry_from_paths(paths: impl IntoIterator<Item = (ModelId, PathBuf)>) -> ModelRegistry {
+    let mut registry = ModelRegistry::new();
+    for (id, path) in paths {
+        if let Err(e) = registry.register(ModelDescriptor::text(id, path, DEFAULT_N_CTX)) {
+            tracing::error!(error = %e, "skipping model in registry shim (unexpected)");
+        }
+    }
+    registry
+}
+
+impl std::fmt::Debug for LlamaInferenceBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlamaInferenceBackend")
+            .field("n_ctx", &self.n_ctx)
+            .field("cache_capacity", &self.cache_capacity)
+            .field("cache_spawned", &self.cache.get().is_some())
+            .finish_non_exhaustive()
     }
 }
 
@@ -145,18 +176,18 @@ impl InferenceBackend for LlamaInferenceBackend {
         params: &InferenceParams,
         warrant: &WarrantSpec,
     ) -> Result<InferenceOutput, InferenceError> {
-        // ---- Forward-compat reservation gates (PR 8 plan) -----------------
+        // ---- Forward-compat reservation gates (fire BEFORE any model work) ----
         let prompt = match input {
             InferenceInput::Text(s) => s.as_str(),
             InferenceInput::Multimodal { .. } => {
                 return Err(InferenceError::Unsupported {
-                    reason: "multimodal input reserved for post-PR-9; see HANDOFF §3.8",
+                    reason: "multimodal input reserved for the multi-modal PRs; see HANDOFF",
                 });
             }
         };
         if params.grammar.is_some() {
             return Err(InferenceError::Unsupported {
-                reason: "constrained generation (grammar) reserved for post-PR-9; see HANDOFF §3.8",
+                reason: "constrained generation (grammar) reserved; see HANDOFF",
             });
         }
 
@@ -169,89 +200,31 @@ impl InferenceBackend for LlamaInferenceBackend {
         }
         check_within(params, warrant)?;
 
-        // ---- Resolve registered path --------------------------------------
-        let path = self
-            .model_paths
-            .get(model_id)
-            .ok_or_else(|| InferenceError::ModelNotFound {
-                model_id: model_id.0.clone(),
-            })?;
+        // ---- Resolve the model descriptor (paths + capabilities) ----------
+        let descriptor =
+            self.resolver
+                .resolve(model_id)
+                .ok_or_else(|| InferenceError::ModelNotFound {
+                    model_id: model_id.0.clone(),
+                })?;
 
-        // ---- Timeout setup -------------------------------------------------
-        let start = Instant::now();
-        let timeout = Duration::from_millis(warrant.resource_ceiling.wall_clock_ms);
-        let check_timeout = |elapsed: Duration| -> Result<(), InferenceError> {
-            if elapsed >= timeout {
-                Err(InferenceError::Timeout {
-                    wall_clock_ms: warrant.resource_ceiling.wall_clock_ms,
-                })
-            } else {
-                Ok(())
-            }
-        };
-
-        // ---- llama.cpp setup (per-call; see module docs) ------------------
-        let backend = kx_llamacpp::LlamaBackend::new().map_err(map_llama_err)?;
-        let model = kx_llamacpp::Model::load(&backend, path).map_err(map_llama_err)?;
-        check_timeout(start.elapsed())?;
-
-        let ctx_params = kx_llamacpp::ContextParams::new().with_n_ctx(self.n_ctx);
-        let mut ctx =
-            kx_llamacpp::Context::new_with_params(&model, &ctx_params).map_err(map_llama_err)?;
-        let vocab = model.vocab();
-
-        let prompt_tokens = vocab.tokenize(prompt, true, false).map_err(map_llama_err)?;
-        check_timeout(start.elapsed())?;
-
-        // ---- Sampler chain -------------------------------------------------
-        let mut sampler = if params.temperature_bps == 0 {
-            kx_llamacpp::Sampler::greedy(&backend).map_err(map_llama_err)?
-        } else {
-            #[allow(clippy::cast_precision_loss)]
-            let temp = (params.temperature_bps as f32) / 10_000.0;
-            #[allow(clippy::cast_precision_loss)]
-            let top_p = (params.top_p_bps as f32) / 10_000.0;
-            #[allow(clippy::cast_possible_wrap)]
-            let top_k = params.top_k as i32;
-            kx_llamacpp::Sampler::typical(&backend, temp, top_k, top_p, params.seed)
-                .map_err(map_llama_err)?
-        };
-
-        // ---- Generation loop ----------------------------------------------
-        let generator = kx_llamacpp::Generator::new(&mut ctx, &mut sampler, &vocab, prompt_tokens)
-            .map_err(map_llama_err)?;
-
-        let mut output_bytes: Vec<u8> = Vec::with_capacity(
-            usize::try_from(params.max_output_tokens.saturating_mul(4)).unwrap_or(2048),
-        );
-        let mut output_tokens: u32 = 0;
-
-        for token_result in generator {
-            check_timeout(start.elapsed())?;
-            let token = token_result.map_err(map_llama_err)?;
-            vocab
-                .token_to_piece_into(token, 0, false, &mut output_bytes)
-                .map_err(map_llama_err)?;
-            output_tokens = output_tokens.saturating_add(1);
-            if output_tokens >= params.max_output_tokens {
-                break;
-            }
-            if vocab.is_eog(token) {
-                break;
-            }
-        }
-
-        Ok(InferenceOutput {
-            bytes: output_bytes,
-            output_tokens,
-            backend_name: BACKEND_NAME,
-            model_id: model_id.clone(),
-            elapsed: start.elapsed(),
-        })
+        // ---- Dispatch through the loaded-model cache (owner thread) -------
+        let cache = self
+            .cache
+            .get_or_init(|| ModelCache::spawn(self.cache_capacity));
+        cache.dispatch(
+            descriptor.identity_digest,
+            descriptor.gguf_path.clone(),
+            model_id.clone(),
+            prompt.to_string(),
+            params.clone(),
+            self.n_ctx,
+            warrant.resource_ceiling.wall_clock_ms,
+        )
     }
 
     fn supports(&self, model_id: &ModelId) -> bool {
-        self.model_paths.contains_key(model_id)
+        self.resolver.resolve(model_id).is_some()
     }
 
     fn name(&self) -> &'static str {

--- a/crates/kx-inference/tests/model_cache.rs
+++ b/crates/kx-inference/tests/model_cache.rs
@@ -1,0 +1,108 @@
+//! Loaded-model cache + `ModelResolver` rewiring (M4, PR-1).
+//!
+//! These run WITHOUT a real GGUF: they exercise the resolver-miss path (no
+//! worker thread) and the owner-thread round-trip + load-failure path (the
+//! worker spawns, attempts `Model::load` on a non-existent file, and the typed
+//! `BackendFailure` is relayed back). Byte-identical-cache-hit and
+//! no-reload-on-hit are validated against a real model in `kx-model-harness`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_content::ContentRef;
+use kx_inference::{
+    InferenceBackend, InferenceError, InferenceInput, InferenceParams, LlamaInferenceBackend,
+};
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+/// A warrant routed to `model_id` with a POSITIVE wall-clock budget, so a valid
+/// text dispatch reaches the model-load step instead of timing out immediately.
+fn warrant(model_id: ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 2048,
+            // Above the default params' `max_output_tokens` so a valid dispatch
+            // clears `check_within` and reaches the resolver/cache step.
+            max_output_tokens: 2048,
+            max_calls: 100,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn dispatch_unknown_model_is_model_not_found() {
+    let registered = ModelId("registered".into());
+    let backend = LlamaInferenceBackend::with_model(
+        registered,
+        std::path::PathBuf::from("/tmp/whatever.gguf"),
+    );
+    let unknown = ModelId("unknown".into());
+    let err = backend
+        .dispatch(
+            &unknown,
+            &InferenceInput::Text("hi".into()),
+            &InferenceParams::default(),
+            &warrant(unknown.clone()),
+        )
+        .expect_err("an unregistered model must be ModelNotFound");
+    assert!(matches!(err, InferenceError::ModelNotFound { .. }));
+    // Resolver miss never spawns the worker / loads a model.
+    assert_eq!(backend.loads_performed(), 0);
+}
+
+#[test]
+fn dispatch_missing_file_surfaces_backend_failure() {
+    let id = ModelId("ghost".into());
+    let backend = LlamaInferenceBackend::with_model(
+        id.clone(),
+        std::path::PathBuf::from("/nonexistent/definitely/not/a/model.gguf"),
+    );
+    let err = backend
+        .dispatch(
+            &id,
+            &InferenceInput::Text("hello".into()),
+            &InferenceParams::default(),
+            &warrant(id.clone()),
+        )
+        .expect_err("loading a non-existent model file must fail");
+    // The owner thread round-tripped the load failure as a typed BackendFailure.
+    assert!(
+        matches!(err, InferenceError::BackendFailure { .. }),
+        "expected BackendFailure, got {err:?}"
+    );
+    // A *failed* load does not count as a completed load.
+    assert_eq!(backend.loads_performed(), 0);
+}
+
+#[test]
+fn backend_is_cloneable_and_shares_one_cache() {
+    let id = ModelId("m".into());
+    let backend = LlamaInferenceBackend::with_model(id, std::path::PathBuf::from("/tmp/m.gguf"));
+    let clone = backend.clone();
+    // Fresh backends have performed no loads.
+    assert_eq!(backend.loads_performed(), 0);
+    assert_eq!(clone.loads_performed(), 0);
+}

--- a/crates/kx-model-harness/tests/model_cache.rs
+++ b/crates/kx-model-harness/tests/model_cache.rs
@@ -1,0 +1,100 @@
+//! Loaded-model cache validation against the real GGUF (M4, PR-1).
+//!
+//! Needs the pinned model; run with `--features with-model` (the
+//! `smoke-test-with-model` gate). These are the assertions that prove the
+//! 16GB-reload-per-dispatch bug is gone and that the cache is *transparent*:
+//!
+//! - A cache HIT is byte-identical to the cold load (greedy decode).
+//! - The second dispatch performs NO second load (`loads_performed` stays 1) —
+//!   the deterministic, non-flaky proof (vs. timing) that the model is reused.
+//! - Four concurrent dispatches against one backend share one cached model and
+//!   serialize through the owner thread (exactly one cold load total).
+
+#![cfg(feature = "with-model")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::thread;
+
+use kx_inference::{InferenceBackend, InferenceInput, InferenceParams, LlamaInferenceBackend};
+use kx_model_harness::{default_gguf_path, harness_warrant, model_id_for, ROW_PROMPT};
+
+/// Greedy, short — deterministic and fast.
+fn greedy() -> InferenceParams {
+    InferenceParams {
+        max_output_tokens: 16,
+        temperature_bps: 0,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn cache_hit_is_byte_identical_and_does_not_reload() {
+    let gguf = default_gguf_path();
+    let model_id = model_id_for(&gguf).unwrap();
+    let warrant = harness_warrant(&model_id, 16, 60_000);
+    let backend = LlamaInferenceBackend::with_model(model_id.clone(), gguf);
+    let input = InferenceInput::Text(ROW_PROMPT.to_string());
+    let params = greedy();
+
+    let out1 = backend
+        .dispatch(&model_id, &input, &params, &warrant)
+        .unwrap();
+    assert_eq!(
+        backend.loads_performed(),
+        1,
+        "first dispatch performs exactly one cold load"
+    );
+
+    let out2 = backend
+        .dispatch(&model_id, &input, &params, &warrant)
+        .unwrap();
+    assert_eq!(
+        backend.loads_performed(),
+        1,
+        "second dispatch is a cache HIT — the per-dispatch reload is gone"
+    );
+
+    assert!(!out1.bytes.is_empty(), "model produced output");
+    assert_eq!(
+        out1.bytes, out2.bytes,
+        "greedy ⇒ a cache hit yields byte-identical output to the cold load"
+    );
+    assert_eq!(out1.output_tokens, out2.output_tokens);
+}
+
+#[test]
+fn concurrent_dispatch_shares_one_cached_model() {
+    let gguf = default_gguf_path();
+    let model_id = model_id_for(&gguf).unwrap();
+    let backend: Arc<LlamaInferenceBackend> =
+        Arc::new(LlamaInferenceBackend::with_model(model_id.clone(), gguf));
+
+    let mut handles = Vec::with_capacity(4);
+    for _ in 0..4 {
+        let b = Arc::clone(&backend);
+        let id = model_id.clone();
+        handles.push(thread::spawn(move || {
+            let warrant = harness_warrant(&id, 16, 60_000);
+            let out = b
+                .dispatch(
+                    &id,
+                    &InferenceInput::Text(ROW_PROMPT.to_string()),
+                    &greedy(),
+                    &warrant,
+                )
+                .unwrap();
+            assert!(!out.bytes.is_empty());
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    // All four threads serialized through the owner thread and shared one
+    // cached model: exactly one cold load total.
+    assert_eq!(
+        backend.loads_performed(),
+        1,
+        "four concurrent dispatches load the model exactly once"
+    );
+}

--- a/crates/kx-model-store/Cargo.toml
+++ b/crates/kx-model-store/Cargo.toml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-model-store"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx model lifecycle (M4, D108.2): the backend-agnostic registry of model IDENTITY, declared MODALITIES (text/image/audio/video), projector (mmproj) path, and a fail-closed GGUF-header validator. A ModelResolver maps a ModelId → ModelDescriptor so an InferenceBackend sources paths + capabilities from one place instead of a frozen HashMap. FFI-FREE by construction (no kx-llamacpp dep) so `cargo install kx-runtime` still needs no C++ toolchain; the LIVE loaded-model handle cache lives in the backend (kx-inference), keyed by this crate's identity_digest. Off the trust path (SN-8): never gates selection/commit/audit."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# ModelId — the pinned model identity (name+version+quant) this registry keys on.
+kx-mote    = { workspace = true }
+# ContentRef — the 32-byte content-address newtype reused as the stable
+# loaded-model cache key (identity_digest). kx-content sits below everything,
+# so depending on it never widens the dependency wall.
+kx-content = { workspace = true }
+# Stack-inline modality lists (1–4 entries) without per-descriptor heap churn.
+smallvec   = { workspace = true, features = ["serde"] }
+# Domain-tagged blake3 for the path+modality identity_digest (NOT a hash of the
+# multi-GB weights — a cheap, stable cache identity).
+blake3     = { workspace = true }
+# serde derives so a descriptor set is a sharable, persistence-friendly bundle.
+serde      = { workspace = true }
+# Typed ModelStoreError (fail-closed GGUF validation + registry guards).
+thiserror  = { workspace = true }
+# Append/validate observability (debug-level only; never on a truth path).
+tracing    = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-model-store/src/descriptor.rs
+++ b/crates/kx-model-store/src/descriptor.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`ModelDescriptor`] — a model's identity, modalities, and cache key.
+
+use std::path::{Path, PathBuf};
+
+use kx_content::ContentRef;
+use kx_mote::ModelId;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
+use crate::errors::ModelStoreError;
+use crate::gguf;
+
+/// Domain separator for the `identity_digest` blake3 — versioned so the cache
+/// key scheme can evolve without colliding with a future scheme.
+const IDENTITY_DOMAIN: &[u8] = b"kx-model-store/identity/v1";
+
+/// A modality a model can consume (and, in future, produce).
+///
+/// This is a *capability declaration*: the author states what the model accepts
+/// so the backend can reject a mismatched input (a text-only model handed an
+/// image, or an image-only projector handed audio — the Gemma-3-has-no-audio
+/// trap) *before* reaching the FFI. The discriminants are explicit for clarity;
+/// `Modality` is off the journal/identity path, so it is not a frozen tag.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Modality {
+    /// Text tokens (every model).
+    Text = 0,
+    /// Raster images (vision projector / clip).
+    Image = 1,
+    /// Audio waveforms (audio encoder / conformer).
+    Audio = 2,
+    /// Video frames (reserved; no OSS backend serves it yet).
+    Video = 3,
+}
+
+/// The identity and capabilities of a single registered model.
+///
+/// Registration is **lazy**: constructing a descriptor does no file I/O and does
+/// not require the GGUF to exist (mirrors the backend's existing laziness — the
+/// file is only opened on first dispatch). Call [`validate`](Self::validate) to
+/// run the fail-closed GGUF-header check explicitly.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelDescriptor {
+    /// Pinned model identity (name + version + quantization).
+    pub model_id: ModelId,
+    /// Path to the model weights (GGUF).
+    pub gguf_path: PathBuf,
+    /// Path to the multi-modal projector (`mmproj`), if this is a multi-modal
+    /// model. `None` for a text-only model.
+    pub mmproj_path: Option<PathBuf>,
+    /// Modalities this model accepts. Always contains [`Modality::Text`].
+    pub modalities: SmallVec<[Modality; 4]>,
+    /// Default context window (`n_ctx`) for this model.
+    pub context_window: u32,
+    /// Stable cache identity (domain-tagged blake3 of path + modalities). The
+    /// loaded-model handle cache keys on this; it is NOT a hash of the weights
+    /// and is never journaled. See the crate docs.
+    pub identity_digest: ContentRef,
+}
+
+impl ModelDescriptor {
+    /// Construct a text-only descriptor with the given default context window.
+    #[must_use]
+    pub fn text(model_id: ModelId, gguf_path: impl Into<PathBuf>, context_window: u32) -> Self {
+        let mut modalities = SmallVec::new();
+        modalities.push(Modality::Text);
+        Self::new(model_id, gguf_path, None, modalities, context_window)
+    }
+
+    /// Construct a descriptor with an explicit modality set and optional
+    /// projector. [`Modality::Text`] is added if the caller omits it (every
+    /// model consumes a textual instruction alongside any media).
+    #[must_use]
+    pub fn new(
+        model_id: ModelId,
+        gguf_path: impl Into<PathBuf>,
+        mmproj_path: Option<PathBuf>,
+        mut modalities: SmallVec<[Modality; 4]>,
+        context_window: u32,
+    ) -> Self {
+        if !modalities.contains(&Modality::Text) {
+            modalities.insert(0, Modality::Text);
+        }
+        let gguf_path = gguf_path.into();
+        let identity_digest = compute_identity(&gguf_path, &modalities);
+        Self {
+            model_id,
+            gguf_path,
+            mmproj_path,
+            modalities,
+            context_window,
+            identity_digest,
+        }
+    }
+
+    /// Whether this model accepts inputs of modality `m`.
+    #[must_use]
+    pub fn supports(&self, m: Modality) -> bool {
+        self.modalities.contains(&m)
+    }
+
+    /// Whether this is a multi-modal model (declares a projector AND a non-text
+    /// modality).
+    #[must_use]
+    pub fn is_multimodal(&self) -> bool {
+        self.mmproj_path.is_some() && self.modalities.iter().any(|m| *m != Modality::Text)
+    }
+
+    /// Run the fail-closed GGUF-header validation against the weights file (and
+    /// the projector file, if declared). Does real file I/O; call it when you
+    /// want to fail fast at registration time rather than at first dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`ModelStoreError::ModelFileNotReadable`] /
+    /// [`ModelStoreError::InvalidGguf`] from [`gguf::validate_gguf_header`].
+    pub fn validate(&self) -> Result<(), ModelStoreError> {
+        gguf::validate_gguf_header(&self.gguf_path)?;
+        if let Some(mmproj) = &self.mmproj_path {
+            // The mmproj is itself a GGUF (clip/audio projector weights).
+            gguf::validate_gguf_header(mmproj)?;
+        }
+        Ok(())
+    }
+}
+
+/// Compute the domain-tagged identity digest from the path + declared modalities.
+///
+/// Path-based (no weight read) so it is computable lazily and is stable: the same
+/// file referenced by two `ModelId`s yields the same digest ⇒ one shared cached
+/// load. Modalities are folded in so a re-declaration with different modalities
+/// (e.g. adding audio) is a distinct cache identity.
+fn compute_identity(gguf_path: &Path, modalities: &[Modality]) -> ContentRef {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(IDENTITY_DOMAIN);
+    hasher.update(gguf_path.as_os_str().as_encoded_bytes());
+    hasher.update(&[0xff]); // delimiter so path/modality bytes can't run together
+    for m in modalities {
+        hasher.update(&[*m as u8]);
+    }
+    ContentRef::from_bytes(*hasher.finalize().as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mid(s: &str) -> ModelId {
+        ModelId(s.to_string())
+    }
+
+    #[test]
+    fn text_descriptor_supports_only_text() {
+        let d = ModelDescriptor::text(mid("llama-3-8b-q4"), "/m/llama.gguf", 4096);
+        assert!(d.supports(Modality::Text));
+        assert!(!d.supports(Modality::Image));
+        assert!(!d.supports(Modality::Audio));
+        assert!(!d.is_multimodal());
+    }
+
+    #[test]
+    fn multimodal_descriptor_adds_text_and_reports_modalities() {
+        let mut mods = SmallVec::new();
+        mods.push(Modality::Image);
+        mods.push(Modality::Audio);
+        let d = ModelDescriptor::new(
+            mid("gemma-4-q4"),
+            "/m/gemma4.gguf",
+            Some("/m/gemma4-mmproj.gguf".into()),
+            mods,
+            8192,
+        );
+        assert!(d.supports(Modality::Text)); // auto-added
+        assert!(d.supports(Modality::Image));
+        assert!(d.supports(Modality::Audio));
+        assert!(!d.supports(Modality::Video));
+        assert!(d.is_multimodal());
+    }
+
+    #[test]
+    fn identity_digest_is_stable_for_same_path_and_modalities() {
+        let a = ModelDescriptor::text(mid("a"), "/m/x.gguf", 4096);
+        let b = ModelDescriptor::text(mid("b"), "/m/x.gguf", 2048); // different id + n_ctx
+        assert_eq!(
+            a.identity_digest, b.identity_digest,
+            "same file path + modalities ⇒ same cache identity (shared load)"
+        );
+    }
+
+    #[test]
+    fn identity_digest_differs_for_different_path() {
+        let a = ModelDescriptor::text(mid("a"), "/m/x.gguf", 4096);
+        let b = ModelDescriptor::text(mid("a"), "/m/y.gguf", 4096);
+        assert_ne!(a.identity_digest, b.identity_digest);
+    }
+
+    #[test]
+    fn identity_digest_differs_when_modalities_change() {
+        let text = ModelDescriptor::text(mid("a"), "/m/x.gguf", 4096);
+        let mut mods = SmallVec::new();
+        mods.push(Modality::Image);
+        let img = ModelDescriptor::new(mid("a"), "/m/x.gguf", Some("/m/p.gguf".into()), mods, 4096);
+        assert_ne!(
+            text.identity_digest, img.identity_digest,
+            "adding a modality is a distinct cache identity"
+        );
+    }
+}

--- a/crates/kx-model-store/src/errors.rs
+++ b/crates/kx-model-store/src/errors.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed, fail-closed errors for the model store.
+
+use std::path::PathBuf;
+
+/// Failure modes surfaced by descriptor validation and the registry.
+///
+/// Every variant is a *refusal* — there is no partial / best-effort path. A
+/// malformed model file, a missing file at validation time, a duplicate
+/// registration, or an over-cap registry all fail closed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ModelStoreError {
+    /// The model file could not be opened for validation (does not exist, no
+    /// permission, etc). Registration itself is lazy and does NOT require the
+    /// file — this only fires from an explicit [`crate::ModelDescriptor::validate`].
+    #[error("model file not readable: {path} ({reason})")]
+    ModelFileNotReadable {
+        /// The path that could not be read.
+        path: PathBuf,
+        /// OS-level reason (stringified `io::Error` kind).
+        reason: String,
+    },
+
+    /// The file is not a valid GGUF model — bad magic, an unsupported version,
+    /// or an absurd header count (treated as corruption / hostile input).
+    #[error("invalid GGUF file {path}: {reason}")]
+    InvalidGguf {
+        /// The offending model path.
+        path: PathBuf,
+        /// What specifically failed the bounded header check.
+        reason: String,
+    },
+
+    /// A descriptor for this `ModelId` is already registered. Re-registration
+    /// is refused so identity never silently changes under a live cache.
+    #[error("duplicate model registration: {model_id}")]
+    DuplicateModel {
+        /// The id that was already present.
+        model_id: String,
+    },
+
+    /// The registry is at its capacity ceiling (a resource-exhaustion guard).
+    #[error("model registry full: {cap} descriptors is the ceiling")]
+    TooManyModels {
+        /// The configured ceiling.
+        cap: usize,
+    },
+}

--- a/crates/kx-model-store/src/gguf.rs
+++ b/crates/kx-model-store/src/gguf.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Fail-closed GGUF-header validation.
+//!
+//! A model file is **new untrusted input** (it may be corrupt, truncated, or
+//! hostile). We do not parse the whole file or the full metadata KV block — we
+//! read a bounded fixed-size header prefix and reject anything that is not a
+//! plausible GGUF v2/v3 file. Heavy parsing is llama.cpp's job at load time;
+//! this is the cheap gate that turns "garbage path" into a typed refusal instead
+//! of a deep-in-FFI surprise.
+//!
+//! GGUF layout (little-endian), the prefix we validate:
+//! ```text
+//! offset 0:  u8[4]  magic            = b"GGUF"
+//! offset 4:  u32    version          ∈ {2, 3}
+//! offset 8:  u64    tensor_count
+//! offset 16: u64    metadata_kv_count
+//! ```
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use crate::errors::ModelStoreError;
+
+/// The fixed GGUF prefix we read: magic(4) + version(4) + 2×u64(16) = 24 bytes.
+const GGUF_HEADER_LEN: usize = 24;
+
+/// GGUF magic bytes.
+const GGUF_MAGIC: &[u8; 4] = b"GGUF";
+
+/// GGUF versions this runtime accepts. v1 is obsolete; current llama.cpp emits
+/// v3. Anything else is refused so an unknown layout cannot be mistaken for a
+/// model.
+const SUPPORTED_VERSIONS: [u32; 2] = [2, 3];
+
+/// A sanity ceiling on the header counts. Real models are well under this; a
+/// value above it is treated as corruption rather than trusted.
+const MAX_PLAUSIBLE_COUNT: u64 = 1 << 32;
+
+/// The validated GGUF header prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GgufHeader {
+    /// GGUF container version (2 or 3).
+    pub version: u32,
+    /// Number of tensors declared in the file.
+    pub tensor_count: u64,
+    /// Number of metadata key/value pairs declared in the file.
+    pub metadata_kv_count: u64,
+}
+
+/// Read and validate the GGUF header prefix of `path`, fail-closed.
+///
+/// # Errors
+///
+/// - [`ModelStoreError::ModelFileNotReadable`] if the file cannot be opened.
+/// - [`ModelStoreError::InvalidGguf`] if the file is shorter than the header,
+///   the magic is wrong, the version is unsupported, or a count is implausible.
+pub fn validate_gguf_header(path: &Path) -> Result<GgufHeader, ModelStoreError> {
+    let mut file = File::open(path).map_err(|e| ModelStoreError::ModelFileNotReadable {
+        path: path.to_path_buf(),
+        reason: e.kind().to_string(),
+    })?;
+
+    let mut buf = [0u8; GGUF_HEADER_LEN];
+    // `read_exact` fails closed on a file shorter than the header.
+    file.read_exact(&mut buf)
+        .map_err(|_| ModelStoreError::InvalidGguf {
+            path: path.to_path_buf(),
+            reason: format!("file shorter than the {GGUF_HEADER_LEN}-byte GGUF header"),
+        })?;
+
+    if &buf[0..4] != GGUF_MAGIC {
+        return Err(ModelStoreError::InvalidGguf {
+            path: path.to_path_buf(),
+            reason: "bad magic (not a GGUF file)".to_string(),
+        });
+    }
+
+    let version = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    if !SUPPORTED_VERSIONS.contains(&version) {
+        return Err(ModelStoreError::InvalidGguf {
+            path: path.to_path_buf(),
+            reason: format!(
+                "unsupported GGUF version {version} (accepted: {SUPPORTED_VERSIONS:?})"
+            ),
+        });
+    }
+
+    let tensor_count = read_u64_le(&buf, 8);
+    let metadata_kv_count = read_u64_le(&buf, 16);
+    if tensor_count > MAX_PLAUSIBLE_COUNT || metadata_kv_count > MAX_PLAUSIBLE_COUNT {
+        return Err(ModelStoreError::InvalidGguf {
+            path: path.to_path_buf(),
+            reason: format!(
+                "implausible header counts (tensors={tensor_count}, kv={metadata_kv_count}); \
+                 treating as corruption"
+            ),
+        });
+    }
+
+    Ok(GgufHeader {
+        version,
+        tensor_count,
+        metadata_kv_count,
+    })
+}
+
+/// Read a little-endian `u64` at `offset` from a buffer known to be long enough.
+#[inline]
+fn read_u64_le(buf: &[u8; GGUF_HEADER_LEN], offset: usize) -> u64 {
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&buf[offset..offset + 8]);
+    u64::from_le_bytes(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(bytes: &[u8]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("tmp file");
+        f.write_all(bytes).expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    fn valid_header(version: u32) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(GGUF_MAGIC);
+        v.extend_from_slice(&version.to_le_bytes());
+        v.extend_from_slice(&3u64.to_le_bytes()); // tensor_count
+        v.extend_from_slice(&7u64.to_le_bytes()); // metadata_kv_count
+        v
+    }
+
+    #[test]
+    fn accepts_valid_v3_header() {
+        let f = write_tmp(&valid_header(3));
+        let h = validate_gguf_header(f.path()).expect("v3 header valid");
+        assert_eq!(h.version, 3);
+        assert_eq!(h.tensor_count, 3);
+        assert_eq!(h.metadata_kv_count, 7);
+    }
+
+    #[test]
+    fn accepts_valid_v2_header() {
+        let f = write_tmp(&valid_header(2));
+        assert_eq!(validate_gguf_header(f.path()).unwrap().version, 2);
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut bytes = valid_header(3);
+        bytes[0] = b'X';
+        let f = write_tmp(&bytes);
+        let err = validate_gguf_header(f.path()).unwrap_err();
+        assert!(matches!(err, ModelStoreError::InvalidGguf { .. }));
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let f = write_tmp(&valid_header(1));
+        assert!(matches!(
+            validate_gguf_header(f.path()).unwrap_err(),
+            ModelStoreError::InvalidGguf { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_file() {
+        let f = write_tmp(b"GGUF\x03"); // 5 bytes, shorter than the header
+        assert!(matches!(
+            validate_gguf_header(f.path()).unwrap_err(),
+            ModelStoreError::InvalidGguf { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_implausible_counts() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(GGUF_MAGIC);
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&u64::MAX.to_le_bytes()); // absurd tensor_count
+        bytes.extend_from_slice(&7u64.to_le_bytes());
+        let f = write_tmp(&bytes);
+        assert!(matches!(
+            validate_gguf_header(f.path()).unwrap_err(),
+            ModelStoreError::InvalidGguf { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_file_is_not_readable() {
+        let err = validate_gguf_header(Path::new("/nonexistent/model.gguf")).unwrap_err();
+        assert!(matches!(err, ModelStoreError::ModelFileNotReadable { .. }));
+    }
+}

--- a/crates/kx-model-store/src/lib.rs
+++ b/crates/kx-model-store/src/lib.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//! # kx-model-store — model lifecycle (M4, D108.2)
+//!
+//! The model store is the runtime's single source of truth for **which model
+//! files exist, what modalities they serve, and where their projector lives** —
+//! the vocabulary every multi-modal dispatch needs. Before this crate the OSS
+//! the `InferenceBackend` registered models as a frozen
+//! `HashMap<ModelId, PathBuf>` with no capability metadata; a caller could not
+//! ask "does this model accept images?" and so could not reject a text-only
+//! model handed an image, or a vision projector handed audio.
+//!
+//! ## What it owns
+//!
+//! - [`ModelDescriptor`] — a model's identity: its `ModelId`, GGUF path, optional
+//!   multi-modal projector (`mmproj`) path, declared [`Modality`] set, default
+//!   context window, and a stable [`identity_digest`](ModelDescriptor::identity_digest).
+//! - [`ModelRegistry`] — a `BTreeMap`-backed set of descriptors (deterministic
+//!   iteration) implementing [`ModelResolver`], the seam a backend resolves through.
+//! - [`gguf`] — a **fail-closed** GGUF-header validator: the model file is *new
+//!   untrusted input*, so the header is parsed with bounded reads and rejected on
+//!   bad magic / unknown version / absurd counts ([`ModelStoreError::InvalidGguf`]).
+//!
+//! ## FFI-free by construction (the install-barrier guarantee, D127.3)
+//!
+//! This crate depends on **no** `kx-llamacpp` / C++ FFI — only `kx-mote` and
+//! `kx-content`. It therefore stays in the dependency closure that builds with no
+//! C++ toolchain, preserving `cargo install kx-runtime`. The **live** loaded-model
+//! handle (the heavyweight `llama_model`) is cached in the backend
+//! (`kx-inference`), keyed by [`ModelDescriptor::identity_digest`]; this crate
+//! holds only paths + metadata.
+//!
+//! ## `identity_digest` is a CACHE identity, not a weight hash
+//!
+//! Hashing multi-GB weights on every registration would be ruinous, and the
+//! backend's laziness (a model file need not exist until first dispatch) forbids
+//! reading the file at registration. So [`identity_digest`](ModelDescriptor::identity_digest)
+//! is a domain-tagged blake3 over the **path + declared modalities** — stable
+//! (same file ⇒ same key ⇒ one cached load shared across `ModelId`s that point at
+//! it) without touching the weights. It is the loaded-model cache key, never a
+//! cryptographic commitment to the weights and never journaled.
+//!
+//! ## Off the trust path (SN-8)
+//!
+//! The store never gates selection, commitment, eviction, or the audit path, and
+//! carries no floats. The guarantee-path crates (`kx-scheduler` / `kx-executor` /
+//! `kx-projection` / `kx-journal`) do not depend on it; the one inbound edge is
+//! `kx-inference → kx-model-store` (behind the `llamacpp` feature), a capability
+//! dependency, not a trust dependency.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+// Tests assert on known-good values where `unwrap`/`expect` document the
+// invariant being checked; the workspace policy denies them in library code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod descriptor;
+pub mod errors;
+pub mod gguf;
+pub mod registry;
+
+pub use descriptor::{Modality, ModelDescriptor};
+pub use errors::ModelStoreError;
+pub use gguf::GgufHeader;
+pub use registry::{ModelRegistry, ModelResolver};

--- a/crates/kx-model-store/src/registry.rs
+++ b/crates/kx-model-store/src/registry.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+//! [`ModelResolver`] — the seam a backend resolves a `ModelId` through — and the
+//! in-memory [`ModelRegistry`] implementation.
+
+use std::collections::BTreeMap;
+
+use kx_mote::ModelId;
+
+use crate::descriptor::ModelDescriptor;
+use crate::errors::ModelStoreError;
+
+/// Capacity ceiling on a single registry — a resource-exhaustion guard so an
+/// unbounded registration loop cannot grow memory without bound. Far above any
+/// realistic single-node model count.
+pub const MAX_MODELS: usize = 4096;
+
+/// Resolve a [`ModelId`] to its [`ModelDescriptor`].
+///
+/// This is the seam an `InferenceBackend` holds (as `Arc<dyn ModelResolver>`)
+/// instead of a frozen `HashMap` — a future durable / remote registry (a cloud
+/// backend, a hot-swap-on-journaled-fact registry) implements the same trait
+/// without the backend changing. `Send + Sync` so it can live in a shared,
+/// thread-safe backend.
+pub trait ModelResolver: Send + Sync {
+    /// The descriptor for `id`, or `None` if no model is registered under it.
+    fn resolve(&self, id: &ModelId) -> Option<&ModelDescriptor>;
+}
+
+/// An in-memory model registry: a deterministic `BTreeMap<ModelId, _>`.
+///
+/// `BTreeMap` (not `HashMap`) so iteration order is stable — useful for
+/// diagnostics and any future canonical listing.
+#[derive(Debug, Clone, Default)]
+pub struct ModelRegistry {
+    models: BTreeMap<ModelId, ModelDescriptor>,
+}
+
+impl ModelRegistry {
+    /// An empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a descriptor under its `model_id`.
+    ///
+    /// Lazy: does NOT touch the model file (call
+    /// [`ModelDescriptor::validate`](crate::ModelDescriptor::validate) for that).
+    ///
+    /// # Errors
+    ///
+    /// - [`ModelStoreError::DuplicateModel`] if the id is already registered
+    ///   (re-registration is refused so identity cannot silently change under a
+    ///   live cache).
+    /// - [`ModelStoreError::TooManyModels`] if the registry is at [`MAX_MODELS`].
+    pub fn register(&mut self, descriptor: ModelDescriptor) -> Result<(), ModelStoreError> {
+        if self.models.contains_key(&descriptor.model_id) {
+            return Err(ModelStoreError::DuplicateModel {
+                model_id: descriptor.model_id.0.clone(),
+            });
+        }
+        if self.models.len() >= MAX_MODELS {
+            return Err(ModelStoreError::TooManyModels { cap: MAX_MODELS });
+        }
+        tracing::debug!(model_id = %descriptor.model_id.0, "registering model descriptor");
+        self.models.insert(descriptor.model_id.clone(), descriptor);
+        Ok(())
+    }
+
+    /// Build a registry from an iterator of descriptors, failing closed on the
+    /// first duplicate or over-cap.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`register`](Self::register)'s errors.
+    pub fn from_descriptors(
+        descriptors: impl IntoIterator<Item = ModelDescriptor>,
+    ) -> Result<Self, ModelStoreError> {
+        let mut reg = Self::new();
+        for d in descriptors {
+            reg.register(d)?;
+        }
+        Ok(reg)
+    }
+
+    /// Number of registered models.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.models.len()
+    }
+
+    /// Whether the registry is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.models.is_empty()
+    }
+
+    /// Iterate the registered descriptors in `ModelId` order.
+    pub fn iter(&self) -> impl Iterator<Item = &ModelDescriptor> {
+        self.models.values()
+    }
+}
+
+impl ModelResolver for ModelRegistry {
+    fn resolve(&self, id: &ModelId) -> Option<&ModelDescriptor> {
+        self.models.get(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptor::Modality;
+
+    fn mid(s: &str) -> ModelId {
+        ModelId(s.to_string())
+    }
+
+    #[test]
+    fn register_and_resolve() {
+        let mut reg = ModelRegistry::new();
+        reg.register(ModelDescriptor::text(mid("a"), "/m/a.gguf", 4096))
+            .unwrap();
+        let d = reg.resolve(&mid("a")).expect("registered");
+        assert_eq!(d.gguf_path.to_str().unwrap(), "/m/a.gguf");
+        assert!(d.supports(Modality::Text));
+        assert!(reg.resolve(&mid("missing")).is_none());
+    }
+
+    #[test]
+    fn duplicate_registration_is_refused() {
+        let mut reg = ModelRegistry::new();
+        reg.register(ModelDescriptor::text(mid("a"), "/m/a.gguf", 4096))
+            .unwrap();
+        let err = reg
+            .register(ModelDescriptor::text(mid("a"), "/m/other.gguf", 4096))
+            .unwrap_err();
+        assert!(matches!(err, ModelStoreError::DuplicateModel { .. }));
+        // Original is intact.
+        assert_eq!(
+            reg.resolve(&mid("a")).unwrap().gguf_path.to_str().unwrap(),
+            "/m/a.gguf"
+        );
+    }
+
+    #[test]
+    fn from_descriptors_roundtrips() {
+        let reg = ModelRegistry::from_descriptors([
+            ModelDescriptor::text(mid("a"), "/m/a.gguf", 4096),
+            ModelDescriptor::text(mid("b"), "/m/b.gguf", 2048),
+        ])
+        .unwrap();
+        assert_eq!(reg.len(), 2);
+        assert!(!reg.is_empty());
+        // Deterministic ModelId order.
+        let ids: Vec<_> = reg.iter().map(|d| d.model_id.0.clone()).collect();
+        assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+    }
+}


### PR DESCRIPTION
## Context

First PR of the OSS multi-modal track (**D128**, amends D126.2/D127 — multi-modal pulled onto the OSS runtime). Foundation for the image/audio PRs that follow.

## What

- **NEW crate `kx-model-store`** (additive, **FFI-free**): a backend-agnostic `ModelResolver`/`ModelRegistry` over `ModelDescriptor`s — model identity, declared `Modality` set (text/image/audio/video), projector (`mmproj`) path, default context window, and a stable path-derived `identity_digest`. Fail-closed GGUF-header validator (bounded reads; rejects bad magic / unknown version / implausible counts). This is the capability vocabulary later PRs use to reject a text-only model handed an image.
- **`LlamaInferenceBackend` rewired**: resolves paths + capabilities through a `ModelResolver` (default `BTreeMap` `ModelRegistry`) instead of a frozen `HashMap`, and dispatches through a **loaded-model cache** (`cache.rs`): a single owner thread owns the `!Send+!Sync` `LlamaBackend` + an LRU of loaded `Model`s keyed by `identity_digest`. **Ends the per-dispatch `Model::load`** (ruinous for a multi-GB model). `with_model`/`with_models` retained as shims (no caller change); `loads_performed()` is the observable no-reload proof.

## Pre-flight (Golden Rule 8)

**Pass A** — (a) *breaks*: no truth-path change — `a0_guard` digest `a6b5c679…` invariant; gate ordering preserved; `proptest_dispatch` green. (b) *perf*: fixes the reload; LRU bounds RAM; cache hit ≡ cold load. (c) *security*: GGUF header is new untrusted input → fail-closed parse; registry capacity cap; local paths only.
**Pass B**: the owner thread is the seam for future concurrent multi-model serving + journaled hot-swap; `loads_performed` is the measured trust receipt.

**Frozen-trio thesis preserved** (kx-scheduler/kx-executor src untouched; the kx-inference change is sanctioned capability work per D108.2). **FFI-free guarantee intact**: `build-no-inference` green — neither kx-llamacpp nor kx-model-store is in kx-runtime's normal dependency closure.

### Design note (Rule 8 (ii))
The cache owner thread lives in `kx-inference` (not `kx-llamacpp` as first sketched): the generation loop maps `InferenceParams`→sampler, and `kx-llamacpp` must not depend on `kx-inference`/`kx-mote`. Same mechanism (owner thread + mpsc, because `LlamaBackend`/`Model` are `!Send`/`!Sync`), cleaner layering, fewer crates touched.

## Tests
- `kx-model-store`: 15 unit (descriptor / registry / gguf incl. corrupt / truncated / bad-magic / implausible-counts / missing-file).
- `kx-inference/tests/model_cache.rs` (no model): resolver miss → `ModelNotFound`; missing file → worker round-trips `BackendFailure`; clone shares one cache.
- `kx-model-harness/tests/model_cache.rs` (`--features with-model`, manual/smoke): cache hit byte-identical + `loads_performed()==1` (no reload); 4 concurrent dispatches share one cached model.

## Local gate
fmt · clippy `--workspace -D warnings` · test `--workspace` · deny · doc `-D warnings` · build-no-inference · ffi-link — all green. `check-reproducible` + `scale-smoke` run on CI (unaffected — no projection/fold change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)