### PR TITLE
feat(workflow,mote): R6 (D130) — Morphic recipe library + prompt-templating

### DIFF
--- a/crates/kx-model-harness/src/prompt.rs
+++ b/crates/kx-model-harness/src/prompt.rs
@@ -16,7 +16,10 @@ use kx_inference::InferenceInput;
 use kx_mote::{ConfigKey, ConfigVal, Mote};
 
 /// `config_subset` key under which the harness carries a Mote's prompt text.
-pub const PROMPT_KEY: &str = "prompt";
+///
+/// Re-exported from [`kx_mote::PROMPT_KEY`] — the single source of truth shared
+/// with the workflow recipe library + the planner (no hand-mirrored copies).
+pub use kx_mote::PROMPT_KEY;
 
 /// Insert `prompt` into a `config_subset` map under [`PROMPT_KEY`]. The map is
 /// part of `MoteDef`, so the prompt folds into the Mote's identity.

--- a/crates/kx-mote/src/lib.rs
+++ b/crates/kx-mote/src/lib.rs
@@ -88,7 +88,9 @@ pub use id::{InputDataId, LogicRef, MoteDefHash, MoteId, PromptTemplateHash};
 pub use inference_params::{Grammar, InferenceParams};
 pub use mote::Mote;
 pub use ndclass::NdClass;
-pub use strings::{ConfigKey, ConfigVal, GraphPosition, ModelId, ToolName, ToolVersion};
+pub use strings::{
+    ConfigKey, ConfigVal, GraphPosition, ModelId, ToolName, ToolVersion, PROMPT_KEY,
+};
 pub use topology::{ChildDescriptor, RoleId, TopologyDecision};
 
 #[cfg(test)]

--- a/crates/kx-mote/src/strings.rs
+++ b/crates/kx-mote/src/strings.rs
@@ -43,6 +43,23 @@ pub struct ConfigKey(pub String);
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ConfigVal(pub Vec<u8>);
 
+/// The single canonical [`ConfigKey`] *name* under which a Mote's instruction
+/// prompt is carried in its `config_subset`.
+///
+/// `MoteDef` has no prompt field — in the full runtime the prompt is assembled
+/// at context-assembly time, but its identity-bearing text is carried here, in
+/// `config_subset`, so the prompt folds into [`crate::MoteDef::hash`] (same
+/// prompt ⇒ same `MoteId`, different prompt ⇒ different `MoteId`). This constant
+/// is promoted to the shared substrate so every layer that writes or reads a
+/// prompt (the workflow recipe library, the model harness, the planner)
+/// references **one** source rather than hand-mirroring the literal `"prompt"`
+/// across crates (closes the IMP-7 hand-mirrored-constant hazard).
+///
+/// Only the *string value* participates in identity (it is a [`ConfigKey`]'s
+/// inner `String`); the constant binding itself is never serialized, so adding
+/// or referencing it cannot move any digest.
+pub const PROMPT_KEY: &str = "prompt";
+
 /// The stable position of a Mote in its DAG.
 ///
 /// Assigned at DAG-compile time (workflow SDK) or derived from a topology

--- a/crates/kx-planner/src/lower.rs
+++ b/crates/kx-planner/src/lower.rs
@@ -29,9 +29,12 @@ use crate::role::{RoleRecipe, RoleRecipeResolver};
 /// The `config_subset` key under which a step's `intent` is carried — the same
 /// stable convention `kx_model_harness::prompt::PROMPT_KEY` reads, so a model
 /// executor uses the intent as the step's instruction. Identity-bearing (two
-/// plans with different intents compile to different `MoteId`s). A drift guard
-/// in `kx-model-harness` asserts the two constants stay equal.
-pub const PLAN_PROMPT_KEY: &str = "prompt";
+/// plans with different intents compile to different `MoteId`s).
+///
+/// Re-exported from [`kx_mote::PROMPT_KEY`], the single source of truth: the
+/// planner intent key and the harness prompt key are now the **same** constant
+/// by construction (the drift guard in `kx-model-harness` can no longer fail).
+pub use kx_mote::PROMPT_KEY as PLAN_PROMPT_KEY;
 
 /// Derive a replay-stable `WorkflowDef` seed from the committed plan bytes.
 ///

--- a/crates/kx-workflow/examples/recipe_to_digest.rs
+++ b/crates/kx-workflow/examples/recipe_to_digest.rs
@@ -1,0 +1,142 @@
+//! Author a workflow from the **recipe library**, run it to a reproducible
+//! committed digest, then bind a **prompt template** and watch the rendered
+//! prompt flow into Mote identity.
+//!
+//! This is the "how do I use the recipes + prompt-templating?" example. Part 1
+//! uses an all-PURE `map_reduce` so it needs no model / network / capability
+//! wiring and is fully deterministic; Part 2 shows that a rendered prompt is
+//! identity-bearing (same prompt ⇒ same `MoteId`, different prompt ⇒ different).
+//!
+//! Run it:
+//!
+//! ```text
+//! cargo run -p kx-workflow --example recipe_to_digest
+//! ```
+//!
+//! See ARCHITECTURE.md / GLOSSARY.md for how the pieces fit.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use kx_executor::{run_pure_mote, LocalResourceManager, TestMoteExecutor};
+use kx_journal::SqliteJournal;
+use kx_mote::{ConfigKey, ConfigVal, LogicRef, ModelId, ToolName, PROMPT_KEY};
+use kx_projection::Projection;
+use kx_runtime::digest_journal;
+use kx_scheduler::{LocalPlacement, Scheduler};
+use kx_workflow::{
+    compile, map_reduce, permissive_warrant, render_prompts, transform, WorkerKind, WorkflowDef,
+    TEMPLATE_KEY,
+};
+
+fn short(bytes: &[u8]) -> String {
+    let mut s = String::new();
+    for b in &bytes[..4] {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model = ModelId("local".into());
+    let cap = ToolName("demo".into());
+
+    // ── Part 1. A recipe → a reproducible run ───────────────────────────────
+    // `map_reduce` fans out to N PURE mappers and folds them in one reduce step.
+    // Authored as data — pin the seed and the logic refs and it re-derives the
+    // same Mote DAG every time.
+    let mappers = [
+        LogicRef::from_bytes([1; 32]),
+        LogicRef::from_bytes([2; 32]),
+        LogicRef::from_bytes([3; 32]),
+    ];
+    let wf = map_reduce(
+        42,
+        model.clone(),
+        cap.clone(),
+        WorkerKind::Transform,
+        &mappers,
+        LogicRef::from_bytes([9; 32]),
+    )?;
+    let compiled = compile(&wf)?;
+    println!(
+        "1. map_reduce recipe → {} Motes ({} mappers + 1 reduce)",
+        compiled.motes.len(),
+        mappers.len()
+    );
+
+    // Submit + run every Mote through the real single-node primitives, then fold
+    // the journal back to a digest. Re-running yields the SAME digest.
+    let journal = SqliteJournal::open_in_memory()?;
+    let rm = LocalResourceManager::dev_defaults();
+    let executor = TestMoteExecutor::deterministic();
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    for cm in &compiled.motes {
+        scheduler.submit(cm.mote.clone(), cm.warrant.clone(), &mut projection)?;
+    }
+    for cm in &compiled.motes {
+        run_pure_mote(&cm.mote, &cm.warrant, &journal, &rm, &executor)?;
+    }
+    let committed = Projection::from_journal(&journal)?.committed_count();
+    let digest = digest_journal(&journal)?;
+    println!(
+        "2. ran to {committed} committed; journal digest = {} (re-run → identical)",
+        digest.to_hex()
+    );
+
+    // ── Part 2. A prompt template → identity-bearing prompt ─────────────────
+    // A step carries an un-rendered template under TEMPLATE_KEY with named
+    // {slots}. `render_prompts` substitutes params into the final prompt BEFORE
+    // compile, so the rendered prompt folds into the Mote's identity.
+    let build_templated = || -> WorkflowDef {
+        let mut wf = WorkflowDef::new(7);
+        let mut step = transform(
+            LogicRef::from_bytes([5; 32]),
+            model.clone(),
+            permissive_warrant(model.clone()),
+            cap.clone(),
+        );
+        step.config_subset.insert(
+            ConfigKey(TEMPLATE_KEY.to_string()),
+            ConfigVal(b"summarize {topic} for {audience}".to_vec()),
+        );
+        wf.add_step(step);
+        wf
+    };
+
+    let mut a = build_templated();
+    let mut b = build_templated();
+    let params = |topic: &str, audience: &str| {
+        BTreeMap::from([
+            ("topic".to_string(), topic.to_string()),
+            ("audience".to_string(), audience.to_string()),
+        ])
+    };
+    render_prompts(&mut a, &params("outages", "SREs"))?;
+    render_prompts(&mut b, &params("revenue", "execs"))?;
+
+    let ca = compile(&a)?;
+    let cb = compile(&b)?;
+    let prompt_a = ca.motes[0]
+        .mote
+        .def
+        .config_subset
+        .get(&ConfigKey(PROMPT_KEY.to_string()))
+        .map(|v| String::from_utf8_lossy(&v.0).into_owned())
+        .unwrap_or_default();
+
+    println!("3. rendered prompt   = {prompt_a:?}");
+    println!(
+        "4. mote id (outages) = {}…   mote id (revenue) = {}…",
+        short(ca.motes[0].mote.id.as_bytes()),
+        short(cb.motes[0].mote.id.as_bytes())
+    );
+    assert_ne!(
+        ca.motes[0].mote.id, cb.motes[0].mote.id,
+        "a different rendered prompt is a different Mote — fresh call, not recipe reuse"
+    );
+    println!("   → distinct prompts ⇒ distinct Mote identity (SN-8: derived, exact, never fuzzy)");
+
+    Ok(())
+}

--- a/crates/kx-workflow/src/error.rs
+++ b/crates/kx-workflow/src/error.rs
@@ -43,4 +43,48 @@ pub enum CompileError {
         /// The child step's index.
         child: usize,
     },
+
+    /// A prompt template (see [`crate::PromptTemplate`]) is structurally
+    /// malformed — an unbalanced, empty, nested, or invalid-character
+    /// `{placeholder}` brace. Detected by the pure [`crate::PromptTemplate::parse`].
+    #[error("malformed prompt template: {reason}")]
+    MalformedTemplate {
+        /// Human-readable description of the structural defect.
+        reason: String,
+    },
+
+    /// A template placeholder has no bound parameter at render time. Fail-closed:
+    /// every `{name}` MUST be supplied — a recipe never renders a half-bound prompt.
+    #[error("prompt template placeholder '{name}' has no bound parameter")]
+    MissingPlaceholder {
+        /// The unfilled placeholder name.
+        name: String,
+    },
+
+    /// A supplied parameter names no placeholder the template declares.
+    /// Fail-closed: an unknown parameter is a caller error, never silently dropped
+    /// (a typo'd param would otherwise leave the intended placeholder unfilled).
+    #[error("prompt parameter '{name}' names no template placeholder")]
+    UnknownParam {
+        /// The unrecognized parameter name.
+        name: String,
+    },
+
+    /// [`crate::render_prompts`] failed rendering the template carried by a
+    /// specific step. Carries the step index and the underlying reason; the
+    /// `WorkflowDef` is left byte-unchanged (the pass is atomic — clone-then-commit).
+    #[error("prompt render failed at step {step}: {reason}")]
+    RenderPromptStep {
+        /// The index of the step whose template failed to render.
+        step: usize,
+        /// The underlying [`MalformedTemplate`](Self::MalformedTemplate) /
+        /// [`MissingPlaceholder`](Self::MissingPlaceholder) /
+        /// [`UnknownParam`](Self::UnknownParam) failure, rendered.
+        reason: String,
+    },
+
+    /// A recipe builder was given an empty set of required step logics (zero
+    /// mappers / workers / attempts / images). A recipe must declare ≥1 such step.
+    #[error("recipe requires at least one step but none were provided")]
+    EmptyRecipe,
 }

