### PR TITLE
feat(gateway,cli): R5 (D130) — live-tail StreamEvents + WebSocket bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1248,6 +1261,7 @@ name = "kx-gateway"
 version = "0.0.1"
 dependencies = [
  "bincode",
+ "futures-util",
  "kx-capability",
  "kx-catalog",
  "kx-content",
@@ -1261,13 +1275,18 @@ dependencies = [
  "kx-warrant",
  "kx-worker",
  "kx-workflow",
+ "serde",
+ "serde_json",
  "smallvec",
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -2448,6 +2467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2710,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +2892,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +2971,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,16 @@ tokio              = { version = "1", features = ["rt-multi-thread", "macros", "
 # present transitively (tonic pulls it in) — promoting it to a direct dep adds NO
 # new crate to the build/deny graph; `tokio_stream::iter` backs the resumable cursor.
 tokio-stream       = "0.1"
+# R5 (D120.3): the WebSocket bridge transport for the browser `StreamEvents`
+# surface, in the `kx-gateway` binary only (the dep wall keeps kx-gateway-core a
+# passive read-fold). MIT; default features = plaintext handshake + client connect
+# (no TLS backend — loopback dev, transport TLS is a later seam like gRPC TLS);
+# http/hyper/tower already locked via tonic, so this adds the tungstenite codec only.
+tokio-tungstenite  = "0.24"
+# R5: `Sink`/`Stream` combinators for the WS bridge (split read/write so the
+# server pushes frames while handling the client's Close/Ping). MIT/Apache;
+# already transitive via tonic/hyper. Lean feature set (no executor/io-compat).
+futures-util       = { version = "0.3", default-features = false, features = ["std", "sink", "async-await"] }
 tonic-build        = "0.12"
 protoc-bin-vendored = "3"
 

--- a/crates/kx-cli/Cargo.toml
+++ b/crates/kx-cli/Cargo.toml
@@ -40,7 +40,9 @@ kx-gateway = { workspace = true }
 tempfile   = { workspace = true }
 # `net` for the E2E readiness probe (wait until the in-process gateway's port
 # accepts before driving the CLI — the serve task may bind just after `start`).
-tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net"] }
+# `process`/`io-util` for the R5 `events --follow` E2E (spawn the long-running
+# follow subprocess + read its stdout line-by-line, then kill it).
+tokio      = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net", "process", "io-util"] }
 # Parse the verbs' --json output back in the E2E assertions (separate test crate
 # ⇒ a dev-dep even though it's a normal dep of the lib).
 serde_json = { workspace = true }

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -22,9 +22,10 @@ usage: kx <command> [args]
                          [--audit-log <path>] [--json]
 
   server:
-    kx serve --journal <path> --content <dir> [--listen <addr:port>] [--dev-allow-local]
-             [--auth-token <tok>=<party>]... [--auth-token-file <path>] [--max-lease N] [--catalog-dir <dir>]
-             (--listen defaults to 127.0.0.1:50151)
+    kx serve --journal <path> --content <dir> [--listen <addr:port>] [--ws-listen <addr:port>]
+             [--dev-allow-local] [--auth-token <tok>=<party>]... [--auth-token-file <path>]
+             [--max-lease N] [--catalog-dir <dir>]
+             (--listen defaults to 127.0.0.1:50151; --ws-listen — the live-event WebSocket — to :50152)
 
   client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --json):
     kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>]
@@ -259,8 +260,9 @@ kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--check
   (off the truth path; never changes the digest). Honored by run/replay."
             .into(),
         "serve" => "\
-kx serve --journal <path> --content <dir> [--listen <addr:port>] [--dev-allow-local] ...
-  Hosts the embedded single-system gateway. --listen defaults to 127.0.0.1:50151.
+kx serve --journal <path> --content <dir> [--listen <addr:port>] [--ws-listen <addr:port>] [--dev-allow-local] ...
+  Hosts the embedded single-system gateway. --listen (gRPC) defaults to 127.0.0.1:50151;
+  --ws-listen (the R5 live-event WebSocket bridge) defaults to 127.0.0.1:50152.
   Deny-all by default: pass --dev-allow-local (loopback only) or --auth-token(-file)."
             .into(),
         "invoke" => "\

--- a/crates/kx-cli/src/verbs/events.rs
+++ b/crates/kx-cli/src/verbs/events.rs
@@ -1,21 +1,19 @@
 //! `kx events --instance <hex16> [--since N] [--follow]` — print a run's event
-//! deltas. `StreamEvents` is snapshot-to-head today (it catches up to the
-//! current journal boundary and ends); `--follow` re-polls from the last cursor
-//! on a bounded backoff until Ctrl-C. True live-tail arrives with the R5
-//! WebSocket bridge — the verb surface is unchanged when it does.
-
-use std::time::Duration;
+//! deltas. Without `--follow` it reads one snapshot (`since_seq` → the current
+//! journal boundary) and exits. With `--follow` (R5) it consumes the server's
+//! LIVE TAIL: one open `StreamEvents` stream that keeps delivering frames as the
+//! journal advances, until Ctrl-C. If the server drops a slow consumer with
+//! `resource_exhausted` (CatchupRequired), the client transparently reconnects
+//! from its last `next_seq` — no lost or duplicated delta.
 
 use kx_proto::proto;
 use kx_proto::proto::kx_gateway_client::KxGatewayClient;
 use tonic::transport::Channel;
+use tonic::Code;
 
 use crate::client::{next_value, take_fixed, ClientCommon, Resolved};
 use crate::error::CliError;
 use crate::format;
-
-/// Re-poll cadence under `--follow` (bounded backoff — never a busy-spin).
-const FOLLOW_POLL: Duration = Duration::from_millis(250);
 
 /// Parsed `events` arguments.
 #[derive(Debug)]
@@ -103,19 +101,57 @@ pub async fn execute(args: EventsArgs) -> Result<(), CliError> {
     let mut client = resolved.connect().await?;
     let json = args.common.json;
 
-    let mut cursor = args.since;
-    loop {
-        cursor = drain_once(&mut client, &resolved, &args.instance, cursor, json).await?;
-        if !args.follow {
-            if !json {
-                println!("-- caught up at seq {cursor} --");
-            }
-            return Ok(());
+    if !args.follow {
+        let cursor = drain_once(&mut client, &resolved, &args.instance, args.since, json).await?;
+        if !json {
+            println!("-- caught up at seq {cursor} --");
         }
-        // --follow: back off, then re-poll from the cursor; a clean Ctrl-C exits.
-        tokio::select! {
-            () = tokio::time::sleep(FOLLOW_POLL) => {}
-            _ = tokio::signal::ctrl_c() => return Ok(()),
+        return Ok(());
+    }
+    follow_live(&mut client, &resolved, &args.instance, args.since, json).await
+}
+
+/// Consume the server's live tail: ONE open `StreamEvents` stream, printing deltas
+/// as they arrive until Ctrl-C. On a `resource_exhausted` (CatchupRequired) drop,
+/// reconnect from the last `next_seq` (resume — no lost/duplicated delta).
+async fn follow_live(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance: &[u8; 16],
+    mut cursor: u64,
+    json: bool,
+) -> Result<(), CliError> {
+    loop {
+        let mut stream = client
+            .stream_events(resolved.request(proto::StreamEventsRequest {
+                instance_id: instance.to_vec(),
+                since_seq: cursor,
+            })?)
+            .await
+            .map_err(CliError::from_status)?
+            .into_inner();
+
+        loop {
+            tokio::select! {
+                message = stream.message() => match message {
+                    Ok(Some(frame)) => {
+                        for delta in &frame.deltas {
+                            if let Some(line) = format::render_delta(delta, json) {
+                                println!("{line}");
+                            }
+                        }
+                        cursor = frame.next_seq;
+                    }
+                    // The live tail does not end on its own; a clean end means the
+                    // server is snapshot-only — we are done.
+                    Ok(None) => return Ok(()),
+                    // CatchupRequired: the server dropped a slow consumer. Resume
+                    // from the last acked cursor.
+                    Err(status) if status.code() == Code::ResourceExhausted => break,
+                    Err(status) => return Err(CliError::from_status(status)),
+                },
+                _ = tokio::signal::ctrl_c() => return Ok(()),
+            }
         }
     }
 }

--- a/crates/kx-cli/tests/common/mod.rs
+++ b/crates/kx-cli/tests/common/mod.rs
@@ -29,6 +29,7 @@ pub fn gateway_config(
 ) -> GatewayConfig {
     GatewayConfig {
         listen: "127.0.0.1:0".parse().unwrap(),
+        ws_listen: "127.0.0.1:0".parse().unwrap(),
         journal_path: dir.path().join("kx.db"),
         content_root: dir.path().join("blobs"),
         max_lease: 16,

--- a/crates/kx-cli/tests/events_follow_e2e.rs
+++ b/crates/kx-cli/tests/events_follow_e2e.rs
@@ -1,0 +1,75 @@
+//! R5 — `kx events --follow` consumes the gateway's LIVE TAIL: ONE open stream
+//! that keeps delivering deltas as the journal advances (no 250ms re-poll). This
+//! spawns the long-running follow subprocess against an in-process gateway, reads
+//! its stdout until the committed delta appears (delivered live by the tail), then
+//! kills it (the follow path never exits on its own).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::time::Duration;
+
+use common::{argv, endpoint, json_ok, run_kx, start_gateway};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn events_follow_streams_the_live_committed_delta() {
+    let dir = TempDir::new().unwrap();
+    let running = start_gateway(&dir, true, HashMap::new()).await;
+    let ep = endpoint(&running);
+
+    // Submit the demo run; grab its instance id (hex). The embedded worker commits
+    // the PURE Mote shortly after.
+    let submit = json_ok(&run_kx(argv(&["submit", "--demo", "--endpoint", &ep, "--json"])).await);
+    let instance = submit["instance_id"]
+        .as_str()
+        .expect("submit --json carries instance_id")
+        .to_string();
+
+    // `events --follow` opens ONE live stream and does not exit on its own.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kx"))
+        .args([
+            "events",
+            "--instance",
+            &instance,
+            "--endpoint",
+            &ep,
+            "--follow",
+        ])
+        .env("RUST_LOG", "warn")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn kx events --follow");
+    let mut lines = BufReader::new(child.stdout.take().unwrap()).lines();
+
+    // The live tail delivers the committed delta on the open stream; the CLI prints
+    // it. (Generous timeout; the kill below guarantees the test terminates.)
+    let first = timeout(Duration::from_secs(20), async {
+        loop {
+            match lines.next_line().await.unwrap() {
+                Some(line) if !line.trim().is_empty() => return Some(line),
+                Some(_) => {}        // skip blank lines
+                None => return None, // process ended unexpectedly (would be a bug)
+            }
+        }
+    })
+    .await
+    .expect("did not time out waiting for a live delta line");
+
+    // --follow never exits; kill it, then tear down.
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+    running.shutdown().await.unwrap();
+
+    let line = first.expect("events --follow printed a delta before the process ended");
+    assert!(
+        line.to_lowercase().contains("committed"),
+        "the live follow stream printed the committed delta: {line:?}"
+    );
+}

--- a/crates/kx-gateway-core/src/events.rs
+++ b/crates/kx-gateway-core/src/events.rs
@@ -1,8 +1,15 @@
-//! The `StreamEvents` cursor. Reads the run's journal deltas in `(since_seq,
+//! The `StreamEvents` event source: reads a run's journal deltas in `(since_seq,
 //! head]`, chunks them into bounded [`EventFrame`](proto::EventFrame)s, and never
-//! advances `next_seq` past the journal head. For the D120 freeze this is a
-//! snapshot-to-head stream; the cursor protocol (`since_seq -> next_seq`,
-//! resumable, bounded) is frozen now so live tailing (M8) is additive.
+//! advances `next_seq` past the journal head. The cursor protocol (`since_seq ->
+//! next_seq`, resumable, bounded) is frozen at D120.
+//!
+//! Split into reusable pieces so both the default snapshot path and the live
+//! tailer (R5, in the `kx-gateway` binary) share ONE event source:
+//! - [`check_run_ownership`] — the one-time fold-to-head ownership gate.
+//! - [`frames_for_range`] — frames for the deltas in `(since_seq, head]`, taking
+//!   the already-polled `head` so a live tailer calls it once per advance.
+//! - `build_frames` — the snapshot composition (ownership + one range to head),
+//!   backing the default [`crate::SnapshotTailer`].
 
 use kx_journal::JournalEntry;
 use kx_proto::proto;
@@ -12,28 +19,39 @@ use crate::reader::JournalReader;
 use crate::view::fold_through;
 
 /// Max deltas per frame — bounds frame size (mirrors the coordinator's
-/// `READ_ENTRIES_MAX`). A run with more deltas than this is split across frames;
+/// `READ_ENTRIES_MAX`). A range with more deltas than this is split across frames;
 /// the client resumes from each frame's `next_seq`.
 const MAX_FRAME_DELTAS: usize = 4096;
 
-/// Build the frames for `StreamEvents(instance_id, since_seq)`. Validates run
-/// ownership first (uniform `NotAuthorized`), then emits resumable frames.
-pub(crate) fn build_frames(
+/// Validate run ownership (uniform `NotAuthorized`). Folds to head to read the
+/// run's `RunRegistered` entry (which is typically at seq=1, before `since_seq`).
+///
+/// The live tailer calls this ONCE at subscribe; per-poll re-reads skip it
+/// (ownership of an already-registered run cannot change). `O(journal)` once.
+pub fn check_run_ownership(
     reader: &dyn JournalReader,
     instance_id: [u8; 16],
-    since_seq: u64,
-) -> Result<Vec<proto::EventFrame>, GatewayError> {
+) -> Result<(), GatewayError> {
     let head = reader.current_seq().map_err(internal)?;
-
-    // Ownership: fold to head to read the run's registration (RunRegistered at
-    // seq=1 may be before `since_seq`).
     let (projection, _) = fold_through(reader, head)?;
     match projection.run_registration() {
-        Some((inst, _)) if inst == instance_id => {}
-        _ => return Err(GatewayError::NotAuthorized),
+        Some((inst, _)) if inst == instance_id => Ok(()),
+        _ => Err(GatewayError::NotAuthorized),
     }
+}
 
-    // Collect surfaced deltas in (since_seq, head].
+/// Build resumable frames for the surfaced deltas in `(since_seq, head]`, the
+/// caller supplying the already-polled `head`. Assumes ownership was already
+/// checked (the snapshot path checks in `build_frames`; the live tailer checks
+/// once at subscribe). `next_seq` is never `> head` by construction; the final
+/// frame flags `journal_boundary` at the supplied head.
+pub fn frames_for_range(
+    reader: &dyn JournalReader,
+    since_seq: u64,
+    head: u64,
+) -> Result<Vec<proto::EventFrame>, GatewayError> {
+    // Collect surfaced deltas in (since_seq, head]. The range is half-open
+    // `[start, end)`, so `+1` on both bounds yields the inclusive `(since_seq, head]`.
     let mut deltas: Vec<(u64, proto::event_delta::Kind)> = Vec::new();
     let entries = reader
         .read_entries_by_seq(since_seq.saturating_add(1)..head.saturating_add(1))
@@ -80,6 +98,20 @@ pub(crate) fn build_frames(
         }
     }
     Ok(frames)
+}
+
+/// The snapshot composition for `StreamEvents(instance_id, since_seq)`: validate
+/// ownership, then emit the frames for `(since_seq, head]` once. Backs the default
+/// [`crate::SnapshotTailer`]; the live tailer composes the pieces itself so it can
+/// re-poll the head.
+pub(crate) fn build_frames(
+    reader: &dyn JournalReader,
+    instance_id: [u8; 16],
+    since_seq: u64,
+) -> Result<Vec<proto::EventFrame>, GatewayError> {
+    check_run_ownership(reader, instance_id)?;
+    let head = reader.current_seq().map_err(internal)?;
+    frames_for_range(reader, since_seq, head)
 }
 
 /// Map a journal entry to a streamed delta, or `None` for kinds the cursor does

--- a/crates/kx-gateway-core/src/lib.rs
+++ b/crates/kx-gateway-core/src/lib.rs
@@ -54,11 +54,15 @@ mod submit;
 mod view;
 
 pub use error::GatewayError;
+// The event-source pieces a live tailer (R5, `kx-gateway`) reuses: the one-time
+// ownership gate + the per-range frame builder. The snapshot composition stays
+// crate-private (it backs the default `SnapshotTailer`).
+pub use events::{check_run_ownership, frames_for_range};
 pub use identity::CallerParty;
 pub use reader::{ContentReader, JournalReader, ReadOnly};
 pub use service::{
-    BinderError, BoundRecipe, CatalogSeamError, GatewayService, RecipeBinder, RegisteredSignature,
-    SignatureCatalog, SignatureSummaryEntry,
+    BinderError, BoundRecipe, CatalogSeamError, EventStream, EventTailer, GatewayService,
+    RecipeBinder, RegisteredSignature, SignatureCatalog, SignatureSummaryEntry, SnapshotTailer,
 };
 pub use submit::{
     RunSubmitter, SubmitMoteOutcome, SubmitStatus, SubmitterError, TonicCoordinatorSubmitter,

--- a/crates/kx-gateway-core/src/service.rs
+++ b/crates/kx-gateway-core/src/service.rs
@@ -126,6 +126,59 @@ pub trait RecipeBinder: Send + Sync {
     ) -> Result<BoundRecipe, BinderError>;
 }
 
+/// The boxed server-streaming type the `StreamEvents` RPC returns.
+pub type EventStream =
+    Pin<Box<dyn Stream<Item = Result<proto::EventFrame, Status>> + Send + 'static>>;
+
+/// The event-tailing seam behind `StreamEvents`. The default [`SnapshotTailer`]
+/// emits the deltas in `(since_seq, head]` once and ends (snapshot-to-head); the
+/// host can inject a LIVE tailer (R5 — `kx-gateway`'s `LiveTailer`) that keeps the
+/// stream open and emits frames as the journal advances. Spoken in gateway-core's
+/// own vocabulary (a [`JournalReader`] + the frozen [`EventFrame`](proto::EventFrame))
+/// so the live tailer lives in the binary WITHOUT putting a runtime/timer dep on
+/// the read-fold crate (the dep wall).
+pub trait EventTailer: Send + Sync {
+    /// Open the event stream for `(instance_id, since_seq)`. `reader` is owned
+    /// (`Arc`) so a tailer that spawns a poller can outlive the handler call. The
+    /// ownership check is the tailer's first action.
+    ///
+    /// # Errors
+    /// A uniform `permission_denied` if the caller does not own the run (no
+    /// existence oracle); `internal` on a read/fold failure.
+    // The Ok variant is a thin boxed stream while `tonic::Status` is large, which
+    // trips `result_large_err`; boxing the Status would force every caller to
+    // unbox to satisfy the tonic handler's own `Result<_, Status>`. A clean
+    // pre-stream ownership error (vs. an in-band error frame) is the right
+    // semantics, so allow the lint on this seam.
+    #[allow(clippy::result_large_err)]
+    fn stream(
+        &self,
+        reader: Arc<dyn JournalReader>,
+        instance_id: [u8; 16],
+        since_seq: u64,
+    ) -> Result<EventStream, Status>;
+}
+
+/// The default, dependency-free tailer: emit `(since_seq, head]` once, then END
+/// (snapshot-to-head). This was gateway-core's behavior before R5; it is kept as
+/// the default so the crate stays self-contained and its round-trip tests need no
+/// async runtime. A live tail is opt-in via [`GatewayService::with_event_tailer`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SnapshotTailer;
+
+impl EventTailer for SnapshotTailer {
+    #[allow(clippy::result_large_err)] // see the trait method.
+    fn stream(
+        &self,
+        reader: Arc<dyn JournalReader>,
+        instance_id: [u8; 16],
+        since_seq: u64,
+    ) -> Result<EventStream, Status> {
+        let frames = events::build_frames(reader.as_ref(), instance_id, since_seq)?;
+        Ok(Box::pin(tokio_stream::iter(frames.into_iter().map(Ok))))
+    }
+}
+
 /// The backend behind the external `KxGateway` service: a read-only journal +
 /// content reader (the read-fold) and a [`RunSubmitter`] (the propose-proxy).
 /// Holds no writer; auth/ownership stay cloud-side (the host wraps this with
@@ -142,6 +195,9 @@ pub struct GatewayService {
     /// The optional recipe-binding seam (the host injects a kx-invoke-backed
     /// binder). `None` ⇒ `Invoke` returns `unimplemented`.
     binder: Option<Arc<dyn RecipeBinder>>,
+    /// The `StreamEvents` tailer. Defaults to [`SnapshotTailer`]; the host injects
+    /// a live tailer via [`GatewayService::with_event_tailer`].
+    tailer: Arc<dyn EventTailer>,
 }
 
 impl GatewayService {
@@ -159,6 +215,7 @@ impl GatewayService {
             content,
             catalog: None,
             binder: None,
+            tailer: Arc::new(SnapshotTailer),
         }
     }
 
@@ -175,6 +232,15 @@ impl GatewayService {
     #[must_use]
     pub fn with_recipe_binder(mut self, binder: Arc<dyn RecipeBinder>) -> Self {
         self.binder = Some(binder);
+        self
+    }
+
+    /// Wire a live `StreamEvents` tailer (R5 — `kx-gateway`'s `LiveTailer`),
+    /// replacing the default snapshot-to-head [`SnapshotTailer`]. Read-side only;
+    /// it never changes the journal or the digest.
+    #[must_use]
+    pub fn with_event_tailer(mut self, tailer: Arc<dyn EventTailer>) -> Self {
+        self.tailer = tailer;
         self
     }
 }
@@ -310,8 +376,7 @@ impl KxGateway for GatewayService {
         Ok(Response::new(proto::ContentBlob { payload }))
     }
 
-    type StreamEventsStream =
-        Pin<Box<dyn Stream<Item = Result<proto::EventFrame, Status>> + Send + 'static>>;
+    type StreamEventsStream = EventStream;
 
     async fn stream_events(
         &self,
@@ -319,9 +384,13 @@ impl KxGateway for GatewayService {
     ) -> Result<Response<Self::StreamEventsStream>, Status> {
         let req = request.into_inner();
         let instance_id = instance_id_16(&req.instance_id)?;
-        let frames = events::build_frames(self.reader.as_ref(), instance_id, req.since_seq)?;
-        let stream = tokio_stream::iter(frames.into_iter().map(Ok));
-        Ok(Response::new(Box::pin(stream)))
+        // Delegate to the injected tailer (default snapshot-to-head; the host
+        // wires a live tailer via `with_event_tailer`). Ownership is the tailer's
+        // first action → uniform `permission_denied`.
+        let stream = self
+            .tailer
+            .stream(self.reader.clone(), instance_id, req.since_seq)?;
+        Ok(Response::new(stream))
     }
 
     async fn list_signatures(

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -54,8 +54,23 @@ kx-capability   = { workspace = true, optional = true }
 tonic              = { workspace = true }
 # Additive feature bump over the workspace tokio (rt-multi-thread/macros/net):
 # `signal` for graceful Ctrl-C shutdown, `time` for the worker poll/backoff +
-# connect-retry. Member-level feature additions are honored (unlike default-features).
-tokio              = { workspace = true, features = ["signal", "time"] }
+# connect-retry + the R5 live-tail poll interval, `sync` for the R5 per-subscriber
+# bounded mpsc. Member-level feature additions are honored (unlike default-features).
+tokio              = { workspace = true, features = ["signal", "time", "sync"] }
+# R5: `ReceiverStream` adapts the live-tail mpsc into the tonic server stream.
+# Already a transitive dep (tonic) — promoting it adds no new crate.
+tokio-stream       = { workspace = true }
+# R5: the WebSocket bridge transport (the browser StreamEvents surface). MIT;
+# hyper/tower already locked via tonic. Lives in the binary only (the dep wall
+# keeps kx-gateway-core a passive read-fold).
+tokio-tungstenite  = { workspace = true }
+# R5: split the WS into read/write halves (push frames while handling Close/Ping).
+futures-util       = { workspace = true }
+# R5: parse the WS upgrade request's query string (instance_id + since_seq) +
+# the JSON hex wire DTO. Both already workspace deps (no new crate).
+url                = { workspace = true }
+serde              = { workspace = true }
+serde_json         = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror          = { workspace = true }

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -3,7 +3,7 @@
 //! minimal and matches the workspace's established CLI style. R3 matures the CLI.
 
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use crate::error::GatewayError;
@@ -12,12 +12,21 @@ use crate::error::GatewayError;
 /// pulls per `run_once`. Modest by default; tune with `--max-lease`.
 pub const DEFAULT_MAX_LEASE: u32 = 16;
 
+/// Default address for the R5 WebSocket `StreamEvents` bridge (the browser live-
+/// tail surface). Loopback by default (like the gRPC port); override with
+/// `--ws-listen`. A `:0` port asks the OS for an ephemeral one (used by tests).
+pub const DEFAULT_WS_LISTEN: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50152);
+
 /// Resolved `serve` configuration.
 #[derive(Debug, Clone)]
 pub struct GatewayConfig {
     /// The address:port the gateway gRPC service binds (e.g. `127.0.0.1:50151`).
     /// A `0` port asks the OS for an ephemeral one (used by tests).
     pub listen: SocketAddr,
+    /// The address:port the R5 WebSocket `StreamEvents` bridge binds (the browser
+    /// live-tail surface; default [`DEFAULT_WS_LISTEN`]). A `0` port is ephemeral.
+    /// Loopback-only under `--dev-allow-local` (same Rule-8c check as `listen`).
+    pub ws_listen: SocketAddr,
     /// On-disk SQLite journal path. The embedded coordinator opens this
     /// read-write (sole writer); the gateway opens a SECOND read-only handle.
     pub journal_path: PathBuf,
@@ -52,8 +61,9 @@ pub enum Cli {
 /// One-line usage string (printed on `--help` and on a parse error).
 pub const USAGE: &str =
     "usage: kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
-[--max-lease <N>] [--dev-allow-local] [--auth-token <token>=<party>]... \
-[--auth-token-file <path>] [--catalog-dir <dir>]\n       kx-gateway --help | --version";
+[--ws-listen <addr:port>] [--max-lease <N>] [--dev-allow-local] \
+[--auth-token <token>=<party>]... [--auth-token-file <path>] [--catalog-dir <dir>]\n       \
+kx-gateway --help | --version";
 
 impl Cli {
     /// Parse `argv` (excluding the program name).
@@ -80,6 +90,7 @@ impl Cli {
 
 fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, GatewayError> {
     let mut listen: Option<SocketAddr> = None;
+    let mut ws_listen: SocketAddr = DEFAULT_WS_LISTEN;
     let mut journal_path: Option<PathBuf> = None;
     let mut content_root: Option<PathBuf> = None;
     let mut max_lease: u32 = DEFAULT_MAX_LEASE;
@@ -100,6 +111,14 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
                         "--listen expects an addr:port (IP literal), got {v:?}"
                     ))
                 })?);
+            }
+            "--ws-listen" => {
+                let v = take_value("--ws-listen")?;
+                ws_listen = v.parse::<SocketAddr>().map_err(|_| {
+                    GatewayError::Config(format!(
+                        "--ws-listen expects an addr:port (IP literal), got {v:?}"
+                    ))
+                })?;
             }
             "--journal" => journal_path = Some(PathBuf::from(take_value("--journal")?)),
             "--content" => content_root = Some(PathBuf::from(take_value("--content")?)),
@@ -146,6 +165,7 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
 
     Ok(GatewayConfig {
         listen,
+        ws_listen,
         journal_path,
         content_root,
         max_lease,
@@ -217,6 +237,55 @@ mod tests {
         assert_eq!(c.content_root, PathBuf::from("/tmp/blobs"));
         assert_eq!(c.max_lease, 8);
         assert!(c.dev_allow_local);
+    }
+
+    #[test]
+    fn ws_listen_parses_and_defaults() {
+        // Default when omitted.
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(c.ws_listen, DEFAULT_WS_LISTEN);
+
+        // Explicit override.
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--ws-listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(c.ws_listen, "127.0.0.1:0".parse::<SocketAddr>().unwrap());
+
+        // Bad value is a config error.
+        assert!(Cli::from_args([
+            "serve",
+            "--listen",
+            "127.0.0.1:0",
+            "--ws-listen",
+            "not-an-addr",
+            "--journal",
+            "/tmp/j",
+            "--content",
+            "/tmp/c",
+        ])
+        .is_err());
     }
 
     #[test]

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -54,12 +54,16 @@
 mod auth;
 mod config;
 mod error;
+mod live_tail;
 mod provision;
 mod server;
+#[cfg(feature = "embedded-worker")]
+mod ws;
 
 pub use auth::{DenyAll, DevAllowLocal, Principal, PrincipalResolver, TokenResolver};
-pub use config::{Cli, GatewayConfig, DEFAULT_MAX_LEASE, USAGE};
+pub use config::{Cli, GatewayConfig, DEFAULT_MAX_LEASE, DEFAULT_WS_LISTEN, USAGE};
 pub use error::GatewayError;
+pub use live_tail::LiveTailer;
 pub use provision::{DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RECIPE_HANDLE};
 pub use server::{serve, start, RunningGateway};
 

--- a/crates/kx-gateway/src/live_tail.rs
+++ b/crates/kx-gateway/src/live_tail.rs
@@ -1,0 +1,171 @@
+//! [`LiveTailer`] — the R5 live-tail [`EventTailer`] (the gRPC `StreamEvents`
+//! upgrade + the source the WebSocket bridge reuses).
+//!
+//! Unlike the default snapshot-to-head [`kx_gateway_core::SnapshotTailer`], this
+//! keeps the stream OPEN: after catching up to the current head it polls
+//! `current_seq()` on a fixed interval and emits a new [`EventFrame`] whenever the
+//! journal advances. The journal exposes no change-notification, so polling is the
+//! honest interim — a push-based journal `watch` seam is a flagged optimization
+//! (own PR). It is **read-side only**: it never writes the journal or touches the
+//! digest; the coordinator stays the sole writer.
+//!
+//! ## Lifecycle + backpressure
+//! - **Bounded per-subscriber queue** (`SUBSCRIBER_QUEUE` frames). A consumer that
+//!   falls behind fills the queue; the poller then terminates the stream with
+//!   `Status::resource_exhausted` (the "CatchupRequired" signal — it is a `Status`,
+//!   not a wire field, since the frozen proto has no such message). The client
+//!   resumes a fresh `StreamEvents` from its last `next_seq` — bounded memory, the
+//!   journal + other subscribers untouched.
+//! - **No task leak.** The poller `select!`s the poll timer against
+//!   [`Sender::closed`]; when the client disconnects (the `ReceiverStream` drops),
+//!   the poller returns promptly. A send error (receiver gone) also returns.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_gateway_core::{
+    check_run_ownership, frames_for_range, EventStream, EventTailer, JournalReader,
+};
+use kx_proto::proto;
+use tokio::sync::{mpsc, watch};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Status;
+
+/// How often the poller re-reads `current_seq()` to detect new entries. Matches
+/// the CLI/worker idle cadence; sub-interval latency awaits the push-based journal
+/// `watch` seam (a flagged optimization).
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Bounded per-subscriber frame queue. A consumer that lags past this is dropped
+/// with `resource_exhausted` (CatchupRequired) and resumes from its last `next_seq`.
+const SUBSCRIBER_QUEUE: usize = 256;
+
+/// The live-tail [`EventTailer`]: per subscriber, spawn a poller that emits frames
+/// as the journal advances. Held in the `kx-gateway` binary (where tokio
+/// `time`/`sync` live) so `kx-gateway-core` keeps its passive-read-fold dep wall.
+#[derive(Clone)]
+pub struct LiveTailer {
+    /// Flips to `true` on server shutdown so in-flight poll loops exit promptly,
+    /// their streams end, and tonic's graceful drain completes — a live stream
+    /// otherwise keeps its RPC in-flight forever and would deadlock shutdown.
+    shutdown: watch::Receiver<bool>,
+}
+
+impl LiveTailer {
+    /// Build a live tailer whose poll loops stop when `shutdown` flips to `true`.
+    #[must_use]
+    pub fn new(shutdown: watch::Receiver<bool>) -> Self {
+        Self { shutdown }
+    }
+}
+
+impl EventTailer for LiveTailer {
+    #[allow(clippy::result_large_err)] // see the `EventTailer` trait method.
+    fn stream(
+        &self,
+        reader: Arc<dyn JournalReader>,
+        instance_id: [u8; 16],
+        since_seq: u64,
+    ) -> Result<EventStream, Status> {
+        // Ownership is a clean PRE-stream error (uniform permission_denied), so an
+        // unauthorized caller never spawns a poller.
+        check_run_ownership(reader.as_ref(), instance_id).map_err(Status::from)?;
+        let (tx, rx) = mpsc::channel::<Result<proto::EventFrame, Status>>(SUBSCRIBER_QUEUE);
+        tokio::spawn(poll_loop(reader, since_seq, tx, self.shutdown.clone()));
+        Ok(Box::pin(ReceiverStream::new(rx)))
+    }
+}
+
+/// The per-subscriber poll loop: catch up to head, then emit on each advance until
+/// the client disconnects, a read fails, the consumer falls too far behind, or the
+/// server shuts down.
+async fn poll_loop(
+    reader: Arc<dyn JournalReader>,
+    since_seq: u64,
+    tx: mpsc::Sender<Result<proto::EventFrame, Status>>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    // Subscribed during shutdown (or the sender already dropped): stop immediately.
+    if *shutdown.borrow() {
+        return;
+    }
+    let mut cursor = since_seq;
+
+    // Initial catch-up: ALWAYS emit (frames_for_range yields a boundary frame even
+    // when the range is empty, so the client learns it is caught up + the stream is
+    // live). Afterwards, only emit when the head actually advanced — an idle stream
+    // must not enqueue an empty boundary frame every tick.
+    let Some(head) = read_head(&reader, &tx).await else {
+        return;
+    };
+    if !emit_range(&reader, &mut cursor, head, &tx).await {
+        return;
+    }
+
+    loop {
+        // Wait for the next tick OR a client disconnect OR server shutdown (prompt
+        // cleanup, no task leak, no shutdown deadlock).
+        tokio::select! {
+            () = tokio::time::sleep(POLL_INTERVAL) => {}
+            () = tx.closed() => return,
+            _ = shutdown.changed() => return,
+        }
+        let Some(head) = read_head(&reader, &tx).await else {
+            return;
+        };
+        if head > cursor && !emit_range(&reader, &mut cursor, head, &tx).await {
+            return;
+        }
+    }
+}
+
+/// Read the journal head; on error, signal it (best-effort) and return `None`.
+async fn read_head(
+    reader: &Arc<dyn JournalReader>,
+    tx: &mpsc::Sender<Result<proto::EventFrame, Status>>,
+) -> Option<u64> {
+    match reader.current_seq() {
+        Ok(head) => Some(head),
+        Err(error) => {
+            let _ = tx.send(Err(Status::internal(error.to_string()))).await;
+            None
+        }
+    }
+}
+
+/// Emit the frames for `(cursor, head]`, advancing `cursor` per sent frame.
+/// Returns `false` (stop) on a read error, a client disconnect, or a slow-consumer
+/// overflow (CatchupRequired).
+async fn emit_range(
+    reader: &Arc<dyn JournalReader>,
+    cursor: &mut u64,
+    head: u64,
+    tx: &mpsc::Sender<Result<proto::EventFrame, Status>>,
+) -> bool {
+    let frames = match frames_for_range(reader.as_ref(), *cursor, head) {
+        Ok(frames) => frames,
+        Err(error) => {
+            let _ = tx.send(Err(Status::from(error))).await;
+            return false;
+        }
+    };
+    for frame in frames {
+        let next = frame.next_seq;
+        match tx.try_send(Ok(frame)) {
+            Ok(()) => *cursor = next, // advance per-frame so a mid-range stop resumes correctly
+            Err(mpsc::error::TrySendError::Closed(_)) => return false, // client gone
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // Slow consumer: terminate with CatchupRequired. The buffered
+                // frames drain first, then this error; the client resumes from its
+                // last `next_seq`. Bounded memory; never blocks the journal.
+                let _ = tx
+                    .send(Err(Status::resource_exhausted(
+                        "catch up: resume StreamEvents from your last next_seq",
+                    )))
+                    .await;
+                return false;
+            }
+        }
+    }
+    true
+}

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -17,7 +17,7 @@
 
 use std::net::SocketAddr;
 
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 
 use crate::config::GatewayConfig;
@@ -36,7 +36,8 @@ use {
     kx_coordinator::CoordinatorService,
     kx_executor::{LocalResourceManager, MoteExecutor, TestMoteExecutor},
     kx_gateway_core::{
-        GatewayService, ReadOnly, RecipeBinder, SignatureCatalog, TonicCoordinatorSubmitter,
+        EventTailer, GatewayService, JournalReader, ReadOnly, RecipeBinder, SignatureCatalog,
+        TonicCoordinatorSubmitter,
     },
     kx_journal::SqliteJournal,
     kx_proto::proto::coordinator_server::CoordinatorServer,
@@ -188,10 +189,15 @@ fn demo_pure_warrant() -> kx_warrant::WarrantSpec {
 /// gracefully. Returned by [`start`]; [`serve`] drives it to a Ctrl-C.
 pub struct RunningGateway {
     local_addr: SocketAddr,
+    ws_local_addr: SocketAddr,
     shutdown: oneshot::Sender<()>,
+    /// Flips the live-tail poll loops off so their (otherwise endless) streams end
+    /// and the gateway's graceful drain can complete (R5). Signalled BEFORE the
+    /// gateway is awaited on shutdown.
+    live_shutdown: watch::Sender<bool>,
     gateway: JoinHandle<Result<(), GatewayError>>,
-    /// Background tasks (embedded coordinator server, worker loop, heartbeat)
-    /// aborted after the gateway drains.
+    /// Background tasks (embedded coordinator server, worker loop, heartbeat, the
+    /// R5 WebSocket-bridge accept loop) aborted after the gateway drains.
     aux: Vec<JoinHandle<()>>,
 }
 
@@ -203,6 +209,13 @@ impl RunningGateway {
         self.local_addr
     }
 
+    /// The address the R5 WebSocket `StreamEvents` bridge is bound to (resolved
+    /// from a `:0` request to the OS-assigned port).
+    #[must_use]
+    pub fn ws_local_addr(&self) -> SocketAddr {
+        self.ws_local_addr
+    }
+
     /// Stop accepting new gateway RPCs, drain in-flight ones, then abort the
     /// embedded coordinator + worker. The journal is always left at a safe
     /// boundary: commits are durable before they are acked, and any
@@ -210,10 +223,14 @@ impl RunningGateway {
     pub async fn shutdown(self) -> Result<(), GatewayError> {
         let RunningGateway {
             shutdown,
+            live_shutdown,
             gateway,
             aux,
             ..
         } = self;
+        // Stop the live-tail poll loops FIRST so their endless streams end —
+        // otherwise the graceful drain below would wait on them forever (R5).
+        let _ = live_shutdown.send(true);
         // Signal the gateway server to stop; it finishes in-flight requests
         // (which may still proxy to the not-yet-aborted coordinator).
         let _ = shutdown.send(());
@@ -232,11 +249,13 @@ impl RunningGateway {
 /// Build the runtime + bind the gateway, returning a [`RunningGateway`] handle
 /// (with the bound address) without blocking. The caller owns shutdown.
 pub async fn start(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> {
-    // Rule 8c: the dev local-allow resolver is loopback-only. (Deny-all may bind
-    // anywhere — every RPC is refused, so a public bind is still a closed door.)
-    if cfg.dev_allow_local && !cfg.listen.ip().is_loopback() {
+    // Rule 8c: the dev local-allow resolver is loopback-only — for BOTH the gRPC
+    // and the WebSocket (R5) ports. (Deny-all may bind anywhere — every RPC /
+    // handshake is refused, so a public bind is still a closed door.)
+    if cfg.dev_allow_local && (!cfg.listen.ip().is_loopback() || !cfg.ws_listen.ip().is_loopback())
+    {
         return Err(GatewayError::Config(
-            "--dev-allow-local permits a loopback --listen address only".into(),
+            "--dev-allow-local permits loopback --listen and --ws-listen addresses only".into(),
         ));
     }
     start_impl(cfg).await
@@ -305,7 +324,9 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     //     plus the shared content store as the read-only content seam.
     let read_journal =
         SqliteJournal::open(&cfg.journal_path).map_err(|e| GatewayError::Journal(e.to_string()))?;
-    let reader = Arc::new(ReadOnly::new(read_journal));
+    // Typed as `Arc<dyn JournalReader>` so the SAME read-only handle backs both the
+    // gateway read-fold and the R5 WebSocket bridge (cheap clone, one fold source).
+    let reader: Arc<dyn JournalReader> = Arc::new(ReadOnly::new(read_journal));
     let submitter = Arc::new(
         TonicCoordinatorSubmitter::connect(coord_endpoint.clone())
             .await
@@ -324,12 +345,21 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     let parties: Vec<String> = cfg.auth_tokens.values().cloned().collect();
     let demo = DemoLibrary::open(&catalog_dir, default_executor_class(), &parties)?;
     let binder: Arc<dyn RecipeBinder> = Arc::new(HostRecipeBinder::new(demo));
-    let gateway = GatewayService::new(reader, submitter, content)
+    // R5: the gRPC `StreamEvents` becomes a live tail (resumable, bounded,
+    // recovery-safe). Read-side only — the digest + frozen proto are untouched. The
+    // `live_shutdown` watch lets shutdown stop the poll loops (so their endless
+    // streams end and the graceful drain completes).
+    let (live_shutdown, live_shutdown_rx) = watch::channel(false);
+    let gateway = GatewayService::new(reader.clone(), submitter, content)
         .with_signature_catalog(signature_catalog)
-        .with_recipe_binder(binder);
+        .with_recipe_binder(binder)
+        .with_event_tailer(Arc::new(crate::live_tail::LiveTailer::new(
+            live_shutdown_rx.clone(),
+        )));
 
     // (4) Auth interceptor + bind + serve. Posture: --dev-allow-local (loopback
-    //     dev) → configured bearer tokens → deny-all (the safe default).
+    //     dev) → configured bearer tokens → deny-all (the safe default). The SAME
+    //     resolver gates the WS-bridge handshake (R5).
     let resolver: Arc<dyn crate::auth::PrincipalResolver> = if cfg.dev_allow_local {
         Arc::new(crate::auth::DevAllowLocal)
     } else if !cfg.auth_tokens.is_empty() {
@@ -337,6 +367,26 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     } else {
         Arc::new(crate::auth::DenyAll)
     };
+
+    // (5) R5 WebSocket bridge: a second listener serving the SAME live-tail event
+    //     stream over WS for browser clients, behind the same auth resolver. Bound
+    //     before spawning so the resolved (ephemeral) addr is known; aborted on
+    //     shutdown like the other aux tasks.
+    let ws_tcp = tokio::net::TcpListener::bind(cfg.ws_listen)
+        .await
+        .map_err(|e| GatewayError::Bind(e.to_string()))?;
+    let ws_local_addr = ws_tcp
+        .local_addr()
+        .map_err(|e| GatewayError::Bind(e.to_string()))?;
+    let ws_tailer: Arc<dyn EventTailer> =
+        Arc::new(crate::live_tail::LiveTailer::new(live_shutdown_rx));
+    let ws_task = tokio::spawn(crate::ws::serve_ws(
+        ws_tcp,
+        reader.clone(),
+        ws_tailer,
+        resolver.clone(),
+    ));
+
     let svc = KxGatewayServer::with_interceptor(gateway, crate::auth::interceptor(resolver));
     let local_addr = resolve_listen(cfg.listen).await?;
     let (shutdown, shutdown_rx) = oneshot::channel::<()>();
@@ -352,9 +402,11 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
 
     Ok(RunningGateway {
         local_addr,
+        ws_local_addr,
         shutdown,
+        live_shutdown,
         gateway,
-        aux: vec![coord_task, worker_task, heartbeat_task],
+        aux: vec![coord_task, worker_task, heartbeat_task, ws_task],
     })
 }
 

--- a/crates/kx-gateway/src/ws.rs
+++ b/crates/kx-gateway/src/ws.rs
@@ -1,0 +1,438 @@
+//! The R5 WebSocket `StreamEvents` bridge — the BROWSER live-tail surface.
+//!
+//! A browser cannot speak gRPC server-streaming, so this re-skins the SAME
+//! [`LiveTailer`](crate::live_tail::LiveTailer) event stream over a WebSocket on a
+//! separate port (`--ws-listen`, default [`DEFAULT_WS_LISTEN`](crate::DEFAULT_WS_LISTEN)).
+//! Each [`EventFrame`](kx_proto::proto::EventFrame) is sent as one JSON text
+//! message with ids/refs rendered as lowercase hex (a SIEM/browser-ergonomic wire
+//! that mirrors the R4 audit DTO — no protobuf-es decoder needed downstream).
+//!
+//! ## Auth (handshake, reusing R2)
+//! The bearer token is read from the upgrade request's `Authorization: Bearer …`
+//! header, or — for browsers that cannot set arbitrary headers — the
+//! `Sec-WebSocket-Protocol: bearer, <token>` subprotocol. Either way it feeds the
+//! SAME [`PrincipalResolver`](crate::auth::PrincipalResolver) (deny-all default /
+//! token / dev), so an unauthenticated upgrade is rejected BEFORE any stream opens.
+//!
+//! ## Read-side only
+//! It folds the read-only journal handle through the live tailer; it never writes
+//! the journal or touches the digest. Slow consumers / ownership failures close
+//! the socket with a reason; the client resumes from its last `next_seq`.
+
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
+
+use futures_util::{SinkExt, StreamExt};
+use kx_gateway_core::{EventTailer, JournalReader};
+use kx_proto::proto;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse, Request as HsRequest, Response as HsResponse,
+};
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::Message;
+use tonic::metadata::MetadataMap;
+use tonic::{Code, Status};
+
+use crate::auth::PrincipalResolver;
+
+/// Run the WebSocket bridge accept loop until the task is aborted (on shutdown).
+/// Each accepted connection is handled on its own task; a per-connection failure
+/// is logged, never fatal to the loop.
+pub(crate) async fn serve_ws(
+    listener: TcpListener,
+    reader: Arc<dyn JournalReader>,
+    tailer: Arc<dyn EventTailer>,
+    resolver: Arc<dyn PrincipalResolver>,
+) {
+    loop {
+        let (stream, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(error) => {
+                tracing::warn!(%error, "ws-bridge accept failed");
+                continue;
+            }
+        };
+        let reader = reader.clone();
+        let tailer = tailer.clone();
+        let resolver = resolver.clone();
+        tokio::spawn(async move {
+            if let Err(error) = handle_conn(stream, reader, tailer, resolver).await {
+                tracing::debug!(%error, "ws-bridge connection ended");
+            }
+        });
+    }
+}
+
+/// The `(instance_id, since_seq)` the handshake parsed from the upgrade request.
+type StreamTarget = ([u8; 16], u64);
+
+/// Handshake (auth + parse) then stream live frames to one client.
+// The tungstenite handshake closure returns `Result<_, ErrorResponse>`; that error
+// type is large + API-fixed, so allow `result_large_err` for the whole fn.
+#[allow(clippy::result_large_err)]
+async fn handle_conn(
+    stream: TcpStream,
+    reader: Arc<dyn JournalReader>,
+    tailer: Arc<dyn EventTailer>,
+    resolver: Arc<dyn PrincipalResolver>,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    // The handshake callback runs synchronously during the upgrade; it stashes the
+    // parsed target here on success. `Mutex` (not `RefCell`) so the enclosing
+    // future stays `Send` for `tokio::spawn`.
+    let parsed: Arc<Mutex<Option<StreamTarget>>> = Arc::new(Mutex::new(None));
+    let parsed_cb = parsed.clone();
+
+    let ws = tokio_tungstenite::accept_hdr_async(
+        stream,
+        move |req: &HsRequest, mut resp: HsResponse| {
+            // Auth (uniform reject; no existence oracle) + selected subprotocol.
+            let selected = authorize(req, resolver.as_ref())?;
+            // instance_id + since_seq from the query string.
+            let target = parse_query(req).map_err(|msg| bad_request(&msg))?;
+            *parsed_cb
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(target);
+            // Echo the selected subprotocol so a browser that offered `bearer`
+            // completes the handshake.
+            if let Some(proto_name) = selected {
+                resp.headers_mut().insert(
+                    "sec-websocket-protocol",
+                    HeaderValue::from_static(proto_name),
+                );
+            }
+            Ok(resp)
+        },
+    )
+    .await?;
+
+    let (instance_id, since_seq) = parsed
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .expect("handshake set the target on success");
+
+    pump(ws, reader, tailer, instance_id, since_seq).await
+}
+
+/// Drive the live tailer → JSON-over-WS, while reacting to the client's Close/Ping.
+async fn pump(
+    ws: tokio_tungstenite::WebSocketStream<TcpStream>,
+    reader: Arc<dyn JournalReader>,
+    tailer: Arc<dyn EventTailer>,
+    instance_id: [u8; 16],
+    since_seq: u64,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    let (mut write, mut read) = ws.split();
+
+    // Ownership is checked here (the tailer's first action); on failure close with
+    // a reason rather than silently dropping.
+    let mut events = match tailer.stream(reader, instance_id, since_seq) {
+        Ok(stream) => stream,
+        Err(status) => {
+            let _ = write.send(Message::Close(Some(close_for(&status)))).await;
+            return write.close().await;
+        }
+    };
+
+    loop {
+        tokio::select! {
+            frame = events.next() => match frame {
+                Some(Ok(frame)) => {
+                    let json = serde_json::to_string(&WsFrame::from_proto(frame))
+                        .unwrap_or_else(|_| "{}".to_string());
+                    write.send(Message::Text(json)).await?;
+                }
+                // A terminal Status (CatchupRequired / internal / permission): close
+                // with a reason so the client can resume from its last next_seq.
+                Some(Err(status)) => {
+                    let _ = write.send(Message::Close(Some(close_for(&status)))).await;
+                    return write.close().await;
+                }
+                None => return write.close().await,
+            },
+            incoming = read.next() => match incoming {
+                // Client closed, or the socket ended.
+                Some(Ok(Message::Close(_))) | None => return Ok(()),
+                // Ping is auto-ponged by reading; ignore other client messages
+                // (this is a server→client push stream).
+                Some(Ok(_)) => {}
+                Some(Err(error)) => return Err(error),
+            },
+        }
+    }
+}
+
+/// Resolve the caller from the upgrade request, reusing the R2 `PrincipalResolver`.
+/// Returns the selected subprotocol to echo (`Some("bearer")` when the token came
+/// via `Sec-WebSocket-Protocol`), or an `ErrorResponse` to reject the handshake.
+// `ErrorResponse` (the tungstenite handshake-rejection type) is large; it is the
+// API's fixed shape, so allow the lint rather than box it.
+#[allow(clippy::result_large_err)]
+fn authorize(
+    req: &HsRequest,
+    resolver: &dyn PrincipalResolver,
+) -> Result<Option<&'static str>, ErrorResponse> {
+    // Build a fresh tonic MetadataMap from the bearer credential (version-
+    // independent — no coupling to the request's http crate version).
+    let mut md = MetadataMap::new();
+    let mut selected = None;
+
+    if let Some(value) = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+    {
+        md.insert("authorization", value);
+    } else if let Some(token) = subprotocol_bearer(req) {
+        if let Ok(value) = format!("Bearer {token}").parse() {
+            md.insert("authorization", value);
+            selected = Some("bearer");
+        }
+    }
+
+    resolver
+        .resolve(&md)
+        .map_err(|status| status_to_handshake_error(&status))?;
+    Ok(selected)
+}
+
+/// Extract the token from `Sec-WebSocket-Protocol: bearer, <token>` (the browser
+/// path — browsers cannot set an `Authorization` header on a WebSocket).
+fn subprotocol_bearer(req: &HsRequest) -> Option<String> {
+    let raw = req.headers().get("sec-websocket-protocol")?.to_str().ok()?;
+    let mut parts = raw.split(',').map(str::trim);
+    if parts.next() == Some("bearer") {
+        parts.next().filter(|t| !t.is_empty()).map(str::to_string)
+    } else {
+        None
+    }
+}
+
+/// `instance` (hex16) + optional `since` (u64, default 0) from the request query.
+fn parse_query(req: &HsRequest) -> Result<([u8; 16], u64), String> {
+    let query = req.uri().query().unwrap_or("");
+    let mut instance: Option<[u8; 16]> = None;
+    let mut since: u64 = 0;
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "instance" => instance = hex_decode_16(&value),
+            "since" => since = value.parse().unwrap_or(0),
+            _ => {}
+        }
+    }
+    let instance = instance.ok_or_else(|| "missing or malformed ?instance=<hex16>".to_string())?;
+    Ok((instance, since))
+}
+
+/// Map a resolver `Status` to a handshake rejection (uniform — no oracle).
+fn status_to_handshake_error(status: &Status) -> ErrorResponse {
+    let code = match status.code() {
+        Code::Unauthenticated => StatusCode::UNAUTHORIZED,
+        Code::PermissionDenied => StatusCode::FORBIDDEN,
+        _ => StatusCode::BAD_REQUEST,
+    };
+    let mut resp = ErrorResponse::new(Some(status.message().to_string()));
+    *resp.status_mut() = code;
+    resp
+}
+
+/// A 400 handshake rejection for a malformed query.
+fn bad_request(message: &str) -> ErrorResponse {
+    let mut resp = ErrorResponse::new(Some(message.to_string()));
+    *resp.status_mut() = StatusCode::BAD_REQUEST;
+    resp
+}
+
+/// Map a terminal stream `Status` to a WS close frame so the client can react
+/// (e.g. resume from its last `next_seq` on a CatchupRequired).
+fn close_for(status: &Status) -> CloseFrame<'static> {
+    let code = match status.code() {
+        Code::ResourceExhausted => CloseCode::Again,
+        Code::PermissionDenied | Code::Unauthenticated => CloseCode::Policy,
+        _ => CloseCode::Error,
+    };
+    CloseFrame {
+        code,
+        reason: Cow::Owned(status.message().to_string()),
+    }
+}
+
+// --- JSON hex wire DTO (mirrors the R4 audit DTO: ids/refs as 64-hex strings) ---
+
+#[derive(serde::Serialize)]
+struct WsFrame {
+    seq: u64,
+    deltas: Vec<WsDelta>,
+    next_seq: u64,
+    journal_boundary: bool,
+}
+
+#[derive(serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum WsDelta {
+    Committed {
+        seq: u64,
+        mote_id: String,
+        result_ref: String,
+        nd_class: &'static str,
+    },
+    Failed {
+        seq: u64,
+        mote_id: String,
+        reason_class: u32,
+    },
+    Repudiated {
+        seq: u64,
+        target_mote_id: String,
+        target_committed_seq: u64,
+    },
+    EffectStaged {
+        seq: u64,
+        mote_id: String,
+    },
+    /// An unrecognized delta kind (forward-compat: a future proto variant).
+    Unknown {
+        seq: u64,
+    },
+}
+
+impl WsFrame {
+    fn from_proto(frame: proto::EventFrame) -> Self {
+        Self {
+            seq: frame.seq,
+            deltas: frame.deltas.into_iter().map(WsDelta::from_proto).collect(),
+            next_seq: frame.next_seq,
+            journal_boundary: frame.journal_boundary,
+        }
+    }
+}
+
+impl WsDelta {
+    fn from_proto(delta: proto::EventDelta) -> Self {
+        let seq = delta.seq;
+        match delta.kind {
+            Some(proto::event_delta::Kind::Committed(c)) => Self::Committed {
+                seq,
+                mote_id: hex_encode(&c.mote_id),
+                result_ref: hex_encode(&c.result_ref),
+                nd_class: nd_str(c.nd_class),
+            },
+            Some(proto::event_delta::Kind::Failed(f)) => Self::Failed {
+                seq,
+                mote_id: hex_encode(&f.mote_id),
+                reason_class: f.reason_class,
+            },
+            Some(proto::event_delta::Kind::Repudiated(r)) => Self::Repudiated {
+                seq,
+                target_mote_id: hex_encode(&r.target_mote_id),
+                target_committed_seq: r.target_committed_seq,
+            },
+            Some(proto::event_delta::Kind::EffectStaged(e)) => Self::EffectStaged {
+                seq,
+                mote_id: hex_encode(&e.mote_id),
+            },
+            None => Self::Unknown { seq },
+        }
+    }
+}
+
+/// Stable lowercase nd-class tag (matches the kx-audit wire vocabulary).
+fn nd_str(nd: i32) -> &'static str {
+    match proto::NdClass::try_from(nd) {
+        Ok(proto::NdClass::Pure) => "pure",
+        Ok(proto::NdClass::ReadOnlyNondet) => "read_only_nondet",
+        Ok(proto::NdClass::WorldMutating) => "world_mutating",
+        _ => "unspecified",
+    }
+}
+
+/// Lowercase hex of arbitrary bytes (no `unwrap`).
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Decode exactly 32 lowercase/uppercase hex chars into a 16-byte instance id.
+fn hex_decode_16(s: &str) -> Option<[u8; 16]> {
+    if s.len() != 32 {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let mut out = [0u8; 16];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let hi = hex_val(bytes[2 * i])?;
+        let lo = hex_val(bytes[2 * i + 1])?;
+        *slot = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+fn hex_val(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_roundtrip_16() {
+        let id = [0xabu8; 16];
+        let s = hex_encode(&id);
+        assert_eq!(s, "ab".repeat(16));
+        assert_eq!(hex_decode_16(&s), Some(id));
+        assert_eq!(hex_decode_16("ab"), None, "wrong length");
+        assert_eq!(hex_decode_16(&"z".repeat(32)), None, "non-hex");
+    }
+
+    #[test]
+    fn nd_str_maps_known_classes() {
+        assert_eq!(nd_str(proto::NdClass::Pure as i32), "pure");
+        assert_eq!(
+            nd_str(proto::NdClass::ReadOnlyNondet as i32),
+            "read_only_nondet"
+        );
+        assert_eq!(
+            nd_str(proto::NdClass::WorldMutating as i32),
+            "world_mutating"
+        );
+        assert_eq!(nd_str(999), "unspecified");
+    }
+
+    #[test]
+    fn frame_serializes_with_hex_ids() {
+        let frame = proto::EventFrame {
+            seq: 5,
+            deltas: vec![proto::EventDelta {
+                seq: 5,
+                kind: Some(proto::event_delta::Kind::Committed(proto::CommittedDelta {
+                    mote_id: vec![0xcd; 32],
+                    result_ref: vec![0xef; 32],
+                    nd_class: proto::NdClass::Pure as i32,
+                })),
+            }],
+            next_seq: 5,
+            journal_boundary: true,
+        };
+        let json = serde_json::to_value(WsFrame::from_proto(frame)).unwrap();
+        assert_eq!(json["seq"], 5);
+        assert_eq!(json["journal_boundary"], true);
+        assert_eq!(json["deltas"][0]["type"], "committed");
+        assert_eq!(json["deltas"][0]["mote_id"], "cd".repeat(32));
+        assert_eq!(json["deltas"][0]["result_ref"], "ef".repeat(32));
+        assert_eq!(json["deltas"][0]["nd_class"], "pure");
+    }
+}

--- a/crates/kx-gateway/tests/common/mod.rs
+++ b/crates/kx-gateway/tests/common/mod.rs
@@ -12,18 +12,87 @@
 )]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use kx_gateway::GatewayConfig;
 use kx_mote::{
     EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote,
     MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
 };
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
 use kx_warrant::{
     FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
 };
 use smallvec::SmallVec;
 use tempfile::TempDir;
+use tonic::transport::Channel;
+
+/// Connect a gRPC client to `addr`, retrying briefly while the server binds.
+pub async fn connect_client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+/// `SubmitRun` one parentless PURE demo Mote (`seed`); return its journaled
+/// 16-byte `instance_id`.
+pub async fn submit_pure_run(client: &mut KxGatewayClient<Channel>, seed: u8) -> Vec<u8> {
+    client
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: vec![0x5a; 32],
+            motes: vec![proto::SubmitMoteSpec {
+                mote: Some(pure_mote(seed, &[]).into()),
+                warrant: Some(pure_warrant().into()),
+                accept_at_least_once: false,
+            }],
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .instance_id
+}
+
+/// Poll `GetProjection` until the run has a `Committed` Mote; return its
+/// `(mote_id, result_ref)`. Panics on timeout.
+pub async fn await_committed(
+    client: &mut KxGatewayClient<Channel>,
+    instance_id: &[u8],
+) -> ([u8; 32], [u8; 32]) {
+    for _ in 0..200 {
+        let view = client
+            .get_projection(proto::GetProjectionRequest {
+                instance_id: instance_id.to_vec(),
+                at_seq: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(m) = view
+            .motes
+            .iter()
+            .find(|m| m.state == proto::MoteSnapshotState::Committed as i32)
+        {
+            let mote_id: [u8; 32] = m.mote_id.clone().try_into().unwrap();
+            let result_ref: [u8; 32] = m
+                .result_ref
+                .clone()
+                .expect("a committed Mote carries a result_ref")
+                .try_into()
+                .unwrap();
+            return (mote_id, result_ref);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("the submitted Mote never reached Committed");
+}
 
 /// A gateway config rooted at `dir` (ephemeral journal + content + catalog).
 /// `dev_allow_local` installs the dev resolver; a non-empty `auth_tokens`
@@ -36,6 +105,7 @@ pub fn gateway_config(
 ) -> GatewayConfig {
     GatewayConfig {
         listen: "127.0.0.1:0".parse().unwrap(),
+        ws_listen: "127.0.0.1:0".parse().unwrap(),
         journal_path: dir.path().join("kx.db"),
         content_root: dir.path().join("blobs"),
         max_lease: 16,

--- a/crates/kx-gateway/tests/live_tail_e2e.rs
+++ b/crates/kx-gateway/tests/live_tail_e2e.rs
@@ -1,0 +1,169 @@
+//! R5 — the gRPC `StreamEvents` LIVE TAIL (the snapshot-to-head → live-tail
+//! upgrade), end-to-end over a real bound port.
+//!
+//! - `live_tail_stays_open_after_catchup`: the defining property vs. the old
+//!   snapshot-to-head — after the catch-up + boundary the stream STAYS OPEN.
+//! - `live_tail_delivers_a_commit_to_an_open_stream`: a commit that lands after
+//!   subscribe arrives on the SAME open stream (the poller picking up the advance).
+//! - `shutdown_does_not_hang_with_an_open_live_stream`: an endless live stream
+//!   does not deadlock graceful shutdown (the live-shutdown watch stops it).
+//! - `live_stream_ownership_is_uniform_permission_denied`: an unowned run is a
+//!   clean pre-stream `permission_denied` (no existence oracle), on the live path.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use kx_gateway::start;
+use kx_proto::proto;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+use common::{await_committed, connect_client, gateway_config, submit_pure_run};
+
+fn open_stream_request(instance_id: &[u8], since_seq: u64) -> proto::StreamEventsRequest {
+    proto::StreamEventsRequest {
+        instance_id: instance_id.to_vec(),
+        since_seq,
+    }
+}
+
+#[tokio::test]
+async fn live_tail_stays_open_after_catchup() {
+    let dir = TempDir::new().unwrap();
+    let running = start(gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = connect_client(running.local_addr()).await;
+
+    let instance = submit_pure_run(&mut c, 1).await;
+    let (mote_id, _) = await_committed(&mut c, &instance).await;
+
+    let mut stream = c
+        .stream_events(open_stream_request(&instance, 0))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Catch-up: read to the boundary, asserting we saw the Committed delta.
+    let mut saw_committed = false;
+    loop {
+        let frame = stream
+            .message()
+            .await
+            .unwrap()
+            .expect("a catch-up frame arrives before the stream could ever end");
+        for delta in frame.deltas {
+            if let Some(proto::event_delta::Kind::Committed(d)) = delta.kind {
+                if d.mote_id == mote_id.to_vec() {
+                    saw_committed = true;
+                }
+            }
+        }
+        if frame.journal_boundary {
+            break;
+        }
+    }
+    assert!(saw_committed, "catch-up delivered the Committed delta");
+
+    // THE live-tail property: after the boundary the stream does NOT end — the next
+    // read blocks (times out). The old snapshot tailer would return `None` here.
+    let next = timeout(Duration::from_millis(500), stream.message()).await;
+    assert!(
+        next.is_err(),
+        "live tail stays open past the boundary (a snapshot stream would end)"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn live_tail_delivers_a_commit_to_an_open_stream() {
+    let dir = TempDir::new().unwrap();
+    let running = start(gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = connect_client(running.local_addr()).await;
+
+    // Subscribe right after submit — the Mote may still be Proposed; the commit
+    // lands later and MUST arrive on this already-open stream.
+    let instance = submit_pure_run(&mut c, 2).await;
+    let mut stream = c
+        .stream_events(open_stream_request(&instance, 0))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let saw_committed = timeout(Duration::from_secs(10), async {
+        loop {
+            match stream.message().await.unwrap() {
+                Some(frame) => {
+                    if frame
+                        .deltas
+                        .iter()
+                        .any(|d| matches!(d.kind, Some(proto::event_delta::Kind::Committed(_))))
+                    {
+                        return true;
+                    }
+                    // Keep reading past boundary frames — the live tail stays open.
+                }
+                // A snapshot stream would end here before the commit → the test fails.
+                None => return false,
+            }
+        }
+    })
+    .await
+    .expect("did not time out waiting for the live commit");
+    assert!(
+        saw_committed,
+        "the live tail delivered the post-subscribe commit on the open stream"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn shutdown_does_not_hang_with_an_open_live_stream() {
+    let dir = TempDir::new().unwrap();
+    let running = start(gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = connect_client(running.local_addr()).await;
+    let instance = submit_pure_run(&mut c, 3).await;
+    await_committed(&mut c, &instance).await;
+
+    // Hold an endless live stream open across shutdown; shutdown must still return
+    // (the live-shutdown watch stops the poll loop so the graceful drain completes).
+    let _stream = c
+        .stream_events(open_stream_request(&instance, 0))
+        .await
+        .unwrap()
+        .into_inner();
+    timeout(Duration::from_secs(10), running.shutdown())
+        .await
+        .expect("shutdown did not hang on the open live stream")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn live_stream_ownership_is_uniform_permission_denied() {
+    let dir = TempDir::new().unwrap();
+    let running = start(gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = connect_client(running.local_addr()).await;
+
+    // An unregistered instance_id is refused with a clean PRE-stream, uniform
+    // permission_denied (no existence oracle) — on the live path.
+    let err = c
+        .stream_events(open_stream_request(&[0u8; 16], 0))
+        .await
+        .expect_err("an unowned run is refused");
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-gateway/tests/ws_e2e.rs
+++ b/crates/kx-gateway/tests/ws_e2e.rs
@@ -1,0 +1,155 @@
+//! R5 — the WebSocket `StreamEvents` bridge (the browser live-tail surface),
+//! end-to-end over a real bound WS port.
+//!
+//! - `ws_streams_committed_delta_as_json`: a committed delta arrives as a JSON
+//!   text frame with lowercase-hex ids (the browser-ergonomic wire).
+//! - `ws_handshake_denied_without_auth`: deny-all rejects the WS upgrade.
+//! - `ws_token_auth_accepts_good_rejects_bad`: the SAME `PrincipalResolver` gates
+//!   the handshake (valid bearer accepted, invalid rejected).
+//! - `ws_missing_instance_is_rejected`: a malformed query is a handshake error.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use kx_gateway::start;
+use serde_json::Value;
+use tempfile::TempDir;
+use tokio::time::timeout;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message;
+
+use common::{await_committed, connect_client, gateway_config, submit_pure_run};
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+#[tokio::test]
+async fn ws_streams_committed_delta_as_json() {
+    let dir = TempDir::new().unwrap();
+    let running = start(gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = connect_client(running.local_addr()).await;
+    let instance = submit_pure_run(&mut c, 1).await;
+    let (mote_id, _) = await_committed(&mut c, &instance).await;
+
+    let url = format!(
+        "ws://{}/v1/events?instance={}&since=0",
+        running.ws_local_addr(),
+        hex(&instance)
+    );
+    let (mut ws, _resp) = connect_async(url)
+        .await
+        .expect("dev-allow-local accepts the WS handshake");
+
+    let saw = timeout(Duration::from_secs(5), async {
+        while let Some(message) = ws.next().await {
+            if let Ok(Message::Text(text)) = message {
+                let frame: Value =
+                    serde_json::from_str(&text).expect("each WS frame is valid JSON");
+                if let Some(deltas) = frame["deltas"].as_array() {
+                    for delta in deltas {
+                        if delta["type"] == "committed" {
+                            // The wire renders ids as 64-char lowercase hex.
+                            assert_eq!(delta["mote_id"], hex(&mote_id));
+                            assert_eq!(delta["mote_id"].as_str().unwrap().len(), 64);
+                            assert_eq!(delta["nd_class"], "pure");
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    })
+    .await
+    .expect("did not time out reading WS frames");
+    assert!(
+        saw,
+        "the WS bridge delivered the committed delta as hex JSON"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn ws_handshake_denied_without_auth() {
+    let dir = TempDir::new().unwrap();
+    // Deny-all (no --dev-allow-local, no tokens).
+    let running = start(gateway_config(&dir, false, HashMap::new()))
+        .await
+        .unwrap();
+    let url = format!(
+        "ws://{}/v1/events?instance={}&since=0",
+        running.ws_local_addr(),
+        "ab".repeat(16)
+    );
+    assert!(
+        connect_async(url).await.is_err(),
+        "deny-all rejects the WS handshake (Rule 8c — no silent open door)"
+    );
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn ws_token_auth_accepts_good_rejects_bad() {
+    let dir = TempDir::new().unwrap();
+    let mut tokens = HashMap::new();
+    tokens.insert("tok-good".to_string(), "alice@acme".to_string());
+    let running = start(gateway_config(&dir, false, tokens)).await.unwrap();
+    let base = format!(
+        "ws://{}/v1/events?instance={}&since=0",
+        running.ws_local_addr(),
+        "ab".repeat(16)
+    );
+
+    // Valid bearer → the handshake (auth) passes (the stream then closes on the
+    // unowned instance, but the AUTH gate accepted the upgrade).
+    let mut good = base.clone().into_client_request().unwrap();
+    good.headers_mut()
+        .insert("authorization", "Bearer tok-good".parse().unwrap());
+    assert!(
+        connect_async(good).await.is_ok(),
+        "a valid bearer token passes the WS handshake"
+    );
+
+    // Invalid bearer → rejected at the handshake (uniform, no oracle).
+    let mut bad = base.into_client_request().unwrap();
+    bad.headers_mut()
+        .insert("authorization", "Bearer nope".parse().unwrap());
+    assert!(
+        connect_async(bad).await.is_err(),
+        "an invalid bearer token is rejected at the WS handshake"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn ws_missing_instance_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let running = start(gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    // No ?instance → a malformed-query handshake rejection.
+    let url = format!("ws://{}/v1/events?since=0", running.ws_local_addr());
+    assert!(
+        connect_async(url).await.is_err(),
+        "a missing ?instance is a handshake error"
+    );
+    running.shutdown().await.unwrap();
+}


### PR DESCRIPTION
## R5 (D130) — live-tail `StreamEvents` + WebSocket bridge

Closes the audit's live-UX gap (reachability re-plan R5 / D120.3). The gateway's `StreamEvents` RPC was **snapshot-to-head** (it caught up to the journal boundary and *ended*; the CLI `events --follow` re-polled every 250ms to fake liveness). R5 makes it a true **live tail** — the stream stays open and keeps delivering `EventFrame`s as the journal advances — and adds the **browser WebSocket bridge** that re-skins the same live stream as JSON.

### What this adds
- **`kx-gateway-core` (NO new deps — dep wall pristine):** an `EventTailer` seam (default `SnapshotTailer`, zero-dep) + `events.rs` refactored into reusable `check_run_ownership` + `frames_for_range`. `stream_events` delegates to the injected tailer.
- **`kx-gateway` (the binary, where tokio time/sync live):** `LiveTailer` — a per-subscriber poller (bounded `mpsc(256)`, 250ms poll of `current_seq()`, reused framing) that keeps the stream open after the boundary, never acks past head, terminates a slow consumer with `Status::resource_exhausted` (the "CatchupRequired" signal — a `Status`, **not** a wire field, since the frozen proto has none), and cleans up on client disconnect (`select!` on `tx.closed()`). A **`watch` shutdown** flips the poll loops off so the (otherwise endless) streams end and graceful drain completes. A **WebSocket bridge** (`ws.rs`, `tokio-tungstenite`) on a separate `--ws-listen` (default `127.0.0.1:50152`): handshake-auth reuses the R2 `PrincipalResolver` (bearer `Authorization` **or** `Sec-WebSocket-Protocol`), `?instance=&since=` from the query, frames serialized as a **JSON hex DTO** (mirrors R4 — browser-ergonomic, no protobuf-es needed).
- **`kx-cli`:** `events --follow` now consumes the single live stream (drops the re-poll) and auto-resumes from its last `next_seq` on a CatchupRequired drop.

### Don't-break invariants (verified)
- **Frozen proto = ZERO edits**; **frozen-trio `kx-scheduler`/`kx-executor`/`kx-inference` `src/**` diff-EMPTY**.
- **Read-side only** — no new journal write path; coordinator stays sole writer; the projection digest `a6b5c679…` is untouched (the existing digest tests pass).
- **`kx-gateway-core` deps unchanged** — the WS transport (`tokio-tungstenite`, `futures-util`, `serde_json`) lives in the binary only; the `dep_wall` cargo-tree test still passes.
- **SN-8** — `EventDelta` carries only ids/refs/classes (no payload/secrets); ownership is uniform `permission_denied` (no existence oracle) on the live path.

### Golden Rule 8 — pre-flight
**Pass A (a) breaks:** the live tail's MoteCommitted/boundary set stays consistent with the journal (resume never rewinds; never acks past head — half-open `+1` arithmetic reused verbatim); the existing `serve_e2e` still passes (backward-compat: snapshot consumers break at `journal_boundary`); **shutdown does not hang** on an endless stream (the `watch` stops poll loops — proven by a test). **(b) perf:** zero cost when the snapshot tailer is used; per-subscriber poll is a cheap `current_seq()` every 250ms (not a busy-spin); bounded 256-frame memory; `try_send` → CatchupRequired on overflow (never blocks the journal/other subscribers); ownership fold is once per subscribe (not per poll). **(c) security:** new long-lived connection surface is gated by R2 auth *before* the handler runs (deny-all default; WS handshake-auth reuses `PrincipalResolver`); deltas carry no PII/secrets; no rotation/global-cap (single-system) — flagged.

**Pass B / tech-stack flag (ii):** one new third-party dep — **`tokio-tungstenite` (MIT)** — plus `futures-util` (already transitive) and tokio `sync`/`tokio-stream` in the binary. Flagged follow-ons (recorded in the corpus as the **runtime-optimization backlog**): the **journal `watch`/notify push seam** (kills poll latency+CPU — the principled endpoint), a shared-broadcast poller (scale), a server-projection-cache (D120.4), a max-subscribers semaphore (cloud), and protobuf-over-WS framing.

### Tests
`kx-gateway` live-tail e2e (stays-open-after-catchup, live-delivery-to-open-stream, **shutdown-does-not-hang**, uniform-ownership); WS e2e (committed delta as hex JSON, deny-all rejected, token accept/reject, missing-instance rejected); the existing `serve_e2e` + `signature_e2e` unchanged + green; `kx-cli` `events --follow` subprocess e2e (live committed delta) + unit tests; gateway-core unit (hex DTO, nd-class, frame). Full `just ci` green (fmt · clippy `-D warnings` · test · deny · doc `-D warnings` · ffi-link · build-no-inference · I1.c byte-determinism · scale-smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
