### PR TITLE
feat(cli): R3 (D130) — the unified `kx` CLI (serve + engine forwarding + gRPC client verbs with --wait/--json)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-cli"
+version = "0.0.1"
+dependencies = [
+ "kx-gateway",
+ "kx-proto",
+ "kx-runtime",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-content"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "crates/kx-gateway",
     "crates/kx-invoke",
     "crates/kx-model-store",
+    "crates/kx-cli",
 ]
 exclude = [
     "kx-cloud",

--- a/crates/kx-cli/Cargo.toml
+++ b/crates/kx-cli/Cargo.toml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-cli"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx unified `kx` CLI (R3, D130): a hand-rolled (no-clap) front end that forwards run|replay|digest to the kx-runtime engine and serve to the kx-gateway server, and is a gRPC client of the FROZEN KxGateway service for invoke|submit|projection|content|events|signatures. Adds --wait (run-to-result) + --json so an agent can call the runtime like a function. FFI-free by default."
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "kx"
+path = "src/main.rs"
+
+[dependencies]
+# run|replay|digest forward to the engine VERBATIM (digest invariant). FFI-free by default.
+kx-runtime = { workspace = true }
+# `serve` forwards to kx_gateway::serve; `submit --demo` uses kx_gateway::demo_submit_run_request.
+# Default features ON ⇒ the embedded-worker closure; FFI-free (the dep_wall pins it).
+kx-gateway = { workspace = true }
+# The FROZEN KxGateway client stubs + request/response messages.
+kx-proto   = { workspace = true }
+# gRPC transport + Request/Status/Code for the client verbs.
+tonic        = { workspace = true }
+# `time` for the --wait / --follow poll backoff; `signal` for a clean --follow Ctrl-C.
+tokio        = { workspace = true, features = ["rt-multi-thread", "macros", "time", "signal"] }
+# --json machine output (a workspace dep; no new dependency).
+serde_json   = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror          = { workspace = true }
+
+[dev-dependencies]
+# E2E: host an in-process gateway (kx_gateway::start) + drive CLIENT verbs as subprocesses.
+kx-gateway = { workspace = true }
+tempfile   = { workspace = true }
+# `net` for the E2E readiness probe (wait until the in-process gateway's port
+# accepts before driving the CLI — the serve task may bind just after `start`).
+tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }
+# Parse the verbs' --json output back in the E2E assertions (separate test crate
+# ⇒ a dev-dep even though it's a normal dep of the lib).
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -1,0 +1,387 @@
+//! Top-level verb dispatch + hand-rolled arg parsing (no clap — matures at
+//! D127 step 1.2). `run` / `replay` / `digest` forward to the [`kx_runtime`]
+//! engine; `serve` forwards to [`kx_gateway`]; the rest are gRPC client verbs.
+
+use std::process::ExitCode;
+
+use serde_json::json;
+
+use crate::error::CliError;
+use crate::verbs;
+
+/// The default `serve` listen address (and the conventional client endpoint —
+/// see [`crate::client::DEFAULT_ENDPOINT`]).
+pub const DEFAULT_LISTEN: &str = "127.0.0.1:50151";
+
+/// One-line-per-section usage, printed on `--help` and on a parse error.
+pub const USAGE: &str = "\
+usage: kx <command> [args]
+
+  engine (local, no server):
+    kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--checkpoint-every N] [--json]
+
+  server:
+    kx serve --journal <path> --content <dir> [--listen <addr:port>] [--dev-allow-local]
+             [--auth-token <tok>=<party>]... [--auth-token-file <path>] [--max-lease N] [--catalog-dir <dir>]
+             (--listen defaults to 127.0.0.1:50151)
+
+  client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --json):
+    kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>]
+    kx submit --demo [--wait] [--timeout-secs N] [--out <file>]
+    kx projection --instance <hex16> [--at-seq N]
+    kx content --ref <hex32> --instance <hex16> [--out <file>]
+    kx events --instance <hex16> [--since N] [--follow]
+    kx signatures list | get --id <hex32> | register --manifest-file <path>
+
+    --endpoint defaults to http://127.0.0.1:50151
+
+  kx --help | --version | help <command>";
+
+/// A parsed invocation.
+#[derive(Debug)]
+pub enum Cli {
+    /// Print usage (global, or for a specific command) and exit 0.
+    Help(Option<String>),
+    /// Print the version and exit 0.
+    Version,
+    /// Forward to the engine: the full `<mode> ...` argv + whether `--json` was set.
+    Runtime {
+        /// The engine argv with the mode (`run`/`replay`/`digest`) re-prepended.
+        argv: Vec<String>,
+        /// Whether `--json` was requested (stripped before forwarding).
+        json: bool,
+    },
+    /// Forward to the gateway server: the `serve` args (verb stripped).
+    Serve(Vec<String>),
+    /// `invoke` a published recipe by handle.
+    Invoke(verbs::invoke::InvokeArgs),
+    /// `submit` a built-in demo run.
+    Submit(verbs::submit::SubmitArgs),
+    /// Render a run as a DAG of Mote states.
+    Projection(verbs::projection::ProjectionArgs),
+    /// Fetch a committed result.
+    Content(verbs::content::ContentArgs),
+    /// Stream/poll a run's event deltas.
+    Events(verbs::events::EventsArgs),
+    /// Catalog signature RPCs.
+    Signatures(verbs::signatures::SignaturesArgs),
+}
+
+impl Cli {
+    /// Parse `argv` (excluding the program name). An empty argv is `--help`.
+    pub fn from_args<I, S>(args: I) -> Result<Cli, CliError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut args = args.into_iter().map(Into::into);
+        match args.next().as_deref() {
+            None | Some("--help" | "-h") => Ok(Cli::Help(None)),
+            Some("help") => Ok(Cli::Help(args.next())),
+            Some("--version" | "-V") => Ok(Cli::Version),
+            Some(verb @ ("run" | "replay" | "digest")) => {
+                // The engine parser doesn't know `--json`; strip it here and
+                // forward the rest with the mode re-prepended.
+                let mut engine_argv = vec![verb.to_string()];
+                let mut json = false;
+                for a in args {
+                    if a == "--json" {
+                        json = true;
+                    } else {
+                        engine_argv.push(a);
+                    }
+                }
+                Ok(Cli::Runtime {
+                    argv: engine_argv,
+                    json,
+                })
+            }
+            Some("serve") => Ok(Cli::Serve(args.collect())),
+            Some("invoke") => Ok(Cli::Invoke(verbs::invoke::parse(args)?)),
+            Some("submit") => Ok(Cli::Submit(verbs::submit::parse(args)?)),
+            Some("projection") => Ok(Cli::Projection(verbs::projection::parse(args)?)),
+            Some("content") => Ok(Cli::Content(verbs::content::parse(args)?)),
+            Some("events") => Ok(Cli::Events(verbs::events::parse(args)?)),
+            Some("signatures") => Ok(Cli::Signatures(verbs::signatures::parse(args)?)),
+            Some(other) => Err(CliError::Usage(format!(
+                "unknown command {other:?} (try `kx --help`)"
+            ))),
+        }
+    }
+}
+
+/// Parse `argv` and run, returning the process exit code. The single entry point
+/// the binary calls.
+pub async fn run<I, S>(args: I) -> ExitCode
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let cli = match Cli::from_args(args) {
+        Ok(c) => c,
+        Err(e) => return render_error(&e),
+    };
+    match dispatch(cli).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => render_error(&e),
+    }
+}
+
+/// Render an error to stderr (with the usage block for usage/config errors) and
+/// return its exit code.
+fn render_error(e: &CliError) -> ExitCode {
+    if e.is_usage() {
+        eprintln!("{USAGE}");
+    }
+    eprintln!("kx: {e}");
+    e.exit_code()
+}
+
+async fn dispatch(cli: Cli) -> Result<(), CliError> {
+    match cli {
+        Cli::Help(None) => {
+            println!("{USAGE}");
+            Ok(())
+        }
+        Cli::Help(Some(cmd)) => {
+            println!("{}", help_for(&cmd));
+            Ok(())
+        }
+        Cli::Version => {
+            println!("kx {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        Cli::Runtime { argv, json } => run_engine(argv, json).await,
+        Cli::Serve(rest) => serve(rest).await,
+        Cli::Invoke(a) => verbs::invoke::execute(a).await,
+        Cli::Submit(a) => verbs::submit::execute(a).await,
+        Cli::Projection(a) => verbs::projection::execute(a).await,
+        Cli::Content(a) => verbs::content::execute(a).await,
+        Cli::Events(a) => verbs::events::execute(a).await,
+        Cli::Signatures(a) => verbs::signatures::execute(a).await,
+    }
+}
+
+/// The engine result, distinguished so `digest` and `run`/`replay` render
+/// differently (parity with the `kx-runtime` binary's output).
+enum EngineOut {
+    Digest(kx_runtime::ProjectionDigest),
+    Run(kx_runtime::RunOutcome),
+}
+
+/// Forward to the engine on a blocking thread (the orchestrator is CPU-bound and
+/// reused VERBATIM — the projection-digest invariant is preserved).
+async fn run_engine(argv: Vec<String>, json: bool) -> Result<(), CliError> {
+    let config =
+        kx_runtime::RuntimeConfig::from_args(argv).map_err(|e| CliError::Config(e.to_string()))?;
+    let out =
+        tokio::task::spawn_blocking(move || -> Result<EngineOut, kx_runtime::RuntimeError> {
+            match config.mode {
+                kx_runtime::Mode::Digest => kx_runtime::digest_only(&config).map(EngineOut::Digest),
+                kx_runtime::Mode::Run | kx_runtime::Mode::Replay => {
+                    kx_runtime::run(&config).map(EngineOut::Run)
+                }
+            }
+        })
+        .await
+        .map_err(|e| CliError::Runtime(format!("engine task panicked: {e}")))?
+        .map_err(|e| CliError::Runtime(e.to_string()))?;
+
+    let rendered = match out {
+        EngineOut::Digest(d) => {
+            let hex = d.to_hex();
+            if json {
+                json!({ "digest": hex }).to_string()
+            } else {
+                hex
+            }
+        }
+        EngineOut::Run(o) => {
+            let hex = o.digest.to_hex();
+            if json {
+                json!({ "digest": hex, "committed": o.committed, "total": o.total }).to_string()
+            } else {
+                format!("{hex} ({}/{} committed)", o.committed, o.total)
+            }
+        }
+    };
+    println!("{rendered}");
+    Ok(())
+}
+
+/// Forward to the embedded gateway server, defaulting `--listen` when absent.
+async fn serve(rest: Vec<String>) -> Result<(), CliError> {
+    let argv = inject_listen_default(rest);
+    let cli = kx_gateway::Cli::from_args(std::iter::once("serve".to_string()).chain(argv))
+        .map_err(|e| CliError::Config(e.to_string()))?;
+    match cli {
+        kx_gateway::Cli::Serve(cfg) => kx_gateway::serve(cfg).await.map_err(map_gateway_err),
+        // Unreachable (we always pass "serve"), but keep the match total + safe.
+        kx_gateway::Cli::Help => {
+            println!("{}", kx_gateway::USAGE);
+            Ok(())
+        }
+        kx_gateway::Cli::Version => {
+            println!("kx-gateway");
+            Ok(())
+        }
+    }
+}
+
+/// A gateway config error keeps exit-2 semantics; a bind/runtime failure is exit 1.
+fn map_gateway_err(e: kx_gateway::GatewayError) -> CliError {
+    match e {
+        kx_gateway::GatewayError::Config(m) => CliError::Config(m),
+        other => CliError::Runtime(other.to_string()),
+    }
+}
+
+/// Inject the default `--listen` if the operator didn't pass one.
+fn inject_listen_default(mut rest: Vec<String>) -> Vec<String> {
+    if !rest.iter().any(|a| a == "--listen") {
+        rest.push("--listen".to_string());
+        rest.push(DEFAULT_LISTEN.to_string());
+    }
+    rest
+}
+
+/// Longer help for a single command (`kx help <command>`).
+fn help_for(cmd: &str) -> String {
+    match cmd {
+        "run" | "replay" | "digest" => "\
+kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--checkpoint-every N] [--json]
+  Forwards to the kx-runtime engine. `run` drives the canonical demo from scratch;
+  `replay` recovers + finishes an existing journal; `digest` prints the projection
+  digest. Output is parity-identical to the `kx-runtime` binary."
+            .into(),
+        "serve" => "\
+kx serve --journal <path> --content <dir> [--listen <addr:port>] [--dev-allow-local] ...
+  Hosts the embedded single-system gateway. --listen defaults to 127.0.0.1:50151.
+  Deny-all by default: pass --dev-allow-local (loopback only) or --auth-token(-file)."
+            .into(),
+        "invoke" => "\
+kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>] [client flags]
+  Bind a PUBLISHED recipe by handle (e.g. kx/recipes/echo) to JSON args and run it.
+  With --wait, poll to completion and print the committed result (run the runtime like
+  a function). Without --wait, print the async handle (instance_id/terminal_mote_id)."
+            .into(),
+        "submit" => "\
+kx submit --demo [--wait] [--timeout-secs N] [--out <file>] [client flags]
+  Submit a built-in PURE demo run via the low-level SubmitRun path."
+            .into(),
+        "projection" => "\
+kx projection --instance <hex16> [--at-seq N] [client flags]
+  Render a run as a DAG: each Mote's state, nd-class, result ref, and committed seq."
+            .into(),
+        "content" => "\
+kx content --ref <hex32> --instance <hex16> [--out <file>] [client flags]
+  Fetch a committed result. Writes RAW bytes to stdout (binary-safe, no newline);
+  use --out <file> to save, or --json for a hex-encoded object (terminal-safe)."
+            .into(),
+        "events" => "\
+kx events --instance <hex16> [--since N] [--follow] [client flags]
+  Print the run's event deltas. StreamEvents is snapshot-to-head today: this catches
+  up to the current journal boundary and stops. --follow re-polls from the last cursor
+  (~250ms) until Ctrl-C; true live-tail arrives in a later release."
+            .into(),
+        "signatures" => "\
+kx signatures list | get --id <hex32> | register --manifest-file <path> [client flags]
+  Browse / fetch / register catalog task signatures over the gateway."
+            .into(),
+        other => format!("no help for {other:?}; try `kx --help`"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_and_help_and_version() {
+        assert!(matches!(
+            Cli::from_args(Vec::<String>::new()).unwrap(),
+            Cli::Help(None)
+        ));
+        assert!(matches!(
+            Cli::from_args(["--help"]).unwrap(),
+            Cli::Help(None)
+        ));
+        assert!(matches!(Cli::from_args(["-h"]).unwrap(), Cli::Help(None)));
+        assert!(matches!(
+            Cli::from_args(["help", "invoke"]).unwrap(),
+            Cli::Help(Some(v)) if v == "invoke"
+        ));
+        assert!(matches!(
+            Cli::from_args(["--version"]).unwrap(),
+            Cli::Version
+        ));
+        assert!(matches!(Cli::from_args(["-V"]).unwrap(), Cli::Version));
+    }
+
+    #[test]
+    fn runtime_forwarding_preserves_verb_and_strips_json() {
+        let Cli::Runtime { argv, json } = Cli::from_args([
+            "digest",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--json",
+        ])
+        .unwrap() else {
+            panic!("expected Runtime");
+        };
+        assert!(json, "--json is extracted");
+        assert_eq!(
+            argv[0], "digest",
+            "the mode is re-prepended for the engine parser"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "--json"),
+            "--json is not forwarded"
+        );
+        assert!(argv.iter().any(|a| a == "/tmp/j"));
+    }
+
+    #[test]
+    fn serve_collects_rest() {
+        let Cli::Serve(rest) =
+            Cli::from_args(["serve", "--journal", "/tmp/j", "--content", "/tmp/c"]).unwrap()
+        else {
+            panic!("expected Serve");
+        };
+        assert_eq!(rest, vec!["--journal", "/tmp/j", "--content", "/tmp/c"]);
+    }
+
+    #[test]
+    fn listen_default_injection() {
+        // Absent → injected.
+        let injected = inject_listen_default(vec!["--journal".into(), "/tmp/j".into()]);
+        assert!(injected
+            .windows(2)
+            .any(|w| w[0] == "--listen" && w[1] == DEFAULT_LISTEN));
+        // Present → unchanged.
+        let kept = inject_listen_default(vec!["--listen".into(), "0.0.0.0:9".into()]);
+        assert_eq!(kept.iter().filter(|a| *a == "--listen").count(), 1);
+        assert!(kept.iter().any(|a| a == "0.0.0.0:9"));
+        // And the gateway parser accepts the injected form.
+        let argv = inject_listen_default(vec![
+            "--journal".into(),
+            "/tmp/j".into(),
+            "--content".into(),
+            "/tmp/c".into(),
+            "--dev-allow-local".into(),
+        ]);
+        let cli =
+            kx_gateway::Cli::from_args(std::iter::once("serve".to_string()).chain(argv)).unwrap();
+        let kx_gateway::Cli::Serve(cfg) = cli else {
+            panic!("expected Serve")
+        };
+        assert_eq!(cfg.listen.to_string(), DEFAULT_LISTEN);
+    }
+
+    #[test]
+    fn unknown_command_is_usage_error() {
+        assert!(Cli::from_args(["frobnicate"]).is_err());
+    }
+}

--- a/crates/kx-cli/src/client.rs
+++ b/crates/kx-cli/src/client.rs
@@ -1,0 +1,272 @@
+//! Gateway-client plumbing shared by the client verbs: the common flags
+//! (`--endpoint` / `--token` / `--token-file` / `--json`), credential
+//! resolution, dialing a [`KxGatewayClient`], and attaching a bearer token to a
+//! request.
+//!
+//! Identity is server-derived (SN-8): the CLI sends a *credential* (a bearer
+//! token), never a claimed identity. A `--dev-allow-local` server needs no token.
+
+use std::path::PathBuf;
+
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+use crate::error::CliError;
+
+/// The default gateway endpoint (matches the conventional `kx serve` listen
+/// address; see [`crate::cli::DEFAULT_LISTEN`]).
+pub const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:50151";
+
+/// Flags every client verb accepts. Populated by the per-verb arg loops via
+/// [`ClientCommon::try_consume`].
+#[derive(Debug, Clone)]
+pub struct ClientCommon {
+    /// The gateway endpoint URL (`--endpoint`, default [`DEFAULT_ENDPOINT`]).
+    pub endpoint: String,
+    /// An inline bearer token (`--token`). Visible in `ps`; prefer `--token-file`.
+    pub token: Option<String>,
+    /// A file holding a bearer token (`--token-file`); the file is read + trimmed.
+    pub token_file: Option<PathBuf>,
+    /// Emit machine-readable JSON instead of the human rendering (`--json`).
+    pub json: bool,
+}
+
+impl Default for ClientCommon {
+    fn default() -> Self {
+        Self {
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            token: None,
+            token_file: None,
+            json: false,
+        }
+    }
+}
+
+/// Pull the next value for a flag, erroring with a usage message if absent.
+pub fn next_value<I: Iterator<Item = String>>(
+    args: &mut I,
+    name: &str,
+) -> Result<String, CliError> {
+    args.next()
+        .ok_or_else(|| CliError::Usage(format!("{name} requires a value")))
+}
+
+/// Pull the next value and hex-decode it to a fixed-size byte array (a
+/// wrong-length / non-hex value becomes a usage error). Used by the verbs that
+/// take a `--instance` (16B) / `--ref` / `--id` (32B).
+pub fn take_fixed<I: Iterator<Item = String>, const N: usize>(
+    args: &mut I,
+    name: &str,
+) -> Result<[u8; N], CliError> {
+    Ok(crate::hex::decode_fixed::<N>(&next_value(args, name)?)?)
+}
+
+impl ClientCommon {
+    /// If `flag` is a common client flag, consume it (pulling its value from
+    /// `args` when needed) and return `Ok(true)`; otherwise `Ok(false)` so the
+    /// caller can handle a verb-specific flag.
+    pub fn try_consume<I: Iterator<Item = String>>(
+        &mut self,
+        flag: &str,
+        args: &mut I,
+    ) -> Result<bool, CliError> {
+        match flag {
+            "--endpoint" => self.endpoint = next_value(args, "--endpoint")?,
+            "--token" => self.token = Some(next_value(args, "--token")?),
+            "--token-file" => {
+                self.token_file = Some(PathBuf::from(next_value(args, "--token-file")?));
+            }
+            "--json" => self.json = true,
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+
+    /// Resolve the effective credential, applying the precedence + safety nudges:
+    /// `--token-file` (preferred) over `--token`; the two are mutually exclusive.
+    /// Warns (stderr, non-fatal) when an inline `--token` is used (argv-visible)
+    /// and when a token would be sent to a non-loopback plaintext endpoint
+    /// (bearer-over-plaintext is dev/loopback only; TLS/mTLS is a later step).
+    pub fn resolve(&self) -> Result<Resolved, CliError> {
+        if self.token.is_some() && self.token_file.is_some() {
+            return Err(CliError::Usage(
+                "--token and --token-file are mutually exclusive".into(),
+            ));
+        }
+        let token = match &self.token_file {
+            Some(path) => {
+                let body = std::fs::read_to_string(path)
+                    .map_err(|e| CliError::Io(format!("--token-file {}: {e}", path.display())))?;
+                let trimmed = body.trim().to_string();
+                if trimmed.is_empty() {
+                    return Err(CliError::Usage(format!(
+                        "--token-file {} is empty",
+                        path.display()
+                    )));
+                }
+                Some(trimmed)
+            }
+            None => self.token.clone(),
+        };
+        if self.token.is_some() {
+            eprintln!("kx: warning: --token is visible in the process list; prefer --token-file");
+        }
+        if token.is_some() && is_nonloopback_plaintext(&self.endpoint) {
+            eprintln!(
+                "kx: warning: sending a bearer token to a non-loopback plaintext endpoint ({}); \
+                 it travels in cleartext — TLS/mTLS is a later step",
+                self.endpoint
+            );
+        }
+        Ok(Resolved {
+            endpoint: self.endpoint.clone(),
+            token,
+        })
+    }
+}
+
+/// A resolved endpoint + optional bearer token.
+#[derive(Debug, Clone)]
+pub struct Resolved {
+    /// The gateway endpoint to dial.
+    pub endpoint: String,
+    /// The bearer token to attach (if any).
+    pub token: Option<String>,
+}
+
+impl Resolved {
+    /// Dial the gateway, mapping a transport failure to [`CliError::Connect`].
+    pub async fn connect(&self) -> Result<KxGatewayClient<Channel>, CliError> {
+        KxGatewayClient::connect(self.endpoint.clone())
+            .await
+            .map_err(|e| CliError::Connect {
+                endpoint: self.endpoint.clone(),
+                detail: e.to_string(),
+            })
+    }
+
+    /// Wrap `payload` in a request, attaching `authorization: Bearer <token>`
+    /// when a token is set. A token with non-ASCII / control characters is a
+    /// usage error (it can't form a valid metadata value) rather than a panic.
+    pub fn request<T>(&self, payload: T) -> Result<tonic::Request<T>, CliError> {
+        let mut req = tonic::Request::new(payload);
+        if let Some(token) = &self.token {
+            let value = format!("Bearer {token}").parse().map_err(|_| {
+                CliError::Usage("--token contains characters not valid in an HTTP header".into())
+            })?;
+            req.metadata_mut().insert("authorization", value);
+        }
+        Ok(req)
+    }
+}
+
+/// `true` iff `endpoint` is plaintext `http://` to a non-loopback host (the case
+/// where a bearer token would travel in cleartext over a network).
+#[must_use]
+pub fn is_nonloopback_plaintext(endpoint: &str) -> bool {
+    let Some(rest) = endpoint.strip_prefix("http://") else {
+        return false; // https:// (or anything else) is not plaintext-http
+    };
+    // A bracketed IPv6 host (`[::1]:port`) keeps its colons inside the brackets;
+    // a plain host runs up to the first ':' (port) or '/' (path).
+    let host = if let Some(after) = rest.strip_prefix('[') {
+        after.split(']').next().unwrap_or(after)
+    } else {
+        rest.split(['/', ':']).next().unwrap_or(rest)
+    };
+    !matches!(host, "127.0.0.1" | "::1" | "localhost")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_endpoint_and_no_token() {
+        let c = ClientCommon::default();
+        assert_eq!(c.endpoint, DEFAULT_ENDPOINT);
+        assert!(c.token.is_none() && c.token_file.is_none() && !c.json);
+    }
+
+    #[test]
+    fn try_consume_handles_common_flags_only() {
+        let mut c = ClientCommon::default();
+        let mut it = vec!["http://h:1".to_string()].into_iter();
+        assert!(c.try_consume("--endpoint", &mut it).unwrap());
+        assert_eq!(c.endpoint, "http://h:1");
+        assert!(c.try_consume("--json", &mut std::iter::empty()).unwrap());
+        assert!(c.json);
+        // A non-common flag is left for the caller.
+        assert!(!c
+            .try_consume("--instance", &mut std::iter::empty())
+            .unwrap());
+        // A common flag missing its value is a usage error.
+        assert!(c.try_consume("--token", &mut std::iter::empty()).is_err());
+    }
+
+    #[test]
+    fn token_and_token_file_are_mutually_exclusive() {
+        let c = ClientCommon {
+            token: Some("t".into()),
+            token_file: Some(PathBuf::from("/x")),
+            ..ClientCommon::default()
+        };
+        assert!(c.resolve().is_err());
+    }
+
+    #[test]
+    fn token_file_is_trimmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tok");
+        std::fs::write(&path, "  s3cr3t\n").unwrap();
+        let c = ClientCommon {
+            token_file: Some(path),
+            ..ClientCommon::default()
+        };
+        assert_eq!(c.resolve().unwrap().token.as_deref(), Some("s3cr3t"));
+    }
+
+    #[test]
+    fn empty_token_file_is_usage_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tok");
+        std::fs::write(&path, "   \n").unwrap();
+        let c = ClientCommon {
+            token_file: Some(path),
+            ..ClientCommon::default()
+        };
+        assert!(c.resolve().is_err());
+    }
+
+    #[test]
+    fn plaintext_detection() {
+        assert!(is_nonloopback_plaintext("http://example.com:50151"));
+        assert!(is_nonloopback_plaintext("http://10.0.0.5:50151"));
+        assert!(!is_nonloopback_plaintext("http://127.0.0.1:50151"));
+        assert!(!is_nonloopback_plaintext("http://localhost:50151"));
+        assert!(!is_nonloopback_plaintext("http://[::1]:50151"));
+        assert!(!is_nonloopback_plaintext("https://example.com")); // TLS, not plaintext
+    }
+
+    #[test]
+    fn request_attaches_bearer_and_rejects_bad_token() {
+        let ok = Resolved {
+            endpoint: DEFAULT_ENDPOINT.into(),
+            token: Some("s3cr3t".into()),
+        };
+        let req = ok.request(()).unwrap();
+        assert_eq!(
+            req.metadata()
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "Bearer s3cr3t"
+        );
+        let bad = Resolved {
+            endpoint: DEFAULT_ENDPOINT.into(),
+            token: Some("bad\ntoken".into()),
+        };
+        assert!(bad.request(()).is_err());
+    }
+}

--- a/crates/kx-cli/src/error.rs
+++ b/crates/kx-cli/src/error.rs
@@ -1,0 +1,94 @@
+//! [`CliError`] — the CLI's typed failure surface, with an explicit exit-code
+//! mapping so a script or agent never mistakes a failure for success:
+//!
+//! | code | meaning                                                            |
+//! |------|--------------------------------------------------------------------|
+//! | `0`  | success (handled by the verb, not here)                            |
+//! | `2`  | usage / configuration error (bad flags, bad hex, client-side bad JSON) |
+//! | `3`  | `--wait` timed out — the run is still in progress and resumable     |
+//! | `1`  | everything else (RPC error, connect failure, failed Mote, IO)      |
+
+use std::process::ExitCode;
+
+use crate::hex::HexError;
+
+/// A CLI failure. Rendered to stderr as `kx: {error}`; the [`exit_code`] decides
+/// the process status.
+///
+/// [`exit_code`]: CliError::exit_code
+#[derive(Debug, thiserror::Error)]
+pub enum CliError {
+    /// Bad arguments: unknown flag, missing required value, bad hex length,
+    /// mutually-exclusive flags, or client-side-invalid `--args` JSON. Exit `2`.
+    #[error("{0}")]
+    Usage(String),
+    /// A forwarded engine/gateway configuration error (`run`/`serve`). Exit `2`.
+    #[error("{0}")]
+    Config(String),
+    /// The gateway endpoint could not be dialed. Exit `1`.
+    #[error("could not connect to {endpoint}: {detail}")]
+    Connect {
+        /// The endpoint URL that failed to dial.
+        endpoint: String,
+        /// The transport-level detail.
+        detail: String,
+    },
+    /// The gateway returned a gRPC error status. Exit `1`.
+    #[error("{code:?}: {message}")]
+    Rpc {
+        /// The gRPC status code (e.g. `Unauthenticated`, `PermissionDenied`).
+        code: tonic::Code,
+        /// The status message.
+        message: String,
+    },
+    /// The forwarded [`kx_runtime`] engine returned an error. Exit `1`.
+    #[error("{0}")]
+    Runtime(String),
+    /// A local IO error (reading a token / manifest file, writing `--out`). Exit `1`.
+    #[error("io: {0}")]
+    Io(String),
+    /// `--wait` reached its timeout while the run was still in progress. The
+    /// verb has already printed the resumable handle. Exit `3`.
+    #[error(
+        "run still in progress (timed out waiting); resume with `kx projection` / `kx events`"
+    )]
+    WaitTimeout,
+    /// `--wait` observed the terminal Mote reach a `Failed` state. Exit `1`.
+    #[error("the run's terminal Mote failed")]
+    Failed,
+}
+
+impl CliError {
+    /// Build an [`Rpc`](CliError::Rpc) error from a tonic status. Takes the
+    /// status by value so it composes as `.map_err(CliError::from_status)`.
+    #[must_use]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn from_status(status: tonic::Status) -> Self {
+        CliError::Rpc {
+            code: status.code(),
+            message: status.message().to_string(),
+        }
+    }
+
+    /// The process exit code for this error (see the module table).
+    #[must_use]
+    pub fn exit_code(&self) -> ExitCode {
+        match self {
+            CliError::Usage(_) | CliError::Config(_) => ExitCode::from(2),
+            CliError::WaitTimeout => ExitCode::from(3),
+            _ => ExitCode::FAILURE,
+        }
+    }
+
+    /// `true` for the errors whose remedy is the usage text (so `run` prints it).
+    #[must_use]
+    pub fn is_usage(&self) -> bool {
+        matches!(self, CliError::Usage(_) | CliError::Config(_))
+    }
+}
+
+impl From<HexError> for CliError {
+    fn from(e: HexError) -> Self {
+        CliError::Usage(e.to_string())
+    }
+}

