### PR TITLE
feat(docker): build-speed — cargo-chef caching + prebuilt-COPY fast variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ kx-cloud/
 /.claude/
 /docs/design/*.md
 /docs/suggestions/*.md
+# Internal analysis / feasibility reviews — private-only (docs default to private).
+/docs/analysis/
 # Plan files are private-only (SN-5: plans NEVER land in the public OSS repo).
 /docs/plans/
 # Internal warning/debug log — kept in the private kortecx-core repo only.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,48 +13,112 @@
 # GPU/CUDA is the cloud-side seam — see `Dockerfile.cuda` (D28: CUDA inference is
 # cloud-tier; OSS ships the seam, not the build).
 #
+# TWO ways to get `kx` into the image (selected with --build-arg KX_SOURCE=…):
+#   builder  (DEFAULT) — compile from source with cargo-chef dependency-layer
+#                        caching, so source-only rebuilds skip recompiling deps.
+#                        Self-contained: needs nothing but this build context.
+#   prebuilt (FAST)    — COPY the SHA-256-verified `kx` from the GitHub Release
+#                        instead of compiling (near-zero build). Requires
+#                        --build-arg KX_VERSION=<release tag>. FFI-free-only,
+#                        exactly matching what the Release (A0) publishes.
+#
 # Durable state lives in mounted volumes (the durability spine survives the
 # container boundary — see docker-compose.yml):
 #   /var/lib/kortecx/journal   the SQLite journal (sole-writer; exactly-once truth)
 #   /var/lib/kortecx/content   the content-addressed store
 #   /var/lib/kortecx/catalog   the durable signature/recipe catalog
 #
-#   build : docker build -t kortecx/kx:dev .
-#   smoke : just docker-smoke           (in-container digest reproduction)
-#   run   : docker run --rm kortecx/kx:dev run --journal /tmp/kx.db --content /tmp/c
-#   serve : docker compose up           (see docker-compose.yml)
+#   build (chef)     : docker build -t kortecx/kx:dev .
+#   build (prebuilt) : docker build --build-arg KX_SOURCE=prebuilt \
+#                        --build-arg KX_VERSION=v0.1.0 -t kortecx/kx:dev .
+#   smoke            : just docker-smoke    (in-container digest reproduction)
+#   run              : docker run --rm kortecx/kx:dev run --journal /tmp/kx.db --content /tmp/c
+#   serve            : docker compose up    (see docker-compose.yml)
 
-# ---- builder ---------------------------------------------------------------
+# Global ARG (declared before the first FROM so it can drive `FROM ${KX_SOURCE}`).
+# DEFAULT = the self-contained chef builder. `prebuilt` switches to the Release
+# download. Only the SELECTED stage is built — the other never runs.
+ARG KX_SOURCE=builder
+
+# ---- chef base: cargo-chef for dependency-layer caching --------------------
 # Pinned to the workspace toolchain channel (rust-toolchain.toml = 1.94.0). The
 # official `rust` image ships rustup, so the exact pinned toolchain is honored on
-# the first cargo invocation.
+# the first cargo invocation. cargo-chef is `cargo install`ed from this same pinned
+# image (no external base-image dependency — supply-chain minimalism, Rule 6).
 # HARDENING (Pass B): pin the base by @sha256 digest for a reproducible supply chain.
-FROM rust:1.94-bookworm AS builder
-
+FROM rust:1.94-bookworm AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
 
-# The whole workspace, minus what `.dockerignore` strips (target/, .git/, the
-# PRIVATE kx-cloud/, the llama.cpp submodule, local DBs + models).
+# ---- planner: distill the dependency graph into recipe.json -----------------
+# recipe.json is a function of the Cargo manifests + lockfile ONLY, so the cooked
+# layer below is reused across every source-only change.
+FROM chef AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Build the FFI-free `kx`. NO submodules, NO clang/cmake. If the llama.cpp FFI ever
+# ---- builder (DEFAULT): cook deps, then build the FFI-free `kx` -------------
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Cook ONLY kx-cli's dependency closure. This layer is cached unless the manifests
+# / lockfile change — the ~3-5 min dependency-compile win on a typical rebuild. The
+# BuildKit cache mounts further persist the cargo registry + target dir locally.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json -p kx-cli
+# Now the app sources. NO submodules, NO clang/cmake. If the llama.cpp FFI ever
 # leaked into kx-cli's normal dependency closure, this stage would suddenly need a
-# C++ toolchain — `build-no-inference` catches that earlier, but this is a second
-# line of defense.
-RUN cargo build --release -p kx-cli \
+# C++ toolchain — `build-no-inference` catches that earlier, this is a second line
+# of defense. `cp` out of the (cache-mounted) target so the binary lands in a layer.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p kx-cli \
  && strip target/release/kx \
  && cp target/release/kx /usr/local/bin/kx
+
+# ---- prebuilt (FAST variant): COPY the verified `kx` from the GitHub Release ---
+# Compiles NOTHING. Downloads the per-target binary + its `.sha256` sidecar and
+# verifies the bytes before installing. The Release (A0) ships only the FFI-free
+# `kx`, so this path is FFI-free-only — exactly this image. Not built unless
+# --build-arg KX_SOURCE=prebuilt is set.
+FROM debian:bookworm-slim AS prebuilt
+ARG KX_REPO=Kortecx/kortecx
+ARG KX_VERSION
+ARG TARGETARCH
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    : "${KX_VERSION:?set --build-arg KX_VERSION=<release tag> for the prebuilt variant}"; \
+    case "$TARGETARCH" in \
+      amd64) triple=x86_64-unknown-linux-gnu ;; \
+      arm64) triple=aarch64-unknown-linux-gnu ;; \
+      *) echo "prebuilt variant: unsupported TARGETARCH=${TARGETARCH:-<unset>}" >&2; exit 1 ;; \
+    esac; \
+    base="https://github.com/${KX_REPO}/releases/download/${KX_VERSION}"; \
+    curl -fsSL -o /tmp/kx        "${base}/kx-${triple}"; \
+    curl -fsSL -o /tmp/kx.sha256 "${base}/kx-${triple}.sha256"; \
+    printf '%s  /tmp/kx\n' "$(awk '{print $1}' /tmp/kx.sha256)" | sha256sum -c -; \
+    install -m 0755 /tmp/kx /usr/local/bin/kx
+
+# ---- kx-bin: the selected source of the `kx` binary ------------------------
+# Aliases either `builder` (default) or `prebuilt`. The runtime copies from here,
+# so BuildKit only ever builds the one the operator chose.
+FROM ${KX_SOURCE} AS kx-bin
 
 # ---- runtime ---------------------------------------------------------------
 # debian-slim: glibc matches the builder (no GLIBC-version drift for a glibc-linked
 # binary), ships a shell (the in-container smoke + the CLI healthcheck want one) and
 # ca-certificates (for the later TLS + model-fetch paths). Distroless is the
-# hardening target (Pass B roadmap), traded off now because it has no shell.
+# hardening target (Pass B roadmap) — evaluated and DEFERRED here: it has no shell
+# and no tini, and the smoke harness + operational debugging both want one. A
+# distroless variant is its own hardening PR.
 FROM debian:bookworm-slim AS runtime
 
-# ca-certificates: outbound TLS (future A1 + model fetch). tini: a tiny init that
-# becomes PID 1 and FORWARDS SIGTERM to `kx serve` (+ reaps any children), so
-# `docker stop` triggers the graceful drain rather than a SIGKILL.
+# ca-certificates: outbound TLS (A1 + model fetch). tini: a tiny init that becomes
+# PID 1 and FORWARDS SIGTERM to `kx serve` (+ reaps any children), so `docker stop`
+# triggers the graceful drain rather than a SIGKILL.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates tini \
  && rm -rf /var/lib/apt/lists/*
@@ -67,7 +131,7 @@ RUN groupadd --gid 10001 kx \
  && mkdir -p /var/lib/kortecx/journal /var/lib/kortecx/content /var/lib/kortecx/catalog \
  && chown -R 10001:10001 /var/lib/kortecx
 
-COPY --from=builder /usr/local/bin/kx /usr/local/bin/kx
+COPY --from=kx-bin /usr/local/bin/kx /usr/local/bin/kx
 
 # Convention defaults. NOTE: `kx serve` reads FLAGS, not env — these are
 # documentation + compose-interpolation only (the compose passes explicit flags).

--- a/justfile
+++ b/justfile
@@ -173,11 +173,21 @@ verify-quickstart:
 # ============================================================================
 
 # Build the FFI-free `kx` runtime image (no C++ toolchain, no llama.cpp submodule).
-# Tags `kortecx/kx:dev` by default; override with KX_IMAGE.
+# Compiles from source via cargo-chef (dependency layer cached across source-only
+# rebuilds). Tags `kortecx/kx:dev` by default; override with KX_IMAGE.
 #   just docker-build                       # → kortecx/kx:dev
 #   KX_IMAGE=ghcr.io/you/kx:v0 just docker-build
 docker-build:
     DOCKER_BUILDKIT=1 docker build -f Dockerfile -t {{ env_var_or_default("KX_IMAGE", "kortecx/kx:dev") }} .
+
+# Build the FFI-free image WITHOUT compiling — COPY the SHA-256-verified `kx` from
+# the GitHub Release (near-zero build). Requires KX_VERSION (the Release tag).
+#   KX_VERSION=v0.1.0 just docker-build-fast
+docker-build-fast:
+    DOCKER_BUILDKIT=1 docker build -f Dockerfile \
+      --build-arg KX_SOURCE=prebuilt \
+      --build-arg KX_VERSION={{ env_var_or_default("KX_VERSION", "") }} \
+      -t {{ env_var_or_default("KX_IMAGE", "kortecx/kx:dev") }} .
 
 # Build the CPU inference image (fetches the PINNED llama.cpp inside the builder;
 # needs a C++ toolchain in the BUILDER only, not at runtime). CPU-only — Metal is


### PR DESCRIPTION
## What

Build-speed + minimal-friction optimization of the already-merged FFI-free `kx` image (Docker Scope A). No architecture change.

- **`Dockerfile`** — cargo-chef dependency-layer split (`prepare → cook → build`) + BuildKit cache mounts, so source-only rebuilds skip recompiling deps. Default target stays self-contained (buildable from this context alone).
- **`Dockerfile` — `prebuilt` FAST variant** (`--build-arg KX_SOURCE=prebuilt --build-arg KX_VERSION=<release tag>`): COPYs the SHA-256-verified `kx` from the GitHub Release instead of compiling (near-zero build). `FROM ${KX_SOURCE} AS kx-bin` ensures only the chosen stage builds; SHA-256 verify is fail-closed.
- **`justfile`** — `docker-build-fast` recipe for the prebuilt path.
- **`.gitignore`** — keep `/docs/analysis/` private (internal analysis docs; matches the existing `/docs/design` + `/docs/plans` pattern).

## Verification

`scripts/docker-smoke.sh` green on the new chef path — canonical digest `a6b5c679…` reproduces in-container across **clean run / crash-replay-over-persisted-volume / read-only-rootfs** (all 8/8 committed). Prebuilt SHA-256 verify unit-checked (matching→PASS, tampered→fail-closed). Frozen-trio source diff **EMPTY**; digest invariant.

Cold builds pay a small `cook` overhead; iterative local rebuilds drop from ~8–9 min to ~30s–1 min.

## Deferred (own PRs)

- **Distroless runtime** — evaluated, kept `debian-slim`+`tini` (smoke harness + ops want a shell).
- **`Dockerfile.inference` cache-mounts** — deferred: build-validation surfaced a **pre-existing arm64 break** (llama.cpp `ggml-cpu` FP16-NEON under GCC-12/aarch64: `vfmaq_f16` "target specific option mismatch"). The fix (clang) + the cache-mounts land together in a dedicated inference PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)