### PR TITLE
feat(gateway): A1 — in-binary TLS (rustls) on the wire for kx serve + the kx client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +483,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1276,6 +1301,7 @@ dependencies = [
  "kx-worker",
  "kx-workflow",
  "nix",
+ "rcgen",
  "serde",
  "serde_json",
  "smallvec",
@@ -1877,6 +1903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1928,22 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1953,6 +2001,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2242,6 +2296,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2439,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2504,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2638,6 +2758,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,8 +2905,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -3364,6 +3516,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,10 @@ serde_json         = "1"
 regex              = "1"
 proptest           = "1"
 tempfile           = "3"
+# A1 TLS — self-signed cert/key generation for the TLS handshake integration tests
+# (dev-only). Pinned to the `ring` backend (already in the lock via ureq/rustls) so
+# it adds NO new crypto provider / no aws-lc-rs C build / no new license surface.
+rcgen              = { version = "0.13", default-features = false, features = ["pem", "ring"] }
 # Benchmark harness (dev-only). default-features off drops the html_reports
 # (plotters) + rayon trees to keep the dep surface — and cargo-deny — minimal;
 # `cargo_bench_support` is the bit the `harness = false` benches actually need.

--- a/README.md
+++ b/README.md
@@ -195,11 +195,12 @@ container runs as a **non-root** user (uid 10001), keeps durable state under
 compatible (only the mounted volumes + `/tmp` are writable). `Dockerfile.inference`
 adds the CPU llama.cpp link + a `kx-generate` example for a real CPU inference run.
 
-**Auth on a published port.** A non-loopback bind refuses `--dev-allow-local`, so the
-compose uses **bearer-token auth** (a Docker secret). Plaintext gRPC carries the
-bearer in cleartext — **front `kx serve` with a TLS reverse proxy** for any
-non-loopback deployment (in-binary TLS is on the roadmap). Replace the dev tokens in
-`deploy/secrets/` for anything real.
+**Auth + TLS on a published port.** A non-loopback bind refuses `--dev-allow-local`, so
+the compose uses **bearer-token auth** (a Docker secret). Bearer-over-plaintext travels
+in cleartext, so enable **in-binary TLS** with `kx serve --tls-cert <pem> --tls-key
+<pem>` (rustls) and dial it with `kx … --endpoint https://… --tls-ca <pem>` (or a
+public CA via the OS trust store) — or front with a TLS reverse proxy. Replace the dev
+tokens in `deploy/secrets/` for anything real.
 
 **GPU posture.** OSS GPU inference today is **Metal, on an Apple host** — not in a
 Linux container (Metal is macOS-host-only). NVIDIA **CUDA inference is cloud-tier**
@@ -217,7 +218,7 @@ The `kx` CLI is one binary. `run`/`replay`/`digest` drive the engine locally;
 | `kx run` | Drive the canonical demo workflow from scratch | `--journal` `--content` · `--crash-at <pt>` · `--checkpoint-every N` · `--audit-log <path>` · `--json` |
 | `kx replay` | Recover an existing journal and finish the run | `--journal` `--content` · `--audit-log` · `--json` |
 | `kx digest` | Print the projection digest of a journal | `--journal` `--content` · `--json` |
-| `kx serve` | Host the embedded single-system gateway | `--journal` `--content` · `--listen` *(default `127.0.0.1:50151`)* · `--ws-listen` *(default `:50152`)* · `--dev-allow-local` · `--auth-token <t>=<party>` · `--auth-token-file` · `--max-lease N` · `--catalog-dir` |
+| `kx serve` | Host the embedded single-system gateway | `--journal` `--content` · `--listen` *(default `127.0.0.1:50151`)* · `--ws-listen` *(default `:50152`)* · `--dev-allow-local` · `--auth-token <t>=<party>` · `--auth-token-file` · `--tls-cert <path> --tls-key <path>` *(in-binary TLS)* · `--max-lease N` · `--catalog-dir` |
 | `kx invoke <handle>` | Bind a published recipe to JSON args and run it | `--args <json>` / `--args-file` · `--wait` · `--timeout-secs N` · `--out <file>` |
 | `kx submit --demo` | Submit a built-in pure demo run | `--wait` · `--timeout-secs N` · `--out` |
 | `kx projection` | Render a run as a DAG of Mote states | `--instance <id>` · `--at-seq N` |
@@ -349,9 +350,12 @@ Implement a trait, swap it in at construction — the guarantee machinery is unc
 kortecx is in early development; the durability spine is real and tested, but the
 reach surface is young. We name the boundaries plainly rather than hide them:
 
-- **Transport is plaintext.** The gateway speaks plain gRPC; bearer tokens over a
-  non-loopback endpoint are warned about. **Front `kx serve` with TLS** (a reverse
-  proxy or service mesh) for any non-loopback deployment.
+- **Transport: in-binary TLS or plaintext.** `kx serve --tls-cert/--tls-key` serves
+  rustls TLS on the gRPC listener (clients dial `https://…` with `--tls-ca` for a
+  self-signed cert, or the OS trust store for a public CA); the bearer-over-plaintext
+  path is still warned about. The **WebSocket bridge stays plaintext** for now — front
+  it (or the whole server) with a TLS proxy if you need `wss`. **mTLS** client-cert auth
+  is a follow-on.
 - **Auth is bearer-token + deny-all.** Identity is server-derived; the
   `PrincipalResolver` seam is where OIDC/mTLS plug in later. There is no
   multi-tenant isolation or per-tenant quota yet.

--- a/crates/kx-cli/Cargo.toml
+++ b/crates/kx-cli/Cargo.toml
@@ -24,8 +24,12 @@ kx-runtime = { workspace = true }
 kx-gateway = { workspace = true }
 # The FROZEN KxGateway client stubs + request/response messages.
 kx-proto   = { workspace = true }
-# gRPC transport + Request/Status/Code for the client verbs.
-tonic        = { workspace = true }
+# gRPC transport + Request/Status/Code for the client verbs. `tls` lets the client
+# dial an `https://` gateway (A1); `tls-native-roots` trusts the OS trust store for
+# a public CA (Apache/MIT — `tls-webpki-roots` is MPL-2.0, which deny.toml forbids).
+# A custom/self-signed CA comes from `--tls-ca`. Reuses the rustls 0.23 + ring
+# already in the lock (via ureq) — no new crypto provider.
+tonic        = { workspace = true, features = ["tls", "tls-native-roots"] }
 # `time` for the --wait / --follow poll backoff; `signal` for a clean --follow Ctrl-C.
 tokio        = { workspace = true, features = ["rt-multi-thread", "macros", "time", "signal"] }
 # --json machine output (a workspace dep; no new dependency).

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -27,7 +27,7 @@ usage: kx <command> [args]
              [--max-lease N] [--catalog-dir <dir>]
              (--listen defaults to 127.0.0.1:50151; --ws-listen — the live-event WebSocket — to :50152)
 
-  client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --json):
+  client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --tls-ca <path> --json):
     kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>]
     kx submit --demo [--wait] [--timeout-secs N] [--out <file>]
     kx projection --instance <hex16> [--at-seq N]

