### PR TITLE
feat(audit): R4 (D130) — kx-audit sink: off-truth-path runtime audit trail wired into run_with_seams + `kx run --audit-log`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-audit"
+version = "0.0.1"
+dependencies = [
+ "kx-content",
+ "kx-mote",
+ "proptest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kx-capability"
 version = "0.0.1"
 dependencies = [
@@ -1561,6 +1575,7 @@ version = "0.0.1"
 dependencies = [
  "bincode",
  "blake3",
+ "kx-audit",
  "kx-capability",
  "kx-capture",
  "kx-content",
@@ -1571,6 +1586,7 @@ dependencies = [
  "kx-scheduler",
  "kx-warrant",
  "rusqlite",
+ "serde_json",
  "smallvec",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/kx-critic-types",
     "crates/kx-critic",
     "crates/kx-capture",
+    "crates/kx-audit",
     "crates/kx-refusal",
     "crates/kx-mcp",
     "crates/kx-planner",
@@ -137,6 +138,12 @@ kx-critic            = { path = "crates/kx-critic",            version = "0.0.1"
 # Step-capture projection (P4.2 pivot) — opt-in, off-truth-path per-Mote capture of
 # input/output/reasoning/thinking in blob storage; reuse the action, never the thinking.
 kx-capture           = { path = "crates/kx-capture",           version = "0.0.1" }
+# Runtime audit sink (R4, D127 step 2.1) — append-only, off-truth-path, best-effort/
+# non-fatal lifecycle trail (AuditSink trait + AuditEvent + JsonlAuditSink/InMemory).
+# Join keys only (no payload/secrets); timestamps live only on the JSONL wire and
+# never feed the digest; SN-8 integer/crypto-equality. The guarantee-path crates
+# (frozen trio + journal/projection/memoizer) NEVER depend on it (a dep-wall test pins it).
+kx-audit             = { path = "crates/kx-audit",             version = "0.0.1" }
 # Submission-time refusal vocabulary + predicates (M1.3) — a dependency-light LEAF
 # (kx-mote / kx-tool-registry / kx-warrant only) so the control-plane kx-coordinator
 # can enforce R-1..R-15 + D66 at SubmitMote WITHOUT linking kx-executor's inference

--- a/crates/kx-audit/Cargo.toml
+++ b/crates/kx-audit/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name         = "kx-audit"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx runtime audit sink (R4, D127 step 2.1) — an append-only, OFF-TRUTH-PATH, best-effort/non-fatal record of the runtime's execution lifecycle (run started / recovered / children-derived / mote dispatched / committed / failed / repudiated / inconsistent / run completed). Pluggable behind the AuditSink trait (InMemory for tests/embedding, JSONL for an operator log; OTLP/syslog are future impls). Records JOIN KEYS ONLY (MoteId/ContentRef hashes, NdClass, integer counts, the product digest) — NEVER payload bytes, model output, or secrets. Timestamps live only on the JSONL wire and NEVER feed the digest; SN-8 (no float/similarity on the audit path; integer/crypto-equality only). The dependency wall: guarantee-path crates (the frozen trio + journal/projection/memoizer) never depend on this crate."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Join keys ECHOED into events (the atomic Mote id + its non-determinism class) +
+# the committed action's content-addressed result ref. The sink never recomputes
+# an identity — it echoes already-derived runtime state (SN-8).
+kx-mote    = { workspace = true }
+kx-content = { workspace = true }
+# The JSONL wire DTO derives Serialize; serde_json encodes one object per line.
+# Values are emitted as integers / hex strings and are NEVER decoded to floats —
+# no NaN/float-ordering ever touches the audit path (SN-8).
+serde      = { workspace = true }
+serde_json = { workspace = true }
+# Construction-time open error only (record-time write errors are swallowed).
+thiserror  = { workspace = true }
+# Best-effort `warn` on a dropped/failed audit write — NEVER propagated to the
+# run loop (the audit subsystem must never be able to fail the run it audits).
+tracing    = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-audit/src/error.rs
+++ b/crates/kx-audit/src/error.rs
@@ -1,0 +1,15 @@
+//! [`AuditError`] — construction-time errors only.
+
+/// An error constructing an audit sink (opening/creating the log file).
+///
+/// Record-time write errors are deliberately NOT modelled here: they are
+/// swallowed (best-effort), logged via `tracing`, and counted via
+/// [`crate::AuditSink::dropped`] — never surfaced to the run loop. The only
+/// failure a caller handles is at construction, where it can fail fast on a
+/// misconfigured path rather than mid-run.
+#[derive(Debug, thiserror::Error)]
+pub enum AuditError {
+    /// The audit log file could not be opened or created.
+    #[error("audit log open failed: {0}")]
+    Open(#[from] std::io::Error),
+}

--- a/crates/kx-audit/src/event.rs
+++ b/crates/kx-audit/src/event.rs
@@ -1,0 +1,112 @@
+//! [`AuditEvent`] — the time-free, float-free, off-truth-path lifecycle event.
+//!
+//! This is a pure typed value: it derives `Clone, Debug, PartialEq, Eq` (so the
+//! [`crate::InMemoryAuditSink`] can be asserted on deterministically) and it
+//! deliberately carries **no `Serialize`** — the on-disk JSONL shape lives in
+//! `crate::wire`, which adds the wall-clock stamp + sequence number + optional
+//! principal. Keeping time out of this type makes "timestamps never feed the
+//! digest" a *structural* guarantee, not a discipline.
+
+use kx_content::ContentRef;
+use kx_mote::{MoteId, NdClass};
+
+/// Which dispatch path the orchestrator took for a Mote (echoed from the run
+/// loop's `Action` arm — no recomputation).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DispatchKind {
+    /// A PURE, recomputable body.
+    Pure,
+    /// A native deterministic-critic check (PURE, but the body is the check, not
+    /// an executor spawn).
+    Critic,
+    /// The first dispatch of a WORLD-MUTATING / READ-ONLY-NONDET Mote.
+    WmFresh,
+    /// A re-dispatch of an in-flight WM/ROND Mote after a crash (recovery path;
+    /// the broker's idempotency key keeps the external effect exactly-once).
+    WmRecovery,
+}
+
+impl DispatchKind {
+    /// The stable lowercase tag used on the JSONL wire.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pure => "pure",
+            Self::Critic => "critic",
+            Self::WmFresh => "wm_fresh",
+            Self::WmRecovery => "wm_recovery",
+        }
+    }
+}
+
+/// One off-truth-path runtime lifecycle event.
+///
+/// Every field is an ALREADY-DERIVED join key (a `MoteId`/`ContentRef` hash, an
+/// `NdClass`, an integer count, or the 32-byte product digest). The sink echoes
+/// runtime state — it NEVER recomputes a `MoteId` (SN-8). There is **no float and
+/// no timestamp** anywhere here: time is added by the sink at the wire layer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuditEvent {
+    /// The drive loop is starting with `runnable` declared workflow Motes.
+    RunStarted {
+        /// Number of declared workflow Motes in the runnable set at start.
+        runnable: u32,
+    },
+    /// A resume folded an existing journal before the loop began.
+    Recovered {
+        /// Number of already-committed Motes folded from the journal on resume.
+        committed_through: u32,
+        /// The journal sequence number the fold reached.
+        folded_through: u64,
+    },
+    /// A committed topology shaper materialized its children into the runnable set.
+    ChildrenDerived {
+        /// The shaper Mote whose committed decision produced the children.
+        shaper: MoteId,
+        /// Number of children materialized.
+        children: u32,
+    },
+    /// A Mote was dispatched for execution.
+    MoteDispatched {
+        /// The dispatched Mote.
+        mote_id: MoteId,
+        /// Its non-determinism class.
+        nd_class: NdClass,
+        /// Which dispatch path was taken.
+        kind: DispatchKind,
+    },
+    /// A Mote reached the terminal `Committed` state (its action is durable).
+    MoteCommitted {
+        /// The committed Mote.
+        mote_id: MoteId,
+        /// The committed action's content-addressed result ref.
+        result_ref: ContentRef,
+        /// Its non-determinism class.
+        nd_class: NdClass,
+    },
+    /// A Mote reached the terminal `Failed` state (no later `Committed`).
+    MoteFailed {
+        /// The failed Mote.
+        mote_id: MoteId,
+    },
+    /// A committed Mote was later `Repudiated` (a repudiation targeting it landed).
+    MoteRepudiated {
+        /// The repudiated Mote.
+        mote_id: MoteId,
+    },
+    /// A journal-consistency anomaly: an `EffectStaged`-then-`Repudiated` sequence
+    /// with no intervening `Committed` (surfaced for operator review).
+    MoteInconsistent {
+        /// The Mote in the inconsistent state.
+        mote_id: MoteId,
+    },
+    /// The drive loop finished.
+    RunCompleted {
+        /// Number of Motes in a `Committed` (non-repudiated) state.
+        committed: u32,
+        /// Total declared workflow Motes.
+        total: u32,
+        /// The deterministic product-identity digest of the committed-result set.
+        digest: [u8; 32],
+    },
+}

--- a/crates/kx-audit/src/in_memory.rs
+++ b/crates/kx-audit/src/in_memory.rs
@@ -1,0 +1,114 @@
+//! [`InMemoryAuditSink`] — a deterministic, in-memory [`AuditSink`] for tests and
+//! embedding.
+//!
+//! Stores the typed [`AuditEvent`]s verbatim (no time, no hex rendering), so two
+//! byte-identical runs produce equal [`Self::events`] — the deterministic assertion
+//! surface. Lock poisoning is recovered (never propagated): a panicking auditor
+//! thread must not crash a later `record`.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use crate::event::AuditEvent;
+use crate::sink::AuditSink;
+
+/// A cheap, cloneable, thread-safe in-memory audit sink. Clones share one slot
+/// (an `Arc<Mutex<…>>`), so the orchestrator and any reader observe the same log.
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryAuditSink {
+    events: Arc<Mutex<Vec<AuditEvent>>>,
+}
+
+impl InMemoryAuditSink {
+    /// A new, empty in-memory sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A point-in-time clone of the recorded events, in record order. The caller
+    /// holds no lock across iteration. Lock poisoning is recovered.
+    pub fn events(&self) -> Vec<AuditEvent> {
+        self.events
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Number of recorded events (cheap; avoids cloning).
+    pub fn len(&self) -> usize {
+        self.events
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len()
+    }
+
+    /// `true` when nothing has been recorded yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl AuditSink for InMemoryAuditSink {
+    fn record(&self, event: AuditEvent) {
+        self.events
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kx_content::ContentRef;
+    use kx_mote::{MoteId, NdClass};
+
+    use super::*;
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    #[test]
+    fn records_in_order_and_counts() {
+        let sink = InMemoryAuditSink::new();
+        assert!(sink.is_empty());
+        sink.record(AuditEvent::RunStarted { runnable: 8 });
+        sink.record(AuditEvent::MoteCommitted {
+            mote_id: mid(1),
+            result_ref: ContentRef::from_bytes([2; 32]),
+            nd_class: NdClass::Pure,
+        });
+        assert_eq!(sink.len(), 2);
+        let events = sink.events();
+        assert_eq!(events[0], AuditEvent::RunStarted { runnable: 8 });
+        assert!(matches!(events[1], AuditEvent::MoteCommitted { .. }));
+    }
+
+    #[test]
+    fn dropped_defaults_to_zero() {
+        let sink = InMemoryAuditSink::new();
+        assert_eq!(sink.dropped(), 0);
+        sink.record(AuditEvent::RunStarted { runnable: 1 });
+        assert_eq!(sink.dropped(), 0, "an in-memory sink never drops");
+    }
+
+    #[test]
+    fn clone_shares_one_slot() {
+        let sink = InMemoryAuditSink::new();
+        let clone = sink.clone();
+        clone.record(AuditEvent::RunStarted { runnable: 3 });
+        assert_eq!(sink.len(), 1, "the original observes the clone's write");
+    }
+
+    #[test]
+    fn poisoning_is_recovered() {
+        let sink = InMemoryAuditSink::new();
+        let clone = sink.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = clone.events.lock().unwrap();
+            panic!("poison the audit lock");
+        })
+        .join();
+        sink.record(AuditEvent::RunStarted { runnable: 1 });
+        assert_eq!(sink.len(), 1, "poison recovered, never propagated");
+    }
+}

--- a/crates/kx-audit/src/jsonl.rs
+++ b/crates/kx-audit/src/jsonl.rs
@@ -1,0 +1,294 @@
+//! [`JsonlAuditSink`] — a best-effort, line-delimited-JSON [`AuditSink`].
+//!
+//! One JSON object per line (JSONL): a SIEM / `jq -c` ingestion contract. Each
+//! line carries a monotonic `seq`, a wall-clock `ts_ms`, an optional `principal`,
+//! and the internally-tagged event body with ids rendered as lowercase hex
+//! (see `crate::wire`). The open is fail-fast (surfaced at construction); every
+//! record-time failure is swallowed + `warn`-logged + counted ([`Self::dropped`]),
+//! so the run it audits can never fail because of audit I/O.
+//!
+//! Durability is deliberately *best-effort*: writes are buffered and there is NO
+//! per-event `fsync` (that would serialize the run on disk latency). Buffered
+//! lines are flushed on [`Self::flush`] (the orchestrator calls it at run-complete)
+//! and again on `Drop` (the crash/early-return safety net). On a hard kill the
+//! buffered tail may be lost — acceptable, because the journal is the durable
+//! truth and the digest is recomputable from it.
+//!
+//! There is NO log rotation: the file grows append-only and the caller owns
+//! retention/rotation (e.g. logrotate). A rotating backend is a future impl
+//! behind the same [`AuditSink`] trait.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::AuditError;
+use crate::event::AuditEvent;
+use crate::sink::AuditSink;
+use crate::wire::AuditEventWire;
+
+/// A best-effort JSONL audit sink over a single append target.
+#[derive(Debug)]
+pub struct JsonlAuditSink {
+    writer: Mutex<BufWriter<File>>,
+    seq: AtomicU64,
+    dropped: AtomicU64,
+    principal: Option<String>,
+}
+
+impl JsonlAuditSink {
+    /// Create (truncating any existing file) a fresh audit log at `path`. Use this
+    /// for a single run (`kx run`), where each invocation starts a clean trail.
+    pub fn create(path: impl AsRef<Path>) -> Result<Self, AuditError> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        Ok(Self::from_file(file))
+    }
+
+    /// Open `path` for append, creating it if absent (existing lines preserved).
+    /// Use this for a long-lived process (`kx serve`) accumulating a trail across
+    /// runs. Note: `seq` is per-sink and resets to 0 on each open — segment runs
+    /// by the (future) `principal`/`run_id` envelope, not by a global `seq`.
+    pub fn append(path: impl AsRef<Path>) -> Result<Self, AuditError> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self::from_file(file))
+    }
+
+    fn from_file(file: File) -> Self {
+        Self {
+            writer: Mutex::new(BufWriter::new(file)),
+            seq: AtomicU64::new(0),
+            dropped: AtomicU64::new(0),
+            principal: None,
+        }
+    }
+
+    /// Stamp every line with a run-scoped `principal` ("who"). Absent by default;
+    /// the gateway/auth layer supplies the authenticated principal (a follow-on).
+    #[must_use]
+    pub fn with_principal(mut self, principal: impl Into<String>) -> Self {
+        self.principal = Some(principal.into());
+        self
+    }
+
+    /// Serialize the line OUTSIDE the writer lock (small critical section), then
+    /// append it. Returns the I/O result; the caller absorbs it.
+    fn write_line(&self, event: &AuditEvent) -> std::io::Result<()> {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let ts_ms = now_epoch_millis();
+        let wire = AuditEventWire::from_event(seq, ts_ms, event, self.principal.clone());
+        let mut line = serde_json::to_string(&wire).map_err(std::io::Error::other)?;
+        line.push('\n');
+        let mut w = self.writer.lock().unwrap_or_else(PoisonError::into_inner);
+        w.write_all(line.as_bytes())
+    }
+}
+
+impl AuditSink for JsonlAuditSink {
+    fn record(&self, event: AuditEvent) {
+        if let Err(e) = self.write_line(&event) {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(error = %e, "audit: dropped event (jsonl write failed; best-effort)");
+        }
+    }
+
+    fn flush(&self) {
+        let mut w = self.writer.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Err(e) = w.flush() {
+            tracing::warn!(error = %e, "audit: flush failed (best-effort)");
+        }
+    }
+
+    fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for JsonlAuditSink {
+    fn drop(&mut self) {
+        // Crash/early-return safety net: flush any buffered tail (RunCompleted +
+        // the final commits) even if the orchestrator never called `flush()`.
+        let mut w = self.writer.lock().unwrap_or_else(PoisonError::into_inner);
+        let _ = w.flush();
+    }
+}
+
+/// Wall-clock epoch milliseconds. OFF the digest/identity path — used only on the
+/// JSONL wire. Saturates rather than panicking on a pre-epoch / overflowing clock.
+fn now_epoch_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use kx_content::ContentRef;
+    use kx_mote::{MoteId, NdClass};
+    use serde_json::Value;
+
+    use super::*;
+    use crate::event::DispatchKind;
+
+    fn mid(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    fn read_lines(path: &Path) -> Vec<Value> {
+        let text = std::fs::read_to_string(path).unwrap();
+        text.lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str::<Value>(l).expect("each line is valid JSON"))
+            .collect()
+    }
+
+    #[test]
+    fn writes_valid_jsonl_with_hex_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        {
+            let sink = JsonlAuditSink::create(&path).unwrap();
+            sink.record(AuditEvent::RunStarted { runnable: 8 });
+            sink.record(AuditEvent::MoteDispatched {
+                mote_id: mid(0xab),
+                nd_class: NdClass::WorldMutating,
+                kind: DispatchKind::WmFresh,
+            });
+            sink.record(AuditEvent::MoteCommitted {
+                mote_id: mid(0xab),
+                result_ref: ContentRef::from_bytes([0xcd; 32]),
+                nd_class: NdClass::WorldMutating,
+            });
+            sink.record(AuditEvent::RunCompleted {
+                committed: 8,
+                total: 8,
+                digest: [0xef; 32],
+            });
+            sink.flush();
+        }
+        let lines = read_lines(&path);
+        assert_eq!(lines.len(), 4);
+
+        // seq is gap-free from 0.
+        for (i, line) in lines.iter().enumerate() {
+            assert_eq!(line["seq"], i as u64);
+            assert!(line["ts_ms"].is_u64(), "ts_ms present and numeric");
+        }
+        // ids are 64-char lowercase hex, NOT an int array.
+        assert_eq!(lines[0]["type"], "run_started");
+        assert_eq!(lines[0]["runnable"], 8);
+        assert_eq!(lines[1]["type"], "mote_dispatched");
+        assert_eq!(lines[1]["mote_id"], "ab".repeat(32));
+        assert_eq!(lines[1]["nd_class"], "world_mutating");
+        assert_eq!(lines[1]["kind"], "wm_fresh");
+        assert_eq!(lines[2]["result_ref"], "cd".repeat(32));
+        assert_eq!(lines[3]["type"], "run_completed");
+        assert_eq!(lines[3]["digest"], "ef".repeat(32));
+        // No `principal` field unless set.
+        assert!(lines[0].get("principal").is_none());
+    }
+
+    #[test]
+    fn principal_is_stamped_when_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let sink = JsonlAuditSink::create(&path)
+            .unwrap()
+            .with_principal("svc-account-7");
+        sink.record(AuditEvent::RunStarted { runnable: 1 });
+        sink.flush();
+        let lines = read_lines(&path);
+        assert_eq!(lines[0]["principal"], "svc-account-7");
+    }
+
+    #[test]
+    fn open_failure_surfaces_at_construction() {
+        // A path under a nonexistent directory cannot be created.
+        let err = JsonlAuditSink::create("/no/such/dir/deeper/audit.jsonl");
+        assert!(matches!(err, Err(AuditError::Open(_))));
+    }
+
+    #[test]
+    fn flush_persists_buffered_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let sink = JsonlAuditSink::create(&path).unwrap();
+        sink.record(AuditEvent::RunStarted { runnable: 1 });
+        sink.flush();
+        assert_eq!(read_lines(&path).len(), 1);
+    }
+
+    #[test]
+    fn drop_flushes_without_explicit_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        {
+            let sink = JsonlAuditSink::create(&path).unwrap();
+            sink.record(AuditEvent::RunStarted { runnable: 1 });
+            // No explicit flush — Drop must persist it.
+        }
+        assert_eq!(read_lines(&path).len(), 1);
+    }
+
+    #[test]
+    fn truncate_vs_append_semantics() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        {
+            let s = JsonlAuditSink::create(&path).unwrap();
+            s.record(AuditEvent::RunStarted { runnable: 1 });
+            s.flush();
+        }
+        // `create` truncates: a fresh run starts empty.
+        {
+            let s = JsonlAuditSink::create(&path).unwrap();
+            s.record(AuditEvent::RunStarted { runnable: 2 });
+            s.flush();
+        }
+        assert_eq!(read_lines(&path).len(), 1, "create truncates");
+        // `append` preserves prior lines.
+        {
+            let s = JsonlAuditSink::append(&path).unwrap();
+            s.record(AuditEvent::RunStarted { runnable: 3 });
+            s.flush();
+        }
+        assert_eq!(read_lines(&path).len(), 2, "append preserves");
+    }
+
+    #[test]
+    fn seq_is_unique_and_gapfree_under_concurrency() {
+        use std::sync::Arc;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let sink = Arc::new(JsonlAuditSink::create(&path).unwrap());
+        let threads = 8;
+        let per = 250;
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                let s = Arc::clone(&sink);
+                std::thread::spawn(move || {
+                    for _ in 0..per {
+                        s.record(AuditEvent::RunStarted { runnable: 1 });
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        sink.flush();
+        let lines = read_lines(&path);
+        assert_eq!(lines.len(), threads * per);
+        let mut seqs: Vec<u64> = lines.iter().map(|l| l["seq"].as_u64().unwrap()).collect();
+        seqs.sort_unstable();
+        let expected: Vec<u64> = (0..(threads * per) as u64).collect();
+        assert_eq!(seqs, expected, "seq set is exactly 0..N — unique, gap-free");
+        assert_eq!(sink.dropped(), 0);
+    }
+}

--- a/crates/kx-audit/src/lib.rs
+++ b/crates/kx-audit/src/lib.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-audit` — the OFF-TRUTH-PATH, best-effort runtime audit sink (R4, D127 step 2.1).
+//!
+//! An audit trail makes the runtime's execution *observable*: a structured,
+//! append-only stream of lifecycle events — a run started, it recovered N
+//! committed Motes, a shaper derived children, a Mote was dispatched / committed /
+//! failed / repudiated, the run completed with digest D and K-of-N committed. It
+//! closes the "no observability" gap the architecture audit named, without ever
+//! touching the durability/identity spine.
+//!
+//! ## What it records, and what it is NOT
+//!
+//! - **Join keys only.** Every [`AuditEvent`] field is an ALREADY-DERIVED value —
+//!   a [`kx_mote::MoteId`] / [`kx_content::ContentRef`] hash, an
+//!   [`kx_mote::NdClass`], an integer count, or the 32-byte product digest. The
+//!   sink ECHOES runtime state; it NEVER recomputes a `MoteId` (SN-8). It records
+//!   **no payload bytes, no model output, no warrant secrets** — only the hashes
+//!   that join back to truth.
+//! - **Operational telemetry, not the source of truth.** The journal is the
+//!   durable truth and the product digest is recomputable from it; the audit log
+//!   is a best-effort operational stream. On a hard crash the buffered tail may be
+//!   lost — recompute from the journal.
+//!
+//! ## Invariants (the wall)
+//!
+//! - **Off the truth path.** Audit is NEVER journaled, is NEVER an input to a
+//!   `MoteId`, and NEVER gates scheduling / promotion / eviction. Turning it on
+//!   changes only what is *observed*, never the committed facts — so the canonical
+//!   product digest `a6b5c679…` is byte-unchanged with audit on, off, or inspected.
+//! - **Best-effort / non-fatal.** [`AuditSink::record`] returns unit: an audit
+//!   write failure can NEVER propagate into the run loop. Failures are swallowed,
+//!   logged via `tracing`, and counted via [`AuditSink::dropped`].
+//! - **Timestamps never feed the digest.** [`AuditEvent`] carries **no time and no
+//!   float**. A wall-clock stamp (epoch millis) + a monotonic sequence number are
+//!   added by the sink at the *wire* layer ([`JsonlAuditSink`]) only, so time can
+//!   never reach identity or the digest.
+//! - **The dependency wall.** Guarantee-path crates (the frozen trio
+//!   `kx-scheduler`/`kx-executor`/`kx-inference` + `kx-journal`/`kx-projection`/
+//!   `kx-memoizer`) do **not** depend on this crate. The compiler enforces the
+//!   direction every build; `tests/boundary.rs` is the tripwire.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod error;
+mod event;
+mod in_memory;
+mod jsonl;
+mod sink;
+mod wire;
+
+pub use error::AuditError;
+pub use event::{AuditEvent, DispatchKind};
+pub use in_memory::InMemoryAuditSink;
+pub use jsonl::JsonlAuditSink;
+pub use sink::AuditSink;

--- a/crates/kx-audit/src/sink.rs
+++ b/crates/kx-audit/src/sink.rs
@@ -1,0 +1,32 @@
+//! [`AuditSink`] — the pluggable, best-effort audit seam.
+
+use crate::event::AuditEvent;
+
+/// A pluggable destination for [`AuditEvent`]s.
+///
+/// Implementations are `Send + Sync` and take `&self` (interior mutability) so a
+/// single sink can be shared as `Arc<dyn AuditSink>` across the orchestrator and
+/// any reader.
+///
+/// **Best-effort / non-fatal by construction.** [`Self::record`] returns unit:
+/// an audit-write failure can NEVER propagate into the run loop (there is no
+/// `Result` a maintainer could accidentally `?`-propagate). Implementations
+/// swallow write errors, log them via `tracing`, and count them in
+/// [`Self::dropped`] so the loss is observable rather than silent. An audit
+/// subsystem that can abort the run it audits is a self-inflicted availability
+/// bug; this trait shape makes that impossible.
+pub trait AuditSink: Send + Sync {
+    /// Record one lifecycle event. Infallible from the caller's perspective —
+    /// failures are absorbed and counted ([`Self::dropped`]).
+    fn record(&self, event: AuditEvent);
+
+    /// Flush any buffered records to the backing store. Default: no-op (e.g. an
+    /// in-memory sink has nothing to flush).
+    fn flush(&self) {}
+
+    /// Number of events dropped due to backend write failures — best-effort
+    /// telemetry an operator (or a test) can assert on. Default: `0`.
+    fn dropped(&self) -> u64 {
+        0
+    }
+}

--- a/crates/kx-audit/src/wire.rs
+++ b/crates/kx-audit/src/wire.rs
@@ -1,0 +1,200 @@
+//! The on-disk JSONL wire shape for an [`crate::AuditEvent`].
+//!
+//! The typed [`crate::AuditEvent`] is time-free and id-typed; this module is the
+//! ONE place that (a) renders ids/digests as lowercase hex strings (so the audit
+//! log correlates by `grep` with the journal / CLI / `digest` output, which are
+//! all hex — the default `serde` derive over a `[u8; 32]` newtype would emit a
+//! 32-integer array that no SIEM keyed on hex ids could match), and (b) adds the
+//! wall-clock stamp + monotonic sequence + optional principal envelope. Time and
+//! "who" live here and ONLY here — never in the typed event, never near the digest.
+
+use serde::Serialize;
+
+use crate::event::AuditEvent;
+
+/// One JSONL line: a stamped, sequenced envelope flattening the event body.
+///
+/// Serializes to e.g. `{"seq":0,"ts_ms":1717545600000,"type":"run_started","runnable":8}`.
+#[derive(Debug, Serialize)]
+pub(crate) struct AuditEventWire {
+    /// Monotonic per-sink sequence number (a gap signals a dropped/removed line).
+    seq: u64,
+    /// Wall-clock stamp, epoch milliseconds. OFF the digest / identity path.
+    ts_ms: u64,
+    /// Optional run-scoped principal ("who"); absent unless the caller sets it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    principal: Option<String>,
+    /// The internally-tagged event body, flattened onto the line.
+    #[serde(flatten)]
+    body: AuditBody,
+}
+
+impl AuditEventWire {
+    /// Build a wire line from a typed event + the sink-supplied stamp/seq/principal.
+    pub(crate) fn from_event(
+        seq: u64,
+        ts_ms: u64,
+        event: &AuditEvent,
+        principal: Option<String>,
+    ) -> Self {
+        Self {
+            seq,
+            ts_ms,
+            principal,
+            body: AuditBody::from_event(event),
+        }
+    }
+}
+
+/// The internally-tagged (`"type"`) body. New variants are additive for an
+/// external JSONL parser (it ignores unknown `type` values).
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AuditBody {
+    RunStarted {
+        runnable: u32,
+    },
+    Recovered {
+        committed_through: u32,
+        folded_through: u64,
+    },
+    ChildrenDerived {
+        shaper: String,
+        children: u32,
+    },
+    MoteDispatched {
+        mote_id: String,
+        nd_class: &'static str,
+        kind: &'static str,
+    },
+    MoteCommitted {
+        mote_id: String,
+        result_ref: String,
+        nd_class: &'static str,
+    },
+    MoteFailed {
+        mote_id: String,
+    },
+    MoteRepudiated {
+        mote_id: String,
+    },
+    MoteInconsistent {
+        mote_id: String,
+    },
+    RunCompleted {
+        committed: u32,
+        total: u32,
+        digest: String,
+    },
+}
+
+impl AuditBody {
+    fn from_event(event: &AuditEvent) -> Self {
+        match *event {
+            AuditEvent::RunStarted { runnable } => Self::RunStarted { runnable },
+            AuditEvent::Recovered {
+                committed_through,
+                folded_through,
+            } => Self::Recovered {
+                committed_through,
+                folded_through,
+            },
+            AuditEvent::ChildrenDerived { shaper, children } => Self::ChildrenDerived {
+                shaper: hex32(shaper.as_bytes()),
+                children,
+            },
+            AuditEvent::MoteDispatched {
+                mote_id,
+                nd_class,
+                kind,
+            } => Self::MoteDispatched {
+                mote_id: hex32(mote_id.as_bytes()),
+                nd_class: nd_str(nd_class),
+                kind: kind.as_str(),
+            },
+            AuditEvent::MoteCommitted {
+                mote_id,
+                result_ref,
+                nd_class,
+            } => Self::MoteCommitted {
+                mote_id: hex32(mote_id.as_bytes()),
+                result_ref: result_ref.to_hex(),
+                nd_class: nd_str(nd_class),
+            },
+            AuditEvent::MoteFailed { mote_id } => Self::MoteFailed {
+                mote_id: hex32(mote_id.as_bytes()),
+            },
+            AuditEvent::MoteRepudiated { mote_id } => Self::MoteRepudiated {
+                mote_id: hex32(mote_id.as_bytes()),
+            },
+            AuditEvent::MoteInconsistent { mote_id } => Self::MoteInconsistent {
+                mote_id: hex32(mote_id.as_bytes()),
+            },
+            AuditEvent::RunCompleted {
+                committed,
+                total,
+                digest,
+            } => Self::RunCompleted {
+                committed,
+                total,
+                digest: hex32(&digest),
+            },
+        }
+    }
+}
+
+/// Stable lowercase tag for a non-determinism class (matches the rest of the
+/// codebase's snake_case wire vocabulary).
+fn nd_str(nd: kx_mote::NdClass) -> &'static str {
+    match nd {
+        kx_mote::NdClass::Pure => "pure",
+        kx_mote::NdClass::ReadOnlyNondet => "read_only_nondet",
+        kx_mote::NdClass::WorldMutating => "world_mutating",
+    }
+}
+
+/// Render 32 bytes as 64 lowercase hex chars (matches `MoteId`/`ContentRef`
+/// `Display`/`to_hex`). Allocation-bounded, no `unwrap`.
+fn hex32(bytes: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::DispatchKind;
+
+    #[test]
+    fn hex32_matches_lowercase_64char_hex() {
+        let s = hex32(&[0xab; 32]);
+        assert_eq!(s.len(), 64);
+        assert_eq!(s, "ab".repeat(32));
+        assert_eq!(hex32(&[0x00; 32]), "0".repeat(64));
+
+        // First eight bytes carry every nibble; the rest are zero.
+        let mut b = [0u8; 32];
+        b[..8].copy_from_slice(&[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        assert_eq!(hex32(&b), format!("0123456789abcdef{}", "00".repeat(24)));
+    }
+
+    #[test]
+    fn nd_str_is_snake_case() {
+        assert_eq!(nd_str(kx_mote::NdClass::Pure), "pure");
+        assert_eq!(nd_str(kx_mote::NdClass::ReadOnlyNondet), "read_only_nondet");
+        assert_eq!(nd_str(kx_mote::NdClass::WorldMutating), "world_mutating");
+    }
+
+    #[test]
+    fn dispatch_kind_tags() {
+        assert_eq!(DispatchKind::Pure.as_str(), "pure");
+        assert_eq!(DispatchKind::Critic.as_str(), "critic");
+        assert_eq!(DispatchKind::WmFresh.as_str(), "wm_fresh");
+        assert_eq!(DispatchKind::WmRecovery.as_str(), "wm_recovery");
+    }
+}

--- a/crates/kx-audit/tests/boundary.rs
+++ b/crates/kx-audit/tests/boundary.rs
@@ -1,0 +1,76 @@
+//! Boundary lint (the audit wall's tripwire).
+//!
+//! `kx-audit` is an OFF-TRUTH-PATH, best-effort observability sink. The
+//! guarantee-path crates — the frozen trio (`kx-scheduler`/`kx-executor`/
+//! `kx-inference`) plus the journal / projection / memoizer truth-path set — MUST
+//! NEVER depend on it nor import it. The real wall is the dependency graph (the
+//! compiler enforces it every build); this test fails loudly the instant the wall
+//! erodes — e.g. someone adds `kx-audit` to a guarantee-path crate to "conveniently"
+//! emit audit events from inside the executor, which is itself the boundary
+//! violation: the moment audit/observability influences scheduling/commit/identity,
+//! the off-truth-path guarantee (and the `a6b5c679…` digest invariant) is gone.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Crates on the exactly-once guarantee / identity path. None may reach the audit
+/// layer. Includes the full frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`).
+const GUARANTEE_PATH_CRATES: [&str; 6] = [
+    "kx-journal",
+    "kx-scheduler",
+    "kx-executor",
+    "kx-inference",
+    "kx-projection",
+    "kx-memoizer",
+];
+
+/// `<repo>/crates` (`CARGO_MANIFEST_DIR` is `<repo>/crates/kx-audit`).
+fn crates_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("kx-audit lives under crates/")
+        .to_path_buf()
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn guarantee_path_crates_do_not_depend_on_audit() {
+    let crates = crates_dir();
+    for krate in GUARANTEE_PATH_CRATES {
+        // 1. Cargo.toml must not list kx-audit.
+        let manifest = crates.join(krate).join("Cargo.toml");
+        if let Ok(text) = fs::read_to_string(&manifest) {
+            assert!(
+                !text.contains("kx-audit"),
+                "{krate}/Cargo.toml depends on kx-audit — the audit wall is breached"
+            );
+        }
+        // 2. No source file may import it.
+        let src = crates.join(krate).join("src");
+        let mut files = Vec::new();
+        collect_rs_files(&src, &mut files);
+        for f in files {
+            let text = fs::read_to_string(&f).unwrap();
+            assert!(
+                !text.contains("kx_audit") && !text.contains("kx-audit"),
+                "{} imports kx-audit — the audit wall is breached",
+                f.display()
+            );
+        }
+    }
+}

--- a/crates/kx-audit/tests/scale.rs
+++ b/crates/kx-audit/tests/scale.rs
@@ -1,0 +1,78 @@
+//! Scale-smoke: the audit sink is flat per-event at scale.
+//!
+//! `#[ignore]`d — run in `--release` via the `scale-smoke` recipe. Unlike capture
+//! (a once-at-end sweep), the audit sink is called on the hot drive loop at each
+//! lifecycle transition, so this proves the per-event cost stays flat (no
+//! super-linear path) for BOTH backends: the in-memory `Vec` push and the JSONL
+//! buffered serialize+write. A regression (e.g. an O(n) rescan per event, or a
+//! per-event fsync) would turn a large run super-linear and trip this gate.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Instant;
+
+use kx_audit::{AuditEvent, AuditSink, InMemoryAuditSink, JsonlAuditSink};
+use kx_content::ContentRef;
+use kx_mote::{MoteId, NdClass};
+
+const SIZES: &[usize] = &[1_000, 5_000, 10_000, 25_000];
+
+fn mote_at(i: usize) -> MoteId {
+    let mut b = [0u8; 32];
+    b[..8].copy_from_slice(&(i as u64).to_le_bytes());
+    MoteId::from_bytes(b)
+}
+
+fn committed(i: usize) -> AuditEvent {
+    AuditEvent::MoteCommitted {
+        mote_id: mote_at(i),
+        result_ref: ContentRef::from_bytes([3u8; 32]),
+        nd_class: NdClass::Pure,
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn per_event_ratio(label: &str, sink: &dyn AuditSink, n_sizes: &[usize]) -> (f64, f64) {
+    let mut per_event_ns: Vec<(usize, f64)> = Vec::new();
+    for &n in n_sizes {
+        let start = Instant::now();
+        for i in 0..n {
+            sink.record(committed(i));
+        }
+        sink.flush();
+        let elapsed = start.elapsed();
+        let per = elapsed.as_nanos() as f64 / n as f64;
+        println!(
+            "{label}: n={n} total_ms={} per_event_ns={per:.1}",
+            elapsed.as_millis()
+        );
+        per_event_ns.push((n, per));
+    }
+    (
+        per_event_ns.first().unwrap().1,
+        per_event_ns.last().unwrap().1,
+    )
+}
+
+#[test]
+#[ignore = "scale-smoke: run with --release --ignored --nocapture --test-threads=1"]
+fn audit_sink_is_flat_per_event() {
+    // In-memory: a `Vec` push is amortized O(1); the 25k/1k ratio should be ~1×.
+    let mem = InMemoryAuditSink::new();
+    let (mem_first, mem_last) = per_event_ratio("audit-in-memory", &mem, SIZES);
+    assert!(
+        mem_last <= mem_first * 4.0,
+        "in-memory per-event must stay flat (1k {mem_first:.1}ns vs 25k {mem_last:.1}ns)"
+    );
+
+    // JSONL: serialize + buffered write per event (NO per-event fsync), so the
+    // per-event cost is bounded and flat across sizes (a quadratic regression ≈ 25×).
+    let dir = tempfile::tempdir().unwrap();
+    let jsonl = JsonlAuditSink::create(dir.path().join("audit.jsonl")).unwrap();
+    let (j_first, j_last) = per_event_ratio("audit-jsonl", &jsonl, SIZES);
+    assert!(
+        j_last <= j_first * 4.0,
+        "jsonl per-event must stay flat (1k {j_first:.1}ns vs 25k {j_last:.1}ns)"
+    );
+    assert_eq!(jsonl.dropped(), 0, "no events dropped at scale");
+}

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -18,7 +18,8 @@ pub const USAGE: &str = "\
 usage: kx <command> [args]
 
   engine (local, no server):
-    kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--checkpoint-every N] [--json]
+    kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--checkpoint-every N]
+                         [--audit-log <path>] [--json]
 
   server:
     kx serve --journal <path> --content <dir> [--listen <addr:port>] [--dev-allow-local]
@@ -249,10 +250,13 @@ fn inject_listen_default(mut rest: Vec<String>) -> Vec<String> {
 fn help_for(cmd: &str) -> String {
     match cmd {
         "run" | "replay" | "digest" => "\
-kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--checkpoint-every N] [--json]
+kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--checkpoint-every N]
+                     [--audit-log <path>] [--json]
   Forwards to the kx-runtime engine. `run` drives the canonical demo from scratch;
   `replay` recovers + finishes an existing journal; `digest` prints the projection
-  digest. Output is parity-identical to the `kx-runtime` binary."
+  digest. Output is parity-identical to the `kx-runtime` binary.
+  --audit-log <path> writes a best-effort JSONL audit trail of the run lifecycle
+  (off the truth path; never changes the digest). Honored by run/replay."
             .into(),
         "serve" => "\
 kx serve --journal <path> --content <dir> [--listen <addr:port>] [--dev-allow-local] ...

--- a/crates/kx-cli/tests/runtime_parity.rs
+++ b/crates/kx-cli/tests/runtime_parity.rs
@@ -57,6 +57,64 @@ fn run_then_digest_agree_on_the_projection_digest() {
 }
 
 #[test]
+fn run_with_audit_log_writes_a_parseable_trail_and_preserves_digest() {
+    // R4 reachability: `kx run --audit-log <path>` writes a best-effort JSONL audit
+    // trail of the run lifecycle, off the truth path (the digest is unchanged).
+    let dir = TempDir::new().unwrap();
+    let journal = dir.path().join("kx.db");
+    let content = dir.path().join("blobs");
+    let audit = dir.path().join("audit.jsonl");
+    let (j, c, a) = (
+        journal.to_str().unwrap(),
+        content.to_str().unwrap(),
+        audit.to_str().unwrap(),
+    );
+
+    let run = kx(&[
+        "run",
+        "--journal",
+        j,
+        "--content",
+        c,
+        "--audit-log",
+        a,
+        "--json",
+    ]);
+    assert!(
+        run.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let rv: serde_json::Value = serde_json::from_slice(&run.stdout).unwrap();
+    let digest = rv["digest"]
+        .as_str()
+        .expect("digest in --json output")
+        .to_string();
+
+    // The audit log exists and every line is valid line-delimited JSON.
+    let text = std::fs::read_to_string(&audit).expect("`kx run --audit-log` wrote the trail");
+    let lines: Vec<serde_json::Value> = text
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("each audit line is valid JSON"))
+        .collect();
+    assert!(!lines.is_empty(), "the trail is non-empty");
+
+    // Bookends: run_started first; run_completed last carrying the SAME digest the
+    // CLI printed (the audit trail and the engine agree, off the truth path).
+    assert_eq!(lines.first().unwrap()["type"], "run_started");
+    let done = lines.last().unwrap();
+    assert_eq!(done["type"], "run_completed");
+    assert_eq!(
+        done["digest"].as_str(),
+        Some(digest.as_str()),
+        "audit RunCompleted digest == the digest the CLI reported"
+    );
+    assert_eq!(done["committed"], 8);
+    assert_eq!(done["total"], 8);
+}
+
+#[test]
 fn missing_required_flag_is_usage_exit_2() {
     let out = kx(&["run", "--content", "/tmp/c"]); // no --journal
     assert_eq!(out.status.code(), Some(2), "usage error exits 2");

--- a/crates/kx-model-harness/src/bin/harness.rs
+++ b/crates/kx-model-harness/src/bin/harness.rs
@@ -71,6 +71,7 @@ fn main() -> ExitCode {
         crash_at,
         // Mirror the production binary default (M2.2b live checkpointing on).
         checkpoint_every: Some(kx_runtime::config::DEFAULT_CHECKPOINT_EVERY),
+        audit_log: None,
     };
 
     if mode == Mode::Digest {

--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -323,6 +323,8 @@ impl Harness {
             // capture_sink — off for the harness; the runtime seam captures only
             // the action, and `Full` reasoning/thinking enrichment is M3.2 (D67).
             None,
+            // audit_sink (R4) — off for the harness driver.
+            None,
         )
     }
 }

--- a/crates/kx-model-harness/tests/a0_guard.rs
+++ b/crates/kx-model-harness/tests/a0_guard.rs
@@ -25,6 +25,7 @@ fn seam_preserves_canonical_demo_digest() {
         // discardable checkpoint live (the checkpoint never touches the truth
         // path). This is test T9 of the M2.2b matrix.
         checkpoint_every: Some(2),
+        audit_log: None,
     };
     let outcome = kx_runtime::run(&config).unwrap();
     assert_eq!(outcome.committed, 8, "committed count");

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -195,6 +195,7 @@ fn config_for(dir: &Path) -> RuntimeConfig {
         mode: Mode::Run,
         crash_at: None,
         checkpoint_every: None,
+        audit_log: None,
     }
 }
 
@@ -247,6 +248,7 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         None,
         Some(&sink),
         None, // capture_sink (D67) — off for this assemble-wiring test
+        None, // audit_sink (R4) — off for this assemble-wiring test
     );
     let captured = inputs.lock().unwrap().clone();
     (result, captured)
@@ -452,6 +454,7 @@ fn image_parent_routes_child_to_multimodal_input() {
         None,
         Some(&sink),
         None,
+        None, // audit_sink (R4)
     );
     assert!(result.unwrap().is_complete(), "both Motes committed");
 

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -225,6 +225,7 @@ fn config_for(dir: &Path) -> RuntimeConfig {
         mode: Mode::Run,
         crash_at: None,
         checkpoint_every: None,
+        audit_log: None,
     }
 }
 
