### PR TITLE
feat(gateway): R2 (D130) — real auth + Invoke RPC (wire kx-invoke) + catalog signature RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,16 +1217,20 @@ dependencies = [
 name = "kx-gateway"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "kx-capability",
+ "kx-catalog",
  "kx-content",
  "kx-coordinator",
  "kx-executor",
  "kx-gateway-core",
+ "kx-invoke",
  "kx-journal",
  "kx-mote",
  "kx-proto",
  "kx-warrant",
  "kx-worker",
+ "kx-workflow",
  "smallvec",
  "tempfile",
  "thiserror",

--- a/crates/kx-gateway-core/src/identity.rs
+++ b/crates/kx-gateway-core/src/identity.rs
@@ -1,0 +1,16 @@
+//! The server-derived caller identity the host's auth interceptor stashes in a
+//! request's extensions for the gateway handlers to read.
+//!
+//! gateway-core owns this type because it depends on neither `kx-gateway`'s
+//! `Principal` nor `kx-catalog`'s `PartyId` (the dependency wall). The host
+//! authenticates the caller (R2: a bearer token), derives the party, and inserts
+//! a [`CallerParty`] into the [`tonic::Request`] extensions; handlers that act on
+//! behalf of a party (the `Invoke` path, R2b) read it back. The client NEVER
+//! supplies it — identity is server-derived (SN-8 / D70).
+
+/// A resolved caller party, as an opaque handle string.
+///
+/// Held as a plain `String` so gateway-core stays off `kx-catalog`; the host
+/// re-wraps it into a `kx_catalog::PartyId` when resolving authority.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallerParty(pub String);

--- a/crates/kx-gateway-core/src/lib.rs
+++ b/crates/kx-gateway-core/src/lib.rs
@@ -47,14 +47,19 @@
 
 mod error;
 mod events;
+mod identity;
 mod reader;
 mod service;
 mod submit;
 mod view;
 
 pub use error::GatewayError;
+pub use identity::CallerParty;
 pub use reader::{ContentReader, JournalReader, ReadOnly};
-pub use service::GatewayService;
+pub use service::{
+    BinderError, BoundRecipe, CatalogSeamError, GatewayService, RecipeBinder, RegisteredSignature,
+    SignatureCatalog, SignatureSummaryEntry,
+};
 pub use submit::{
     RunSubmitter, SubmitMoteOutcome, SubmitStatus, SubmitterError, TonicCoordinatorSubmitter,
 };

--- a/crates/kx-gateway-core/src/service.rs
+++ b/crates/kx-gateway-core/src/service.rs
@@ -1,6 +1,8 @@
 //! [`GatewayService`] — the [`KxGateway`] tonic implementation. Read RPCs fold
-//! through the read-only seam; `SubmitRun` proxies through the [`RunSubmitter`];
-//! the M7 signature RPCs are stubbed (`unimplemented`) at the D120 freeze.
+//! through the read-only seam; `SubmitRun` and `Invoke` proxy through the
+//! [`RunSubmitter`]; the signature RPCs and `Invoke` dispatch to the optional
+//! [`SignatureCatalog`] / [`RecipeBinder`] seams the host injects (each returns
+//! `unimplemented` when its seam is absent — backward-compatible).
 
 use std::pin::Pin;
 use std::sync::Arc;
@@ -11,24 +13,141 @@ use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use crate::error::{hash_32, instance_id_16};
+use crate::identity::CallerParty;
 use crate::reader::{ContentReader, JournalReader};
 use crate::submit::{RunSubmitter, SubmitterError};
 use crate::{events, view};
 
+/// The id a `RegisterSignature` server-derived from the manifest bytes (SN-8:
+/// the client never supplies the id; the host derives it from the decoded entry).
+#[derive(Clone, Copy, Debug)]
+pub struct RegisteredSignature {
+    /// The 32-byte content-addressed signature id.
+    pub signature_id: [u8; 32],
+}
+
+/// One entry in a `ListSignatures` enumeration: the content-addressed id plus a
+/// host-derived human label.
+#[derive(Clone, Debug)]
+pub struct SignatureSummaryEntry {
+    /// The 32-byte content-addressed signature id.
+    pub signature_id: [u8; 32],
+    /// A short, stable, human-distinguishable label (the catalog stores no name
+    /// of its own; a richer name belongs in advisory metadata later).
+    pub name: String,
+}
+
+/// A failure from the [`SignatureCatalog`] seam.
+///
+/// The catalog is a PUBLIC discovery surface (authoritative for *what recipes
+/// exist*), so — unlike the `Invoke` execution surface, which collapses to a
+/// uniform "not authorized" with no existence oracle — these stay honest,
+/// distinct codes.
+#[derive(Debug)]
+pub enum CatalogSeamError {
+    /// A DIFFERENT entry already exists at this content-addressed id.
+    ImmutabilityConflict,
+    /// The `manifest` bytes could not be decoded into a signature entry.
+    Malformed(String),
+    /// A backend storage failure (durable-backend I/O, a corrupt row).
+    Internal(String),
+}
+
+/// The signature-catalog seam (the M7 catalog RPCs frozen at D120).
+///
+/// Spoken in the gateway's WIRE vocabulary — opaque `manifest` bytes + a 32-byte
+/// server-derived id — so gateway-core stays off `kx-catalog` (the
+/// dependency wall). The host implements it over a `kx_catalog::CatalogRegistry`,
+/// decoding/encoding with the catalog's canonical codec and server-deriving the
+/// id from the decoded entry. A `None` seam on the service means the host wired
+/// no catalog, so the three signature RPCs return `unimplemented`.
+pub trait SignatureCatalog: Send + Sync {
+    /// Decode `manifest`, server-derive its id, register it (idempotent +
+    /// immutable), and return the id.
+    ///
+    /// # Errors
+    /// [`CatalogSeamError`] on a malformed manifest, an immutability conflict, or
+    /// a storage failure.
+    fn register(&self, manifest: &[u8]) -> Result<RegisteredSignature, CatalogSeamError>;
+    /// The encoded manifest for `signature_id`, or `None` if absent.
+    fn get(&self, signature_id: &[u8; 32]) -> Option<Vec<u8>>;
+    /// Every registered signature as an `(id, name)` summary, in deterministic
+    /// (hash) order.
+    fn list(&self) -> Vec<SignatureSummaryEntry>;
+}
+
+/// A recipe resolved + bound to concrete args, ready to submit. Mirrors
+/// `kx_invoke::BoundRun`, but in gateway-core's own vocabulary (`kx_mote` +
+/// `kx_warrant` types it already depends on) so the binding seam stays off
+/// kx-invoke / kx-catalog (the dependency wall).
+pub struct BoundRecipe {
+    /// The recipe identity → the `recipe_fingerprint` passed to `RegisterRun`.
+    pub recipe_fingerprint: [u8; 32],
+    /// The runnable Motes in submission order, each paired with its narrowed
+    /// warrant (⊆ the caller's Use authority AND the recipe's step warrant).
+    pub motes: Vec<(kx_mote::Mote, kx_warrant::WarrantSpec)>,
+    /// The terminal (sink) Mote whose committed result is the invocation output.
+    pub terminal_mote_id: kx_mote::MoteId,
+}
+
+/// A bind failure the host's [`RecipeBinder`] surfaces. The gateway collapses
+/// [`BinderError::NotAuthorized`] to a UNIFORM `permission_denied` (no existence
+/// oracle on the execution surface); [`BinderError::InvalidArgs`] is the only
+/// distinct, caller-actionable code.
+#[derive(Debug)]
+pub enum BinderError {
+    /// Unauthorized OR not-found OR not-a-workflow OR body-unavailable — collapsed
+    /// by the host so an unauthorized caller learns nothing about what exists.
+    NotAuthorized,
+    /// Argument validation / parse / unbound slot / uncompilable / empty recipe.
+    InvalidArgs(String),
+    /// An internal binder failure (storage, etc.).
+    Internal(String),
+}
+
+/// The recipe-binding seam (the `Invoke` path). The host implements it with
+/// `kx_invoke::bind_snapshot` over its provisioned ledgers + the per-handle
+/// free-param contract, resolving the caller's Use authority from the
+/// authoritative grant ledger (never a caller-supplied warrant — SN-8). It does
+/// NO journal write (that is the [`RunSubmitter`]'s job). A `None` seam on the
+/// service ⇒ `Invoke` returns `unimplemented`.
+#[tonic::async_trait]
+pub trait RecipeBinder: Send + Sync {
+    /// Resolve `handle` + `args` for the SERVER-DERIVED `party` into a runnable,
+    /// least-privilege [`BoundRecipe`].
+    ///
+    /// # Errors
+    /// [`BinderError`] — `NotAuthorized` (uniform, no oracle) or `InvalidArgs`.
+    async fn bind(
+        &self,
+        party: &str,
+        handle: &str,
+        args: &[u8],
+    ) -> Result<BoundRecipe, BinderError>;
+}
+
 /// The backend behind the external `KxGateway` service: a read-only journal +
 /// content reader (the read-fold) and a [`RunSubmitter`] (the propose-proxy).
 /// Holds no writer; auth/ownership stay cloud-side (the host wraps this with
-/// middleware). Construct with [`GatewayService::new`].
+/// middleware). Construct with [`GatewayService::new`]; wire the optional
+/// catalog seam with [`GatewayService::with_signature_catalog`].
 #[derive(Clone)]
 pub struct GatewayService {
     reader: Arc<dyn JournalReader>,
     submitter: Arc<dyn RunSubmitter>,
     content: Arc<dyn ContentReader>,
+    /// The optional signature-catalog seam (the host injects a concrete catalog).
+    /// `None` ⇒ the three signature RPCs return `unimplemented`.
+    catalog: Option<Arc<dyn SignatureCatalog>>,
+    /// The optional recipe-binding seam (the host injects a kx-invoke-backed
+    /// binder). `None` ⇒ `Invoke` returns `unimplemented`.
+    binder: Option<Arc<dyn RecipeBinder>>,
 }
 
 impl GatewayService {
     /// Wire a gateway over a read-only journal seam, a propose-proxy, and a
-    /// read-only content seam.
+    /// read-only content seam. No catalog seam (the signature RPCs stay
+    /// `unimplemented` until [`GatewayService::with_signature_catalog`] wires one).
     pub fn new(
         reader: Arc<dyn JournalReader>,
         submitter: Arc<dyn RunSubmitter>,
@@ -38,7 +157,25 @@ impl GatewayService {
             reader,
             submitter,
             content,
+            catalog: None,
+            binder: None,
         }
+    }
+
+    /// Wire the signature-catalog seam (the host's concrete `kx-catalog`-backed
+    /// impl). Enables `ListSignatures` / `GetSignature` / `RegisterSignature`.
+    #[must_use]
+    pub fn with_signature_catalog(mut self, catalog: Arc<dyn SignatureCatalog>) -> Self {
+        self.catalog = Some(catalog);
+        self
+    }
+
+    /// Wire the recipe-binding seam (the host's `kx-invoke`-backed binder).
+    /// Enables `Invoke` (recipe-by-handle execution).
+    #[must_use]
+    pub fn with_recipe_binder(mut self, binder: Arc<dyn RecipeBinder>) -> Self {
+        self.binder = Some(binder);
+        self
     }
 }
 
@@ -96,6 +233,57 @@ impl KxGateway for GatewayService {
         }))
     }
 