--- a/crates/kx-cli/src/client.rs
+++ b/crates/kx-cli/src/client.rs
@@ -9,7 +9,7 @@
 use std::path::PathBuf;
 
 use kx_proto::proto::kx_gateway_client::KxGatewayClient;
-use tonic::transport::Channel;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 
 use crate::error::CliError;
 
@@ -27,6 +27,9 @@ pub struct ClientCommon {
     pub token: Option<String>,
     /// A file holding a bearer token (`--token-file`); the file is read + trimmed.
     pub token_file: Option<PathBuf>,
+    /// A PEM CA certificate to trust for an `https://` endpoint (`--tls-ca`) — e.g.
+    /// the gateway's self-signed cert. `None` ⇒ the OS trust store (public CAs).
+    pub tls_ca: Option<PathBuf>,
     /// Emit machine-readable JSON instead of the human rendering (`--json`).
     pub json: bool,
 }
@@ -37,6 +40,7 @@ impl Default for ClientCommon {
             endpoint: DEFAULT_ENDPOINT.to_string(),
             token: None,
             token_file: None,
+            tls_ca: None,
             json: false,
         }
     }
@@ -76,6 +80,7 @@ impl ClientCommon {
             "--token-file" => {
                 self.token_file = Some(PathBuf::from(next_value(args, "--token-file")?));
             }
+            "--tls-ca" => self.tls_ca = Some(PathBuf::from(next_value(args, "--tls-ca")?)),
             "--json" => self.json = true,
             _ => return Ok(false),
         }
