### PR TITLE
feat(gateway,cli): A2 — grpc.health.v1 liveness + `kx health` (purpose-built healthcheck)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1311,6 +1312,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tonic",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2929,6 +2931,19 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,12 +206,16 @@ sha2               = "0.10"
 libc               = "0.2"
 nix                = { version = "0.29", features = ["process", "signal", "resource", "fs"] }
 # Distribution (P2) gRPC stack — kx-proto is the first async + network crate.
-# tonic default features (transport + codegen + prost) are kept; TLS is NOT
-# enabled (no `ring`/`rustls`) — P2 is plaintext Unix-socket / TCP, hardening is
-# a later step. tonic 0.12 pairs with prost 0.13 and the stable tonic-build API.
-# protoc is supplied build-time by the pinned `protoc-bin-vendored` binary (no
-# system protoc on CI or local; deterministic; ships linux-x86_64 + macos-aarch64).
+# tonic default features (transport + codegen + prost) are kept. The workspace
+# default has no TLS; `kx-gateway`/`kx-cli` opt into the `tls` feature for the
+# gateway's in-binary rustls TLS (A1). tonic 0.12 pairs with prost 0.13 and the
+# stable tonic-build API. protoc is supplied build-time by the pinned
+# `protoc-bin-vendored` binary (no system protoc on CI or local; deterministic;
+# ships linux-x86_64 + macos-aarch64).
 tonic              = "0.12"
+# A2: the standard `grpc.health.v1.Health` service + client (liveness/readiness),
+# version-locked to tonic 0.12. FFI-free (pure Rust over the same prost/tonic).
+tonic-health       = "0.12"
 prost              = "0.13"
 tokio              = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 # Server-streaming adapter for the KxGateway `StreamEvents` RPC (M8/D120). Already

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The `kx` CLI is one binary. `run`/`replay`/`digest` drive the engine locally;
 | `kx content` | Fetch a committed result by ref (binary-safe) | `--ref <r>` · `--instance <id>` · `--out <file>` |
 | `kx events` | Print / live-tail a run's event deltas | `--instance <id>` · `--since N` · `--follow` |
 | `kx signatures` | Browse / fetch / register catalog task signatures | `list` · `get --id <id>` · `register --manifest-file <path>` |
+| `kx health` | Probe gateway liveness (`grpc.health.v1`); exit 0 iff SERVING | `--endpoint` · `--tls-ca` · `--json` |
 
 Client verbs share `--endpoint <url>` *(default `http://127.0.0.1:50151`)*,
 `--token <t>` / `--token-file <p>`, and `--json`.
@@ -365,8 +366,10 @@ reach surface is young. We name the boundaries plainly rather than hide them:
   default single-system runtime.
 - **Inference is single-stream** (N=1, serialized) and models are referenced by
   path — there is no model registry or auto-download in the runtime yet.
-- **Observability** today is the audit log + the event stream; a metrics/OTel
-  export seam is on the roadmap.
+- **Observability**: liveness/readiness is the standard `grpc.health.v1` service
+  (probe it with `kx health`, `grpc_health_probe`, or a k8s gRPC probe), plus the
+  audit log + the event stream. A **Prometheus/OTel metrics** export seam is the
+  next step.
 
 Interfaces will change before 1.0 — **pin a commit** if you build on it now.
 

--- a/crates/kx-cli/Cargo.toml
+++ b/crates/kx-cli/Cargo.toml
@@ -30,6 +30,9 @@ kx-proto   = { workspace = true }
 # A custom/self-signed CA comes from `--tls-ca`. Reuses the rustls 0.23 + ring
 # already in the lock (via ureq) — no new crypto provider.
 tonic        = { workspace = true, features = ["tls", "tls-native-roots"] }
+# A2: the `grpc.health.v1.Health` client for `kx health` (the liveness probe the
+# compose healthcheck uses — a purpose-built endpoint, not a side-effectful RPC).
+tonic-health = { workspace = true }
 # `time` for the --wait / --follow poll backoff; `signal` for a clean --follow Ctrl-C.
 tokio        = { workspace = true, features = ["rt-multi-thread", "macros", "time", "signal"] }
 # --json machine output (a workspace dep; no new dependency).

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -34,6 +34,7 @@ usage: kx <command> [args]
     kx content --ref <hex32> --instance <hex16> [--out <file>]
     kx events --instance <hex16> [--since N] [--follow]
     kx signatures list | get --id <hex32> | register --manifest-file <path>