@@ -311,6 +312,7 @@ fn drive(
         None,
         Some(&sink),
         None, // capture_sink (D67) — off for this MCP HTTP e2e test
+        None, // audit_sink (R4) — off for this MCP HTTP e2e test
     );
     (result, store, journal, m_id)
 }

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -136,6 +136,7 @@ fn config_for(dir: &Path) -> RuntimeConfig {
         mode: Mode::Run,
         crash_at: None,
         checkpoint_every: None,
+        audit_log: None,
     }
 }
 
@@ -211,6 +212,7 @@ fn drive(
         None,
         Some(&sink),
         None, // capture_sink (D67) — off for this MCP model-driven test
+        None, // audit_sink (R4) — off for this MCP model-driven test
     );
     (result, store, journal, m_id)
 }

--- a/crates/kx-model-harness/tests/model_invariants.rs
+++ b/crates/kx-model-harness/tests/model_invariants.rs
@@ -43,6 +43,7 @@ fn config(dir: &Path) -> RuntimeConfig {
         // These invariants are unrelated to checkpointing; keep the cadence off
         // so no sidecar is written (recovery would read it harmlessly anyway).
         checkpoint_every: None,
+        audit_log: None,
     }
 }
 

--- a/crates/kx-model-harness/tests/planner_e2e.rs
+++ b/crates/kx-model-harness/tests/planner_e2e.rs
@@ -176,6 +176,7 @@ fn config_for(dir: &Path) -> RuntimeConfig {
         mode: Mode::Run,
         crash_at: None,
         checkpoint_every: None,
+        audit_log: None,
     }
 }
 
