### PR TITLE
feat(runtime): kortecx-in-a-box — Docker/OCI packaging + graceful SIGTERM + GPU seam

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+# Build-context hygiene for the kortecx images.
+#
+# Keep the context small (faster `docker build`) and — load-bearing — keep the
+# PRIVATE cloud code and internal corpus OUT of any image layer (the SN-2 OSS↔cloud
+# boundary). The FFI-free `Dockerfile` builds only `kx-cli`, so the llama.cpp
+# submodule is excluded too; `Dockerfile.inference` fetches a pinned llama.cpp
+# inside its own builder stage (no context dependency).
+
+# ---- build artifacts ----
+target/
+**/target/
+*.pdb
+*.profraw
+*.gcda
+*.gcno
+**/*.proptest-regressions
+
+# ---- VCS + CI ----
+.git/
+.gitignore
+.github/
+
+# ---- PRIVATE / internal — must NEVER land in an OSS image layer (SN-2) ----
+kx-cloud/
+docs/plans/
+docs/design/
+docs/suggestions/
+WARNINGS.md
+CLAUDE.md
+/00-*.md
+/01-*.md
+/02-*.md
+/03-*.md
+/04-*.md
+/05-*.md
+/06-*.md
+/07-*.md
+
+# ---- local agent state + editor/OS noise ----
+.claude/
+.idea/
+.vscode/
+.DS_Store
+*.swp
+*~
+
+# ---- local runtime state / models — never bake into the context ----
+*.db
+*.db-wal
+*.db-shm
+**/models/
+*.gguf
+
+# ---- the llama.cpp submodule: not needed for the FFI-free image; the inference
+#      image fetches the pinned commit itself. Excluding it keeps the default
+#      (FFI-free) build context tiny even when a dev has run `just setup-inference`.
+crates/kx-llamacpp-sys/llama.cpp/
+
+# ---- the compose dev secrets (real ones are gitignored; only *.example ships) ----
+deploy/secrets/kx_authtokens
+deploy/secrets/kx_token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,29 @@ jobs:
         run: just verify-quickstart
 
   # ---------------------------------------------------------------------------
-  # sdk-python — the Python gRPC client SDK (bindings/python). Builds the FFI-free
+  # docker-smoke — in-container docs-as-test (the Docker track, Scope A). Builds the
+  # FFI-free `kx` image and reproduces the canonical projection digest THROUGH the
+  # container: a clean run, a crash-then-replay over a PERSISTED volume, and a
+  # read-only rootfs. This proves exactly-once durability survives the container
+  # boundary — a measured green/red claim, not a "runs in Docker" badge.
+  # FFI-free (NO submodules, NO C++ toolchain — the image needs neither).
+  # NON-REQUIRED: a new context, not in branch protection — promote to required once
+  # green across a few runs (a separate, authorized change). Mirrors verify-quickstart.
+  # ---------------------------------------------------------------------------
+  docker-smoke:
+    name: docker-smoke (in-container digest reproduction; FFI-free)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (NO submodules — the FFI-free image needs none)
+        uses: actions/checkout@v6
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      # ubuntu-latest ships Docker + BuildKit. The script builds the image and drives
+      # run → crash → replay → digest in-container, asserting the canonical digest.
+      - name: just docker-smoke
+        run: just docker-smoke
   # `kx` (serve + client), checks the vendored protobuf stubs are still fresh
   # against the FROZEN proto (codegen-fresh), then runs ruff + mypy + the unit and
   # contract-e2e suites (which spin up a real `kx serve` and compare the SDK's

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ kx-cloud/
 /docs/plans/
 # Internal warning/debug log — kept in the private kortecx-core repo only.
 /WARNINGS.md
