### PR TITLE
feat(gateway): R1 — kx-gateway dev binary (host the frozen KxGateway proto; first network server outside tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-gateway"
+version = "0.0.1"
+dependencies = [
+ "kx-capability",
+ "kx-content",
+ "kx-coordinator",
+ "kx-executor",
+ "kx-gateway-core",
+ "kx-journal",
+ "kx-mote",
+ "kx-proto",
+ "kx-warrant",
+ "kx-worker",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-gateway-core"
 version = "0.0.1"
 dependencies = [
@@ -2415,6 +2438,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2615,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "crates/kx-fleet",
     "crates/kx-model-harness",
     "crates/kx-gateway-core",
+    "crates/kx-gateway",
     "crates/kx-invoke",
     "crates/kx-model-store",
 ]
@@ -166,6 +167,10 @@ kx-fleet             = { path = "crates/kx-fleet",             version = "0.0.1"
 # StreamEvents) + propose-proxy (SubmitRun -> coordinator). No journal write path;
 # never links the frozen-trio writers (a dep-wall test pins it).
 kx-gateway-core      = { path = "crates/kx-gateway-core",      version = "0.0.1" }
+# R1 (D130) gateway dev BINARY: hosts the FROZEN KxGateway proto over kx-gateway-core
+# with an embedded single-system coordinator + local worker; the first network server
+# that binds a port outside tests. Deny-all auth stub (R2 fills it). FFI-free by default.
+kx-gateway           = { path = "crates/kx-gateway",           version = "0.0.1" }
 # M8 (D121) inbound execution: resolve a published recipe by handle, validate +
 # bind args, compile, and submit under intersect(use, step) via the gateway
 # RunSubmitter. A composition over the catalog + gateway; adds no new write path.

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-gateway"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx single-system gateway server (R1, D130): a tonic gRPC binary hosting the FROZEN KxGateway service over kx-gateway-core, with an embedded loopback coordinator + local worker so a hosted SubmitRun reaches Committed. The auth seam is a deny-all stub (serving requires --dev-allow-local). FFI-free by default."
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "kx-gateway"
+path = "src/main.rs"
+
+[dependencies]
+# The KxGateway backend (read-fold + propose-proxy) being hosted + the generated
+# tonic server/client stubs. Always required (the gateway is always hosted).
+kx-gateway-core = { workspace = true }
+kx-proto        = { workspace = true }
+# Read-only seams the gateway folds over (a SECOND journal handle + the content store).
+kx-journal      = { workspace = true }
+kx-content      = { workspace = true }
+# ExecutorClass (worker registration + the platform-default class). A tiny FFI-free leaf.
+kx-warrant      = { workspace = true }
+# The embedded single-system engine (D129-sanctioned single-process worker management),
+# behind a default-on feature so R13's `cluster` story can disable it for a lib consumer.
+# kx-executor -> kx-inference is `default-features = false` at the workspace root, so this
+# closure stays FFI-free (no llama.cpp toolchain) — the dep_wall test pins it.
+kx-coordinator  = { workspace = true, optional = true }
+kx-worker       = { workspace = true, optional = true }
+kx-executor     = { workspace = true, optional = true }
+kx-capability   = { workspace = true, optional = true }
+tonic              = { workspace = true }
+# Additive feature bump over the workspace tokio (rt-multi-thread/macros/net):
+# `signal` for graceful Ctrl-C shutdown, `time` for the worker poll/backoff +
+# connect-retry. Member-level feature additions are honored (unlike default-features).
+tokio              = { workspace = true, features = ["signal", "time"] }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror          = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+kx-mote  = { workspace = true }
+smallvec = { workspace = true }
+tokio    = { workspace = true, features = ["time"] }
+
+[features]
+default = ["embedded-worker"]
+# The in-process coordinator + local worker (single-system OSS, D129). On by default so
+# the binary is genuinely reachable end-to-end (SubmitRun -> Committed). A future library
+# consumer can disable it to embed a gateway-only front end (then `serve` requires an
+# external coordinator — a later step; R1 refuses without the feature).
+embedded-worker = ["dep:kx-coordinator", "dep:kx-worker", "dep:kx-executor", "dep:kx-capability"]
+# Reserved (R2+): the in-process model / WORLD-MUTATING dispatch path. Mirrors the
+# workspace's llamacpp gate; OFF by default so `build-no-inference` stays green.
+llamacpp = []
+
+[lints]
+workspace = true

--- a/crates/kx-gateway/src/auth.rs
+++ b/crates/kx-gateway/src/auth.rs
@@ -1,0 +1,124 @@
+// `tonic::Status` is a large error type (~176 B), but it is the REQUIRED error
+// of the tonic `Interceptor` contract (`Result<Request<()>, Status>`) and of
+// `Status`-returning resolvers — it cannot be boxed without an extra conversion
+// at every call site. Allow the perf lint here where the type is dictated by
+// tonic, not chosen by us.
+#![allow(clippy::result_large_err)]
+
+//! The deny-all auth seam (R1 stub; R2 fills it).
+//!
+//! Rule 8c — *the moment a port is bound there is no OSS auth* — so the freshly
+//! bound gateway defaults to [`DenyAll`]: every RPC is rejected with
+//! `unauthenticated` until the operator opts into [`DevAllowLocal`] via
+//! `--dev-allow-local`. The [`PrincipalResolver`] trait is the fill point: R2
+//! swaps in a real token / mTLS resolver WITHOUT changing this trait, the
+//! [`Principal`] type (which grows additively), or the interceptor wiring.
+//!
+//! Identity is **server-derived** from transport metadata (SN-8) — the client
+//! never asserts who it is into the snapshot path. gateway-core stays auth-free
+//! (its dep-wall + `lib.rs` comment); auth lives here, in the host binary.
+
+use tonic::metadata::MetadataMap;
+use tonic::Status;
+
+#[cfg(feature = "embedded-worker")]
+use std::sync::Arc;
+#[cfg(feature = "embedded-worker")]
+use tonic::Request;
+
+/// A resolved caller identity. Opaque in R1 (just a subject label); R2 fills it
+/// with real claims. A struct (not an enum matched at call sites) so new fields
+/// are additive and never a breaking change.
+#[derive(Clone, Debug)]
+pub struct Principal {
+    /// The caller's subject. `"local-dev"` under [`DevAllowLocal`].
+    pub subject: String,
+}
+
+/// The auth seam: resolve a [`Principal`] from request metadata, or reject. The
+/// resolver runs in a tonic interceptor BEFORE the request reaches the gateway
+/// service, so a rejected request never touches the read-fold / propose-proxy.
+pub trait PrincipalResolver: Send + Sync + 'static {
+    /// Resolve the caller, or return the `Status` to fail the RPC with.
+    fn resolve(&self, metadata: &MetadataMap) -> Result<Principal, Status>;
+}
+
+/// The SAFE default: reject every request. A bound port with no explicit
+/// `--dev-allow-local` is a closed door (no silent open access).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DenyAll;
+
+impl PrincipalResolver for DenyAll {
+    fn resolve(&self, _metadata: &MetadataMap) -> Result<Principal, Status> {
+        Err(Status::unauthenticated(
+            "kx-gateway: no auth configured; pass --dev-allow-local for loopback-only dev access (R2 adds real auth)",
+        ))
+    }
+}
+
+/// The explicit dev escape hatch (`--dev-allow-local`): allow every request,
+/// attributing a fixed `local-dev` principal. Intended for a loopback `--listen`
+/// only; the server refuses a non-loopback bind under this resolver.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DevAllowLocal;
+
+impl PrincipalResolver for DevAllowLocal {
+    fn resolve(&self, _metadata: &MetadataMap) -> Result<Principal, Status> {
+        Ok(Principal {
+            subject: "local-dev".to_string(),
+        })
+    }
+}
+
+/// Build the tonic request interceptor for `resolver`. On success it stashes the
+/// resolved [`Principal`] in the request extensions (server-derived identity for
+/// R2 to read) and forwards the request; on failure it short-circuits with the
+/// resolver's `Status`. The closure captures only an `Arc`, so it is `Clone`
+/// (required for the intercepted service to be `Clone` for `tonic::Server`).
+#[cfg(feature = "embedded-worker")]
+pub(crate) fn interceptor(
+    resolver: Arc<dyn PrincipalResolver>,
+) -> impl FnMut(Request<()>) -> Result<Request<()>, Status> + Clone {
+    move |mut req: Request<()>| {
+        let principal = resolver.resolve(req.metadata())?;
+        req.extensions_mut().insert(principal);
+        Ok(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_all_rejects_with_unauthenticated() {
+        let md = MetadataMap::new();
+        let err = DenyAll.resolve(&md).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn dev_allow_local_attributes_a_local_principal() {
+        let md = MetadataMap::new();
+        let principal = DevAllowLocal.resolve(&md).unwrap();
+        assert_eq!(principal.subject, "local-dev");
+    }
+
+    #[cfg(feature = "embedded-worker")]
+    #[test]
+    fn interceptor_denies_then_allows_by_resolver() {
+        // Deny resolver short-circuits.
+        let mut deny = interceptor(Arc::new(DenyAll));
+        assert!(deny(Request::new(())).is_err());
+
+        // Allow resolver forwards the request with the principal stashed.
+        let mut allow = interceptor(Arc::new(DevAllowLocal));
+        let out = allow(Request::new(())).unwrap();
+        assert_eq!(
+            out.extensions()
+                .get::<Principal>()
+                .map(|p| p.subject.as_str()),
+            Some("local-dev"),
+        );
+    }
+}

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -1,0 +1,231 @@
+//! CLI parsing for the `kx-gateway` binary. Hand-rolled, no clap (mirrors
+//! `kx-runtime`): the verb-then-`--flag value` loop keeps the dependency surface
+//! minimal and matches the workspace's established CLI style. R3 matures the CLI.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use crate::error::GatewayError;
+
+/// Default worker lease batch size — how many ready Motes the embedded worker
+/// pulls per `run_once`. Modest by default; tune with `--max-lease`.
+pub const DEFAULT_MAX_LEASE: u32 = 16;
+
+/// Resolved `serve` configuration.
+#[derive(Debug, Clone)]
+pub struct GatewayConfig {
+    /// The address:port the gateway gRPC service binds (e.g. `127.0.0.1:50151`).
+    /// A `0` port asks the OS for an ephemeral one (used by tests).
+    pub listen: SocketAddr,
+    /// On-disk SQLite journal path. The embedded coordinator opens this
+    /// read-write (sole writer); the gateway opens a SECOND read-only handle.
+    pub journal_path: PathBuf,
+    /// Directory backing the shared local-FS content store.
+    pub content_root: PathBuf,
+    /// Worker lease batch size (see [`DEFAULT_MAX_LEASE`]).
+    pub max_lease: u32,
+    /// Install the dev `local-allow` auth resolver instead of deny-all. Refuses a
+    /// non-loopback `listen` (loopback-only dev access).
+    pub dev_allow_local: bool,
+}
+
+/// A parsed invocation: print help / version, or serve with a config.
+#[derive(Debug, Clone)]
+pub enum Cli {
+    /// Print usage and exit 0.
+    Help,
+    /// Print the version and exit 0.
+    Version,
+    /// Run the server with the resolved config.
+    Serve(GatewayConfig),
+}
+
+/// One-line usage string (printed on `--help` and on a parse error).
+pub const USAGE: &str =
+    "usage: kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
+[--max-lease <N>] [--dev-allow-local]\n       kx-gateway --help | --version";
+
+impl Cli {
+    /// Parse `argv` (excluding the program name).
+    ///
+    /// Grammar: `serve --listen <addr:port> --journal <path> --content <dir>
+    /// [--max-lease <N>] [--dev-allow-local]`, or `--help`/`-h`, or
+    /// `--version`/`-V`. An empty argv is treated as `--help`.
+    pub fn from_args<I, S>(args: I) -> Result<Self, GatewayError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut args = args.into_iter().map(Into::into);
+        match args.next().as_deref() {
+            None | Some("--help" | "-h") => Ok(Cli::Help),
+            Some("--version" | "-V") => Ok(Cli::Version),
+            Some("serve") => Ok(Cli::Serve(parse_serve(args)?)),
+            Some(other) => Err(GatewayError::Config(format!(
+                "unknown command {other:?} (expected: serve | --help | --version)"
+            ))),
+        }
+    }
+}
+
+fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, GatewayError> {
+    let mut listen: Option<SocketAddr> = None;
+    let mut journal_path: Option<PathBuf> = None;
+    let mut content_root: Option<PathBuf> = None;
+    let mut max_lease: u32 = DEFAULT_MAX_LEASE;
+    let mut dev_allow_local = false;
+
+    while let Some(flag) = args.next() {
+        let mut take_value = |name: &str| -> Result<String, GatewayError> {
+            args.next()
+                .ok_or_else(|| GatewayError::Config(format!("{name} requires a value")))
+        };
+        match flag.as_str() {
+            "--listen" => {
+                let v = take_value("--listen")?;
+                listen = Some(v.parse::<SocketAddr>().map_err(|_| {
+                    GatewayError::Config(format!(
+                        "--listen expects an addr:port (IP literal), got {v:?}"
+                    ))
+                })?);
+            }
+            "--journal" => journal_path = Some(PathBuf::from(take_value("--journal")?)),
+            "--content" => content_root = Some(PathBuf::from(take_value("--content")?)),
+            "--max-lease" => {
+                let v = take_value("--max-lease")?;
+                max_lease = v.parse::<u32>().ok().filter(|n| *n > 0).ok_or_else(|| {
+                    GatewayError::Config(format!(
+                        "--max-lease expects a positive integer, got {v:?}"
+                    ))
+                })?;
+            }
+            "--dev-allow-local" => dev_allow_local = true,
+            other => return Err(GatewayError::Config(format!("unknown flag {other:?}"))),
+        }
+    }
+
+    let listen = listen.ok_or_else(|| GatewayError::Config("--listen is required".into()))?;
+    let journal_path =
+        journal_path.ok_or_else(|| GatewayError::Config("--journal is required".into()))?;
+    let content_root =
+        content_root.ok_or_else(|| GatewayError::Config("--content is required".into()))?;
+
+    Ok(GatewayConfig {
+        listen,
+        journal_path,
+        content_root,
+        max_lease,
+        dev_allow_local,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn serve(cli: Cli) -> GatewayConfig {
+        match cli {
+            Cli::Serve(c) => c,
+            other => panic!("expected Serve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_serve_with_all_flags() {
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:50151",
+                "--journal",
+                "/tmp/kx.db",
+                "--content",
+                "/tmp/blobs",
+                "--max-lease",
+                "8",
+                "--dev-allow-local",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(c.listen, "127.0.0.1:50151".parse::<SocketAddr>().unwrap());
+        assert_eq!(c.journal_path, PathBuf::from("/tmp/kx.db"));
+        assert_eq!(c.content_root, PathBuf::from("/tmp/blobs"));
+        assert_eq!(c.max_lease, 8);
+        assert!(c.dev_allow_local);
+    }
+
+    #[test]
+    fn max_lease_defaults_and_dev_allow_defaults_off() {
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(c.max_lease, DEFAULT_MAX_LEASE);
+        assert!(!c.dev_allow_local, "deny-all is the default posture");
+    }
+
+    #[test]
+    fn help_and_version_are_recognized() {
+        assert!(matches!(Cli::from_args(["--help"]).unwrap(), Cli::Help));
+        assert!(matches!(Cli::from_args(["-h"]).unwrap(), Cli::Help));
+        assert!(matches!(
+            Cli::from_args(Vec::<String>::new()).unwrap(),
+            Cli::Help
+        ));
+        assert!(matches!(
+            Cli::from_args(["--version"]).unwrap(),
+            Cli::Version
+        ));
+        assert!(matches!(Cli::from_args(["-V"]).unwrap(), Cli::Version));
+    }
+
+    #[test]
+    fn rejects_missing_required_and_unknown() {
+        // Missing --listen / --journal / --content.
+        assert!(Cli::from_args(["serve", "--journal", "/tmp/j", "--content", "/tmp/c"]).is_err());
+        assert!(Cli::from_args(["serve", "--listen", "127.0.0.1:0"]).is_err());
+        // Unknown verb + unknown flag + bad listen + bad max-lease.
+        assert!(Cli::from_args(["frobnicate"]).is_err());
+        assert!(Cli::from_args([
+            "serve",
+            "--listen",
+            "127.0.0.1:0",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--nope"
+        ])
+        .is_err());
+        assert!(Cli::from_args([
+            "serve",
+            "--listen",
+            "not-an-addr",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c"
+        ])
+        .is_err());
+        assert!(Cli::from_args([
+            "serve",
+            "--listen",
+            "127.0.0.1:0",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--max-lease",
+            "0"
+        ])
+        .is_err());
+    }
+}

--- a/crates/kx-gateway/src/error.rs
+++ b/crates/kx-gateway/src/error.rs
@@ -1,0 +1,28 @@
+//! [`GatewayError`] — the binary's typed failure surface. Thin: CLI / bind /
+//! seam-construction / transport errors, each carrying an owned message so the
+//! type stays dependency-light (no `#[from]` on a foreign error keeps it simple
+//! for `main` to render).
+
+/// A failure starting or running the gateway server.
+#[derive(Debug, thiserror::Error)]
+pub enum GatewayError {
+    /// Bad CLI arguments / configuration.
+    #[error("config: {0}")]
+    Config(String),
+    /// Could not bind / serve on the requested listen address.
+    #[error("bind: {0}")]
+    Bind(String),
+    /// Opening the journal (writer or the gateway's read handle) failed.
+    #[error("journal: {0}")]
+    Journal(String),
+    /// Opening the content store failed.
+    #[error("content store: {0}")]
+    Content(String),
+    /// Connecting / talking to the embedded coordinator failed.
+    #[error("coordinator: {0}")]
+    Coordinator(String),
+    /// A required capability is missing from this build (e.g. the embedded
+    /// worker was compiled out with `--no-default-features`).
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+}

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -1,0 +1,63 @@
+#![forbid(unsafe_code)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-gateway — the kortecx single-system gateway server (R1 / D130)
+//!
+//! > **Phase: reachability (v0.1.0).** The first kortecx binary that binds a
+//! > network port outside tests. It hosts the FROZEN
+//! > [`KxGateway`](kx_proto::proto::kx_gateway_server::KxGateway) gRPC service
+//! > over [`kx_gateway_core`] so a human / SDK / browser can connect and run a
+//! > workflow over the wire. See `ARCHITECTURE.md` (core-vs-distributed legend).
+//!
+//! ## What it hosts
+//!
+//! `kx-gateway serve` brings up, in ONE process:
+//! - an embedded **coordinator** (the sole journal writer, D40) on a loopback
+//!   port (behind the default-on `embedded-worker` feature);
+//! - an embedded **local worker** that leases → runs (PURE, deterministic) →
+//!   proposes commits, so a submitted run actually reaches `Committed`;
+//! - the **gateway** service ([`kx_gateway_core::GatewayService`]) over a
+//!   *second, read-only* journal handle + the shared content store. `SubmitRun`
+//!   proxies to the embedded coordinator; `GetProjection` / `GetContent` /
+//!   `StreamEvents` fold the journal read-only.
+//!
+//! This is a **single-system** server (D129): one process, one journal, one
+//! principal namespace. Multi-node coordination + multi-tenant isolation are the
+//! cloud product; a hosted OSS server is single-tenant by construction.
+//!
+//! ## Auth (R1 stub; R2 fills it)
+//!
+//! The freshly-bound port defaults to **deny-all** ([`auth::DenyAll`]): every RPC
+//! returns `unauthenticated` unless the operator passes `--dev-allow-local`
+//! (which attributes a fixed local-dev principal and refuses a non-loopback bind).
+//! The [`auth::PrincipalResolver`] seam is the fill point — R2 adds a real
+//! token / mTLS resolver without changing the trait. Identity is **server-derived**
+//! from transport metadata, never client-asserted (SN-8).
+//!
+//! ## The no-write discipline (D120.5)
+//!
+//! The gateway never writes the journal: it holds a [`kx_gateway_core::ReadOnly`]
+//! handle (no `append`) + a `ContentReader` (no `put`) and a propose-proxy. Only
+//! the embedded coordinator appends — sole-writer is structural, not by
+//! convention. The frozen trio (`kx-scheduler` / `kx-executor`) source is
+//! untouched; this crate only *consumes* their public API.
+
+mod auth;
+mod config;
+mod error;
+mod server;
+
+pub use auth::{DenyAll, DevAllowLocal, Principal, PrincipalResolver};
+pub use config::{Cli, GatewayConfig, DEFAULT_MAX_LEASE, USAGE};
+pub use error::GatewayError;
+pub use server::{serve, start, RunningGateway};
+
+#[cfg(feature = "embedded-worker")]
+pub use server::{default_executor_class, demo_pure_result};

--- a/crates/kx-gateway/src/main.rs
+++ b/crates/kx-gateway/src/main.rs
@@ -1,0 +1,56 @@
+#![forbid(unsafe_code)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+
+//! `kx-gateway` — the kortecx single-system gateway server binary (R1 / D130).
+//!
+//! ```text
+//! kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
+//!                  [--max-lease <N>] [--dev-allow-local]
+//! kx-gateway --help | --version
+//! ```
+//!
+//! `serve` brings up an embedded single-system runtime (coordinator + local
+//! worker) and hosts the FROZEN `KxGateway` gRPC service over it, so a client
+//! can `SubmitRun` a workflow and observe it reach `Committed` over the network.
+//! The bound port defaults to deny-all auth; pass `--dev-allow-local` (loopback
+//! only) for dev access. Thin: parse → call the library. `RUST_LOG` controls
+//! tracing (default `info`).
+
+use std::process::ExitCode;
+
+use kx_gateway::{serve, Cli, USAGE};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .try_init()
+        .ok();
+
+    match Cli::from_args(std::env::args().skip(1)) {
+        Ok(Cli::Help) => {
+            println!("{USAGE}");
+            ExitCode::SUCCESS
+        }
+        Ok(Cli::Version) => {
+            println!("kx-gateway {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        Ok(Cli::Serve(cfg)) => match serve(cfg).await {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("kx-gateway: {e}");
+                ExitCode::FAILURE
+            }
+        },
+        Err(e) => {
+            eprintln!("kx-gateway: {e}");
+            eprintln!("{USAGE}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -1,0 +1,319 @@
+//! Server wiring: bring up the (single-system) runtime and host the FROZEN
+//! `KxGateway` service over it.
+//!
+//! With the default `embedded-worker` feature, one process hosts:
+//!   1. an **embedded coordinator** (the sole journal writer, D40) on a loopback
+//!      port — it owns the read-write [`SqliteJournal`] handle;
+//!   2. an **embedded local worker** that leases → runs (PURE, deterministic) →
+//!      proposes commits, so a submitted run actually reaches `Committed`;
+//!   3. the **gateway** ([`GatewayService`]) over a SECOND, read-only journal
+//!      handle + the shared content store, behind a deny-all auth interceptor.
+//!
+//! The gateway's `SubmitRun` proxies to the embedded coordinator via the
+//! [`TonicCoordinatorSubmitter`] over loopback (reused verbatim — no new
+//! submitter impl). Reads fold the journal read-only. Sole-writer is structural:
+//! only the coordinator's owner thread appends; the gateway holds a
+//! [`ReadOnly`] handle with no `append`.
+
+use std::net::SocketAddr;
+
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::config::GatewayConfig;
+use crate::error::GatewayError;
+
+#[cfg(feature = "embedded-worker")]
+use std::sync::Arc;
+#[cfg(feature = "embedded-worker")]
+use std::time::Duration;
+#[cfg(feature = "embedded-worker")]
+use {
+    kx_capability::{CapabilityBroker, LocalCapabilityBroker},
+    kx_content::{ContentRef, ContentStore, LocalFsContentStore},
+    kx_coordinator::CoordinatorService,
+    kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor},
+    kx_gateway_core::{GatewayService, ReadOnly, TonicCoordinatorSubmitter},
+    kx_journal::SqliteJournal,
+    kx_proto::proto::coordinator_server::CoordinatorServer,
+    kx_proto::proto::kx_gateway_server::KxGatewayServer,
+    kx_warrant::ExecutorClass,
+    kx_worker::{Worker, WorkerClient, DEFAULT_HEARTBEAT_CADENCE},
+    tonic::transport::Server,
+};
+
+/// Backoff when a `run_once` lease found no ready work (keeps an idle server off
+/// a busy-spin while staying responsive when a run is submitted).
+#[cfg(feature = "embedded-worker")]
+const POLL_IDLE: Duration = Duration::from_millis(25);
+/// Backoff after a `run_once` error (transient coordinator hiccup).
+#[cfg(feature = "embedded-worker")]
+const POLL_ERR: Duration = Duration::from_millis(200);
+
+/// The platform-appropriate executor class the embedded worker registers as
+/// (mirrors `kx_executor::default_executor()`'s platform choice). A client's
+/// submitted warrant must name this class for the local worker to lease it.
+#[cfg(feature = "embedded-worker")]
+#[must_use]
+pub fn default_executor_class() -> ExecutorClass {
+    #[cfg(target_os = "macos")]
+    {
+        ExecutorClass::MacOsSandbox
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        ExecutorClass::Bwrap
+    }
+}
+
+/// The deterministic payload the embedded demo executor publishes for a PURE
+/// Mote. Exposed so an end-to-end test (a separate crate) can assert the exact
+/// bytes `GetContent` returns without duplicating the format (no drift).
+#[cfg(feature = "embedded-worker")]
+#[must_use]
+pub fn demo_pure_result(mote_id: &[u8; 32]) -> Vec<u8> {
+    let mut payload = b"kx-gateway demo result for mote ".to_vec();
+    payload.extend_from_slice(mote_id);
+    payload
+}
+
+/// A running gateway: the bound address plus the handles needed to stop it
+/// gracefully. Returned by [`start`]; [`serve`] drives it to a Ctrl-C.
+pub struct RunningGateway {
+    local_addr: SocketAddr,
+    shutdown: oneshot::Sender<()>,
+    gateway: JoinHandle<Result<(), GatewayError>>,
+    /// Background tasks (embedded coordinator server, worker loop, heartbeat)
+    /// aborted after the gateway drains.
+    aux: Vec<JoinHandle<()>>,
+}
+
+impl RunningGateway {
+    /// The address the gateway gRPC service is bound to (resolved from a `:0`
+    /// request to the OS-assigned port).
+    #[must_use]
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Stop accepting new gateway RPCs, drain in-flight ones, then abort the
+    /// embedded coordinator + worker. The journal is always left at a safe
+    /// boundary: commits are durable before they are acked, and any
+    /// leased-but-uncommitted Mote is re-leased on the next start.
+    pub async fn shutdown(self) -> Result<(), GatewayError> {
+        let RunningGateway {
+            shutdown,
+            gateway,
+            aux,
+            ..
+        } = self;
+        // Signal the gateway server to stop; it finishes in-flight requests
+        // (which may still proxy to the not-yet-aborted coordinator).
+        let _ = shutdown.send(());
+        let result = match gateway.await {
+            Ok(inner) => inner,
+            Err(join) if join.is_cancelled() => Ok(()),
+            Err(join) => Err(GatewayError::Bind(format!("gateway task failed: {join}"))),
+        };
+        for handle in &aux {
+            handle.abort();
+        }
+        result
+    }
+}
+
+/// Build the runtime + bind the gateway, returning a [`RunningGateway`] handle
+/// (with the bound address) without blocking. The caller owns shutdown.
+pub async fn start(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> {
+    // Rule 8c: the dev local-allow resolver is loopback-only. (Deny-all may bind
+    // anywhere — every RPC is refused, so a public bind is still a closed door.)
+    if cfg.dev_allow_local && !cfg.listen.ip().is_loopback() {
+        return Err(GatewayError::Config(
+            "--dev-allow-local permits a loopback --listen address only".into(),
+        ));
+    }
+    start_impl(cfg).await
+}
+
+/// Start the server, then block until Ctrl-C and shut down gracefully.
+pub async fn serve(cfg: GatewayConfig) -> Result<(), GatewayError> {
+    let running = start(cfg).await?;
+    tracing::info!(addr = %running.local_addr(), "kx-gateway listening (Ctrl-C to stop)");
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!("shutdown signal received; draining");
+    running.shutdown().await
+}
+
+#[cfg(feature = "embedded-worker")]
+async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> {
+    let content = Arc::new(
+        LocalFsContentStore::open(&cfg.content_root)
+            .map_err(|e| GatewayError::Content(e.to_string()))?,
+    );
+
+    // (1) Embedded coordinator — the SOLE journal writer. It opens the journal
+    //     read-write (by value) and verifies each committed result_ref against
+    //     the shared store (D55). Hosted on a loopback ephemeral port.
+    let writer =
+        SqliteJournal::open(&cfg.journal_path).map_err(|e| GatewayError::Journal(e.to_string()))?;
+    let coordinator = CoordinatorService::with_store(writer, content.clone());
+    let coord_addr = resolve_listen(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+    let coord_task = tokio::spawn(async move {
+        if let Err(error) = Server::builder()
+            .add_service(CoordinatorServer::new(coordinator))
+            .serve(coord_addr)
+            .await
+        {
+            tracing::error!(%error, "embedded coordinator server exited");
+        }
+    });
+    let coord_endpoint = format!("http://{coord_addr}");
+
+    // (2) Embedded local worker — leases ready PURE Motes, runs them through the
+    //     deterministic content-storing executor (publishes bytes into the shared
+    //     store BEFORE proposing, so D55 holds), and proposes the commit.
+    let client = connect_worker(&coord_endpoint).await?;
+    let executor: Arc<dyn MoteExecutor> = storing_executor(content.clone());
+    let broker: Arc<dyn CapabilityBroker> =
+        Arc::new(LocalCapabilityBroker::new((*content).clone()));
+    let worker = Worker::register(
+        client,
+        default_executor_class(),
+        "inproc://kx-gateway-worker",
+        executor,
+        LocalResourceManager::dev_defaults(),
+        content.clone(),
+        broker,
+        cfg.max_lease,
+    )
+    .await
+    .map_err(|e| GatewayError::Coordinator(e.to_string()))?;
+    // Keep the idle worker live in the registry (background heartbeat) so a run
+    // submitted after an idle period leases promptly (no false-death/reschedule).
+    let heartbeat_task = worker.spawn_heartbeat(DEFAULT_HEARTBEAT_CADENCE);
+    let worker_task = spawn_worker_loop(worker);
+
+    // (3) Gateway read seams: a SECOND (read-only) journal handle on the SAME
+    //     path observes the coordinator's commits (WAL: one writer, many readers),
+    //     plus the shared content store as the read-only content seam.
+    let read_journal =
+        SqliteJournal::open(&cfg.journal_path).map_err(|e| GatewayError::Journal(e.to_string()))?;
+    let reader = Arc::new(ReadOnly::new(read_journal));
+    let submitter = Arc::new(
+        TonicCoordinatorSubmitter::connect(coord_endpoint.clone())
+            .await
+            .map_err(|e| GatewayError::Coordinator(e.to_string()))?,
+    );
+    let gateway = GatewayService::new(reader, submitter, content);
+
+    // (4) Auth interceptor (deny-all unless --dev-allow-local) + bind + serve.
+    let resolver: Arc<dyn crate::auth::PrincipalResolver> = if cfg.dev_allow_local {
+        Arc::new(crate::auth::DevAllowLocal)
+    } else {
+        Arc::new(crate::auth::DenyAll)
+    };
+    let svc = KxGatewayServer::with_interceptor(gateway, crate::auth::interceptor(resolver));
+    let local_addr = resolve_listen(cfg.listen).await?;
+    let (shutdown, shutdown_rx) = oneshot::channel::<()>();
+    let gateway = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown(local_addr, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .map_err(|e| GatewayError::Bind(e.to_string()))
+    });
+
+    Ok(RunningGateway {
+        local_addr,
+        shutdown,
+        gateway,
+        aux: vec![coord_task, worker_task, heartbeat_task],
+    })
+}
+
+#[cfg(not(feature = "embedded-worker"))]
+#[allow(clippy::unused_async)]
+async fn start_impl(_cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> {
+    Err(GatewayError::Unsupported(
+        "kx-gateway was built without the `embedded-worker` feature (default on); \
+         the gateway-only / external-coordinator mode is a later step. \
+         Rebuild with default features."
+            .into(),
+    ))
+}
+
+/// A `MoteExecutor` for PURE Motes that PUBLISHES its deterministic result bytes
+/// into the shared store and returns the ref (the correct producer for the PURE
+/// path — content-addressed, so the committed ref == the stored object, and the
+/// coordinator's D55 phantom-ref guard passes). Built from the existing public
+/// `TestMoteExecutor::new` — kx-executor source is untouched. (R1 does NOT
+/// sandbox; the hardened spawn backend is a later step — stated honestly.)
+#[cfg(feature = "embedded-worker")]
+fn storing_executor(store: Arc<LocalFsContentStore>) -> Arc<dyn MoteExecutor> {
+    Arc::new(TestMoteExecutor::new(move |mote, _warrant| {
+        let payload = demo_pure_result(mote.id.as_bytes());
+        store.put(&payload).unwrap_or_else(|error| {
+            // No unwrap/panic on the worker task: a phantom (absent) ref makes the
+            // coordinator reject the commit; run_once errors and the loop backs off.
+            tracing::error!(%error, "content-store put failed; proposing a phantom ref");
+            ContentRef::from_bytes([0u8; 32])
+        })
+    }))
+}
+
+/// Drive the worker: lease → run → propose, forever, with idle/error backoff.
+/// Aborted on shutdown. Never returns on its own.
+#[cfg(feature = "embedded-worker")]
+fn spawn_worker_loop(mut worker: Worker) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match worker.run_once().await {
+                Ok(0) => tokio::time::sleep(POLL_IDLE).await,
+                Ok(n) => tracing::debug!(committed = n, "worker committed a lease batch"),
+                Err(error) => {
+                    tracing::warn!(%error, "worker run_once failed; backing off");
+                    tokio::time::sleep(POLL_ERR).await;
+                }
+            }
+        }
+    })
+}
+
+/// Connect a worker client to the embedded coordinator, retrying briefly while
+/// the loopback server comes up (mirrors the established test idiom).
+#[cfg(feature = "embedded-worker")]
+async fn connect_worker(endpoint: &str) -> Result<WorkerClient, GatewayError> {
+    let mut last = String::new();
+    for _ in 0..100 {
+        match WorkerClient::connect(endpoint.to_string()).await {
+            Ok(client) => return Ok(client),
+            Err(error) => {
+                last = error.to_string();
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+    Err(GatewayError::Coordinator(format!(
+        "the embedded worker could not reach the coordinator at {endpoint}: {last}"
+    )))
+}
+
+/// Resolve a listen address: if the port is `0`, bind a probe to learn the
+/// OS-assigned port, then release it (the server re-binds). Mirrors the existing
+/// in-tree test idiom; the tiny re-bind race is acceptable for a dev server.
+#[cfg(feature = "embedded-worker")]
+async fn resolve_listen(listen: SocketAddr) -> Result<SocketAddr, GatewayError> {
+    if listen.port() != 0 {
+        return Ok(listen);
+    }
+    let probe = tokio::net::TcpListener::bind(listen)
+        .await
+        .map_err(|e| GatewayError::Bind(e.to_string()))?;
+    let addr = probe
+        .local_addr()
+        .map_err(|e| GatewayError::Bind(e.to_string()))?;
+    drop(probe);
+    Ok(addr)
+}

--- a/crates/kx-gateway/tests/common/mod.rs
+++ b/crates/kx-gateway/tests/common/mod.rs
@@ -1,0 +1,96 @@
+//! Compact PURE fixtures for the gateway e2e: a parentless PURE Mote + a warrant
+//! whose `executor_class` matches the embedded worker the server registers
+//! (`kx_gateway::default_executor_class()`), so the worker leases it. Built from
+//! the real `kx-mote` / `kx-warrant` types (mirrors `kx-worker/tests/common`).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    dead_code,
+    unreachable_pub
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use kx_mote::{
+    EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
+    MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use smallvec::SmallVec;
+
+fn pure_def() -> MoteDef {
+    MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    }
+}
+
+/// A PURE Mote, made unique by `seed`, with optional data-edge parents.
+#[must_use]
+pub fn pure_mote(seed: u8, parent_ids: &[MoteId]) -> Mote {
+    let parents: SmallVec<[ParentRef; 4]> = parent_ids
+        .iter()
+        .map(|id| ParentRef {
+            parent_id: *id,
+            edge: EdgeMeta::data(),
+        })
+        .collect();
+    Mote::new(
+        pure_def(),
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        parents,
+    )
+}
+
+/// A warrant the embedded gateway worker can run: its `executor_class` is the
+/// server's `default_executor_class()`, so the in-process worker leases it.
+#[must_use]
+pub fn pure_warrant() -> WarrantSpec {
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist({
+            let mut h = BTreeSet::new();
+            h.insert(Host("api.example.com:443".into()));
+            h
+        }),
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([4u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(kx_content::ContentRef::from_bytes([8u8; 32])),
+        executor_class: kx_gateway::default_executor_class(),
+        ..Default::default()
+    }
+}

--- a/crates/kx-gateway/tests/dep_wall.rs
+++ b/crates/kx-gateway/tests/dep_wall.rs
@@ -1,0 +1,60 @@
+//! The FFI wall. The gateway binary is a single-system SERVER — it legitimately
+//! links the coordinator/worker/executor (unlike `kx-gateway-core`, which forbids
+//! the writers). What it must NOT pull is the **llama.cpp FFI**: `kx-llamacpp` /
+//! `kx-llamacpp-sys`. The default build stays FFI-free (kx-inference is
+//! `default-features = false` at the workspace root), so `cargo install kx-gateway`
+//! needs no C++ toolchain. This is the binary's analogue of `build-no-inference`.
+//!
+//! Two independent proofs: a manifest `[dependencies]` scan + a `cargo tree` over
+//! the normal edges.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+const FORBIDDEN: &[&str] = &["kx-llamacpp", "kx-llamacpp-sys"];
+
+#[test]
+fn cargo_manifest_dependencies_exclude_the_ffi() {
+    let manifest = include_str!("../Cargo.toml");
+    let deps = manifest
+        .split("[dependencies]")
+        .nth(1)
+        .expect("a [dependencies] section")
+        .split("\n[")
+        .next()
+        .expect("the end of the [dependencies] section");
+    for forbidden in FORBIDDEN {
+        assert!(
+            !deps.contains(forbidden),
+            "{forbidden} must not be a normal dependency of kx-gateway"
+        );
+    }
+}
+
+#[test]
+fn cargo_tree_normal_edges_exclude_the_ffi() {
+    // `cargo tree --edges normal` lists only non-dev dependencies (default features).
+    let output = std::process::Command::new(env!("CARGO"))
+        .args([
+            "tree",
+            "-p",
+            "kx-gateway",
+            "--edges",
+            "normal",
+            "--prefix",
+            "none",
+        ])
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        // In sandboxed environments cargo-tree may be unavailable; the manifest
+        // scan above is the load-bearing gate, so skip rather than false-fail.
+        _ => return,
+    };
+    let tree = String::from_utf8_lossy(&output.stdout);
+    for forbidden in FORBIDDEN {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the normal dependency tree of kx-gateway:\n{tree}"
+        );
+    }
+}

--- a/crates/kx-gateway/tests/serve_e2e.rs
+++ b/crates/kx-gateway/tests/serve_e2e.rs
@@ -1,0 +1,249 @@
+//! End-to-end witnesses over a REAL bound tonic port — the first real-transport
+//! run through a hosted kortecx binary (the architecture audit's #1 gap closed):
+//!
+//! - `committed_run_is_observable_end_to_end`: a client `SubmitRun`s a PURE
+//!   workflow, the embedded worker leases→runs→commits it, and the client sees
+//!   it reach `Committed` via `GetProjection`, fetches the deterministic result
+//!   via `GetContent`, and resumes the `StreamEvents` cursor.
+//! - `deny_all_rejects_every_rpc_without_the_dev_flag`: a port bound WITHOUT
+//!   `--dev-allow-local` refuses every RPC (Rule 8c — no silent open door).
+//! - `restart_recovers_the_committed_run`: graceful shutdown leaves the journal
+//!   at a safe boundary; a fresh server on the same paths re-serves the run.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use kx_gateway::{demo_pure_result, start, GatewayConfig};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tempfile::TempDir;
+use tonic::transport::Channel;
+
+fn config(dir: &TempDir, dev_allow_local: bool) -> GatewayConfig {
+    GatewayConfig {
+        listen: "127.0.0.1:0".parse().unwrap(),
+        journal_path: dir.path().join("kx.db"),
+        content_root: dir.path().join("blobs"),
+        max_lease: 16,
+        dev_allow_local,
+    }
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+/// Poll `GetProjection` until the run's single Mote is `Committed`; return its
+/// (mote_id, result_ref). Fails the test on timeout.
+async fn await_committed(
+    client: &mut KxGatewayClient<Channel>,
+    instance_id: &[u8],
+) -> ([u8; 32], [u8; 32]) {
+    for _ in 0..100 {
+        let view = client
+            .get_projection(proto::GetProjectionRequest {
+                instance_id: instance_id.to_vec(),
+                at_seq: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(m) = view
+            .motes
+            .iter()
+            .find(|m| m.state == proto::MoteSnapshotState::Committed as i32)
+        {
+            let mote_id: [u8; 32] = m.mote_id.clone().try_into().unwrap();
+            let result_ref: [u8; 32] = m
+                .result_ref
+                .clone()
+                .expect("a committed Mote carries a result_ref")
+                .try_into()
+                .unwrap();
+            return (mote_id, result_ref);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("the submitted Mote never reached Committed");
+}
+
+#[tokio::test]
+async fn committed_run_is_observable_end_to_end() {
+    let dir = TempDir::new().unwrap();
+    let running = start(config(&dir, true)).await.unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // (1) SubmitRun a single PURE Mote.
+    let mote = common::pure_mote(1, &[]);
+    let warrant = common::pure_warrant();
+    let handle = c
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: vec![0x5a; 32],
+            motes: vec![proto::SubmitMoteSpec {
+                mote: Some(mote.into()),
+                warrant: Some(warrant.into()),
+                accept_at_least_once: false,
+            }],
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(handle.instance_id.len(), 16, "journaled instance_id is 16B");
+
+    // (2) The embedded worker drives it to Committed; the client observes it.
+    let (mote_id, result_ref) = await_committed(&mut c, &handle.instance_id).await;
+
+    // (3) GetContent returns the deterministic result the executor published.
+    let blob = c
+        .get_content(proto::GetContentRequest {
+            content_ref: result_ref.to_vec(),
+            instance_id: handle.instance_id.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        blob.payload,
+        demo_pure_result(&mote_id),
+        "GetContent returns the bytes the embedded worker committed"
+    );
+
+    // (4) StreamEvents carries a Committed delta for the Mote, resumably.
+    let mut stream = c
+        .stream_events(proto::StreamEventsRequest {
+            instance_id: handle.instance_id.clone(),
+            since_seq: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let mut saw_committed = false;
+    let mut last_next_seq = 0u64;
+    while let Some(frame) = stream.message().await.unwrap() {
+        last_next_seq = frame.next_seq;
+        for delta in frame.deltas {
+            if let Some(proto::event_delta::Kind::Committed(c)) = delta.kind {
+                if c.mote_id == mote_id.to_vec() {
+                    saw_committed = true;
+                }
+            }
+        }
+        if frame.journal_boundary {
+            break;
+        }
+    }
+    assert!(saw_committed, "StreamEvents reported the Committed delta");
+
+    // Resuming from the caught-up cursor yields no earlier events (never < cursor).
+    let mut resumed = c
+        .stream_events(proto::StreamEventsRequest {
+            instance_id: handle.instance_id.clone(),
+            since_seq: last_next_seq,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    while let Some(frame) = resumed.message().await.unwrap() {
+        assert!(
+            frame.next_seq >= last_next_seq,
+            "a resumed cursor never rewinds below the ack point"
+        );
+        if frame.journal_boundary {
+            break;
+        }
+    }
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn deny_all_rejects_every_rpc_without_the_dev_flag() {
+    let dir = TempDir::new().unwrap();
+    let running = start(config(&dir, false)).await.unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // A bound port with no --dev-allow-local is a closed door (Rule 8c).
+    let submit = c
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: vec![0x5a; 32],
+            motes: vec![],
+        })
+        .await;
+    assert_eq!(
+        submit.unwrap_err().code(),
+        tonic::Code::Unauthenticated,
+        "SubmitRun is denied"
+    );
+
+    let projection = c
+        .get_projection(proto::GetProjectionRequest {
+            instance_id: vec![0u8; 16],
+            at_seq: None,
+        })
+        .await;
+    assert_eq!(
+        projection.unwrap_err().code(),
+        tonic::Code::Unauthenticated,
+        "GetProjection is denied"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn restart_recovers_the_committed_run() {
+    let dir = TempDir::new().unwrap();
+
+    // First server: submit + drive to Committed, then shut down gracefully.
+    let instance_id = {
+        let running = start(config(&dir, true)).await.unwrap();
+        let mut c = client(running.local_addr()).await;
+        let handle = c
+            .submit_run(proto::SubmitRunRequest {
+                recipe_fingerprint: vec![0x5a; 32],
+                motes: vec![proto::SubmitMoteSpec {
+                    mote: Some(common::pure_mote(7, &[]).into()),
+                    warrant: Some(common::pure_warrant().into()),
+                    accept_at_least_once: false,
+                }],
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        await_committed(&mut c, &handle.instance_id).await;
+        running.shutdown().await.unwrap(); // graceful: returns Ok
+        handle.instance_id
+    };
+
+    // Second server on the SAME journal + content: the committed run is recovered
+    // from the durable log and re-served read-only (no re-execution needed).
+    let running = start(config(&dir, true)).await.unwrap();
+    let mut c = client(running.local_addr()).await;
+    let view = c
+        .get_projection(proto::GetProjectionRequest {
+            instance_id: instance_id.clone(),
+            at_seq: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(
+        view.motes
+            .iter()
+            .any(|m| m.state == proto::MoteSnapshotState::Committed as i32),
+        "the committed run survives a restart (durable journal)"
+    );
+    running.shutdown().await.unwrap();
+}


### PR DESCRIPTION
## What & why

The architecture audit ratified **reachability** as the #1 gap: no network server binds a port outside tests, the only binary runs a hardcoded demo, and a new adopter cannot start a server or run a recipe without writing Rust. **R1** lands the first connectable surface.

NEW `kx-gateway` binary crate. `kx-gateway serve` brings up, in **one process**:
1. an embedded **coordinator** (the sole journal writer) on a loopback port;
2. an embedded **local worker** (lease → run PURE → propose-commit) so `SubmitRun` actually reaches `Committed`;
3. the **gateway** (`kx-gateway-core::GatewayService`) over a **second, read-only** journal handle + the shared content store.

`SubmitRun` proxies to the embedded coordinator via the existing `TonicCoordinatorSubmitter` over loopback (no new submitter impl); reads fold the journal read-only.

## Design

- **Single-system**: one process, one journal. The embedded coordinator/worker sit behind a default-on `embedded-worker` feature.
- **Deny-all auth seam STUB**: a bound port refuses every RPC unless the operator passes `--dev-allow-local` (loopback only). The `PrincipalResolver` trait is the fill point for real auth; identity is server-derived from transport metadata (never client-asserted). `kx-gateway-core` stays auth-free.
- **Hand-rolled CLI** (no clap, mirrors `kx-runtime`): `serve --listen/--journal/--content [--max-lease] [--dev-allow-local]`, plus `--help`/`--version`. Graceful shutdown via `tokio::signal::ctrl_c` + `serve_with_shutdown`.
- **FFI-free by default** (`kx-inference` is `default-features=false` at the workspace root); a dep-wall test pins no `kx-llamacpp` in the normal tree. A `llamacpp` feature is reserved for the model/WM path.

## Invariants

- Frozen-trio (`kx-scheduler`/`kx-executor`) `src` diff **EMPTY** (this crate only *consumes* their public API).
- Projection digest **invariant** — no journal/fold/`MoteDef` change; `clean_run` + `kill_and_replay` pass.
- The frozen `gateway.proto` is untouched; the signature RPCs stay `unimplemented`.

## Tests

- **7 unit** — CLI parse (serve flags, help/version, rejections), auth (deny-all default, dev-allow, interceptor).
- **3 e2e over a REAL bound tonic port** — the first real-transport run through a hosted binary:
  - `committed_run_is_observable_end_to_end`: `SubmitRun` → poll `GetProjection` until `Committed` → `GetContent` the deterministic result → `StreamEvents` resume.
  - `deny_all_rejects_every_rpc_without_the_dev_flag`.
  - `restart_recovers_the_committed_run` (graceful shutdown + durable recovery on a fresh server).
- **2 dep-wall** — no FFI in the normal dependency tree.

Local gate green: fmt; clippy `--workspace --all-targets -D warnings`; test `--workspace`; deny; doc `-D warnings`; build-no-inference; digest invariant. Manual binary smoke: CLI + graceful SIGINT (exit 0).

## Golden Rule 8 — pre-flight

**Pass A** — *breaks*: none (frozen-trio empty, digest invariant, server-derived identity + sole-writer are structural). *degrades*: one extra WAL reader handle + a worker poll loop; `GetProjection` fold stays linear (the gateway-core scale gate is unchanged). *opens-a-hole*: a newly-bound network port — the chief risk — mitigated by the deny-all default (a bound port is a closed door), loopback-only dev access, single-system scope, and server-derived identity. A hosted server is single-tenant by construction.

**Pass B** — unblocks the auth fill + wired inbound execution + catalog RPCs (next), then the CLI verbs, the WebSocket bridge, the client SDKs, and the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)