@@ -114,35 +119,73 @@ impl ClientCommon {
         if token.is_some() && is_nonloopback_plaintext(&self.endpoint) {
             eprintln!(
                 "kx: warning: sending a bearer token to a non-loopback plaintext endpoint ({}); \
-                 it travels in cleartext — TLS/mTLS is a later step",
+                 it travels in cleartext — use an https:// endpoint (kx serve --tls-cert/--tls-key)",
                 self.endpoint
             );
         }
+        // `--tls-ca`: read the PEM now (a missing file fails before we dial) and
+        // require an https:// endpoint (a CA on a plaintext endpoint is a misconfig).
+        let ca_pem = match &self.tls_ca {
+            Some(path) => {
+                if !self.endpoint.starts_with("https://") {
+                    return Err(CliError::Usage(
+                        "--tls-ca requires an https:// --endpoint".into(),
+                    ));
+                }
+                Some(
+                    std::fs::read(path)
+                        .map_err(|e| CliError::Io(format!("--tls-ca {}: {e}", path.display())))?,
+                )
+            }
+            None => None,
+        };
         Ok(Resolved {
             endpoint: self.endpoint.clone(),
             token,
+            ca_pem,
         })
     }
 }
 
-/// A resolved endpoint + optional bearer token.
+/// A resolved endpoint + optional bearer token + optional trust anchor.
 #[derive(Debug, Clone)]
 pub struct Resolved {
     /// The gateway endpoint to dial.
     pub endpoint: String,
     /// The bearer token to attach (if any).
     pub token: Option<String>,
+    /// A PEM CA to trust for an `https://` endpoint (`--tls-ca`); `None` ⇒ the OS
+    /// trust store for a public CA, or irrelevant for a plaintext `http://` dial.
+    pub ca_pem: Option<Vec<u8>>,
 }
 
 impl Resolved {
-    /// Dial the gateway, mapping a transport failure to [`CliError::Connect`].
+    /// Dial the gateway, mapping a transport failure to [`CliError::Connect`]. An
+    /// `https://` endpoint is dialed over TLS (A1): a `--tls-ca` PEM is the explicit
+    /// trust anchor (self-signed gateway cert), else the OS trust store (public CA).
     pub async fn connect(&self) -> Result<KxGatewayClient<Channel>, CliError> {
-        KxGatewayClient::connect(self.endpoint.clone())
+        let connect_err = |detail: String| CliError::Connect {
+            endpoint: self.endpoint.clone(),
+            detail,
+        };
+        let mut endpoint =
+            Endpoint::from_shared(self.endpoint.clone()).map_err(|e| connect_err(e.to_string()))?;
+        if self.endpoint.starts_with("https://") {
+            let tls = match &self.ca_pem {
+                Some(ca) => {
+                    ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca.clone()))
+                }
+                None => ClientTlsConfig::new().with_native_roots(),
+            };
+            endpoint = endpoint
+                .tls_config(tls)
+                .map_err(|e| connect_err(e.to_string()))?;
+        }
+        let channel = endpoint
+            .connect()
             .await
-            .map_err(|e| CliError::Connect {
-                endpoint: self.endpoint.clone(),
-                detail: e.to_string(),
-            })
+            .map_err(|e| connect_err(e.to_string()))?;
+        Ok(KxGatewayClient::new(channel))
     }
 
     /// Wrap `payload` in a request, attaching `authorization: Bearer <token>`
@@ -239,6 +282,31 @@ mod tests {
     }
 
     #[test]