+    kx health                                   (grpc.health.v1 liveness; exit 0 iff SERVING)
 
     --endpoint defaults to http://127.0.0.1:50151
 
@@ -67,6 +68,8 @@ pub enum Cli {
     Events(verbs::events::EventsArgs),
     /// Catalog signature RPCs.
     Signatures(verbs::signatures::SignaturesArgs),
+    /// Liveness/readiness probe (grpc.health.v1).
+    Health(verbs::health::HealthArgs),
 }
 
 impl Cli {
@@ -105,6 +108,7 @@ impl Cli {
             Some("content") => Ok(Cli::Content(verbs::content::parse(args)?)),
             Some("events") => Ok(Cli::Events(verbs::events::parse(args)?)),
             Some("signatures") => Ok(Cli::Signatures(verbs::signatures::parse(args)?)),
+            Some("health") => Ok(Cli::Health(verbs::health::parse(args)?)),
             Some(other) => Err(CliError::Usage(format!(
                 "unknown command {other:?} (try `kx --help`)"
             ))),
@@ -161,6 +165,7 @@ async fn dispatch(cli: Cli) -> Result<(), CliError> {
         Cli::Content(a) => verbs::content::execute(a).await,
         Cli::Events(a) => verbs::events::execute(a).await,
         Cli::Signatures(a) => verbs::signatures::execute(a).await,
+        Cli::Health(a) => verbs::health::execute(a).await,
     }
 }
 
@@ -293,6 +298,12 @@ kx events --instance <hex16> [--since N] [--follow] [client flags]
         "signatures" => "\
 kx signatures list | get --id <hex32> | register --manifest-file <path> [client flags]
   Browse / fetch / register catalog task signatures over the gateway."
+            .into(),
+        "health" => "\
+kx health [client flags]
+  Probe the gateway's grpc.health.v1 liveness/readiness. Prints SERVING / NOT_SERVING
+  (or --json) and exits 0 iff SERVING — a purpose-built healthcheck (the compose
+  stack uses it). Unauthenticated; honors --endpoint / --tls-ca for a TLS gateway."
             .into(),
         other => format!("no help for {other:?}; try `kx --help`"),
     }