@@ -230,6 +231,7 @@ fn drive(
         None,
         Some(&sink),
         None,
+        None, // audit_sink (R4)
     );
     (result, calls.load(Ordering::SeqCst))
 }

--- a/crates/kx-runtime/Cargo.toml
+++ b/crates/kx-runtime/Cargo.toml
@@ -18,6 +18,9 @@ path = "src/main.rs"
 [dependencies]
 kx-mote       = { workspace = true }
 kx-capture    = { workspace = true }
+# R4 off-truth-path audit seam — wired into run_with_seams like capture_sink;
+# best-effort/non-fatal, timestamps never feed the digest. FFI-free leaf.
+kx-audit      = { workspace = true }
 kx-content    = { workspace = true }
 kx-journal    = { workspace = true }
 kx-projection = { workspace = true }
@@ -35,6 +38,8 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 rusqlite = { workspace = true }
+# Parse the R4 JSONL audit trail in tests/audit_trail.rs (test-only).
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kx-runtime/src/audit_sink.rs
+++ b/crates/kx-runtime/src/audit_sink.rs
@@ -1,0 +1,75 @@
+//! [`RuntimeAuditSink`] — the R4 off-truth-path audit seam.
+//!
+//! A thin kx-runtime handle over a pluggable [`kx_audit::AuditSink`], mirroring
+//! [`crate::CaptureSink`] / [`crate::SnapshotSink`]: the orchestrator
+//! ([`crate::run_with_seams`]) takes `Option<&RuntimeAuditSink>` and emits an
+//! [`kx_audit::AuditEvent`] at each lifecycle transition. `None` disables auditing
+//! (the byte-identity-without-overhead path); `Some` records the run's lifecycle
+//! to the wrapped sink.
+//!
+//! Like the other two seams it is **OFF THE TRUTH PATH**: audit is never journaled,
+//! is never a `MoteId` input, and never gates scheduling / promotion / eviction
+//! (the dependency wall in `kx-audit/tests/boundary.rs` is the compiler-enforced
+//! tripwire). Turning it on changes only what is *observed*, never the committed
+//! facts — so the canonical product digest `a6b5c679…` is byte-unchanged.
+//!
+//! It owns the run-scoped context (today: nothing beyond the wrapped sink; a
+//! future gateway wiring stamps the authenticated `principal` here without
+//! re-touching the run loop or the event enum).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use kx_audit::{AuditEvent, AuditSink, JsonlAuditSink};
+
+use crate::error::RuntimeError;
+
+/// A cheap, cloneable handle over a pluggable [`AuditSink`]. Clones share one
+/// underlying sink (an `Arc`), so the orchestrator and any reader observe the same
+/// trail.
+#[derive(Clone)]
+pub struct RuntimeAuditSink {
+    inner: Arc<dyn AuditSink>,
+}
+
+impl RuntimeAuditSink {
+    /// Wrap an arbitrary [`AuditSink`] (the general constructor — tests pass an
+    /// `Arc<InMemoryAuditSink>` and keep a clone to assert on its `events()`).
+    #[must_use]
+    pub fn from_arc(inner: Arc<dyn AuditSink>) -> Self {
+        Self { inner }
+    }
+
+    /// A run-scoped JSONL audit log at `path`, truncated fresh for this run (the
+    /// `kx run --audit-log` default). Open failure is surfaced here (fail-fast on
+    /// a bad path), never mid-run.
+    pub fn jsonl(path: impl AsRef<Path>) -> Result<Self, RuntimeError> {
+        let sink = JsonlAuditSink::create(path)?;
+        Ok(Self::from_arc(Arc::new(sink)))
+    }
+
+    /// Record one lifecycle event. Best-effort / non-fatal (delegates to the
+    /// wrapped sink, whose `record` cannot fail the run).
+    pub fn record(&self, event: AuditEvent) {
+        self.inner.record(event);
+    }
+
+    /// Flush any buffered records (the orchestrator calls this at run-complete).
+    pub fn flush(&self) {
+        self.inner.flush();
+    }
+
+    /// Number of events dropped due to backend write failures (best-effort telemetry).
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.inner.dropped()
+    }
+}
+
+impl std::fmt::Debug for RuntimeAuditSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeAuditSink")
+            .field("dropped", &self.inner.dropped())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/kx-runtime/src/config.rs
+++ b/crates/kx-runtime/src/config.rs
@@ -41,16 +41,24 @@ pub struct RuntimeConfig {
     /// still *reads* any existing sidecar — the read path is always safe). The
     /// sidecar only ever speeds up resume; it can never change the outcome.
     pub checkpoint_every: Option<u64>,
+    /// Off-truth-path audit log path (R4). `Some(path)` writes a best-effort JSONL
+    /// trail of the run's lifecycle, truncated fresh per run; `None` disables
+    /// auditing (the byte-identity-without-overhead path). Audit is never journaled
+    /// and never feeds the digest, so this never changes the run outcome.
+    pub audit_log: Option<PathBuf>,
 }
 
 impl RuntimeConfig {
     /// Parse `argv` (excluding the program name) into a [`RuntimeConfig`].
     ///
     /// Grammar: `<run|replay|digest> --journal <path> --content <dir>
-    /// [--crash-at <pre-commit-stc|post-commit-vtc>] [--checkpoint-every <N>]`.
+    /// [--crash-at <pre-commit-stc|post-commit-vtc>] [--checkpoint-every <N>]
+    /// [--audit-log <path>]`.
     /// `--crash-at` is honored only in `run` mode (a crash point in replay/digest
     /// is a config error). `--checkpoint-every 0` disables checkpoint writing;
-    /// omitting it uses [`DEFAULT_CHECKPOINT_EVERY`].
+    /// omitting it uses [`DEFAULT_CHECKPOINT_EVERY`]. `--audit-log <path>` enables
+    /// the off-truth-path JSONL audit trail for `run`/`replay` (ignored by
+    /// `digest`, which only prints a digest and exits).
     pub fn from_args<I, S>(args: I) -> Result<Self, RuntimeError>
     where
         I: IntoIterator<Item = S>,
@@ -77,6 +85,7 @@ impl RuntimeConfig {
         let mut content_root: Option<PathBuf> = None;
         let mut crash_at: Option<CrashPoint> = None;
         let mut checkpoint_every: Option<u64> = Some(DEFAULT_CHECKPOINT_EVERY);
+        let mut audit_log: Option<PathBuf> = None;
 
         while let Some(flag) = args.next() {
             let mut take_value = |name: &str| -> Result<String, RuntimeError> {
@@ -100,6 +109,7 @@ impl RuntimeConfig {
                     // 0 == disabled; any positive N is the cadence.
                     checkpoint_every = (n != 0).then_some(n);
                 }
+                "--audit-log" => audit_log = Some(PathBuf::from(take_value("--audit-log")?)),
                 other => {
                     return Err(RuntimeError::Config(format!("unknown flag {other:?}")));
                 }
@@ -123,6 +133,7 @@ impl RuntimeConfig {
             mode,
             crash_at,
             checkpoint_every,
+            audit_log,
         })
     }
 }
@@ -149,6 +160,52 @@ mod tests {
         assert_eq!(c.crash_at, Some(CrashPoint::PostCommitVtc));
         // Checkpointing is on by default at the coarse cadence.
         assert_eq!(c.checkpoint_every, Some(DEFAULT_CHECKPOINT_EVERY));
+        // Auditing is OFF by default (the byte-identity-without-overhead path).
+        assert_eq!(c.audit_log, None);
+    }
+
+    #[test]
+    fn audit_log_flag_parses_and_defaults_off() {
+        let on = RuntimeConfig::from_args([
+            "run",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--audit-log",
+            "/tmp/audit.jsonl",
+        ])
+        .unwrap();
+        assert_eq!(on.audit_log, Some(PathBuf::from("/tmp/audit.jsonl")));
+
+        // Honored in replay too.
+        let replay = RuntimeConfig::from_args([
+            "replay",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--audit-log",
+            "/tmp/a.jsonl",
+        ])
+        .unwrap();
+        assert_eq!(replay.audit_log, Some(PathBuf::from("/tmp/a.jsonl")));
+
+        // Absent by default.
+        let off = RuntimeConfig::from_args(["run", "--journal", "/tmp/j", "--content", "/tmp/c"])
+            .unwrap();
+        assert_eq!(off.audit_log, None);
+
+        // Missing value is a config error.
+        let bad = RuntimeConfig::from_args([
+            "run",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+            "--audit-log",
+        ]);
+        assert!(matches!(bad, Err(RuntimeError::Config(_))));
     }
 
     #[test]

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -15,9 +15,10 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use kx_audit::{AuditEvent, DispatchKind};
 use kx_capability::EffectRequest;
 use kx_capture::StepRecord;
-use kx_content::{ContentStore, LocalFsContentStore};
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_executor::{
     redispatch_wm_mote, run_native_critic_mote, run_pure_mote, run_wm_mote, CommitProtocol,
     LocalResourceManager, MoteExecutor, StandardCommitProtocol, TestMoteExecutor,
@@ -30,6 +31,7 @@ use kx_projection::{
 use kx_scheduler::{LocalPlacement, Scheduler};
 use kx_warrant::{FsScope, NetScope};
 
+use crate::audit_sink::RuntimeAuditSink;
 use crate::broker::DemoBroker;
 use crate::capture_sink::CaptureSink;
 use crate::checkpoint_io;
@@ -77,6 +79,34 @@ enum Action {
         /// `true` ⇒ recover an in-flight WM Mote (re-dispatch); `false` ⇒ fresh.
         recover: bool,
     },
+}
+
+impl Action {
+    /// The Mote being dispatched (R4 audit echo — already-derived, no recompute).
+    fn mote_id(&self) -> MoteId {
+        match self {
+            Action::RunPure(w) | Action::RunNativeCritic(w) => w.mote.id,
+            Action::RunWm { wm, .. } => wm.mote.id,
+        }
+    }
+
+    /// Its non-determinism class.
+    fn nd_class(&self) -> NdClass {
+        match self {
+            Action::RunPure(w) | Action::RunNativeCritic(w) => w.mote.nd_class(),
+            Action::RunWm { wm, .. } => wm.mote.nd_class(),
+        }
+    }
+
+    /// Which dispatch path this action takes (for the R4 audit trail).
+    fn dispatch_kind(&self) -> DispatchKind {
+        match self {
+            Action::RunPure(_) => DispatchKind::Pure,
+            Action::RunNativeCritic(_) => DispatchKind::Critic,
+            Action::RunWm { recover: false, .. } => DispatchKind::WmFresh,
+            Action::RunWm { recover: true, .. } => DispatchKind::WmRecovery,
+        }
+    }
 }
 
 /// Run (or replay) the canonical demo workflow per `config`. Returns the final
@@ -144,6 +174,16 @@ pub fn run_with_capture(
     ));
     let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker.clone());
 