+    async fn invoke(
+        &self,
+        request: Request<proto::InvokeRequest>,
+    ) -> Result<Response<proto::InvokeResponse>, Status> {
+        let binder = self.binder.as_ref().ok_or_else(|| {
+            Status::unimplemented("Invoke: no recipe binder wired (host provisioned no recipes)")
+        })?;
+        // SERVER-DERIVED identity (SN-8): the party the auth interceptor resolved
+        // and stashed. Absent ⇒ no caller was resolved ⇒ deny. The wire request
+        // carries no party field, so a caller cannot assert who it is.
+        let party = request
+            .extensions()
+            .get::<CallerParty>()
+            .map(|p| p.0.clone())
+            .ok_or_else(|| Status::unauthenticated("no resolved caller identity"))?;
+        let req = request.into_inner();
+
+        let bound = binder
+            .bind(&party, &req.handle, &req.args)
+            .await
+            .map_err(|e| match e {
+                // Uniform "not authorized" — no existence oracle on the execution
+                // surface (unauthorized / unknown handle are indistinguishable).
+                BinderError::NotAuthorized => Status::permission_denied("not authorized"),
+                BinderError::InvalidArgs(detail) => Status::invalid_argument(detail),
+                BinderError::Internal(detail) => Status::internal(detail),
+            })?;
+
+        // The SAME propose-proxy as SubmitRun: register first (returns only after
+        // the journaled instance_id), then submit each bound Mote. No new write
+        // path; the coordinator stays the sole journal writer.
+        let instance_id = self
+            .submitter
+            .register_run(bound.recipe_fingerprint)
+            .await
+            .map_err(submit_status)?;
+        for (mote, warrant) in bound.motes {
+            self.submitter
+                .submit_mote(mote, warrant, false)
+                .await
+                .map_err(submit_status)?;
+        }
+
+        Ok(Response::new(proto::InvokeResponse {
+            instance_id: instance_id.to_vec(),
+            recipe_fingerprint: bound.recipe_fingerprint.to_vec(),
+            // SERVER-DERIVED (from bind → compile, never client-supplied — SN-8).
+            terminal_mote_id: bound.terminal_mote_id.as_bytes().to_vec(),
+        }))
+    }
+
     async fn get_projection(
         &self,
         request: Request<proto::GetProjectionRequest>,
@@ -140,26 +328,65 @@ impl KxGateway for GatewayService {
         &self,
         _request: Request<proto::ListSignaturesRequest>,
     ) -> Result<Response<proto::ListSignaturesResponse>, Status> {
-        Err(Status::unimplemented(
-            "ListSignatures: stubbed at the D120 freeze (M7 catalog read path is M8)",
-        ))
+        let catalog = self
+            .catalog
+            .as_ref()
+            .ok_or_else(|| Status::unimplemented("ListSignatures: no signature catalog wired"))?;
+        let signatures = catalog
+            .list()
+            .into_iter()
+            .map(|e| proto::SignatureSummary {
+                signature_id: e.signature_id.to_vec(),
+                name: e.name,
+            })
+            .collect();
+        Ok(Response::new(proto::ListSignaturesResponse { signatures }))
     }
 
     async fn get_signature(
         &self,
-        _request: Request<proto::GetSignatureRequest>,
+        request: Request<proto::GetSignatureRequest>,
     ) -> Result<Response<proto::GetSignatureResponse>, Status> {
-        Err(Status::unimplemented(
-            "GetSignature: stubbed at the D120 freeze (M7 catalog read path is M8)",
-        ))
+        let catalog = self
+            .catalog
+            .as_ref()
+            .ok_or_else(|| Status::unimplemented("GetSignature: no signature catalog wired"))?;
+        let id = hash_32(
+            &request.into_inner().signature_id,
+            "signature_id must be 32 bytes",
+        )?;
+        // A public discovery surface: `not_found` here is intended (the catalog is
+        // authoritative for WHAT recipes exist), NOT collapsed like the Invoke
+        // execution surface.
+        let manifest = catalog
+            .get(&id)
+            .ok_or_else(|| Status::not_found("signature not found"))?;
+        Ok(Response::new(proto::GetSignatureResponse {
+            signature_id: id.to_vec(),
+            manifest,
+        }))
     }
 
     async fn register_signature(
         &self,
-        _request: Request<proto::RegisterSignatureRequest>,
+        request: Request<proto::RegisterSignatureRequest>,
     ) -> Result<Response<proto::RegisterSignatureResponse>, Status> {
-        Err(Status::unimplemented(
-            "RegisterSignature: stubbed at the D120 freeze (M7 catalog write path is M8)",
-        ))
+        let catalog = self.catalog.as_ref().ok_or_else(|| {
+            Status::unimplemented("RegisterSignature: no signature catalog wired")
+        })?;
+        // The host server-derives the id from the decoded manifest (SN-8) and the
+        // registry enforces idempotency + immutability.
+        let registered = catalog
+            .register(&request.into_inner().manifest)
+            .map_err(|e| match e {
+                CatalogSeamError::ImmutabilityConflict => {
+                    Status::failed_precondition("immutable catalog conflict")
+                }
+                CatalogSeamError::Malformed(detail) => Status::invalid_argument(detail),
+                CatalogSeamError::Internal(detail) => Status::internal(detail),
+            })?;
+        Ok(Response::new(proto::RegisterSignatureResponse {
+            signature_id: registered.signature_id.to_vec(),
+        }))
     }
 }

--- a/crates/kx-gateway-core/tests/common/mod.rs
+++ b/crates/kx-gateway-core/tests/common/mod.rs
@@ -6,6 +6,10 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::pedantic,
+    // The `spawn_with_party` interceptor closure returns `Result<_, tonic::Status>`
+    // — the type is dictated by tonic's `Interceptor` contract, not chosen here
+    // (same justification as `kx-gateway/src/auth.rs`).
+    clippy::result_large_err,
     dead_code,
     unreachable_pub
 )]