+    fn tls_ca_requires_https_and_is_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = dir.path().join("ca.pem");
+        std::fs::write(
+            &ca,
+            "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        // A CA with a plaintext http:// endpoint is a misconfig → usage error.
+        let c = ClientCommon {
+            endpoint: "http://example.com:50151".into(),
+            tls_ca: Some(ca.clone()),
+            ..ClientCommon::default()
+        };
+        assert!(c.resolve().is_err());
+        // With https:// the CA PEM is read and carried for the dial.
+        let c = ClientCommon {
+            endpoint: "https://example.com:50151".into(),
+            tls_ca: Some(ca),
+            ..ClientCommon::default()
+        };
+        assert!(c.resolve().unwrap().ca_pem.is_some());
+    }
+
+    #[test]
     fn plaintext_detection() {
         assert!(is_nonloopback_plaintext("http://example.com:50151"));
         assert!(is_nonloopback_plaintext("http://10.0.0.5:50151"));
@@ -253,6 +321,7 @@ mod tests {
         let ok = Resolved {
             endpoint: DEFAULT_ENDPOINT.into(),
             token: Some("s3cr3t".into()),
+            ca_pem: None,
         };
         let req = ok.request(()).unwrap();
         assert_eq!(
@@ -266,6 +335,7 @@ mod tests {
         let bad = Resolved {
             endpoint: DEFAULT_ENDPOINT.into(),
             token: Some("bad\ntoken".into()),
+            ca_pem: None,
         };
         assert!(bad.request(()).is_err());
     }

--- a/crates/kx-cli/tests/common/mod.rs
+++ b/crates/kx-cli/tests/common/mod.rs
@@ -36,6 +36,7 @@ pub fn gateway_config(
         dev_allow_local,
         auth_tokens,
         catalog_dir: None,
+        tls: None,
     }
 }
 

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -51,7 +51,10 @@ kx-coordinator  = { workspace = true, optional = true }
 kx-worker       = { workspace = true, optional = true }
 kx-executor     = { workspace = true, optional = true }
 kx-capability   = { workspace = true, optional = true }
-tonic              = { workspace = true }
+# A1: `tls` enables in-binary rustls TLS on the gRPC listener (reuses the rustls
+# 0.23 + ring already in the lock via ureq — no new crypto provider). Server cert/
+# key via `--tls-cert`/`--tls-key`; plaintext stays the default (TLS opt-in).
+tonic              = { workspace = true, features = ["tls"] }
 # Additive feature bump over the workspace tokio (rt-multi-thread/macros/net):
 # `signal` for graceful Ctrl-C shutdown, `time` for the worker poll/backoff +
 # connect-retry + the R5 live-tail poll interval, `sync` for the R5 per-subscriber
@@ -82,6 +85,11 @@ tokio    = { workspace = true, features = ["time"] }
 # `#![forbid(unsafe_code)]`) for the graceful-shutdown signal test. Unix-only,
 # test-only; stays out of the FFI-free normal closure `build-no-inference` asserts.
 nix      = { workspace = true }
+# A1: generate a self-signed cert/key for the TLS handshake integration test.
+rcgen    = { workspace = true }
+# A1: a tonic TLS client (Endpoint + ClientTlsConfig) to drive the TLS gateway in
+# the handshake test; `transport` is already on via tonic's default features.
+tonic    = { workspace = true, features = ["tls"] }
 
 [features]
 default = ["embedded-worker"]

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -45,9 +45,29 @@ pub struct GatewayConfig {
     /// Directory for the durable catalog SQLite files (the signature registry +,
     /// in R2b, the recipe ledgers). `None` ⇒ alongside the journal.
     pub catalog_dir: Option<PathBuf>,
+    /// In-binary TLS for the gRPC listener (A1). `Some` ⇒ serve TLS (rustls) from
+    /// the given PEM cert + key; `None` ⇒ plaintext (the default). `--tls-cert` and
+    /// `--tls-key` are given together or not at all.
+    pub tls: Option<TlsPaths>,
+}
+
+/// PEM paths for the gRPC listener's server TLS (A1). The embedded loopback
+/// coordinator + worker stay plaintext (internal); only the external listener is
+/// encrypted. The WebSocket bridge stays plaintext for now (wss is a fast-follow —
+/// front it with the same TLS proxy, or upgrade in a focused PR).
+#[derive(Debug, Clone)]
+pub struct TlsPaths {
+    /// PEM-encoded server certificate chain (leaf first).
+    pub cert_path: PathBuf,
+    /// PEM-encoded private key for the leaf certificate.
+    pub key_path: PathBuf,
 }
 
 /// A parsed invocation: print help / version, or serve with a config.
+// `Serve` legitimately carries the full `GatewayConfig`; `Help`/`Version` are rare
+// one-shots. Boxing the common variant to shave a few bytes off a parse-once enum
+// buys an allocation for no benefit — allow the size difference.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum Cli {
     /// Print usage and exit 0.
@@ -62,7 +82,8 @@ pub enum Cli {
 pub const USAGE: &str =
     "usage: kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
 [--ws-listen <addr:port>] [--max-lease <N>] [--dev-allow-local] \
-[--auth-token <token>=<party>]... [--auth-token-file <path>] [--catalog-dir <dir>]\n       \
+[--auth-token <token>=<party>]... [--auth-token-file <path>] [--catalog-dir <dir>] \
+[--tls-cert <path> --tls-key <path>]\n       \
 kx-gateway --help | --version";
 
 impl Cli {
@@ -97,6 +118,8 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
     let mut dev_allow_local = false;
     let mut auth_tokens: HashMap<String, String> = HashMap::new();
     let mut catalog_dir: Option<PathBuf> = None;
+    let mut tls_cert: Option<PathBuf> = None;
+    let mut tls_key: Option<PathBuf> = None;
 
     while let Some(flag) = args.next() {
         let mut take_value = |name: &str| -> Result<String, GatewayError> {
@@ -145,6 +168,8 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
                 parse_token_file(&body, &mut auth_tokens)?;
             }
             "--catalog-dir" => catalog_dir = Some(PathBuf::from(take_value("--catalog-dir")?)),
+            "--tls-cert" => tls_cert = Some(PathBuf::from(take_value("--tls-cert")?)),
+            "--tls-key" => tls_key = Some(PathBuf::from(take_value("--tls-key")?)),
             other => return Err(GatewayError::Config(format!("unknown flag {other:?}"))),
         }
     }
@@ -163,6 +188,21 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
         ));
     }
 