+    // R4: enable the off-truth-path audit log iff the operator passed
+    // `--audit-log <path>` (a `kx run --audit-log` JSONL trail, truncated fresh per
+    // run). Open failure is surfaced here (fail-fast on a bad path), never mid-run.
+    // Audit is OFF the truth path, so the digest `a6b5c679…` is byte-unchanged
+    // whether the log is on or off.
+    let audit = match &config.audit_log {
+        Some(path) => Some(RuntimeAuditSink::jsonl(path)?),
+        None => None,
+    };
+
     run_with_seams(
         config,
         &workflow,
@@ -157,6 +197,7 @@ pub fn run_with_capture(
         // ever published ⇒ the truth path (digest `a6b5c679…`) is byte-unchanged.
         None,
         capture_sink,
+        audit.as_ref(),
     )
 }
 
@@ -204,6 +245,7 @@ pub fn run_with_seams<S, E, CP>(
     shaper: Option<(&WorkflowMote, &TopologyDecision)>,
     snapshot_sink: Option<&SnapshotSink>,
     capture_sink: Option<&CaptureSink>,
+    audit_sink: Option<&RuntimeAuditSink>,
 ) -> Result<RunOutcome, RuntimeError>
 where
     S: ContentStore + Send + Sync + 'static,
@@ -250,6 +292,24 @@ where
     // incremental fold doesn't re-apply (and trip `DuplicateCommitted`).
     let mut folded_through: u64 = journal.current_seq()?;
     log_recovery(recovery_outcome, folded_through, recovery_start.elapsed());
