### PR TITLE
fix(coordinator): idempotent re-invoke — surface instance_id on a duplicate submit

### DIFF
--- a/bindings/python/tests/test_contract_e2e.py
+++ b/bindings/python/tests/test_contract_e2e.py
@@ -105,19 +105,18 @@ async def test_async_invoke_and_wait_modes(dev_server):
     assert polled.ok and polled.to_dict() == evented.to_dict()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="RUNTIME bug (not SDK): re-invoking with identical args yields the same "
-    "already-committed terminal Mote, and the coordinator's duplicate-submit path "
-    "returns an empty instance_id (kx-gateway-core submit.rs / kx-coordinator "
-    "SubmitMote) → UNAVAILABLE. Tracked for a runtime fix; this xfail flips when fixed.",
-)
 def test_idempotent_reinvoke_same_args(dev_server):
+    """Idempotent re-invoke: the same recipe+args resolves to the same already-
+    committed terminal Mote and result (exactly-once-per-input). Regression for the
+    coordinator duplicate-submit fix — previously the second invoke failed with
+    `UNAVAILABLE: non-16-byte instance_id` because the duplicate path dropped the
+    run's instance_id."""
     with KxClient(dev_server.endpoint) as kx:
         a = kx.invoke(ECHO_HANDLE, {"topic": "same"}, wait=True)
-        b = kx.invoke(ECHO_HANDLE, {"topic": "same"}, wait=True)  # currently raises KxUnavailable
-        assert a.terminal_mote_id == b.terminal_mote_id
-        assert a.result_ref == b.result_ref
+        b = kx.invoke(ECHO_HANDLE, {"topic": "same"}, wait=True)
+    assert a.instance_id == b.instance_id
+    assert a.terminal_mote_id == b.terminal_mote_id
+    assert a.result_ref == b.result_ref
 
 
 # --- the projection → content flow -------------------------------------------

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -60,9 +60,10 @@ const MAX_DRAIN: usize = 256;
 
 /// Outcome of a `SubmitMote`: the canonically re-derived id, whether it was a
 /// duplicate (idempotent re-submit before commit), and the registered run's
-/// `instance_id` if the run was registered (M1.2/D64 — the resume key surfaced
-/// on the wire; `None` for an unregistered run, where M1.2 captures no metadata
-/// and the worker falls back to the MoteId-only token).
+/// `instance_id` (M1.2/D64 — the resume key surfaced on the wire). Registration
+/// is enforced before submit (Gate 1), so a returned outcome always carries
+/// `Some(instance_id)` for BOTH a fresh and a duplicate submit; the `Option` only
+/// reflects the internal pre-fill before `submit_and_capture` resolves the run.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SubmitOutcome {
     pub(crate) mote_id: MoteId,