+    // TLS cert + key are given together or not at all (a half-configured TLS would
+    // silently fall back to plaintext — fail closed instead).
+    let tls = match (tls_cert, tls_key) {
+        (Some(cert_path), Some(key_path)) => Some(TlsPaths {
+            cert_path,
+            key_path,
+        }),
+        (None, None) => None,
+        _ => {
+            return Err(GatewayError::Config(
+                "--tls-cert and --tls-key must be given together".into(),
+            ))
+        }
+    };
+
     Ok(GatewayConfig {
         listen,
         ws_listen,
@@ -172,6 +212,7 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
         dev_allow_local,
         auth_tokens,
         catalog_dir,
+        tls,
     })
 }
 
@@ -351,6 +392,33 @@ mod tests {
         );
         assert_eq!(c.catalog_dir, Some(PathBuf::from("/tmp/cat")));
         assert!(!c.dev_allow_local);
+    }
+
+    #[test]
+    fn tls_cert_and_key_must_be_given_together() {
+        let base = |extra: &[&str]| {
+            let mut a = vec![
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+            ];
+            a.extend_from_slice(extra);
+            Cli::from_args(a)
+        };
+        // Both → Some(TlsPaths).
+        let c = serve(base(&["--tls-cert", "/tmp/cert.pem", "--tls-key", "/tmp/key.pem"]).unwrap());
+        let tls = c.tls.expect("tls configured");
+        assert_eq!(tls.cert_path, PathBuf::from("/tmp/cert.pem"));
+        assert_eq!(tls.key_path, PathBuf::from("/tmp/key.pem"));
+        // Cert-without-key and key-without-cert are both errors (fail closed).
+        assert!(base(&["--tls-cert", "/tmp/cert.pem"]).is_err());
+        assert!(base(&["--tls-key", "/tmp/key.pem"]).is_err());
+        // Neither → None (plaintext default).
+        assert!(serve(base(&[]).unwrap()).tls.is_none());
     }
 
     #[test]

--- a/crates/kx-gateway/src/error.rs
+++ b/crates/kx-gateway/src/error.rs
@@ -29,4 +29,7 @@ pub enum GatewayError {
     /// worker was compiled out with `--no-default-features`).
     #[error("unsupported: {0}")]
     Unsupported(String),
+    /// Loading the TLS cert/key or applying the TLS config failed (A1).
+    #[error("tls: {0}")]
+    Tls(String),
 }

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -57,11 +57,12 @@ mod error;
 mod live_tail;
 mod provision;
 mod server;
+mod tls;
 #[cfg(feature = "embedded-worker")]
 mod ws;
 
 pub use auth::{DenyAll, DevAllowLocal, Principal, PrincipalResolver, TokenResolver};
-pub use config::{Cli, GatewayConfig, DEFAULT_MAX_LEASE, DEFAULT_WS_LISTEN, USAGE};
+pub use config::{Cli, GatewayConfig, TlsPaths, DEFAULT_MAX_LEASE, DEFAULT_WS_LISTEN, USAGE};
 pub use error::GatewayError;
 pub use live_tail::LiveTailer;
 pub use provision::{DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RECIPE_HANDLE};

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -306,6 +306,11 @@ async fn wait_for_shutdown_signal() {
     }
 }
 