--- a/crates/kx-cli/src/format.rs
+++ b/crates/kx-cli/src/format.rs
@@ -1,0 +1,420 @@
+//! Rendering for the client verbs — a human-readable default and an opt-in
+//! `--json` machine form. All ids / refs / digests are lowercase hex. The
+//! functions return `String`s (so they're unit-testable); the verbs do the
+//! actual stdout write. `content`'s raw-bytes path is the one exception (the
+//! verb writes the payload directly — see [`crate::verbs::content`]).
+
+use std::fmt::Write as _;
+
+use kx_proto::proto;
+use serde_json::{json, Value};
+
+use crate::hex;
+use crate::wait::{WaitOutcome, WaitState};
+
+/// Map a [`proto::MoteSnapshotState`] discriminant to a stable display name.
+/// An out-of-range value renders `UNKNOWN` (forward-compatible with a future
+/// proto that adds a state — no panic, no silent mis-label).
+#[must_use]
+pub fn state_name(state: i32) -> &'static str {
+    use proto::MoteSnapshotState as S;
+    if state == S::Pending as i32 {
+        "PENDING"
+    } else if state == S::Scheduled as i32 {
+        "SCHEDULED"
+    } else if state == S::Committed as i32 {
+        "COMMITTED"
+    } else if state == S::Failed as i32 {
+        "FAILED"
+    } else if state == S::Repudiated as i32 {
+        "REPUDIATED"
+    } else if state == S::Inconsistent as i32 {
+        "INCONSISTENT"
+    } else {
+        "UNKNOWN"
+    }
+}
+
+/// Render an `invoke` (no `--wait`) result: the async run handle.
+#[must_use]
+pub fn render_invoke(resp: &proto::InvokeResponse, json: bool) -> String {
+    if json {
+        json!({
+            "instance_id": hex::encode(&resp.instance_id),
+            "recipe_fingerprint": hex::encode(&resp.recipe_fingerprint),
+            "terminal_mote_id": hex::encode(&resp.terminal_mote_id),
+        })
+        .to_string()
+    } else {
+        format!(
+            "instance_id        {}\nrecipe_fingerprint {}\nterminal_mote_id   {}",
+            hex::encode(&resp.instance_id),
+            hex::encode(&resp.recipe_fingerprint),
+            hex::encode(&resp.terminal_mote_id),
+        )
+    }
+}
+
+/// Render a `submit` (no `--wait`) run handle.
+#[must_use]
+pub fn render_submit(handle: &proto::RunHandle, json: bool) -> String {
+    if json {
+        json!({
+            "instance_id": hex::encode(&handle.instance_id),
+            "recipe_fingerprint": hex::encode(&handle.recipe_fingerprint),
+        })
+        .to_string()
+    } else {
+        format!(
+            "instance_id        {}\nrecipe_fingerprint {}",
+            hex::encode(&handle.instance_id),
+            hex::encode(&handle.recipe_fingerprint),
+        )
+    }
+}
+
+/// Render a projection view (the run rendered as a DAG of Mote states).
+#[must_use]
+pub fn render_projection(view: &proto::ProjectionView, json: bool) -> String {
+    if json {
+        let motes: Vec<Value> = view
+            .motes
+            .iter()
+            .map(|m| {
+                json!({
+                    "mote_id": hex::encode(&m.mote_id),
+                    "state": state_name(m.state),
+                    "nd_class": m.nd_class,
+                    "promotion": m.promotion,
+                    "result_ref": m.result_ref.as_deref().map(hex::encode),
+                    "committed_seq": m.committed_seq,
+                    "anomaly": m.anomaly,
+                })
+            })
+            .collect();
+        json!({
+            "instance_id": hex::encode(&view.instance_id),
+            "recipe_fingerprint": hex::encode(&view.recipe_fingerprint),
+            "current_seq": view.current_seq,
+            "motes": motes,
+        })
+        .to_string()
+    } else {
+        let mut out = format!(
+            "instance {}  recipe {}  seq {}",
+            hex::encode(&view.instance_id),
+            hex::encode(&view.recipe_fingerprint),
+            view.current_seq,
+        );
+        for m in &view.motes {
+            let _ = write!(
+                out,
+                "\n  {}  {:<12} nd={} result={} committed_seq={}",
+                hex::encode(&m.mote_id),
+                state_name(m.state),
+                m.nd_class,
+                hex::encode_opt(m.result_ref.as_deref()),
+                m.committed_seq
+                    .map_or_else(|| "-".to_string(), |s| s.to_string()),
+            );
+        }
+        out
+    }
+}
+
+/// Render a single event delta as one human line / one NDJSON object. `None`
+/// for a delta with no recognized `kind` (forward-compat: skip silently).
+#[must_use]
+pub fn render_delta(delta: &proto::EventDelta, json: bool) -> Option<String> {
+    use proto::event_delta::Kind;
+    let kind = delta.kind.as_ref()?;
+    let seq = delta.seq;
+    let line = match kind {
+        Kind::Committed(c) => {
+            if json {
+                json!({"seq": seq, "kind": "committed", "mote_id": hex::encode(&c.mote_id),
+                       "result_ref": hex::encode(&c.result_ref), "nd_class": c.nd_class})
+                .to_string()
+            } else {
+                format!(
+                    "seq {seq} COMMITTED  mote={} result={} nd={}",
+                    hex::encode(&c.mote_id),
+                    hex::encode(&c.result_ref),
+                    c.nd_class
+                )
+            }
+        }
+        Kind::Failed(fd) => {
+            if json {
+                json!({"seq": seq, "kind": "failed", "mote_id": hex::encode(&fd.mote_id),
+                       "reason_class": fd.reason_class})
+                .to_string()
+            } else {
+                format!(
+                    "seq {seq} FAILED     mote={} reason={}",
+                    hex::encode(&fd.mote_id),
+                    fd.reason_class
+                )
+            }
+        }
+        Kind::Repudiated(r) => {
+            if json {
+                json!({"seq": seq, "kind": "repudiated",
+                       "target_mote_id": hex::encode(&r.target_mote_id),
+                       "target_committed_seq": r.target_committed_seq})
+                .to_string()
+            } else {
+                format!(
+                    "seq {seq} REPUDIATED mote={} target_seq={}",
+                    hex::encode(&r.target_mote_id),
+                    r.target_committed_seq
+                )
+            }
+        }
+        Kind::EffectStaged(e) => {
+            if json {
+                json!({"seq": seq, "kind": "effect_staged", "mote_id": hex::encode(&e.mote_id)})
+                    .to_string()
+            } else {
+                format!("seq {seq} EFFECT_STAGED mote={}", hex::encode(&e.mote_id))
+            }
+        }
+    };
+    Some(line)
+}
+
+/// Render the result of a `--wait` run. `include_payload` is `false` when the
+/// caller wrote the payload to `--out` (then only metadata is emitted).
+#[must_use]
+pub fn render_wait(outcome: &WaitOutcome, json: bool, include_payload: bool) -> String {
+    let state = match outcome.state {
+        WaitState::Committed => "COMMITTED",
+        WaitState::Failed => "FAILED",
+        WaitState::Running => "RUNNING",
+    };
+    if json {
+        // Build the map directly (no `as_object_mut().expect(...)` — lib code
+        // denies `expect_used`).
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "instance_id".into(),
+            json!(hex::encode(&outcome.instance_id)),
+        );
+        map.insert(
+            "terminal_mote_id".into(),
+            json!(hex::encode(&outcome.terminal_mote_id)),
+        );
+        map.insert("state".into(), json!(state));
+        if let Some(ref_bytes) = &outcome.result_ref {
+            map.insert("result_ref".into(), json!(hex::encode(ref_bytes)));
+        }
+        if let WaitState::Running = outcome.state {
+            map.insert("timed_out".into(), json!(true));
+        }
+        if let Some(payload) = &outcome.payload {
+            map.insert("result_len".into(), json!(payload.len()));
+            if include_payload {
+                if let Ok(text) = std::str::from_utf8(payload) {
+                    map.insert("result_utf8".into(), json!(text));
+                }
+                map.insert("result_hex".into(), json!(hex::encode(payload)));
+            }
+        }
+        Value::Object(map).to_string()
+    } else {
+        let mut out = format!(
+            "instance_id      {}\nterminal_mote_id {}\nstate            {state}",
+            hex::encode(&outcome.instance_id),
+            hex::encode(&outcome.terminal_mote_id),
+        );
+        if let Some(ref_bytes) = &outcome.result_ref {
+            let _ = write!(out, "\nresult_ref       {}", hex::encode(ref_bytes));
+        }
+        if let Some(payload) = &outcome.payload {
+            let _ = write!(out, "\nresult_len       {}", payload.len());
+            if include_payload {
+                match std::str::from_utf8(payload) {
+                    Ok(text) => {
+                        let _ = write!(out, "\nresult           {text}");
+                    }
+                    Err(_) => {
+                        let _ = write!(out, "\nresult_hex       {}", hex::encode(payload));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Render the JSON form of a fetched content blob (the human path writes raw
+/// bytes; this is only used under `--json`).
+#[must_use]
+pub fn render_content_json(content_ref: &[u8], payload: &[u8]) -> String {
+    json!({
+        "content_ref": hex::encode(content_ref),
+        "len": payload.len(),
+        "payload_hex": hex::encode(payload),
+    })
+    .to_string()
+}
+
+/// Render `signatures list`.
+#[must_use]
+pub fn render_signatures_list(resp: &proto::ListSignaturesResponse, json: bool) -> String {
+    if json {
+        let sigs: Vec<Value> = resp
+            .signatures
+            .iter()
+            .map(|s| json!({"signature_id": hex::encode(&s.signature_id), "name": s.name}))
+            .collect();
+        json!({ "signatures": sigs }).to_string()
+    } else if resp.signatures.is_empty() {
+        "(no signatures registered)".to_string()
+    } else {
+        resp.signatures
+            .iter()
+            .map(|s| format!("{}  {}", hex::encode(&s.signature_id), s.name))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Render `signatures get` (the manifest is opaque bincode — hex, never decoded).
+#[must_use]
+pub fn render_signature_get(resp: &proto::GetSignatureResponse, json: bool) -> String {
+    if json {
+        json!({
+            "signature_id": hex::encode(&resp.signature_id),
+            "manifest_hex": hex::encode(&resp.manifest),
+            "manifest_len": resp.manifest.len(),
+        })
+        .to_string()
+    } else {
+        format!(
+            "signature_id {}\nmanifest     {} bytes (opaque)",
+            hex::encode(&resp.signature_id),
+            resp.manifest.len(),
+        )
+    }
+}
+
+/// Render `signatures register`.
+#[must_use]
+pub fn render_signature_register(resp: &proto::RegisterSignatureResponse, json: bool) -> String {
+    if json {
+        json!({ "signature_id": hex::encode(&resp.signature_id) }).to_string()
+    } else {
+        format!("signature_id {}", hex::encode(&resp.signature_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wait::{WaitOutcome, WaitState};
+
+    #[test]
+    fn state_names_cover_range_and_unknown() {
+        use proto::MoteSnapshotState as S;
+        assert_eq!(state_name(S::Committed as i32), "COMMITTED");
+        assert_eq!(state_name(S::Failed as i32), "FAILED");
+        assert_eq!(state_name(S::Pending as i32), "PENDING");
+        assert_eq!(state_name(999), "UNKNOWN");
+    }
+
+    #[test]
+    fn invoke_json_has_hex_ids() {
+        let resp = proto::InvokeResponse {
+            instance_id: vec![0xab; 16],
+            recipe_fingerprint: vec![0xcd; 32],
+            terminal_mote_id: vec![0xef; 32],
+        };
+        let v: Value = serde_json::from_str(&render_invoke(&resp, true)).unwrap();
+        assert_eq!(v["instance_id"].as_str().unwrap().len(), 32); // 16B -> 32 hex
+        assert_eq!(v["terminal_mote_id"].as_str().unwrap().len(), 64); // 32B -> 64 hex
+        assert_eq!(v["recipe_fingerprint"], json!("cd".repeat(32)));
+    }
+
+    #[test]
+    fn projection_json_renders_states_and_refs() {
+        let view = proto::ProjectionView {
+            instance_id: vec![1u8; 16],
+            recipe_fingerprint: vec![2u8; 32],
+            current_seq: 7,
+            motes: vec![proto::MoteSnapshot {
+                mote_id: vec![3u8; 32],
+                state: proto::MoteSnapshotState::Committed as i32,
+                nd_class: 1,
+                promotion: 1,
+                result_ref: Some(vec![4u8; 32]),
+                warrant_ref: None,
+                mote_def_hash: vec![5u8; 32],
+                committed_seq: Some(7),
+                parents: vec![],
+                verdict: None,
+                anomaly: None,
+            }],
+        };
+        let v: Value = serde_json::from_str(&render_projection(&view, true)).unwrap();
+        assert_eq!(v["current_seq"], 7);
+        assert_eq!(v["motes"][0]["state"], "COMMITTED");
+        assert_eq!(v["motes"][0]["result_ref"].as_str().unwrap().len(), 64);
+        // Human form mentions the state name + the seq.
+        let human = render_projection(&view, false);
+        assert!(human.contains("COMMITTED") && human.contains("seq 7"));
+    }
+
+    #[test]
+    fn wait_committed_json_has_utf8_and_hex() {
+        let outcome = WaitOutcome {
+            instance_id: vec![1u8; 16],
+            terminal_mote_id: vec![2u8; 32],
+            state: WaitState::Committed,
+            result_ref: Some(vec![3u8; 32]),
+            payload: Some(b"hello".to_vec()),
+        };
+        let v: Value = serde_json::from_str(&render_wait(&outcome, true, true)).unwrap();
+        assert_eq!(v["state"], "COMMITTED");
+        assert_eq!(v["result_utf8"], "hello");
+        assert_eq!(v["result_len"], 5);
+        assert_eq!(v["result_hex"], hex::encode(b"hello"));
+        // With include_payload=false (–-out path), the bytes are omitted.
+        let meta: Value = serde_json::from_str(&render_wait(&outcome, true, false)).unwrap();
+        assert!(meta.get("result_hex").is_none());
+        assert_eq!(meta["result_len"], 5);
+    }
+
+    #[test]
+    fn wait_running_json_flags_timeout() {
+        let outcome = WaitOutcome {
+            instance_id: vec![1u8; 16],
+            terminal_mote_id: vec![2u8; 32],
+            state: WaitState::Running,
+            result_ref: None,
+            payload: None,
+        };
+        let v: Value = serde_json::from_str(&render_wait(&outcome, true, true)).unwrap();
+        assert_eq!(v["state"], "RUNNING");
+        assert_eq!(v["timed_out"], true);
+    }
+
+    #[test]
+    fn delta_committed_renders_both_forms() {
+        let delta = proto::EventDelta {
+            seq: 5,
+            kind: Some(proto::event_delta::Kind::Committed(proto::CommittedDelta {
+                mote_id: vec![7u8; 32],
+                result_ref: vec![8u8; 32],
+                nd_class: 1,
+            })),
+        };
+        let human = render_delta(&delta, false).unwrap();
+        assert!(human.contains("seq 5 COMMITTED"));
+        let v: Value = serde_json::from_str(&render_delta(&delta, true).unwrap()).unwrap();
+        assert_eq!(v["kind"], "committed");
+        assert_eq!(v["seq"], 5);
+        // A delta with no kind is skipped.
+        assert!(render_delta(&proto::EventDelta { seq: 1, kind: None }, false).is_none());
+    }
+}

--- a/crates/kx-cli/src/hex.rs
+++ b/crates/kx-cli/src/hex.rs
@@ -1,0 +1,142 @@
+//! A tiny hex codec for the byte ids the gateway speaks (16-byte `instance_id`,
+//! 32-byte content refs / Mote ids / signature ids). Hand-rolled to keep the
+//! dependency surface minimal (Rule 6) — `hex` is not in the workspace lockfile
+//! and a length-checked encode/decode is a dozen lines. Encoding is lowercase;
+//! decoding accepts either case.
+
+use std::fmt;
+
+/// A hex-decoding failure. Carries enough to render a precise CLI usage error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HexError {
+    /// The input had an odd number of hex digits (can't form whole bytes).
+    OddLength,
+    /// A character was not a hex digit (`0-9a-fA-F`).
+    BadDigit(char),
+    /// A fixed-length decode got the wrong number of bytes.
+    WrongLength {
+        /// The number of bytes the field requires.
+        want: usize,
+        /// The number of bytes the input decoded to.
+        got: usize,
+    },
+}
+
+impl fmt::Display for HexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HexError::OddLength => write!(f, "hex string has an odd number of digits"),
+            HexError::BadDigit(c) => write!(f, "not a hex digit: {c:?}"),
+            HexError::WrongLength { want, got } => {
+                write!(
+                    f,
+                    "expected {want} bytes ({} hex chars), got {got}",
+                    want * 2
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for HexError {}
+
+/// Lowercase-hex-encode `bytes`.
+#[must_use]
+pub fn encode(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(DIGITS[(b >> 4) as usize] as char);
+        out.push(DIGITS[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Lowercase-hex-encode an `Option`, rendering `None` as `-` (the dash the
+/// human renderers print for an absent ref).
+#[must_use]
+pub fn encode_opt(bytes: Option<&[u8]>) -> String {
+    bytes.map_or_else(|| "-".to_string(), encode)
+}
+
+fn nibble(c: u8) -> Result<u8, HexError> {
+    match c {
+        b'0'..=b'9' => Ok(c - b'0'),
+        b'a'..=b'f' => Ok(c - b'a' + 10),
+        b'A'..=b'F' => Ok(c - b'A' + 10),
+        _ => Err(HexError::BadDigit(c as char)),
+    }
+}
+
+/// Decode a hex string to bytes. Rejects odd length and non-hex digits.
+pub fn decode(s: &str) -> Result<Vec<u8>, HexError> {
+    let bytes = s.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return Err(HexError::OddLength);
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        out.push((nibble(pair[0])? << 4) | nibble(pair[1])?);
+    }
+    Ok(out)
+}
+
+/// Decode a hex string to a fixed-size array, rejecting a wrong byte count.
+pub fn decode_fixed<const N: usize>(s: &str) -> Result<[u8; N], HexError> {
+    let v = decode(s)?;
+    v.clone().try_into().map_err(|_| HexError::WrongLength {
+        want: N,
+        got: v.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_empty_16_and_32() {
+        for n in [0usize, 16, 32] {
+            let bytes: Vec<u8> = (0..n).map(|i| u8::try_from(i).unwrap()).collect();
+            let s = encode(&bytes);
+            assert_eq!(s.len(), n * 2);
+            assert_eq!(decode(&s).unwrap(), bytes);
+        }
+    }
+
+    #[test]
+    fn encode_is_lowercase_decode_is_case_insensitive() {
+        assert_eq!(encode(&[0xab, 0xcd, 0xef]), "abcdef");
+        assert_eq!(decode("ABCDEF").unwrap(), vec![0xab, 0xcd, 0xef]);
+        assert_eq!(decode("AbCdEf").unwrap(), vec![0xab, 0xcd, 0xef]);
+    }
+
+    #[test]
+    fn rejects_odd_length_and_non_hex() {
+        assert_eq!(decode("abc"), Err(HexError::OddLength));
+        assert_eq!(decode("zz"), Err(HexError::BadDigit('z')));
+        assert_eq!(decode("0g"), Err(HexError::BadDigit('g')));
+    }
+
+    #[test]
+    fn decode_fixed_enforces_length() {
+        let id16 = encode(&[7u8; 16]);
+        assert_eq!(decode_fixed::<16>(&id16).unwrap(), [7u8; 16]);
+        // 16 bytes into a 32-byte field is a length error, not a panic.
+        assert_eq!(
+            decode_fixed::<32>(&id16),
+            Err(HexError::WrongLength { want: 32, got: 16 })
+        );
+        // Non-hex propagates from `decode`.
+        assert!(matches!(
+            decode_fixed::<16>("zz"),
+            Err(HexError::BadDigit('z'))
+        ));
+    }
+
+    #[test]
+    fn encode_opt_renders_dash_for_none() {
+        assert_eq!(encode_opt(None), "-");
+        assert_eq!(encode_opt(Some(&[0xaa])), "aa");
+    }
+}

--- a/crates/kx-cli/src/lib.rs
+++ b/crates/kx-cli/src/lib.rs
@@ -1,0 +1,47 @@
+#![forbid(unsafe_code)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! # kx-cli — the unified `kx` command-line front end (R3 / D130)
+//!
+//! > **Phase: reachability (v0.1.0).** The single binary a human (or an agent)
+//! > uses to touch the kortecx runtime. It is a thin dispatcher — every verb
+//! > either forwards to an existing library or makes a gRPC call against the
+//! > FROZEN [`KxGateway`](kx_proto::proto::kx_gateway_server::KxGateway) service.
+//!
+//! ## Verbs
+//!
+//! - **`run` / `replay` / `digest`** — forward VERBATIM to the
+//!   [`kx_runtime`] engine (the projection-digest invariant is preserved; the
+//!   CLI never re-implements the orchestrator).
+//! - **`serve`** — forward to [`kx_gateway::serve`] (the embedded single-system
+//!   server). `--listen` defaults to `127.0.0.1:50151` when omitted.
+//! - **`invoke` / `submit` / `projection` / `content` / `events` /
+//!   `signatures`** — gRPC client calls over the gateway. `invoke`/`submit`
+//!   accept `--wait` to run-to-result (poll the projection, then fetch the
+//!   committed content) and print one parseable object; every verb accepts
+//!   `--json`.
+//!
+//! ## Discipline
+//!
+//! The CLI holds no journal handle and adds no write path (the coordinator is
+//! the sole writer, D40). It never computes a `MoteId` / `instance_id` — those
+//! are server-derived (SN-8); the CLI only echoes server bytes as hex and sends
+//! a credential (a bearer token), never a claimed identity.
+
+pub mod cli;
+pub mod client;
+pub mod error;
+pub mod format;
+pub mod hex;
+pub mod verbs;
+pub mod wait;
+
+pub use cli::{run, Cli, USAGE};
+pub use error::CliError;

--- a/crates/kx-cli/src/main.rs
+++ b/crates/kx-cli/src/main.rs
@@ -1,0 +1,36 @@
+#![forbid(unsafe_code)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+
+//! `kx` — the kortecx unified CLI binary (R3 / D130). Thin: init tracing, parse
+//! `argv`, hand off to [`kx_cli::run`], propagate its [`std::process::ExitCode`].
+//!
+//! ```text
+//! kx run|replay|digest --journal <path> --content <dir> [...]      # forward to the engine
+//! kx serve --journal <path> --content <dir> [--listen addr:port] [...]   # forward to the gateway
+//! kx invoke <handle> --args <json> [--wait] [--endpoint url] [--token t]  # gRPC client verbs
+//! kx submit --demo [--wait]
+//! kx projection --instance <hex16> [--at-seq N]
+//! kx content --ref <hex32> --instance <hex16> [--out <file>]
+//! kx events --instance <hex16> [--since N] [--follow]
+//! kx signatures list | get --id <hex32> | register --manifest-file <path>
+//! kx --help | --version | help <command>
+//! ```
+//!
+//! `RUST_LOG` controls tracing (default `info`); logs go to stderr so stdout
+//! stays a clean, parseable result channel for agents and pipelines.
+
+use std::process::ExitCode;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .try_init()
+        .ok();
+
+    kx_cli::run(std::env::args().skip(1)).await
+}

--- a/crates/kx-cli/src/verbs/content.rs
+++ b/crates/kx-cli/src/verbs/content.rs
@@ -1,0 +1,126 @@
+//! `kx content --ref <hex32> --instance <hex16> [--out <file>]` — fetch a
+//! committed result. The instance id is the ownership ticket (the run's
+//! committed result refs are the authorized set; a non-owned ref is uniformly
+//! "not authorized" — no existence oracle). The human path writes RAW bytes
+//! (binary-safe); `--out` saves to a file; `--json` emits a hex object.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use kx_proto::proto;
+
+use crate::client::{next_value, take_fixed, ClientCommon};
+use crate::error::CliError;
+use crate::format;
+
+/// Parsed `content` arguments.
+#[derive(Debug)]
+pub struct ContentArgs {
+    /// The content ref to fetch (32B).
+    pub content_ref: [u8; 32],
+    /// The owning run (16B instance id).
+    pub instance: [u8; 16],
+    /// Write the bytes to this file instead of stdout.
+    pub out: Option<PathBuf>,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `content` args (the verb already consumed).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ContentArgs, CliError> {
+    let mut content_ref: Option<[u8; 32]> = None;
+    let mut instance: Option<[u8; 16]> = None;
+    let mut out: Option<PathBuf> = None;
+    let mut common = ClientCommon::default();
+
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--ref" => content_ref = Some(take_fixed::<_, 32>(&mut args, "--ref")?),
+            "--instance" => instance = Some(take_fixed::<_, 16>(&mut args, "--instance")?),
+            "--out" => out = Some(PathBuf::from(next_value(&mut args, "--out")?)),
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+
+    let content_ref =
+        content_ref.ok_or_else(|| CliError::Usage("content requires --ref <hex32>".into()))?;
+    let instance =
+        instance.ok_or_else(|| CliError::Usage("content requires --instance <hex16>".into()))?;
+    Ok(ContentArgs {
+        content_ref,
+        instance,
+        out,
+        common,
+    })
+}
+
+/// Execute `content`.
+pub async fn execute(args: ContentArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+
+    let blob = client
+        .get_content(resolved.request(proto::GetContentRequest {
+            content_ref: args.content_ref.to_vec(),
+            instance_id: args.instance.to_vec(),
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+
+    if args.common.json {
+        println!(
+            "{}",
+            format::render_content_json(&args.content_ref, &blob.payload)
+        );
+    } else if let Some(path) = &args.out {
+        std::fs::write(path, &blob.payload)
+            .map_err(|e| CliError::Io(format!("--out {}: {e}", path.display())))?;
+    } else {
+        // Raw bytes, no trailing newline — binary-safe + pipe-correct.
+        std::io::stdout()
+            .write_all(&blob.payload)
+            .map_err(|e| CliError::Io(e.to_string()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<ContentArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn parses_ref_instance_and_out() {
+        let a = p(&[
+            "--ref",
+            &"cd".repeat(32),
+            "--instance",
+            &"ab".repeat(16),
+            "--out",
+            "/tmp/x",
+        ])
+        .unwrap();
+        assert_eq!(a.content_ref, [0xcd; 32]);
+        assert_eq!(a.instance, [0xab; 16]);
+        assert_eq!(a.out.as_deref(), Some(std::path::Path::new("/tmp/x")));
+    }
+
+    #[test]
+    fn missing_required_is_usage() {
+        assert!(p(&["--instance", &"ab".repeat(16)]).is_err(), "no --ref");
+        assert!(p(&["--ref", &"cd".repeat(32)]).is_err(), "no --instance");
+    }
+
+    #[test]
+    fn bad_hex_lengths_are_usage() {
+        assert!(p(&["--ref", &"cd".repeat(16), "--instance", &"ab".repeat(16)]).is_err());
+        assert!(p(&["--ref", &"cd".repeat(32), "--instance", &"ab".repeat(32)]).is_err());
+    }
+}

--- a/crates/kx-cli/src/verbs/events.rs
+++ b/crates/kx-cli/src/verbs/events.rs
@@ -1,0 +1,152 @@
+//! `kx events --instance <hex16> [--since N] [--follow]` — print a run's event
+//! deltas. `StreamEvents` is snapshot-to-head today (it catches up to the
+//! current journal boundary and ends); `--follow` re-polls from the last cursor
+//! on a bounded backoff until Ctrl-C. True live-tail arrives with the R5
+//! WebSocket bridge — the verb surface is unchanged when it does.
+
+use std::time::Duration;
+
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+use crate::client::{next_value, take_fixed, ClientCommon, Resolved};
+use crate::error::CliError;
+use crate::format;
+
+/// Re-poll cadence under `--follow` (bounded backoff — never a busy-spin).
+const FOLLOW_POLL: Duration = Duration::from_millis(250);
+
+/// Parsed `events` arguments.
+#[derive(Debug)]
+pub struct EventsArgs {
+    /// The run to stream (16B instance id).
+    pub instance: [u8; 16],
+    /// Resume cursor (0 = from start).
+    pub since: u64,
+    /// Keep polling from the last cursor until Ctrl-C.
+    pub follow: bool,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `events` args (the verb already consumed).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<EventsArgs, CliError> {
+    let mut instance: Option<[u8; 16]> = None;
+    let mut since: u64 = 0;
+    let mut follow = false;
+    let mut common = ClientCommon::default();
+
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--instance" => instance = Some(take_fixed::<_, 16>(&mut args, "--instance")?),
+            "--since" => {
+                let v = next_value(&mut args, "--since")?;
+                since = v.parse().map_err(|_| {
+                    CliError::Usage(format!("--since expects an integer, got {v:?}"))
+                })?;
+            }
+            "--follow" => follow = true,
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+
+    let instance =
+        instance.ok_or_else(|| CliError::Usage("events requires --instance <hex16>".into()))?;
+    Ok(EventsArgs {
+        instance,
+        since,
+        follow,
+        common,
+    })
+}
+
+/// Read one snapshot (`since_seq` → head), printing each delta; return the
+/// caught-up cursor (`next_seq` at the journal boundary).
+async fn drain_once(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance: &[u8; 16],
+    since: u64,
+    json: bool,
+) -> Result<u64, CliError> {
+    let mut stream = client
+        .stream_events(resolved.request(proto::StreamEventsRequest {
+            instance_id: instance.to_vec(),
+            since_seq: since,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+
+    let mut cursor = since;
+    while let Some(frame) = stream.message().await.map_err(CliError::from_status)? {
+        for delta in &frame.deltas {
+            if let Some(line) = format::render_delta(delta, json) {
+                println!("{line}");
+            }
+        }
+        cursor = frame.next_seq;
+        if frame.journal_boundary {
+            break;
+        }
+    }
+    Ok(cursor)
+}
+
+/// Execute `events`.
+pub async fn execute(args: EventsArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+    let json = args.common.json;
+
+    let mut cursor = args.since;
+    loop {
+        cursor = drain_once(&mut client, &resolved, &args.instance, cursor, json).await?;
+        if !args.follow {
+            if !json {
+                println!("-- caught up at seq {cursor} --");
+            }
+            return Ok(());
+        }
+        // --follow: back off, then re-poll from the cursor; a clean Ctrl-C exits.
+        tokio::select! {
+            () = tokio::time::sleep(FOLLOW_POLL) => {}
+            _ = tokio::signal::ctrl_c() => return Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<EventsArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn parses_instance_since_follow() {
+        let a = p(&["--instance", &"ab".repeat(16), "--since", "7", "--follow"]).unwrap();
+        assert_eq!(a.instance, [0xab; 16]);
+        assert_eq!(a.since, 7);
+        assert!(a.follow);
+    }
+
+    #[test]
+    fn defaults_since_zero_no_follow() {
+        let a = p(&["--instance", &"ab".repeat(16)]).unwrap();
+        assert_eq!(a.since, 0);
+        assert!(!a.follow);
+    }
+
+    #[test]
+    fn missing_instance_bad_since_unknown_flag_are_usage() {
+        assert!(p(&["--follow"]).is_err(), "no --instance");
+        assert!(p(&["--instance", &"ab".repeat(16), "--since", "x"]).is_err());
+        assert!(p(&["--instance", &"ab".repeat(16), "--nope"]).is_err());
+    }
+}

--- a/crates/kx-cli/src/verbs/invoke.rs
+++ b/crates/kx-cli/src/verbs/invoke.rs
@@ -1,0 +1,218 @@
+//! `kx invoke <handle> --args <json> [--wait] ...` — bind a PUBLISHED recipe by
+//! handle to JSON args and run it. The CLI sends only `handle` + raw args bytes;
+//! the server does resolve → validate → bind → intersect → submit (fail-closed).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_proto::proto;
+
+use crate::client::{next_value, ClientCommon};
+use crate::error::CliError;
+use crate::{format, verbs, wait};
+
+/// Default `--wait` timeout.
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+/// Parsed `invoke` arguments.
+#[derive(Debug)]
+pub struct InvokeArgs {
+    /// The recipe handle (`namespace/collection/name`).
+    pub handle: String,
+    /// Opaque JSON args bytes (validated server-side; sanity-checked client-side).
+    pub args_json: Vec<u8>,
+    /// Run to completion and print the committed result (`--wait`).
+    pub wait: bool,
+    /// `--wait` timeout in seconds.
+    pub timeout_secs: u64,
+    /// Write the committed result bytes to this file instead of inlining them.
+    pub out: Option<PathBuf>,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `invoke` args (the verb already consumed).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<InvokeArgs, CliError> {
+    let mut handle: Option<String> = None;
+    let mut args_json: Option<Vec<u8>> = None;
+    let mut wait = false;
+    let mut timeout_secs = DEFAULT_TIMEOUT_SECS;
+    let mut out: Option<PathBuf> = None;
+    let mut common = ClientCommon::default();
+
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--args" => {
+                reject_duplicate_args(args_json.is_some())?;
+                args_json = Some(next_value(&mut args, "--args")?.into_bytes());
+            }
+            "--args-file" => {
+                reject_duplicate_args(args_json.is_some())?;
+                let p = next_value(&mut args, "--args-file")?;
+                args_json = Some(
+                    std::fs::read(&p).map_err(|e| CliError::Io(format!("--args-file {p}: {e}")))?,
+                );
+            }
+            "--wait" => wait = true,
+            "--timeout-secs" => {
+                let v = next_value(&mut args, "--timeout-secs")?;
+                timeout_secs = v.parse().map_err(|_| {
+                    CliError::Usage(format!("--timeout-secs expects an integer, got {v:?}"))
+                })?;
+            }
+            "--out" => out = Some(PathBuf::from(next_value(&mut args, "--out")?)),
+            other => {
+                if other.starts_with("--") {
+                    return Err(CliError::Usage(format!("unknown flag {other:?}")));
+                }
+                if handle.is_some() {
+                    return Err(CliError::Usage(format!("unexpected argument {other:?}")));
+                }
+                handle = Some(other.to_string());
+            }
+        }
+    }
+
+    let handle = handle.ok_or_else(|| {
+        CliError::Usage("invoke requires a recipe handle (e.g. kx/recipes/echo)".into())
+    })?;
+    let args_json = args_json.ok_or_else(|| {
+        CliError::Usage("invoke requires --args <json> (or --args-file <path>)".into())
+    })?;
+    // Fail fast on client-side-invalid JSON (before the round trip). Valid-but-
+    // wrong JSON (e.g. a missing field) is still the server's fail-closed call.
+    // The message names neither flag (the bytes may have come from either source).
+    if serde_json::from_slice::<serde_json::Value>(&args_json).is_err() {
+        return Err(CliError::Usage("the args are not valid JSON".into()));
+    }
+
+    Ok(InvokeArgs {
+        handle,
+        args_json,
+        wait,
+        timeout_secs,
+        out,
+        common,
+    })
+}
+
+/// Reject a second args source: `--args` and `--args-file` set the same slot, so
+/// silently last-wins would be a footgun (mirrors the `--token`/`--token-file`
+/// guard in [`crate::client`]).
+fn reject_duplicate_args(already_set: bool) -> Result<(), CliError> {
+    if already_set {
+        return Err(CliError::Usage(
+            "--args and --args-file are mutually exclusive (give exactly one)".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Execute `invoke`.
+pub async fn execute(args: InvokeArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+
+    let resp = client
+        .invoke(resolved.request(proto::InvokeRequest {
+            handle: args.handle,
+            args: args.args_json,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+
+    if args.wait {
+        let outcome = wait::await_result(
+            &mut client,
+            &resolved,
+            resp.instance_id,
+            resp.terminal_mote_id,
+            Duration::from_secs(args.timeout_secs),
+        )
+        .await?;
+        verbs::finish_wait(&outcome, args.common.json, args.out.as_deref())
+    } else {
+        println!("{}", format::render_invoke(&resp, args.common.json));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_v(parts: &[&str]) -> Result<InvokeArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn parses_handle_and_args() {
+        let a = parse_v(&["kx/recipes/echo", "--args", r#"{"topic":"x"}"#]).unwrap();
+        assert_eq!(a.handle, "kx/recipes/echo");
+        assert_eq!(a.args_json, br#"{"topic":"x"}"#);
+        assert!(!a.wait && a.out.is_none());
+    }
+
+    #[test]
+    fn handle_can_follow_flags() {
+        // The positional handle is recognized wherever it appears.
+        let a = parse_v(&["--args", "{}", "kx/recipes/echo", "--wait"]).unwrap();
+        assert_eq!(a.handle, "kx/recipes/echo");
+        assert!(a.wait);
+    }
+
+    #[test]
+    fn missing_handle_or_args_is_usage() {
+        assert!(parse_v(&["--args", "{}"]).is_err(), "no handle");
+        assert!(parse_v(&["kx/recipes/echo"]).is_err(), "no args");
+    }
+
+    #[test]
+    fn args_and_args_file_are_mutually_exclusive() {
+        // The fix for the reviewed defect: a second args source is rejected, not
+        // silently shadowed.
+        let err =
+            parse_v(&["kx/recipes/echo", "--args", "{}", "--args-file", "/tmp/x"]).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+        // A duplicate --args is likewise rejected.
+        assert!(parse_v(&["kx/recipes/echo", "--args", "{}", "--args", "{}"]).is_err());
+    }
+
+    #[test]
+    fn client_side_invalid_json_is_usage() {
+        assert!(parse_v(&["kx/recipes/echo", "--args", "{"]).is_err());
+    }
+
+    #[test]
+    fn unknown_flag_and_extra_positional_are_usage() {
+        assert!(parse_v(&["kx/recipes/echo", "--args", "{}", "--nope"]).is_err());
+        assert!(
+            parse_v(&["a/b/c", "x/y/z", "--args", "{}"]).is_err(),
+            "two handles"
+        );
+    }
+
+    #[test]
+    fn bad_timeout_is_usage() {
+        assert!(parse_v(&["kx/recipes/echo", "--args", "{}", "--timeout-secs", "soon"]).is_err());
+    }
+
+    #[test]
+    fn common_flags_are_consumed() {
+        let a = parse_v(&[
+            "kx/recipes/echo",
+            "--args",
+            "{}",
+            "--endpoint",
+            "http://h:1",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(a.common.endpoint, "http://h:1");
+        assert!(a.common.json);
+    }
+}

--- a/crates/kx-cli/src/verbs/mod.rs
+++ b/crates/kx-cli/src/verbs/mod.rs
@@ -1,0 +1,44 @@
+//! The gRPC client verbs. Each module exposes an `Args` struct, a hand-rolled
+//! `parse(...)`, and an async `execute(...)`. Shared `--wait` finishing lives
+//! here (used by `invoke` + `submit`).
+
+pub mod content;
+pub mod events;
+pub mod invoke;
+pub mod projection;
+pub mod signatures;
+pub mod submit;
+
+use std::io::Write;
+use std::path::Path;
+
+use crate::error::CliError;
+use crate::format;
+use crate::wait::{WaitOutcome, WaitState};
+
+/// Emit a `--wait` outcome (writing the committed payload to `--out` if given)
+/// and map its terminal disposition to the exit-code contract: `Committed` →
+/// success, `Failed` → exit 1, `Running` (timeout) → exit 3 (resumable). The
+/// result object is always printed first so an agent gets the handle back even
+/// on a timeout.
+pub(crate) fn finish_wait(
+    outcome: &WaitOutcome,
+    json: bool,
+    out: Option<&Path>,
+) -> Result<(), CliError> {
+    let include_payload = out.is_none();
+    if let (Some(path), Some(payload)) = (out, &outcome.payload) {
+        std::fs::write(path, payload)
+            .map_err(|e| CliError::Io(format!("--out {}: {e}", path.display())))?;
+    }
+    let rendered = format::render_wait(outcome, json, include_payload);
+    // Use a single locked write so the object is emitted atomically.
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "{rendered}").map_err(|e| CliError::Io(e.to_string()))?;
+
+    match outcome.state {
+        WaitState::Committed => Ok(()),
+        WaitState::Failed => Err(CliError::Failed),
+        WaitState::Running => Err(CliError::WaitTimeout),
+    }
+}

--- a/crates/kx-cli/src/verbs/projection.rs
+++ b/crates/kx-cli/src/verbs/projection.rs
@@ -1,0 +1,101 @@
+//! `kx projection --instance <hex16> [--at-seq N]` — render a run as a DAG of
+//! Mote states (all fields server-derived from the kx-projection fold).
+
+use kx_proto::proto;
+
+use crate::client::{next_value, take_fixed, ClientCommon};
+use crate::error::CliError;
+use crate::format;
+
+/// Parsed `projection` arguments.
+#[derive(Debug)]
+pub struct ProjectionArgs {
+    /// The run to render (16B instance id).
+    pub instance: [u8; 16],
+    /// Fold up to and including this seq (absent = current head).
+    pub at_seq: Option<u64>,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `projection` args (the verb already consumed).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ProjectionArgs, CliError> {
+    let mut instance: Option<[u8; 16]> = None;
+    let mut at_seq: Option<u64> = None;
+    let mut common = ClientCommon::default();
+
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--instance" => instance = Some(take_fixed::<_, 16>(&mut args, "--instance")?),
+            "--at-seq" => {
+                let v = next_value(&mut args, "--at-seq")?;
+                at_seq = Some(v.parse().map_err(|_| {
+                    CliError::Usage(format!("--at-seq expects an integer, got {v:?}"))
+                })?);
+            }
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+
+    let instance =
+        instance.ok_or_else(|| CliError::Usage("projection requires --instance <hex16>".into()))?;
+    Ok(ProjectionArgs {
+        instance,
+        at_seq,
+        common,
+    })
+}
+
+/// Execute `projection`.
+pub async fn execute(args: ProjectionArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+
+    let view = client
+        .get_projection(resolved.request(proto::GetProjectionRequest {
+            instance_id: args.instance.to_vec(),
+            at_seq: args.at_seq,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+
+    println!("{}", format::render_projection(&view, args.common.json));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<ProjectionArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn parses_instance_and_at_seq() {
+        let a = p(&["--instance", &"ab".repeat(16), "--at-seq", "5"]).unwrap();
+        assert_eq!(a.at_seq, Some(5));
+        assert_eq!(a.instance, [0xab; 16]);
+    }
+
+    #[test]
+    fn missing_instance_is_usage() {
+        assert!(p(&["--at-seq", "1"]).is_err());
+    }
+
+    #[test]
+    fn bad_hex_instance_is_usage() {
+        assert!(p(&["--instance", "abcd"]).is_err(), "wrong length");
+        assert!(p(&["--instance", &"zz".repeat(16)]).is_err(), "non-hex");
+    }
+
+    #[test]
+    fn bad_at_seq_and_unknown_flag_are_usage() {
+        assert!(p(&["--instance", &"ab".repeat(16), "--at-seq", "soon"]).is_err());
+        assert!(p(&["--instance", &"ab".repeat(16), "--nope"]).is_err());
+    }
+}

--- a/crates/kx-cli/src/verbs/signatures.rs
+++ b/crates/kx-cli/src/verbs/signatures.rs
@@ -1,0 +1,143 @@
+//! `kx signatures list | get --id <hex32> | register --manifest-file <path>` —
+//! the catalog task-signature RPCs over the gateway. The manifest is opaque
+//! encoded bytes (the CLI never decodes it); the server derives the id (SN-8).
+
+use std::path::PathBuf;
+
+use kx_proto::proto;
+
+use crate::client::{next_value, take_fixed, ClientCommon};
+use crate::error::CliError;
+use crate::format;
+
+/// The `signatures` subcommand.
+#[derive(Debug)]
+pub enum SignaturesSub {
+    /// List registered signatures.
+    List,
+    /// Fetch one signature's manifest by id (32B).
+    Get([u8; 32]),
+    /// Register a signature from an encoded-manifest file.
+    Register(PathBuf),
+}
+
+/// Parsed `signatures` arguments.
+#[derive(Debug)]
+pub struct SignaturesArgs {
+    /// The subcommand.
+    pub sub: SignaturesSub,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `signatures` args (the verb already consumed). The first token selects
+/// the subcommand (`list` / `get` / `register`).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<SignaturesArgs, CliError> {
+    let kw = args.next().ok_or_else(|| {
+        CliError::Usage("signatures requires a subcommand: list | get | register".into())
+    })?;
+
+    let mut id: Option<[u8; 32]> = None;
+    let mut manifest_file: Option<PathBuf> = None;
+    let mut common = ClientCommon::default();
+
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--id" => id = Some(take_fixed::<_, 32>(&mut args, "--id")?),
+            "--manifest-file" => {
+                manifest_file = Some(PathBuf::from(next_value(&mut args, "--manifest-file")?));
+            }
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+
+    let sub = match kw.as_str() {
+        "list" => SignaturesSub::List,
+        "get" => SignaturesSub::Get(
+            id.ok_or_else(|| CliError::Usage("signatures get requires --id <hex32>".into()))?,
+        ),
+        "register" => SignaturesSub::Register(manifest_file.ok_or_else(|| {
+            CliError::Usage("signatures register requires --manifest-file <path>".into())
+        })?),
+        other => {
+            return Err(CliError::Usage(format!(
+                "unknown signatures subcommand {other:?} (expected list | get | register)"
+            )))
+        }
+    };
+    Ok(SignaturesArgs { sub, common })
+}
+
+/// Execute `signatures`.
+pub async fn execute(args: SignaturesArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+    let json = args.common.json;
+
+    match args.sub {
+        SignaturesSub::List => {
+            let resp = client
+                .list_signatures(resolved.request(proto::ListSignaturesRequest {})?)
+                .await
+                .map_err(CliError::from_status)?
+                .into_inner();
+            println!("{}", format::render_signatures_list(&resp, json));
+        }
+        SignaturesSub::Get(id) => {
+            let resp = client
+                .get_signature(resolved.request(proto::GetSignatureRequest {
+                    signature_id: id.to_vec(),
+                })?)
+                .await
+                .map_err(CliError::from_status)?
+                .into_inner();
+            println!("{}", format::render_signature_get(&resp, json));
+        }
+        SignaturesSub::Register(path) => {
+            let manifest = std::fs::read(&path)
+                .map_err(|e| CliError::Io(format!("--manifest-file {}: {e}", path.display())))?;
+            let resp = client
+                .register_signature(resolved.request(proto::RegisterSignatureRequest { manifest })?)
+                .await
+                .map_err(CliError::from_status)?
+                .into_inner();
+            println!("{}", format::render_signature_register(&resp, json));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<SignaturesArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn parses_each_subcommand() {
+        assert!(matches!(p(&["list"]).unwrap().sub, SignaturesSub::List));
+        assert!(matches!(
+            p(&["get", "--id", &"ab".repeat(32)]).unwrap().sub,
+            SignaturesSub::Get(id) if id == [0xab; 32]
+        ));
+        assert!(matches!(
+            p(&["register", "--manifest-file", "/tmp/m"]).unwrap().sub,
+            SignaturesSub::Register(_)
+        ));
+    }
+
+    #[test]
+    fn missing_required_and_unknown_are_usage() {
+        assert!(p(&[]).is_err(), "no subcommand");
+        assert!(p(&["get"]).is_err(), "get needs --id");
+        assert!(p(&["get", "--id", "abcd"]).is_err(), "id wrong length");
+        assert!(p(&["register"]).is_err(), "register needs --manifest-file");
+        assert!(p(&["frobnicate"]).is_err(), "unknown subcommand");
+        assert!(p(&["list", "--nope"]).is_err(), "unknown flag");
+    }
+}

--- a/crates/kx-cli/src/verbs/submit.rs
+++ b/crates/kx-cli/src/verbs/submit.rs
@@ -1,0 +1,122 @@
+//! `kx submit --demo [--wait] ...` — submit a built-in PURE demo run via the
+//! low-level SubmitRun path (the request shape comes from
+//! [`kx_gateway::demo_submit_run_request`], the single source of truth shared
+//! with the gateway e2e). Arbitrary run authoring is not a v0.1.0 CLI capability
+//! (recipes + SDKs are the authoring path); `invoke` is the real recipe path.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::client::{next_value, ClientCommon};
+use crate::error::CliError;
+use crate::{format, verbs, wait};
+
+/// Default `--wait` timeout.
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+/// Parsed `submit` arguments.
+#[derive(Debug)]
+pub struct SubmitArgs {
+    /// Run to completion and print the committed result (`--wait`).
+    pub wait: bool,
+    /// `--wait` timeout in seconds.
+    pub timeout_secs: u64,
+    /// Write the committed result bytes to this file instead of inlining them.
+    pub out: Option<PathBuf>,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `submit` args (the verb already consumed). `--demo` is currently the
+/// only mode (stated honestly: a richer SubmitRun authoring path arrives with
+/// recipes/SDKs).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<SubmitArgs, CliError> {
+    let mut demo = false;
+    let mut wait = false;
+    let mut timeout_secs = DEFAULT_TIMEOUT_SECS;
+    let mut out: Option<PathBuf> = None;
+    let mut common = ClientCommon::default();
+
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--demo" => demo = true,
+            "--wait" => wait = true,
+            "--timeout-secs" => {
+                let v = next_value(&mut args, "--timeout-secs")?;
+                timeout_secs = v.parse().map_err(|_| {
+                    CliError::Usage(format!("--timeout-secs expects an integer, got {v:?}"))
+                })?;
+            }
+            "--out" => out = Some(PathBuf::from(next_value(&mut args, "--out")?)),
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+
+    if !demo {
+        return Err(CliError::Usage(
+            "submit currently supports only --demo (use `invoke` to run a published recipe)".into(),
+        ));
+    }
+    Ok(SubmitArgs {
+        wait,
+        timeout_secs,
+        out,
+        common,
+    })
+}
+
+/// Execute `submit --demo`.
+pub async fn execute(args: SubmitArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+
+    let handle = client
+        .submit_run(resolved.request(kx_gateway::demo_submit_run_request())?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+
+    if args.wait {
+        let outcome = wait::await_any_result(
+            &mut client,
+            &resolved,
+            handle.instance_id,
+            Duration::from_secs(args.timeout_secs),
+        )
+        .await?;
+        verbs::finish_wait(&outcome, args.common.json, args.out.as_deref())
+    } else {
+        println!("{}", format::render_submit(&handle, args.common.json));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<SubmitArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn requires_demo() {
+        assert!(p(&[]).is_err(), "submit without --demo is a usage error");
+    }
+
+    #[test]
+    fn parses_demo_wait_and_common() {
+        let a = p(&["--demo", "--wait", "--json", "--timeout-secs", "30"]).unwrap();
+        assert!(a.wait && a.common.json);
+        assert_eq!(a.timeout_secs, 30);
+    }
+
+    #[test]
+    fn unknown_flag_and_bad_timeout_are_usage() {
+        assert!(p(&["--demo", "--nope"]).is_err());
+        assert!(p(&["--demo", "--timeout-secs", "soon"]).is_err());
+    }
+}

--- a/crates/kx-cli/src/wait.rs
+++ b/crates/kx-cli/src/wait.rs
@@ -1,0 +1,217 @@
+//! `--wait` orchestration: turn an async run handle into a single result by
+//! composing existing RPCs client-side — poll `GetProjection` until the target
+//! Mote reaches a terminal state, then `GetContent` its committed result. This is
+//! what lets an agent call the runtime like a function (one command in, one
+//! parseable result out) without managing a stream. No new server capability is
+//! used; it is forward-compatible with R5's live events (the poll loop becomes a
+//! subscription, the [`WaitOutcome`] is unchanged).
+//!
+//! Two entry points: [`await_result`] targets a specific `terminal_mote_id` (the
+//! `invoke` path, which gets one from `InvokeResponse`); [`await_any_result`]
+//! waits for the first committed Mote in a run (the `submit` path, whose
+//! `RunHandle` carries no terminal id).
+
+use std::time::Duration;
+
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+use crate::client::Resolved;
+use crate::error::CliError;
+
+/// Polling cadence while waiting (bounded backoff — never a busy-spin). Same
+/// order of magnitude as the embedded worker's idle poll.
+const POLL: Duration = Duration::from_millis(250);
+
+/// The terminal disposition of a waited-on run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitState {
+    /// The target Mote committed; [`WaitOutcome::payload`] holds its result.
+    Committed,
+    /// The target Mote reached a failure/anomaly state.
+    Failed,
+    /// The timeout elapsed before a terminal state — the run is still in
+    /// progress and resumable (via `kx projection` / `kx events`).
+    Running,
+}
+
+/// The result of a `--wait`: server-derived ids + the terminal disposition and,
+/// when committed, the result ref + payload.
+#[derive(Debug, Clone)]
+pub struct WaitOutcome {
+    /// The run the invocation joined (16B).
+    pub instance_id: Vec<u8>,
+    /// The server-derived terminal/sink Mote (32B); empty if a failure/timeout
+    /// occurred before any Mote was identified (the `submit` path).
+    pub terminal_mote_id: Vec<u8>,
+    /// The terminal disposition.
+    pub state: WaitState,
+    /// The committed result ref (32B), present iff `state == Committed`.
+    pub result_ref: Option<Vec<u8>>,
+    /// The committed result bytes, fetched via `GetContent` iff `Committed`.
+    pub payload: Option<Vec<u8>>,
+}
+
+/// `true` for a state we should keep polling (not yet terminal).
+fn is_pending(state: i32) -> bool {
+    state == proto::MoteSnapshotState::Pending as i32
+        || state == proto::MoteSnapshotState::Scheduled as i32
+}
+
+fn is_committed(state: i32) -> bool {
+    state == proto::MoteSnapshotState::Committed as i32
+}
+
+async fn get_projection(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance_id: &[u8],
+) -> Result<proto::ProjectionView, CliError> {
+    Ok(client
+        .get_projection(resolved.request(proto::GetProjectionRequest {
+            instance_id: instance_id.to_vec(),
+            at_seq: None,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner())
+}
+
+async fn fetch_payload(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance_id: &[u8],
+    content_ref: &[u8],
+) -> Result<Vec<u8>, CliError> {
+    Ok(client
+        .get_content(resolved.request(proto::GetContentRequest {
+            content_ref: content_ref.to_vec(),
+            instance_id: instance_id.to_vec(),
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner()
+        .payload)
+}
+
+/// Build a `Committed` outcome, fetching the result content.
+async fn committed_outcome(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance_id: Vec<u8>,
+    mote_id: Vec<u8>,
+    result_ref: Option<Vec<u8>>,
+) -> Result<WaitOutcome, CliError> {
+    let payload = match &result_ref {
+        Some(content_ref) => {
+            Some(fetch_payload(client, resolved, &instance_id, content_ref).await?)
+        }
+        None => None,
+    };
+    Ok(WaitOutcome {
+        instance_id,
+        terminal_mote_id: mote_id,
+        state: WaitState::Committed,
+        result_ref,
+        payload,
+    })
+}
+
+fn terminal(instance_id: Vec<u8>, mote_id: Vec<u8>, state: WaitState) -> WaitOutcome {
+    WaitOutcome {
+        instance_id,
+        terminal_mote_id: mote_id,
+        state,
+        result_ref: None,
+        payload: None,
+    }
+}
+
+/// Poll until `terminal_mote_id` is terminal (or `timeout` elapses), fetching
+/// the committed content on success. Every RPC carries the resolved bearer token.
+pub async fn await_result(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance_id: Vec<u8>,
+    terminal_mote_id: Vec<u8>,
+    timeout: Duration,
+) -> Result<WaitOutcome, CliError> {
+    let start = tokio::time::Instant::now();
+    loop {
+        let view = get_projection(client, resolved, &instance_id).await?;
+        if let Some((state, result_ref)) = view
+            .motes
+            .iter()
+            .find(|m| m.mote_id == terminal_mote_id)
+            .map(|m| (m.state, m.result_ref.clone()))
+        {
+            if is_committed(state) {
+                return committed_outcome(
+                    client,
+                    resolved,
+                    instance_id,
+                    terminal_mote_id,
+                    result_ref,
+                )
+                .await;
+            } else if !is_pending(state) {
+                return Ok(terminal(instance_id, terminal_mote_id, WaitState::Failed));
+            }
+        }
+        if start.elapsed() >= timeout {
+            return Ok(terminal(instance_id, terminal_mote_id, WaitState::Running));
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+/// Poll until ANY Mote in the run commits (the `submit` path: a `RunHandle` has
+/// no terminal id). If every Mote reaches a terminal non-committed state, the
+/// run is `Failed`; on timeout it is `Running`.
+pub async fn await_any_result(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance_id: Vec<u8>,
+    timeout: Duration,
+) -> Result<WaitOutcome, CliError> {
+    let start = tokio::time::Instant::now();
+    loop {
+        let view = get_projection(client, resolved, &instance_id).await?;
+        if let Some((mote_id, result_ref)) = view
+            .motes
+            .iter()
+            .find(|m| is_committed(m.state))
+            .map(|m| (m.mote_id.clone(), m.result_ref.clone()))
+        {
+            return committed_outcome(client, resolved, instance_id, mote_id, result_ref).await;
+        }
+        // All Motes terminal (and none committed) ⇒ the run failed.
+        if !view.motes.is_empty() && view.motes.iter().all(|m| !is_pending(m.state)) {
+            let first = view
+                .motes
+                .first()
+                .map(|m| m.mote_id.clone())
+                .unwrap_or_default();
+            return Ok(terminal(instance_id, first, WaitState::Failed));
+        }
+        if start.elapsed() >= timeout {
+            return Ok(terminal(instance_id, Vec::new(), WaitState::Running));
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_predicates() {
+        assert!(is_pending(proto::MoteSnapshotState::Pending as i32));
+        assert!(is_pending(proto::MoteSnapshotState::Scheduled as i32));
+        assert!(!is_pending(proto::MoteSnapshotState::Committed as i32));
+        assert!(is_committed(proto::MoteSnapshotState::Committed as i32));
+        assert!(!is_committed(proto::MoteSnapshotState::Failed as i32));
+    }
+}

--- a/crates/kx-cli/tests/auth_e2e.rs
+++ b/crates/kx-cli/tests/auth_e2e.rs
@@ -1,0 +1,109 @@
+//! Auth posture over the wire: a deny-all port refuses every verb; a token-gated
+//! port requires a valid bearer token (via `--token` or `--token-file`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{argv, endpoint, json_ok, run_kx, start_gateway, stderr};
+use tempfile::TempDir;
+
+fn tokens() -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    m.insert("s3cr3t".to_string(), "alice@acme".to_string());
+    m
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn deny_all_refuses_every_verb() {
+    let dir = TempDir::new().unwrap();
+    // No --dev-allow-local, no tokens ⇒ deny-all.
+    let running = start_gateway(&dir, false, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"x"}"#,
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert!(!out.status.success(), "deny-all refuses invoke");
+    assert!(
+        stderr(&out).contains("Unauthenticated"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn token_gated_requires_a_valid_credential() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, false, tokens()).await;
+    let ep = endpoint(&running);
+
+    // No credential → Unauthenticated.
+    let none = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"x"}"#,
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert!(!none.status.success());
+    assert!(stderr(&none).contains("Unauthenticated"));
+
+    // Valid --token → the configured party holds a Use grant → runs to Committed.
+    let with_tok = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"incidents"}"#,
+        "--wait",
+        "--token",
+        "s3cr3t",
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    assert_eq!(json_ok(&with_tok)["state"], "COMMITTED");
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn token_file_authenticates() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, false, tokens()).await;
+    let ep = endpoint(&running);
+
+    // A token file (with a trailing newline, which is trimmed) authenticates.
+    let tok_path = dir.path().join("token");
+    std::fs::write(&tok_path, "s3cr3t\n").unwrap();
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"incidents"}"#,
+        "--wait",
+        "--token-file",
+        tok_path.to_str().unwrap(),
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    assert_eq!(json_ok(&out)["state"], "COMMITTED");
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-cli/tests/client_e2e.rs
+++ b/crates/kx-cli/tests/client_e2e.rs
@@ -1,0 +1,192 @@
+//! End-to-end witnesses over a REAL bound port: the operator hosts a gateway
+//! in-process, an analyst drives the `kx` CLIENT verbs as subprocesses. Covers
+//! the real-life flow — invoke a recipe, inspect the projection, fetch the
+//! committed result, tail events — plus `submit --demo` and a restart.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{argv, endpoint, json_ok, poll_committed, run_kx, start_gateway, stdout};
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invoke_projection_content_events_flow() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // (1) invoke (async handle).
+    let inv = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"incidents"}"#,
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    let inv = json_ok(&inv);
+    let instance = inv["instance_id"].as_str().unwrap().to_string();
+    let terminal = inv["terminal_mote_id"].as_str().unwrap().to_string();
+    assert_eq!(instance.len(), 32, "16B instance id");
+    assert_eq!(terminal.len(), 64, "32B terminal mote id");
+
+    // (2) projection: poll until the terminal Mote commits.
+    let mote = poll_committed(&ep, &instance, &terminal).await;
+    let result_ref = mote["result_ref"].as_str().unwrap().to_string();
+    assert_eq!(result_ref.len(), 64);
+
+    // (3) content: the human path writes RAW bytes == the worker's demo result.
+    let content = run_kx(argv(&[
+        "content",
+        "--ref",
+        &result_ref,
+        "--instance",
+        &instance,
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert!(content.status.success(), "content failed");
+    let mote_bytes = kx_cli::hex::decode_fixed::<32>(&terminal).unwrap();
+    assert_eq!(
+        content.stdout,
+        kx_gateway::demo_pure_result(&mote_bytes),
+        "content returns the exact committed bytes"
+    );
+
+    // (4) events: NDJSON to head carries the Committed delta for the Mote.
+    let events = run_kx(argv(&[
+        "events",
+        "--instance",
+        &instance,
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    assert!(events.status.success());
+    let saw_committed = stdout(&events).lines().any(|line| {
+        serde_json::from_str::<serde_json::Value>(line)
+            .ok()
+            .is_some_and(|v| v["kind"] == "committed" && v["mote_id"] == terminal)
+    });
+    assert!(saw_committed, "events reported the Committed delta");
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn submit_demo_commits() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let out = run_kx(argv(&["submit", "--demo", "--endpoint", &ep, "--json"])).await;
+    let v = json_ok(&out);
+    assert_eq!(v["instance_id"].as_str().unwrap().len(), 32);
+    assert_eq!(v["recipe_fingerprint"].as_str().unwrap().len(), 64);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn committed_run_survives_a_restart() {
+    let dir = TempDir::new().unwrap();
+    let instance = {
+        let running = start_gateway(&dir, true, HashMap::new()).await;
+        let ep = endpoint(&running);
+        let inv = json_ok(
+            &run_kx(argv(&[
+                "invoke",
+                "kx/recipes/echo",
+                "--args",
+                r#"{"topic":"durable"}"#,
+                "--wait",
+                "--endpoint",
+                &ep,
+                "--json",
+            ]))
+            .await,
+        );
+        assert_eq!(inv["state"], "COMMITTED");
+        let id = inv["instance_id"].as_str().unwrap().to_string();
+        running.shutdown().await.unwrap();
+        id
+    };
+
+    // A fresh server on the same journal + content re-serves the committed run.
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+    let view = json_ok(
+        &run_kx(argv(&[
+            "projection",
+            "--instance",
+            &instance,
+            "--endpoint",
+            &ep,
+            "--json",
+        ]))
+        .await,
+    );
+    let any_committed = view["motes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|m| m["state"] == "COMMITTED");
+    assert!(any_committed, "the committed run survives a restart");
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn content_out_writes_committed_bytes_to_file() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // Run a recipe to completion, then fetch its result with `content --out`.
+    let inv = json_ok(
+        &run_kx(argv(&[
+            "invoke",
+            "kx/recipes/echo",
+            "--args",
+            r#"{"topic":"to-disk"}"#,
+            "--endpoint",
+            &ep,
+            "--json",
+        ]))
+        .await,
+    );
+    let instance = inv["instance_id"].as_str().unwrap().to_string();
+    let terminal = inv["terminal_mote_id"].as_str().unwrap().to_string();
+    let mote = poll_committed(&ep, &instance, &terminal).await;
+    let result_ref = mote["result_ref"].as_str().unwrap().to_string();
+
+    let out_path = dir.path().join("fetched.bin");
+    let out = run_kx(argv(&[
+        "content",
+        "--ref",
+        &result_ref,
+        "--instance",
+        &instance,
+        "--out",
+        out_path.to_str().unwrap(),
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert!(out.status.success(), "stderr: {}", stdout(&out));
+    let mote_bytes = kx_cli::hex::decode_fixed::<32>(&terminal).unwrap();
+    assert_eq!(
+        std::fs::read(&out_path).unwrap(),
+        kx_gateway::demo_pure_result(&mote_bytes),
+        "content --out writes the exact committed bytes"
+    );
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-cli/tests/common/mod.rs
+++ b/crates/kx-cli/tests/common/mod.rs
@@ -1,0 +1,141 @@
+//! Shared E2E harness: host an in-process gateway via `kx_gateway::start` (a
+//! deterministic `:0` bound addr + graceful shutdown) and drive the `kx` CLIENT
+//! verbs as subprocesses against it. The server runs in-process so the gateway's
+//! tokio tasks (coordinator + worker) keep progressing while the test thread
+//! awaits each `kx` subprocess (which runs on a blocking thread). Mirrors
+//! `kx-gateway/tests/common` for the config shape.
+
+#![allow(
+    dead_code,
+    unreachable_pub,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic
+)]
+
+use std::collections::HashMap;
+use std::process::Output;
+use std::time::Duration;
+
+use kx_gateway::{start, GatewayConfig, RunningGateway};
+use tempfile::TempDir;
+
+/// A gateway config rooted at `dir` (ephemeral journal + content + catalog).
+#[must_use]
+pub fn gateway_config(
+    dir: &TempDir,
+    dev_allow_local: bool,
+    auth_tokens: HashMap<String, String>,
+) -> GatewayConfig {
+    GatewayConfig {
+        listen: "127.0.0.1:0".parse().unwrap(),
+        journal_path: dir.path().join("kx.db"),
+        content_root: dir.path().join("blobs"),
+        max_lease: 16,
+        dev_allow_local,
+        auth_tokens,
+        catalog_dir: None,
+    }
+}
+
+/// Start an in-process gateway and wait until its port accepts connections (the
+/// serve task may bind just after `start` returns the resolved addr; the `kx`
+/// client connects once and fails fast, so the harness — which owns the server
+/// lifecycle — synchronizes here).
+pub async fn start_gateway(
+    dir: &TempDir,
+    dev_allow_local: bool,
+    auth_tokens: HashMap<String, String>,
+) -> RunningGateway {
+    let running = start(gateway_config(dir, dev_allow_local, auth_tokens))
+        .await
+        .expect("gateway starts");
+    let addr = running.local_addr();
+    for _ in 0..500 {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return running;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("gateway never started accepting on {addr}");
+}
+
+/// The `http://addr` endpoint of a running gateway.
+#[must_use]
+pub fn endpoint(running: &RunningGateway) -> String {
+    format!("http://{}", running.local_addr())
+}
+
+/// Build an owned-`String` argv from string slices.
+#[must_use]
+pub fn argv(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// Run the `kx` binary with `args` (on a blocking thread so the in-process
+/// gateway keeps serving). `RUST_LOG=warn` keeps stderr quiet.
+pub async fn run_kx(args: Vec<String>) -> Output {
+    tokio::task::spawn_blocking(move || {
+        std::process::Command::new(env!("CARGO_BIN_EXE_kx"))
+            .args(&args)
+            .env("RUST_LOG", "warn")
+            .output()
+            .expect("spawn kx")
+    })
+    .await
+    .expect("join kx subprocess")
+}
+
+/// stdout of an output as a `String`.
+#[must_use]
+pub fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// stderr of an output as a `String`.
+#[must_use]
+pub fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Parse stdout as JSON, asserting the verb succeeded.
+pub fn json_ok(out: &Output) -> serde_json::Value {
+    assert!(
+        out.status.success(),
+        "expected success; stderr={}",
+        stderr(out)
+    );
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("stdout is not JSON ({e}): {}", stdout(out)))
+}
+
+/// Poll `kx projection --json` until `mote_hex` is COMMITTED; return its mote
+/// object. Fails the test on timeout.
+pub async fn poll_committed(
+    endpoint: &str,
+    instance_hex: &str,
+    mote_hex: &str,
+) -> serde_json::Value {
+    for _ in 0..100 {
+        let out = run_kx(argv(&[
+            "projection",
+            "--instance",
+            instance_hex,
+            "--endpoint",
+            endpoint,
+            "--json",
+        ]))
+        .await;
+        let v = json_ok(&out);
+        if let Some(motes) = v["motes"].as_array() {
+            if let Some(m) = motes
+                .iter()
+                .find(|m| m["mote_id"] == mote_hex && m["state"] == "COMMITTED")
+            {
+                return m.clone();
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("mote {mote_hex} never reached COMMITTED");
+}

--- a/crates/kx-cli/tests/dep_wall.rs
+++ b/crates/kx-cli/tests/dep_wall.rs
@@ -1,0 +1,54 @@
+//! The FFI wall for the user-facing `kx` binary. It forwards `serve` to the
+//! gateway and `run`/`replay`/`digest` to the engine — both FFI-free by default
+//! (kx-inference is `default-features = false` at the workspace root) — so
+//! `cargo install kx-cli` needs no C++ toolchain. What it must NOT pull is the
+//! llama.cpp FFI (`kx-llamacpp` / `kx-llamacpp-sys`). Mirrors
+//! `kx-gateway/tests/dep_wall.rs`; the justfile `build-no-inference` gate also
+//! pins this.
+//!
+//! Two independent proofs: a manifest `[dependencies]` scan + a `cargo tree`
+//! over the normal edges.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+const FORBIDDEN: &[&str] = &["kx-llamacpp", "kx-llamacpp-sys"];
+
+#[test]
+fn cargo_manifest_dependencies_exclude_the_ffi() {
+    let manifest = include_str!("../Cargo.toml");
+    let deps = manifest
+        .split("[dependencies]")
+        .nth(1)
+        .expect("a [dependencies] section")
+        .split("\n[")
+        .next()
+        .expect("the end of the [dependencies] section");
+    for forbidden in FORBIDDEN {
+        assert!(
+            !deps.contains(forbidden),
+            "{forbidden} must not be a normal dependency of kx-cli"
+        );
+    }
+}
+
+#[test]
+fn cargo_tree_normal_edges_exclude_the_ffi() {
+    let output = std::process::Command::new(env!("CARGO"))
+        .args([
+            "tree", "-p", "kx-cli", "--edges", "normal", "--prefix", "none",
+        ])
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        // cargo-tree may be unavailable in sandboxed CI; the manifest scan is the
+        // load-bearing gate, so skip rather than false-fail.
+        _ => return,
+    };
+    let tree = String::from_utf8_lossy(&output.stdout);
+    for forbidden in FORBIDDEN {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the normal dependency tree of kx-cli:\n{tree}"
+        );
+    }
+}

--- a/crates/kx-cli/tests/invoke_errors_e2e.rs
+++ b/crates/kx-cli/tests/invoke_errors_e2e.rs
@@ -1,0 +1,192 @@
+//! Fail-closed error surfaces for `invoke`: an unknown handle is uniformly
+//! permission-denied (no existence oracle on the execution surface); malformed
+//! args are invalid-argument (server-side, fail-closed); client-side-invalid
+//! JSON is rejected before the round trip.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{argv, endpoint, run_kx, start_gateway, stderr};
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unknown_handle_is_permission_denied() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/does-not-exist",
+        "--args",
+        r#"{"topic":"x"}"#,
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(out.status.code(), Some(1), "RPC error exits 1");
+    assert!(
+        stderr(&out).contains("PermissionDenied"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn malformed_args_are_invalid_argument() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // Valid JSON, but the wrong shape for the recipe's free-params (topic: number).
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":5}"#,
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr(&out).contains("InvalidArgument"),
+        "stderr: {}",
+        stderr(&out)
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn client_side_invalid_json_is_usage_exit_2() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // `{` is not valid JSON — rejected client-side (exit 2) before any round trip.
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        "{",
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(out.status.code(), Some(2), "client-side bad JSON exits 2");
+    assert!(stderr(&out).to_lowercase().contains("json"));
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bad_hex_instance_is_usage_exit_2() {
+    // A wrong-length --instance is a client-side usage error (no server needed,
+    // but a live endpoint proves it fails BEFORE connecting).
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let out = run_kx(argv(&[
+        "projection",
+        "--instance",
+        "abcd",
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(out.status.code(), Some(2), "bad hex length exits 2");
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn args_file_valid_runs_to_committed() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let args_path = dir.path().join("args.json");
+    std::fs::write(&args_path, r#"{"topic":"from-file"}"#).unwrap();
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args-file",
+        args_path.to_str().unwrap(),
+        "--wait",
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["state"], "COMMITTED");
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn args_file_errors_and_mutual_exclusion() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // Missing file → IO error (exit 1).
+    let missing = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args-file",
+        "/no/such/file.json",
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(
+        missing.status.code(),
+        Some(1),
+        "missing --args-file is IO/exit 1"
+    );
+
+    // Invalid JSON in the file → client-side usage (exit 2), no round trip.
+    let bad_path = dir.path().join("bad.json");
+    std::fs::write(&bad_path, "{").unwrap();
+    let bad = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args-file",
+        bad_path.to_str().unwrap(),
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(bad.status.code(), Some(2), "invalid JSON in file exits 2");
+
+    // --args and --args-file together → mutual-exclusion usage error (exit 2).
+    let both = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        "{}",
+        "--args-file",
+        bad_path.to_str().unwrap(),
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(
+        both.status.code(),
+        Some(2),
+        "--args + --args-file is exit 2"
+    );
+    assert!(stderr(&both).contains("mutually exclusive"));
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-cli/tests/runtime_parity.rs
+++ b/crates/kx-cli/tests/runtime_parity.rs
@@ -1,0 +1,90 @@
+//! `run` / `replay` / `digest` forwarding parity + global flags. No server: the
+//! engine verbs are local. Proves the unified `kx` reproduces the kx-runtime
+//! engine's output (the projection-digest invariant is preserved by reusing the
+//! engine VERBATIM) and that usage/version/help behave.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn kx(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kx"))
+        .args(args)
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("spawn kx")
+}
+
+#[test]
+fn run_then_digest_agree_on_the_projection_digest() {
+    let dir = TempDir::new().unwrap();
+    let journal = dir.path().join("kx.db");
+    let content = dir.path().join("blobs");
+    let (j, c) = (journal.to_str().unwrap(), content.to_str().unwrap());
+
+    // run: "<hex> (<committed>/<total> committed)".
+    let run = kx(&["run", "--journal", j, "--content", c]);
+    assert!(
+        run.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let run_line = String::from_utf8_lossy(&run.stdout);
+    let run_hex = run_line.split_whitespace().next().expect("a digest token");
+    assert_eq!(run_hex.len(), 64, "digest is 64 hex chars");
+    assert!(run_line.contains("committed"));
+
+    // digest: "<hex>" — must equal run's digest (same on-disk journal).
+    let dig = kx(&["digest", "--journal", j, "--content", c]);
+    assert!(dig.status.success());
+    let dig_hex = String::from_utf8_lossy(&dig.stdout).trim().to_string();
+    assert_eq!(
+        run_hex, dig_hex,
+        "run and digest agree on the projection digest"
+    );
+
+    // --json forms parse + carry the same digest.
+    let dig_json = kx(&["digest", "--journal", j, "--content", c, "--json"]);
+    let v: serde_json::Value = serde_json::from_slice(&dig_json.stdout).unwrap();
+    assert_eq!(v["digest"], dig_hex);
+
+    let run_json = kx(&["run", "--journal", j, "--content", c, "--json"]);
+    let rv: serde_json::Value = serde_json::from_slice(&run_json.stdout).unwrap();
+    assert_eq!(rv["digest"], dig_hex);
+    assert!(rv["committed"].is_number() && rv["total"].is_number());
+}
+
+#[test]
+fn missing_required_flag_is_usage_exit_2() {
+    let out = kx(&["run", "--content", "/tmp/c"]); // no --journal
+    assert_eq!(out.status.code(), Some(2), "usage error exits 2");
+    let err = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(err.contains("journal"), "names the missing flag: {err}");
+}
+
+#[test]
+fn version_and_help_and_unknown() {
+    let ver = kx(&["--version"]);
+    assert!(ver.status.success());
+    assert!(String::from_utf8_lossy(&ver.stdout).starts_with("kx "));
+
+    let help = kx(&["--help"]);
+    assert!(help.status.success());
+    let h = String::from_utf8_lossy(&help.stdout);
+    assert!(h.contains("invoke") && h.contains("serve") && h.contains("digest"));
+
+    // Empty argv is treated as help (exit 0).
+    let empty = kx(&[]);
+    assert!(empty.status.success());
+
+    // `help <verb>` prints verb help.
+    let hv = kx(&["help", "invoke"]);
+    assert!(hv.status.success());
+    assert!(String::from_utf8_lossy(&hv.stdout).contains("--wait"));
+
+    // Unknown command is a usage error (exit 2).
+    let unknown = kx(&["frobnicate"]);
+    assert_eq!(unknown.status.code(), Some(2));
+}

--- a/crates/kx-cli/tests/signatures_e2e.rs
+++ b/crates/kx-cli/tests/signatures_e2e.rs
@@ -1,0 +1,69 @@
+//! The `signatures` catalog verbs over the wire. The demo provisioning seeds a
+//! recipe but no signatures, so the registry starts empty: `list` is empty,
+//! `get` of an unknown id is not-found (the catalog is a public discovery
+//! surface — not collapsed like the execution path), and `register` of a
+//! malformed manifest is invalid-argument (fail-closed).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{argv, endpoint, run_kx, start_gateway, stderr, stdout};
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn list_is_empty_then_get_unknown_then_register_garbage() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // list: empty registry (human form says so; JSON form is an empty array).
+    let list = run_kx(argv(&["signatures", "list", "--endpoint", &ep])).await;
+    assert!(list.status.success(), "stderr: {}", stderr(&list));
+    assert!(stdout(&list).contains("no signatures"));
+
+    let list_json = run_kx(argv(&["signatures", "list", "--endpoint", &ep, "--json"])).await;
+    let v: serde_json::Value = serde_json::from_slice(&list_json.stdout).unwrap();
+    assert_eq!(v["signatures"].as_array().unwrap().len(), 0);
+
+    // get an unknown id → not_found (exit 1). The discovery surface is honest
+    // about existence (unlike the execution surface).
+    let get = run_kx(argv(&[
+        "signatures",
+        "get",
+        "--id",
+        &"ab".repeat(32),
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(get.status.code(), Some(1));
+    assert!(
+        stderr(&get).contains("NotFound"),
+        "stderr: {}",
+        stderr(&get)
+    );
+
+    // register a malformed manifest → invalid_argument (exit 1), fail-closed.
+    let manifest = dir.path().join("garbage.bin");
+    std::fs::write(&manifest, b"not a valid signature manifest").unwrap();
+    let reg = run_kx(argv(&[
+        "signatures",
+        "register",
+        "--manifest-file",
+        manifest.to_str().unwrap(),
+        "--endpoint",
+        &ep,
+    ]))
+    .await;
+    assert_eq!(reg.status.code(), Some(1));
+    assert!(
+        stderr(&reg).contains("InvalidArgument"),
+        "stderr: {}",
+        stderr(&reg)
+    );
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-cli/tests/wait_e2e.rs
+++ b/crates/kx-cli/tests/wait_e2e.rs
@@ -1,0 +1,161 @@
+//! The `--wait` agent path: one command in, one parseable result out. Covers the
+//! committed result (inline + `--out`), distinct-args exactly-once, and the
+//! timeout/exit-3 shape.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{argv, endpoint, json_ok, run_kx, start_gateway, stdout};
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invoke_wait_returns_committed_result() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"incidents"}"#,
+        "--wait",
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    let v = json_ok(&out);
+    assert_eq!(v["state"], "COMMITTED");
+    let terminal = v["terminal_mote_id"].as_str().unwrap();
+    let mote_bytes = kx_cli::hex::decode_fixed::<32>(terminal).unwrap();
+    let expected = kx_gateway::demo_pure_result(&mote_bytes);
+    // The demo result is an ASCII prefix + the raw 32-byte mote id, so it is NOT
+    // valid UTF-8: result_hex is always present; result_utf8 is absent here.
+    assert_eq!(v["result_len"].as_u64().unwrap() as usize, expected.len());
+    assert_eq!(v["result_hex"], kx_cli::hex::encode(&expected));
+    assert!(
+        v.get("result_utf8").is_none(),
+        "binary payload ⇒ no result_utf8"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invoke_wait_out_writes_raw_bytes() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+    let out_path = dir.path().join("result.bin");
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"save-me"}"#,
+        "--wait",
+        "--out",
+        out_path.to_str().unwrap(),
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    let v = json_ok(&out);
+    assert_eq!(v["state"], "COMMITTED");
+    // With --out the payload is NOT inlined.
+    assert!(
+        v.get("result_hex").is_none(),
+        "payload not inlined under --out"
+    );
+    let terminal = v["terminal_mote_id"].as_str().unwrap();
+    let mote_bytes = kx_cli::hex::decode_fixed::<32>(terminal).unwrap();
+    let written = std::fs::read(&out_path).unwrap();
+    assert_eq!(written, kx_gateway::demo_pure_result(&mote_bytes));
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn distinct_args_yield_distinct_committed_results() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let a = json_ok(
+        &run_kx(argv(&[
+            "invoke",
+            "kx/recipes/echo",
+            "--args",
+            r#"{"topic":"alpha"}"#,
+            "--wait",
+            "--endpoint",
+            &ep,
+            "--json",
+        ]))
+        .await,
+    );
+    let b = json_ok(
+        &run_kx(argv(&[
+            "invoke",
+            "kx/recipes/echo",
+            "--args",
+            r#"{"topic":"bravo"}"#,
+            "--wait",
+            "--endpoint",
+            &ep,
+            "--json",
+        ]))
+        .await,
+    );
+    assert_eq!(a["instance_id"], b["instance_id"], "same recipe ⇒ one run");
+    assert_ne!(
+        a["terminal_mote_id"], b["terminal_mote_id"],
+        "distinct args ⇒ distinct committed Motes (exactly-once-per-input)"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wait_timeout_zero_is_committed_or_running() {
+    // --timeout-secs 0 polls once then decides. If the worker already committed,
+    // exit 0 (COMMITTED) is CORRECT; otherwise exit 3 (RUNNING, resumable). Either
+    // is valid — assert the contract, not a flaky race.
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    let out = run_kx(argv(&[
+        "invoke",
+        "kx/recipes/echo",
+        "--args",
+        r#"{"topic":"race"}"#,
+        "--wait",
+        "--timeout-secs",
+        "0",
+        "--endpoint",
+        &ep,
+        "--json",
+    ]))
+    .await;
+    let code = out.status.code();
+    assert!(
+        matches!(code, Some(0) | Some(3)),
+        "exit 0 (committed) or 3 (running); got {code:?}: {}",
+        stdout(&out)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    if code == Some(3) {
+        assert_eq!(v["state"], "RUNNING");
+        assert_eq!(v["timed_out"], true);
+    } else {
+        assert_eq!(v["state"], "COMMITTED");
+    }
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -38,6 +38,11 @@ bincode         = { workspace = true }
 kx-invoke       = { workspace = true }
 kx-mote         = { workspace = true }
 kx-workflow     = { workspace = true }
+# Inline parent-edge storage for the demo Mote built by `demo_submit_run_request`
+# (`Mote::new`'s `parents` is a `SmallVec<[ParentRef; 4]>`). Promoted from a dev-dep
+# (R3) so the helper is a NORMAL public library fn. FFI-free (the dep_wall forbids
+# only the llama.cpp FFI crates).
+smallvec        = { workspace = true }
 # The embedded single-system engine (D129-sanctioned single-process worker management),
 # behind a default-on feature so R13's `cluster` story can disable it for a lib consumer.
 # kx-executor -> kx-inference is `default-features = false` at the workspace root, so this
@@ -57,7 +62,6 @@ thiserror          = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-smallvec = { workspace = true }
 tokio    = { workspace = true, features = ["time"] }
 
 [features]

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -64,4 +64,4 @@ pub use provision::{DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RE
 pub use server::{serve, start, RunningGateway};
 
 #[cfg(feature = "embedded-worker")]
-pub use server::{default_executor_class, demo_pure_result};
+pub use server::{default_executor_class, demo_pure_result, demo_submit_run_request};

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -82,6 +82,108 @@ pub fn demo_pure_result(mote_id: &[u8; 32]) -> Vec<u8> {
     payload
 }
 
+/// A ready-to-send [`proto::SubmitRunRequest`](kx_proto::proto::SubmitRunRequest)
+/// admitting a single PURE demo Mote whose warrant names the embedded worker's
+/// [`default_executor_class`], so a bound `SubmitRun` leases → runs → reaches
+/// `Committed`.
+///
+/// This is the ONE source of truth for the demo run shared by `kx submit --demo`
+/// (the R3 CLI's low-level SubmitRun path) and the gateway end-to-end tests — the
+/// shape mirrors `tests/common::{pure_mote, pure_warrant}` so the two never drift.
+/// The `recipe_fingerprint` is a fixed discovery-only sentinel (`SubmitRun` takes
+/// it as-is; it is NEVER identity — the coordinator re-derives every `MoteId`
+/// Rust-side, SN-8). The advisory `mote_id` inside the Mote is likewise re-derived.
+#[cfg(feature = "embedded-worker")]
+#[must_use]
+pub fn demo_submit_run_request() -> kx_proto::proto::SubmitRunRequest {
+    use kx_proto::proto::{SubmitMoteSpec, SubmitRunRequest};
+    SubmitRunRequest {
+        // Fixed discovery/dedup sentinel — not identity (SN-8). Matches the e2e fixture.
+        recipe_fingerprint: vec![0x5a; 32],
+        motes: vec![SubmitMoteSpec {
+            mote: Some(demo_pure_mote(1).into()),
+            warrant: Some(demo_pure_warrant().into()),
+            accept_at_least_once: false,
+        }],
+    }
+}
+
+/// A parentless PURE demo Mote, made unique by `seed`. Mirrors
+/// `tests/common::pure_mote` (kept in lockstep so `submit --demo` and the e2e
+/// tests admit the identical Mote shape).
+#[cfg(feature = "embedded-worker")]
+fn demo_pure_mote(seed: u8) -> kx_mote::Mote {
+    use kx_mote::{
+        EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
+        MoteDef, NdClass, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    };
+    use smallvec::SmallVec;
+    use std::collections::BTreeMap;
+
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([7u8; 32]),
+        model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    )
+}
+
+/// A warrant the embedded demo worker can lease: its `executor_class` is the
+/// server's [`default_executor_class`]. Mirrors `tests/common::pure_warrant`.
+#[cfg(feature = "embedded-worker")]
+fn demo_pure_warrant() -> kx_warrant::WarrantSpec {
+    use kx_content::ContentRef;
+    use kx_mote::ModelId;
+    use kx_warrant::{
+        FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let mut mounts = BTreeMap::new();
+    mounts.insert(PathBuf::from("/tmp/in"), FsMode::ReadOnly);
+    let mut egress = BTreeSet::new();
+    egress.insert(Host("api.example.com:443".into()));
+
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::EgressAllowlist(egress),
+        syscall_profile_ref: ContentRef::from_bytes([4u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: ModelId("llama-3.1-8b-instruct-q4_k_m".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 3,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1_000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 30_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: default_executor_class(),
+        ..Default::default()
+    }
+}
+
 /// A running gateway: the bound address plus the handles needed to stop it
 /// gracefully. Returned by [`start`]; [`serve`] drives it to a Ctrl-C.
 pub struct RunningGateway {

--- a/justfile
+++ b/justfile
@@ -88,7 +88,15 @@ build-no-inference:
         exit 1
     fi
     echo " ✓ no kx-llamacpp in kx-runtime closure"
+    echo "Asserting kx-cli's dependency closure is FFI-free (the user-facing binary installs without a C++ toolchain)..."
+    if cargo tree -p kx-cli -e normal | grep -qE 'kx-llamacpp'; then
+        echo " ✗ FAIL: kx-llamacpp is in kx-cli's dependency closure (the FFI leaked into the CLI)"
+        cargo tree -p kx-cli -e normal | grep -E 'kx-llamacpp' || true
+        exit 1
+    fi
+    echo " ✓ no kx-llamacpp in kx-cli closure"
     cargo build -p kx-runtime
+    cargo build -p kx-cli
     cargo build -p kx-inference --no-default-features
     echo " ✓ build-no-inference: PASS"
 


### PR DESCRIPTION
## R3 (D130) — the unified `kx` CLI

The OSS v0.1.0 **reachability** track. R1 bound the first network port (`kx-gateway`); R2 wired real auth + `Invoke` + catalog RPCs. **R3 is how a human — or an agent — first touches the runtime**: a single `kx` binary that keeps `run`/`replay`/`digest`, forwards `serve`, and adds gRPC **client** verbs over the FROZEN `KxGateway` service.

### What ships
- **New crate `crates/kx-cli`** (binary `kx`, thin `lib.rs`, hand-rolled parser — no clap). FFI-free by default (`cargo install kx-cli` needs no C++ toolchain; a `dep_wall` test + the `build-no-inference` gate pin it).
- **Verbs:** `run`/`replay`/`digest` (forward VERBATIM to the engine via `spawn_blocking` — digest invariant preserved), `serve` (forwards to `kx_gateway::serve`, defaulting `--listen 127.0.0.1:50151`), and the client verbs `invoke` · `submit --demo` · `projection` · `content` · `events` · `signatures {list,get,register}`.
- **Agent-ergonomics:** `--wait` on `invoke`/`submit` composes `Invoke → poll GetProjection → GetContent` client-side and prints ONE result object (the runtime as a callable function); `--json` on every verb; distinct exit codes (`0` ok · `2` usage · `3` wait-timeout/resumable · `1` rpc/io). `events --follow` polls from the last cursor (snapshot-to-head today; honest until R5's live tail).
- **Additive gateway helper** `kx_gateway::demo_submit_run_request()` — one source of truth for the demo PURE run shared by `kx submit --demo` and the gateway e2e (no fixture drift). Promotes `smallvec` dev→normal in `kx-gateway`.

### Pre-flight (Golden Rule 8)
- Frozen-trio `src/**` diff-EMPTY; projection digest `a6b5c679…` invariant (engine reused verbatim — a parity test asserts `kx run` hex == `kx digest` hex).
- **SN-8:** the CLI never computes a MoteId/instance_id/fingerprint — it echoes server bytes as hex and sends a *credential* (bearer token), never a claimed identity.
- No new journal write path (the coordinator stays sole writer); the CLI is a pure client + a `serve` forwarder.
- Bearer-over-plaintext warns on a non-loopback `http://` endpoint (TLS/mTLS is a later seam); `--token` warns it's argv-visible (prefer `--token-file`).

### Tests
43 `kx-cli` tests (unit + E2E): arg-parsing/hex/format unit tests; subprocess E2E driving the client verbs against an in-process gateway — full invoke→projection→content→events flow, `--wait` (inline + `--out` + distinct-args + timeout-shape), auth (deny-all/token/token-file), fail-closed error surfaces (unknown-handle PermissionDenied, malformed-args InvalidArgument, client-side bad-JSON exit 2), restart-recovers, and run/digest parity. Local gate green: fmt, clippy `--workspace --all-targets -D warnings`, doc `-D warnings`, cargo-deny, build-no-inference, byte-determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