+
+# ---- Docker compose dev secrets ----
+# Only the *.example templates are committed. A developer may copy them to the
+# un-suffixed names below (or replace them) for local customization; the real
+# secret files never land in git.
+/deploy/secrets/kx_authtokens
+/deploy/secrets/kx_token

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,7 @@ dependencies = [
  "kx-warrant",
  "kx-worker",
  "kx-workflow",
+ "nix",
  "serde",
  "serde_json",
  "smallvec",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,91 @@
+# syntax=docker/dockerfile:1
+#
+# kortecx — the FFI-free `kx` runtime, in a box.
+#
+# `kx` (the kx-cli binary) is FFI-FREE by DEFAULT: the workspace pins
+# `kx-inference = { default-features = false }`, so this image needs NO C++
+# toolchain, NO CUDA, and NO llama.cpp submodule — the exact property the
+# `build-no-inference` CI gate proves. The image runs the local engine verbs
+# (`kx run|replay|digest`) and the embedded single-system gateway (`kx serve`:
+# gRPC + the live-event WebSocket).
+#
+# For LOCAL LLM inference (CPU), build `Dockerfile.inference` instead.
+# GPU/CUDA is the cloud-side seam — see `Dockerfile.cuda` (D28: CUDA inference is
+# cloud-tier; OSS ships the seam, not the build).
+#
+# Durable state lives in mounted volumes (the durability spine survives the
+# container boundary — see docker-compose.yml):
+#   /var/lib/kortecx/journal   the SQLite journal (sole-writer; exactly-once truth)
+#   /var/lib/kortecx/content   the content-addressed store
+#   /var/lib/kortecx/catalog   the durable signature/recipe catalog
+#
+#   build : docker build -t kortecx/kx:dev .
+#   smoke : just docker-smoke           (in-container digest reproduction)
+#   run   : docker run --rm kortecx/kx:dev run --journal /tmp/kx.db --content /tmp/c
+#   serve : docker compose up           (see docker-compose.yml)
+
+# ---- builder ---------------------------------------------------------------
+# Pinned to the workspace toolchain channel (rust-toolchain.toml = 1.94.0). The
+# official `rust` image ships rustup, so the exact pinned toolchain is honored on
+# the first cargo invocation.
+# HARDENING (Pass B): pin the base by @sha256 digest for a reproducible supply chain.
+FROM rust:1.94-bookworm AS builder
+
+WORKDIR /app
+
+# The whole workspace, minus what `.dockerignore` strips (target/, .git/, the
+# PRIVATE kx-cloud/, the llama.cpp submodule, local DBs + models).
+COPY . .
+
+# Build the FFI-free `kx`. NO submodules, NO clang/cmake. If the llama.cpp FFI ever
+# leaked into kx-cli's normal dependency closure, this stage would suddenly need a
+# C++ toolchain — `build-no-inference` catches that earlier, but this is a second
+# line of defense.
+RUN cargo build --release -p kx-cli \
+ && strip target/release/kx \
+ && cp target/release/kx /usr/local/bin/kx
+
+# ---- runtime ---------------------------------------------------------------
+# debian-slim: glibc matches the builder (no GLIBC-version drift for a glibc-linked
+# binary), ships a shell (the in-container smoke + the CLI healthcheck want one) and
+# ca-certificates (for the later TLS + model-fetch paths). Distroless is the
+# hardening target (Pass B roadmap), traded off now because it has no shell.
+FROM debian:bookworm-slim AS runtime
+
+# ca-certificates: outbound TLS (future A1 + model fetch). tini: a tiny init that
+# becomes PID 1 and FORWARDS SIGTERM to `kx serve` (+ reaps any children), so
+# `docker stop` triggers the graceful drain rather than a SIGKILL.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates tini \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root runtime identity. Create + own the durable-state dirs so a FRESH named
+# volume mounted at any of them inherits uid:gid 10001 (a host BIND mount must be
+# chowned by the operator — documented in the README).
+RUN groupadd --gid 10001 kx \
+ && useradd  --uid 10001 --gid 10001 --home-dir /var/lib/kortecx --shell /usr/sbin/nologin kx \
+ && mkdir -p /var/lib/kortecx/journal /var/lib/kortecx/content /var/lib/kortecx/catalog \
+ && chown -R 10001:10001 /var/lib/kortecx
+
+COPY --from=builder /usr/local/bin/kx /usr/local/bin/kx
+
+# Convention defaults. NOTE: `kx serve` reads FLAGS, not env — these are
+# documentation + compose-interpolation only (the compose passes explicit flags).
+ENV KX_JOURNAL=/var/lib/kortecx/journal/kx.db \
+    KX_CONTENT=/var/lib/kortecx/content \
+    KX_CATALOG=/var/lib/kortecx/catalog \
+    RUST_LOG=info
+
+# 50151 gRPC · 50152 live-event WebSocket. Declaring the state dirs as VOLUMEs
+# makes them writable mounts even under `docker run --read-only` (so the read-only
+# rootfs smoke works without explicit -v).
+EXPOSE 50151 50152
+VOLUME ["/var/lib/kortecx/journal", "/var/lib/kortecx/content", "/var/lib/kortecx/catalog"]
+
+USER 10001:10001
+WORKDIR /var/lib/kortecx
+
+# tini as PID 1 → clean SIGTERM forwarding + zombie reaping. `kx` is the real arg0;
+# `--help` is the default verb (override with `run`/`replay`/`digest`/`serve`/…).
+ENTRYPOINT ["/usr/bin/tini", "--", "kx"]
+CMD ["--help"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1
+#
+# ============================================================================
+#  DOCUMENTED SEAM — NOT a buildable OSS image.
+# ============================================================================
+#
+# GPU/CUDA inference is CLOUD-TIER (decision D28: "CUDA is cloud-side" — the same
+# boundary `crates/kx-llamacpp-sys/build.rs` enforces with `GGML_CUDA=OFF`). The
+# OSS runtime ships the *seam* — this template + the `nvidia-smi` detection hook in
+# the install script — but NOT the CUDA build itself. The opt-in `cuda` cargo
+# feature that would flip `GGML_CUDA=ON` is part of the kortecx cloud offering and
+# is NOT present in OSS, so building this file in OSS fails by design (the guard
+# stage below stops it with a helpful message).
+#
+# Why a single-node CUDA image stays OUT of OSS (and what stays IN):
+#   • IN  (today): Metal single-node GPU inference, on an Apple host.
+#   • OUT (cloud): NVIDIA/CUDA inference + multi-tenant GPU-batched serving
+#                  (vLLM / SGLang / Triton). The OSS/cloud line (D28) is named,
+#                  never blurred.
+#
+# This template exists so the path is a localized add (base images + a feature
+# flag), never a rewrite, IF the boundary is ever moved by a sanctioned decision.
+#
+# Intended usage IF the `cuda` feature lands (cloud / a sanctioned line-move):
+#   docker build -f Dockerfile.cuda --build-arg I_UNDERSTAND_CUDA_IS_CLOUD_SIDE=1 \
+#                -t kortecx/kx:cuda .
+#   docker run --gpus all ... kortecx/kx:cuda ...        # NVIDIA Container Toolkit
+
+# ---- guard: fail helpfully on an accidental OSS build ----------------------
+FROM debian:bookworm-slim AS guard
+ARG I_UNDERSTAND_CUDA_IS_CLOUD_SIDE=0
+RUN if [ "${I_UNDERSTAND_CUDA_IS_CLOUD_SIDE}" != "1" ]; then \
+      echo "" >&2; \
+      echo "Dockerfile.cuda is a DOCUMENTED SEAM, not a buildable OSS image." >&2; \
+      echo "CUDA inference is cloud-tier (D28): OSS ships the seam, not the build." >&2; \
+      echo "The opt-in 'cuda' feature on kx-llamacpp-sys is NOT present in OSS, so" >&2; \
+      echo "the builder stage below would fail at 'cargo build --features cuda'." >&2; \
+      echo "See the README 'Run in Docker -> GPU posture' section." >&2; \
+      echo "" >&2; \
+      exit 2; \
+    fi
+
+# ---- builder (the intended shape; requires the cloud-side `cuda` feature) ---
+# nvidia/cuda *-devel carries nvcc + the CUDA toolkit headers/libs needed to
+# compile ggml's CUDA backend. HARDENING: pin by @sha256.
+FROM nvidia/cuda:12.6.2-devel-ubuntu24.04 AS builder
+COPY --from=guard /etc/hostname /tmp/.cuda-build-acknowledged
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates cmake clang libclang-dev build-essential git \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.94.0 --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /app
+COPY . .
+ARG LLAMA_CPP_REF=1a03cf47f67be591699d1f0f7ca28e1ed6eb8c7e
+RUN rm -rf crates/kx-llamacpp-sys/llama.cpp \
+ && git init -q crates/kx-llamacpp-sys/llama.cpp \
+ && git -C crates/kx-llamacpp-sys/llama.cpp remote add origin https://github.com/ggerganov/llama.cpp \
+ && git -C crates/kx-llamacpp-sys/llama.cpp fetch -q --depth 1 origin "${LLAMA_CPP_REF}" \
+ && git -C crates/kx-llamacpp-sys/llama.cpp checkout -q FETCH_HEAD
+
+# The load-bearing line: the `cuda` feature (NOT in OSS) makes build.rs flip
+# GGML_CUDA=ON + link cudart/cublas. Without it, this fails — by design.
+RUN cargo build --release -p kx-cli \
+ && cargo build --release -p kx-llamacpp --example generate --features cuda \
+ && cp target/release/kx /usr/local/bin/kx \
+ && cp target/release/examples/generate /usr/local/bin/kx-generate
+
+# ---- runtime ---------------------------------------------------------------
+# nvidia/cuda *-runtime ships the CUDA runtime libs (no toolkit). Run with
+# `--gpus all` (NVIDIA Container Toolkit) so the GPU is visible to `n_gpu_layers`.
+FROM nvidia/cuda:12.6.2-runtime-ubuntu24.04 AS runtime
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates libstdc++6 tini \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd --gid 10001 kx \
+ && useradd  --uid 10001 --gid 10001 --home-dir /var/lib/kortecx --shell /usr/sbin/nologin kx \
+ && mkdir -p /var/lib/kortecx/journal /var/lib/kortecx/content /var/lib/kortecx/catalog /var/lib/kortecx/models \
+ && chown -R 10001:10001 /var/lib/kortecx
+COPY --from=builder /usr/local/bin/kx          /usr/local/bin/kx
+COPY --from=builder /usr/local/bin/kx-generate /usr/local/bin/kx-generate
+ENV RUST_LOG=info NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility
+EXPOSE 50151 50152
+USER 10001:10001
+WORKDIR /var/lib/kortecx
+ENTRYPOINT ["/usr/bin/tini", "--", "kx"]
+CMD ["--help"]

--- a/Dockerfile.inference
+++ b/Dockerfile.inference
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1
+#
+# kortecx — CPU inference image (Linux).
+#
+# This image adds the llama.cpp FFI (built from the PINNED submodule commit) on top
+# of the `kx` runtime, so the inference toolchain is proven to build + LINK inside a
+# Linux container. It ships TWO binaries:
+#
+#   kx           — the runtime (serve / run / replay / digest). Same as the FFI-free
+#                  image: `kx` itself has NO model-inference verb yet — the in-process
+#                  model-dispatch path wires at A4 (until then `kx serve` uses the
+#                  deterministic demo executor). This image is the forward base for it.
+#   kx-generate  — the `kx-llamacpp` `generate` example: a REAL CPU inference run
+#                  (load GGUF → tokenize → decode → sample → detokenize). Use it to
+#                  actually run a model on CPU in a container today:
+#                    docker run --rm -v $PWD/models:/models \
+#                      --entrypoint kx-generate kortecx/kx:inference-cpu \
+#                      /models/stories260K.gguf "Once upon a time"
+#
+# CPU ONLY. Metal is macOS-HOST-only (`kx-llamacpp-sys/build.rs` links Metal solely
+# on `target.contains("apple")`) — a Linux container cannot use Metal regardless of
+# the host. GPU/NVIDIA is the cloud-side seam — see `Dockerfile.cuda` (D28: CUDA
+# inference is cloud-tier; OSS ships the seam, not the build).
+#
+#   build : docker build -f Dockerfile.inference -t kortecx/kx:inference-cpu .
+#           (or: just docker-build-inference)
+
+# ---- builder ---------------------------------------------------------------
+FROM rust:1.94-bookworm AS builder
+
+# The native build deps the FFI link needs (mirrors the CI `ffi-link` job +
+# `just setup-inference`): cmake + clang/libclang (bindgen) + a C++ toolchain.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cmake clang libclang-dev build-essential git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Fetch the PINNED llama.cpp commit into the submodule path (the submodule itself is
+# .dockerignore'd to keep the FFI-free context lean). KEEP THIS SHA IN SYNC WITH
+# `crates/kx-llamacpp-sys/PIN.md` — that file is the source of truth for the ABI pin.
+ARG LLAMA_CPP_REF=1a03cf47f67be591699d1f0f7ca28e1ed6eb8c7e
+RUN rm -rf crates/kx-llamacpp-sys/llama.cpp \
+ && git init -q crates/kx-llamacpp-sys/llama.cpp \
+ && git -C crates/kx-llamacpp-sys/llama.cpp remote add origin https://github.com/ggerganov/llama.cpp \
+ && git -C crates/kx-llamacpp-sys/llama.cpp fetch -q --depth 1 origin "${LLAMA_CPP_REF}" \
+ && git -C crates/kx-llamacpp-sys/llama.cpp checkout -q FETCH_HEAD
+
+# Build the runtime + the FFI link (proves the static archives build + link under
+# Linux) + the real CPU-inference example. GGML_CUDA stays OFF (build.rs default).
+RUN cargo build --release -p kx-cli \
+ && cargo build --release -p kx-llamacpp --example generate \
+ && strip target/release/kx target/release/examples/generate \
+ && cp target/release/kx /usr/local/bin/kx \
+ && cp target/release/examples/generate /usr/local/bin/kx-generate
+
+# ---- runtime ---------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# libstdc++6: the Linux FFI link pulls `stdc++` (build.rs:169). ca-certificates +
+# tini as in the FFI-free image (TLS-ready; PID-1 SIGTERM forwarding + reaping).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates libstdc++6 tini \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 10001 kx \
+ && useradd  --uid 10001 --gid 10001 --home-dir /var/lib/kortecx --shell /usr/sbin/nologin kx \
+ && mkdir -p /var/lib/kortecx/journal /var/lib/kortecx/content /var/lib/kortecx/catalog /var/lib/kortecx/models \
+ && chown -R 10001:10001 /var/lib/kortecx
+
+COPY --from=builder /usr/local/bin/kx          /usr/local/bin/kx
+COPY --from=builder /usr/local/bin/kx-generate /usr/local/bin/kx-generate
+
+ENV KX_JOURNAL=/var/lib/kortecx/journal/kx.db \
+    KX_CONTENT=/var/lib/kortecx/content \
+    KX_CATALOG=/var/lib/kortecx/catalog \
+    KX_MODELS=/var/lib/kortecx/models \
+    RUST_LOG=info
+
+EXPOSE 50151 50152
+VOLUME ["/var/lib/kortecx/journal", "/var/lib/kortecx/content", "/var/lib/kortecx/catalog", "/var/lib/kortecx/models"]
+
+USER 10001:10001
+WORKDIR /var/lib/kortecx
+
+ENTRYPOINT ["/usr/bin/tini", "--", "kx"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -162,6 +162,51 @@ real principals use `--auth-token <token>=<party>` (or `--auth-token-file`), and
 pass `--token`/`--token-file` on the client. Identity is always derived
 server-side — never asserted by the client.
 
+## Run in Docker
+
+The `kx` binary is FFI-free, so the runtime ships as a small container image — no
+C++ toolchain, no CUDA, no model baked in. The durability guarantee is proven
+*through* the container, not just asserted:
+
+```bash
+# Build the FFI-free image + reproduce the canonical digest IN-CONTAINER
+# (clean run · crash-then-replay over a persisted volume · read-only rootfs):
+just docker-smoke
+
+# Or bring up the server stack — embedded coordinator + worker + gateway — with the
+# journal & content on named volumes that survive a restart:
+docker compose up --build
+```
+
+With the stack up, drive it from the host (the compose dev token is `kx-dev-token`):
+
+```bash
+kx submit --demo --wait --endpoint http://127.0.0.1:50151 --token kx-dev-token
+kx invoke kx/recipes/echo --args '{"topic":"durable agents"}' --wait \
+    --endpoint http://127.0.0.1:50151 --token kx-dev-token
+
+docker compose restart kx     # journal + content persist on the named volumes
+docker compose down           # SIGTERM → graceful drain, not a hard kill
+```
+
+**Images.** `Dockerfile` builds the FFI-free runtime (`kortecx/kx:dev`); the
+container runs as a **non-root** user (uid 10001), keeps durable state under
+`/var/lib/kortecx/{journal,content,catalog}`, and is `--read-only`-rootfs
+compatible (only the mounted volumes + `/tmp` are writable). `Dockerfile.inference`
+adds the CPU llama.cpp link + a `kx-generate` example for a real CPU inference run.
+
+**Auth on a published port.** A non-loopback bind refuses `--dev-allow-local`, so the
+compose uses **bearer-token auth** (a Docker secret). Plaintext gRPC carries the
+bearer in cleartext — **front `kx serve` with a TLS reverse proxy** for any
+non-loopback deployment (in-binary TLS is on the roadmap). Replace the dev tokens in
+`deploy/secrets/` for anything real.
+
+**GPU posture.** OSS GPU inference today is **Metal, on an Apple host** — not in a
+Linux container (Metal is macOS-host-only). NVIDIA **CUDA inference is cloud-tier**
+(decision D28): `Dockerfile.cuda` is a *documented seam* (the intended image shape +
+an `nvidia-smi` detection hook), not a buildable OSS image; multi-tenant
+GPU-batched serving lives in the cloud offering.
+
 ## Commands
 
 The `kx` CLI is one binary. `run`/`replay`/`digest` drive the engine locally;

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -78,6 +78,10 @@ thiserror          = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio    = { workspace = true, features = ["time"] }
+# `nix::sys::signal::raise(SIGTERM)` (a SAFE wrapper — kx-gateway is
+# `#![forbid(unsafe_code)]`) for the graceful-shutdown signal test. Unix-only,
+# test-only; stays out of the FFI-free normal closure `build-no-inference` asserts.
+nix      = { workspace = true }
 
 [features]
 default = ["embedded-worker"]

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -261,13 +261,49 @@ pub async fn start(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> {
     start_impl(cfg).await
 }
 
-/// Start the server, then block until Ctrl-C and shut down gracefully.
+/// Start the server, then block until a shutdown signal and drain gracefully.
+///
+/// Waits for **Ctrl-C (SIGINT)** on every platform, plus **SIGTERM** on Unix —
+/// the signal `docker stop`, Kubernetes, and systemd send FIRST (then SIGKILL
+/// after a grace period). Without the SIGTERM arm a containerized `kx serve` was
+/// hard-killed at the end of the grace window, skipping the graceful drain
+/// ([`RunningGateway::shutdown`] flips the live-tail loops off so the gRPC +
+/// WebSocket streams end and `tonic` finishes in-flight requests). The journal is
+/// crash-safe either way (replay recovers), but a clean drain avoids dropping
+/// in-flight responses + leaving the live-tail sockets abruptly reset.
 pub async fn serve(cfg: GatewayConfig) -> Result<(), GatewayError> {
     let running = start(cfg).await?;
-    tracing::info!(addr = %running.local_addr(), "kx-gateway listening (Ctrl-C to stop)");
-    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!(addr = %running.local_addr(), "kx-gateway listening (Ctrl-C / SIGTERM to stop)");
+    wait_for_shutdown_signal().await;
     tracing::info!("shutdown signal received; draining");
     running.shutdown().await
+}
+
+/// Resolve when the process receives a shutdown signal: Ctrl-C (SIGINT) on every
+/// platform, or SIGTERM on Unix (whichever arrives first). If the SIGTERM handler
+/// cannot be installed it falls back to Ctrl-C only — a missing handler is never a
+/// hard failure of `serve`.
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        match signal(SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {}
+                    _ = sigterm.recv() => {}
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, "could not install a SIGTERM handler; waiting on Ctrl-C only");
+                let _ = tokio::signal::ctrl_c().await;
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 #[cfg(feature = "embedded-worker")]
@@ -517,4 +553,39 @@ async fn resolve_listen(listen: SocketAddr) -> Result<SocketAddr, GatewayError> 
         .map_err(|e| GatewayError::Bind(e.to_string()))?;
     drop(probe);
     Ok(addr)
+}
+
+#[cfg(all(test, unix))]
+mod sigterm_tests {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// SIGTERM (what `docker stop` / Kubernetes / systemd send first) must wake the
+    /// shutdown wait, not just Ctrl-C — otherwise a containerized `kx serve` is
+    /// SIGKILLed after the stop-grace period and skips the graceful drain. We
+    /// pre-register a SIGTERM stream so tokio installs its process-global handler
+    /// (replacing the default *terminate* action — the raised signal can't kill the
+    /// test binary), spawn the real `wait_for_shutdown_signal`, raise SIGTERM, and
+    /// assert the wait resolves. Only our two registered streams consume the signal;
+    /// no other code in this binary awaits SIGTERM, so parallel unit tests are
+    /// unaffected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_for_shutdown_signal_wakes_on_sigterm() {
+        use tokio::signal::unix::{signal, SignalKind};
+        // Install the global SIGTERM handler BEFORE raising so the default
+        // terminate action is replaced and this test process survives the signal.
+        let mut _guard = signal(SignalKind::terminate()).expect("install SIGTERM guard stream");
+        let waiter = tokio::spawn(super::wait_for_shutdown_signal());
+        // Give the spawned task a beat to register its own SIGTERM stream before we
+        // raise — tokio streams only observe signals delivered AFTER registration.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Deliver SIGTERM to this process. `nix`'s `raise` is a safe wrapper (no
+        // `unsafe` block — kx-gateway forbids it); the handler installed above turns
+        // delivery into a stream notification rather than terminating the test binary.
+        nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).expect("raise(SIGTERM) failed");
+        timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("the shutdown wait did not wake on SIGTERM within 5s")
+            .expect("the shutdown-wait task panicked");
+    }
 }

--- a/deploy/secrets/kx_authtokens.example
+++ b/deploy/secrets/kx_authtokens.example
@@ -1,0 +1,11 @@
+# kortecx compose — DEV-ONLY bearer tokens for a LOCALHOST gateway.
+#
+# Format: <token>=<party>  (one per line; '#' comments + blank lines are ignored).
+# The server resolves a request's bearer token to this party; identity is ALWAYS
+# derived server-side, never asserted by the client (SN-8).
+#
+# ⚠️  Plaintext gRPC carries the bearer in CLEARTEXT (TLS in-binary is A1, a later
+#     step). REPLACE this token for any real / non-loopback deployment, and front
+#     `kx serve` with a TLS reverse proxy. Copy this file to `kx_authtokens` (which
+#     is gitignored) to customize without editing the committed template.
+kx-dev-token=local@kortecx

--- a/deploy/secrets/kx_token.example
+++ b/deploy/secrets/kx_token.example
@@ -1,0 +1,1 @@
+kx-dev-token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,87 @@
+# kortecx single-system gateway — docker compose.
+#
+# Brings up `kx serve` (the embedded coordinator + local worker + gateway) bound to
+# all interfaces, behind bearer-token auth, with the durable spine on NAMED VOLUMES
+# so the journal + content survive `docker compose restart` — exactly-once across
+# the container boundary, not just within one container.
+#
+#   docker compose up --build           # first run builds the FFI-free image
+#   # from the host, against the published port:
+#   kx invoke kx/recipes/echo --args '{"topic":"durable agents"}' --wait \
+#       --endpoint http://127.0.0.1:50151 --token kx-dev-token
+#   docker compose restart kx           # journal + content persist on the volumes
+#   docker compose down                 # SIGTERM → graceful drain (stop_grace_period)
+#
+# Auth: the example secrets are DEV-ONLY (localhost). Plaintext gRPC carries the
+# bearer in cleartext — front with a TLS reverse proxy for any non-loopback
+# deployment (in-binary TLS is A1, a later step). The bind is non-loopback, so
+# `--dev-allow-local` is REFUSED by design — token auth is required.
+
+services:
+  kx:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: kortecx/kx:dev
+    command:
+      - serve
+      - --journal
+      - /var/lib/kortecx/journal/kx.db
+      - --content
+      - /var/lib/kortecx/content
+      - --catalog-dir
+      - /var/lib/kortecx/catalog
+      - --listen
+      - 0.0.0.0:50151
+      - --ws-listen
+      - 0.0.0.0:50152
+      - --auth-token-file
+      - /run/secrets/kx_authtokens
+    ports:
+      - "50151:50151"   # gRPC (Submit/Invoke/Fetch/Catalog)
+      - "50152:50152"   # live-event WebSocket (StreamEvents bridge)
+    volumes:
+      - kx-journal:/var/lib/kortecx/journal
+      - kx-content:/var/lib/kortecx/content
+      - kx-catalog:/var/lib/kortecx/catalog
+    secrets:
+      - kx_authtokens   # server: <token>=<party> lines (--auth-token-file)
+      - kx_token        # client/healthcheck: the raw bearer token (--token-file)
+    # Hardening: read-only rootfs — only the named volumes + /tmp are writable.
+    read_only: true
+    tmpfs:
+      - /tmp
+    user: "10001:10001"
+    # No /healthz yet (observability = A2). `kx signatures list` is a read-only RPC
+    # exercising the full bind→auth→RPC path; a clean exit ⇒ the server is live.
+    healthcheck:
+      test:
+        - CMD
+        - kx
+        - signatures
+        - list
+        - --endpoint
+        - http://127.0.0.1:50151
+        - --token-file
+        - /run/secrets/kx_token
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    # `docker compose stop/down` sends SIGTERM first; `kx serve` now drains on it
+    # (graceful gRPC + WebSocket shutdown). Give the drain room before SIGKILL.
+    stop_grace_period: 30s
+    restart: unless-stopped
+
+volumes:
+  kx-journal:
+  kx-content:
+  kx-catalog:
+
+secrets:
+  # DEV defaults — copy the *.example to the un-suffixed name (gitignored) to
+  # customize, or replace inline. NEVER ship these tokens to a real deployment.
+  kx_authtokens:
+    file: ./deploy/secrets/kx_authtokens.example
+  kx_token:
+    file: ./deploy/secrets/kx_token.example

--- a/justfile
+++ b/justfile
@@ -169,6 +169,31 @@ verify-quickstart:
     echo "   digest fold all produce the canonical digest (8/8 committed)."
 
 # ============================================================================
+# Container (Docker / OCI) recipes
+# ============================================================================
+
+# Build the FFI-free `kx` runtime image (no C++ toolchain, no llama.cpp submodule).
+# Tags `kortecx/kx:dev` by default; override with KX_IMAGE.
+#   just docker-build                       # → kortecx/kx:dev
+#   KX_IMAGE=ghcr.io/you/kx:v0 just docker-build
+docker-build:
+    DOCKER_BUILDKIT=1 docker build -f Dockerfile -t {{ env_var_or_default("KX_IMAGE", "kortecx/kx:dev") }} .
+
+# Build the CPU inference image (fetches the PINNED llama.cpp inside the builder;
+# needs a C++ toolchain in the BUILDER only, not at runtime). CPU-only — Metal is
+# macOS-host-only and GPU/CUDA is the cloud-side seam (Dockerfile.cuda, D28).
+docker-build-inference:
+    DOCKER_BUILDKIT=1 docker build -f Dockerfile.inference -t {{ env_var_or_default("KX_IMAGE", "kortecx/kx:inference-cpu") }} .
+
+# In-container docs-as-test: build the FFI-free image, then reproduce the canonical
+# projection digest THROUGH the container (clean run · crash-then-replay over a
+# persisted volume · read-only rootfs). The Docker analog of `verify-quickstart`,
+# and what the CI `docker-smoke` job runs. Requires a working Docker daemon. NOT
+# part of `just ci` (a separate, Docker-dependent gate — like verify-quickstart).
+docker-smoke:
+    ./scripts/docker-smoke.sh
+
+# ============================================================================
 # Policy + supply-chain recipes
 # ============================================================================
 

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# docker-smoke — in-container docs-as-test for the FFI-free `kx` image.
+#
+# Builds the FFI-free image, then reproduces the CANONICAL projection digest
+# THROUGH the container across three scenarios: a clean run, a crash-then-replay
+# over a persisted volume, and a read-only rootfs. Asserting the exact digest is
+# the measured "runs in Docker" claim — a green/red proof, not a badge. Tokenless
+# (the engine verbs `run`/`replay`/`digest` need no server/auth).
+# Shared verbatim by `just docker-smoke` and the CI `docker-smoke` job.
+#
+#   ./scripts/docker-smoke.sh                 # builds kortecx/kx:dev from ./Dockerfile
+#   KX_IMAGE=foo KX_DOCKERFILE=Dockerfile ./scripts/docker-smoke.sh
+set -euo pipefail
+
+IMAGE="${KX_IMAGE:-kortecx/kx:dev}"
+DOCKERFILE="${KX_DOCKERFILE:-Dockerfile}"
+# The canonical projection digest (8/8 committed) — the same invariant asserted by
+# `just verify-quickstart` (justfile) and the docs-as-test gate. Keep in lock-step.
+CANON="a6b5c67939f14bfcbd125f7461b2bd0e481f6ee2fc98c1ab638730e2d2ace2e9"
+
+JRN=/var/lib/kortecx/journal/kx.db
+CNT=/var/lib/kortecx/content
+S="$$"
+vols=()
+
+mkvol() { local n="kx-smoke-$1-$S"; docker volume create "$n" >/dev/null; vols+=("$n"); printf '%s' "$n"; }
+cleanup() { for v in "${vols[@]:-}"; do docker volume rm -f "$v" >/dev/null 2>&1 || true; done; }
+trap cleanup EXIT
+
+# `kx run` prints "<digest> (N/N committed)" on stdout; tracing logs go to stderr,
+# so `2>/dev/null` leaves just the result line. ${OUT%% *} is the digest token.
+assert_digest() { # $1 = label, $2 = captured stdout
+  local got="${2%% *}"
+  if [ "$got" != "$CANON" ]; then
+    echo " ✗ $1: digest ${got} != canonical ${CANON}" >&2
+    exit 1
+  fi
+  echo " ✓ $1: $2"
+}
+
+echo "[build] ${IMAGE}  (-f ${DOCKERFILE}, FFI-free, no submodules, no C++ toolchain)"
+DOCKER_BUILDKIT=1 docker build -f "$DOCKERFILE" -t "$IMAGE" .
+
+echo "[1/3] clean run in-container → canonical digest (8/8 committed)"
+VJ="$(mkvol clean-j)"; VC="$(mkvol clean-c)"
+OUT="$(docker run --rm \
+  -v "$VJ:/var/lib/kortecx/journal" -v "$VC:/var/lib/kortecx/content" \
+  "$IMAGE" run --journal "$JRN" --content "$CNT" 2>/dev/null)"
+assert_digest "clean run" "$OUT"
+case "$OUT" in *"(8/8 committed)"*) ;; *) echo " ✗ expected 8/8 committed: $OUT" >&2; exit 1 ;; esac
+
+echo "[2/3] crash-then-replay across the container boundary → same digest"
+VJ="$(mkvol crash-j)"; VC="$(mkvol crash-c)"
+M=(-v "$VJ:/var/lib/kortecx/journal" -v "$VC:/var/lib/kortecx/content")
+# Fresh volume; hard-abort right after a side effect commits (non-zero is expected).
+docker run --rm "${M[@]}" "$IMAGE" run --journal "$JRN" --content "$CNT" --crash-at post-commit-vtc >/dev/null 2>&1 || true
+# Recover from the SAME persisted journal+content (the durable boundary).
+OUT="$(docker run --rm "${M[@]}" "$IMAGE" replay --journal "$JRN" --content "$CNT" 2>/dev/null)"
+assert_digest "replay (recovered)" "$OUT"
+DOUT="$(docker run --rm "${M[@]}" "$IMAGE" digest --journal "$JRN" --content "$CNT" 2>/dev/null)"
+if [ "$DOUT" != "$CANON" ]; then echo " ✗ standalone digest ${DOUT} != ${CANON}" >&2; exit 1; fi
+echo " ✓ standalone digest fold: $DOUT"
+
+echo "[3/3] read-only rootfs (+ tmpfs /tmp), non-root uid → canonical digest"
+VJ="$(mkvol ro-j)"; VC="$(mkvol ro-c)"
+OUT="$(docker run --rm --read-only --tmpfs /tmp \
+  -v "$VJ:/var/lib/kortecx/journal" -v "$VC:/var/lib/kortecx/content" \
+  "$IMAGE" run --journal "$JRN" --content "$CNT" 2>/dev/null)"
+assert_digest "read-only run" "$OUT"
+
+echo ""
+echo " ✓ docker-smoke PASS — the canonical digest reproduces IN-CONTAINER across a"
+echo "   clean run, a crash-then-replay over a persisted volume, and a read-only"
+echo "   rootfs. Exactly-once durability survives the container boundary."