@@ -1065,14 +1066,17 @@ fn submit_and_capture<J: Journal>(
     let warrant_for_capture = warrant.clone();
     let mut outcome = handle_submit(scheduler, projection, dispatch, mote, warrant);
 
-    // M1.2 (D79): on a FRESH (non-duplicate) submit, surface the run's
-    // instance_id and — when the tools resolved cleanly — capture the resolved
-    // tool/model/warrant versions as off-DAG run metadata. Registration is now
-    // guaranteed (Gate 1), so every fresh submit anchors to a real instance_id.
-    // A WM Unresolved submit never reaches here (refused at Gate 2); a PURE/ROND
-    // Unresolved submit reaches here and skips capture (the M1.2 behavior).
+    // The run's instance_id is known (Gate 1 guarantees registration) for BOTH a
+    // fresh AND a duplicate submit — surface it ALWAYS (the M2 resume key / server-
+    // derived identity). A DUPLICATE (idempotent re-submit: the same already-
+    // committed Mote, e.g. an Invoke of the same recipe+args) must still resolve to
+    // its run, not return an empty instance_id that a client decodes into a 16-byte
+    // id. M1.2 (D79) version CAPTURE stays FRESH-only — a duplicate already recorded
+    // its run metadata, and re-capture would double-append. (A WM Unresolved submit
+    // never reaches here — refused at Gate 2; a PURE/ROND Unresolved submit reaches
+    // here and skips capture, the M1.2 behavior.)
+    outcome.instance_id = Some(instance_id);
     if !outcome.duplicate {
-        outcome.instance_id = Some(instance_id);
         if let ToolResolution::Resolved(_) = resolution {
             capture_run_versions(
                 journal,

--- a/crates/kx-coordinator/tests/run_versions.rs
+++ b/crates/kx-coordinator/tests/run_versions.rs
@@ -212,6 +212,44 @@ async fn submit_response_surfaces_instance_id() {
 }
 
 #[tokio::test]
+async fn duplicate_submit_response_also_surfaces_instance_id() {
+    // Regression — idempotent re-invoke. A DUPLICATE submit (the same Mote
+    // re-submitted before commit — e.g. an Invoke of the same recipe+args, which
+    // re-derives the same terminal Mote) MUST still surface the registered run's
+    // instance_id. Before the fix the duplicate path returned `instance_id = None`,
+    // so the gateway decoded an empty 16-byte id and failed the whole call with
+    // `UNAVAILABLE("non-16-byte instance_id")` — breaking exactly-once-per-input.
+    let instance_id = [0xe7u8; 16];
+    let svc = coordinator(InMemoryJournal::new(), instance_id);
+
+    let mote = common::mote(2, NdClass::Pure, &[]);
+    let warrant = warrant_granting(&[("fs-read", "1")], "m");
+
+    let first = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(first.status, proto::SubmitStatus::Accepted as i32);
+    assert_eq!(first.instance_id, instance_id);
+
+    // Re-submit the SAME Mote → Duplicate, but the instance_id must be present.
+    let second = common::submit(&svc, &mote, &warrant).await;
+    assert_eq!(
+        second.status,
+        proto::SubmitStatus::Duplicate as i32,
+        "re-submitting the same Mote before commit is a duplicate"
+    );
+    assert_eq!(
+        second.instance_id, instance_id,
+        "a duplicate submit surfaces the SAME registered run id (not an empty one)"
+    );
+    assert_eq!(second.mote_id, first.mote_id, "same canonical Mote id");
+    // Capture stays fresh-only: the duplicate appended no second metadata fact.
+    assert_eq!(
+        svc.run_resolved_versions().await.unwrap().len(),
+        1,
+        "duplicate submit must NOT re-capture run-version metadata"
+    );
+}
+
+#[tokio::test]
 async fn unregistered_submit_is_refused() {
     // M1.3 (was M1.1/M1.2 `unregistered_run_captures_nothing`): submit-before-register
     // is now REFUSED (failed_precondition). An unregistered run has no journaled


### PR DESCRIPTION
## The bug (found by the R8 SDK contract tests; reproduced with the `kx` CLI)

Re-invoking a published recipe with **identical args** failed on the second call:

```
$ kx invoke kx/recipes/echo --args '{"topic":"same"}' --wait   # 1st: OK
$ kx invoke kx/recipes/echo --args '{"topic":"same"}' --wait   # 2nd: kx: Unavailable: non-16-byte instance_id
```

Identical args re-derive the same terminal Mote, so the second submit hits an already-committed Mote → `SubmitStatus::Duplicate`. `submit_and_capture` only wrote `outcome.instance_id = Some(instance_id)` on the **non-duplicate** path, so `kx-coordinator::handle_submit` returned `instance_id: None` for the duplicate and the gateway's `submit.rs:133-136` failed to decode an empty 16-byte id → `Transport("non-16-byte instance_id")` → gRPC `UNAVAILABLE`. This broke **idempotent re-invocation** — the bread-and-butter of agentic retries / exactly-once-per-input.

## The fix

The run is registered before submit (Gate 1), so the `instance_id` is known for **both** a fresh and a duplicate submit. Set `outcome.instance_id` unconditionally; keep `capture_run_versions` **fresh-only** (a duplicate already recorded its run metadata; re-capture would double-append). A response-field-only change in `kx-coordinator` (not the frozen trio).

## Verification (Golden Rule 8)

- **Pass A — breaks:** none. The fresh path is byte-identical; no journal entry / projection / digest change — **digest `a6b5c679…` proven invariant** (`just verify-quickstart` 8/8); **frozen-trio (`kx-scheduler`/`kx-executor`/`kx-inference`) src diff EMPTY**. *degrades:* none (one `Option` assignment). *opens-a-hole:* none — the `instance_id` is already server-derived and returned on fresh submits, owned by the caller; SN-8 intact.
- **Pass B:** makes exactly-once-per-input actually work — core to the durable thesis. No new follow-on.

## Tests

- **New** `kx-coordinator::duplicate_submit_response_also_surfaces_instance_id` — asserts a duplicate response carries the run id **and** does not re-capture run-version metadata.
- The R8 SDK contract test `test_idempotent_reinvoke_same_args` **flips from a strict-`xfail` to a passing test** (the SDK suite is now **35 passed, 0 xfail**).
- Full `kx-coordinator` suite green (incl. `concurrent_duplicate_submit_is_idempotent`); end-to-end double-invoke confirmed fixed with the rebuilt `kx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)