### PR TITLE
PR-2.5 (D128) — projector cache: ModelWithProjector ends the per-dispatch mmproj reload

### DIFF
--- a/crates/kx-inference/src/cache.rs
+++ b/crates/kx-inference/src/cache.rs
@@ -17,11 +17,14 @@
 // model). The owner thread loads each model once, keyed by its
 // `kx_model_store` `identity_digest`, and reuses it. A small LRU bounds RAM.
 //
-// MULTI-MODAL (PR-2): an image dispatch carries already-resolved image bytes +
-// the projector (`mmproj`) path. The owner thread reuses the cached base model
-// but (PR-2) re-creates the `Mtmd` projector context per dispatch — the base
-// model cache (the PR-1 win) is preserved; the projector reload is *measured*
-// via `mmproj_loads` and eliminated in the PR-2.5 projector-cache follow-up.
+// MULTI-MODAL (PR-2 → PR-2.5): an image dispatch carries already-resolved image
+// bytes + the projector (`mmproj`) path. The owner thread caches each loaded
+// model together with its projector in a `ModelWithProjector` bundle, so the
+// projector (`Mtmd`) — like the base model — is loaded ONCE per distinct
+// model+projector and reused across dispatches (PR-2.5). `mmproj_loads` counts
+// only those cold projector loads; a per-dispatch rise would mean the projector
+// cache regressed. (PR-2 reloaded the projector on every image dispatch and
+// merely *measured* it via the same counter.)
 //
 // CONCURRENCY: dispatch is serialized by the single owner thread — exactly the
 // discipline `kx-llamacpp` mandates ("never `&Context` from two threads").
@@ -36,8 +39,8 @@ use std::time::{Duration, Instant};
 
 use kx_content::ContentRef;
 use kx_llamacpp::{
-    Bitmap, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, Mtmd, Sampler,
-    Vocab,
+    Bitmap, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, ModelWithProjector,
+    Mtmd, Sampler, Vocab,
 };
 use kx_mote::{InferenceParams, ModelId};
 use smallvec::SmallVec;
@@ -101,10 +104,10 @@ pub(crate) struct ModelCache {
     /// Number of cold `Model::load`s performed — the observable proof that a
     /// cache hit did NOT reload (and the ops metric for "the reload is gone").
     loads: Arc<AtomicU64>,
-    /// Number of `Mtmd` projector loads performed. In PR-2 this increments once
-    /// per image dispatch (the projector is re-created each time); the PR-2.5
-    /// projector cache will make it increment once per distinct model. Exposed
-    /// as the measured signal that justifies that follow-up.
+    /// Number of cold `Mtmd` projector loads performed. With the PR-2.5
+    /// projector cache this increments once per distinct model+projector (the
+    /// bundle loads it on the first image dispatch, then reuses it); a rise on
+    /// every image dispatch would mean the projector cache regressed.
     mmproj_loads: Arc<AtomicU64>,
 }
 
@@ -199,10 +202,12 @@ fn owner_loop(rx: &Receiver<Job>, capacity: usize, loads: &AtomicU64, mmproj_loa
         }
     };
 