@@ -16,8 +20,8 @@ use std::time::Duration;
 
 use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
 use kx_gateway_core::{
-    ContentReader, GatewayService, JournalReader, ReadOnly, RunSubmitter, SubmitMoteOutcome,
-    SubmitStatus, SubmitterError,
+    CallerParty, ContentReader, GatewayService, JournalReader, ReadOnly, RunSubmitter,
+    SubmitMoteOutcome, SubmitStatus, SubmitterError,
 };
 use kx_journal::{InMemoryJournal, Journal, JournalEntry, ParentEntry};
 use kx_mote::{
@@ -240,6 +244,37 @@ pub async fn spawn(service: GatewayService) -> KxGatewayClient<Channel> {
     tokio::spawn(async move {
         Server::builder()
             .add_service(KxGatewayServer::new(service))
+            .serve(addr)
+            .await
+            .unwrap();
+    });
+
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(client) = KxGatewayClient::connect(endpoint.clone()).await {
+            return client;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client failed to connect to the gateway server");
+}
+
+/// Spawn `service` behind an interceptor that stamps every request with a
+/// server-derived [`CallerParty`] — the test stand-in for the host's auth
+/// interceptor — so the `Invoke` handler can resolve identity.
+pub async fn spawn_with_party(service: GatewayService, party: &str) -> KxGatewayClient<Channel> {
+    let party = party.to_string();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    tokio::spawn(async move {
+        let svc = KxGatewayServer::with_interceptor(service, move |mut req: tonic::Request<()>| {
+            req.extensions_mut().insert(CallerParty(party.clone()));
+            Ok(req)
+        });
+        Server::builder()
+            .add_service(svc)
             .serve(addr)
             .await
             .unwrap();

--- a/crates/kx-gateway-core/tests/gateway_e2e.rs
+++ b/crates/kx-gateway-core/tests/gateway_e2e.rs
@@ -10,10 +10,13 @@ mod common;
 use std::sync::Arc;
 
 use common::{
-    build_run, sample_mote, sample_warrant, service_from, spawn, MockSubmitter, INSTANCE_ID,
-    RECIPE_FP,
+    build_run, sample_mote, sample_warrant, service_from, spawn, spawn_with_party, MockSubmitter,
+    INSTANCE_ID, RECIPE_FP,
 };
-use kx_gateway_core::RunSubmitter;
+use kx_gateway_core::{
+    BinderError, BoundRecipe, CatalogSeamError, GatewayService, RecipeBinder, RegisteredSignature,
+    RunSubmitter, SignatureCatalog, SignatureSummaryEntry,
+};
 use kx_proto::proto;
 use tonic::Code;
 
@@ -264,15 +267,211 @@ fn submit_boundary_rederives_mote_id_discarding_wire_advisory() {
     assert_ne!(*rebuilt.id.as_bytes(), [0xFF; 32]);
 }
 
-// --- Stubbed signature RPCs ------------------------------------------------
+// --- Signature RPCs: the optional catalog seam (R2a) ------------------------
+
+/// A mock [`SignatureCatalog`] that knows exactly one id (`[0x11; 32]`) and can
+/// be configured to fail registration with an immutability conflict.
+#[derive(Default)]
+struct MockCatalog {
+    conflict: bool,
+}
+
+const MOCK_ID: [u8; 32] = [0x11; 32];
+
+impl SignatureCatalog for MockCatalog {
+    fn register(&self, _manifest: &[u8]) -> Result<RegisteredSignature, CatalogSeamError> {
+        if self.conflict {
+            Err(CatalogSeamError::ImmutabilityConflict)
+        } else {
+            Ok(RegisteredSignature {
+                signature_id: MOCK_ID,
+            })
+        }
+    }
+
+    fn get(&self, signature_id: &[u8; 32]) -> Option<Vec<u8>> {
+        (*signature_id == MOCK_ID).then(|| b"mock-manifest".to_vec())
+    }
+
+    fn list(&self) -> Vec<SignatureSummaryEntry> {
+        vec![SignatureSummaryEntry {
+            signature_id: MOCK_ID,
+            name: "sig-11111111".to_string(),
+        }]
+    }
+}
+
+fn service_with_catalog(catalog: MockCatalog) -> GatewayService {
+    service_from(build_run(), Arc::new(MockSubmitter::default()))
+        .with_signature_catalog(Arc::new(catalog))
+}
 
 #[tokio::test]
-async fn signature_rpcs_are_unimplemented_at_freeze() {
+async fn signature_rpcs_unimplemented_without_a_catalog_seam() {
+    // The default service wires no catalog → all three RPCs are unimplemented
+    // (backward-compatible: SubmitRun-only hosts are unaffected).
     let svc = service_from(build_run(), Arc::new(MockSubmitter::default()));
     let mut client = spawn(svc).await;
-    let err = client
+    assert_eq!(
+        client
+            .list_signatures(proto::ListSignaturesRequest {})
+            .await
+            .unwrap_err()
+            .code(),
+        Code::Unimplemented,
+    );
+    assert_eq!(
+        client
+            .get_signature(proto::GetSignatureRequest {
+                signature_id: vec![0u8; 32],
+            })
+            .await
+            .unwrap_err()
+            .code(),
+        Code::Unimplemented,
+    );
+    assert_eq!(
+        client
+            .register_signature(proto::RegisterSignatureRequest { manifest: vec![] })
+            .await
+            .unwrap_err()
+            .code(),
+        Code::Unimplemented,
+    );
+}
+
+#[tokio::test]
+async fn signature_rpcs_dispatch_to_the_catalog_seam() {
+    let mut client = spawn(service_with_catalog(MockCatalog::default())).await;
+
+    let reg = client
+        .register_signature(proto::RegisterSignatureRequest {
+            manifest: b"anything".to_vec(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(reg.signature_id, MOCK_ID.to_vec());
+
+    let got = client
+        .get_signature(proto::GetSignatureRequest {
+            signature_id: MOCK_ID.to_vec(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(got.manifest, b"mock-manifest".to_vec());
+
+    // A public discovery surface: an unknown id is `not_found` (NOT collapsed).
+    let unknown = client
+        .get_signature(proto::GetSignatureRequest {
+            signature_id: vec![0x22; 32],
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(unknown.code(), Code::NotFound);
+
+    let list = client
         .list_signatures(proto::ListSignaturesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(list.signatures.len(), 1);
+    assert_eq!(list.signatures[0].signature_id, MOCK_ID.to_vec());
+}
+
+#[tokio::test]
+async fn register_immutability_conflict_is_failed_precondition() {
+    let mut client = spawn(service_with_catalog(MockCatalog { conflict: true })).await;
+    let err = client
+        .register_signature(proto::RegisterSignatureRequest {
+            manifest: b"x".to_vec(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::FailedPrecondition);
+}
+
+// --- Invoke RPC: the optional recipe-binding seam (R2b) ---------------------
+
+/// A mock [`RecipeBinder`] that binds any request to a single canned Mote.
+struct MockBinder;
+
+#[tonic::async_trait]
+impl RecipeBinder for MockBinder {
+    async fn bind(
+        &self,
+        _party: &str,
+        _handle: &str,
+        _args: &[u8],
+    ) -> Result<BoundRecipe, BinderError> {
+        Ok(BoundRecipe {
+            recipe_fingerprint: RECIPE_FP,
+            motes: vec![(sample_mote(), sample_warrant())],
+            terminal_mote_id: sample_mote().id,
+        })
+    }
+}
+
+#[tokio::test]
+async fn invoke_unimplemented_without_a_binder() {
+    // The default service wires no binder → Invoke is unimplemented (backward
+    // compatible: SubmitRun-only hosts are unaffected).
+    let mut client = spawn(service_from(
+        build_run(),
+        Arc::new(MockSubmitter::default()),
+    ))
+    .await;
+    let err = client
+        .invoke(proto::InvokeRequest {
+            handle: "ns/coll/name".to_string(),
+            args: vec![],
+        })
         .await
         .unwrap_err();
     assert_eq!(err.code(), Code::Unimplemented);
+}
+
+#[tokio::test]
+async fn invoke_without_a_resolved_party_is_unauthenticated() {
+    // Binder wired, but the plain harness injects no CallerParty (no interceptor)
+    // → the handler refuses (identity is server-derived; absent ⇒ deny).
+    let svc = service_from(build_run(), Arc::new(MockSubmitter::default()))
+        .with_recipe_binder(Arc::new(MockBinder));
+    let mut client = spawn(svc).await;
+    let err = client
+        .invoke(proto::InvokeRequest {
+            handle: "ns/coll/name".to_string(),
+            args: vec![],
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::Unauthenticated);
+}
+
+#[tokio::test]
+async fn invoke_dispatches_to_binder_then_proposes() {
+    let submitter = Arc::new(MockSubmitter::default());
+    let svc = service_from(build_run(), submitter.clone()).with_recipe_binder(Arc::new(MockBinder));
+    let mut client = spawn_with_party(svc, "alice@acme").await;
+
+    let resp = client
+        .invoke(proto::InvokeRequest {
+            handle: "ns/coll/name".to_string(),
+            args: vec![],
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.instance_id, INSTANCE_ID.to_vec());
+    assert_eq!(
+        resp.terminal_mote_id,
+        sample_mote().id.as_bytes().to_vec(),
+        "the server-derived terminal Mote is returned (SN-8)"
+    );
+
+    // Register-first, then one submit per bound Mote (the propose-proxy order).
+    let calls = submitter.calls();
+    assert!(calls.first().is_some_and(|c| c.starts_with("register_run")));
+    assert_eq!(calls.iter().filter(|c| *c == "submit_mote").count(), 1);
 }

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -26,6 +26,18 @@ kx-journal      = { workspace = true }
 kx-content      = { workspace = true }
 # ExecutorClass (worker registration + the platform-default class). A tiny FFI-free leaf.
 kx-warrant      = { workspace = true }
+# R2a: the signature catalog (the 3 catalog RPCs) — FFI-free (pulls kx-dataset /
+# kx-tool-registry / rusqlite, none of which link llama.cpp; the dep_wall pins it).
+# `bincode` (+ canonical_config from kx-catalog) round-trips a SignatureEntry to
+# the opaque wire `manifest` bytes and server-derives its id.
+kx-catalog      = { workspace = true }
+bincode         = { workspace = true }
+# R2b: the inbound recipe-by-handle execution path (resolve→validate→bind→
+# intersect) + the recipe types the host provisions the demo library from. All
+# FFI-free (the dep_wall pins it).
+kx-invoke       = { workspace = true }
+kx-mote         = { workspace = true }
+kx-workflow     = { workspace = true }
 # The embedded single-system engine (D129-sanctioned single-process worker management),
 # behind a default-on feature so R13's `cluster` story can disable it for a lib consumer.
 # kx-executor -> kx-inference is `default-features = false` at the workspace root, so this
@@ -45,7 +57,6 @@ thiserror          = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-kx-mote  = { workspace = true }
 smallvec = { workspace = true }
 tokio    = { workspace = true, features = ["time"] }
 

--- a/crates/kx-gateway/src/auth.rs
+++ b/crates/kx-gateway/src/auth.rs
@@ -5,18 +5,24 @@
 // tonic, not chosen by us.
 #![allow(clippy::result_large_err)]
 
-//! The deny-all auth seam (R1 stub; R2 fills it).
+//! The auth seam (R1 deny-all stub; R2 fills it with a real bearer-token
+//! resolver).
 //!
 //! Rule 8c — *the moment a port is bound there is no OSS auth* — so the freshly
 //! bound gateway defaults to [`DenyAll`]: every RPC is rejected with
-//! `unauthenticated` until the operator opts into [`DevAllowLocal`] via
-//! `--dev-allow-local`. The [`PrincipalResolver`] trait is the fill point: R2
-//! swaps in a real token / mTLS resolver WITHOUT changing this trait, the
-//! [`Principal`] type (which grows additively), or the interceptor wiring.
+//! `unauthenticated` unless the operator opts into [`DevAllowLocal`]
+//! (`--dev-allow-local`, loopback-only) or configures real credentials
+//! ([`TokenResolver`], `--auth-token`/`--auth-token-file`). R2 fills the
+//! [`PrincipalResolver`] seam WITHOUT changing the trait: [`Principal`] grows
+//! additively (a `party` field), and the interceptor wiring is unchanged.
 //!
 //! Identity is **server-derived** from transport metadata (SN-8) — the client
-//! never asserts who it is into the snapshot path. gateway-core stays auth-free
-//! (its dep-wall + `lib.rs` comment); auth lives here, in the host binary.
+//! supplies a *credential* (a bearer token), never a claimed identity. mTLS /
+//! OIDC are later impls of the SAME trait (OIDC stays cloud, D94/D101.1).
+//! gateway-core stays auth-free (its dep-wall + `lib.rs` comment); auth lives
+//! here, in the host binary.
+
+use std::collections::HashMap;
 
 use tonic::metadata::MetadataMap;
 use tonic::Status;
@@ -26,13 +32,17 @@ use std::sync::Arc;
 #[cfg(feature = "embedded-worker")]
 use tonic::Request;
 
-/// A resolved caller identity. Opaque in R1 (just a subject label); R2 fills it
-/// with real claims. A struct (not an enum matched at call sites) so new fields
-/// are additive and never a breaking change.
+/// A resolved caller identity. A struct (not an enum matched at call sites) so
+/// new fields are additive and never a breaking change.
 #[derive(Clone, Debug)]
 pub struct Principal {
-    /// The caller's subject. `"local-dev"` under [`DevAllowLocal`].
+    /// The caller's subject. `"local-dev"` under [`DevAllowLocal`]; the party
+    /// handle under [`TokenResolver`].
     pub subject: String,
+    /// The party handle the caller acts as — the server-derived identity a recipe
+    /// `Invoke` binds authority under (R2b). Equals `subject` for the token + dev
+    /// resolvers; a future mTLS / OIDC resolver may diverge the two.
+    pub party: String,
 }
 
 /// The auth seam: resolve a [`Principal`] from request metadata, or reject. The
@@ -66,6 +76,55 @@ impl PrincipalResolver for DevAllowLocal {
     fn resolve(&self, _metadata: &MetadataMap) -> Result<Principal, Status> {
         Ok(Principal {
             subject: "local-dev".to_string(),
+            party: "local-dev".to_string(),
+        })
+    }
+}
+
+/// A bearer-token [`PrincipalResolver`]: a configured map of opaque token → party
+/// handle. The token is read from the `authorization: Bearer <token>` gRPC
+/// metadata header; the caller supplies a *credential*, never a claimed identity
+/// (SN-8 — identity is server-derived). OIDC stays cloud (D94/D101.1); this is
+/// the OSS single-system credential check.
+///
+/// Every failure mode — missing header, wrong scheme, malformed value, unknown
+/// token — returns the SAME `unauthenticated` (no "valid-format-but-unknown"
+/// oracle). Token comparison is a `HashMap` lookup (not constant-time); the
+/// constant-time / OIDC path is cloud. Prefer `--auth-token-file` over
+/// `--auth-token` so tokens stay off a world-readable `argv`.
+#[derive(Clone, Debug, Default)]
+pub struct TokenResolver {
+    tokens: HashMap<String, String>,
+}
+
+impl TokenResolver {
+    /// Build a resolver from a `token → party` map.
+    #[must_use]
+    pub fn new(tokens: HashMap<String, String>) -> Self {
+        Self { tokens }
+    }
+
+    /// `true` when no tokens are configured (the host then keeps deny-all).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+/// The required `authorization` scheme prefix.
+const BEARER_PREFIX: &str = "Bearer ";
+
+impl PrincipalResolver for TokenResolver {
+    fn resolve(&self, metadata: &MetadataMap) -> Result<Principal, Status> {
+        // One uniform error for every failure mode — no existence oracle.
+        let unauth = || Status::unauthenticated("invalid or missing bearer token");
+        let raw = metadata.get("authorization").ok_or_else(unauth)?;
+        let value = raw.to_str().map_err(|_| unauth())?;
+        let token = value.strip_prefix(BEARER_PREFIX).ok_or_else(unauth)?;
+        let party = self.tokens.get(token).ok_or_else(unauth)?;
+        Ok(Principal {
+            subject: party.clone(),
+            party: party.clone(),
         })
     }
 }
@@ -81,6 +140,10 @@ pub(crate) fn interceptor(
 ) -> impl FnMut(Request<()>) -> Result<Request<()>, Status> + Clone {
     move |mut req: Request<()>| {
         let principal = resolver.resolve(req.metadata())?;
+        // Server-derived identity for the gateway handlers (the Invoke path, R2b)
+        // — gateway-core reads `CallerParty`, not the host-owned `Principal`.
+        req.extensions_mut()
+            .insert(kx_gateway_core::CallerParty(principal.party.clone()));
         req.extensions_mut().insert(principal);
         Ok(req)
     }
@@ -102,16 +165,74 @@ mod tests {
         let md = MetadataMap::new();
         let principal = DevAllowLocal.resolve(&md).unwrap();
         assert_eq!(principal.subject, "local-dev");
+        assert_eq!(principal.party, "local-dev");
+    }
+
+    fn md_with_auth(value: &str) -> MetadataMap {
+        let mut md = MetadataMap::new();
+        md.insert("authorization", value.parse().unwrap());
+        md
+    }
+
+    fn token_resolver() -> TokenResolver {
+        let mut tokens = HashMap::new();
+        tokens.insert("s3cr3t".to_string(), "alice@acme".to_string());
+        TokenResolver::new(tokens)
+    }
+
+    #[test]
+    fn token_resolver_maps_valid_bearer_to_party() {
+        let p = token_resolver()
+            .resolve(&md_with_auth("Bearer s3cr3t"))
+            .unwrap();
+        assert_eq!(p.party, "alice@acme");
+        assert_eq!(p.subject, "alice@acme");
+    }
+
+    #[test]
+    fn token_resolver_rejects_missing_authorization() {
+        let err = token_resolver().resolve(&MetadataMap::new()).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn token_resolver_rejects_non_bearer_scheme() {
+        let err = token_resolver()
+            .resolve(&md_with_auth("Basic s3cr3t"))
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn token_resolver_unknown_token_is_indistinguishable_from_missing() {
+        // No "valid-format-but-unknown" oracle: the unknown-token error must be
+        // byte-identical (code + message) to the missing-header one.
+        let unknown = token_resolver()
+            .resolve(&md_with_auth("Bearer nope"))
+            .unwrap_err();
+        let missing = token_resolver().resolve(&MetadataMap::new()).unwrap_err();
+        assert_eq!(unknown.code(), tonic::Code::Unauthenticated);
+        assert_eq!(unknown.code(), missing.code());
+        assert_eq!(unknown.message(), missing.message());
+    }
+
+    #[test]
+    fn empty_token_resolver_is_empty() {
+        assert!(TokenResolver::default().is_empty());
+        assert!(!token_resolver().is_empty());
     }
 
     #[cfg(feature = "embedded-worker")]
     #[test]
     fn interceptor_denies_then_allows_by_resolver() {
+        use kx_gateway_core::CallerParty;
+
         // Deny resolver short-circuits.
         let mut deny = interceptor(Arc::new(DenyAll));
         assert!(deny(Request::new(())).is_err());
 
-        // Allow resolver forwards the request with the principal stashed.
+        // Allow resolver forwards the request with BOTH the host Principal and the
+        // gateway-core CallerParty stashed (server-derived identity for handlers).
         let mut allow = interceptor(Arc::new(DevAllowLocal));
         let out = allow(Request::new(())).unwrap();
         assert_eq!(
@@ -119,6 +240,26 @@ mod tests {
                 .get::<Principal>()
                 .map(|p| p.subject.as_str()),
             Some("local-dev"),
+        );
+        assert_eq!(
+            out.extensions().get::<CallerParty>().map(|p| p.0.as_str()),
+            Some("local-dev"),
+        );
+    }
+
+    #[cfg(feature = "embedded-worker")]
+    #[test]
+    fn interceptor_stashes_token_resolved_party() {
+        use kx_gateway_core::CallerParty;
+
+        let mut intercept = interceptor(Arc::new(token_resolver()));
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert("authorization", "Bearer s3cr3t".parse().unwrap());
+        let out = intercept(req).unwrap();
+        assert_eq!(
+            out.extensions().get::<CallerParty>().map(|p| p.0.as_str()),
+            Some("alice@acme"),
         );
     }
 }

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -2,6 +2,7 @@
 //! `kx-runtime`): the verb-then-`--flag value` loop keeps the dependency surface
 //! minimal and matches the workspace's established CLI style. R3 matures the CLI.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -25,8 +26,16 @@ pub struct GatewayConfig {
     /// Worker lease batch size (see [`DEFAULT_MAX_LEASE`]).
     pub max_lease: u32,
     /// Install the dev `local-allow` auth resolver instead of deny-all. Refuses a
-    /// non-loopback `listen` (loopback-only dev access).
+    /// non-loopback `listen` (loopback-only dev access). Mutually exclusive with
+    /// `auth_tokens`.
     pub dev_allow_local: bool,
+    /// Bearer tokens the gateway accepts, as `token → party handle`. Empty ⇒ no
+    /// token resolver (deny-all unless `dev_allow_local`). Parsed from
+    /// `--auth-token <token>=<party>` (repeatable) and `--auth-token-file <path>`.
+    pub auth_tokens: HashMap<String, String>,
+    /// Directory for the durable catalog SQLite files (the signature registry +,
+    /// in R2b, the recipe ledgers). `None` ⇒ alongside the journal.
+    pub catalog_dir: Option<PathBuf>,
 }
 
 /// A parsed invocation: print help / version, or serve with a config.
@@ -43,7 +52,8 @@ pub enum Cli {
 /// One-line usage string (printed on `--help` and on a parse error).
 pub const USAGE: &str =
     "usage: kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
-[--max-lease <N>] [--dev-allow-local]\n       kx-gateway --help | --version";
+[--max-lease <N>] [--dev-allow-local] [--auth-token <token>=<party>]... \
+[--auth-token-file <path>] [--catalog-dir <dir>]\n       kx-gateway --help | --version";
 
 impl Cli {
     /// Parse `argv` (excluding the program name).
@@ -74,6 +84,8 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
     let mut content_root: Option<PathBuf> = None;
     let mut max_lease: u32 = DEFAULT_MAX_LEASE;
     let mut dev_allow_local = false;
+    let mut auth_tokens: HashMap<String, String> = HashMap::new();
+    let mut catalog_dir: Option<PathBuf> = None;
 
     while let Some(flag) = args.next() {
         let mut take_value = |name: &str| -> Result<String, GatewayError> {
@@ -100,6 +112,20 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
                 })?;
             }
             "--dev-allow-local" => dev_allow_local = true,
+            "--auth-token" => {
+                let v = take_value("--auth-token")?;
+                let (token, party) = split_token_party(&v).ok_or_else(|| {
+                    GatewayError::Config(format!("--auth-token expects <token>=<party>, got {v:?}"))
+                })?;
+                auth_tokens.insert(token, party);
+            }
+            "--auth-token-file" => {
+                let path = take_value("--auth-token-file")?;
+                let body = std::fs::read_to_string(&path)
+                    .map_err(|e| GatewayError::Config(format!("--auth-token-file {path}: {e}")))?;
+                parse_token_file(&body, &mut auth_tokens)?;
+            }
+            "--catalog-dir" => catalog_dir = Some(PathBuf::from(take_value("--catalog-dir")?)),
             other => return Err(GatewayError::Config(format!("unknown flag {other:?}"))),
         }
     }
@@ -110,13 +136,52 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
     let content_root =
         content_root.ok_or_else(|| GatewayError::Config("--content is required".into()))?;
 
+    // Exactly one auth posture: dev-allow-local and configured tokens are
+    // mutually exclusive (no ambiguity about which resolver wins).
+    if dev_allow_local && !auth_tokens.is_empty() {
+        return Err(GatewayError::Config(
+            "--dev-allow-local and --auth-token/--auth-token-file are mutually exclusive".into(),
+        ));
+    }
+
     Ok(GatewayConfig {
         listen,
         journal_path,
         content_root,
         max_lease,
         dev_allow_local,
+        auth_tokens,
+        catalog_dir,
     })
+}
+
+/// Split a `token=party` spec on the LAST `=` (so a base64 token with `=`
+/// padding survives — the party handle never contains `=`). Both sides must be
+/// non-empty.
+fn split_token_party(spec: &str) -> Option<(String, String)> {
+    let (token, party) = spec.rsplit_once('=')?;
+    if token.is_empty() || party.is_empty() {
+        return None;
+    }
+    Some((token.to_string(), party.to_string()))
+}
+
+/// Parse a token file: one `token=party` per line, skipping blank lines and
+/// `#` comments. A non-conforming line is a hard error (fail-closed config).
+fn parse_token_file(body: &str, tokens: &mut HashMap<String, String>) -> Result<(), GatewayError> {
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (token, party) = split_token_party(line).ok_or_else(|| {
+            GatewayError::Config(format!(
+                "--auth-token-file line is not <token>=<party>: {line:?}"
+            ))
+        })?;
+        tokens.insert(token, party);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -185,6 +250,80 @@ mod tests {
             Cli::Version
         ));
         assert!(matches!(Cli::from_args(["-V"]).unwrap(), Cli::Version));
+    }
+
+    #[test]
+    fn parses_auth_tokens_and_catalog_dir() {
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+                "--auth-token",
+                "tok-a=alice@acme",
+                "--auth-token",
+                "tok-b=bob@acme",
+                "--catalog-dir",
+                "/tmp/cat",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(
+            c.auth_tokens.get("tok-a").map(String::as_str),
+            Some("alice@acme")
+        );
+        assert_eq!(
+            c.auth_tokens.get("tok-b").map(String::as_str),
+            Some("bob@acme")
+        );
+        assert_eq!(c.catalog_dir, Some(PathBuf::from("/tmp/cat")));
+        assert!(!c.dev_allow_local);
+    }
+
+    #[test]
+    fn auth_token_and_dev_allow_local_are_mutually_exclusive() {
+        assert!(Cli::from_args([
+            "serve",
+            "--listen",
+            "127.0.0.1:0",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--dev-allow-local",
+            "--auth-token",
+            "tok=alice",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn split_token_party_keeps_base64_padding_in_token() {
+        // The separator is the LAST '=', so a token with '=' padding survives.
+        assert_eq!(
+            split_token_party("YWJj==alice@acme"),
+            Some(("YWJj=".to_string(), "alice@acme".to_string()))
+        );
+        assert_eq!(split_token_party("noequals"), None);
+        assert_eq!(split_token_party("=party"), None);
+        assert_eq!(split_token_party("token="), None);
+    }
+
+    #[test]
+    fn token_file_parses_lines_and_skips_comments() {
+        let mut tokens = HashMap::new();
+        let body = "# a comment\n\n  tok-a=alice@acme  \ntok-b=bob@acme\n# trailing\n";
+        parse_token_file(body, &mut tokens).unwrap();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.get("tok-a").map(String::as_str), Some("alice@acme"));
+        assert_eq!(tokens.get("tok-b").map(String::as_str), Some("bob@acme"));
+        // A non-conforming line is a hard error.
+        let mut bad = HashMap::new();
+        assert!(parse_token_file("not-a-pair\n", &mut bad).is_err());
     }
 
     #[test]

--- a/crates/kx-gateway/src/error.rs
+++ b/crates/kx-gateway/src/error.rs
@@ -21,6 +21,10 @@ pub enum GatewayError {
     /// Connecting / talking to the embedded coordinator failed.
     #[error("coordinator: {0}")]
     Coordinator(String),
+    /// Opening / seeding the durable catalog (signature registry + recipe
+    /// ledgers) failed.
+    #[error("catalog: {0}")]
+    Catalog(String),
     /// A required capability is missing from this build (e.g. the embedded
     /// worker was compiled out with `--no-default-features`).
     #[error("unsupported: {0}")]

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -32,14 +32,16 @@
 //! principal namespace. Multi-node coordination + multi-tenant isolation are the
 //! cloud product; a hosted OSS server is single-tenant by construction.
 //!
-//! ## Auth (R1 stub; R2 fills it)
+//! ## Auth (R2: real bearer-token resolver)
 //!
 //! The freshly-bound port defaults to **deny-all** ([`auth::DenyAll`]): every RPC
-//! returns `unauthenticated` unless the operator passes `--dev-allow-local`
-//! (which attributes a fixed local-dev principal and refuses a non-loopback bind).
-//! The [`auth::PrincipalResolver`] seam is the fill point — R2 adds a real
-//! token / mTLS resolver without changing the trait. Identity is **server-derived**
-//! from transport metadata, never client-asserted (SN-8).
+//! returns `unauthenticated` unless the operator either passes `--dev-allow-local`
+//! (a fixed local-dev principal, loopback-only) or configures bearer tokens
+//! (`--auth-token <token>=<party>` / `--auth-token-file <path>`) which install a
+//! [`auth::TokenResolver`]. The [`auth::PrincipalResolver`] seam is the fill point
+//! — mTLS / OIDC are later impls of the same trait (OIDC stays cloud, D94/D101.1).
+//! Identity is **server-derived** from transport metadata, never client-asserted
+//! (SN-8): the client supplies a credential, not a claimed identity.
 //!
 //! ## The no-write discipline (D120.5)
 //!
@@ -52,11 +54,13 @@
 mod auth;
 mod config;
 mod error;
+mod provision;
 mod server;
 
-pub use auth::{DenyAll, DevAllowLocal, Principal, PrincipalResolver};
+pub use auth::{DenyAll, DevAllowLocal, Principal, PrincipalResolver, TokenResolver};
 pub use config::{Cli, GatewayConfig, DEFAULT_MAX_LEASE, USAGE};
 pub use error::GatewayError;
+pub use provision::{DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RECIPE_HANDLE};
 pub use server::{serve, start, RunningGateway};
 
 #[cfg(feature = "embedded-worker")]

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -1,0 +1,586 @@
+//! Host-side seam implementations the binary injects into
+//! [`kx_gateway_core::GatewayService`].
+//!
+//! gateway-core stays off `kx-catalog` (the dependency wall), so the concrete,
+//! catalog-backed implementations of its seams live HERE, in the host binary,
+//! which is free to depend on `kx-catalog`. R2a provides
+//! [`HostSignatureCatalog`] (the three catalog signature RPCs); R2b adds the
+//! recipe binder (the `Invoke` path).
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use kx_catalog::{
+    canonical_config, encode_param_schema, AssetBinding, AssetPath, AssetRef, AssetVersion,
+    BodyLedger, CatalogAction, CatalogActionSet, CatalogError, CatalogRegistry, FreeParamContract,
+    FreeParamSlot, Grant, GrantLedger, ParamType, PartyId, Provenance, SchemaResolver,
+    SignatureEntry, SqliteBodyLedger, SqliteGrantLedger, SqliteVersionLedger, TaskSignatureHash,
+    VersionLedger, VersionedContent,
+};
+use kx_content::ContentRef;
+use kx_gateway_core::{
+    BinderError, BoundRecipe, CatalogSeamError, RecipeBinder, RegisteredSignature,
+    SignatureCatalog, SignatureSummaryEntry,
+};
+use kx_invoke::{bind_snapshot, InvokeError, UseWarrantResolver};
+use kx_mote::{ConfigKey, ConfigVal, LogicRef, ToolName};
+use kx_warrant::{
+    ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, Role,
+    WarrantSpec,
+};
+use kx_workflow::{transform, WorkflowDef};
+
+use crate::error::GatewayError;
+
+/// A [`SignatureCatalog`] backed by any `kx-catalog` [`CatalogRegistry`]
+/// (the durable [`kx_catalog::SqliteCatalog`] in the server, or an in-memory one
+/// in tests).
+///
+/// It translates between the gateway's WIRE vocabulary (opaque `manifest` bytes +
+/// a 32-byte id) and the catalog's [`SignatureEntry`] via the catalog's canonical
+/// codec, and **server-derives** the id from the decoded entry (SN-8: the client
+/// never supplies an id). Registration inherits the registry's idempotent +
+/// immutable contract.
+pub struct HostSignatureCatalog<R> {
+    registry: R,
+}
+
+impl<R: CatalogRegistry> HostSignatureCatalog<R> {
+    /// Wrap a catalog registry.
+    pub fn new(registry: R) -> Self {
+        Self { registry }
+    }
+}
+
+impl<R: CatalogRegistry + Send + Sync> SignatureCatalog for HostSignatureCatalog<R> {
+    fn register(&self, manifest: &[u8]) -> Result<RegisteredSignature, CatalogSeamError> {
+        // Decode the opaque manifest into a typed entry (fail-closed on garbage).
+        let (entry, _len): (SignatureEntry, usize) =
+            bincode::serde::decode_from_slice(manifest, canonical_config())
+                .map_err(|e| CatalogSeamError::Malformed(e.to_string()))?;
+        // The registry server-derives the id (content-addressed) and enforces
+        // idempotency + immutability.
+        let outcome = self
+            .registry
+            .register_signature(entry)
+            .map_err(|e| match e {
+                CatalogError::ImmutabilityConflict(_) => CatalogSeamError::ImmutabilityConflict,
+                CatalogError::Storage(detail) => CatalogSeamError::Internal(detail),
+            })?;
+        Ok(RegisteredSignature {
+            signature_id: *outcome.hash().as_bytes(),
+        })
+    }
+
+    fn get(&self, signature_id: &[u8; 32]) -> Option<Vec<u8>> {
+        let entry = self
+            .registry
+            .lookup(&TaskSignatureHash::from_bytes(*signature_id))?;
+        // Re-encode with the canonical codec — byte-identical to what was
+        // registered (content-addressed). Infallible for a SignatureEntry (no
+        // floats); `.ok()?` keeps this non-panicking without an `expect`.
+        let bytes = bincode::serde::encode_to_vec(&entry, canonical_config()).ok()?;
+        Some(bytes)
+    }
+
+    fn list(&self) -> Vec<SignatureSummaryEntry> {
+        self.registry
+            .list_signatures()
+            .map(|entry| {
+                let id = *entry.hash().as_bytes();
+                SignatureSummaryEntry {
+                    name: short_label(&id),
+                    signature_id: id,
+                }
+            })
+            .collect()
+    }
+}
+
+/// A short, stable, human-distinguishable label for a signature (the catalog
+/// stores no name of its own; a richer name belongs in advisory metadata later).
+fn short_label(id: &[u8; 32]) -> String {
+    let mut s = String::from("sig-");
+    for b in &id[..4] {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+// ===========================================================================
+// R2b — the recipe-binding seam (the `Invoke` path).
+// ===========================================================================
+
+/// The wire handle of the single PURE demo recipe R2b provisions, so the
+/// `Invoke` path has something to run end-to-end. (The real authored recipe
+/// library is a later PR, R6.) Shared with the e2e test (no drift).
+pub const DEMO_RECIPE_HANDLE: &str = "kx/recipes/echo";
+
+/// The content-ref of the demo recipe's single typed free-param (`topic`).
+const TOPIC_SCHEMA_REF: [u8; 32] = [0x2b; 32];
+
+/// A server-provisioned recipe library backing the `Invoke` path, over the
+/// durable G1a SQLite ledgers (so a registered recipe survives restart). R2b
+/// seeds ONE PURE demo recipe whose step warrant uses the embedded worker's
+/// `executor_class` — otherwise a bound run would never lease and `Invoke` would
+/// hang. WORLD-MUTATING recipes need the capability path (a later wave).
+pub struct DemoLibrary {
+    versions: SqliteVersionLedger,
+    bodies: SqliteBodyLedger,
+    grants: SqliteGrantLedger,
+    /// The owner's base warrant the grant fold narrows from (== the recipe step
+    /// warrant, so the bound run keeps the worker's `executor_class` and the
+    /// `intersect` chain never attempts a widen).
+    owner_root: WarrantSpec,
+    free_params: FreeParamContract,
+}
+
+impl DemoLibrary {
+    /// Open the durable ledgers under `dir` and idempotently seed the demo recipe,
+    /// granting `Use`+`Read` to each party in `parties` (plus the dev `local-dev`
+    /// principal). Re-opening on restart is a no-op (publishes/grants are
+    /// idempotent; the version publish is guarded by a resolve check).
+    ///
+    /// # Errors
+    /// [`GatewayError::Catalog`] on a ledger open / seed failure.
+    pub fn open(
+        dir: &Path,
+        exec_class: ExecutorClass,
+        parties: &[String],
+    ) -> Result<Self, GatewayError> {
+        let cat = |e: String| GatewayError::Catalog(e);
+        let versions =
+            SqliteVersionLedger::open(dir.join("versions.db")).map_err(|e| cat(e.to_string()))?;
+        let bodies =
+            SqliteBodyLedger::open(dir.join("bodies.db")).map_err(|e| cat(e.to_string()))?;
+        let grants =
+            SqliteGrantLedger::open(dir.join("grants.db")).map_err(|e| cat(e.to_string()))?;
+
+        let warrant = demo_warrant(exec_class);
+        let owner = PartyId::new("kx-gateway");
+        let handle = demo_handle()?;
+        let asset = AssetRef::Path(handle.clone());
+
+        // (1) Own the asset (idempotent on re-open with the same owner).
+        grants
+            .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+            .map_err(|e| cat(e.to_string()))?;
+
+        // (2) Publish the executable body (content-addressed, idempotent) + move
+        //     the handle to it (guarded so a restart re-seed is a no-op).
+        let (manifest_id, _) = bodies
+            .publish_body(recipe_body(&warrant))
+            .map_err(|e| cat(e.to_string()))?;
+        if versions.resolve(&handle).is_none() {
+            versions
+                .publish(AssetVersion::root(
+                    handle.clone(),
+                    VersionedContent::Workflow(manifest_id),
+                    owner.clone(),
+                    Provenance::from_recipe(manifest_id.0),
+                ))
+                .map_err(|e| cat(e.to_string()))?;
+        }
+
+        // (3) Grant Use+Read to every configured party (and the dev principal),
+        //     under a runtime scope == the recipe warrant.
+        let role = Role {
+            name: "demo-use".to_string(),
+            version: 1,
+            spec: warrant.clone(),
+            description: String::new(),
+        };
+        let mut granted: BTreeSet<&str> = BTreeSet::new();
+        for party in parties
+            .iter()
+            .map(String::as_str)
+            .chain(std::iter::once("local-dev"))
+        {
+            if !granted.insert(party) {
+                continue;
+            }
+            grants
+                .append_grant(Grant::root(
+                    asset.clone(),
+                    owner.clone(),
+                    PartyId::new(party),
+                    CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
+                    role.clone(),
+                ))
+                .map_err(|e| cat(e.to_string()))?;
+        }
+
+        Ok(Self {
+            versions,
+            bodies,
+            grants,
+            owner_root: warrant,
+            free_params: topic_contract(),
+        })
+    }
+}
+
+/// A [`RecipeBinder`] over a [`DemoLibrary`]: resolves a handle + args for the
+/// server-derived party via [`bind_snapshot`], collapsing the
+/// authorization/existence errors to a uniform `NotAuthorized` (no oracle on the
+/// execution surface).
+pub struct HostRecipeBinder {
+    lib: DemoLibrary,
+}
+
+impl HostRecipeBinder {
+    /// Wrap a provisioned [`DemoLibrary`].
+    pub fn new(lib: DemoLibrary) -> Self {
+        Self { lib }
+    }
+}
+
+#[tonic::async_trait]
+impl RecipeBinder for HostRecipeBinder {
+    async fn bind(
+        &self,
+        party: &str,
+        handle: &str,
+        args: &[u8],
+    ) -> Result<BoundRecipe, BinderError> {
+        // A malformed handle reveals nothing (uniform NotAuthorized — no probing).
+        let asset_path = parse_handle(handle).ok_or(BinderError::NotAuthorized)?;
+        let party_id = PartyId::new(party);
+        let resolver = HostUseResolver {
+            grants: &self.lib.grants,
+            owner_root: self.lib.owner_root.clone(),
+        };
+        let bound = bind_snapshot(
+            &self.lib.versions,
+            &self.lib.bodies,
+            &resolver,
+            &party_id,
+            &asset_path,
+            &self.lib.free_params,
+            &DemoSchemaResolver,
+            args,
+        )
+        .map_err(map_invoke_err)?;
+        Ok(BoundRecipe {
+            recipe_fingerprint: bound.recipe_fingerprint,
+            motes: bound.motes,
+            terminal_mote_id: bound.terminal_mote_id,
+        })
+    }
+}
+
+/// Resolves a party's effective `Use` warrant from the authoritative grant ledger
+/// (never a caller-supplied warrant — SN-8). `None` ⇒ unauthorized.
+struct HostUseResolver<'a> {
+    grants: &'a SqliteGrantLedger,
+    owner_root: WarrantSpec,
+}
+
+impl UseWarrantResolver for HostUseResolver<'_> {
+    fn resolve_use(&self, party: &PartyId, asset: &AssetRef) -> Option<WarrantSpec> {
+        self.grants
+            .resolve_effective_warrant_for(party, asset, CatalogAction::Use, &self.owner_root)
+            .ok()
+            .flatten()
+    }
+}
+
+/// Map a `kx-invoke` bind failure to the gateway seam vocabulary: existence /
+/// authority → uniform `NotAuthorized` (no oracle); bad args → `InvalidArgs`;
+/// a broken provisioned recipe / submit failure → `Internal`.
+fn map_invoke_err(e: InvokeError) -> BinderError {
+    match e {
+        InvokeError::Unauthorized
+        | InvokeError::NotFound
+        | InvokeError::NotAWorkflow
+        | InvokeError::BodyUnavailable
+        | InvokeError::WarrantNarrowing(_) => BinderError::NotAuthorized,
+        InvokeError::ArgValidation(d) | InvokeError::ArgParse(d) => BinderError::InvalidArgs(d),
+        InvokeError::SlotMissing(s) => BinderError::InvalidArgs(format!("missing argument '{s}'")),
+        InvokeError::Schema(e) => BinderError::Internal(e.to_string()),
+        InvokeError::SlotUnbound(s) => {
+            BinderError::Internal(format!("recipe slot '{s}' binds no step"))
+        }
+        InvokeError::Uncompilable(d) => BinderError::Internal(d),
+        InvokeError::EmptyRecipe => BinderError::Internal("recipe is empty".into()),
+        InvokeError::Submit(e) => BinderError::Internal(e.to_string()),
+    }
+}
+
+/// Parse a `"namespace/collection/name"` wire handle into an [`AssetPath`].
+/// Exactly three non-empty segments; anything else ⇒ `None`.
+fn parse_handle(handle: &str) -> Option<AssetPath> {
+    let mut parts = handle.split('/');
+    let ns = parts.next()?;
+    let collection = parts.next()?;
+    let name = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    AssetPath::new(ns, collection, name).ok()
+}
+
+fn demo_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(DEMO_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid demo recipe handle".into()))
+}
+
+/// The PURE demo recipe body: a single content-addressed step that declares a
+/// `topic` variable slot (so a bound free-param can overwrite it). PURE so the
+/// embedded worker's deterministic content-storing executor runs it.
+fn recipe_body(warrant: &WarrantSpec) -> WorkflowDef {
+    let mut wf = WorkflowDef::new(0x2b2b_2b2b);
+    let mut step = transform(
+        LogicRef::from_bytes([0x2b; 32]),
+        warrant.model_route.model_id.clone(),
+        warrant.clone(),
+        ToolName("demo".into()),
+    );
+    step.config_subset
+        .insert(ConfigKey("topic".into()), ConfigVal(Vec::new()));
+    wf.add_step(step);
+    wf
+}
+
+/// The demo recipe's free-param contract: one `topic` variable slot typed `Str`.
+fn topic_contract() -> FreeParamContract {
+    FreeParamContract::new().with_slot("topic", FreeParamSlot::variable(Some(TOPIC_SCHEMA_REF)))
+}
+
+/// Resolves the demo recipe's `topic` schema-ref to a `Str` param schema.
+struct DemoSchemaResolver;
+
+impl SchemaResolver for DemoSchemaResolver {
+    fn resolve_schema(&self, schema_ref: &[u8; 32]) -> Option<Vec<u8>> {
+        (*schema_ref == TOPIC_SCHEMA_REF)
+            .then(|| encode_param_schema(&ParamType::Str { max_len: 4096 }))
+    }
+}
+
+/// The PURE demo recipe warrant. Its `executor_class` MUST equal the embedded
+/// worker's (`default_executor_class()`); used identically as the owner root,
+/// the grant runtime scope, and the recipe step warrant, so every `intersect`
+/// in the bind chain is a no-op narrowing (no `AttemptedWiden`) and the bound
+/// run leases on the worker. Mirrors the proven `tests/common::pure_warrant`.
+fn demo_warrant(exec_class: ExecutorClass) -> WarrantSpec {
+    let mut mounts = std::collections::BTreeMap::new();
+    mounts.insert(std::path::PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist({
+            let mut h = BTreeSet::new();
+            h.insert(Host("api.example.com:443".into()));
+            h
+        }),
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: kx_mote::ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: exec_class,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_catalog::{InMemoryCatalog, RecipeSnapshot, SignatureEntry, TaskSignature};
+
+    /// Build a minimal, valid `SignatureEntry` for `fingerprint` (a distinct
+    /// fingerprint → a distinct task signature → a distinct id).
+    fn entry(fingerprint: [u8; 32]) -> SignatureEntry {
+        SignatureEntry::new(
+            TaskSignature::model_invariant(kx_mote::MoteDefHash(fingerprint)),
+            kx_workflow::ManifestId(fingerprint),
+            RecipeSnapshot::new(fingerprint),
+        )
+    }
+
+    fn encode(e: &SignatureEntry) -> Vec<u8> {
+        bincode::serde::encode_to_vec(e, canonical_config()).unwrap()
+    }
+
+    #[test]
+    fn register_then_get_round_trips_and_server_derives_id() {
+        let cat = HostSignatureCatalog::new(InMemoryCatalog::new());
+        let e = entry([7; 32]);
+        let manifest = encode(&e);
+
+        let reg = cat.register(&manifest).unwrap();
+        assert_eq!(
+            reg.signature_id,
+            *e.hash().as_bytes(),
+            "id is server-derived"
+        );
+
+        let got = cat.get(&reg.signature_id).expect("present after register");
+        assert_eq!(got, manifest, "GetSignature byte-round-trips the manifest");
+    }
+
+    #[test]
+    fn register_is_idempotent() {
+        let cat = HostSignatureCatalog::new(InMemoryCatalog::new());
+        let manifest = encode(&entry([9; 32]));
+        let a = cat.register(&manifest).unwrap();
+        let b = cat.register(&manifest).unwrap();
+        assert_eq!(a.signature_id, b.signature_id);
+    }
+
+    #[test]
+    fn malformed_manifest_is_rejected() {
+        let cat = HostSignatureCatalog::new(InMemoryCatalog::new());
+        assert!(matches!(
+            cat.register(b"not a signature entry"),
+            Err(CatalogSeamError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn get_unknown_is_none_and_list_enumerates() {
+        let cat = HostSignatureCatalog::new(InMemoryCatalog::new());
+        assert!(cat.get(&[0xab; 32]).is_none());
+        cat.register(&encode(&entry([1; 32]))).unwrap();
+        cat.register(&encode(&entry([2; 32]))).unwrap();
+        let listed = cat.list();
+        assert_eq!(listed.len(), 2);
+        assert!(listed.iter().all(|s| s.name.starts_with("sig-")));
+    }
+
+    // --- R2b: the recipe binder (the Invoke path) --------------------------
+
+    /// Build a demo library in a fresh temp dir granting `Use` to `alice@acme`.
+    fn demo_lib(dir: &std::path::Path) -> HostRecipeBinder {
+        let lib =
+            DemoLibrary::open(dir, ExecutorClass::Bwrap, &["alice@acme".to_string()]).unwrap();
+        HostRecipeBinder::new(lib)
+    }
+
+    #[tokio::test]
+    async fn bind_is_deterministic_and_input_addressed() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path());
+
+        let a1 = binder
+            .bind("alice@acme", DEMO_RECIPE_HANDLE, br#"{"topic":"x"}"#)
+            .await
+            .unwrap();
+        let a2 = binder
+            .bind("alice@acme", DEMO_RECIPE_HANDLE, br#"{"topic":"x"}"#)
+            .await
+            .unwrap();
+        assert_eq!(
+            a1.terminal_mote_id, a2.terminal_mote_id,
+            "identical args → identical identity (idempotent re-invoke)"
+        );
+        assert_eq!(a1.recipe_fingerprint, a2.recipe_fingerprint);
+
+        let b = binder
+            .bind("alice@acme", DEMO_RECIPE_HANDLE, br#"{"topic":"y"}"#)
+            .await
+            .unwrap();
+        assert_ne!(
+            a1.terminal_mote_id, b.terminal_mote_id,
+            "distinct args → distinct identity (exactly-once-per-input)"
+        );
+    }
+
+    #[tokio::test]
+    async fn bind_no_widen_keeps_worker_executor_class() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path());
+        let bound = binder
+            .bind("alice@acme", DEMO_RECIPE_HANDLE, br#"{"topic":"x"}"#)
+            .await
+            .unwrap();
+        assert!(!bound.motes.is_empty());
+        for (_, w) in &bound.motes {
+            // The bound warrant keeps the worker's executor_class (so it leases)
+            // and never widens beyond the demo recipe's declared scope.
+            assert_eq!(w.executor_class, ExecutorClass::Bwrap);
+            assert!(w.model_route.max_calls <= 3);
+        }
+    }
+
+    #[tokio::test]
+    async fn bind_unauthorized_party_is_uniformly_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path());
+        // "mallory" was never granted Use.
+        assert!(matches!(
+            binder
+                .bind("mallory@acme", DEMO_RECIPE_HANDLE, br#"{"topic":"x"}"#)
+                .await,
+            Err(BinderError::NotAuthorized)
+        ));
+    }
+
+    #[tokio::test]
+    async fn bind_unknown_or_malformed_handle_is_uniformly_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path());
+        // Unknown handle and a malformed handle both → uniform NotAuthorized.
+        assert!(matches!(
+            binder
+                .bind("alice@acme", "kx/recipes/nope", br#"{"topic":"x"}"#)
+                .await,
+            Err(BinderError::NotAuthorized)
+        ));
+        assert!(matches!(
+            binder
+                .bind("alice@acme", "not-a-handle", br#"{"topic":"x"}"#)
+                .await,
+            Err(BinderError::NotAuthorized)
+        ));
+    }
+
+    #[tokio::test]
+    async fn bind_bad_args_are_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path());
+        // Wrong type for `topic`.
+        assert!(matches!(
+            binder
+                .bind("alice@acme", DEMO_RECIPE_HANDLE, br#"{"topic":5}"#)
+                .await,
+            Err(BinderError::InvalidArgs(_))
+        ));
+        // Missing `topic`.
+        assert!(matches!(
+            binder.bind("alice@acme", DEMO_RECIPE_HANDLE, b"{}").await,
+            Err(BinderError::InvalidArgs(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn demo_library_reopens_idempotently() {
+        // A second open on the same dir (restart) must not error (durable ledgers
+        // + idempotent seeding + guarded version publish).
+        let dir = tempfile::tempdir().unwrap();
+        let _a = DemoLibrary::open(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+        );
+        let b = DemoLibrary::open(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+        );
+        assert!(b.is_ok(), "re-opening the durable demo library is a no-op");
+    }
+}

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -29,16 +29,21 @@ use std::sync::Arc;
 use std::time::Duration;
 #[cfg(feature = "embedded-worker")]
 use {
+    crate::provision::{DemoLibrary, HostRecipeBinder, HostSignatureCatalog},
     kx_capability::{CapabilityBroker, LocalCapabilityBroker},
+    kx_catalog::SqliteCatalog,
     kx_content::{ContentRef, ContentStore, LocalFsContentStore},
     kx_coordinator::CoordinatorService,
     kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor},
-    kx_gateway_core::{GatewayService, ReadOnly, TonicCoordinatorSubmitter},
+    kx_gateway_core::{
+        GatewayService, ReadOnly, RecipeBinder, SignatureCatalog, TonicCoordinatorSubmitter,
+    },
     kx_journal::SqliteJournal,
     kx_proto::proto::coordinator_server::CoordinatorServer,
     kx_proto::proto::kx_gateway_server::KxGatewayServer,
     kx_warrant::ExecutorClass,
     kx_worker::{Worker, WorkerClient, DEFAULT_HEARTBEAT_CADENCE},
+    std::path::{Path, PathBuf},
     tonic::transport::Server,
 };
 
@@ -204,11 +209,29 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
             .await
             .map_err(|e| GatewayError::Coordinator(e.to_string()))?,
     );
-    let gateway = GatewayService::new(reader, submitter, content);
 
-    // (4) Auth interceptor (deny-all unless --dev-allow-local) + bind + serve.
+    // (3b) Durable catalog directory (R2a/R2b): `--catalog-dir` (default:
+    //      alongside the journal), holding the signature registry + recipe ledgers
+    //      so registered signatures + recipes survive restart.
+    let catalog_dir = resolve_catalog_dir(&cfg)?;
+    let signature_catalog = open_signature_catalog(&catalog_dir)?;
+    // (3c) Server-provisioned demo recipe library (R2b) so `Invoke` runs E2E.
+    //      Grant `Use` to every configured token party (+ the dev principal); the
+    //      step warrant uses the embedded worker's executor_class so a bound run
+    //      leases (see `provision::demo_warrant`).
+    let parties: Vec<String> = cfg.auth_tokens.values().cloned().collect();
+    let demo = DemoLibrary::open(&catalog_dir, default_executor_class(), &parties)?;
+    let binder: Arc<dyn RecipeBinder> = Arc::new(HostRecipeBinder::new(demo));
+    let gateway = GatewayService::new(reader, submitter, content)
+        .with_signature_catalog(signature_catalog)
+        .with_recipe_binder(binder);
+
+    // (4) Auth interceptor + bind + serve. Posture: --dev-allow-local (loopback
+    //     dev) → configured bearer tokens → deny-all (the safe default).
     let resolver: Arc<dyn crate::auth::PrincipalResolver> = if cfg.dev_allow_local {
         Arc::new(crate::auth::DevAllowLocal)
+    } else if !cfg.auth_tokens.is_empty() {
+        Arc::new(crate::auth::TokenResolver::new(cfg.auth_tokens.clone()))
     } else {
         Arc::new(crate::auth::DenyAll)
     };
@@ -242,6 +265,30 @@ async fn start_impl(_cfg: GatewayConfig) -> Result<RunningGateway, GatewayError>
          Rebuild with default features."
             .into(),
     ))
+}
+
+/// Resolve (creating if absent) the durable catalog directory: `--catalog-dir`
+/// if set, else the journal's parent directory (else the cwd). Holds the
+/// signature registry + the recipe ledgers (the G1a SQLite backends).
+#[cfg(feature = "embedded-worker")]
+fn resolve_catalog_dir(cfg: &GatewayConfig) -> Result<PathBuf, GatewayError> {
+    let dir = cfg.catalog_dir.clone().unwrap_or_else(|| {
+        cfg.journal_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+    });
+    std::fs::create_dir_all(&dir).map_err(|e| GatewayError::Catalog(e.to_string()))?;
+    Ok(dir)
+}
+
+/// Open the durable signature catalog under `dir` and wrap it as the gateway's
+/// catalog seam. Registered signatures survive restart (the G1a SQLite backend).
+#[cfg(feature = "embedded-worker")]
+fn open_signature_catalog(dir: &Path) -> Result<Arc<dyn SignatureCatalog>, GatewayError> {
+    let registry = SqliteCatalog::open(dir.join("catalog.db"))
+        .map_err(|e| GatewayError::Catalog(e.to_string()))?;
+    Ok(Arc::new(HostSignatureCatalog::new(registry)))
 }
 
 /// A `MoteExecutor` for PURE Motes that PUBLISHES its deterministic result bytes

--- a/crates/kx-gateway/tests/common/mod.rs
+++ b/crates/kx-gateway/tests/common/mod.rs
@@ -11,9 +11,10 @@
     unreachable_pub
 )]
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 
+use kx_gateway::GatewayConfig;
 use kx_mote::{
     EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
     MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
@@ -22,6 +23,27 @@ use kx_warrant::{
     FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
 };
 use smallvec::SmallVec;
+use tempfile::TempDir;
+
+/// A gateway config rooted at `dir` (ephemeral journal + content + catalog).
+/// `dev_allow_local` installs the dev resolver; a non-empty `auth_tokens`
+/// (token → party) installs the bearer-token resolver instead.
+#[must_use]
+pub fn gateway_config(
+    dir: &TempDir,
+    dev_allow_local: bool,
+    auth_tokens: HashMap<String, String>,
+) -> GatewayConfig {
+    GatewayConfig {
+        listen: "127.0.0.1:0".parse().unwrap(),
+        journal_path: dir.path().join("kx.db"),
+        content_root: dir.path().join("blobs"),
+        max_lease: 16,
+        dev_allow_local,
+        auth_tokens,
+        catalog_dir: None,
+    }
+}
 
 fn pure_def() -> MoteDef {
     MoteDef {

--- a/crates/kx-gateway/tests/dep_wall.rs
+++ b/crates/kx-gateway/tests/dep_wall.rs
@@ -58,3 +58,49 @@ fn cargo_tree_normal_edges_exclude_the_ffi() {
         );
     }
 }
+
+#[test]
+fn cargo_manifest_includes_the_catalog_edge() {
+    // R2a intentionally adds kx-catalog (the signature registry) to the host. It
+    // is FFI-free (kx-dataset / kx-tool-registry / rusqlite, none link llama.cpp).
+    let manifest = include_str!("../Cargo.toml");
+    let deps = manifest
+        .split("[dependencies]")
+        .nth(1)
+        .expect("a [dependencies] section")
+        .split("\n[")
+        .next()
+        .expect("the end of the [dependencies] section");
+    assert!(
+        deps.contains("kx-catalog"),
+        "R2a wires the kx-catalog signature registry into the host"
+    );
+}
+
+#[test]
+fn catalog_subtree_excludes_the_ffi() {
+    // Defense-in-depth: prove the newly-added kx-catalog edge does not, on its own
+    // normal tree, drag in the llama.cpp FFI (attributes a regression to catalog).
+    let output = std::process::Command::new(env!("CARGO"))
+        .args([
+            "tree",
+            "-p",
+            "kx-catalog",
+            "--edges",
+            "normal",
+            "--prefix",
+            "none",
+        ])
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return,
+    };
+    let tree = String::from_utf8_lossy(&output.stdout);
+    for forbidden in FORBIDDEN {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the normal dependency tree of kx-catalog:\n{tree}"
+        );
+    }
+}

--- a/crates/kx-gateway/tests/invoke_e2e.rs
+++ b/crates/kx-gateway/tests/invoke_e2e.rs
@@ -1,0 +1,319 @@
+//! End-to-end witnesses for the `Invoke` RPC over a REAL bound port (R2b) — the
+//! G3 enterprise-adoption unlock made reachable:
+//!
+//! - `Invoke` a server-provisioned PURE recipe by handle+args → the embedded
+//!   worker leases→runs→commits the bound Mote → the client awaits ITS
+//!   `terminal_mote_id` and fetches the deterministic result via `GetContent`;
+//! - a recipe run is keyed by recipe identity, so distinct args → distinct
+//!   `terminal_mote_id`s WITHIN one run (exactly-once-per-input);
+//! - an unknown handle is uniformly `permission_denied` (no existence oracle on
+//!   the execution surface); malformed args are `invalid_argument` (fail-closed);
+//! - a deny-all port refuses `Invoke` (`unauthenticated`); a bearer-token port
+//!   authorizes a configured party end-to-end;
+//! - many concurrent `Invoke`s (distinct args) all commit distinct Motes.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::{BTreeSet, HashMap};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use kx_gateway::{demo_pure_result, start, DEMO_RECIPE_HANDLE};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+use tonic::Request;
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+fn with_bearer<T>(payload: T, token: Option<&str>) -> Request<T> {
+    let mut req = Request::new(payload);
+    if let Some(token) = token {
+        req.metadata_mut()
+            .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    }
+    req
+}
+
+fn args(topic: &str) -> Vec<u8> {
+    format!("{{\"topic\":\"{topic}\"}}").into_bytes()
+}
+
+/// Poll `GetProjection` (optionally bearer-authenticated) until the specific
+/// `mote_id` is `Committed`; return its `result_ref`. Fails on timeout.
+async fn await_mote_committed(
+    c: &mut KxGatewayClient<Channel>,
+    instance_id: &[u8],
+    mote_id: &[u8],
+    token: Option<&str>,
+) -> [u8; 32] {
+    for _ in 0..100 {
+        let view = c
+            .get_projection(with_bearer(
+                proto::GetProjectionRequest {
+                    instance_id: instance_id.to_vec(),
+                    at_seq: None,
+                },
+                token,
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(m) = view
+            .motes
+            .iter()
+            .find(|m| m.mote_id == mote_id && m.state == proto::MoteSnapshotState::Committed as i32)
+        {
+            return m
+                .result_ref
+                .clone()
+                .expect("a committed Mote carries a result_ref")
+                .try_into()
+                .unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("the invoked Mote never reached Committed");
+}
+
+#[tokio::test]
+async fn invoke_runs_demo_recipe_to_committed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: DEMO_RECIPE_HANDLE.to_string(),
+            args: args("incidents"),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
+    assert_eq!(
+        resp.terminal_mote_id.len(),
+        32,
+        "server-derived terminal Mote"
+    );
+
+    // Await THIS invocation's Mote, then fetch its committed result.
+    let result_ref =
+        await_mote_committed(&mut c, &resp.instance_id, &resp.terminal_mote_id, None).await;
+    let mote_id: [u8; 32] = resp.terminal_mote_id.clone().try_into().unwrap();
+    let blob = c
+        .get_content(proto::GetContentRequest {
+            content_ref: result_ref.to_vec(),
+            instance_id: resp.instance_id.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        blob.payload,
+        demo_pure_result(&mote_id),
+        "GetContent returns the bytes the worker committed for the invoked recipe"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn invoke_distinct_args_yield_distinct_motes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let a = c
+        .invoke(proto::InvokeRequest {
+            handle: DEMO_RECIPE_HANDLE.to_string(),
+            args: args("alpha"),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let b = c
+        .invoke(proto::InvokeRequest {
+            handle: DEMO_RECIPE_HANDLE.to_string(),
+            args: args("bravo"),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Same recipe ⇒ one run instance; distinct args ⇒ distinct Motes within it.
+    assert_eq!(a.instance_id, b.instance_id, "same recipe shares one run");
+    assert_ne!(
+        a.terminal_mote_id, b.terminal_mote_id,
+        "distinct args → distinct committed Mote identities (exactly-once-per-input)"
+    );
+
+    // Both reach Committed.
+    await_mote_committed(&mut c, &a.instance_id, &a.terminal_mote_id, None).await;
+    await_mote_committed(&mut c, &b.instance_id, &b.terminal_mote_id, None).await;
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn invoke_unknown_handle_is_permission_denied() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // An authenticated caller probing a non-existent recipe learns nothing —
+    // uniform permission_denied (no existence oracle on the execution surface).
+    let err = c
+        .invoke(proto::InvokeRequest {
+            handle: "kx/recipes/does-not-exist".to_string(),
+            args: args("x"),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn invoke_malformed_args_are_invalid_argument() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    for bad in [br#"{"topic":5}"#.to_vec(), b"{}".to_vec()] {
+        let err = c
+            .invoke(proto::InvokeRequest {
+                handle: DEMO_RECIPE_HANDLE.to_string(),
+                args: bad,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn invoke_under_deny_all_is_unauthenticated() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, false, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let err = c
+        .invoke(proto::InvokeRequest {
+            handle: DEMO_RECIPE_HANDLE.to_string(),
+            args: args("x"),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn invoke_with_bearer_token_runs_to_committed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut tokens = HashMap::new();
+    tokens.insert("s3cr3t".to_string(), "alice@acme".to_string());
+    let running = start(common::gateway_config(&dir, false, tokens))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // No credential → denied (every RPC is gated by the interceptor).
+    let no_tok = c
+        .invoke(proto::InvokeRequest {
+            handle: DEMO_RECIPE_HANDLE.to_string(),
+            args: args("x"),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(no_tok.code(), tonic::Code::Unauthenticated);
+
+    // Valid credential → the configured party holds a Use grant → runs to Committed.
+    let resp = c
+        .invoke(with_bearer(
+            proto::InvokeRequest {
+                handle: DEMO_RECIPE_HANDLE.to_string(),
+                args: args("incidents"),
+            },
+            Some("s3cr3t"),
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    // The polling RPCs are gated too — carry the token.
+    await_mote_committed(
+        &mut c,
+        &resp.instance_id,
+        &resp.terminal_mote_id,
+        Some("s3cr3t"),
+    )
+    .await;
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_invokes_all_commit() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let c = client(running.local_addr()).await;
+
+    // 16 concurrent invokes with DISTINCT args → 16 distinct Motes, all commit.
+    let mut tasks = Vec::new();
+    for i in 0..16u32 {
+        let mut c = c.clone();
+        tasks.push(tokio::spawn(async move {
+            let resp = c
+                .invoke(proto::InvokeRequest {
+                    handle: DEMO_RECIPE_HANDLE.to_string(),
+                    args: args(&format!("topic-{i}")),
+                })
+                .await
+                .unwrap()
+                .into_inner();
+            await_mote_committed(&mut c, &resp.instance_id, &resp.terminal_mote_id, None).await;
+            let id: [u8; 32] = resp.terminal_mote_id.try_into().unwrap();
+            id
+        }));
+    }
+    let mut committed = BTreeSet::new();
+    for t in tasks {
+        committed.insert(t.await.unwrap());
+    }
+    assert_eq!(
+        committed.len(),
+        16,
+        "all 16 concurrent invokes committed distinct Motes"
+    );
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-gateway/tests/serve_e2e.rs
+++ b/crates/kx-gateway/tests/serve_e2e.rs
@@ -15,6 +15,7 @@
 
 mod common;
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -25,13 +26,7 @@ use tempfile::TempDir;
 use tonic::transport::Channel;
 
 fn config(dir: &TempDir, dev_allow_local: bool) -> GatewayConfig {
-    GatewayConfig {
-        listen: "127.0.0.1:0".parse().unwrap(),
-        journal_path: dir.path().join("kx.db"),
-        content_root: dir.path().join("blobs"),
-        max_lease: 16,
-        dev_allow_local,
-    }
+    common::gateway_config(dir, dev_allow_local, HashMap::new())
 }
 
 async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {

--- a/crates/kx-gateway/tests/signature_e2e.rs
+++ b/crates/kx-gateway/tests/signature_e2e.rs
@@ -1,0 +1,222 @@
+//! End-to-end witnesses for the catalog signature RPCs over a REAL bound port
+//! (R2a):
+//!
+//! - register → the server derives the id → get round-trips the exact manifest →
+//!   list enumerates it → re-register is idempotent;
+//! - an unknown id → `not_found`, a wrong-length id / malformed manifest →
+//!   `invalid_argument` (fail-closed, but a *public* discovery surface — not the
+//!   collapsed no-oracle of the execution surface);
+//! - the registry is **durable across a restart** (the G1a SQLite backend);
+//! - the bearer-token resolver gates the surface (no/!wrong token →
+//!   `unauthenticated`; a valid token authorizes).
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use kx_catalog::{canonical_config, RecipeSnapshot, SignatureEntry, TaskSignature};
+use kx_gateway::start;
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+use tonic::Request;
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+/// A manifest = the canonical-encoded `SignatureEntry` for `fp` (a distinct
+/// fingerprint → a distinct task signature → a distinct server-derived id).
+fn manifest(fp: [u8; 32]) -> Vec<u8> {
+    let entry = SignatureEntry::new(
+        TaskSignature::model_invariant(kx_mote::MoteDefHash(fp)),
+        kx_workflow::ManifestId(fp),
+        RecipeSnapshot::new(fp),
+    );
+    bincode::serde::encode_to_vec(&entry, canonical_config()).unwrap()
+}
+
+/// Wrap a payload in a request carrying an `authorization: Bearer <token>` header.
+fn with_bearer<T>(payload: T, token: &str) -> Request<T> {
+    let mut req = Request::new(payload);
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    req
+}
+
+#[tokio::test]
+async fn signature_register_get_list_round_trip() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let m = manifest([7; 32]);
+    let reg = c
+        .register_signature(proto::RegisterSignatureRequest {
+            manifest: m.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(reg.signature_id.len(), 32, "server-derived 32-byte id");
+
+    // GetSignature byte-round-trips the exact manifest.
+    let got = c
+        .get_signature(proto::GetSignatureRequest {
+            signature_id: reg.signature_id.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(got.signature_id, reg.signature_id);
+    assert_eq!(
+        got.manifest, m,
+        "GetSignature byte-round-trips the manifest"
+    );
+
+    // ListSignatures enumerates it.
+    let list = c
+        .list_signatures(proto::ListSignaturesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(list
+        .signatures
+        .iter()
+        .any(|s| s.signature_id == reg.signature_id));
+    assert!(list.signatures.iter().all(|s| !s.name.is_empty()));
+
+    // Re-register the identical manifest → the same id (idempotent).
+    let reg2 = c
+        .register_signature(proto::RegisterSignatureRequest { manifest: m })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(reg2.signature_id, reg.signature_id);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn get_unknown_is_not_found_and_malformed_is_invalid_argument() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let unknown = c
+        .get_signature(proto::GetSignatureRequest {
+            signature_id: vec![0xab; 32],
+        })
+        .await;
+    assert_eq!(unknown.unwrap_err().code(), tonic::Code::NotFound);
+
+    let badlen = c
+        .get_signature(proto::GetSignatureRequest {
+            signature_id: vec![0u8; 5],
+        })
+        .await;
+    assert_eq!(badlen.unwrap_err().code(), tonic::Code::InvalidArgument);
+
+    let malformed = c
+        .register_signature(proto::RegisterSignatureRequest {
+            manifest: b"not a signature entry".to_vec(),
+        })
+        .await;
+    assert_eq!(malformed.unwrap_err().code(), tonic::Code::InvalidArgument);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn registered_signature_survives_restart() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let m = manifest([9; 32]);
+
+    // First server: register, then shut down gracefully.
+    let id = {
+        let running = start(common::gateway_config(&dir, true, HashMap::new()))
+            .await
+            .unwrap();
+        let mut c = client(running.local_addr()).await;
+        let reg = c
+            .register_signature(proto::RegisterSignatureRequest {
+                manifest: m.clone(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        running.shutdown().await.unwrap();
+        reg.signature_id
+    };
+
+    // Fresh server on the SAME catalog dir (default = the journal's dir): the
+    // durable SQLite registry re-serves the signature.
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+    let got = c
+        .get_signature(proto::GetSignatureRequest {
+            signature_id: id.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        got.manifest, m,
+        "the registered signature survives a restart"
+    );
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn bearer_token_gates_the_signature_surface() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut tokens = HashMap::new();
+    tokens.insert("s3cr3t".to_string(), "alice@acme".to_string());
+    let running = start(common::gateway_config(&dir, false, tokens))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // No credential → unauthenticated.
+    let no_tok = c.list_signatures(proto::ListSignaturesRequest {}).await;
+    assert_eq!(no_tok.unwrap_err().code(), tonic::Code::Unauthenticated);
+
+    // Wrong credential → unauthenticated (indistinguishable from no credential).
+    let wrong = c
+        .list_signatures(with_bearer(proto::ListSignaturesRequest {}, "nope"))
+        .await;
+    assert_eq!(wrong.unwrap_err().code(), tonic::Code::Unauthenticated);
+
+    // Valid credential → authorized.
+    let reg = c
+        .register_signature(with_bearer(
+            proto::RegisterSignatureRequest {
+                manifest: manifest([3; 32]),
+            },
+            "s3cr3t",
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(reg.signature_id.len(), 32);
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-proto/proto/kortecx/v1/gateway.proto
+++ b/crates/kx-proto/proto/kortecx/v1/gateway.proto
@@ -86,6 +86,35 @@ message RunHandle {
 }
 
 // ---------------------------------------------------------------------------
+// Invoke — bind a PUBLISHED recipe by handle to args and run it (R2 / D121).
+// Additive RPC (D120.6). The caller's party is SERVER-DERIVED from the auth
+// interceptor (there is NO party/principal field on the wire — SN-8). The
+// gateway resolves handle+args under the party's authoritative Use warrant via
+// the host's recipe binder (kx-invoke: resolve→validate→bind→intersect), then
+// register-then-submits through the SAME propose-proxy as SubmitRun (no new
+// journal write path).
+//
+// A run is keyed by recipe identity (RegisterRun dedups by recipe_fingerprint),
+// so every invocation of the SAME recipe joins ONE run instance; distinct args
+// yield distinct Motes WITHIN it (exactly-once-per-input). Invoke therefore
+// returns the SERVER-DERIVED `terminal_mote_id` (never client-supplied — SN-8)
+// so the caller knows which committed Mote in the run is THIS invocation's
+// output: poll GetProjection on instance_id, find terminal_mote_id, then
+// GetContent on its result_ref.
+// ---------------------------------------------------------------------------
+
+message InvokeRequest {
+  string handle = 1;                     // "namespace/collection/name" recipe handle (AssetPath)
+  bytes  args   = 2;                     // opaque JSON object bytes; validated server-side, fail-closed
+}
+
+message InvokeResponse {
+  bytes instance_id = 1;                 // 16B — the run this invocation joined (coordinator-assigned)
+  bytes recipe_fingerprint = 2;          // 32B — the resolved recipe identity
+  bytes terminal_mote_id = 3;            // 32B — SERVER-DERIVED sink Mote; its committed result is THIS invocation's output
+}
+
+// ---------------------------------------------------------------------------
 // GetProjection — the "render my run as a DAG" READ query (missing today).
 // All fields server-derived from the kx-projection fold. D120.2.
 // ---------------------------------------------------------------------------
@@ -213,6 +242,7 @@ message RegisterSignatureResponse {
 
 service KxGateway {
   rpc SubmitRun(SubmitRunRequest) returns (RunHandle);
+  rpc Invoke(InvokeRequest) returns (InvokeResponse);
   rpc GetProjection(GetProjectionRequest) returns (ProjectionView);
   rpc GetContent(GetContentRequest) returns (ContentBlob);
   rpc StreamEvents(StreamEventsRequest) returns (stream EventFrame);


### PR DESCRIPTION
## R2 — the gateway does real authenticated work over the wire

Builds on R1 (#129, the `kx-gateway` dev binary). Closes the architecture-audit gaps where `kx-invoke` was dead code (zero reverse-deps) and the catalog RPCs were `unimplemented`. **All additive; the frozen trio (`kx-scheduler`/`kx-executor`) is untouched and the projection digest `a6b5c679…` is invariant.**

A token-authenticated client can now **invoke a server-provisioned, durable recipe and watch it reach `Committed`** over a real port, and **browse/register catalog signatures**.

### R2a — real auth + catalog signature RPCs
- **Bearer-token auth** filling the `PrincipalResolver` seam (no trait change): `--auth-token <token>=<party>` / `--auth-token-file`. One uniform `unauthenticated` for missing/malformed/unknown token (no oracle). mTLS/OIDC remain later impls (OIDC stays cloud, D94/D101.1).
- **`SignatureCatalog` seam** in gateway-core (optional; `unimplemented` when unwired → backward-compatible) backed by a **durable `SqliteCatalog`** (registered signatures survive restart). Ids are **server-derived** from the manifest (SN-8).
- New `CallerParty` identity type owned by gateway-core (off `kx-catalog`, per the dependency wall).

### R2b — Invoke RPC + durable recipe provisioning
- Additive `rpc Invoke(InvokeRequest) returns (InvokeResponse)` (D120.6). `InvokeResponse` carries the **server-derived `terminal_mote_id`** (a run is keyed by recipe identity, so distinct args → distinct Motes within one run; the client needs the terminal Mote to find its result). **No party field on the wire** — identity is server-derived (SN-8).
- `RecipeBinder` seam + an `invoke` handler that binds via `kx_invoke::bind_snapshot` then **register-then-submits through the same propose-proxy as SubmitRun** (no new journal write path; coordinator stays the sole writer). Uniform `permission_denied` (no existence oracle).
- Host `DemoLibrary` over the durable Sqlite version/body/grant ledgers, seeding one PURE demo recipe whose step warrant uses `default_executor_class()` so a bound run leases on the embedded worker.

### Tests (+16; full suite 1605/0)
7 invoke-e2e over a **real bound port** (run-to-Committed + GetContent, unknown-handle/deny-all/bad-args denials, distinct-args→distinct-Motes, bearer-token gating, **16 concurrent invokes**), 6 binder unit (determinism / no-widen / authz / args / idempotent reopen), 3 gateway-core invoke (no-binder→Unimplemented, no-party→Unauthenticated, binder dispatch), plus auth/config unit + signature-e2e (round-trip + **restart durability**).

### Pre-flight (Golden Rule 8)
- **Breaks:** none — optional seams keep existing `GatewayService::new` callers compiling; additive proto; exactly-once preserved (distinct args→distinct MoteId, identical→dedup); recovery identical to SubmitRun.
- **Perf:** one new RPC; in-memory-cached ledger reads per bind; read-fold unchanged (linear). `ListSignatures` returns `(id,name)` summaries (a future `list_summaries()` avoids the full-entry clone — flagged, not in this PR).
- **Security:** new authenticated execution surface gated by deny-all default + server-derived party + authoritative Use-warrant; uniform no-oracle denials; `--auth-token-file` keeps secrets off argv (honest caveat: `HashMap` lookup is not constant-time — the constant-time/OIDC path is cloud). A hosted OSS server is single-tenant by construction (D129).

Gate: fmt · clippy `-D warnings` · `test --workspace` (1605/0) · deny · doc `-D warnings` · frozen-trio diff EMPTY · digest `a6b5c679…` invariant · dep-wall (kx-invoke/kx-catalog added, **llama.cpp FFI absent**) · real binary binds a port + clean shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)