--- a/crates/kx-cli/src/client.rs
+++ b/crates/kx-cli/src/client.rs
@@ -160,10 +160,12 @@ pub struct Resolved {
 }
 
 impl Resolved {
-    /// Dial the gateway, mapping a transport failure to [`CliError::Connect`]. An
+    /// Dial the gateway and return the raw transport [`Channel`] (TLS-aware). An
     /// `https://` endpoint is dialed over TLS (A1): a `--tls-ca` PEM is the explicit
     /// trust anchor (self-signed gateway cert), else the OS trust store (public CA).
-    pub async fn connect(&self) -> Result<KxGatewayClient<Channel>, CliError> {
+    /// Shared by [`Resolved::connect`] (the KxGateway client) and the `health` verb
+    /// (the grpc.health.v1 client), so both honor `--endpoint`/`--tls-ca`.
+    pub async fn channel(&self) -> Result<Channel, CliError> {
         let connect_err = |detail: String| CliError::Connect {
             endpoint: self.endpoint.clone(),
             detail,
@@ -181,10 +183,16 @@ impl Resolved {
                 .tls_config(tls)
                 .map_err(|e| connect_err(e.to_string()))?;
         }
-        let channel = endpoint
+        endpoint
             .connect()
             .await
-            .map_err(|e| connect_err(e.to_string()))?;
+            .map_err(|e| connect_err(e.to_string()))
+    }
+
+    /// Dial the gateway as a [`KxGatewayClient`], mapping a transport failure to
+    /// [`CliError::Connect`].
+    pub async fn connect(&self) -> Result<KxGatewayClient<Channel>, CliError> {
+        let channel = self.channel().await?;
         Ok(KxGatewayClient::new(channel))
     }
 

--- a/crates/kx-cli/src/verbs/health.rs
+++ b/crates/kx-cli/src/verbs/health.rs
@@ -1,0 +1,65 @@
+//! `kx health` — the gateway liveness/readiness probe (A2).
+//!
+//! Calls the standard `grpc.health.v1.Health/Check` and exits 0 when the gateway
+//! reports SERVING, non-zero otherwise — a purpose-built endpoint, unlike the
+//! side-effectful `signatures list` the compose healthcheck used before. The
+//! health service is NOT behind the auth interceptor (a health probe is
+//! unauthenticated by design), so no token is needed; `--endpoint`/`--tls-ca` are
+//! honored so it works against a TLS gateway too.
+
+use serde_json::json;
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+use crate::client::ClientCommon;
+use crate::error::CliError;
+
+/// Parsed `kx health` arguments — just the common client flags.
+#[derive(Debug)]
+pub struct HealthArgs {
+    /// Common client flags (`--endpoint` / `--tls-ca` / `--json`). A bearer token
+    /// is accepted but not required (the health probe is unauthenticated).
+    pub common: ClientCommon,
+}
+
+/// Parse `health` args (the verb already consumed).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<HealthArgs, CliError> {
+    let mut common = ClientCommon::default();
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        return Err(CliError::Usage(format!("health: unknown flag {flag:?}")));
+    }
+    Ok(HealthArgs { common })
+}
+
+/// Execute `health`: Check the overall ("") serving status; exit 0 iff SERVING.
+pub async fn execute(args: HealthArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let channel = resolved.channel().await?;
+    let mut client = HealthClient::new(channel);
+    let status = client
+        .check(HealthCheckRequest {
+            service: String::new(),
+        })
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner()
+        .status();
+    let serving = status == ServingStatus::Serving;
+    if args.common.json {
+        println!(
+            "{}",
+            json!({ "status": status.as_str_name(), "serving": serving })
+        );
+    } else {
+        println!("{}", status.as_str_name());
+    }
+    if serving {
+        Ok(())
+    } else {
+        Err(CliError::Failed)
+    }
+}

--- a/crates/kx-cli/src/verbs/mod.rs
+++ b/crates/kx-cli/src/verbs/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod content;
 pub mod events;
+pub mod health;
 pub mod invoke;
 pub mod projection;
 pub mod signatures;

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -55,6 +55,10 @@ kx-capability   = { workspace = true, optional = true }
 # 0.23 + ring already in the lock via ureq — no new crypto provider). Server cert/
 # key via `--tls-cert`/`--tls-key`; plaintext stays the default (TLS opt-in).
 tonic              = { workspace = true, features = ["tls"] }
+# A2: serve the standard `grpc.health.v1.Health` service (liveness/readiness) on the
+# gRPC listener, alongside the KxGateway service (NOT behind the auth interceptor —
+# a health probe is unauthenticated by design).
+tonic-health       = { workspace = true }
 # Additive feature bump over the workspace tokio (rt-multi-thread/macros/net):
 # `signal` for graceful Ctrl-C shutdown, `time` for the worker poll/backoff +
 # connect-retry + the R5 live-tail poll interval, `sync` for the R5 per-subscriber

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -453,6 +453,16 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         %local_addr,
         "gateway gRPC listener ready"
     );