### PR DESCRIPTION
## Summary

Make the FFI-free `kx` runtime run robustly in a container, with the **exactly-once durability guarantee proven *through* the container** — measured, not claimed. This is the packaging/DX track ("kortecx-in-a-box"): additive, zero core-runtime risk.

## What's in it

**Images**
- **`Dockerfile`** — multi-stage builder → `debian:bookworm-slim` runtime shipping the FFI-free `kx` (no C++ toolchain, no llama.cpp submodule). Non-root `uid 10001`, `tini` PID-1 (clean SIGTERM forwarding + zombie reaping), durable state under `/var/lib/kortecx/{journal,content,catalog}`, `--read-only`-rootfs compatible.
- **`Dockerfile.inference`** — CPU llama.cpp link (fetches the pinned commit) + a `kx-generate` example for a real CPU inference run. Metal is macOS-host-only (documented).
- **`Dockerfile.cuda`** — a **documented GPU seam**, not a buildable OSS image: CUDA inference stays cloud-side (the existing **D28** boundary already in `kx-llamacpp-sys/build.rs`). A guard stage fails the build helpfully.

**Compose + smoke**
- **`docker-compose.yml`** — `kx serve` (embedded coordinator + worker + gateway) on **named volumes that survive a restart**, behind bearer-token auth (a Docker secret), a healthcheck via `kx signatures list`, and a 30s graceful stop. (A non-loopback bind refuses `--dev-allow-local`, so token auth is used.)
- **`scripts/docker-smoke.sh`** + a **non-required** CI `docker-smoke` job — reproduce the canonical projection digest `a6b5c679…` **in-container** across a clean run, a crash-then-replay over a persisted volume, and a read-only rootfs.