--- a/crates/kx-workflow/src/lib.rs
+++ b/crates/kx-workflow/src/lib.rs
@@ -52,6 +52,8 @@
 mod compile;
 mod def;
 mod error;
+mod prompt;
+mod recipes;
 mod retrieval;
 mod share;
 mod synthesis;
@@ -59,6 +61,11 @@ mod synthesis;
 pub use compile::compile;
 pub use def::{CompiledMote, CompiledWorkflow, StepDef, StepEdge, StepRef, StepRole, WorkflowDef};
 pub use error::CompileError;
+pub use prompt::{put_rendered_prompt, render_prompts, PromptTemplate, TEMPLATE_KEY};
+pub use recipes::{
+    fan_out_gather, image_batch_describe_reduce, map_reduce, react_tool_loop, retry_until_critic,
+    WorkerKind, IMAGE_REF_KEY,
+};
 pub use retrieval::{encode_retrieval_fact, retrieval, retrieval_result_ref};
 pub use share::{Manifest, ManifestId};
 pub use synthesis::{

--- a/crates/kx-workflow/src/prompt.rs
+++ b/crates/kx-workflow/src/prompt.rs
@@ -1,0 +1,290 @@
+//! A pure, deterministic, fail-closed **prompt-template engine** for the
+//! authoring layer.
+//!
+//! `MoteDef` has no prompt field — the identity-bearing instruction text is
+//! carried in `config_subset` under [`kx_mote::PROMPT_KEY`], so it folds into
+//! [`kx_mote::MoteDef::hash`] → `MoteId` (same prompt ⇒ same identity, different
+//! prompt ⇒ different identity). This module lets a recipe author carry an
+//! *un-rendered* template under [`TEMPLATE_KEY`] with named `{placeholder}`
+//! slots, then bind named parameters into the final prompt **before**
+//! [`crate::compile`] — so the *rendered* prompt is what folds into identity.
+//!
+//! # Where rendering happens (and why)
+//!
+//! Rendering is an **authoring/bind-time** step (run after
+//! [`WorkflowDef::bind_param`](crate::WorkflowDef::bind_param), before
+//! [`compile`](crate::compile)), never a dispatch-time step. That is the only
+//! placement that keeps the prompt identity-bearing and composable with the
+//! existing free-param binding path (the D121 inbound-execution path binds
+//! structural slots, then a caller may [`render_prompts`] the text). A prompt
+//! substituted at dispatch time would NOT fold into `MoteId`, silently breaking
+//! recipe-reuse / fresh-call semantics.
+//!
+//! # Guarantees
+//!
+//! - **Pure / total / deterministic.** [`PromptTemplate::parse`] is a function of
+//!   its input string only; [`PromptTemplate::render`] is a function of the
+//!   template + the (`BTreeMap`-ordered) params — no clock, host, PID, float, or
+//!   hash-map iteration order.
+//! - **Fail-closed.** A malformed template, an unfilled placeholder, or an
+//!   unknown parameter is an error — never a silently dropped or half-rendered
+//!   prompt.
+//! - **Structure-safe, not content-safe.** The engine validates template
+//!   *structure*; it does not sanitize param *content*. A param value is an
+//!   opaque `config_subset` byte string — it cannot widen a warrant, mint a
+//!   capability, or alter DAG topology. Content trust stays the warrant +
+//!   `deterministic_critic`'s job. (A rendered prompt folds into `MoteId`, so
+//!   callers must not pass secrets as prompt params — same property as
+//!   [`WorkflowDef::bind_param`](crate::WorkflowDef::bind_param).)
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_mote::{ConfigKey, ConfigVal, PROMPT_KEY};
+
+use crate::def::WorkflowDef;
+use crate::error::CompileError;
+
+/// The `config_subset` key under which a step carries its **un-rendered** prompt
+/// template — read, rendered, and cleared by [`render_prompts`].
+///
+/// Distinct from [`kx_mote::PROMPT_KEY`] (the key the *rendered* prompt lands
+/// under). A step carrying `TEMPLATE_KEY` is "render me"; once rendered, only
+/// `PROMPT_KEY` remains, so a rendered `WorkflowDef` is indistinguishable from
+/// one authored with a literal prompt (and the pass is idempotent).
+pub const TEMPLATE_KEY: &str = "prompt_template";
+
+/// One segment of a parsed [`PromptTemplate`], in source order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Segment {
+    /// A run of literal characters (with `{{`/`}}` already de-escaped to `{`/`}`).
+    Literal(String),
+    /// A `{name}` placeholder slot to be filled at render time.
+    Slot(String),
+}
+
+/// A parsed prompt template: an ordered sequence of literal + `{placeholder}`
+/// segments, plus the (sorted) set of placeholder names it declares.
+///
+/// Build one with [`PromptTemplate::parse`]; fill it with
+/// [`PromptTemplate::render`]. Both are pure — the type holds no interior
+/// mutability and no allocation beyond its segment list.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptTemplate {
+    segments: Vec<Segment>,
+    declared: BTreeSet<String>,
+}
+
+impl PromptTemplate {
+    /// Parse a template string with `{name}` placeholder slots.
+    ///
+    /// Slot names are `[A-Za-z0-9_]+`. `{{` and `}}` are literal escapes for `{`
+    /// and `}`. Pure, total, and deterministic — a function of `src` alone.
+    ///
+    /// # Errors
+    ///
+    /// [`CompileError::MalformedTemplate`] on an unterminated placeholder, an
+    /// empty `{}`, a nested `{`, an unescaped lone `}`, or a placeholder name
+    /// with a non-`[A-Za-z0-9_]` character.
+    pub fn parse(src: &str) -> Result<Self, CompileError> {
+        let chars: Vec<char> = src.chars().collect();
+        let mut segments: Vec<Segment> = Vec::new();
+        let mut declared: BTreeSet<String> = BTreeSet::new();
+        let mut lit = String::new();
+        let mut i = 0usize;
+
+        while i < chars.len() {
+            let c = chars[i];
+            if c == '{' {
+                // `{{` → a literal '{'.
+                if chars.get(i + 1) == Some(&'{') {
+                    lit.push('{');
+                    i += 2;
+                    continue;
+                }
+                // Start of a placeholder — flush any pending literal first.
+                if !lit.is_empty() {
+                    segments.push(Segment::Literal(std::mem::take(&mut lit)));
+                }
+                i += 1; // consume '{'
+                let mut name = String::new();
+                let mut closed = false;
+                while i < chars.len() {
+                    let d = chars[i];
+                    if d == '}' {
+                        closed = true;
+                        i += 1;
+                        break;
+                    }
+                    if d == '{' {
+                        return Err(CompileError::MalformedTemplate {
+                            reason: "nested '{' inside a placeholder".to_string(),
+                        });
+                    }
+                    name.push(d);
+                    i += 1;
+                }
+                if !closed {
+                    return Err(CompileError::MalformedTemplate {
+                        reason: format!("unterminated placeholder '{{{name}'"),
+                    });
+                }
+                if name.is_empty() {
+                    return Err(CompileError::MalformedTemplate {
+                        reason: "empty placeholder '{}'".to_string(),
+                    });
+                }
+                if !name
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+                {
+                    return Err(CompileError::MalformedTemplate {
+                        reason: format!(
+                            "placeholder '{name}' has a character outside [A-Za-z0-9_]"
+                        ),
+                    });
+                }
+                declared.insert(name.clone());
+                segments.push(Segment::Slot(name));
+            } else if c == '}' {
+                // `}}` → a literal '}'. A lone '}' is a structural error.
+                if chars.get(i + 1) == Some(&'}') {
+                    lit.push('}');
+                    i += 2;
+                    continue;
+                }
+                return Err(CompileError::MalformedTemplate {
+                    reason: "unescaped '}' (use '}}' for a literal brace)".to_string(),
+                });
+            } else {
+                lit.push(c);
+                i += 1;
+            }
+        }
+        if !lit.is_empty() {
+            segments.push(Segment::Literal(lit));
+        }
+        Ok(Self { segments, declared })
+    }
+
+    /// The placeholder names this template declares, in deterministic (sorted) order.
+    pub fn slots(&self) -> impl Iterator<Item = &str> {
+        self.declared.iter().map(String::as_str)
+    }
+
+    /// Render the template into the final prompt string.
+    ///
+    /// Fail-closed: every key in `params` MUST be a declared slot, and every
+    /// declared slot MUST be present in `params`. Deterministic — output bytes
+    /// depend only on the (source-order) segments and the param values.
+    ///
+    /// # Errors
+    ///
+    /// [`CompileError::UnknownParam`] if a param names no declared slot;
+    /// [`CompileError::MissingPlaceholder`] if a declared slot has no param.
+    pub fn render(&self, params: &BTreeMap<String, String>) -> Result<String, CompileError> {
+        // Unknown-param check first (deterministic first-failure over BTreeMap order).
+        for key in params.keys() {
+            if !self.declared.contains(key) {
+                return Err(CompileError::UnknownParam { name: key.clone() });
+            }
+        }
+        // Every declared slot must be supplied.
+        for name in &self.declared {
+            if !params.contains_key(name) {
+                return Err(CompileError::MissingPlaceholder { name: name.clone() });
+            }
+        }
+        let capacity: usize = self
+            .segments
+            .iter()
+            .map(|s| match s {
+                Segment::Literal(l) => l.len(),
+                Segment::Slot(n) => params.get(n).map_or(0, String::len),
+            })
+            .sum();
+        let mut out = String::with_capacity(capacity);
+        for s in &self.segments {
+            match s {
+                Segment::Literal(l) => out.push_str(l),
+                // Presence is guaranteed by the missing-placeholder check above;
+                // the defensive arm keeps this total without an `expect`.
+                Segment::Slot(n) => match params.get(n) {
+                    Some(v) => out.push_str(v),
+                    None => return Err(CompileError::MissingPlaceholder { name: n.clone() }),
+                },
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Render `template` with `params` and write the result into
+/// `config_subset[`[`PROMPT_KEY`]`]` — the author-side convenience for a single
+/// step. Identity-bearing: the rendered prompt folds into the step's `MoteId`.
+///
+/// # Errors
+///
+/// Propagates [`PromptTemplate::parse`] / [`PromptTemplate::render`] failures
+/// (fail-closed — on error the map is left unmodified).
+pub fn put_rendered_prompt(
+    config_subset: &mut BTreeMap<ConfigKey, ConfigVal>,
+    template: &str,
+    params: &BTreeMap<String, String>,
+) -> Result<(), CompileError> {
+    let rendered = PromptTemplate::parse(template)?.render(params)?;
+    config_subset.insert(
+        ConfigKey(PROMPT_KEY.to_string()),
+        ConfigVal(rendered.into_bytes()),
+    );
+    Ok(())
+}
+
+/// The bind-time prompt-render pass: for every step carrying a [`TEMPLATE_KEY`]
+/// slot, render its template against `params`, write the result under
+/// [`PROMPT_KEY`], and remove the template slot. Returns the number of steps
+/// whose prompt was rendered.
+///
+/// Run this **after** [`WorkflowDef::bind_param`](crate::WorkflowDef::bind_param)
+/// and **before** [`compile`](crate::compile) so the rendered prompt is
+/// identity-bearing. Idempotent: a second run is a no-op (the template slot is
+/// already gone). Steps with no template slot are untouched.
+///
+/// **Atomic.** The pass stages its work on a clone and commits only on full
+/// success — a render failure at any step leaves `def` **byte-unchanged**.
+///
+/// # Errors
+///
+/// [`CompileError::RenderPromptStep`] naming the first failing step (template
+/// not valid UTF-8, malformed, or with a missing/unknown param).
+pub fn render_prompts(
+    def: &mut WorkflowDef,
+    params: &BTreeMap<String, String>,
+) -> Result<usize, CompileError> {
+    let template_key = ConfigKey(TEMPLATE_KEY.to_string());
+    let prompt_key = ConfigKey(PROMPT_KEY.to_string());
+
+    // Stage on a clone so any failure is a no-op on the caller's `WorkflowDef`.
+    let mut staged = def.clone();
+    let mut rendered = 0usize;
+    for (i, step) in staged.steps.iter_mut().enumerate() {
+        let Some(tmpl) = step.config_subset.get(&template_key).cloned() else {
+            continue;
+        };
+        let text = std::str::from_utf8(&tmpl.0).map_err(|_| CompileError::RenderPromptStep {
+            step: i,
+            reason: "template bytes are not valid UTF-8".to_string(),
+        })?;
+        let prompt = PromptTemplate::parse(text)
+            .and_then(|t| t.render(params))
+            .map_err(|e| CompileError::RenderPromptStep {
+                step: i,
+                reason: e.to_string(),
+            })?;
+        step.config_subset
+            .insert(prompt_key.clone(), ConfigVal(prompt.into_bytes()));
+        step.config_subset.remove(&template_key);
+        rendered += 1;
+    }
+    *def = staged;
+    Ok(rendered)
+}

--- a/crates/kx-workflow/src/recipes.rs
+++ b/crates/kx-workflow/src/recipes.rs
@@ -1,0 +1,324 @@
+//! The **Morphic recipe library**: ready-to-run multi-agent patterns authored as
+//! pure data, composed entirely from the existing step builders in
+//! [`crate::synthesis`] (`generator` / `transform` / `deterministic_critic`).
+//!
+//! Each recipe returns a [`WorkflowDef`] that [`compile`](crate::compile)s to a
+//! deterministic Mote DAG: pin the `seed` + model + inference params and the
+//! recipe re-derives byte-identical `MoteId`s (D50). Recipes are **additive** —
+//! they wire existing builders + edges and change no core topology, no
+//! `compile` lowering, and no runtime materializer.
+//!
+//! # Width is bounded (single-level) by construction
+//!
+//! Every recipe here has a **bounded, authoring-time width** (a fixed number of
+//! mappers / workers / attempts / images / turns), so the whole graph is a
+//! static, fully-wired DAG. That is the correct single-level form: a
+//! runtime-decided, *dynamic* fan-out width is the job of a `topology_shaper`
+//! ([`crate::topology_shaper`], exercised by the runtime materializer) — and a
+//! true *in-workflow iterative re-shaping* loop (a shaper re-deciding from its
+//! own children's verdicts within one run) is the advanced topology kept for the
+//! cloud tier. Multi-round iteration on the single-node runtime is expressed by
+//! **appending a fresh registered round** (the planner's D76/D77 replanning),
+//! never by mutating a committed Mote.
+//!
+//! # Prompts
+//!
+//! A recipe wires step *structure*; bind each step's prompt with the
+//! [`crate::prompt`] engine (`config_subset[`[`TEMPLATE_KEY`](crate::TEMPLATE_KEY)`]`
+//! → [`render_prompts`](crate::render_prompts)) before [`compile`](crate::compile).
+
+use std::collections::BTreeMap;
+
+use kx_content::ContentRef;
+use kx_critic_types::CheckSpec;
+use kx_mote::{ConfigKey, ConfigVal, EdgeMeta, LogicRef, ModelId, ToolName, ToolVersion};
+
+use crate::def::WorkflowDef;
+use crate::error::CompileError;
+use crate::synthesis::{deterministic_critic, generator, permissive_warrant, transform};
+
+/// Which builder a fan-out leaf step uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkerKind {
+    /// A PURE deterministic mapper ([`crate::transform`]) — `IdempotentByConstruction`.
+    Transform,
+    /// A READ-ONLY-NONDET sampler ([`crate::generator`]) — `StageThenCommit`.
+    Generator,
+}
+
+/// The `config_subset` key under which an image-describe step carries the
+/// content ref of the image it consumes — baked at authoring time by
+/// [`image_batch_describe_reduce`] (one distinct image per describe step,
+/// identity-bearing). The multi-modal image path (PR-2) routes the referenced
+/// content to the model as a `content_ref` at dispatch.
+pub const IMAGE_REF_KEY: &str = "image_ref";
+
+/// Shared fan-in builder: `N` leaf steps of `kind` → one PURE `combine` step,
+/// with a Data edge from each leaf to `combine`.
+fn fan_in(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    kind: WorkerKind,
+    leaf_logics: &[LogicRef],
+    combine_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    if leaf_logics.is_empty() {
+        return Err(CompileError::EmptyRecipe);
+    }
+    let warrant = permissive_warrant(model_id.clone());
+    let mut wf = WorkflowDef::new(seed);
+
+    let mut leaves = Vec::with_capacity(leaf_logics.len());
+    for logic in leaf_logics {
+        let step = match kind {
+            WorkerKind::Transform => transform(
+                *logic,
+                model_id.clone(),
+                warrant.clone(),
+                capability.clone(),
+            ),
+            WorkerKind::Generator => generator(
+                *logic,
+                model_id.clone(),
+                warrant.clone(),
+                capability.clone(),
+            ),
+        };
+        leaves.push(wf.add_step(step));
+    }
+    let combine = wf.add_step(transform(combine_logic, model_id, warrant, capability));
+    for &leaf in &leaves {
+        wf.add_edge(leaf, combine, EdgeMeta::data())?;
+    }
+    Ok(wf)
+}
+
+/// **map-reduce.** `N` mapper steps (each [`WorkerKind`]) → one PURE reduce step
+/// that consumes every mapper on a Data edge. Static `N` (`mapper_logics.len()`).
+///
+/// `WorkerKind::Transform` mappers are PURE (a deterministic map); `Generator`
+/// mappers sample (a model map). The reduce is always a PURE `transform` — a
+/// deterministic fold of the committed mapper outputs.
+///
+/// # Errors
+///
+/// [`CompileError::EmptyRecipe`] if `mapper_logics` is empty; propagates any
+/// edge-declaration error from [`WorkflowDef::add_edge`](crate::WorkflowDef::add_edge).
+pub fn map_reduce(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    kind: WorkerKind,
+    mapper_logics: &[LogicRef],
+    reduce_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    fan_in(
+        seed,
+        model_id,
+        capability,
+        kind,
+        mapper_logics,
+        reduce_logic,
+    )
+}
+
+/// **fan-out / gather.** `N` parallel READ-ONLY-NONDET worker steps (independent
+/// samplers) → one PURE gather step that folds all worker outputs. Static `N`
+/// (`worker_logics.len()`).
+///
+/// Distinguished from [`map_reduce`] by intent: the workers here are always
+/// non-deterministic generators (e.g. `N` independent model samples) and the
+/// gather is a deterministic combine (e.g. majority vote, concatenation).
+///
+/// # Errors
+///
+/// [`CompileError::EmptyRecipe`] if `worker_logics` is empty; propagates edge errors.
+pub fn fan_out_gather(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    worker_logics: &[LogicRef],
+    gather_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    fan_in(
+        seed,
+        model_id,
+        capability,
+        WorkerKind::Generator,
+        worker_logics,
+        gather_logic,
+    )
+}
+
+/// **retry-until-critic (bounded best-of-N).** `N` independent attempt steps
+/// (READ-ONLY-NONDET generators), each gated by a [`deterministic_critic`] that
+/// evaluates `check` against the attempt's committed bytes, and one PURE selector
+/// that consumes every attempt + its verdict and picks the first that passes.
+/// Static `N` (`attempt_logics.len()`) — the bound *is* the authored width.
+///
+/// The critic gates by **exact crypto-equality** of the [`CheckSpec`] outcome
+/// (D60/D70); confidence may steer which attempt is preferred but never gates.
+/// This is the single-level form of "retry until valid": a fixed budget of `N`
+/// attempts judged in parallel. Unbounded sequential retry-until-pass is
+/// iterative re-shaping (the cloud-tier topology); here a fresh budget is a fresh
+/// appended round.
+///
+/// Wiring: `attempt_i ──data──> critic_i` (so each critic's `critic_for` resolves
+/// to its attempt), and `attempt_i ──data──> select` + `critic_i ──data──> select`
+/// (so the selector sees each candidate and its verdict). `critic_logic` and
+/// `check` are reused across attempts — distinct producers yield distinct critic
+/// identities.
+///
+/// # Errors
+///
+/// [`CompileError::EmptyRecipe`] if `attempt_logics` is empty; propagates edge /
+/// critic-ordering errors.
+pub fn retry_until_critic(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    attempt_logics: &[LogicRef],
+    check: &CheckSpec,
+    critic_logic: LogicRef,
+    select_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    if attempt_logics.is_empty() {
+        return Err(CompileError::EmptyRecipe);
+    }
+    let warrant = permissive_warrant(model_id.clone());
+    let mut wf = WorkflowDef::new(seed);
+
+    let mut attempts = Vec::with_capacity(attempt_logics.len());
+    for logic in attempt_logics {
+        attempts.push(wf.add_step(generator(
+            *logic,
+            model_id.clone(),
+            warrant.clone(),
+            capability.clone(),
+        )));
+    }
+    let mut critics = Vec::with_capacity(attempts.len());
+    for &attempt in &attempts {
+        let critic = wf.add_step(deterministic_critic(
+            attempt,
+            check.clone(),
+            critic_logic,
+            model_id.clone(),
+            warrant.clone(),
+            capability.clone(),
+        ));
+        wf.add_edge(attempt, critic, EdgeMeta::data())?;
+        critics.push(critic);
+    }
+    let select = wf.add_step(transform(select_logic, model_id, warrant, capability));
+    for (&attempt, &critic) in attempts.iter().zip(critics.iter()) {
+        wf.add_edge(attempt, select, EdgeMeta::data())?;
+        wf.add_edge(critic, select, EdgeMeta::data())?;
+    }
+    Ok(wf)
+}
+
+/// **`ReAct` tool loop (single turn).** One reason → act → observe turn:
+///
+/// ```text
+/// reason (ROND) ──data──> act (ROND, tool_contract) ──data──> observe (PURE)
+/// ```
+///
+/// `reason` is the model's reasoning step; `act` calls a tool (its
+/// `tool_contract` is the closed, pinned allowlist of tools it may invoke);
+/// `observe` deterministically folds the tool result for the next turn. This is
+/// the single-level "turn-batch": one authored iteration. A multi-turn `ReAct` agent is
+/// expressed by **appending a fresh round** per turn (the planner's D76/D77
+/// replanning, each round reading the prior turn's committed observation) — never
+/// a static back-edge (a Mote's identity derives from its inputs, so a cycle is
+/// unrepresentable) and never an in-workflow self-re-shaping loop (cloud tier).
+///
+/// # Errors
+///
+/// Propagates edge-declaration errors (the fixed three-step shape never produces one).
+pub fn react_tool_loop(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    reason_logic: LogicRef,
+    act_logic: LogicRef,
+    observe_logic: LogicRef,
+    tool_contract: BTreeMap<ToolName, ToolVersion>,
+) -> Result<WorkflowDef, CompileError> {
+    let warrant = permissive_warrant(model_id.clone());
+    let mut wf = WorkflowDef::new(seed);
+
+    let reason = wf.add_step(generator(
+        reason_logic,
+        model_id.clone(),
+        warrant.clone(),
+        capability.clone(),
+    ));
+    let mut act_step = generator(
+        act_logic,
+        model_id.clone(),
+        warrant.clone(),
+        capability.clone(),
+    );
+    act_step.tool_contract = tool_contract;
+    let act = wf.add_step(act_step);
+    let observe = wf.add_step(transform(observe_logic, model_id, warrant, capability));
+
+    wf.add_edge(reason, act, EdgeMeta::data())?;
+    wf.add_edge(act, observe, EdgeMeta::data())?;
+    Ok(wf)
+}
+
+/// **image-batch describe-reduce (multi-modal capstone).** One describe step per
+/// image (READ-ONLY-NONDET generators, all running the same `describe_logic`) →
+/// one PURE reduce step that folds every description. Static `N`
+/// (`image_refs.len()`).
+///
+/// Each describe step carries *its own* image's content ref under
+/// [`IMAGE_REF_KEY`], baked at authoring time — so the `N` describe steps describe
+/// `N` **distinct** images and have distinct identities (the image ref folds into
+/// `config_subset` → `MoteId`; a different image is a different Mote). The
+/// multi-modal image path (PR-2) routes each referenced image to the model as a
+/// `content_ref` at dispatch. The reduce folds the committed descriptions into one
+/// summary.
+///
+/// # Errors
+///
+/// [`CompileError::EmptyRecipe`] if `image_refs` is empty; propagates edge errors.
+pub fn image_batch_describe_reduce(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    describe_logic: LogicRef,
+    image_refs: &[ContentRef],
+    reduce_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    if image_refs.is_empty() {
+        return Err(CompileError::EmptyRecipe);
+    }
+    let warrant = permissive_warrant(model_id.clone());
+    let mut wf = WorkflowDef::new(seed);
+
+    let mut describes = Vec::with_capacity(image_refs.len());
+    for image in image_refs {
+        let mut step = generator(
+            describe_logic,
+            model_id.clone(),
+            warrant.clone(),
+            capability.clone(),
+        );
+        // Bake this step's image ref (identity-bearing) — distinct images yield
+        // distinct describe identities.
+        step.config_subset.insert(
+            ConfigKey(IMAGE_REF_KEY.to_string()),
+            ConfigVal(image.0.to_vec()),
+        );
+        describes.push(wf.add_step(step));
+    }
+    let reduce = wf.add_step(transform(reduce_logic, model_id, warrant, capability));
+    for &d in &describes {
+        wf.add_edge(d, reduce, EdgeMeta::data())?;
+    }
+    Ok(wf)
+}

--- a/crates/kx-workflow/src/recipes.rs
+++ b/crates/kx-workflow/src/recipes.rs
@@ -46,11 +46,15 @@ pub enum WorkerKind {
     Generator,
 }
 
-/// The `config_subset` key under which an image-describe step carries the
-/// content ref of the image it consumes — baked at authoring time by
-/// [`image_batch_describe_reduce`] (one distinct image per describe step,
-/// identity-bearing). The multi-modal image path (PR-2) routes the referenced
-/// content to the model as a `content_ref` at dispatch.
+/// The `config_subset` key under which an image-describe step records *which*
+/// image it describes — its content ref, baked at authoring time by
+/// [`image_batch_describe_reduce`] (one distinct image per describe step). This
+/// is the per-step image *association* (identity-bearing → distinct describe
+/// identities), **not** the dispatch-time image input: the multi-modal path
+/// (PR-2) feeds the model from a describe step's image-sniffed Data-edge *parent*
+/// content, so a runnable multi-modal describe supplies the image as a committed
+/// parent (a dispatch extension that fetches this ref directly is a future
+/// model-harness follow-up).
 pub const IMAGE_REF_KEY: &str = "image_ref";
 
 /// Shared fan-in builder: `N` leaf steps of `kind` → one PURE `combine` step,
@@ -270,17 +274,20 @@ pub fn react_tool_loop(
     Ok(wf)
 }
 
-/// **image-batch describe-reduce (multi-modal capstone).** One describe step per
-/// image (READ-ONLY-NONDET generators, all running the same `describe_logic`) →
-/// one PURE reduce step that folds every description. Static `N`
-/// (`image_refs.len()`).
+/// **image-batch describe-reduce (multi-modal capstone — authoring scaffold).**
+/// One describe step per image (READ-ONLY-NONDET generators, all running the same
+/// `describe_logic`) → one PURE reduce step that folds every description. Static
+/// `N` (`image_refs.len()`).
 ///
-/// Each describe step carries *its own* image's content ref under
+/// Each describe step records *its own* image's content ref under
 /// [`IMAGE_REF_KEY`], baked at authoring time — so the `N` describe steps describe
 /// `N` **distinct** images and have distinct identities (the image ref folds into
-/// `config_subset` → `MoteId`; a different image is a different Mote). The
-/// multi-modal image path (PR-2) routes each referenced image to the model as a
-/// `content_ref` at dispatch. The reduce folds the committed descriptions into one
+/// `config_subset` → `MoteId`; a different image is a different Mote). This builds
+/// the correct DAG shape + per-image identities; to actually *run* it
+/// multi-modally the harness supplies each image as the describe step's
+/// image-sniffed Data-edge **parent** content (the PR-2 dispatch path routes image
+/// parents — not this `config_subset` key — as `content_ref`s) — the local
+/// Gemma-4 milestone wiring. The reduce folds the committed descriptions into one
 /// summary.
 ///
 /// # Errors

--- a/crates/kx-workflow/tests/prompt_template.rs
+++ b/crates/kx-workflow/tests/prompt_template.rs
@@ -1,0 +1,265 @@
+//! The prompt-template engine is pure, deterministic, and fail-closed; the
+//! `render_prompts` bind-time pass is identity-bearing (rendered prompt folds
+//! into `MoteId`), idempotent, and atomic (a render failure leaves the
+//! `WorkflowDef` byte-unchanged). Rendering before `compile` keeps prompt
+//! binding coherent with the free-param `bind_param` path (the D121 inbound path).
+//!
+//! Integration tests compile as their own crate; own lint exemptions.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeMap;
+
+use kx_mote::{ConfigKey, ConfigVal, LogicRef, ModelId, ToolName, PROMPT_KEY};
+use kx_workflow::{
+    compile, permissive_warrant, render_prompts, transform, CompileError, PromptTemplate,
+    WorkflowDef, TEMPLATE_KEY,
+};
+
+fn model() -> ModelId {
+    ModelId("local".into())
+}
+fn cap() -> ToolName {
+    ToolName("demo".into())
+}
+fn params(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+/// A one-step body whose transform carries `template` under `TEMPLATE_KEY`.
+fn templated_body(seed: u32, step_logic: u8, template: &str) -> WorkflowDef {
+    let mut wf = WorkflowDef::new(seed);
+    let mut step = transform(
+        LogicRef::from_bytes([step_logic; 32]),
+        model(),
+        permissive_warrant(model()),
+        cap(),
+    );
+    step.config_subset.insert(
+        ConfigKey(TEMPLATE_KEY.to_string()),
+        ConfigVal(template.as_bytes().to_vec()),
+    );
+    wf.add_step(step);
+    wf
+}
+
+/// The bytes the single compiled mote carries under a `config_subset` key.
+fn compiled_config(wf: &WorkflowDef, key: &str) -> Option<Vec<u8>> {
+    let out = compile(wf).unwrap();
+    out.motes[0]
+        .mote
+        .def
+        .config_subset
+        .get(&ConfigKey(key.to_string()))
+        .map(|v| v.0.clone())
+}
+
+// ── pure engine ─────────────────────────────────────────────────────────────
+
+#[test]
+fn parse_render_substitutes_in_source_order() {
+    let t = PromptTemplate::parse("summarize {topic} for {audience}").unwrap();
+    let out = t
+        .render(&params(&[("topic", "outages"), ("audience", "SREs")]))
+        .unwrap();
+    assert_eq!(out, "summarize outages for SREs");
+}
+
+#[test]
+fn parse_render_is_pure() {
+    let t = PromptTemplate::parse("a {x} b {y} c").unwrap();
+    let p = params(&[("x", "1"), ("y", "2")]);
+    let first = t.render(&p).unwrap();
+    for _ in 0..8 {
+        assert_eq!(t.render(&p).unwrap(), first, "render is a pure function");
+    }
+    assert_eq!(first, "a 1 b 2 c");
+}
+
+#[test]
+fn render_missing_placeholder_fails_closed() {
+    let t = PromptTemplate::parse("hi {name}").unwrap();
+    assert_eq!(
+        t.render(&params(&[])).unwrap_err(),
+        CompileError::MissingPlaceholder {
+            name: "name".to_string()
+        }
+    );
+}
+
+#[test]
+fn render_unknown_param_fails_closed() {
+    let t = PromptTemplate::parse("hi {name}").unwrap();
+    let err = t
+        .render(&params(&[("name", "x"), ("extra", "y")]))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        CompileError::UnknownParam {
+            name: "extra".to_string()
+        }
+    );
+}
+
+#[test]
+fn parse_malformed_fails_closed() {
+    for bad in ["{", "{}", "{a b}", "a}", "{a{b}}", "pre {unterminated"] {
+        assert!(
+            matches!(
+                PromptTemplate::parse(bad),
+                Err(CompileError::MalformedTemplate { .. })
+            ),
+            "template {bad:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn escapes_render_literal_braces() {
+    let t = PromptTemplate::parse("{{x}} and {{{y}}}").unwrap();
+    // `{{` → `{`, `}}` → `}`; the inner `{y}` is a real slot.
+    assert_eq!(t.render(&params(&[("y", "Z")])).unwrap(), "{x} and {Z}");
+}
+
+#[test]
+fn no_slots_renders_with_no_params() {
+    let t = PromptTemplate::parse("plain text, no slots").unwrap();
+    assert_eq!(t.render(&params(&[])).unwrap(), "plain text, no slots");
+    assert_eq!(t.slots().count(), 0);
+}
+
+// ── render_prompts pass (identity-bearing, idempotent, atomic) ───────────────
+
+#[test]
+fn rendered_prompt_is_identity_bearing() {
+    let mut a = templated_body(9, 1, "topic: {topic}");
+    let mut b = templated_body(9, 1, "topic: {topic}");
+    assert_eq!(
+        render_prompts(&mut a, &params(&[("topic", "incidents")])).unwrap(),
+        1
+    );
+    assert_eq!(
+        render_prompts(&mut b, &params(&[("topic", "outages")])).unwrap(),
+        1
+    );
+
+    // The rendered prompt landed under PROMPT_KEY; the template slot is gone.
+    assert_eq!(
+        compiled_config(&a, PROMPT_KEY).unwrap(),
+        b"topic: incidents"
+    );
+    assert!(
+        compiled_config(&a, TEMPLATE_KEY).is_none(),
+        "template slot removed"
+    );
+
+    let id_a = compile(&a).unwrap().motes[0].mote.id;
+    let id_b = compile(&b).unwrap().motes[0].mote.id;
+    assert_ne!(
+        id_a, id_b,
+        "distinct rendered prompts → distinct Mote identity"
+    );
+}
+
+#[test]
+fn same_params_yield_same_identity() {
+    let mut a = templated_body(9, 1, "q={q}");
+    let mut b = templated_body(9, 1, "q={q}");
+    render_prompts(&mut a, &params(&[("q", "same")])).unwrap();
+    render_prompts(&mut b, &params(&[("q", "same")])).unwrap();
+    assert_eq!(
+        compile(&a).unwrap().motes[0].mote.id,
+        compile(&b).unwrap().motes[0].mote.id,
+        "identical rendered prompts → identical identity (reproducible)"
+    );
+}
+
+#[test]
+fn render_prompts_is_atomic_on_failure() {
+    // Step 0 has a valid template; step 1's template is malformed.
+    let mut wf = WorkflowDef::new(9);
+    for (lref, tmpl) in [(1u8, "hi {name}"), (2u8, "{")] {
+        let mut step = transform(
+            LogicRef::from_bytes([lref; 32]),
+            model(),
+            permissive_warrant(model()),
+            cap(),
+        );
+        step.config_subset.insert(
+            ConfigKey(TEMPLATE_KEY.to_string()),
+            ConfigVal(tmpl.as_bytes().to_vec()),
+        );
+        wf.add_step(step);
+    }
+    let before: Vec<_> = compile(&wf)
+        .unwrap()
+        .motes
+        .iter()
+        .map(|m| m.mote.id)
+        .collect();
+    let err = render_prompts(&mut wf, &params(&[("name", "x")])).unwrap_err();
+    assert!(matches!(
+        err,
+        CompileError::RenderPromptStep { step: 1, .. }
+    ));
+    let after: Vec<_> = compile(&wf)
+        .unwrap()
+        .motes
+        .iter()
+        .map(|m| m.mote.id)
+        .collect();
+    assert_eq!(
+        before, after,
+        "a render failure leaves the WorkflowDef byte-unchanged"
+    );
+}
+
+#[test]
+fn render_prompts_is_idempotent() {
+    let mut wf = templated_body(9, 1, "v={v}");
+    assert_eq!(render_prompts(&mut wf, &params(&[("v", "1")])).unwrap(), 1);
+    let id1 = compile(&wf).unwrap().motes[0].mote.id;
+    // Second run: the template slot is gone, so nothing is rendered and identity is unchanged.
+    assert_eq!(
+        render_prompts(&mut wf, &params(&[("v", "ignored")])).unwrap(),
+        0
+    );
+    let id2 = compile(&wf).unwrap().motes[0].mote.id;
+    assert_eq!(id1, id2, "re-running render_prompts is a no-op");
+}
+
+#[test]
+fn bind_param_then_render_through_to_compile_is_coherent() {
+    // A step with BOTH a structural slot ("k") and a prompt template.
+    let build = || {
+        let mut wf = WorkflowDef::new(9);
+        let mut step = transform(
+            LogicRef::from_bytes([1; 32]),
+            model(),
+            permissive_warrant(model()),
+            cap(),
+        );
+        step.config_subset
+            .insert(ConfigKey("k".to_string()), ConfigVal(Vec::new()));
+        step.config_subset.insert(
+            ConfigKey(TEMPLATE_KEY.to_string()),
+            ConfigVal(b"q={q}".to_vec()),
+        );
+        wf.add_step(step);
+        wf
+    };
+    // Same structural binding; the only difference is the rendered prompt.
+    let mut a = build();
+    let mut b = build();
+    assert_eq!(a.bind_param("k", &ConfigVal(b"fixed".to_vec())), 1);
+    assert_eq!(b.bind_param("k", &ConfigVal(b"fixed".to_vec())), 1);
+    render_prompts(&mut a, &params(&[("q", "alpha")])).unwrap();
+    render_prompts(&mut b, &params(&[("q", "beta")])).unwrap();
+    assert_ne!(
+        compile(&a).unwrap().motes[0].mote.id,
+        compile(&b).unwrap().motes[0].mote.id,
+        "bind → render → compile is identity-coherent (prompt param flows into identity)"
+    );
+}

--- a/crates/kx-workflow/tests/recipes.rs
+++ b/crates/kx-workflow/tests/recipes.rs
@@ -1,0 +1,404 @@
+//! The Morphic recipe library compiles to deterministic, well-formed Mote DAGs:
+//! each recipe is reproducible (compile twice → byte-identical `MoteId`s), its
+//! structure is what the recipe promises (fan-out width, edges, roles), and
+//! identity shifts with the workflow seed. Recipes are static single-level
+//! compositions of the existing builders — no topology shaper, no core change.
+//!
+//! Integration tests compile as their own crate; this file carries its own lint
+//! exemptions (the workspace deny on unwrap/expect applies to library code).
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::pedantic
+)]
+
+use std::collections::BTreeMap;
+
+use kx_content::ContentRef;
+use kx_critic_types::{CheckSpec, SchemaSpec, SchemaTag};
+use kx_mote::{ConfigKey, LogicRef, ModelId, NdClass, ToolName, ToolVersion};
+use kx_workflow::{
+    compile, fan_out_gather, image_batch_describe_reduce, map_reduce, react_tool_loop,
+    retry_until_critic, CompileError, WorkerKind, IMAGE_REF_KEY,
+};
+
+fn model() -> ModelId {
+    ModelId("local".into())
+}
+fn cap() -> ToolName {
+    ToolName("demo".into())
+}
+fn logic(seed: u8) -> LogicRef {
+    LogicRef::from_bytes([seed; 32])
+}
+fn json_check() -> CheckSpec {
+    CheckSpec::Schema(SchemaSpec {
+        expected: SchemaTag::Json,
+    })
+}
+
+/// The compiled `MoteId` vector — the determinism fingerprint.
+fn ids(wf: &kx_workflow::WorkflowDef) -> Vec<kx_mote::MoteId> {
+    compile(wf)
+        .unwrap()
+        .motes
+        .iter()
+        .map(|m| m.mote.id)
+        .collect()
+}
+
+// ── map_reduce ──────────────────────────────────────────────────────────────
+
+#[test]
+fn map_reduce_compiles_deterministically_with_n_plus_one_motes() {
+    let mappers = [logic(1), logic(2), logic(3)];
+    let wf = map_reduce(7, model(), cap(), WorkerKind::Transform, &mappers, logic(9)).unwrap();
+    assert_eq!(ids(&wf), ids(&wf), "recipe compile must be deterministic");
+    let out = compile(&wf).unwrap();
+    assert_eq!(out.motes.len(), mappers.len() + 1, "N mappers + 1 reduce");
+}
+
+#[test]
+fn map_reduce_reduce_consumes_every_mapper() {
+    let mappers = [logic(1), logic(2), logic(3), logic(4)];
+    let out =
+        compile(&map_reduce(0, model(), cap(), WorkerKind::Transform, &mappers, logic(9)).unwrap())
+            .unwrap();
+    // The reduce step is the one carrying reduce_logic; it must parent every mapper.
+    let reduce = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(9))
+        .expect("reduce present");
+    assert_eq!(
+        reduce.mote.parents.len(),
+        mappers.len(),
+        "reduce has one Data parent per mapper"
+    );
+    // Parents precede the reduce in topological order.
+    let pos: BTreeMap<_, _> = out
+        .motes
+        .iter()
+        .enumerate()
+        .map(|(i, m)| (m.mote.id, i))
+        .collect();
+    let reduce_pos = pos[&reduce.mote.id];
+    for p in &reduce.mote.parents {
+        assert!(pos[&p.parent_id] < reduce_pos, "mapper precedes reduce");
+    }
+}
+
+#[test]
+fn map_reduce_worker_kind_sets_nd_class() {
+    let mappers = [logic(1), logic(2)];
+    let pure =
+        compile(&map_reduce(0, model(), cap(), WorkerKind::Transform, &mappers, logic(9)).unwrap())
+            .unwrap();
+    for m in pure
+        .motes
+        .iter()
+        .filter(|m| m.mote.def.logic_ref != logic(9))
+    {
+        assert_eq!(
+            m.mote.def.nd_class,
+            NdClass::Pure,
+            "Transform mappers are PURE"
+        );
+    }
+    let nd =
+        compile(&map_reduce(0, model(), cap(), WorkerKind::Generator, &mappers, logic(9)).unwrap())
+            .unwrap();
+    for m in nd.motes.iter().filter(|m| m.mote.def.logic_ref != logic(9)) {
+        assert_eq!(
+            m.mote.def.nd_class,
+            NdClass::ReadOnlyNondet,
+            "Generator mappers are READ-ONLY-NONDET"
+        );
+    }
+}
+
+#[test]
+fn map_reduce_seed_changes_identity() {
+    let mappers = [logic(1), logic(2), logic(3)];
+    let a = ids(&map_reduce(1, model(), cap(), WorkerKind::Transform, &mappers, logic(9)).unwrap());
+    let b = ids(&map_reduce(2, model(), cap(), WorkerKind::Transform, &mappers, logic(9)).unwrap());
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert_ne!(x, y, "every MoteId shifts with the seed");
+    }
+}
+
+#[test]
+fn map_reduce_empty_is_empty_recipe() {
+    let err = map_reduce(0, model(), cap(), WorkerKind::Transform, &[], logic(9)).unwrap_err();
+    assert_eq!(err, CompileError::EmptyRecipe);
+}
+
+// ── fan_out_gather ──────────────────────────────────────────────────────────
+
+#[test]
+fn fan_out_gather_workers_are_nondet_gather_is_pure() {
+    let workers = [logic(1), logic(2), logic(3)];
+    let wf = fan_out_gather(5, model(), cap(), &workers, logic(9)).unwrap();
+    assert_eq!(ids(&wf), ids(&wf), "deterministic compile");
+    let out = compile(&wf).unwrap();
+    assert_eq!(out.motes.len(), workers.len() + 1);
+    let gather = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(9))
+        .unwrap();
+    assert_eq!(gather.mote.def.nd_class, NdClass::Pure, "gather is PURE");
+    assert_eq!(gather.mote.parents.len(), workers.len());
+    for m in out
+        .motes
+        .iter()
+        .filter(|m| m.mote.def.logic_ref != logic(9))
+    {
+        assert_eq!(
+            m.mote.def.nd_class,
+            NdClass::ReadOnlyNondet,
+            "workers sample"
+        );
+    }
+}
+
+#[test]
+fn fan_out_gather_empty_is_empty_recipe() {
+    assert_eq!(
+        fan_out_gather(0, model(), cap(), &[], logic(9)).unwrap_err(),
+        CompileError::EmptyRecipe
+    );
+}
+
+// ── retry_until_critic (bounded best-of-N) ──────────────────────────────────
+
+#[test]
+fn retry_until_critic_gates_each_attempt_with_a_native_critic() {
+    let attempts = [logic(1), logic(2), logic(3)];
+    let wf = retry_until_critic(
+        7,
+        model(),
+        cap(),
+        &attempts,
+        &json_check(),
+        logic(8),
+        logic(9),
+    )
+    .unwrap();
+    assert_eq!(ids(&wf), ids(&wf), "deterministic compile");
+    let out = compile(&wf).unwrap();
+    // N attempts + N critics + 1 selector.
+    assert_eq!(out.motes.len(), 2 * attempts.len() + 1);
+
+    let critics: Vec<_> = out
+        .motes
+        .iter()
+        .filter(|m| m.mote.def.critic_check.is_some())
+        .collect();
+    assert_eq!(critics.len(), attempts.len(), "one critic per attempt");
+    let attempt_ids: std::collections::BTreeSet<_> = out.motes.iter().map(|m| m.mote.id).collect();
+    for c in &critics {
+        assert_eq!(c.mote.def.nd_class, NdClass::Pure, "native critic is PURE");
+        assert!(!c.mote.def.is_topology_shaper, "critic is not a shaper");
+        let producer = c.mote.def.critic_for.expect("critic_for resolves");
+        assert!(
+            attempt_ids.contains(&producer),
+            "critic gates a real attempt"
+        );
+    }
+    // The selector consumes every attempt + every verdict: 2N parents.
+    let select = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(9))
+        .unwrap();
+    assert_eq!(select.mote.parents.len(), 2 * attempts.len());
+}
+
+#[test]
+fn retry_until_critic_empty_is_empty_recipe() {
+    assert_eq!(
+        retry_until_critic(0, model(), cap(), &[], &json_check(), logic(8), logic(9)).unwrap_err(),
+        CompileError::EmptyRecipe
+    );
+}
+
+// ── react_tool_loop (single turn) ───────────────────────────────────────────
+
+#[test]
+fn react_tool_loop_wires_reason_act_observe_with_tool_contract() {
+    let mut tools = BTreeMap::new();
+    tools.insert(ToolName("search".into()), ToolVersion("1".into()));
+    let wf = react_tool_loop(
+        3,
+        model(),
+        cap(),
+        logic(1),
+        logic(2),
+        logic(3),
+        tools.clone(),
+    )
+    .unwrap();
+    assert_eq!(ids(&wf), ids(&wf), "deterministic compile");
+    let out = compile(&wf).unwrap();
+    assert_eq!(out.motes.len(), 3, "reason + act + observe");
+
+    let reason = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(1))
+        .unwrap();
+    let act = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(2))
+        .unwrap();
+    let observe = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(3))
+        .unwrap();
+
+    assert_eq!(reason.mote.def.nd_class, NdClass::ReadOnlyNondet);
+    assert_eq!(act.mote.def.nd_class, NdClass::ReadOnlyNondet);
+    assert_eq!(
+        observe.mote.def.nd_class,
+        NdClass::Pure,
+        "observe folds deterministically"
+    );
+    assert_eq!(
+        act.mote.def.tool_contract, tools,
+        "act carries the closed tool contract"
+    );
+    assert!(reason.mote.parents.is_empty(), "reason is the turn root");
+    assert_eq!(act.mote.parents.len(), 1, "act depends on reason");
+    assert_eq!(observe.mote.parents.len(), 1, "observe depends on act");
+}
+
+// ── image_batch_describe_reduce (multi-modal capstone) ──────────────────────
+
+#[test]
+fn image_batch_bakes_a_distinct_image_into_each_describe_step() {
+    let images = [
+        ContentRef([1; 32]),
+        ContentRef([2; 32]),
+        ContentRef([3; 32]),
+    ];
+    let wf = image_batch_describe_reduce(11, model(), cap(), logic(7), &images, logic(9)).unwrap();
+    assert_eq!(ids(&wf), ids(&wf), "deterministic compile");
+    let out = compile(&wf).unwrap();
+    assert_eq!(out.motes.len(), images.len() + 1, "N describes + 1 reduce");
+
+    let image_key = ConfigKey(IMAGE_REF_KEY.to_string());
+    // Every describe step carries its OWN image ref (not an empty placeholder).
+    let baked: std::collections::BTreeSet<Vec<u8>> = out
+        .motes
+        .iter()
+        .filter(|m| m.mote.def.logic_ref == logic(7))
+        .map(|m| {
+            assert_eq!(
+                m.mote.def.nd_class,
+                NdClass::ReadOnlyNondet,
+                "describe samples"
+            );
+            m.mote
+                .def
+                .config_subset
+                .get(&image_key)
+                .expect("describe carries its image ref")
+                .0
+                .clone()
+        })
+        .collect();
+    assert_eq!(
+        baked.len(),
+        images.len(),
+        "each describe step carries a DISTINCT image ref"
+    );
+    for img in &images {
+        assert!(
+            baked.contains(&img.0[..]),
+            "the exact image ref is baked in"
+        );
+    }
+
+    let reduce = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == logic(9))
+        .unwrap();
+    assert_eq!(reduce.mote.parents.len(), images.len());
+}
+
+#[test]
+fn image_batch_distinct_images_yield_distinct_describe_identities() {
+    // The capstone promise: N distinct images ⇒ N distinct describe Motes.
+    let a = compile(
+        &image_batch_describe_reduce(
+            0,
+            model(),
+            cap(),
+            logic(7),
+            &[ContentRef([1; 32])],
+            logic(9),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let b = compile(
+        &image_batch_describe_reduce(
+            0,
+            model(),
+            cap(),
+            logic(7),
+            &[ContentRef([2; 32])],
+            logic(9),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    // Same describe_logic + same position, only the image differs → different identity.
+    assert_ne!(
+        a.motes[0].mote.id, b.motes[0].mote.id,
+        "a different image is a different describe Mote (image ref folds into identity)"
+    );
+}
+
+#[test]
+fn image_batch_empty_is_empty_recipe() {
+    assert_eq!(
+        image_batch_describe_reduce(0, model(), cap(), logic(7), &[], logic(9)).unwrap_err(),
+        CompileError::EmptyRecipe
+    );
+}
+
+// ── property: arbitrary static-N map_reduce compiles deterministically ───────
+
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn prop_map_reduce_any_n_is_deterministic_and_well_formed(
+        seed in any::<u32>(),
+        n in 1usize..16,
+    ) {
+        let mappers: Vec<LogicRef> = (0..n).map(|i| logic(i as u8)).collect();
+        let wf = map_reduce(seed, model(), cap(), WorkerKind::Transform, &mappers, logic(200)).unwrap();
+        let a = compile(&wf).unwrap();
+        let b = compile(&wf).unwrap();
+        let ids_a: Vec<_> = a.motes.iter().map(|m| m.mote.id).collect();
+        let ids_b: Vec<_> = b.motes.iter().map(|m| m.mote.id).collect();
+        prop_assert_eq!(ids_a, ids_b);
+        prop_assert_eq!(a.motes.len(), n + 1);
+
+        // Well-formed: every parent exists and precedes its child.
+        let pos: BTreeMap<_, _> = a.motes.iter().enumerate().map(|(i, m)| (m.mote.id, i)).collect();
+        for (i, m) in a.motes.iter().enumerate() {
+            for parent in &m.mote.parents {
+                prop_assert!(a.graph.get(&parent.parent_id).is_some());
+                prop_assert!(pos[&parent.parent_id] < i);
+            }
+        }
+    }
+}

--- a/crates/kx-workflow/tests/stress_fanout.rs
+++ b/crates/kx-workflow/tests/stress_fanout.rs
@@ -1,0 +1,124 @@
+//! Recipe-library fan-out scaling stress harness (R6 scale & performance gate).
+//!
+//! `#[ignore]`d; run explicitly in RELEASE (wired into `just scale-smoke`):
+//!
+//! ```text
+//! cargo test -p kx-workflow --release --test stress_fanout \
+//!     -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! Builds a wide fan-out recipe (`map_reduce`: N PURE mappers → 1 reduce, N ∈
+//! {1_000, 5_000, 10_000}), compiles it TWICE, runs both compiled DAGs through
+//! the real single-node runtime surface, and asserts:
+//!   - the recipe compiles to exactly `N + 1` Motes (the gather has `N` parents);
+//!   - compile is DETERMINISTIC at fan-out scale (two runs → byte-identical
+//!     committed journal digest);
+//!   - prints compile-ms / run-ms / node count so the curve stays ~linear.
+//!
+//! The PURE `map_reduce` variant is used so the run is broker-free and fully
+//! deterministic; the ROND `fan_out_gather` has the identical fan-in structure.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::time::Instant;
+
+use kx_executor::{run_pure_mote, LocalResourceManager, TestMoteExecutor};
+use kx_journal::SqliteJournal;
+use kx_mote::{LogicRef, ModelId, ToolName};
+use kx_projection::Projection;
+use kx_runtime::digest_journal;
+use kx_scheduler::{LocalPlacement, Scheduler};
+use kx_workflow::{compile, map_reduce, CompiledWorkflow, WorkerKind, WorkflowDef};
+
+const SIZES: &[usize] = &[1_000, 5_000, 10_000];
+
+/// A wide fan-out recipe: `n` distinct PURE mappers → one reduce.
+fn fanout_workflow(n: usize) -> WorkflowDef {
+    let mappers: Vec<LogicRef> = (0..n)
+        .map(|i| {
+            let mut logic = [0u8; 32];
+            logic[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            LogicRef::from_bytes(logic)
+        })
+        .collect();
+    map_reduce(
+        42,
+        ModelId("local".into()),
+        ToolName("demo".into()),
+        WorkerKind::Transform,
+        &mappers,
+        LogicRef::from_bytes([0xFF; 32]),
+    )
+    .unwrap()
+}
+
+/// Drive a compiled PURE workflow through the runtime; return committed digest.
+fn run_compiled(compiled: &CompiledWorkflow) -> (usize, String) {
+    let journal = SqliteJournal::open_in_memory().unwrap();
+    let rm = LocalResourceManager::dev_defaults();
+    let executor = TestMoteExecutor::deterministic();
+
+    let mut projection = Projection::new();
+    let mut scheduler = Scheduler::new(LocalPlacement);
+    for cm in &compiled.motes {
+        scheduler
+            .submit(cm.mote.clone(), cm.warrant.clone(), &mut projection)
+            .unwrap();
+    }
+    for cm in &compiled.motes {
+        run_pure_mote(&cm.mote, &cm.warrant, &journal, &rm, &executor).unwrap();
+    }
+    let committed = Projection::from_journal(&journal)
+        .unwrap()
+        .committed_count();
+    let digest = digest_journal(&journal).unwrap().to_hex();
+    (committed, digest)
+}
+
+#[test]
+#[ignore = "stress: run with --release --ignored --nocapture --test-threads=1"]
+fn fanout_recipe_scales_linearly_and_deterministically() {
+    let mut all_deterministic = true;
+    for &n in SIZES {
+        let wf = fanout_workflow(n);
+
+        let c_start = Instant::now();
+        let c1 = compile(&wf).unwrap();
+        let compile_ms = c_start.elapsed().as_millis();
+        let nodes = c1.motes.len();
+        assert_eq!(nodes, n + 1, "N mappers + 1 reduce");
+
+        // The reduce gathers every mapper.
+        let reduce = c1
+            .motes
+            .iter()
+            .find(|m| m.mote.def.logic_ref == LogicRef::from_bytes([0xFF; 32]))
+            .unwrap();
+        assert_eq!(
+            reduce.mote.parents.len(),
+            n,
+            "gather has one parent per mapper"
+        );
+
+        let c2 = compile(&wf).unwrap();
+        let r_start = Instant::now();
+        let (committed1, digest1) = run_compiled(&c1);
+        let run_ms = r_start.elapsed().as_millis();
+        let (committed2, digest2) = run_compiled(&c2);
+
+        assert_eq!(committed1, n + 1, "all motes commit");
+        assert_eq!(committed2, n + 1);
+        let deterministic = digest1 == digest2;
+        all_deterministic &= deterministic;
+        let prefix: String = digest1.chars().take(12).collect();
+
+        println!(
+            "fanout N={n}: compile_ms={compile_ms} run_ms={run_ms} nodes={nodes} \
+             deterministic={deterministic} digest_prefix={prefix}"
+        );
+    }
+    assert!(
+        all_deterministic,
+        "fan-out recipe compile must be deterministic at every scale"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -167,6 +167,8 @@ smoke-test-multimodal:
 # assertions are skipped. Also gates (M7 / D86) the kx-catalog governance paths —
 # signature register/lookup, the grant-ledger authorization fold, and the
 # depth-bounded deep-chain query — all stay sub-linear / depth-bounded at 25k-50k.
+# Also gates (R6) the Morphic recipe library's wide fan-out (`map_reduce` to a
+# 10k-wide reduce) — deterministic compile + reproducible run + ~linear curve.
 scale-smoke:
     cargo test -p kx-projection --release --test incremental_children_index -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_checkpoint -- --ignored --nocapture --test-threads=1
@@ -178,6 +180,7 @@ scale-smoke:
     cargo test -p kx-catalog --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-fleet --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-gateway-core --release --test scale -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-workflow --release --test stress_fanout -- --ignored --nocapture --test-threads=1
 
 # IMP-4 (D116) single-writer scale-readiness measurement spike — publish the
 # single-writer journal commit ceiling + the projection-fold curve so a real number


### PR DESCRIPTION
## R6 (D130) — Morphic recipe library + prompt-templating

The headline v0.1.0 **authoring** value of the reachability track: turn the durability spine into something a developer writes against. **Strictly additive** — composes the existing `kx-workflow` builders + `compile` + the runtime materializer. No core/topology change, no frozen-trio change.

### What

**`kx-workflow/src/recipes.rs` (new) — five reusable, deterministic recipes**, each a pure `WorkflowDef` builder composed from `generator`/`transform`/`deterministic_critic` + `add_edge` only:

| Recipe | Shape |
|---|---|
| `map_reduce` | N mappers (`WorkerKind::Transform`/`Generator`) → 1 PURE reduce |
| `fan_out_gather` | N ROND workers → 1 PURE gather |
| `retry_until_critic` | bounded best-of-N: N attempts, each gated by a `deterministic_critic` (exact-crypto-equality, D60/D70), + a selector |
| `react_tool_loop` | single reason→act→observe turn; `act` carries a closed `tool_contract`; multi-turn = append-a-round (D76/D77) |
| `image_batch_describe_reduce` | multi-modal capstone: one describe step per image, each baking its own `ContentRef` under `IMAGE_REF_KEY` → 1 reduce |

**`kx-workflow/src/prompt.rs` (new) — pure, fail-closed prompt-template engine:** `PromptTemplate::parse`/`render` (`{name}` slots, `{{`/`}}` escapes), the identity-bearing `render_prompts` bind-time pass (clone-then-commit **atomic**, idempotent — writes the rendered prompt under `PROMPT_KEY` *before* compile so it folds into `MoteId`), `put_rendered_prompt`. New `CompileError` variants.

**`PROMPT_KEY` promoted into `kx-mote`** (shared substrate), re-exported from `kx-model-harness` + `kx-planner` — single source of truth, closes the IMP-7 hand-mirrored-constant hazard (the drift guard is now true by construction). A `const` is never serialized → the projection digest `a6b5c679…` is provably invariant.

### Why single-level / bounded

Bounded width is static by construction. True in-workflow iterative re-shaping (nested/iterative shapers) stays the cloud-tier B-track (D126.3); the single-level `topology_shaper` + materializer are unchanged and still exercised by `tests/shaper_unroll.rs`.

### Tested

- **14 recipe tests** (per-recipe compile-twice determinism, structural asserts, `critic_for` resolution, `tool_contract`, distinct-image-per-step, `EmptyRecipe` guards, proptest over arbitrary N) + **12 prompt-engine tests** (purity, fail-closed parse/render, escapes, identity-bearing render, atomic-on-failure, idempotent, bind→render→compile coherence).
- **`tests/stress_fanout.rs`** (`#[ignore]`, wired into the required `scale-smoke` gate): 10k-wide fan-out compiles deterministically + runs reproducibly; compile 4→7→13ms, run 48→152→311ms across 1k→5k→10k (linear).
- **`examples/recipe_to_digest.rs`** — author → run → reproducible digest + prompt-templating identity demo.
- Digest `a6b5c679…` invariant (`a0_guard`, `serde_roundtrip`); **frozen-trio (`kx-scheduler`/`kx-executor` src) diff-EMPTY**; thesis test intact.
- Full local gate green: fmt, clippy `--workspace --all-targets -D warnings`, doc `-D warnings`, cargo-deny, build-no-inference, **check-reproducible (I1.c)**, scale-smoke.

### Pre-flight (Golden Rule 8)

- **Breaks:** none — `render_prompts` runs before `compile` (prompt folds into identity), is atomic + idempotent; the const promotion keeps every caller compiling.
- **Performance:** O(N) authoring on top of O(V+E) compile; prompt parse/render are author-time only (off the dispatch hot path); 10k fan-out proven linear.
- **Security:** new untrusted input = prompt templates/params — structure-safe (fail-closed) but not content-safe by design; a param value is an opaque `config_subset` value (cannot widen a warrant / mint a capability / alter topology); `react_tool_loop`'s `tool_contract` is a closed allowlist; documented that a rendered prompt folds into `MoteId` (no secrets as params — same property as `bind_param`).

### Review

17-agent adversarial review: 12 findings → 11 false positives dismissed; the 1 confirmed (image_batch over-promised per-image binding) is fixed here by baking per-image `ContentRef`s at authoring time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
