### PR TITLE
feat(release): A0 — curl|sh install script + GitHub Release of prebuilt binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+# Tag-triggered: publish SHA-256-verified prebuilt FFI-free `kx` binaries on a `v*`
+# tag (the tag is cut from an already-green `main`). This is NOT a pull-request /
+# branch check, so it adds NO branch-protection status context. `scripts/install.sh`
+# downloads these assets. `leak-check.yml` still guards every push/PR to main.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build a release for"
+        required: true
+
+permissions:
+  contents: write # create the GitHub Release + upload assets
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # build — one FFI-free `kx` per target, on a NATIVE runner (no cross-compile):
+  # linux-x86_64 (ubuntu), linux-aarch64 (ubuntu-arm), macos-arm64 (macos-14).
+  # Asset names are the target triples, so adding a future target (e.g.
+  # x86_64-pc-windows-msvc, x86_64-apple-darwin) is a localized matrix add — the
+  # install-script detection already has the seams.
+  # ---------------------------------------------------------------------------
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            runner: macos-14
+    steps:
+      - name: Checkout (NO submodules — the prebuilt `kx` is FFI-free)
+        uses: actions/checkout@v6
+
+      - name: Toolchain (from rust-toolchain.toml)
+        run: cargo --version
+
+      - name: Build the FFI-free kx
+        run: cargo build --release -p kx-cli
+
+      - name: Package + checksum
+        shell: bash
+        run: |
+          asset="kx-${{ matrix.target }}"
+          cp target/release/kx "$asset"
+          strip "$asset" || true
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$asset" > "$asset.sha256"
+          else
+            shasum -a 256 "$asset" > "$asset.sha256"
+          fi
+          cat "$asset.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kx-${{ matrix.target }}
+          path: |
+            kx-${{ matrix.target }}
+            kx-${{ matrix.target }}.sha256
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # publish — gather the per-target binaries, assemble one `checksums.txt`, and
+  # create (or update) the GitHub Release via the gh CLI (no third-party action).
+  # ---------------------------------------------------------------------------
+  publish:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Assemble checksums.txt
+        shell: bash
+        run: |
+          cd dist
+          cat kx-*.sha256 > checksums.txt
+          rm -f kx-*.sha256
+          echo "=== release assets ==="; ls -la
+          echo "=== checksums.txt ==="; cat checksums.txt
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* --repo "${{ github.repository }}" --clobber
+          else
+            gh release create "$tag" dist/* \
+              --repo "${{ github.repository }}" \
+              --title "$tag" \
+              --generate-notes
+          fi

--- a/README.md
+++ b/README.md
@@ -94,11 +94,20 @@ anything missing on your OS.
 
 ## Install & quick start
 
-Install the `kx` binary (Rust only — no C++ toolchain):
+Install the FFI-free `kx` binary — no toolchain, no clone:
+
+```bash
+# Prebuilt binary (Linux x86_64/arm64, macOS arm64) — SHA-256 verified, no sudo,
+# installs to ~/.local/bin (override with KX_INSTALL_DIR):
+curl -fsSL https://raw.githubusercontent.com/Kortecx/kortecx/main/scripts/install.sh | sh
+```
+
+Or from source (Rust 1.94+ only — no C++ toolchain), or via Docker:
 
 ```bash
 git clone https://github.com/Kortecx/kortecx.git && cd kortecx
 just setup            # installs `kx` (or: cargo install --path crates/kx-cli)
+# …or run it containerized — see "Run in Docker" below.
 ```
 
 Now **prove exactly-once end to end** — run the canonical demo workflow, crash it

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# kortecx `kx` installer — the FFI-free runtime, no toolchain required.
+#
+#   curl -fsSL https://raw.githubusercontent.com/Kortecx/kortecx/main/scripts/install.sh | sh
+#
+# Detects your platform, downloads a SHA-256-verified prebuilt `kx` from the pinned
+# GitHub Release, and installs it to ${KX_INSTALL_DIR:-$HOME/.local/bin}. No sudo,
+# no C++ toolchain, idempotent, fail-closed. POSIX sh.
+#
+# Env:
+#   KX_VERSION       release tag to install (default: latest)
+#   KX_INSTALL_DIR   install dir (default: $HOME/.local/bin)
+set -eu
+
+REPO="Kortecx/kortecx"
+KX_VERSION="${KX_VERSION:-latest}"
+KX_INSTALL_DIR="${KX_INSTALL_DIR:-$HOME/.local/bin}"
+
+say() { printf '%s\n' "$*"; }
+err() { printf 'install.sh: %s\n' "$*" >&2; exit 1; }
+
+# --- 1. Detect the target triple --------------------------------------------
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+    Linux)
+        case "$arch" in
+            x86_64 | amd64) triple="x86_64-unknown-linux-gnu" ;;
+            aarch64 | arm64) triple="aarch64-unknown-linux-gnu" ;;
+            *) err "unsupported Linux arch: $arch (prebuilt: x86_64, aarch64)" ;;
+        esac
+        ;;
+    Darwin)
+        case "$arch" in
+            arm64 | aarch64) triple="aarch64-apple-darwin" ;;
+            # Forward seam: an Intel-mac prebuilt (x86_64-apple-darwin) is not
+            # published yet — build from source (`just setup`) or use Apple Silicon.
+            x86_64) err "macOS x86_64 prebuilt not published yet — build from source (just setup)" ;;
+            *) err "unsupported macOS arch: $arch" ;;
+        esac
+        ;;
+    # Forward seam: Windows (x86_64-pc-windows-msvc) is not published yet.
+    MSYS_NT* | CYGWIN* | MINGW*)
+        err "Windows prebuilt not published yet — use WSL, or build from source (just setup)" ;;
+    *) err "unsupported OS: $os" ;;
+esac
+
+# --- 2. Download tooling -----------------------------------------------------
+if command -v curl >/dev/null 2>&1; then
+    dl() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+    dl() { wget -q "$1" -O "$2"; }
+else
+    err "need curl or wget on PATH"
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+    sha256() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+    err "need sha256sum or shasum on PATH"
+fi
+
+# --- 3. Resolve the release URL ---------------------------------------------
+if [ "$KX_VERSION" = "latest" ]; then
+    base="https://github.com/$REPO/releases/latest/download"
+else
+    base="https://github.com/$REPO/releases/download/$KX_VERSION"
+fi
+asset="kx-$triple"
+say "kortecx installer — $triple (version: $KX_VERSION)"
+
+# --- 4. Download + SHA-256 verify (atomic) ----------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+dl "$base/$asset" "$tmp/$asset.partial" || err "download failed: $base/$asset"
+dl "$base/checksums.txt" "$tmp/checksums.txt" || err "download failed: $base/checksums.txt"
+
+want="$(awk -v a="$asset" '$2 == a {print $1}' "$tmp/checksums.txt")"
+[ -n "$want" ] || err "no checksum for $asset in checksums.txt"
+got="$(sha256 "$tmp/$asset.partial")"
+[ "$got" = "$want" ] || err "SHA-256 mismatch for $asset: expected $want, got $got"
+
+# --- 5. Install --------------------------------------------------------------
+mkdir -p "$KX_INSTALL_DIR"
+chmod +x "$tmp/$asset.partial"
+mv -f "$tmp/$asset.partial" "$KX_INSTALL_DIR/kx"
+say " ✓ installed kx → $KX_INSTALL_DIR/kx  (sha256 $got)"
+
+# --- 6. PATH hint + next steps ----------------------------------------------
+case ":${PATH}:" in
+    *":$KX_INSTALL_DIR:"*) ;;
+    *) say "" ; say "Add to PATH:  export PATH=\"$KX_INSTALL_DIR:\$PATH\"" ;;
+esac
+say ""
+say "Next:  kx --help"
+say "       kx run --journal /tmp/kx.db --content /tmp/kx-content   # -> a6b5c679... (8/8 committed)"
+# Forward seam: local LLM inference is a separate opt-in (needs a C++ toolchain);
+# GPU is cloud-side (Metal works on an Apple host).
+if command -v nvidia-smi >/dev/null 2>&1; then
+    say ""
+    say "(NVIDIA GPU detected — local inference is an opt-in toolchain build: see 'just setup-inference'."
+    say " GPU-accelerated inference is cloud-side; on an Apple host, Metal works locally.)"
+fi


### PR DESCRIPTION
## Summary

Remove even the Rust prerequisite — a SHA-256-verified **prebuilt `kx`** install, plus the Release workflow that produces the binaries. **Pure packaging — no runtime code.**

- **`scripts/install.sh`** — `curl -fsSL …/install.sh | sh`: detect `uname` → target triple (`x86_64`/`aarch64`-linux, `aarch64-apple-darwin`), download the pinned-Release `kx` + `checksums.txt`, **SHA-256 verify** (atomic `.partial`→verify→`mv`, mirroring `fetch-demo-model`), install to `${KX_INSTALL_DIR:-$HOME/.local/bin}` (no sudo), PATH hint, idempotent, fail-closed. **Forward seams**: Windows + Intel-mac stubs; an `nvidia-smi` GPU hint.
- **`.github/workflows/release.yml`** — on tag `v*` (NOT a PR check → **no branch-protection context**): build the FFI-free `kx` on **native runners** (ubuntu, ubuntu-arm, macos-14), strip, checksum, assemble `checksums.txt`, `gh release create` (no third-party action). Asset names = target triples, so a future target is a localized matrix add. The prebuilt `kx` ships **WITH TLS (A1) + health (A2)**.
- **README** install section → the `curl|sh` one-liner (source build + Docker as alternatives).

## Validation

`install.sh` passes `sh -n` + a triple-detection logic test; `release.yml` is valid YAML. The full `curl|sh` flow **activates on the first `v*` tag** (no release exists yet — this PR lands the machinery). No Rust code → frozen-trio untouched, canonical digest invariant, fmt/clippy/test trivially unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)