**Graceful shutdown (the one code change)**
- `kx serve` now drains on **SIGTERM** (`docker stop` / k8s / systemd), not just SIGINT — it was being SIGKILLed after the stop-grace period, skipping the gRPC + WebSocket drain. Adds a Unix signal test. `kx-gateway` only.

**DX** — `just docker-build` / `docker-build-inference` / `docker-smoke`; a README "Run in Docker" section; `.dockerignore` keeps the private `kx-cloud/` + internal docs out of image layers.

## Validation (local, all green)

- **`docker-smoke`** — canonical digest `a6b5c679…` (8/8 committed) reproduced in-container across **clean run · crash-then-replay over a persisted volume · read-only rootfs + non-root uid**.
- **compose run** — healthcheck → `healthy`; `kx submit --demo --wait` → **COMMITTED**; `docker compose restart` → healthy again (volume persistence); `docker compose stop` → container **ExitCode 0** (graceful SIGTERM drain).
- `fmt` · `clippy --workspace --all-targets -D warnings` · `test --workspace` · `doc -D warnings` · `build-no-inference` (FFI-free closure intact) — all green.
- **Frozen-trio (`kx-scheduler`/`kx-executor`/`kx-inference`) src diff EMPTY**; canonical digest invariant (re-asserted in-container). `Cargo.lock` delta is one line (a `nix` dev-dep for the signal test).

## Risk & security

- **No core change** — only Dockerfiles/compose/scripts/CI/README + the `kx-gateway` SIGTERM fix. No journal/projection/identity path touched; the digest is re-asserted in-container.
- **Non-root** uid 10001; token via a Docker **secret** (never in env/image); read-only rootfs; base images noted for `@sha256` pinning (hardening follow-up). `.dockerignore` excludes `kx-cloud/` so private code can never enter an image layer.
- **Plaintext gRPC on a published port carries the bearer in cleartext** — the README directs fronting with a TLS reverse proxy until in-binary TLS lands. Documented honestly.

## Scope & roadmap

This PR is the **packaging tier only**. The GPU build tier (an opt-in CUDA feature) and whole-image GPU-Mote execution (an OCI-daemon executor backend, gated on a GPU-under-rootless-bwrap verification spike) are **designed but intentionally not built** — CUDA stays cloud-side per D28. A companion corpus update records the decision + the new engineering rule on execution-substrate integrity & deployment portability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)