+    // R4: a resume folded an existing journal before the drive loop ran. Record
+    // the recovered frontier off the truth path. `folded_through` (the journal
+    // seq) is already in hand; the committed count is a ONE-TIME scan of the
+    // just-folded projection, run only when auditing is enabled — zero cost when
+    // `None`. (Per-Mote `MoteCommitted` events for the recovered set are emitted by
+    // the terminal sweep at run end, so they cover recovery-committed Motes too.)
+    if folded_through > 0 {
+        if let Some(a) = audit_sink {
+            let committed_through = projection
+                .iter_motes()
+                .filter(|(_, s)| *s == MoteState::Committed)
+                .count();
+            a.record(AuditEvent::Recovered {
+                committed_through: as_u32(committed_through),
+                folded_through,
+            });
+        }
+    }
     // Seed the cadence counter from the recovered frontier so the first
     // post-recovery checkpoint fires after N *new* entries, not immediately.
     let mut last_checkpoint_at = folded_through;
@@ -266,6 +326,13 @@ where
     // A shaperless workflow never derives children — start "done".
     let mut children_derived = shaper.is_none();
     let mut child_ids: Vec<MoteId> = Vec::new();
+
+    // R4: the drive loop is starting. Off the truth path — `None` ⇒ no event.
+    if let Some(a) = audit_sink {
+        a.record(AuditEvent::RunStarted {
+            runnable: as_u32(runnable.len()),
+        });
+    }
 
     // The drive loop.
     loop {
@@ -285,6 +352,16 @@ where
                     &mut runnable,
                     &mut child_ids,
                 );