+    // A2: the standard `grpc.health.v1.Health` service, served alongside KxGateway
+    // (NOT behind the auth interceptor — a health probe is unauthenticated by
+    // design). The runtime is wired + about to bind, so the overall service ("")
+    // is set SERVING; `kx health`, `grpc_health_probe`, and k8s gRPC probes read it.
+    // The reporter is dropped after — the service keeps the last-set status; on
+    // shutdown the port closes, so probes get connection-refused (= unhealthy).
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_service_status("", tonic_health::ServingStatus::Serving)
+        .await;
     let (shutdown, shutdown_rx) = oneshot::channel::<()>();
     let gateway = tokio::spawn(async move {
         let mut builder = Server::builder();
@@ -462,6 +472,7 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
                 .map_err(|e| GatewayError::Tls(e.to_string()))?;
         }
         builder
+            .add_service(health_service)
             .add_service(svc)
             .serve_with_shutdown(local_addr, async move {
                 let _ = shutdown_rx.await;

--- a/crates/kx-gateway/tests/health_e2e.rs
+++ b/crates/kx-gateway/tests/health_e2e.rs
@@ -1,0 +1,57 @@
+//! A2 — `grpc.health.v1.Health` service end-to-end.
+//!
+//! A running gateway serves the standard health service (alongside `KxGateway`,
+//! NOT behind the auth interceptor) and reports SERVING for the overall ("")
+//! service — what `kx health`, `grpc_health_probe`, and k8s gRPC probes read.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::time::Duration;
+
+use kx_gateway::start;
+use tonic::transport::Channel;
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gateway_reports_serving_on_grpc_health_unauthenticated() {
+    let dir = tempfile::tempdir().unwrap();
+    // Deny-all auth (no dev-allow-local, no tokens): the health service must STILL
+    // answer — it is not behind the auth interceptor (a probe is unauthenticated).
+    let cfg = common::gateway_config(&dir, false, std::collections::HashMap::new());
+    let running = start(cfg).await.expect("start gateway");
+    let endpoint = format!("http://{}", running.local_addr());
+
+    // Connect a bare health client (no bearer token), retrying while the serve task
+    // finishes binding.
+    let mut client = {
+        let mut found = None;
+        for _ in 0..100 {
+            if let Ok(ch) = Channel::from_shared(endpoint.clone())
+                .unwrap()
+                .connect()
+                .await
+            {
+                found = Some(HealthClient::new(ch));
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        found.expect("connect to the health service")
+    };
+
+    let status = client
+        .check(HealthCheckRequest {
+            service: String::new(),
+        })
+        .await
+        .expect("grpc.health.v1 Check succeeds without auth")
+        .into_inner()
+        .status();
+    assert_eq!(status, ServingStatus::Serving);
+
+    running.shutdown().await.unwrap();
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,24 +46,21 @@ services:
       - kx-catalog:/var/lib/kortecx/catalog
     secrets:
       - kx_authtokens   # server: <token>=<party> lines (--auth-token-file)
-      - kx_token        # client/healthcheck: the raw bearer token (--token-file)
     # Hardening: read-only rootfs — only the named volumes + /tmp are writable.
     read_only: true
     tmpfs:
       - /tmp
     user: "10001:10001"
-    # No /healthz yet (observability = A2). `kx signatures list` is a read-only RPC
-    # exercising the full bind→auth→RPC path; a clean exit ⇒ the server is live.
+    # A2: a purpose-built liveness probe — `kx health` calls grpc.health.v1 and exits
+    # 0 iff the gateway reports SERVING. Unauthenticated by design (the health service
+    # is not behind the auth interceptor), so it needs no token.
     healthcheck:
       test:
         - CMD
         - kx
-        - signatures
-        - list
+        - health
         - --endpoint
         - http://127.0.0.1:50151
-        - --token-file
-        - /run/secrets/kx_token
       interval: 10s
       timeout: 5s
       retries: 5
@@ -79,9 +76,10 @@ volumes:
   kx-catalog:
 
 secrets:
-  # DEV defaults — copy the *.example to the un-suffixed name (gitignored) to
-  # customize, or replace inline. NEVER ship these tokens to a real deployment.
+  # DEV default — copy the *.example to the un-suffixed name (gitignored) to
+  # customize, or replace inline. NEVER ship this token to a real deployment.
+  # (`deploy/secrets/kx_token.example` is the matching CLIENT bearer template for
+  # `kx invoke --token-file` from inside the container; the healthcheck no longer
+  # needs it since `kx health` is unauthenticated.)
   kx_authtokens:
     file: ./deploy/secrets/kx_authtokens.example
-  kx_token:
-    file: ./deploy/secrets/kx_token.example


### PR DESCRIPTION
## Summary

A real **liveness/readiness** surface, replacing the side-effectful `signatures list` healthcheck.

- **Gateway**: serves the standard **`grpc.health.v1.Health`** service alongside `KxGateway`, **NOT behind the auth interceptor** (a health probe is unauthenticated by design), reporting **SERVING** once the runtime is wired + bound.
- **CLI**: a new **`kx health`** verb (`SERVING`/`NOT_SERVING`, **exit 0 iff SERVING**; `--endpoint`/`--tls-ca`/`--json`). `Resolved::channel()` is extracted from `connect()` so the health client honors the same endpoint/TLS flags.
- **Compose**: the healthcheck is now `kx health` (unauthenticated — drops the client-token mount it no longer needed). `grpc_health_probe` + **k8s gRPC probes** also work.

## Validation

- **`health_e2e`** — a **deny-all** gateway still answers `grpc.health.v1` `Check` = **SERVING** (proves the health service is unauthenticated).
- A real **`docker compose up --wait`** reports the container **Healthy** via `kx health`; `kx health` prints `SERVING` (exit 0).
- `fmt` · `clippy -D warnings` · `test` (135 passed) · **`deny`** · `build-no-inference` — all green. **Frozen-trio `src` diff EMPTY; canonical digest invariant** (engine path untouched). `tonic-health 0.12` is pure-Rust (FFI-free), no new license/advisory surface.

## Scope / follow-on

**Prometheus/OTel metrics** export is the next step (**A2.1**) — it needs an HTTP `/metrics` endpoint + an instrumentation decision, separable from this health surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)