+// A flat, sequential wiring function: content store → coordinator → worker →
+// gateway read seams → catalog → auth → (optional) TLS → bind. Splitting it would
+// scatter the one-shot startup wiring across helpers for no clarity gain (the
+// precedent: `kx-runtime::engine`, `kx-executor::spawn`). Allow the length.
+#[allow(clippy::too_many_lines)]
 #[cfg(feature = "embedded-worker")]
 async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> {
     let content = Arc::new(
@@ -414,6 +419,16 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     let ws_local_addr = ws_tcp
         .local_addr()
         .map_err(|e| GatewayError::Bind(e.to_string()))?;
+    // A1: the gRPC listener can be TLS, but the WebSocket bridge is still plaintext
+    // ws:// (wss is a fast-follow). Say so loudly so a TLS deployment doesn't assume
+    // the WS surface is encrypted — front it with a TLS proxy if browsers need wss.
+    if cfg.tls.is_some() {
+        tracing::warn!(
+            ws_listen = %ws_local_addr,
+            "gRPC TLS is enabled but the WebSocket bridge serves PLAINTEXT ws:// — \
+             front it with a TLS proxy for wss (in-binary wss is a follow-on)"
+        );
+    }
     let ws_tailer: Arc<dyn EventTailer> =
         Arc::new(crate::live_tail::LiveTailer::new(live_shutdown_rx));
     let ws_task = tokio::spawn(crate::ws::serve_ws(
@@ -425,9 +440,28 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
 
     let svc = KxGatewayServer::with_interceptor(gateway, crate::auth::interceptor(resolver));
     let local_addr = resolve_listen(cfg.listen).await?;
+    // A1: build the (optional) server TLS config up front so a missing/unreadable
+    // cert or key fails `start` loudly — before the port is bound — never a silent
+    // plaintext fall-back. (The embedded loopback coordinator + worker above stay
+    // plaintext: internal traffic that never leaves the process's loopback.)
+    let tls_config = match cfg.tls.as_ref() {
+        Some(paths) => Some(crate::tls::server_tls_config(paths)?),
+        None => None,
+    };
+    tracing::info!(
+        tls = tls_config.is_some(),
+        %local_addr,
+        "gateway gRPC listener ready"
+    );
     let (shutdown, shutdown_rx) = oneshot::channel::<()>();
     let gateway = tokio::spawn(async move {
-        Server::builder()
+        let mut builder = Server::builder();
+        if let Some(tls) = tls_config {
+            builder = builder
+                .tls_config(tls)
+                .map_err(|e| GatewayError::Tls(e.to_string()))?;
+        }
+        builder
             .add_service(svc)
             .serve_with_shutdown(local_addr, async move {
                 let _ = shutdown_rx.await;

--- a/crates/kx-gateway/src/tls.rs
+++ b/crates/kx-gateway/src/tls.rs
@@ -1,0 +1,42 @@
+//! A1 — in-binary TLS for the gRPC listener.
+//!
+//! Loads a PEM certificate chain + private key into a tonic [`ServerTlsConfig`]
+//! (rustls under the hood — the same rustls 0.23 already in the lock via `ureq`,
+//! so no new crypto provider). Only the **external** gateway listener is wrapped;
+//! the embedded loopback coordinator + worker stay plaintext (internal traffic
+//! that never leaves the process's loopback interface).
+//!
+//! Failure is loud and early: a missing/unreadable cert or key is surfaced by
+//! [`server_tls_config`] when the server starts, before binding the port — never a
+//! silent fall-back to plaintext (the `--tls-cert`/`--tls-key` both-or-neither
+//! check in `config.rs` is the matching guard). Malformed PEM content is rejected
+//! by rustls when the server begins serving.
+
+use std::path::Path;
+
+use tonic::transport::{Identity, ServerTlsConfig};
+
+use crate::config::TlsPaths;
+use crate::error::GatewayError;
+
+/// Read the PEM cert chain + key from disk and build the gRPC server's TLS config.
+pub(crate) fn server_tls_config(paths: &TlsPaths) -> Result<ServerTlsConfig, GatewayError> {
+    let cert = read_pem(&paths.cert_path, "tls-cert")?;
+    let key = read_pem(&paths.key_path, "tls-key")?;
+    let identity = Identity::from_pem(cert, key);
+    Ok(ServerTlsConfig::new().identity(identity))
+}
+
+/// Read a PEM file, mapping IO failures (missing / unreadable / empty) to a typed
+/// TLS error so a bad path fails the server start loudly rather than degrading.
+fn read_pem(path: &Path, what: &str) -> Result<Vec<u8>, GatewayError> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| GatewayError::Tls(format!("--{what} {}: {e}", path.display())))?;
+    if bytes.is_empty() {
+        return Err(GatewayError::Tls(format!(
+            "--{what} {} is empty",
+            path.display()
+        )));
+    }
+    Ok(bytes)
+}

--- a/crates/kx-gateway/tests/common/mod.rs
+++ b/crates/kx-gateway/tests/common/mod.rs
@@ -112,6 +112,7 @@ pub fn gateway_config(
         dev_allow_local,
         auth_tokens,
         catalog_dir: None,
+        tls: None,
     }
 }
 

--- a/crates/kx-gateway/tests/tls_e2e.rs
+++ b/crates/kx-gateway/tests/tls_e2e.rs
@@ -1,0 +1,116 @@
+//! A1 — TLS handshake end-to-end.
+//!
+//! Proves the in-binary rustls TLS path: a gateway started with `--tls-cert`/
+//! `--tls-key` (a self-signed cert generated in-test by `rcgen`) accepts a TLS
+//! client that trusts that CA and round-trips a real RPC; and that a PLAINTEXT
+//! client to the TLS port fails (no silent downgrade). Mirrors `serve_e2e.rs`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::time::Duration;
+
+use kx_gateway::{start, TlsPaths};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::{Certificate, ClientTlsConfig, Endpoint};
+
+/// Generate a self-signed cert (SAN `localhost` + `127.0.0.1`), write the PEMs to
+/// `dir`, and return `(TlsPaths, cert_pem_bytes)` (the cert doubles as the CA the
+/// client trusts).
+fn self_signed(dir: &std::path::Path) -> (TlsPaths, Vec<u8>) {
+    let certified =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("generate self-signed cert");
+    let cert_pem = certified.cert.pem();
+    let key_pem = certified.key_pair.serialize_pem();
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    std::fs::write(&cert_path, &cert_pem).unwrap();
+    std::fs::write(&key_path, &key_pem).unwrap();
+    (
+        TlsPaths {
+            cert_path,
+            key_path,
+        },
+        cert_pem.into_bytes(),
+    )
+}
+
+/// A TLS client trusting `ca_pem`, dialing `https://localhost:<port>`.
+async fn tls_client(port: u16, ca_pem: &[u8]) -> KxGatewayClient<tonic::transport::Channel> {
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(ca_pem))
+        .domain_name("localhost");
+    let endpoint = Endpoint::from_shared(format!("https://localhost:{port}"))
+        .unwrap()
+        .tls_config(tls)
+        .unwrap();
+    // Retry briefly while the serve task finishes binding.
+    for _ in 0..100 {
+        if let Ok(ch) = endpoint.connect().await {
+            return KxGatewayClient::new(ch);
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("TLS client could not connect on :{port}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tls_gateway_accepts_a_trusting_client_and_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let (tls, ca_pem) = self_signed(dir.path());
+    // dev-allow-local (loopback bind) + TLS: no token needed for the round-trip.
+    let mut cfg = common::gateway_config(&dir, true, std::collections::HashMap::new());
+    cfg.tls = Some(tls);
+    let running = start(cfg).await.expect("start TLS gateway");
+    let port = running.local_addr().port();
+
+    let mut client = tls_client(port, &ca_pem).await;
+    // A read RPC over TLS: ListSignatures takes no instance id and exercises the
+    // full TLS handshake -> auth -> RPC -> response path.
+    let resp = client
+        .list_signatures(proto::ListSignaturesRequest {})
+        .await
+        .expect("ListSignatures over TLS succeeds");
+    // A fresh catalog is empty; the point is the RPC completed over TLS.
+    assert!(resp.into_inner().signatures.is_empty());
+
+    // A real submit RPC over TLS: the gateway proxies to the embedded coordinator
+    // and returns a 16-byte server-derived instance id (the work path over TLS).
+    let instance_id = common::submit_pure_run(&mut client, 7).await;
+    assert_eq!(
+        instance_id.len(),
+        16,
+        "submit over TLS returns a 16-byte instance id"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn plaintext_client_to_tls_gateway_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let (tls, _ca) = self_signed(dir.path());
+    let mut cfg = common::gateway_config(&dir, true, std::collections::HashMap::new());
+    cfg.tls = Some(tls);
+    let running = start(cfg).await.expect("start TLS gateway");
+    let port = running.local_addr().port();
+
+    // A PLAINTEXT (http://) client to the TLS port must NOT succeed at an RPC —
+    // either the connect or the first request fails (no silent downgrade).
+    let plaintext = format!("http://127.0.0.1:{port}");
+    let outcome = async {
+        let mut c = KxGatewayClient::connect(plaintext).await?;
+        c.list_signatures(proto::ListSignaturesRequest {}).await?;
+        Ok::<(), Box<dyn std::error::Error>>(())
+    }
+    .await;
+    assert!(
+        outcome.is_err(),
+        "a plaintext client must not complete an RPC against a TLS gateway"
+    );
+
+    running.shutdown().await.unwrap();
+}

--- a/deny.toml
+++ b/deny.toml
@@ -69,6 +69,19 @@ ignore = [
     # Expires 2026-08-31 — forces a re-evaluation before P1.13 (the runtime
     # binary + reproducibility-discipline final check).
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained; migration requires canonical-bytes-shift audit (see HANDOFF §1.8 follow-ups); expires 2026-08-31" },
+    # ----------------------------------------------------------------------
+    # RUSTSEC-2025-0134 — rustls-pemfile unmaintained
+    # ----------------------------------------------------------------------
+    # A transitive dep of tonic's `tls` feature (via tokio-rustls), pulled in by
+    # A1 (in-binary TLS for the gateway). `rustls-pemfile` is a tiny, stable
+    # PEM-object reader; upstream is winding it down because its functionality is
+    # being FOLDED INTO `rustls-pki-types` (the maintained successor), so this is
+    # an "absorbed into the ecosystem", not an abandoned-and-broken, signal — no
+    # known vulnerability, no untrusted input on our path (we only parse an
+    # operator-provided server cert/key + an optional client CA). It is not a
+    # direct dependency; it leaves the tree when tonic/tokio-rustls finish the
+    # `pki-types` migration. Expires 2026-08-31 — re-evaluate when bumping tonic.
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; a tonic-tls transitive (A1), folded into rustls-pki-types upstream; no vuln, operator-supplied PEM only; expires 2026-08-31" },
 ]
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make **TLS on the wire** real — the #1 enterprise-adoption gap the Docker track surfaced (a published port was plaintext; the bearer token travelled in cleartext).

- **Server**: `kx serve --tls-cert <pem> --tls-key <pem>` serves **rustls TLS** on the gRPC listener (both-or-neither, fail-closed; a bad cert/key fails `start` loudly — never a silent plaintext fall-back). The embedded loopback coordinator + worker stay plaintext (internal traffic).
- **Client**: `kx <verb> --endpoint https://… [--tls-ca <pem>]` dials over TLS — a custom CA via `--tls-ca` (self-signed gateway cert), or the OS trust store (`tls-native-roots`) for a public CA. `--tls-ca` requires an `https://` endpoint.
- **WS bridge** stays plaintext `ws://` for now (a loud runtime warning when TLS is on); **wss** + **mTLS** are documented follow-ons.

## Deps (no new crypto provider, no new license surface)

`tonic`'s `tls` (+ `tls-native-roots` on the client) **reuse the `rustls 0.23` + `ring` already in the lock** via `kx-mcp → ureq` — no `aws-lc-rs` C build. `tls-webpki-roots` is **deliberately avoided** (it's MPL-2.0, which `deny.toml` forbids). `rcgen` is dev-only (ring backend) for the handshake test. `cargo deny` is green.

## Tests

- **TLS handshake e2e** — a client trusting the self-signed CA round-trips `ListSignatures` **and a real submit** over TLS; a **plaintext client to the TLS port fails** (no downgrade).
- Config `--tls-cert`/`--tls-key` both-or-neither; client `--tls-ca`-requires-https.
- `fmt` · `clippy -D warnings` · `test` · **`deny`** · `build-no-inference` (the FFI-free closure stays intact — rustls is pure-Rust, the C compiler for `ring` was already required by bundled SQLite) — all green. **Frozen-trio `src` diff EMPTY; canonical digest invariant** (the engine `run`/`replay`/`digest` path is untouched).

## Scope / follow-ons

In-binary **wss** for the WebSocket bridge (needs a `ws.rs` stream-type refactor + tokio-rustls) and **mTLS** client-cert auth are noted follow-ons. This PR delivers the primary "TLS on the wire" for the gRPC API the SDKs + CLI use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)