### PR TITLE
feat(gateway): PR-9b — real sandboxed Mote body-exec wired into kx serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ development; interfaces may change before 1.0 — pin a commit if you build on i
 
 ## [Unreleased]
 
+### Added
+
+- **Real, sandboxed Mote body-execution in `kx serve`** (`crates/kx-gateway`).
+  The embedded worker now runs a real Mote body inside the platform sandbox
+  (bubblewrap on Linux, sandbox-exec on macOS) for the new `kx/recipes/exec-demo`
+  recipe — materializing the body from its `logic_ref`, running it under the
+  warrant's scope, and reconciling its output into the content store so the run
+  commits exactly-once. The demo `echo` path and the canonical projection digest
+  are unchanged (the frozen trio `kx-executor`/`kx-scheduler`/`kx-inference` is
+  untouched — the gateway composes their existing public API). **Fail-closed:** a
+  sandbox that cannot run errors rather than executing on the host. The runtime
+  image ships `bubblewrap` + the demo body; real-exec under the hardened
+  `docker-compose` is a documented `seccomp=unconfined` opt-in (Docker's default
+  seccomp blocks the unprivileged user namespace bubblewrap needs).
+
 ## [0.1.0] — the reachable runtime
 
 The first release where the durable runtime is **reachable end to end**: a server,

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,17 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo build --release -p kx-cli \
  && strip target/release/kx \
- && cp target/release/kx /usr/local/bin/kx
+ && cp target/release/kx /usr/local/bin/kx \
+ && mkdir -p /usr/local/libexec/kx
+# PR-9b: build the sandbox demo body (`pure_body`, the kx-executor example) so
+# `kx serve` can run a REAL sandboxed Mote body (kx/recipes/exec-demo). FFI-FREE
+# (kx-executor → kx-inference is default-features = false), so no C++ toolchain.
+# Staged at the in-image path `real_exec::register_demo_body` looks for.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p kx-executor --example pure_body \
+ && strip target/release/examples/pure_body \
+ && cp target/release/examples/pure_body /usr/local/libexec/kx/pure_body
 
 # ---- prebuilt (FAST variant): COPY the verified `kx` from the GitHub Release ---
 # Compiles NOTHING. Downloads the per-target binary + its `.sha256` sidecar and
@@ -100,7 +110,11 @@ RUN set -eux; \
     curl -fsSL -o /tmp/kx        "${base}/kx-${triple}"; \
     curl -fsSL -o /tmp/kx.sha256 "${base}/kx-${triple}.sha256"; \
     printf '%s  /tmp/kx\n' "$(awk '{print $1}' /tmp/kx.sha256)" | sha256sum -c -; \
-    install -m 0755 /tmp/kx /usr/local/bin/kx
+    install -m 0755 /tmp/kx /usr/local/bin/kx; \
+    mkdir -p /usr/local/libexec/kx; \
+    : "the prebuilt Release ships only kx — no sandbox demo body; the .keep marker"; \
+    : "keeps the libexec dir COPY-able. exec-demo is then gracefully not provisioned."; \
+    touch /usr/local/libexec/kx/.keep
 
 # ---- kx-bin: the selected source of the `kx` binary ------------------------
 # Aliases either `builder` (default) or `prebuilt`. The runtime copies from here,
@@ -118,9 +132,12 @@ FROM debian:bookworm-slim AS runtime
 
 # ca-certificates: outbound TLS (A1 + model fetch). tini: a tiny init that becomes
 # PID 1 and FORWARDS SIGTERM to `kx serve` (+ reaps any children), so `docker stop`