+                // R4: the committed shaper just materialized its children into the
+                // runnable set. Echo the shaper id + child count off the truth path.
+                if children_derived {
+                    if let Some(a) = audit_sink {
+                        a.record(AuditEvent::ChildrenDerived {
+                            shaper: shaper_wm.mote.id,
+                            children: as_u32(child_ids.len()),
+                        });
+                    }
+                }
             }
         }
 
@@ -298,6 +375,15 @@ where
         // (it is in the ready set), so the snapshot carries their `result_ref`s.
         if let Some(sink) = snapshot_sink {
             sink.publish(projection.snapshot());
+        }
+        // R4: record the dispatch off the truth path (echoes the picked Mote's id +
+        // nd_class + which dispatch path was taken; no recomputation, SN-8).
+        if let Some(a) = audit_sink {
+            a.record(AuditEvent::MoteDispatched {
+                mote_id: action.mote_id(),
+                nd_class: action.nd_class(),
+                kind: action.dispatch_kind(),
+            });
         }
         match action {
             Action::RunPure(w) => {
@@ -392,6 +478,24 @@ where
     }
 
     let outcome = outcome(&runnable, &projection);
+
+    // R4: the run finished. Emit the per-Mote terminal-state trail + the run
+    // summary off the truth path, then flush best-effort. A single
+    // O(committed·log) sweep over the FINAL projection — flat per-Mote, and
+    // (unlike a per-dispatch state check) COMPLETE: it covers Motes committed by
+    // recovery before the loop ran. `RunCompleted.digest` is the product digest
+    // bytes (`a6b5c679…` for the canonical demo) — a tamper-evident receipt.
+    // No-op for `None` (the byte-identity-without-overhead path).
+    if let Some(a) = audit_sink {
+        audit_terminal_states(&runnable, &projection, a);
+        a.record(AuditEvent::RunCompleted {
+            committed: as_u32(outcome.committed),
+            total: as_u32(outcome.total),
+            digest: outcome.digest.0,
+        });
+        a.flush();
+    }
+
     if config.mode == Mode::Run && !outcome.is_complete() {
         // A clean run that didn't finish means a Mote is stuck (e.g. a WM Mote
         // with no EffectStaged hint the oracle refuses to re-dispatch).
@@ -655,6 +759,67 @@ fn capture_committed_actions(
     }
 }
 
+/// Saturating `usize → u32` for off-truth-path audit counts (avoids a cast lint;
+/// audit counts never approach `u32::MAX` in practice).
+fn as_u32(n: usize) -> u32 {
+    u32::try_from(n).unwrap_or(u32::MAX)
+}
+
+/// R4: emit one terminal-state [`AuditEvent`] per runnable Mote off the truth path.
+///
+/// A single O(committed·log) sweep over the FINAL projection — flat per-Mote and
+/// COMPLETE (it reads the same `(result_ref, nd_class)` the digest folds, so the
+/// emitted `MoteCommitted` set is exactly the digest's committed set, and it covers
+/// Motes committed by recovery before the loop ran). Non-terminal Motes
+/// (`Pending`/`Scheduled`) emit nothing. Echoes already-derived projection state —
+/// it NEVER recomputes a `MoteId` (SN-8) and NEVER reads payload bytes.
+fn audit_terminal_states(
+    runnable: &[WorkflowMote],
+    projection: &Projection,
+    sink: &RuntimeAuditSink,
+) {
+    for w in runnable {
+        let id = w.mote.id;
+        if let Some(event) = terminal_event_for(
+            id,
+            projection.state_of(&id),
+            projection.result_ref_of(&id),
+            projection.nondeterminism_of(&id),
+        ) {
+            sink.record(event);
+        }
+    }
+}
+
+/// Pure mapping from a Mote's FINAL projection state to its terminal audit event
+/// (R4). Extracted so the per-state mapping — including the rarely-reached
+/// `Failed`/`Repudiated`/`Inconsistent` cases — is exhaustively unit-testable
+/// without standing up a run. `Committed` echoes the SAME `(result_ref, nd_class)`
+/// the digest folds (so the emitted `MoteCommitted` set is exactly the digest's
+/// committed set); a `Committed` missing either is skipped (it would not be in the
+/// digest either). Non-terminal states (`Pending`/`Scheduled`) emit nothing.
+fn terminal_event_for(
+    id: MoteId,
+    state: MoteState,
+    result_ref: Option<ContentRef>,
+    nd_class: Option<NdClass>,
+) -> Option<AuditEvent> {
+    match state {
+        MoteState::Committed => match (result_ref, nd_class) {
+            (Some(result_ref), Some(nd_class)) => Some(AuditEvent::MoteCommitted {
+                mote_id: id,
+                result_ref,
+                nd_class,
+            }),
+            _ => None,
+        },
+        MoteState::Failed => Some(AuditEvent::MoteFailed { mote_id: id }),
+        MoteState::Repudiated => Some(AuditEvent::MoteRepudiated { mote_id: id }),
+        MoteState::Inconsistent => Some(AuditEvent::MoteInconsistent { mote_id: id }),
+        MoteState::Pending | MoteState::Scheduled => None,
+    }
+}
+
 fn outcome(runnable: &[WorkflowMote], projection: &Projection) -> RunOutcome {
     let committed = runnable
         .iter()
@@ -696,4 +861,220 @@ pub fn canonical_mote_ids() -> Vec<MoteId> {
         .iter()
         .map(|w: &WorkflowMote| w.mote.id)
         .collect()
+}
+
+#[cfg(test)]
+mod audit_tests {
+    //! R4 audit-seam unit tests over the engine internals: the pure terminal-state
+    //! mapping (exhaustive over every `MoteState`) and the terminal sweep driven by
+    //! a REAL projection folded into each terminal state (the "producing" test for
+    //! the `Failed`/`Repudiated`/`Inconsistent` variants the canonical demo never
+    //! reaches on its own).
+
+    use std::sync::Arc;
+
+    use kx_audit::{AuditEvent, DispatchKind, InMemoryAuditSink};
+    use kx_content::ContentRef;
+    use kx_journal::{FailureReason, JournalEntry, RepudiationReason};
+    use kx_mote::{MoteDefHash, MoteId, NdClass};
+    use smallvec::SmallVec;
+
+    use super::*;
+
+    fn cref(b: u8) -> ContentRef {
+        ContentRef::from_bytes([b; 32])
+    }
+
+    // `key` is a distinct per-Mote idempotency byte so different Motes' entries
+    // never collide in the dedup index `(idempotency_key, kind)`.
+    fn committed(
+        mote_id: MoteId,
+        seq: u64,
+        key: u8,
+        nd: NdClass,
+        result_ref: ContentRef,
+    ) -> JournalEntry {
+        JournalEntry::Committed {
+            mote_id,
+            idempotency_key: [key; 32],
+            seq,
+            nondeterminism: nd,
+            result_ref,
+            parents: SmallVec::new(),
+            warrant_ref: cref(0xaa),
+            mote_def_hash: MoteDefHash::from_bytes([key; 32]),
+        }
+    }
+
+    fn failed(mote_id: MoteId, seq: u64, key: u8) -> JournalEntry {
+        JournalEntry::Failed {
+            mote_id,
+            idempotency_key: [key; 32],
+            seq,
+            reason_class: FailureReason::TimedOut,
+            reporter_id: 0,
+        }
+    }
+
+    fn effect_staged(mote_id: MoteId, seq: u64, key: u8) -> JournalEntry {
+        JournalEntry::EffectStaged {
+            mote_id,
+            idempotency_key: [key; 32],
+            seq,
+        }
+    }
+
+    fn repudiated(
+        target_mote_id: MoteId,
+        target_committed_seq: u64,
+        seq: u64,
+        key: u8,
+    ) -> JournalEntry {
+        JournalEntry::Repudiated {
+            target_mote_id,
+            idempotency_key: [key; 32],
+            seq,
+            target_committed_seq,
+            reason_class: RepudiationReason::OperatorAction,
+            repudiator_id: 0,
+        }
+    }
+
+    #[test]
+    fn terminal_event_maps_every_state() {
+        let id = MoteId::from_bytes([1u8; 32]);
+        let r = cref(2);
+
+        // Committed with both refs → MoteCommitted echoing the digest's tuple.
+        assert_eq!(
+            terminal_event_for(
+                id,
+                MoteState::Committed,
+                Some(r),
+                Some(NdClass::WorldMutating)
+            ),
+            Some(AuditEvent::MoteCommitted {
+                mote_id: id,
+                result_ref: r,
+                nd_class: NdClass::WorldMutating,
+            })
+        );
+        // Committed missing a ref is NOT emitted (it would not be in the digest either).
+        assert_eq!(
+            terminal_event_for(id, MoteState::Committed, None, Some(NdClass::Pure)),
+            None
+        );
+        assert_eq!(
+            terminal_event_for(id, MoteState::Committed, Some(r), None),
+            None
+        );
+        // The terminal failure / anomaly states each map to their event.
+        assert_eq!(
+            terminal_event_for(id, MoteState::Failed, None, None),
+            Some(AuditEvent::MoteFailed { mote_id: id })
+        );
+        assert_eq!(
+            terminal_event_for(id, MoteState::Repudiated, None, None),
+            Some(AuditEvent::MoteRepudiated { mote_id: id })
+        );
+        assert_eq!(
+            terminal_event_for(id, MoteState::Inconsistent, None, None),
+            Some(AuditEvent::MoteInconsistent { mote_id: id })
+        );
+        // Non-terminal states emit nothing.
+        assert_eq!(terminal_event_for(id, MoteState::Pending, None, None), None);
+        assert_eq!(
+            terminal_event_for(id, MoteState::Scheduled, None, None),
+            None
+        );
+    }
+
+    #[test]
+    fn sweep_emits_each_terminal_state_from_a_real_projection() {
+        // Real demo Motes give real ids; we fold crafted journal entries to drive
+        // four of them into Committed / Failed / Repudiated / Inconsistent and leave
+        // the rest Pending, then assert the sweep emits exactly the right trail.
+        let wf = DemoWorkflow::canonical();
+        assert!(
+            wf.motes.len() >= 5,
+            "demo declares enough motes for the matrix"
+        );
+        let ids: Vec<MoteId> = wf.motes.iter().map(|w| w.mote.id).collect();
+
+        let mut p = Projection::new();
+        // motes[0] → Committed (nd = ReadOnlyNondet, result_ref = cref(9)).
+        p.fold(&committed(
+            ids[0],
+            1,
+            0xa0,
+            NdClass::ReadOnlyNondet,
+            cref(9),
+        ))
+        .unwrap();
+        // motes[1] → Failed.
+        p.fold(&failed(ids[1], 2, 0xa1)).unwrap();
+        // motes[2] → Committed(seq 3) then Repudiated(target 3).
+        p.fold(&committed(ids[2], 3, 0xa2, NdClass::Pure, cref(3)))
+            .unwrap();
+        p.fold(&repudiated(ids[2], 3, 4, 0xa2)).unwrap();
+        // motes[3] → EffectStaged then Repudiated-without-Committed (cell-8 anomaly).
+        p.fold(&effect_staged(ids[3], 5, 0xa3)).unwrap();
+        p.fold(&repudiated(ids[3], 0, 6, 0xa3)).unwrap();
+        // motes[4..] left Pending (never folded).
+
+        assert_eq!(p.state_of(&ids[0]), MoteState::Committed);
+        assert_eq!(p.state_of(&ids[1]), MoteState::Failed);
+        assert_eq!(p.state_of(&ids[2]), MoteState::Repudiated);
+        assert_eq!(p.state_of(&ids[3]), MoteState::Inconsistent);
+
+        let mem = InMemoryAuditSink::new();
+        let sink = RuntimeAuditSink::from_arc(Arc::new(mem.clone()));
+        audit_terminal_states(&wf.motes, &p, &sink);
+
+        let events = mem.events();
+        assert_eq!(
+            events,
+            vec![
+                AuditEvent::MoteCommitted {
+                    mote_id: ids[0],
+                    result_ref: cref(9),
+                    nd_class: NdClass::ReadOnlyNondet,
+                },
+                AuditEvent::MoteFailed { mote_id: ids[1] },
+                AuditEvent::MoteRepudiated { mote_id: ids[2] },
+                AuditEvent::MoteInconsistent { mote_id: ids[3] },
+            ],
+            "the sweep emits one terminal event per non-pending Mote, in runnable order"
+        );
+    }
+
+    #[test]
+    fn action_accessors_echo_the_picked_mote() {
+        // The dispatch-kind mapping the MoteDispatched event relies on.
+        let wf = DemoWorkflow::canonical();
+        let w = wf.motes[0].clone();
+        let pure = Action::RunPure(w.clone());
+        assert_eq!(pure.dispatch_kind(), DispatchKind::Pure);
+        assert_eq!(pure.mote_id(), w.mote.id);
+        let critic = Action::RunNativeCritic(w.clone());
+        assert_eq!(critic.dispatch_kind(), DispatchKind::Critic);
+        let fresh = Action::RunWm {
+            wm: w.clone(),
+            recover: false,
+        };
+        assert_eq!(fresh.dispatch_kind(), DispatchKind::WmFresh);
+        let recovery = Action::RunWm {
+            wm: w.clone(),
+            recover: true,
+        };
+        assert_eq!(recovery.dispatch_kind(), DispatchKind::WmRecovery);
+        assert_eq!(recovery.nd_class(), w.mote.nd_class());
+    }
+
+    #[test]
+    fn as_u32_saturates() {
+        assert_eq!(as_u32(0), 0);
+        assert_eq!(as_u32(8), 8);
+        assert_eq!(as_u32(usize::MAX), u32::MAX);
+    }
 }

--- a/crates/kx-runtime/src/error.rs
+++ b/crates/kx-runtime/src/error.rs
@@ -42,6 +42,13 @@ pub enum RuntimeError {
     #[error("config: {0}")]
     Config(String),
 
+    /// Opening the off-truth-path audit log failed (R4). Surfaced at construction
+    /// (fail-fast on a misconfigured `--audit-log` path) — record-time audit write
+    /// failures are best-effort and NEVER surface here (they are swallowed +
+    /// counted via `kx_audit::AuditSink::dropped`).
+    #[error("audit: {0}")]
+    Audit(#[from] kx_audit::AuditError),
+
     /// A verified schema migration ([`crate::migrate_and_verify`]) rewrote the
     /// journal but the result did not preserve the run's product identity — the
     /// up-converted source and the migrated destination fold to different

--- a/crates/kx-runtime/src/lib.rs
+++ b/crates/kx-runtime/src/lib.rs
@@ -54,6 +54,7 @@
 //! run, (b) no Mote has more than one `Committed` entry, (c) a fresh process
 //! folding only the journal reconstructs a bit-identical projection.
 
+pub mod audit_sink;
 pub mod broker;
 pub mod capture_sink;
 pub mod checkpoint_io;
@@ -67,6 +68,7 @@ pub mod snapshot_sink;
 pub mod topology;
 pub mod workflow;
 
+pub use audit_sink::RuntimeAuditSink;
 pub use capture_sink::CaptureSink;
 pub use config::{Mode, RuntimeConfig};
 pub use crash::CrashPoint;
@@ -76,6 +78,9 @@ pub use engine::{
     RunOutcome,
 };
 pub use error::RuntimeError;
+// Re-export the audit vocabulary so callers (CLI / harness / future gateway) use
+// the runtime facade, mirroring how `CaptureSink` fronts `kx-capture`.
+pub use kx_audit::{AuditEvent, AuditSink, DispatchKind, InMemoryAuditSink, JsonlAuditSink};
 pub use migrate::migrate_and_verify;
 pub use snapshot_sink::SnapshotSink;
 pub use workflow::DemoWorkflow;

--- a/crates/kx-runtime/tests/audit_trail.rs
+++ b/crates/kx-runtime/tests/audit_trail.rs
@@ -1,0 +1,280 @@
+//! R4 — the off-truth-path audit trail, end-to-end over the PUBLIC engine path
+//! (`kx_runtime::run` + `RuntimeConfig.audit_log`, i.e. exactly what
+//! `kx run --audit-log <path>` drives). These tests prove the headline guarantees:
+//! auditing never perturbs the truth (digest `a6b5c679…` invariant with audit ON),
+//! the trail is a complete + ordered + deterministic JSONL stream, and recovery is
+//! audited as a re-read (zero re-dispatch) that still covers every committed Mote.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+
+use kx_runtime::config::Mode;
+use kx_runtime::RuntimeConfig;
+use serde_json::Value;
+
+/// The canonical projection digest (schema v5) — the durability law: audit ON,
+/// audit OFF, or inspected, the committed-facts digest is byte-identical.
+const CANONICAL_DIGEST: &str = "a6b5c67939f14bfcbd125f7461b2bd0e481f6ee2fc98c1ab638730e2d2ace2e9";
+
+fn read_jsonl(path: &Path) -> Vec<Value> {
+    let text = std::fs::read_to_string(path).expect("audit log written");
+    text.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("each audit line is valid JSON"))
+        .collect()
+}
+
+fn types(lines: &[Value]) -> Vec<String> {
+    lines
+        .iter()
+        .map(|l| {
+            l["type"]
+                .as_str()
+                .expect("every line is tagged")
+                .to_string()
+        })
+        .collect()
+}
+
+fn count(lines: &[Value], ty: &str) -> usize {
+    types(lines).iter().filter(|t| *t == ty).count()
+}
+
+fn is_hex64(v: &Value) -> bool {
+    v.as_str().is_some_and(|s| {
+        s.len() == 64
+            && s.bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    })
+}
+
+fn run_cfg(dir: &Path, mode: Mode, audit: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("journal.sqlite"),
+        content_root: dir.join("content"),
+        mode,
+        crash_at: None,
+        checkpoint_every: Some(2),
+        audit_log: Some(audit.to_path_buf()),
+    }
+}
+
+#[test]
+fn audit_off_preserves_canonical_digest() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = RuntimeConfig {
+        journal_path: dir.path().join("j.sqlite"),
+        content_root: dir.path().join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: Some(2),
+        audit_log: None,
+    };
+    let out = kx_runtime::run(&cfg).unwrap();
+    assert_eq!((out.committed, out.total), (8, 8));
+    assert_eq!(out.digest.to_hex(), CANONICAL_DIGEST);
+}
+
+#[test]
+fn audit_on_preserves_digest_and_writes_ordered_trail() {
+    let dir = tempfile::tempdir().unwrap();
+    let audit = dir.path().join("audit.jsonl");
+    let out = kx_runtime::run(&run_cfg(dir.path(), Mode::Run, &audit)).unwrap();
+
+    // The durability law: audit ON does not change the committed-facts digest.
+    assert_eq!((out.committed, out.total), (8, 8));
+    assert_eq!(
+        out.digest.to_hex(),
+        CANONICAL_DIGEST,
+        "audit must not perturb the digest"
+    );
+
+    let lines = read_jsonl(&audit);
+    let tys = types(&lines);
+
+    // Envelope: seq is gap-free from 0, ts_ms present + numeric on every line.
+    for (i, l) in lines.iter().enumerate() {
+        assert_eq!(l["seq"].as_u64(), Some(i as u64), "seq is gap-free from 0");
+        assert!(
+            l["ts_ms"].is_u64(),
+            "ts_ms present + numeric (off the digest)"
+        );
+        assert!(l.get("principal").is_none(), "no principal unless set");
+    }
+
+    // Shape: starts with run_started, ends with run_completed, one children_derived.
+    assert_eq!(tys.first().map(String::as_str), Some("run_started"));
+    assert_eq!(tys.last().map(String::as_str), Some("run_completed"));
+    assert_eq!(
+        count(&lines, "children_derived"),
+        1,
+        "the one shaper unrolls once"
+    );
+
+    // The canonical demo dispatches 8 Motes and commits 8.
+    assert_eq!(
+        count(&lines, "mote_dispatched"),
+        8,
+        "8 dispatches in the clean run"
+    );
+    assert_eq!(
+        count(&lines, "mote_committed"),
+        8,
+        "8 committed Motes in the sweep"
+    );
+
+    // The terminal sweep runs AFTER the loop: every mote_committed comes after every
+    // mote_dispatched.
+    let last_dispatch = tys.iter().rposition(|t| t == "mote_dispatched").unwrap();
+    let first_commit = tys.iter().position(|t| t == "mote_committed").unwrap();
+    assert!(
+        last_dispatch < first_commit,
+        "committed sweep is terminal (after all dispatch)"
+    );
+
+    // children_derived happens during the loop (before the terminal sweep).
+    let children = tys.iter().position(|t| t == "children_derived").unwrap();
+    assert!(children < first_commit, "children derive during the loop");
+
+    // The committed set == the dispatched set (8 unique hex ids), and each is hex.
+    let dispatched: std::collections::BTreeSet<String> = lines
+        .iter()
+        .filter(|l| l["type"] == "mote_dispatched")
+        .map(|l| {
+            assert!(
+                is_hex64(&l["mote_id"]),
+                "dispatched mote_id is 64-hex, not an int array"
+            );
+            l["mote_id"].as_str().unwrap().to_string()
+        })
+        .collect();
+    let committed: std::collections::BTreeSet<String> = lines
+        .iter()
+        .filter(|l| l["type"] == "mote_committed")
+        .map(|l| {
+            assert!(is_hex64(&l["mote_id"]), "committed mote_id is 64-hex");
+            assert!(is_hex64(&l["result_ref"]), "result_ref is 64-hex");
+            let nd = l["nd_class"].as_str().unwrap();
+            assert!(
+                matches!(nd, "pure" | "read_only_nondet" | "world_mutating"),
+                "nd_class is a known class (no float/similarity on the audit path), got {nd:?}"
+            );
+            l["mote_id"].as_str().unwrap().to_string()
+        })
+        .collect();
+    assert_eq!(dispatched.len(), 8);
+    assert_eq!(
+        dispatched, committed,
+        "the audited committed set == the dispatched set"
+    );
+
+    // run_completed is the tamper-evident receipt: 8/8 + the canonical digest hex.
+    let done = lines.last().unwrap();
+    assert_eq!(done["committed"].as_u64(), Some(8));
+    assert_eq!(done["total"].as_u64(), Some(8));
+    assert_eq!(
+        done["digest"].as_str(),
+        Some(CANONICAL_DIGEST),
+        "RunCompleted carries the product digest"
+    );
+
+    // Every dispatch carries a known kind (the mapping is exercised per-variant in
+    // the engine unit test `action_accessors_echo_the_picked_mote`).
+    for l in lines.iter().filter(|l| l["type"] == "mote_dispatched") {
+        let kind = l["kind"].as_str().unwrap();
+        assert!(
+            matches!(kind, "pure" | "critic" | "wm_fresh" | "wm_recovery"),
+            "dispatch kind is one of the known dispatch paths, got {kind:?}"
+        );
+    }
+}
+
+#[test]
+fn audit_trail_is_deterministic_across_runs() {
+    // Two independent runs produce byte-identical trails modulo the wall-clock
+    // (ts_ms) — the typed events carry no time, so order + ids + counts are stable.
+    let normalize = |lines: Vec<Value>| -> Vec<Value> {
+        lines
+            .into_iter()
+            .map(|mut l| {
+                if let Some(obj) = l.as_object_mut() {
+                    obj.remove("ts_ms");
+                }
+                l
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let dir_a = tempfile::tempdir().unwrap();
+    let audit_a = dir_a.path().join("a.jsonl");
+    kx_runtime::run(&run_cfg(dir_a.path(), Mode::Run, &audit_a)).unwrap();
+
+    let dir_b = tempfile::tempdir().unwrap();
+    let audit_b = dir_b.path().join("b.jsonl");
+    kx_runtime::run(&run_cfg(dir_b.path(), Mode::Run, &audit_b)).unwrap();
+
+    assert_eq!(
+        normalize(read_jsonl(&audit_a)),
+        normalize(read_jsonl(&audit_b)),
+        "the audit trail is deterministic (time excluded)"
+    );
+}
+
+#[test]
+fn recovery_is_audited_as_reread_not_rerun() {
+    // Run once to a complete journal, then REPLAY the same journal with audit on.
+    // The headline novel claim, made observable: recovery RE-READS the committed
+    // facts (zero re-dispatch) yet the audit trail still covers every committed
+    // Mote (the terminal sweep reads the folded projection, not the loop).
+    let dir = tempfile::tempdir().unwrap();
+    let audit1 = dir.path().join("run.jsonl");
+    let first = kx_runtime::run(&run_cfg(dir.path(), Mode::Run, &audit1)).unwrap();
+    assert_eq!((first.committed, first.total), (8, 8));
+
+    let audit2 = dir.path().join("replay.jsonl");
+    let replay = kx_runtime::run(&run_cfg(dir.path(), Mode::Replay, &audit2)).unwrap();
+    assert_eq!((replay.committed, replay.total), (8, 8));
+    assert_eq!(
+        replay.digest.to_hex(),
+        CANONICAL_DIGEST,
+        "replay digest == original"
+    );
+
+    let lines = read_jsonl(&audit2);
+
+    // Exactly one Recovered, reporting the folded frontier (all 8 already committed).
+    assert_eq!(
+        count(&lines, "recovered"),
+        1,
+        "replay folds an existing journal once"
+    );
+    let rec = lines.iter().find(|l| l["type"] == "recovered").unwrap();
+    assert_eq!(
+        rec["committed_through"].as_u64(),
+        Some(8),
+        "8 committed Motes recovered"
+    );
+    assert!(
+        rec["folded_through"].as_u64().unwrap() > 0,
+        "folded past the empty journal"
+    );
+
+    // The novel claim, audited: NOTHING is re-dispatched on a fully-committed replay.
+    assert_eq!(
+        count(&lines, "mote_dispatched"),
+        0,
+        "recovery re-reads, never re-runs"
+    );
+    // …yet the trail still covers every committed Mote (the recovery-safe sweep).
+    assert_eq!(
+        count(&lines, "mote_committed"),
+        8,
+        "all committed Motes audited on replay"
+    );
+    assert_eq!(
+        types(&lines).last().map(String::as_str),
+        Some("run_completed"),
+        "replay completes the trail"
+    );
+}

--- a/crates/kx-runtime/tests/capture_flip.rs
+++ b/crates/kx-runtime/tests/capture_flip.rs
@@ -23,6 +23,7 @@ fn cfg(dir: &std::path::Path, mode: Mode) -> RuntimeConfig {
         // Cadence 2 over the 8-Mote demo: capture co-exists with checkpointing
         // (both fire at the loop-bottom frontier) without perturbing either.
         checkpoint_every: Some(2),
+        audit_log: None,
     }
 }
 

--- a/crates/kx-runtime/tests/checkpoint_recovery.rs
+++ b/crates/kx-runtime/tests/checkpoint_recovery.rs
@@ -22,6 +22,7 @@ fn cfg(dir: &Path, checkpoint_every: Option<u64>) -> RuntimeConfig {
         mode: Mode::Run,
         crash_at: None,
         checkpoint_every,
+        audit_log: None,
     }
 }
 

--- a/crates/kx-runtime/tests/clean_run.rs
+++ b/crates/kx-runtime/tests/clean_run.rs
@@ -18,6 +18,7 @@ fn cfg(dir: &std::path::Path, mode: Mode) -> RuntimeConfig {
         // sidecars, and the "replay is a no-op" case then exercises the
         // seeded-recovery (happy) path — recovery stays bit-identical.
         checkpoint_every: Some(2),
+        audit_log: None,
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -174,6 +174,7 @@ scale-smoke:
     cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-journal --release --test schema_evolution -- --ignored --nocapture --test-threads=1
     cargo test -p kx-capture --release --test scale -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-audit --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-catalog --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-fleet --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-gateway-core --release --test scale -- --ignored --nocapture --test-threads=1


### PR DESCRIPTION
## R4 (D130) — `kx-audit` sink: the off-truth-path runtime audit trail

Closes the architecture audit's **"no observability"** gap (the v0.1.0 reachability track, R4 / D127 step 2.1). Adds a structured, append-only, **off-the-truth-path** audit trail of the runtime's execution lifecycle, wired into `kx-runtime::run_with_seams` exactly like `capture_sink` — **best-effort / non-fatal**, with **timestamps that never feed the digest** — plus a `kx run --audit-log <path>` enablement so it's reachable by an operator (not left as the "wired-but-unused" dead code this track exists to remove).

### What this adds
- **NEW leaf crate `kx-audit`** (38→39 crates; template = `kx-capture`'s shape): the `AuditSink` trait (`record(&self, AuditEvent)` returns **unit** → non-fatal is *structural* + `flush()` + observable `dropped()`), the time-free/float-free `AuditEvent` enum, two impls `InMemoryAuditSink` (deterministic test/embed) + `JsonlAuditSink` (best-effort buffered JSONL, fail-fast open, flush-on-`Drop`), and a **hex wire DTO** that renders ids/digests as lowercase hex (`MoteId`/`ContentRef` default-serde would emit a 32-int array no SIEM could correlate). Deps: `kx-mote`, `kx-content`, `serde`, `serde_json`, `thiserror`, `tracing` — all already workspace-approved (no new dependency, no toolchain change).
- **`kx-runtime` wiring**: a `RuntimeAuditSink` newtype over `Arc<dyn AuditSink>` (mirrors `CaptureSink`/`SnapshotSink`); `run_with_seams` gains `audit_sink: Option<&RuntimeAuditSink>` (param #11); inline events (`RunStarted` / `Recovered` / `ChildrenDerived` / `MoteDispatched`) + a **terminal sweep** (`MoteCommitted`/`MoteFailed`/`MoteRepudiated`/`MoteInconsistent` then `RunCompleted{digest}`) that is flat and **recovery-safe** (covers Motes committed before the loop ran, unlike a per-dispatch check).
- **CLI enablement**: `RuntimeConfig.audit_log` + `--audit-log <path>` (run/replay), forwarded verbatim by `kx`; help text updated.

### Don't-break invariants (verified)
- **Frozen trio `kx-scheduler`/`kx-executor`/`kx-inference` `src/**` diff-EMPTY** (additive crate + runtime-only wiring).
- **Projection digest `a6b5c679…` invariant** — `a0_guard` green, plus a new test proving the digest is byte-identical with audit **ON**, and `RunCompleted.digest` echoes it.
- **SN-8** — every `AuditEvent` is an already-derived id/hash/class/integer (no recompute of a `MoteId`); **no float, no time** in the typed event (time lives only on the JSONL wire).
- **Off the truth path** — `tests/boundary.rs` tripwire pins that the guarantee-path crates never depend on `kx-audit`.

### Golden Rule 8 — pre-flight
**Pass A (a) breaks:** the only correctness risk (audit trail disagreeing with the digest's committed set) is closed by the terminal sweep reading the same `(result_ref, nd_class)` the digest folds — proven by the ordered-trail + recovery-coverage tests. **(b) perf:** zero cost when `None` (guarded `if let Some`); flat per-event when `Some` (no per-event fsync; no O(n) hot-path scan; serialize before the writer lock); hex ids are ~2× smaller than the int-array default. `scale-smoke` gains a flat-per-event gate (1k→25k). **(c) security:** records **join keys only** — never payload bytes / model output / warrant secrets; no rotation (documented "caller owns retention") + a `dropped()` counter so loss is observable; best-effort buffering may lose the tail on hard-crash (acceptable — the journal is the durable truth; flush-on-`Drop` + run-complete flush minimize it).

**Pass B:** seams a future **principal/`run_id` envelope** (the gateway "who did what" — fast-follow) and a tamper-evident hash-chain; flags the `Seams` builder refactor + a rotating sink as named follow-ons. No tech-stack change required.

### Tests
`kx-audit` unit/property (wire hex, seq monotonic + gap-free under concurrency, open-failure-at-construction, flush + Drop-flush, truncate/append, principal, poison recovery, dropped counter); `kx-runtime` inline (exhaustive `terminal_event_for` over all 6 `MoteState`s + a real-projection sweep driving Committed/Failed/Repudiated/Inconsistent + dispatch-kind mapping); `kx-runtime` integration (`tests/audit_trail.rs`: digest-invariant-with-audit-ON + full ordered trail + determinism + **recovery audited as re-read with zero re-dispatch**); `kx-cli` e2e (`kx run --audit-log` writes a parseable trail whose `RunCompleted.digest` == the CLI digest). Full `just ci` green (fmt · clippy `-D warnings` · test · deny · doc `-D warnings` · ffi-link · build-no-inference · I1.c byte-determinism · scale-smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