-    // LRU of loaded models. Each `Model<'_>` borrows `backend`; both are locals
-    // of this function, so the borrow is valid for the whole loop and `lru` is
-    // dropped before `backend`.
-    let mut lru: Vec<(ContentRef, Model<'_>)> = Vec::with_capacity(capacity);
+    // LRU of loaded models, each bundled with its (lazily-loaded) projector.
+    // Every `ModelWithProjector<'_>` borrows `backend`; both are locals of this
+    // function, so the borrow is valid for the whole loop and `lru` is dropped
+    // before `backend`. Within a bundle the projector is dropped before its
+    // model (declaration order); across the `lru`, eviction drops a whole bundle.
+    let mut lru: Vec<(ContentRef, ModelWithProjector<'_>)> = Vec::with_capacity(capacity);
 
     while let Ok(job) = rx.recv() {
         let result = run_job(&backend, &mut lru, capacity, loads, mmproj_loads, &job);
@@ -211,10 +216,11 @@ fn owner_loop(rx: &Receiver<Job>, capacity: usize, loads: &AtomicU64, mmproj_loa
     }
 }
 
-/// Resolve-or-load the model, then run (multi-modal or text) generation.
+/// Resolve-or-load the model (+ its cached projector), then run (multi-modal or
+/// text) generation.
 fn run_job<'b>(
     backend: &'b LlamaBackend,
-    lru: &mut Vec<(ContentRef, Model<'b>)>,
+    lru: &mut Vec<(ContentRef, ModelWithProjector<'b>)>,
     capacity: usize,
     loads: &AtomicU64,
     mmproj_loads: &AtomicU64,
@@ -222,12 +228,12 @@ fn run_job<'b>(
 ) -> Result<InferenceOutput, InferenceError> {
     let start = Instant::now();
     let timeout = Duration::from_millis(job.wall_clock_ms);
-    let model = get_or_load(backend, lru, capacity, loads, job.identity, &job.path)
+    let entry = get_or_load(backend, lru, capacity, loads, job.identity, &job.path)
         .map_err(map_llama_err)?;
     check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
 
     let (bytes, output_tokens) = if job.images.is_empty() {
-        generate(backend, model, job, start, timeout)?
+        generate(backend, entry.model(), job, start, timeout)?
     } else {
         let mmproj = job
             .mmproj_path
@@ -235,7 +241,7 @@ fn run_job<'b>(
             .ok_or(InferenceError::Unsupported {
                 reason: "multimodal job is missing its projector (mmproj) path",
             })?;
-        generate_multimodal(backend, model, mmproj, mmproj_loads, job, start, timeout)?
+        generate_multimodal(backend, entry, mmproj, mmproj_loads, job, start, timeout)?
     };
     Ok(InferenceOutput {
         bytes,
@@ -246,33 +252,37 @@ fn run_job<'b>(
     })
 }
 
-/// Return a reference to the cached model for `identity`, loading + inserting it
-/// (and evicting the LRU front at capacity) on a miss. By construction the
-/// wanted model is the last LRU entry on return.
+/// Return a mutable reference to the cached model bundle for `identity`,
+/// loading and inserting it (evicting the LRU front at capacity) on a miss. By
+/// construction the wanted bundle is the last LRU entry on return.
+///
+/// The reference is `&mut` so the multi-modal path can lazily load and cache the
+/// projector via `ensure_projector`; the text path only reads `model()`.
 fn get_or_load<'a, 'b>(
     backend: &'b LlamaBackend,
-    lru: &'a mut Vec<(ContentRef, Model<'b>)>,
+    lru: &'a mut Vec<(ContentRef, ModelWithProjector<'b>)>,
     capacity: usize,
     loads: &AtomicU64,
     identity: ContentRef,
     path: &Path,
-) -> Result<&'a Model<'b>, LlamaError> {
+) -> Result<&'a mut ModelWithProjector<'b>, LlamaError> {
     if let Some(pos) = lru.iter().position(|(id, _)| *id == identity) {
-        // Hit: move to the most-recently-used end.
+        // Hit: move to the most-recently-used end (keeps the cached projector).
         let entry = lru.remove(pos);
         lru.push(entry);
     } else {
-        // Miss: evict LRU front if full, then load + insert.
+        // Miss: evict LRU front if full (dropping its projector then model),
+        // then load + insert. The projector is loaded lazily on first image use.
         if lru.len() >= capacity {
             let _evicted = lru.remove(0);
         }
         let model = Model::load(backend, path)?;
         loads.fetch_add(1, Ordering::Relaxed);
-        lru.push((identity, model));
+        lru.push((identity, ModelWithProjector::new(model)));
     }
     // Non-empty by construction (a hit re-pushes; a miss pushes).
     let idx = lru.len() - 1;
-    Ok(&lru[idx].1)
+    Ok(&mut lru[idx].1)
 }
 
 /// Build the sampler for `params` (greedy when `temperature_bps == 0`, else
@@ -352,31 +362,39 @@ fn generate(
     run_generation(generator, &vocab, job, start, timeout)
 }
 
-/// The multi-modal (image) generation path: load the projector, decode the
+/// The multi-modal (image) generation path: ensure the projector is resident
+/// (loaded once per model+projector, then cached on the bundle), decode the
 /// images into bitmaps (fail-closed), splice them in at the media markers,
 /// run the mtmd prefill, then emit tokens with the SAME sampler + generation
 /// loop as the text path.
 fn generate_multimodal(
     backend: &LlamaBackend,
-    model: &Model<'_>,
+    entry: &mut ModelWithProjector<'_>,
     mmproj: &Path,
     mmproj_loads: &AtomicU64,
     job: &Job,
     start: Instant,
     timeout: Duration,
 ) -> Result<(Vec<u8>, u32), InferenceError> {
-    // A larger batch so a single high-token image does not overflow the decode.
-    let ctx_params = ContextParams::new()
-        .with_n_ctx(job.n_ctx)
-        .with_n_batch(MULTIMODAL_N_BATCH)
-        .with_n_ubatch(MULTIMODAL_N_UBATCH);
-    let mut ctx = Context::new_with_params(model, &ctx_params).map_err(map_llama_err)?;
-    let n_batch = i32::try_from(ctx.n_batch()).unwrap_or(i32::MAX);
-
-    // Load the projector. PR-2: per-dispatch (measured via `mmproj_loads`);
-    // PR-2.5 caches it on this owner thread.
-    let mtmd = Mtmd::from_file(model, mmproj, 0, true).map_err(map_llama_err)?;
-    mmproj_loads.fetch_add(1, Ordering::Relaxed);
+    // Ensure the projector is resident. PR-2.5: loaded ONCE per model+projector
+    // and cached on the bundle (the heavyweight `mtmd_init_from_file` +
+    // GPU upload). `mmproj_loads` rises only on a real (re)load — the measured
+    // proof that the per-dispatch reload is gone.
+    if entry
+        .ensure_projector(mmproj, 0, true)
+        .map_err(map_llama_err)?
+    {
+        mmproj_loads.fetch_add(1, Ordering::Relaxed);
+    }
+    // `ensure_projector` returned `Ok`, so a projector is resident; the `None`
+    // arm is unreachable. Surface it as a typed backend failure (never a panic)
+    // rather than `expect`, keeping the dispatch path fail-closed.
+    let mtmd = entry
+        .projector()
+        .ok_or_else(|| InferenceError::BackendFailure {
+            backend: BACKEND_NAME,
+            message: "projector not resident after ensure_projector returned Ok".to_string(),
+        })?;
     // Defense-in-depth beyond the descriptor's declared modality: the loaded
     // projector itself must accept images.
     if !mtmd.supports_vision() {
@@ -386,12 +404,21 @@ fn generate_multimodal(
     }
     check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
 
+    // A larger batch so a single high-token image does not overflow the decode.
+    let model = entry.model();
+    let ctx_params = ContextParams::new()
+        .with_n_ctx(job.n_ctx)
+        .with_n_batch(MULTIMODAL_N_BATCH)
+        .with_n_ubatch(MULTIMODAL_N_UBATCH);
+    let mut ctx = Context::new_with_params(model, &ctx_params).map_err(map_llama_err)?;
+    let n_batch = i32::try_from(ctx.n_batch()).unwrap_or(i32::MAX);
+
     // Decode each image (untrusted bytes → stb). A decode failure is a typed
     // error, never a panic.
     let bitmaps: Vec<Bitmap> = job
         .images
         .iter()
-        .map(|bytes| Bitmap::from_image_buf(&mtmd, bytes))
+        .map(|bytes| Bitmap::from_image_buf(mtmd, bytes))
         .collect::<Result<_, _>>()
         .map_err(map_llama_err)?;
     let bitmap_refs: Vec<&Bitmap> = bitmaps.iter().collect();

--- a/crates/kx-inference/src/llama.rs
+++ b/crates/kx-inference/src/llama.rs
@@ -196,11 +196,12 @@ impl LlamaInferenceBackend {
         self.cache.get().map_or(0, ModelCache::loads)
     }
 
-    /// Number of multi-modal projector (`mmproj`) loads performed so far. In
-    /// PR-2 this rises once per image dispatch (the projector is re-created each
-    /// time, the base model stays cached); the PR-2.5 projector cache will make
-    /// it rise once per distinct model. The measured signal that justifies that
-    /// follow-up — never a claimed figure.
+    /// Number of cold multi-modal projector (`mmproj`) loads performed so far.
+    /// With the PR-2.5 projector cache this rises once per distinct
+    /// model+projector — the bundle loads the projector on the first image
+    /// dispatch and reuses it thereafter (the base model stays cached too). A
+    /// rise on *every* image dispatch would mean the projector cache regressed;
+    /// the measured signal, never a claimed figure.
     #[must_use]
     pub fn mmproj_loads_performed(&self) -> u64 {
         self.cache.get().map_or(0, ModelCache::mmproj_loads)

--- a/crates/kx-llamacpp/src/lib.rs
+++ b/crates/kx-llamacpp/src/lib.rs
@@ -150,6 +150,18 @@
 //!    holds a `NonNull`. No `*mut T` flows further than the construction
 //!    site.
 //!
+//! 5. **One sanctioned self-reference: [`ModelWithProjector`].** A cached
+//!    multi-modal projector must coexist with the [`Model`] it borrows in a
+//!    single owned value (so a model + its projector can be cached together).
+//!    `ModelWithProjector` is the *only* place that holds such a
+//!    self-referential borrow. Its soundness rests on two facts the compiler
+//!    cannot check — the model is `Box`-pinned (stable address) and
+//!    field-declaration order guarantees the projector is dropped before the
+//!    model — both documented at its definition and guarded by the
+//!    `struct_field_drop_order_is_declaration_order` test. No new FFI handle is
+//!    allocated (it composes `Model` + `Mtmd`, each of which still frees itself
+//!    exactly once per invariant 3).
+//!
 //! ## ABI pin
 //!
 //! The `llama.cpp` source is a **pinned git submodule** at a specific
@@ -180,7 +192,7 @@ pub use context::{Context, ContextParams, PerfData, PoolingType};
 pub use error::LlamaError;
 pub use generator::Generator;
 pub use model::{Model, ModelParams};
-pub use mtmd::{Bitmap, InputChunks, Mtmd};
+pub use mtmd::{Bitmap, InputChunks, ModelWithProjector, Mtmd};
 pub use sampler::{Sampler, SamplerChainBuilder};
 pub use vocab::{Token, Vocab};
 

--- a/crates/kx-llamacpp/src/mtmd.rs
+++ b/crates/kx-llamacpp/src/mtmd.rs
@@ -39,7 +39,7 @@
 //! Each handle is wrapped in `NonNull` at construction and freed exactly once.
 
 use std::ffi::{CStr, CString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
 
 use kx_llamacpp_sys as sys;
@@ -241,6 +241,119 @@ impl Drop for Mtmd<'_, '_> {
     }
 }
 
+/// A loaded text [`Model`] bundled with a lazily-loaded, **cached** multi-modal
+/// projector ([`Mtmd`]).
+///
+/// ## Why this type exists (PR-2.5)
+///
+/// [`Mtmd`] borrows the [`Model`] it is initialized from (`Mtmd<'m, 'b>` holds
+/// `PhantomData<&'m Model<'b>>`), so a `Model` and an `Mtmd` derived from it
+/// cannot live in the same ordinary struct in safe Rust — that is a
+/// self-referential borrow. The in-process backend needs exactly that: keep one
+/// model resident AND keep its projector resident across dispatches, instead of
+/// re-running [`Mtmd::from_file`] (which re-uploads the projector to the GPU —
+/// seconds of work) on **every** multi-modal call. This type resolves the
+/// self-reference soundly and **contains the single `unsafe`** it requires, per
+/// the crate invariant that all `unsafe` lives in `kx-llamacpp`.
+///
+/// ## Why it is sound (the two load-bearing facts)
+///
+/// 1. **Stable address.** The model is heap-pinned in a [`Box`], so its address
+///    never moves when the bundle itself is moved (e.g. within a cache `Vec`
+///    that reorders entries or reallocates).
+/// 2. **Drop order.** Rust drops struct fields in *declaration order*, so the
+///    `projector` field (declared first ⇒ `mtmd_free` first) is always dropped
+///    strictly before the `model` field (`llama_model_free`). The projector
+///    therefore never outlives the model despite the lifetime-erased self-borrow.
+///    The `struct_field_drop_order_is_declaration_order` test guards the
+///    declaration-order ⇒ drop-order mechanism this relies on.
+///
+/// The projector is stored at `Mtmd<'b, 'b>` (the model-borrow lifetime widened
+/// to the backend lifetime `'b`). Because [`Mtmd`] is **covariant** in its
+/// model-borrow lifetime, [`Self::projector`] can still be used wherever a
+/// shorter-lived `Mtmd<'_, 'b>` is expected — e.g. alongside a per-dispatch
+/// [`Context`] in [`Mtmd::eval_chunks`].
+pub struct ModelWithProjector<'b> {
+    // FIELD ORDER IS LOAD-BEARING — DO NOT REORDER. Rust drops struct fields in
+    // declaration order; `projector` borrows `model`, so it MUST be declared
+    // (and therefore dropped) before `model`.
+    projector: Option<Mtmd<'b, 'b>>,
+    /// The projector path currently cached in `projector` (if any). A request
+    /// for a *different* path triggers a reload (defensive — a model identity
+    /// normally maps to exactly one projector).
+    mmproj_path: Option<PathBuf>,
+    model: Box<Model<'b>>,
+}
+
+impl<'b> ModelWithProjector<'b> {
+    /// Wrap a loaded model. No projector is loaded until [`Self::ensure_projector`].
+    #[must_use]
+    pub fn new(model: Model<'b>) -> Self {
+        Self {
+            projector: None,
+            mmproj_path: None,
+            model: Box::new(model),
+        }
+    }
+
+    /// The wrapped text model.
+    #[must_use]
+    pub fn model(&self) -> &Model<'b> {
+        &self.model
+    }
+
+    /// The cached projector, if one has been loaded via [`Self::ensure_projector`].
+    #[must_use]
+    pub fn projector(&self) -> Option<&Mtmd<'b, 'b>> {
+        self.projector.as_ref()
+    }
+
+    /// Ensure a projector for `mmproj_path` is loaded and cached, loading it on a
+    /// miss (or reloading if a *different* path is requested). Returns `true`
+    /// iff a (re)load actually occurred — the caller uses this to count cold
+    /// projector loads (the `mmproj_loads` metric): on a cache HIT it returns
+    /// `false` and performs no FFI work.
+    ///
+    /// `n_threads` / `use_gpu` are forwarded to [`Mtmd::from_file`].
+    ///
+    /// # Errors
+    /// [`LlamaError::MtmdInitFailed`] / [`LlamaError::PathInvalid`] propagated
+    /// from [`Mtmd::from_file`].
+    pub fn ensure_projector(
+        &mut self,
+        mmproj_path: &Path,
+        n_threads: i32,
+        use_gpu: bool,
+    ) -> Result<bool, LlamaError> {
+        if self.projector.is_some() && self.mmproj_path.as_deref() == Some(mmproj_path) {
+            return Ok(false); // cache HIT — the projector is already resident.
+        }
+        // Miss (or a different projector path): drop any existing projector
+        // FIRST — its `mtmd_free` runs while `self.model` is still alive, the
+        // correct drop order — then load the new one.
+        self.projector = None;
+        self.mmproj_path = None;
+
+        // SAFETY: we hand `Mtmd::from_file` a `&'b Model<'b>` synthesized from
+        // the heap-pinned model via a raw pointer. Widening the borrow to `'b`
+        // is a lie the type system cannot verify; it is made sound by this
+        // type's two invariants (see the struct docs): (1) the model is
+        // `Box`-pinned, so its address is stable for as long as `self` lives;
+        // (2) field-declaration order guarantees the projector — stored into
+        // `self.projector` below — is dropped strictly before `self.model`. The
+        // returned `Mtmd` retains only its own `mtmd_context` pointer plus a
+        // zero-sized `PhantomData` of the borrow (no dangling reference is kept
+        // at runtime) and never dereferences the synthesized reference after
+        // construction; `mtmd_init_from_file` reads `model.ptr` only during this
+        // call, while the model is plainly alive and not concurrently mutated.
+        let model_ref: &'b Model<'b> = unsafe { &*std::ptr::addr_of!(*self.model) };
+        let projector = Mtmd::from_file(model_ref, mmproj_path, n_threads, use_gpu)?;
+        self.projector = Some(projector);
+        self.mmproj_path = Some(mmproj_path.to_owned());
+        Ok(true)
+    }
+}
+
 /// RAII handle to a decoded media bitmap.
 pub struct Bitmap {
     ptr: NonNull<sys::mtmd_bitmap>,
@@ -333,5 +446,49 @@ mod tests {
             marker.starts_with('<') && marker.ends_with('>'),
             "media marker should be a bracketed tag, got {marker:?}"
         );
+    }
+
+    /// The load-bearing invariant behind [`ModelWithProjector`]'s soundness:
+    /// Rust drops struct fields in *declaration order*, so a `projector` field
+    /// declared before a `model` field is dropped first (`mtmd_free` before
+    /// `llama_model_free`). The real bundle holds FFI handles we cannot
+    /// instrument from a unit test, so this locks the *mechanism* on a mirror
+    /// struct with the SAME field order. If `ModelWithProjector`'s fields are
+    /// ever reordered, this guard must be revisited together with that change.
+    #[test]
+    fn struct_field_drop_order_is_declaration_order() {
+        use std::cell::RefCell;
+        thread_local! {
+            static LOG: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+        }
+        struct Projector;
+        impl Drop for Projector {
+            fn drop(&mut self) {
+                LOG.with(|l| l.borrow_mut().push("projector"));
+            }
+        }
+        struct Weights;
+        impl Drop for Weights {
+            fn drop(&mut self) {
+                LOG.with(|l| l.borrow_mut().push("model"));
+            }
+        }
+        // MIRROR of `ModelWithProjector`'s field order: projector BEFORE model.
+        struct Mirror {
+            _projector: Option<Projector>,
+            _model: Box<Weights>,
+        }
+        LOG.with(|l| l.borrow_mut().clear());
+        drop(Mirror {
+            _projector: Some(Projector),
+            _model: Box::new(Weights),
+        });
+        LOG.with(|l| {
+            assert_eq!(
+                *l.borrow(),
+                vec!["projector", "model"],
+                "projector (mtmd_free) must drop before model (llama_model_free)"
+            );
+        });
     }
 }

--- a/crates/kx-llamacpp/tests/smoke_multimodal.rs
+++ b/crates/kx-llamacpp/tests/smoke_multimodal.rs
@@ -19,7 +19,8 @@
 #![cfg(feature = "model-smoke-test-multimodal")]
 
 use kx_llamacpp::{
-    Bitmap, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, Mtmd, Sampler,
+    Bitmap, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, ModelWithProjector,
+    Mtmd, Sampler,
 };
 
 const VLM_GGUF: &str = env!(
@@ -161,5 +162,79 @@ fn smoke_projector_capabilities() {
     assert!(
         !mtmd.supports_audio(),
         "an image projector must not claim audio support"
+    );
+}
+
+/// PR-2.5: the projector is cached on a `ModelWithProjector` bundle —
+/// `ensure_projector` performs the cold load once and reports a HIT (no reload)
+/// on the second call with the same path, and inference still runs through the
+/// cached projector. This is the wrapper-level proof behind the backend's
+/// `mmproj_loads` metric (which counts exactly these cold loads); it also
+/// exercises the self-referential bundle (cached `Mtmd<'b,'b>` used with a
+/// per-dispatch `Context`) against a real model.
+#[test]
+fn smoke_cached_projector_loads_once_and_serves() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let model = Model::load(&backend, VLM_GGUF).expect("load VLM gguf");
+    let mut bundle = ModelWithProjector::new(model);
+    let mmproj = std::path::Path::new(VLM_MMPROJ);
+
+    // First ensure: a cold projector load.
+    assert!(
+        bundle
+            .ensure_projector(mmproj, 0, true)
+            .expect("cold-load projector"),
+        "first ensure_projector must perform a cold load"
+    );
+    // Second ensure (same path): a cache HIT — no reload.
+    assert!(
+        !bundle
+            .ensure_projector(mmproj, 0, true)
+            .expect("ensure projector"),
+        "second ensure_projector with the same path must be a cache HIT (no reload)"
+    );
+
+    let mtmd = bundle.projector().expect("projector resident after ensure");
+    assert!(
+        mtmd.supports_vision(),
+        "the cached projector must support vision"
+    );
+
+    // The cached projector still drives a real prefill + generation.
+    let bitmap = Bitmap::from_image_buf(mtmd, RED_SQUARE_PNG).expect("decode the test PNG");
+    let chunks = mtmd
+        .tokenize(&prompt_with_image("What color is the shape?"), &[&bitmap])
+        .expect("tokenize text + image into chunks");
+    let mut ctx = Context::new_with_params(
+        bundle.model(),
+        &ContextParams::new()
+            .with_n_ctx(N_CTX)
+            .with_n_batch(N_BATCH)
+            .with_n_ubatch(N_UBATCH)
+            .with_n_seq_max(1),
+    )
+    .expect("context");
+    let n_batch = ctx.n_batch() as i32;
+    let n_past = mtmd
+        .eval_chunks(&mut ctx, &chunks, 0, 0, n_batch, true)
+        .expect("prefill through the cached projector");
+    assert!(n_past > 0, "prefill must advance n_past past zero");
+
+    let vocab = bundle.model().vocab();
+    let mut sampler = Sampler::greedy(&backend).expect("greedy");
+    let gen = Generator::from_prefilled(&mut ctx, &mut sampler, &vocab, n_past);
+    let mut bytes: Vec<u8> = Vec::new();
+    for tok in gen.take(16) {
+        let tok = tok.expect("token");
+        if tok.is_eog(&vocab) {
+            break;
+        }
+        vocab
+            .token_to_piece_into(tok, 0, false, &mut bytes)
+            .expect("detokenize");
+    }
+    assert!(
+        !String::from_utf8_lossy(&bytes).trim().is_empty(),
+        "generation through the cached projector must be non-empty"
     );
 }


### PR DESCRIPTION
## What

PR-2.5 of the OSS multi-modal track. PR-2 cached the base model but re-created the `Mtmd` **projector** context on *every* image dispatch (`mtmd_init_from_file` + a GPU upload). This caches the projector alongside the model, so it loads **once per distinct model+projector** and is reused.

- **NEW `kx_llamacpp::ModelWithProjector<'b>`** — a `Model` bundled with a lazily-loaded, cached `Mtmd<'b,'b>` projector. Because `Mtmd` borrows its `Model`, this is a *self-referential bundle*. Soundness rests on two facts the compiler can't check, both documented at the type and guarded by a test:
  1. the model is **`Box`-pinned** (stable address across moves in the cache `Vec`);
  2. **field-declaration drop order** drops the projector (`mtmd_free`) strictly before the model (`llama_model_free`).
  One contained `unsafe` (the lifetime-erased self-borrow). `Mtmd` is **covariant** in its model-borrow lifetime, so the cached `'b,'b` projector serves a per-dispatch `Context` with **no `eval_chunks` signature change**.
- **`kx-inference` `ModelCache`** LRU now stores `ModelWithProjector`; `generate_multimodal` calls `ensure_projector` (load-or-hit). `mmproj_loads` now rises **once per distinct model+projector** (was once per dispatch) — the measured proof the reload is gone.

## Tests
- Model-free **drop-order unit test** (`struct_field_drop_order_is_declaration_order`) — locks declaration-order ⇒ drop-order.
- Real-VLM **`smoke_cached_projector_loads_once_and_serves`** under the local `smoke-test-multimodal` gate — `ensure_projector` returns `true` (cold) then `false` (hit), and inference still runs through the cached projector. **Validated on Metal (Qwen2-VL-2B, 5/5; model answered "red").**
- All existing image-path gate/cache tests pass unchanged.

## Golden Rule 8 — pre-flight

**Pass A (risk).**
- *(a) breaks?* No journaled byte / `MoteDef` field changes; the change is confined to the inference backend. **Frozen-trio `kx-scheduler`/`kx-executor` diff is EMPTY**; the `kx-inference` change is sanctioned capability work (D108.2). Projection digest `a6b5c679…` **invariant** (digest guards pass locally). The one new `unsafe` is contained in `kx-llamacpp` (per the crate invariant) with a soundness proof + a drop-order test. Cache eviction now drops a bundle (projector-before-model) — correct order by construction.
- *(b) perf?* Strictly **better**: eliminates a per-dispatch `mtmd_init_from_file` + projector GPU upload on the hot multi-modal path. One `Box` indirection per model access (negligible). No new hot-path allocation.
- *(c) security?* No new untrusted input or egress surface (untrusted image bytes still flow through PR-2's fail-closed decode + `resource_ceiling` gate, unchanged). Default install unaffected — **no `Cargo.toml`/dependency change**, so `build-no-inference` (`cargo install kx-runtime` toolchain-free) is untouched.

**Pass B (enhancement).** `ModelWithProjector` is the reusable seam the **PR-3 audio** path will build on — it caches whatever projector a model needs (vision today, audio next) with a correct, leak-free lifecycle, so the audio PR inherits a sound projector cache instead of re-deriving one alongside new FFI.

## Invariants
Frozen-trio diff EMPTY · digest `a6b5c679…` invariant · SN-7 (Linux CI + Apple-Silicon local, validated) · no schema/`JOURNAL_SCHEMA_VERSION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)