-# triggers the graceful drain rather than a SIGKILL.
+# triggers the graceful drain rather than a SIGKILL. bubblewrap (PR-9b): the Linux
+# sandbox `kx serve` runs a REAL Mote body in (kx-executor `BwrapExecutor`); without
+# it the real-exec recipe fails closed (no host execution). bwrap needs unprivileged
+# user-namespaces — see the docker-compose note if your host restricts them.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates tini \
+ && apt-get install -y --no-install-recommends ca-certificates tini bubblewrap \
  && rm -rf /var/lib/apt/lists/*
 
 # Non-root runtime identity. Create + own the durable-state dirs so a FRESH named
@@ -129,9 +146,16 @@ RUN apt-get update \
 RUN groupadd --gid 10001 kx \
  && useradd  --uid 10001 --gid 10001 --home-dir /var/lib/kortecx --shell /usr/sbin/nologin kx \
  && mkdir -p /var/lib/kortecx/journal /var/lib/kortecx/content /var/lib/kortecx/catalog \
- && chown -R 10001:10001 /var/lib/kortecx
+ && chown -R 10001:10001 /var/lib/kortecx \
+ && mkdir -p /lib64
+# PR-9b: the kx-executor bwrap argv `--ro-bind /lib64 /lib64` unconditionally;
+# arm64 debian has no /lib64, and `--ro-bind` errors on a missing source. An empty
+# /lib64 makes the bind a no-op on arm64 (harmless on amd64, where it exists).
 
 COPY --from=kx-bin /usr/local/bin/kx /usr/local/bin/kx
+# PR-9b: the sandbox demo body (present in the from-source image; the prebuilt fast
+# image carries only a `.keep` marker, so `exec-demo` is gracefully not provisioned).
+COPY --from=kx-bin /usr/local/libexec/kx/ /usr/local/libexec/kx/
 
 # Convention defaults. NOTE: `kx serve` reads FLAGS, not env — these are
 # documentation + compose-interpolation only (the compose passes explicit flags).

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -51,6 +51,11 @@ kx-coordinator  = { workspace = true, optional = true }
 kx-worker       = { workspace = true, optional = true }
 kx-executor     = { workspace = true, optional = true }
 kx-capability   = { workspace = true, optional = true }
+# PR-9b: per-Mote input tempfile for the real, sandboxed body-exec router
+# (`real_exec.rs`). FFI-free + already in the lock (a dev-dep here + a normal dep
+# of kx-executor); gated under `embedded-worker` so the gateway-only closure that
+# `build-no-inference` asserts stays unchanged.
+tempfile        = { workspace = true, optional = true }
 # A1: `tls` enables in-binary rustls TLS on the gRPC listener (reuses the rustls
 # 0.23 + ring already in the lock via ureq — no new crypto provider). Server cert/
 # key via `--tls-cert`/`--tls-key`; plaintext stays the default (TLS opt-in).
@@ -101,7 +106,7 @@ default = ["embedded-worker"]
 # the binary is genuinely reachable end-to-end (SubmitRun -> Committed). A future library
 # consumer can disable it to embed a gateway-only front end (then `serve` requires an
 # external coordinator — a later step; R1 refuses without the feature).
-embedded-worker = ["dep:kx-coordinator", "dep:kx-worker", "dep:kx-executor", "dep:kx-capability"]
+embedded-worker = ["dep:kx-coordinator", "dep:kx-worker", "dep:kx-executor", "dep:kx-capability", "dep:tempfile"]
 # Reserved (R2+): the in-process model / WORLD-MUTATING dispatch path. Mirrors the
 # workspace's llamacpp gate; OFF by default so `build-no-inference` stays green.
 llamacpp = []

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -56,6 +56,8 @@ mod config;
 mod error;
 mod live_tail;
 mod provision;
+#[cfg(feature = "embedded-worker")]
+mod real_exec;
 mod server;
 mod tls;
 #[cfg(feature = "embedded-worker")]
@@ -65,7 +67,9 @@ pub use auth::{DenyAll, DevAllowLocal, Principal, PrincipalResolver, TokenResolv
 pub use config::{Cli, GatewayConfig, TlsPaths, DEFAULT_MAX_LEASE, DEFAULT_WS_LISTEN, USAGE};
 pub use error::GatewayError;
 pub use live_tail::LiveTailer;
-pub use provision::{DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RECIPE_HANDLE};
+pub use provision::{
+    DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RECIPE_HANDLE, EXEC_RECIPE_HANDLE,
+};
 pub use server::{serve, start, RunningGateway};
 
 #[cfg(feature = "embedded-worker")]

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -527,7 +527,7 @@ fn demo_warrant(exec_class: ExecutorClass) -> WarrantSpec {
 /// (`NetScope::None`). `executor_class` MUST equal the embedded worker's so the
 /// bound run leases. NOTE: the temp dir is host-specific but stable across
 /// restarts for the same user — adequate for the single-system demo recipe.
-fn real_exec_warrant(exec_class: ExecutorClass) -> WarrantSpec {
+pub(crate) fn real_exec_warrant(exec_class: ExecutorClass) -> WarrantSpec {
     let tempdir = std::env::temp_dir();
     let tempdir = std::fs::canonicalize(&tempdir).unwrap_or(tempdir);
     let mut mounts = std::collections::BTreeMap::new();
@@ -555,20 +555,36 @@ fn real_exec_warrant(exec_class: ExecutorClass) -> WarrantSpec {
             max_output_tokens: 512,
             max_calls: 1,
         },
-        // Zero = "no setrlimit on this axis" (the proven kx-executor real-spawn
-        // warrant): macOS rejects a tight RLIMIT_AS (mem_bytes) for the body's
-        // virtual-address reservation, so leave the rlimit axes unset and bound
-        // only the wall clock. `intersect` does not validate ceiling zeros.
-        resource_ceiling: ResourceCeiling {
+        resource_ceiling: real_exec_ceiling(exec_class),
+        environment_ref: None,
+        executor_class: exec_class,
+        ..Default::default()
+    }
+}
+
+/// The body's resource ceiling, platform-split. On Linux/bwrap, bound mem/CPU/FD
+/// so a misbehaving body can't OOM or CPU-spin the container (it only ever has a
+/// RO tempdir, so `disk_bytes`/`RLIMIT_FSIZE` stays unbounded). On macOS the axes
+/// stay 0: a tight `RLIMIT_AS` (mem_bytes) is rejected for the body's
+/// virtual-address reservation (`setrlimit` → `_exit(80)`), so the 30 s wall clock
+/// is the only backstop there. `intersect` does not validate ceiling zeros.
+fn real_exec_ceiling(exec_class: ExecutorClass) -> ResourceCeiling {
+    if exec_class == ExecutorClass::Bwrap {
+        ResourceCeiling {
+            cpu_milli: 5_000,     // ceil → 5 s of CPU time (a hash body uses ms)
+            mem_bytes: 512 << 20, // 512 MiB RLIMIT_AS — ample for a small binary
+            wall_clock_ms: 30_000,
+            fd_count: 256,
+            disk_bytes: 0,
+        }
+    } else {
+        ResourceCeiling {
             cpu_milli: 0,
             mem_bytes: 0,
             wall_clock_ms: 30_000,
             fd_count: 0,
             disk_bytes: 0,
-        },
-        environment_ref: None,
-        executor_class: exec_class,
-        ..Default::default()
+        }
     }
 }
 

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -117,6 +117,13 @@ fn short_label(id: &[u8; 32]) -> String {
 /// library is a later PR, R6.) Shared with the e2e test (no drift).
 pub const DEMO_RECIPE_HANDLE: &str = "kx/recipes/echo";
 
+/// The wire handle of the PR-9b real-exec demo recipe: a PURE step whose body
+/// is a REAL binary the embedded worker runs inside the platform sandbox
+/// (bwrap/macOS). Provisioned only when a body binary was located at startup
+/// (see `real_exec::register_demo_body`); takes no free-params (the
+/// body's input is the Mote's identity). Shared with the e2e test (no drift).
+pub const EXEC_RECIPE_HANDLE: &str = "kx/recipes/exec-demo";
+
 /// The content-ref of the demo recipe's single typed free-param (`topic`).
 const TOPIC_SCHEMA_REF: [u8; 32] = [0x2b; 32];
 
@@ -129,9 +136,18 @@ pub struct DemoLibrary {
     versions: SqliteVersionLedger,
     bodies: SqliteBodyLedger,
     grants: SqliteGrantLedger,
-    /// The owner's base warrant the grant fold narrows from (== the recipe step
-    /// warrant, so the bound run keeps the worker's `executor_class` and the
-    /// `intersect` chain never attempts a widen).
+    /// Per-handle binding metadata — one entry per seeded recipe (the demo
+    /// `echo` always; the PR-9b real-exec `exec-demo` when a body was located).
+    /// `bind` looks the handle up here for its owner-root warrant + free-param
+    /// contract; an unknown handle is a uniform `NotAuthorized` (no oracle).
+    recipes: Vec<(AssetPath, RecipeMeta)>,
+}
+
+/// Per-recipe binding metadata: the owner's base warrant the grant fold narrows
+/// from (== the recipe step warrant, so every `intersect` in the bind chain is a
+/// no-op narrowing and the bound run keeps the worker's `executor_class`) + the
+/// recipe's free-param contract.
+struct RecipeMeta {
     owner_root: WarrantSpec,
     free_params: FreeParamContract,
 }
@@ -149,6 +165,34 @@ impl DemoLibrary {
         exec_class: ExecutorClass,
         parties: &[String],
     ) -> Result<Self, GatewayError> {
+        Self::seed(dir, exec_class, parties, None)
+    }
+
+    /// Like [`DemoLibrary::open`], plus (when `real_body_ref` is `Some`) seeds the
+    /// PR-9b real-exec recipe [`EXEC_RECIPE_HANDLE`] whose step body is the located
+    /// sandbox binary. `None` ⇒ byte-identical to [`DemoLibrary::open`].
+    ///
+    /// # Errors
+    /// [`GatewayError::Catalog`] on a ledger open / seed failure.
+    pub fn open_with_real_exec(
+        dir: &Path,
+        exec_class: ExecutorClass,
+        parties: &[String],
+        real_body_ref: Option<ContentRef>,
+    ) -> Result<Self, GatewayError> {
+        Self::seed(dir, exec_class, parties, real_body_ref)
+    }
+
+    /// Open the durable ledgers under `dir` and idempotently seed the demo `echo`
+    /// recipe (always) plus the real-exec `exec-demo` recipe (when `real_body_ref`
+    /// is `Some`). Re-opening on restart is a no-op (content-addressed bodies +
+    /// guarded version publish + idempotent grants).
+    fn seed(
+        dir: &Path,
+        exec_class: ExecutorClass,
+        parties: &[String],
+        real_body_ref: Option<ContentRef>,
+    ) -> Result<Self, GatewayError> {
         let cat = |e: String| GatewayError::Catalog(e);
         let versions =
             SqliteVersionLedger::open(dir.join("versions.db")).map_err(|e| cat(e.to_string()))?;
@@ -156,69 +200,126 @@ impl DemoLibrary {
             SqliteBodyLedger::open(dir.join("bodies.db")).map_err(|e| cat(e.to_string()))?;
         let grants =
             SqliteGrantLedger::open(dir.join("grants.db")).map_err(|e| cat(e.to_string()))?;
-
-        let warrant = demo_warrant(exec_class);
         let owner = PartyId::new("kx-gateway");
-        let handle = demo_handle()?;
-        let asset = AssetRef::Path(handle.clone());
+        let mut recipes: Vec<(AssetPath, RecipeMeta)> = Vec::new();
 
-        // (1) Own the asset (idempotent on re-open with the same owner).
-        grants
-            .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
-            .map_err(|e| cat(e.to_string()))?;
+        // (echo) the PURE demo recipe — a placeholder logic_ref the storing
+        // executor ignores, a `topic` free-param.
+        let echo_warrant = demo_warrant(exec_class);
+        let echo_handle = demo_handle()?;
+        seed_recipe(
+            &versions,
+            &bodies,
+            &grants,
+            &owner,
+            parties,
+            &echo_handle,
+            recipe_body(LogicRef::from_bytes([0x2b; 32]), &echo_warrant, &["topic"]),
+            &echo_warrant,
+        )?;
+        recipes.push((
+            echo_handle,
+            RecipeMeta {
+                owner_root: echo_warrant,
+                free_params: topic_contract(),
+            },
+        ));
 
-        // (2) Publish the executable body (content-addressed, idempotent) + move
-        //     the handle to it (guarded so a restart re-seed is a no-op).
-        let (manifest_id, _) = bodies
-            .publish_body(recipe_body(&warrant))
-            .map_err(|e| cat(e.to_string()))?;
-        if versions.resolve(&handle).is_none() {
-            versions
-                .publish(AssetVersion::root(
-                    handle.clone(),
-                    VersionedContent::Workflow(manifest_id),
-                    owner.clone(),
-                    Provenance::from_recipe(manifest_id.0),
-                ))
-                .map_err(|e| cat(e.to_string()))?;
-        }
-
-        // (3) Grant Use+Read to every configured party (and the dev principal),
-        //     under a runtime scope == the recipe warrant.
-        let role = Role {
-            name: "demo-use".to_string(),
-            version: 1,
-            spec: warrant.clone(),
-            description: String::new(),
-        };
-        let mut granted: BTreeSet<&str> = BTreeSet::new();
-        for party in parties
-            .iter()
-            .map(String::as_str)
-            .chain(std::iter::once("local-dev"))
-        {
-            if !granted.insert(party) {
-                continue;
-            }
-            grants
-                .append_grant(Grant::root(
-                    asset.clone(),
-                    owner.clone(),
-                    PartyId::new(party),
-                    CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
-                    role.clone(),
-                ))
-                .map_err(|e| cat(e.to_string()))?;
+        // (exec-demo) the PR-9b real-exec recipe — step logic_ref == the located
+        // body's content ref, a sandbox warrant, no free-params. Seeded only when
+        // a body binary was found.
+        if let Some(body_ref) = real_body_ref {
+            let exec_warrant = real_exec_warrant(exec_class);
+            let exec_handle = exec_handle()?;
+            let step_logic = LogicRef::from_bytes(*body_ref.as_bytes());
+            seed_recipe(
+                &versions,
+                &bodies,
+                &grants,
+                &owner,
+                parties,
+                &exec_handle,
+                recipe_body(step_logic, &exec_warrant, &[]),
+                &exec_warrant,
+            )?;
+            recipes.push((
+                exec_handle,
+                RecipeMeta {
+                    owner_root: exec_warrant,
+                    free_params: FreeParamContract::new(),
+                },
+            ));
         }
 
         Ok(Self {
             versions,
             bodies,
             grants,
-            owner_root: warrant,
-            free_params: topic_contract(),
+            recipes,
         })
     }
+}
+
+/// Idempotently seed one recipe: own the asset, publish its content-addressed
+/// body (guarding the version publish), and grant `Use`+`Read` to every party
+/// (plus the dev `local-dev` principal) under a runtime scope == the recipe
+/// warrant. Shared by every recipe `DemoLibrary::seed` provisions.
+#[allow(clippy::too_many_arguments)] // seeding genuinely needs all three ledgers + owner/parties/handle/body/warrant
+fn seed_recipe(
+    versions: &SqliteVersionLedger,
+    bodies: &SqliteBodyLedger,
+    grants: &SqliteGrantLedger,
+    owner: &PartyId,
+    parties: &[String],
+    handle: &AssetPath,
+    body: WorkflowDef,
+    warrant: &WarrantSpec,
+) -> Result<(), GatewayError> {
+    let cat = |e: String| GatewayError::Catalog(e);
+    let asset = AssetRef::Path(handle.clone());
+
+    grants
+        .append_binding(AssetBinding::new(asset.clone(), owner.clone()))
+        .map_err(|e| cat(e.to_string()))?;
+
+    let (manifest_id, _) = bodies.publish_body(body).map_err(|e| cat(e.to_string()))?;
+    if versions.resolve(handle).is_none() {
+        versions
+            .publish(AssetVersion::root(
+                handle.clone(),
+                VersionedContent::Workflow(manifest_id),
+                owner.clone(),
+                Provenance::from_recipe(manifest_id.0),
+            ))
+            .map_err(|e| cat(e.to_string()))?;
+    }
+
+    let role = Role {
+        name: "demo-use".to_string(),
+        version: 1,
+        spec: warrant.clone(),
+        description: String::new(),
+    };
+    let mut granted: BTreeSet<&str> = BTreeSet::new();
+    for party in parties
+        .iter()
+        .map(String::as_str)
+        .chain(std::iter::once("local-dev"))
+    {
+        if !granted.insert(party) {
+            continue;
+        }
+        grants
+            .append_grant(Grant::root(
+                asset.clone(),
+                owner.clone(),
+                PartyId::new(party),
+                CatalogActionSet::allow([CatalogAction::Read, CatalogAction::Use]),
+                role.clone(),
+            ))
+            .map_err(|e| cat(e.to_string()))?;
+    }
+    Ok(())
 }
 
 /// A [`RecipeBinder`] over a [`DemoLibrary`]: resolves a handle + args for the
@@ -246,10 +347,19 @@ impl RecipeBinder for HostRecipeBinder {
     ) -> Result<BoundRecipe, BinderError> {
         // A malformed handle reveals nothing (uniform NotAuthorized — no probing).
         let asset_path = parse_handle(handle).ok_or(BinderError::NotAuthorized)?;
+        // Resolve the recipe's binding metadata; an unknown handle is the same
+        // uniform NotAuthorized (no existence oracle on the execution surface).
+        let meta = self
+            .lib
+            .recipes
+            .iter()
+            .find(|(h, _)| *h == asset_path)
+            .map(|(_, m)| m)
+            .ok_or(BinderError::NotAuthorized)?;
         let party_id = PartyId::new(party);
         let resolver = HostUseResolver {
             grants: &self.lib.grants,
-            owner_root: self.lib.owner_root.clone(),
+            owner_root: meta.owner_root.clone(),
         };
         let bound = bind_snapshot(
             &self.lib.versions,
@@ -257,7 +367,7 @@ impl RecipeBinder for HostRecipeBinder {
             &resolver,
             &party_id,
             &asset_path,
-            &self.lib.free_params,
+            &meta.free_params,
             &DemoSchemaResolver,
             args,
         )
@@ -326,19 +436,31 @@ fn demo_handle() -> Result<AssetPath, GatewayError> {
         .ok_or_else(|| GatewayError::Catalog("invalid demo recipe handle".into()))
 }
 
-/// The PURE demo recipe body: a single content-addressed step that declares a
-/// `topic` variable slot (so a bound free-param can overwrite it). PURE so the
-/// embedded worker's deterministic content-storing executor runs it.
-fn recipe_body(warrant: &WarrantSpec) -> WorkflowDef {
-    let mut wf = WorkflowDef::new(0x2b2b_2b2b);
+fn exec_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(EXEC_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid exec recipe handle".into()))
+}
+
+/// A PURE recipe body: a single content-addressed step with `step_logic_ref` as
+/// its body reference + `warrant` as its step warrant, declaring each name in
+/// `var_slots` as a variable slot (so a bound free-param can overwrite it). The
+/// `WorkflowDef` seed is derived from the logic_ref so distinct bodies get
+/// distinct manifests (the `echo` placeholder `[0x2b; 32]` ⇒ the historical
+/// `0x2b2b_2b2b` seed, so its body stays byte-identical + idempotent).
+fn recipe_body(step_logic_ref: LogicRef, warrant: &WarrantSpec, var_slots: &[&str]) -> WorkflowDef {
+    let b = step_logic_ref.as_bytes();
+    let seed = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+    let mut wf = WorkflowDef::new(seed);
     let mut step = transform(
-        LogicRef::from_bytes([0x2b; 32]),
+        step_logic_ref,
         warrant.model_route.model_id.clone(),
         warrant.clone(),
         ToolName("demo".into()),
     );
-    step.config_subset
-        .insert(ConfigKey("topic".into()), ConfigVal(Vec::new()));
+    for slot in var_slots {
+        step.config_subset
+            .insert(ConfigKey((*slot).into()), ConfigVal(Vec::new()));
+    }
     wf.add_step(step);
     wf
 }
@@ -391,6 +513,60 @@ fn demo_warrant(exec_class: ExecutorClass) -> WarrantSpec {
             disk_bytes: 1 << 28,
         },
         environment_ref: Some(ContentRef::from_bytes([8u8; 32])),
+        executor_class: exec_class,
+        ..Default::default()
+    }
+}
+
+/// The PR-9b real-exec recipe warrant: the sandbox scope under which the embedded
+/// worker runs the located body binary. The body + its per-Mote input are
+/// materialized as tempfiles under the process temp dir, so the scope grants
+/// `ExecOnly` on the (canonicalized) temp dir — and, on macOS only, `ReadOnly` on
+/// `/` so dyld can load libsystem (mirrors the proven `kx-executor`
+/// `integration_body_resolver` warrant). Network is fully isolated
+/// (`NetScope::None`). `executor_class` MUST equal the embedded worker's so the
+/// bound run leases. NOTE: the temp dir is host-specific but stable across
+/// restarts for the same user — adequate for the single-system demo recipe.
+fn real_exec_warrant(exec_class: ExecutorClass) -> WarrantSpec {
+    let tempdir = std::env::temp_dir();
+    let tempdir = std::fs::canonicalize(&tempdir).unwrap_or(tempdir);
+    let mut mounts = std::collections::BTreeMap::new();
+    if exec_class == ExecutorClass::MacOsSandbox {
+        // dyld/libsystem load (SBPL file-read*); bwrap binds /usr,/lib,/lib64,/etc
+        // itself, so Linux needs no `/` mount.
+        mounts.insert(std::path::PathBuf::from("/"), FsMode::ReadOnly);
+    }
+    // process-exec on the materialized body (+ read of body/input under the same
+    // dir; on Linux ExecOnly maps to a bwrap `--ro-bind`, which permits exec).
+    mounts.insert(tempdir, FsMode::ExecOnly);
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope { mounts },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        // The body is PURE (no model call), but the warrant-narrowing `intersect`
+        // (kx-warrant) rejects a zero model-route ceiling as structurally invalid,
+        // so declare positive ceilings (the sandbox backends ignore `model_route`).
+        model_route: ModelRoute {
+            model_id: kx_mote::ModelId("local".into()),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 1,
+        },
+        // Zero = "no setrlimit on this axis" (the proven kx-executor real-spawn
+        // warrant): macOS rejects a tight RLIMIT_AS (mem_bytes) for the body's
+        // virtual-address reservation, so leave the rlimit axes unset and bound
+        // only the wall clock. `intersect` does not validate ceiling zeros.
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 30_000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
         executor_class: exec_class,
         ..Default::default()
     }
@@ -582,5 +758,52 @@ mod tests {
             &["alice@acme".to_string()],
         );
         assert!(b.is_ok(), "re-opening the durable demo library is a no-op");
+    }
+
+    // --- PR-9b: the real-exec recipe (provisioning + bind path) -------------
+
+    /// When a body is registered, the `exec-demo` recipe binds for a granted
+    /// party (empty free-params → empty JSON args) and keeps the worker's
+    /// executor_class so the bound run leases. (The real sandboxed spawn is the
+    /// `#[ignore]` `real_exec_e2e` witness — this covers the durable bind path.)
+    #[tokio::test]
+    async fn exec_recipe_binds_when_a_body_is_registered() {
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open_with_real_exec(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            // The bind path resolves the recipe def + warrant only; the body bytes
+            // are fetched at EXECUTION (the resolver), so a stand-in ref binds fine.
+            Some(ContentRef::from_bytes([0x5a; 32])),
+        )
+        .unwrap();
+        let binder = HostRecipeBinder::new(lib);
+
+        let bound = binder
+            .bind("alice@acme", EXEC_RECIPE_HANDLE, b"{}")
+            .await
+            .expect("exec-demo binds for a granted party");
+        assert!(!bound.motes.is_empty());
+        for (_, w) in &bound.motes {
+            assert_eq!(w.executor_class, ExecutorClass::Bwrap);
+        }
+    }
+
+    /// Without a registered body the `exec-demo` recipe is NOT provisioned, so it
+    /// is uniformly `NotAuthorized` (no existence oracle) — while `echo` still binds.
+    #[tokio::test]
+    async fn exec_recipe_absent_without_a_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path()); // open() ⇒ no real body
+        assert!(matches!(
+            binder.bind("alice@acme", EXEC_RECIPE_HANDLE, b"{}").await,
+            Err(BinderError::NotAuthorized)
+        ));
+        // The demo echo recipe is unaffected.
+        assert!(binder
+            .bind("alice@acme", DEMO_RECIPE_HANDLE, br#"{"topic":"x"}"#)
+            .await
+            .is_ok());
     }
 }

--- a/crates/kx-gateway/src/real_exec.rs
+++ b/crates/kx-gateway/src/real_exec.rs
@@ -89,71 +89,83 @@ impl RouterExecutor {
     }
 
     /// Run the Mote's body inside the platform sandbox, then reconcile its result
-    /// bytes into the store. The body program is materialized from `logic_ref` by
-    /// [`ContentStoreBodyResolver`]; its per-Mote input is the Mote's identity
-    /// bytes (deterministic ⇒ exactly-once-per-input).
+    /// bytes into the store (delegates to [`run_body_in_sandbox`], shared with the
+    /// startup probe).
     fn run_sandboxed(
         &self,
         mote: &Mote,
         warrant: &WarrantSpec,
         env: Option<Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
-        // 1. Per-Mote input → a tempfile the sandboxed body reads as argv[1]. The
-        //    NamedTempFile MUST outlive `run()` (the child reads it), so it stays
-        //    in scope until the end of this function.
-        let input_bytes = mote.id.as_bytes().to_vec();
-        let mut input_file = tempfile::NamedTempFile::new()
-            .map_err(|e| internal(&format!("input tempfile: {e}")))?;
-        input_file
-            .write_all(&input_bytes)
-            .map_err(|e| internal(&format!("write input: {e}")))?;
-        input_file
-            .flush()
-            .map_err(|e| internal(&format!("flush input: {e}")))?;
-        let input_path = input_file.path().to_path_buf();
-
-        // 2. The body resolver materializes `logic_ref` → a chmod-+x tempfile.
-        let resolver: Arc<dyn BodyResolver> =
-            Arc::new(ContentStoreBodyResolver::new(self.store.clone()));
-
-        // 3. The platform sandbox, constructed per-call (so each lease gets its own
-        //    per-Mote input). Only the two real-spawn backends are wired into serve;
-        //    anything else fails closed.
-        let result = match self.exec_class {
-            ExecutorClass::MacOsSandbox => MacOsSandboxExecutor::new()
-                .with_body_resolver(resolver)
-                .with_input_file(input_path)
-                .run(mote, warrant, env),
-            ExecutorClass::Bwrap => BwrapExecutor::new()
-                .with_body_resolver(resolver)
-                .with_input_file(input_path)
-                .run(mote, warrant, env),
-            other => Err(MoteExecutorError::BackendUnsupported {
-                class: other,
-                reason: "kx serve wires only the bwrap/macOS sandbox backends".into(),
-            }),
-        }?;
-
-        // 4. Reconcile (D55): the result object IS `PURE_BODY_PREFIX ‖ input`. `put`
-        //    it so the coordinator can verify the committed ref exists, then assert
-        //    the body's printed ref matches (a mismatch ⇒ a phantom; fail closed).
-        let mut object = Vec::with_capacity(PURE_BODY_PREFIX.len() + input_bytes.len());
-        object.extend_from_slice(PURE_BODY_PREFIX);
-        object.extend_from_slice(&input_bytes);
-        let put_ref = self
-            .store
-            .put(&object)
-            .map_err(|e| internal(&format!("reconcile put: {e}")))?;
-        if put_ref != result.result_ref {
-            return Err(internal(
-                "sandbox result_ref != reconstructed object ref (phantom result rejected)",
-            ));
-        }
-
-        // Keep the input tempfile alive until here (the sandboxed child read it).
-        drop(input_file);
-        Ok(result)
+        run_body_in_sandbox(&self.store, self.exec_class, mote, warrant, env)
     }
+}
+
+/// Run `mote`'s body in the platform sandbox under `warrant`, then reconcile its
+/// output into `store`. The body program is materialized from `logic_ref` by
+/// [`ContentStoreBodyResolver`]; its per-Mote input is the Mote's identity bytes
+/// (deterministic ⇒ exactly-once-per-input). Shared by [`RouterExecutor`] and the
+/// startup [`probe_sandbox`].
+fn run_body_in_sandbox(
+    store: &LocalFsContentStore,
+    exec_class: ExecutorClass,
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    env: Option<Rootfs>,
+) -> Result<MoteExecutionResult, MoteExecutorError> {
+    // 1. Per-Mote input → a tempfile the sandboxed body reads as argv[1]. The
+    //    NamedTempFile MUST outlive `run()` (the child reads it), so it stays in
+    //    scope until the end of this function.
+    let input_bytes = mote.id.as_bytes().to_vec();
+    let mut input_file =
+        tempfile::NamedTempFile::new().map_err(|e| internal(&format!("input tempfile: {e}")))?;
+    input_file
+        .write_all(&input_bytes)
+        .map_err(|e| internal(&format!("write input: {e}")))?;
+    input_file
+        .flush()
+        .map_err(|e| internal(&format!("flush input: {e}")))?;
+    let input_path = input_file.path().to_path_buf();
+
+    // 2. The body resolver materializes `logic_ref` → a chmod-+x tempfile.
+    let resolver: Arc<dyn BodyResolver> = Arc::new(ContentStoreBodyResolver::new(store.clone()));
+
+    // 3. The platform sandbox, constructed per-call (so each lease gets its own
+    //    per-Mote input). Only the two real-spawn backends are wired into serve;
+    //    anything else fails closed.
+    let result = match exec_class {
+        ExecutorClass::MacOsSandbox => MacOsSandboxExecutor::new()
+            .with_body_resolver(resolver)
+            .with_input_file(input_path)
+            .run(mote, warrant, env),
+        ExecutorClass::Bwrap => BwrapExecutor::new()
+            .with_body_resolver(resolver)
+            .with_input_file(input_path)
+            .run(mote, warrant, env),
+        other => Err(MoteExecutorError::BackendUnsupported {
+            class: other,
+            reason: "kx serve wires only the bwrap/macOS sandbox backends".into(),
+        }),
+    }?;
+
+    // 4. Reconcile (D55): the result object IS `PURE_BODY_PREFIX ‖ input`. `put` it
+    //    so the coordinator can verify the committed ref exists, then assert the
+    //    body's printed ref matches (a mismatch ⇒ a phantom; fail closed).
+    let mut object = Vec::with_capacity(PURE_BODY_PREFIX.len() + input_bytes.len());
+    object.extend_from_slice(PURE_BODY_PREFIX);
+    object.extend_from_slice(&input_bytes);
+    let put_ref = store
+        .put(&object)
+        .map_err(|e| internal(&format!("reconcile put: {e}")))?;
+    if put_ref != result.result_ref {
+        return Err(internal(
+            "sandbox result_ref != reconstructed object ref (phantom result rejected)",
+        ));
+    }
+
+    // Keep the input tempfile alive until here (the sandboxed child read it).
+    drop(input_file);
+    Ok(result)
 }
 
 impl MoteExecutor for RouterExecutor {
@@ -182,6 +194,65 @@ fn internal(reason: &str) -> MoteExecutorError {
     MoteExecutorError::Internal {
         reason: reason.to_string(),
     }
+}
+
+/// One-shot startup probe: run the registered body once through the platform
+/// sandbox under the real-exec `warrant`. Returns `true` iff it succeeds
+/// end-to-end. The gateway uses this to GATE provisioning of `exec-demo`: when the
+/// sandbox cannot run (e.g. Docker's default seccomp blocks the unprivileged user
+/// namespace bubblewrap needs, or rlimits are too tight), the recipe is NOT
+/// advertised — so an `Invoke` gets a clean refusal instead of a worker that
+/// re-leases a never-committable Mote forever. The durable spine + the `echo`
+/// recipe are unaffected either way.
+pub(crate) fn probe_sandbox(
+    store: &LocalFsContentStore,
+    body_ref: ContentRef,
+    exec_class: ExecutorClass,
+    warrant: &WarrantSpec,
+) -> bool {
+    match run_body_in_sandbox(store, exec_class, &probe_mote(body_ref), warrant, None) {
+        Ok(_) => true,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "PR-9b: sandbox probe failed — kx/recipes/exec-demo NOT provisioned \
+                 (durable spine + echo recipe unaffected; enable real-exec per docker-compose.yml)"
+            );
+            false
+        }
+    }
+}
+
+/// A throwaway PURE Mote whose `logic_ref` is the registered body, used only by
+/// [`probe_sandbox`] (its committed output is content-addressed + discarded).
+fn probe_mote(body_ref: ContentRef) -> Mote {
+    use kx_mote::{
+        EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, MoteDef,
+        NdClass, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    };
+    use smallvec::SmallVec;
+    use std::collections::BTreeMap;
+
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes(*body_ref.as_bytes()),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([0u8; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0u8; 32]),
+        GraphPosition(b"kx-exec-demo-probe".to_vec()),
+        SmallVec::new(),
+    )
 }
 
 /// Locate the sandbox demo-body binary and `put` its bytes into the content

--- a/crates/kx-gateway/src/real_exec.rs
+++ b/crates/kx-gateway/src/real_exec.rs
@@ -1,0 +1,245 @@
+//! Real, sandboxed Mote body-execution for the embedded `kx serve` worker (PR-9b).
+//!
+//! R1 wired the embedded worker to a *deterministic* content-storing executor
+//! (`server::storing_executor`) — a faithful demo of the durability
+//! spine, but it never spawns a real process. PR-9b closes that gap WITHOUT
+//! touching the frozen trio (`kx-executor`/`kx-scheduler`/`kx-inference`): it
+//! composes the EXISTING public `kx-executor` surface
+//! ([`BwrapExecutor`]/[`MacOsSandboxExecutor`] + [`ContentStoreBodyResolver`])
+//! behind a router that the gateway binary owns.
+//!
+//! `RouterExecutor` dispatches per leased Mote:
+//! - a Mote whose `def.logic_ref` is the registered **real body** → run it inside
+//!   the platform sandbox (bwrap on Linux, sandbox-exec/Seatbelt on macOS), then
+//!   **reconcile** its result bytes into the shared content store so the
+//!   coordinator's D55 phantom-ref guard passes at commit;
+//! - any other (the bodyless PURE demo `echo`) Mote → the deterministic
+//!   `storing` fallback — the exact R1 behavior, untouched.
+//!
+//! **Fail-closed (Golden Rule 9).** When the sandbox cannot run (no `bwrap`,
+//! blocked user-namespaces, non-matching platform), the executor returns
+//! [`MoteExecutorError`] and the worker backs off; it NEVER falls back to
+//! un-sandboxed host execution. The demo path and the canonical-digest engine
+//! path (`kx run`, a separate `TestMoteExecutor::deterministic()`) are untouched.
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
+use kx_executor::{
+    BodyResolver, BwrapExecutor, ContentStoreBodyResolver, MacOsSandboxExecutor,
+    MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs,
+};
+use kx_mote::Mote;
+use kx_warrant::{ExecutorClass, WarrantSpec};
+
+/// The content-prefix half of the `pure_body` contract
+/// (`kx-executor/examples/pure_body.rs`): the body prints
+/// `result_ref = BLAKE3(PURE_BODY_PREFIX ‖ input)` on stdout. By the
+/// content-addressing identity, the object whose ref that IS equals exactly
+/// `PURE_BODY_PREFIX ‖ input` — so the gateway reconstructs + `put`s it to
+/// satisfy the coordinator's D55 ref-existence guard. Kept in lock-step with
+/// the example's `b"kx-executor-pure-body-result"` literal.
+const PURE_BODY_PREFIX: &[u8] = b"kx-executor-pure-body-result";
+
+/// A [`MoteExecutor`] the gateway binary composes from the public `kx-executor`
+/// surface. See the module docs. Holds the shared content store (for the body
+/// resolver + the result reconciliation), the registered real-body ref to route
+/// on, the embedded worker's executor class, and the deterministic fallback.
+pub(crate) struct RouterExecutor {
+    /// The shared content store — clones feed [`ContentStoreBodyResolver`] (body
+    /// materialization) and back the result reconciliation `put` (D55).
+    store: LocalFsContentStore,
+    /// The content-ref of the registered real body (== its `logic_ref` bytes). A
+    /// leased Mote carrying this `logic_ref` is dispatched to the sandbox. `None`
+    /// when no body binary was located at startup (the image ran without it) — the
+    /// router then behaves exactly like the R1 storing executor.
+    real_body_ref: Option<ContentRef>,
+    /// The platform executor class the embedded worker registered as
+    /// ([`crate::server::default_executor_class`]).
+    exec_class: ExecutorClass,
+    /// The deterministic content-storing fallback for bodyless PURE Motes (the
+    /// demo `echo`) — the unchanged R1 `server::storing_executor`.
+    fallback: Arc<dyn MoteExecutor>,
+}
+
+impl RouterExecutor {
+    /// Compose the router. `real_body_ref` is the ref the gateway `put` the body
+    /// bytes under at startup (`None` ⇒ pure fallback behavior).
+    pub(crate) fn new(
+        store: LocalFsContentStore,
+        real_body_ref: Option<ContentRef>,
+        exec_class: ExecutorClass,
+        fallback: Arc<dyn MoteExecutor>,
+    ) -> Self {
+        Self {
+            store,
+            real_body_ref,
+            exec_class,
+            fallback,
+        }
+    }
+
+    /// Whether this Mote's `logic_ref` is the registered real body.
+    fn is_real_body(&self, mote: &Mote) -> bool {
+        self.real_body_ref.is_some_and(|registered| {
+            ContentRef::from_bytes(*mote.def.logic_ref.as_bytes()) == registered
+        })
+    }
+
+    /// Run the Mote's body inside the platform sandbox, then reconcile its result
+    /// bytes into the store. The body program is materialized from `logic_ref` by
+    /// [`ContentStoreBodyResolver`]; its per-Mote input is the Mote's identity
+    /// bytes (deterministic ⇒ exactly-once-per-input).
+    fn run_sandboxed(
+        &self,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+        env: Option<Rootfs>,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        // 1. Per-Mote input → a tempfile the sandboxed body reads as argv[1]. The
+        //    NamedTempFile MUST outlive `run()` (the child reads it), so it stays
+        //    in scope until the end of this function.
+        let input_bytes = mote.id.as_bytes().to_vec();
+        let mut input_file = tempfile::NamedTempFile::new()
+            .map_err(|e| internal(&format!("input tempfile: {e}")))?;
+        input_file
+            .write_all(&input_bytes)
+            .map_err(|e| internal(&format!("write input: {e}")))?;
+        input_file
+            .flush()
+            .map_err(|e| internal(&format!("flush input: {e}")))?;
+        let input_path = input_file.path().to_path_buf();
+
+        // 2. The body resolver materializes `logic_ref` → a chmod-+x tempfile.
+        let resolver: Arc<dyn BodyResolver> =
+            Arc::new(ContentStoreBodyResolver::new(self.store.clone()));
+
+        // 3. The platform sandbox, constructed per-call (so each lease gets its own
+        //    per-Mote input). Only the two real-spawn backends are wired into serve;
+        //    anything else fails closed.
+        let result = match self.exec_class {
+            ExecutorClass::MacOsSandbox => MacOsSandboxExecutor::new()
+                .with_body_resolver(resolver)
+                .with_input_file(input_path)
+                .run(mote, warrant, env),
+            ExecutorClass::Bwrap => BwrapExecutor::new()
+                .with_body_resolver(resolver)
+                .with_input_file(input_path)
+                .run(mote, warrant, env),
+            other => Err(MoteExecutorError::BackendUnsupported {
+                class: other,
+                reason: "kx serve wires only the bwrap/macOS sandbox backends".into(),
+            }),
+        }?;
+
+        // 4. Reconcile (D55): the result object IS `PURE_BODY_PREFIX ‖ input`. `put`
+        //    it so the coordinator can verify the committed ref exists, then assert
+        //    the body's printed ref matches (a mismatch ⇒ a phantom; fail closed).
+        let mut object = Vec::with_capacity(PURE_BODY_PREFIX.len() + input_bytes.len());
+        object.extend_from_slice(PURE_BODY_PREFIX);
+        object.extend_from_slice(&input_bytes);
+        let put_ref = self
+            .store
+            .put(&object)
+            .map_err(|e| internal(&format!("reconcile put: {e}")))?;
+        if put_ref != result.result_ref {
+            return Err(internal(
+                "sandbox result_ref != reconstructed object ref (phantom result rejected)",
+            ));
+        }
+
+        // Keep the input tempfile alive until here (the sandboxed child read it).
+        drop(input_file);
+        Ok(result)
+    }
+}
+
+impl MoteExecutor for RouterExecutor {
+    fn run(
+        &self,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+        env: Option<Rootfs>,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        if self.is_real_body(mote) {
+            self.run_sandboxed(mote, warrant, env)
+        } else {
+            self.fallback.run(mote, warrant, env)
+        }
+    }
+
+    fn supports(&self, executor_class: ExecutorClass) -> bool {
+        // The embedded worker leases on a single class; both the real sandbox path
+        // and the storing fallback serve it.
+        executor_class == self.exec_class || self.fallback.supports(executor_class)
+    }
+}
+
+/// A fail-closed [`MoteExecutorError::Internal`] from a `&str` diagnostic.
+fn internal(reason: &str) -> MoteExecutorError {
+    MoteExecutorError::Internal {
+        reason: reason.to_string(),
+    }
+}
+
+/// Locate the sandbox demo-body binary and `put` its bytes into the content
+/// store, returning the resulting ref (== the body's `logic_ref`). `None` when
+/// no body is found — the gateway then provisions only the demo `echo` recipe
+/// and the router behaves exactly like the R1 storing executor.
+///
+/// The body is the existing `kx-executor` `pure_body` example (the
+/// `64-hex-result-on-stdout` contract); reusing it keeps the frozen trio's
+/// source diff-empty.
+pub(crate) fn register_demo_body(store: &LocalFsContentStore) -> Option<ContentRef> {
+    let path = real_body_binary_path()?;
+    let bytes = std::fs::read(&path).ok()?;
+    match store.put(&bytes) {
+        Ok(body_ref) => {
+            tracing::info!(
+                body_path = %path.display(),
+                "PR-9b: real-exec demo body registered (kx/recipes/exec-demo is live)"
+            );
+            Some(body_ref)
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "PR-9b: could not register the real-exec demo body; exec-demo not provisioned"
+            );
+            None
+        }
+    }
+}
+
+/// Resolve the demo-body binary path: an explicit `KX_DEMO_BODY_PATH` override
+/// first, then the fixed in-image path the Dockerfile `COPY`s it to, then a
+/// dev/test convenience search up to the workspace `target/` dir. `None` ⇒ no
+/// body available (the FFI-free prebuilt image, e.g.).
+fn real_body_binary_path() -> Option<PathBuf> {
+    if let Some(over) = std::env::var_os("KX_DEMO_BODY_PATH") {
+        let path = PathBuf::from(over);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let in_image = PathBuf::from("/usr/local/libexec/kx/pure_body");
+    if in_image.exists() {
+        return Some(in_image);
+    }
+    // Dev/test: walk up from the running binary to a `target` dir + look for the
+    // built example (`cargo build --example pure_body -p kx-executor`).
+    let exe = std::env::current_exe().ok()?;
+    for ancestor in exe.ancestors() {
+        if ancestor.file_name().is_some_and(|n| n == "target") {
+            for profile in ["debug", "release"] {
+                let candidate = ancestor.join(profile).join("examples").join("pure_body");
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -344,6 +344,20 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     // this host/image, so the `exec-demo` recipe is not provisioned and the router
     // behaves exactly like the R1 storing executor.
     let real_body_ref = crate::real_exec::register_demo_body(content.as_ref());
+    // Probe the sandbox once before advertising exec-demo: if it can't actually run
+    // here (e.g. Docker's default seccomp blocks the user namespace bubblewrap
+    // needs), DROP the body ref so exec-demo is NOT provisioned — an Invoke then
+    // gets a clean refusal instead of a worker re-leasing a never-committable Mote
+    // forever. The durable spine + the `echo` recipe are unaffected.
+    let exec_class = default_executor_class();
+    let real_body_ref = real_body_ref.filter(|&body_ref| {
+        crate::real_exec::probe_sandbox(
+            content.as_ref(),
+            body_ref,
+            exec_class,
+            &crate::provision::real_exec_warrant(exec_class),
+        )
+    });
     // The embedded worker's executor routes a real-body Mote to the platform
     // sandbox (bwrap on Linux / sandbox-exec on macOS) and the bodyless PURE demo
     // `echo` to the unchanged deterministic storing fallback. Fail-closed: a

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -340,7 +340,20 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     //     deterministic content-storing executor (publishes bytes into the shared
     //     store BEFORE proposing, so D55 holds), and proposes the commit.
     let client = connect_worker(&coord_endpoint).await?;
-    let executor: Arc<dyn MoteExecutor> = storing_executor(content.clone());
+    // PR-9b: locate + register the sandbox demo body. `None` ⇒ no body binary on
+    // this host/image, so the `exec-demo` recipe is not provisioned and the router
+    // behaves exactly like the R1 storing executor.
+    let real_body_ref = crate::real_exec::register_demo_body(content.as_ref());
+    // The embedded worker's executor routes a real-body Mote to the platform
+    // sandbox (bwrap on Linux / sandbox-exec on macOS) and the bodyless PURE demo
+    // `echo` to the unchanged deterministic storing fallback. Fail-closed: a
+    // sandbox that cannot run errors (worker backs off); never host-exec.
+    let executor: Arc<dyn MoteExecutor> = Arc::new(crate::real_exec::RouterExecutor::new(
+        (*content).clone(),
+        real_body_ref,
+        default_executor_class(),
+        storing_executor(content.clone()),
+    ));
     let broker: Arc<dyn CapabilityBroker> =
         Arc::new(LocalCapabilityBroker::new((*content).clone()));
     let worker = Worker::register(
@@ -384,7 +397,12 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     //      step warrant uses the embedded worker's executor_class so a bound run
     //      leases (see `provision::demo_warrant`).
     let parties: Vec<String> = cfg.auth_tokens.values().cloned().collect();
-    let demo = DemoLibrary::open(&catalog_dir, default_executor_class(), &parties)?;
+    let demo = DemoLibrary::open_with_real_exec(
+        &catalog_dir,
+        default_executor_class(),
+        &parties,
+        real_body_ref,
+    )?;
     let binder: Arc<dyn RecipeBinder> = Arc::new(HostRecipeBinder::new(demo));
     // R5: the gRPC `StreamEvents` becomes a live tail (resumable, bounded,
     // recovery-safe). Read-side only — the digest + frozen proto are untouched. The

--- a/crates/kx-gateway/tests/real_exec_e2e.rs
+++ b/crates/kx-gateway/tests/real_exec_e2e.rs
@@ -1,0 +1,161 @@
+//! PR-9b end-to-end witness: `Invoke` the real-exec demo recipe over a REAL
+//! bound port → the embedded worker leases the bound Mote → the
+//! [`kx_gateway`] router runs its body as a REAL process inside the platform
+//! sandbox (bwrap on Linux / sandbox-exec on macOS) → the body's output is
+//! reconciled into the content store and committed exactly-once → the client
+//! fetches the committed bytes and they equal the body's deterministic output.
+//!
+//! This is the proof that `kx serve` runs a REAL sandboxed body (not the demo
+//! storing executor). It is `#[ignore]` + runtime-skips: it needs the
+//! `kx-executor` `pure_body` example built (`cargo build --example pure_body -p
+//! kx-executor`) so the gateway can register it as the demo body, and a working
+//! sandbox on the host. Opt in:
+//!   cargo build --example pure_body -p kx-executor
+//!   cargo test -p kx-gateway --test real_exec_e2e -- --ignored --nocapture
+//!
+//! The regression that the demo `echo` path is UNCHANGED lives in
+//! `invoke_e2e.rs` (always-on); this file only adds the real-spawn witness.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_gateway::{start, EXEC_RECIPE_HANDLE};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+/// The `pure_body` content-prefix (kx-executor/examples/pure_body.rs):
+/// result_ref = BLAKE3(PREFIX ‖ input), so the committed object IS `PREFIX ‖
+/// input`. The gateway feeds the Mote's id as input, so the committed bytes are
+/// `PREFIX ‖ terminal_mote_id`. Kept in lock-step with the example + the
+/// gateway's `real_exec::PURE_BODY_PREFIX`.
+const PURE_BODY_PREFIX: &[u8] = b"kx-executor-pure-body-result";
+
+/// Locate the built `pure_body` example by walking up to the workspace `target`
+/// dir (mirrors the gateway's own `real_exec::real_body_binary_path`). `None` ⇒
+/// the example wasn't built, so the test runtime-skips.
+fn pure_body_built() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    for ancestor in exe.ancestors() {
+        if ancestor.file_name().is_some_and(|n| n == "target") {
+            for profile in ["debug", "release"] {
+                let candidate = ancestor.join(profile).join("examples").join("pure_body");
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+/// Poll `GetProjection` until `mote_id` is `Committed`; return its `result_ref`.
+async fn await_mote_committed(
+    c: &mut KxGatewayClient<Channel>,
+    instance_id: &[u8],
+    mote_id: &[u8],
+) -> [u8; 32] {
+    for _ in 0..200 {
+        let view = c
+            .get_projection(proto::GetProjectionRequest {
+                instance_id: instance_id.to_vec(),
+                at_seq: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(m) = view
+            .motes
+            .iter()
+            .find(|m| m.mote_id == mote_id && m.state == proto::MoteSnapshotState::Committed as i32)
+        {
+            return m
+                .result_ref
+                .clone()
+                .expect("a committed Mote carries a result_ref")
+                .try_into()
+                .unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("the invoked real-exec Mote never reached Committed");
+}
+
+#[tokio::test]
+#[ignore = "real sandbox spawn; build `pure_body` first (cargo build --example pure_body -p kx-executor); opt in with --ignored"]
+async fn invoke_real_exec_recipe_runs_a_sandboxed_body_to_committed() {
+    if pure_body_built().is_none() {
+        eprintln!(
+            "skipping: pure_body example not built — run \
+             `cargo build --example pure_body -p kx-executor` first"
+        );
+        return;
+    }
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // Invoke the real-exec recipe (no free-params → empty JSON args). The bound
+    // Mote leases on the embedded worker, whose router runs the body in the
+    // platform sandbox and reconciles the output into the store.
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: EXEC_RECIPE_HANDLE.to_string(),
+            args: b"{}".to_vec(),
+        })
+        .await
+        .expect("invoke exec-demo (is the sandbox available on this host?)")
+        .into_inner();
+    assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
+    assert_eq!(
+        resp.terminal_mote_id.len(),
+        32,
+        "server-derived terminal Mote"
+    );
+
+    let result_ref = await_mote_committed(&mut c, &resp.instance_id, &resp.terminal_mote_id).await;
+    let mote_id: [u8; 32] = resp.terminal_mote_id.clone().try_into().unwrap();
+
+    // The committed bytes ARE the real sandboxed body's deterministic output:
+    // `PURE_BODY_PREFIX ‖ mote_id` (input-addressed), content-addressed by
+    // result_ref. This proves a real process ran in the sandbox and its output
+    // was committed exactly-once.
+    let blob = c
+        .get_content(proto::GetContentRequest {
+            content_ref: result_ref.to_vec(),
+            instance_id: resp.instance_id.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let mut expected = Vec::with_capacity(PURE_BODY_PREFIX.len() + mote_id.len());
+    expected.extend_from_slice(PURE_BODY_PREFIX);
+    expected.extend_from_slice(&mote_id);
+    assert_eq!(
+        blob.payload, expected,
+        "committed bytes == the sandboxed body's reconciled output"
+    );
+
+    running.shutdown().await.unwrap();
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,18 @@ services:
     user: "10001:10001"
     # PR-9b real, sandboxed Mote body-exec (kx/recipes/exec-demo): the embedded
     # worker runs a real body in bubblewrap, which needs an unprivileged user
-    # namespace. Docker's DEFAULT seccomp profile BLOCKS that, so the real-exec
-    # recipe fails CLOSED here (the durable spine, `kx serve`, the `echo` recipe,
-    # health, TLS + restart/SIGTERM are all unaffected). To OPT IN to real-exec —
-    # a deliberate hardening trade-off — uncomment the relaxed seccomp below (a
-    # narrow custom profile that allows only the namespace syscalls is the
-    # follow-on). On macOS the host path uses sandbox-exec (no namespaces needed).
+    # namespace. Docker's DEFAULT seccomp profile BLOCKS that — so `kx serve`
+    # PROBES the sandbox at startup and, finding it unavailable, simply does NOT
+    # advertise exec-demo (an Invoke gets a clean refusal; the durable spine,
+    # `kx serve`, the `echo` recipe, health, TLS + restart/SIGTERM are unaffected).
+    # To OPT IN to real-exec — a deliberate hardening trade-off — uncomment the
+    # relaxed seccomp below. ⚠ `seccomp=unconfined` removes ALL syscall filtering
+    # for the WHOLE container (not just the body), re-opening the unprivileged-
+    # user-namespace / kernel-LPE surface: acceptable for single-tenant / loopback
+    # dev, but MULTI-TENANT or hostile-workload deployments MUST NOT enable it
+    # without a NARROW custom seccomp profile (allow only the namespace/mount
+    # syscalls — the follow-on). On macOS the host path uses sandbox-exec (no
+    # namespaces), so none of this applies there.
     # security_opt:
     #   - seccomp=unconfined
     # A2: a purpose-built liveness probe — `kx health` calls grpc.health.v1 and exits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,16 @@ services:
     tmpfs:
       - /tmp
     user: "10001:10001"
+    # PR-9b real, sandboxed Mote body-exec (kx/recipes/exec-demo): the embedded
+    # worker runs a real body in bubblewrap, which needs an unprivileged user
+    # namespace. Docker's DEFAULT seccomp profile BLOCKS that, so the real-exec
+    # recipe fails CLOSED here (the durable spine, `kx serve`, the `echo` recipe,
+    # health, TLS + restart/SIGTERM are all unaffected). To OPT IN to real-exec —
+    # a deliberate hardening trade-off — uncomment the relaxed seccomp below (a
+    # narrow custom profile that allows only the namespace syscalls is the
+    # follow-on). On macOS the host path uses sandbox-exec (no namespaces needed).
+    # security_opt:
+    #   - seccomp=unconfined
     # A2: a purpose-built liveness probe — `kx health` calls grpc.health.v1 and exits
     # 0 iff the gateway reports SERVING. Unauthenticated by design (the health service
     # is not behind the auth interceptor), so it needs no token.


### PR DESCRIPTION
## What

Wires **real, sandboxed Mote body-execution into `kx serve`**, replacing the R1 deterministic demo executor for real-body Motes. This closes the largest unwired gap surfaced by the runtime review: the served gateway ran a demo executor and never spawned a real process.

All changes are confined to **`kx-gateway`** (+ the Docker image): the **frozen trio** (`kx-executor`/`kx-scheduler`/`kx-inference`) source diff is **EMPTY** — the gateway composes their existing public API — and the canonical projection digest `a6b5c679…` stays **invariant** (the `kx run` engine path is untouched).

## How

- **`real_exec::RouterExecutor`** — a leased Mote whose `def.logic_ref` is the registered real body → run it in the platform sandbox (`BwrapExecutor` Linux / `MacOsSandboxExecutor` macOS) via `.with_body_resolver(ContentStoreBodyResolver)`; then **reconcile** the body's output into the content store (the result object IS `prefix‖input` — content-addressing identity) so the coordinator's **D55** ref-existence guard passes at commit. The bodyless demo `echo` → the unchanged storing fallback.
- **`kx/recipes/exec-demo`** — `provision.rs` generalized to multi-recipe (per-handle owner-root + free-params). Body = the reused `kx-executor` `pure_body` example (FFI-free), located via `KX_DEMO_BODY_PATH` → `/usr/local/libexec/kx/pure_body` → `target/` search; provisioned only when a body is found.
- **Fail-closed (Golden Rule 9)** — a sandbox that cannot run errors and the worker backs off; it **never** falls back to un-sandboxed host execution.
- **Docker** — the runtime image adds `bubblewrap`, ships `pure_body`, and adds a `/lib64` shim (the frozen bwrap argv binds `/lib64` unconditionally; arm64 debian lacks it).

## Pre-flight risk (Golden Rule 8)

- **Correctness/recovery/digest:** engine path untouched → digest `a6b5c679…` invariant (verified by `verify-quickstart`); demo `echo` → `Committed` regression green (`invoke_e2e.rs`).
- **Security/substrate (the #1 risk, VERIFIED):** Docker's **default seccomp blocks the unprivileged user namespace bubblewrap needs**, so real-exec **fails closed** under the hardened compose (serve / echo / durability / health / TLS / restart all unaffected). `docker-compose.yml` documents the `seccomp=unconfined` **opt-in** as a deliberate hardening trade-off; a narrow custom seccomp profile is the follow-on. macOS host uses sandbox-exec (no namespaces) and is unaffected.

## Tests / gates

- **Proven on macOS:** `tests/real_exec_e2e.rs` (`#[ignore]`, needs `cargo build --example pure_body -p kx-executor`) — invoke `exec-demo` → a real sandbox-exec process runs → committed bytes == the body's deterministic output.
- Non-ignored bind-path tests for `exec-demo`; the `echo` regression stays green.
- Local gate green: `fmt`, `clippy --workspace --all-targets -D warnings`, `test --workspace`, `deny`, `doc -D warnings`, `build-no-inference`, `verify-quickstart` (digest invariant). Frozen-trio src diff **EMPTY**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)