### PR TITLE
feat(runtime): PR-1 — failsafe failure handling (bounded retry + dead-letter) in the drive loop

### DIFF
--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -341,6 +341,9 @@ impl Harness {
             None,
             // audit_sink (R4) — off for the harness driver.
             None,
+            // failure_policy (PR-1) — the harness drives deterministic workflows;
+            // `None` keeps legacy abort-on-failure.
+            None,
         )
     }
 }

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -249,6 +249,7 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         Some(&sink),
         None, // capture_sink (D67) — off for this assemble-wiring test
         None, // audit_sink (R4) — off for this assemble-wiring test
+        None, // failure_policy (PR-1) — legacy abort-on-failure
     );
     let captured = inputs.lock().unwrap().clone();
     (result, captured)
@@ -455,6 +456,7 @@ fn image_parent_routes_child_to_multimodal_input() {
         Some(&sink),
         None,
         None, // audit_sink (R4)
+        None, // failure_policy (PR-1) — legacy abort-on-failure
     );
     assert!(result.unwrap().is_complete(), "both Motes committed");
 

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -313,6 +313,7 @@ fn drive(
         Some(&sink),
         None, // capture_sink (D67) — off for this MCP HTTP e2e test
         None, // audit_sink (R4) — off for this MCP HTTP e2e test
+        None, // failure_policy (PR-1) — legacy abort-on-failure
     );
     (result, store, journal, m_id)
 }

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -213,6 +213,7 @@ fn drive(
         Some(&sink),
         None, // capture_sink (D67) — off for this MCP model-driven test
         None, // audit_sink (R4) — off for this MCP model-driven test
+        None, // failure_policy (PR-1) — legacy abort-on-failure
     );
     (result, store, journal, m_id)
 }

--- a/crates/kx-model-harness/tests/planner_e2e.rs
+++ b/crates/kx-model-harness/tests/planner_e2e.rs
@@ -232,6 +232,7 @@ fn drive(
         Some(&sink),
         None,
         None, // audit_sink (R4)
+        None, // failure_policy (PR-1) — legacy abort-on-failure
     );
     (result, calls.load(Ordering::SeqCst))
 }

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -21,7 +21,7 @@ use kx_capture::StepRecord;
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_executor::{
     redispatch_wm_mote, run_native_critic_mote, run_pure_mote, run_wm_mote, CommitProtocol,
-    LocalResourceManager, MoteExecutor, StandardCommitProtocol, TestMoteExecutor,
+    LifecycleError, LocalResourceManager, MoteExecutor, StandardCommitProtocol, TestMoteExecutor,
 };
 use kx_journal::{Journal, JournalEntry, SqliteJournal};
 use kx_mote::{MoteId, NdClass, TopologyDecision};
@@ -39,6 +39,7 @@ use crate::config::{Mode, RuntimeConfig};
 use crate::crash::CrashPoint;
 use crate::digest::{digest_projection, ProjectionDigest};
 use crate::error::RuntimeError;
+use crate::failure_policy::{classify_lifecycle_error, reason_for, FailureClass, FailurePolicy};
 use crate::snapshot_sink::SnapshotSink;
 use crate::topology;
 use crate::workflow::{DemoWorkflow, WorkflowMote};
@@ -198,6 +199,9 @@ pub fn run_with_capture(
         None,
         capture_sink,
         audit.as_ref(),
+        // The canonical demo never fails a Mote, so no policy is needed; `None`
+        // keeps the legacy abort-on-failure semantics (byte-identical truth path).
+        None,
     )
 }
 
@@ -224,6 +228,16 @@ pub fn run_with_capture(
 /// snapshot is published and the deterministic truth path is byte-unchanged
 /// (the published snapshot is model input only; it never enters identity or the
 /// journal, D64).
+///
+/// `failure_policy` is the PR-1 bounded-retry + dead-letter seam. When `Some`, a
+/// Mote dispatch error no longer aborts the run: a transient infrastructure
+/// failure is retried (bounded by `max_attempts`), and a terminal failure (or an
+/// exhausted transient) is journaled as a `Failed` fact so the drive loop continues
+/// **past** the dead-lettered Mote. The canonical demo + every existing caller pass
+/// `None`, so a dispatch error propagates exactly as the pre-PR-1 `?` did — the
+/// deterministic truth path (digest `a6b5c679…`) is byte-unchanged. (A dead-lettered
+/// `Failed` is the durable, auditable record the model-driven re-plan loop (AL2)
+/// later reads — kortecx never blindly re-runs a failing Mote.)
 // `store` / `journal` are taken by value: the orchestrator owns these `Arc`
 // handles for the run (cloning them into the verdict lookup + materializer +
 // commit calls), so `needless_pass_by_value` is intentional here — the caller
@@ -246,6 +260,7 @@ pub fn run_with_seams<S, E, CP>(
     snapshot_sink: Option<&SnapshotSink>,
     capture_sink: Option<&CaptureSink>,
     audit_sink: Option<&RuntimeAuditSink>,
+    failure_policy: Option<&FailurePolicy>,
 ) -> Result<RunOutcome, RuntimeError>
 where
     S: ContentStore + Send + Sync + 'static,
@@ -326,6 +341,10 @@ where
     // A shaperless workflow never derives children — start "done".
     let mut children_derived = shaper.is_none();
     let mut child_ids: Vec<MoteId> = Vec::new();
+    // PR-1: per-Mote transient-retry counter (in-memory, off the truth path — a
+    // crash simply re-folds the committed prefix and the budget restarts). Only
+    // consulted when `failure_policy` is `Some`; empty + untouched otherwise.
+    let mut attempts: BTreeMap<MoteId, u32> = BTreeMap::new();
 
     // R4: the drive loop is starting. Off the truth path — `None` ⇒ no event.
     if let Some(a) = audit_sink {
@@ -385,16 +404,26 @@ where
                 kind: action.dispatch_kind(),
             });
         }
-        match action {
+        // Dispatch the picked Mote. Each lifecycle entry returns
+        // `Result<_, LifecycleError>`; unify to `Result<(), LifecycleError>` so a
+        // failure can be routed through the PR-1 `failure_policy` (or propagated
+        // verbatim when there is none). `mote_id` + `wm_vtc_target` are captured
+        // before the `match` consumes `action`.
+        let mote_id = action.mote_id();
+        let wm_vtc_target = matches!(
+            &action,
+            Action::RunWm { wm, .. } if wm.mote.id == workflow.vtc_crash_target
+        );
+        let dispatch: Result<(), LifecycleError> = match action {
             Action::RunPure(w) => {
                 crash_if_children_pending(config, &child_ids, w.mote.id);
-                run_pure_mote(&w.mote, &w.warrant, &*journal, rm, executor)?;
+                run_pure_mote(&w.mote, &w.warrant, &*journal, rm, executor).map(|_| ())
             }
             Action::RunNativeCritic(w) => {
                 // Evaluate the declared check in-process against the producer's
                 // committed bytes and commit a CriticVerdict (P4.2-2). The
                 // verdict drives the P4.2-3 promotion gate on the next fold.
-                run_native_critic_mote(&w.mote, &w.warrant, &*journal, &*store)?;
+                run_native_critic_mote(&w.mote, &w.warrant, &*journal, &*store).map(|_| ())
             }
             Action::RunWm { wm, recover } => {
                 let request = effect_request_for(&wm);
@@ -414,7 +443,8 @@ where
                         rm,
                         protocol,
                         &projection,
-                    )?;
+                    )
+                    .map(|_| ())
                 } else {
                     run_wm_mote(
                         &wm.mote,
@@ -425,21 +455,43 @@ where
                         &*journal,
                         rm,
                         protocol,
-                    )?;
+                    )
+                    .map(|_| ())
                 }
+            }
+        };
 
-                // Scenario-2 injection: a hard kill the instant the VTC Mote's
-                // Committed is durable (and the critic's Proposed has been
-                // recorded), before the run finishes. Recovery must RE-READ it,
-                // never re-run its world effect.
-                if config.crash_at == Some(CrashPoint::PostCommitVtc)
-                    && wm.mote.id == workflow.vtc_crash_target
-                {
-                    fold_new(&journal, &mut projection, &mut folded_through)?;
-                    if projection.state_of(&workflow.vtc_crash_target) == MoteState::Committed {
-                        CrashPoint::PostCommitVtc.abort_now();
-                    }
+        // PR-1: a dispatch failure no longer aborts the run when a policy is set.
+        // With no policy (the demo + every existing caller) the error propagates
+        // exactly as the pre-PR-1 `?` did — byte-identical truth path.
+        if let Err(e) = dispatch {
+            match failure_policy {
+                None => return Err(RuntimeError::Lifecycle(e)),
+                Some(policy) => {
+                    handle_failure(
+                        &e,
+                        mote_id,
+                        policy,
+                        &mut attempts,
+                        &journal,
+                        &mut projection,
+                        &mut folded_through,
+                    )?;
+                    // Retry → `pick_next` re-selects the still-ready Mote; dead-letter
+                    // → it is now `Failed` and `pick_next` skips it. Either way, re-loop.
+                    continue;
                 }
+            }
+        }
+
+        // Scenario-2 injection (success path only): a hard kill the instant the VTC
+        // Mote's Committed is durable (and the critic's Proposed has been recorded),
+        // before the run finishes. Recovery must RE-READ it, never re-run its world
+        // effect.
+        if wm_vtc_target && config.crash_at == Some(CrashPoint::PostCommitVtc) {
+            fold_new(&journal, &mut projection, &mut folded_through)?;
+            if projection.state_of(&workflow.vtc_crash_target) == MoteState::Committed {
+                CrashPoint::PostCommitVtc.abort_now();
             }
         }
         fold_new(&journal, &mut projection, &mut folded_through)?;
@@ -496,10 +548,19 @@ where
         a.flush();
     }
 
-    if config.mode == Mode::Run && !outcome.is_complete() {
-        // A clean run that didn't finish means a Mote is stuck (e.g. a WM Mote
-        // with no EffectStaged hint the oracle refuses to re-dispatch).
-        return Err(RuntimeError::Stalled(outcome.total - outcome.committed));
+    if config.mode == Mode::Run {
+        // "Stalled" means a Mote is genuinely stuck — non-terminal with no way
+        // forward (e.g. a WM Mote with no EffectStaged hint the oracle refuses to
+        // re-dispatch). A Mote dead-lettered by the failure policy is *terminal*
+        // (`Failed`), not stuck, so the run completes rather than aborting. On the
+        // demo path no Mote is non-committed, so `stuck == 0` exactly as before.
+        let stuck = runnable
+            .iter()
+            .filter(|w| !is_terminal(projection.state_of(&w.mote.id)))
+            .count();
+        if stuck > 0 {
+            return Err(RuntimeError::Stalled(stuck));
+        }
     }
     Ok(outcome)
 }
@@ -525,6 +586,81 @@ fn fold_new(
         projection.fold(&entry)?;
     }
     *folded_through = current;
+    Ok(())
+}
+
+/// Reporter id stamped on the single-process engine's dead-letter `Failed` entries
+/// (the distributed coordinator uses its own `COORDINATOR_REPORTER_ID = 0`). A
+/// distinct, fixed, UUID-shaped marker — never part of identity or dedup (a
+/// `Failed` entry is not deduped, D19), purely a provenance hint for audit.
+const RUNTIME_REPORTER_ID: u128 = 0x6b78_5f72_756e_7469_6d65_0000_0000_0001;
+
+/// Whether a Mote has reached a terminal state — committed or dead-lettered. The
+/// drive loop never re-picks a terminal Mote, and a `Mode::Run` that leaves only
+/// terminal Motes is *complete*, not *stalled*.
+fn is_terminal(state: MoteState) -> bool {
+    matches!(
+        state,
+        MoteState::Committed | MoteState::Failed | MoteState::Repudiated | MoteState::Inconsistent
+    )
+}
+
+/// PR-1 failure handling (only reached when `failure_policy` is `Some`): retry a
+/// transient infrastructure error within budget, else dead-letter the Mote by
+/// journaling a terminal `Failed` fact so the drive loop can continue **past** it.
+///
+/// First re-folds: a commit-protocol path may have already journaled its own
+/// terminal `Failed` (e.g. an R-13 re-dispatch refusal), in which case the Mote is
+/// already terminal and we must NOT double-write. Otherwise, a transient class is
+/// retried (in-memory attempt counter, backoff) until `max_attempts`, then a single
+/// `Failed{reason_class}` is appended. A terminal-logic class dead-letters at once.
+///
+/// Returns `Ok(())` in every handled case — the caller re-loops: a retry re-selects
+/// the still-ready Mote, a dead-letter is now `MoteState::Failed` and is skipped.
+fn handle_failure(
+    err: &LifecycleError,
+    mote_id: MoteId,
+    policy: &FailurePolicy,
+    attempts: &mut BTreeMap<MoteId, u32>,
+    journal: &SqliteJournal,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+) -> Result<(), RuntimeError> {
+    // Pick up anything the failed dispatch already journaled (e.g. a commit-protocol
+    // terminal `Failed`). If the Mote is already terminal, don't double-write.
+    fold_new(journal, projection, folded_through)?;
+    if is_terminal(projection.state_of(&mote_id)) {
+        tracing::warn!(mote = ?mote_id, error = %err, "dispatch failed; Mote already terminal — not re-writing");
+        return Ok(());
+    }
+
+    let class = classify_lifecycle_error(err);
+    if class == FailureClass::TransientInfra {
+        let n = attempts.entry(mote_id).or_insert(0);
+        *n += 1;
+        if *n < policy.max_attempts {
+            if !policy.backoff.is_zero() {
+                std::thread::sleep(policy.backoff);
+            }
+            tracing::warn!(mote = ?mote_id, attempt = *n, max = policy.max_attempts, error = %err, "transient dispatch failure — retrying");
+            return Ok(());
+        }
+    }
+
+    // Terminal, or transient budget exhausted → dead-letter with a terminal `Failed`
+    // fact. NOT re-running a failing Mote is the whole point (the user's "no point
+    // re-running it"); the durable `Failed` is what a later model re-plan (AL2) reads.
+    let reason_class = reason_for(class);
+    let failed = JournalEntry::Failed {
+        mote_id,
+        idempotency_key: *mote_id.as_bytes(),
+        seq: 0, // journal assigns
+        reason_class,
+        reporter_id: RUNTIME_REPORTER_ID,
+    };
+    journal.append(failed)?;
+    fold_new(journal, projection, folded_through)?;
+    tracing::warn!(mote = ?mote_id, ?reason_class, error = %err, "dead-lettering Mote (failsafe: a failing Mote is recorded, never blindly re-run)");
     Ok(())
 }
 
@@ -689,7 +825,11 @@ fn pick_next(
     for w in runnable {
         let id = w.mote.id;
         let state = projection.state_of(&id);
-        if matches!(state, MoteState::Committed | MoteState::Repudiated) {
+        // Skip any terminal Mote — committed, or dead-lettered (`Failed`/
+        // `Inconsistent`) by the PR-1 failure policy. On the demo path no Mote is
+        // ever `Failed`/`Inconsistent`, so this is byte-identical to skipping only
+        // `Committed | Repudiated`.
+        if is_terminal(state) {
             continue;
         }
         let in_ready = ready.contains(&id);
@@ -1076,5 +1216,197 @@ mod audit_tests {
         assert_eq!(as_u32(0), 0);
         assert_eq!(as_u32(8), 8);
         assert_eq!(as_u32(usize::MAX), u32::MAX);
+    }
+}
+
+#[cfg(test)]
+mod failure_tests {
+    //! PR-1 — the bounded-retry + dead-letter drive-loop behavior. Each test
+    //! drives a flat 2-PURE-Mote workflow through `run_with_seams` with a
+    //! `FailingExecutor` that fails one Mote, asserting the run COMPLETES with the
+    //! failing Mote dead-lettered (`Failed`) and its sibling committed — the live
+    //! correctness fix (a mid-DAG failure no longer aborts the whole run) — while
+    //! the `None` path still aborts exactly as before.
+    #![allow(clippy::unwrap_used)]
+
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use kx_content::LocalFsContentStore;
+    use kx_executor::{
+        LocalResourceManager, MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs,
+        StandardCommitProtocol, TestMoteExecutor,
+    };
+    use kx_journal::SqliteJournal;
+    use kx_mote::Mote;
+    use kx_projection::{MoteState, Projection};
+    use kx_warrant::{ExecutorClass, WarrantSpec};
+
+    use super::{run_with_seams, RunOutcome};
+    use crate::broker::DemoBroker;
+    use crate::config::{Mode, RuntimeConfig};
+    use crate::error::RuntimeError;
+    use crate::failure_policy::FailurePolicy;
+    use crate::workflow::flat_pure_workflow;
+
+    /// A `MoteExecutor` that fails a chosen Mote and delegates the rest to a real
+    /// deterministic stub, counting how many times the chosen Mote is dispatched.
+    struct FailingExecutor {
+        inner: TestMoteExecutor,
+        target: kx_mote::MoteId,
+        error: fn() -> MoteExecutorError,
+        target_calls: Arc<AtomicUsize>,
+    }
+
+    impl MoteExecutor for FailingExecutor {
+        fn run(
+            &self,
+            mote: &Mote,
+            warrant: &WarrantSpec,
+            env: Option<Rootfs>,
+        ) -> Result<MoteExecutionResult, MoteExecutorError> {
+            if mote.id == self.target {
+                self.target_calls.fetch_add(1, Ordering::SeqCst);
+                return Err((self.error)());
+            }
+            self.inner.run(mote, warrant, env)
+        }
+
+        fn supports(&self, class: ExecutorClass) -> bool {
+            self.inner.supports(class)
+        }
+    }
+
+    fn config_for(dir: &std::path::Path) -> RuntimeConfig {
+        RuntimeConfig {
+            journal_path: dir.join("journal.sqlite"),
+            content_root: dir.join("content"),
+            mode: Mode::Run,
+            crash_at: None,
+            checkpoint_every: None,
+            audit_log: None,
+        }
+    }
+
+    /// Drive a flat 2-PURE-Mote workflow whose second Mote fails with `error`,
+    /// under `policy`. Returns the run result, the (target, sibling) ids, the
+    /// re-folded final projection, and the target's dispatch count.
+    fn drive(
+        error: fn() -> MoteExecutorError,
+        policy: Option<&FailurePolicy>,
+    ) -> (
+        Result<RunOutcome, RuntimeError>,
+        kx_mote::MoteId,
+        kx_mote::MoteId,
+        Option<Projection>,
+        usize,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_for(dir.path());
+        let workflow = flat_pure_workflow(&[0x10, 0x11]);
+        let sibling = workflow.motes[0].mote.id;
+        let target = workflow.motes[1].mote.id;
+
+        let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+        let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+        let rm = LocalResourceManager::dev_defaults();
+        let broker = Arc::new(DemoBroker::new(store.clone(), BTreeMap::new(), None, None));
+        let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+        let target_calls = Arc::new(AtomicUsize::new(0));
+        let executor = FailingExecutor {
+            inner: TestMoteExecutor::deterministic(),
+            target,
+            error,
+            target_calls: target_calls.clone(),
+        };
+
+        let result = run_with_seams(
+            &config,
+            &workflow,
+            store,
+            journal.clone(),
+            &rm,
+            &executor,
+            &protocol,
+            None, // shaper — flat DAG
+            None, // snapshot_sink
+            None, // capture_sink
+            None, // audit_sink
+            policy,
+        );
+
+        // Re-fold the on-disk journal into a fresh projection so the assertions read
+        // the same durable truth a cold recovery would.
+        let projection = Projection::from_journal(&*journal).ok();
+        (
+            result,
+            target,
+            sibling,
+            projection,
+            target_calls.load(Ordering::SeqCst),
+        )
+    }
+
+    #[test]
+    fn terminal_failure_dead_letters_and_run_completes() {
+        let policy = FailurePolicy::new(3, Duration::ZERO);
+        let (result, target, sibling, projection, calls) =
+            drive(|| MoteExecutorError::BodyExited { code: 1 }, Some(&policy));
+
+        let outcome = result.expect("the run completes (not aborts) past a dead-lettered Mote");
+        assert_eq!(outcome.total, 2);
+        assert_eq!(
+            outcome.committed, 1,
+            "the sibling commits; the target does not"
+        );
+
+        let projection = projection.unwrap();
+        assert_eq!(
+            projection.state_of(&target),
+            MoteState::Failed,
+            "the failing Mote is dead-lettered (terminal Failed)"
+        );
+        assert_eq!(
+            projection.state_of(&sibling),
+            MoteState::Committed,
+            "its sibling still commits"
+        );
+        // Terminal logic failure ⇒ dispatched exactly once, never retried.
+        assert_eq!(calls, 1, "a terminal failure is not retried");
+    }
+
+    #[test]
+    fn transient_failure_retries_to_budget_then_dead_letters() {
+        let policy = FailurePolicy::new(3, Duration::ZERO);
+        let (result, target, sibling, projection, calls) = drive(
+            || MoteExecutorError::SandboxLoadFailed {
+                reason: "transient".into(),
+            },
+            Some(&policy),
+        );
+
+        let outcome = result.expect("the run completes after exhausting the retry budget");
+        assert_eq!(outcome.committed, 1);
+
+        let projection = projection.unwrap();
+        assert_eq!(projection.state_of(&target), MoteState::Failed);
+        assert_eq!(projection.state_of(&sibling), MoteState::Committed);
+        // A transient error is retried up to `max_attempts` dispatches, then dead-lettered.
+        assert_eq!(calls, 3, "transient retried to the 3-attempt budget");
+    }
+
+    #[test]
+    fn no_policy_aborts_the_run_exactly_as_before() {
+        // The legacy path: with no `FailurePolicy`, a dispatch error propagates and
+        // aborts the whole run (`RuntimeError::Lifecycle`) — byte-identical to the
+        // pre-PR-1 `?`. This is what every existing caller (and the demo) relies on.
+        let (result, _target, _sibling, _projection, _calls) =
+            drive(|| MoteExecutorError::BodyExited { code: 1 }, None);
+        assert!(
+            matches!(result, Err(RuntimeError::Lifecycle(_))),
+            "without a policy a failing Mote aborts the run"
+        );
     }
 }

--- a/crates/kx-runtime/src/failure_policy.rs
+++ b/crates/kx-runtime/src/failure_policy.rs
@@ -1,0 +1,212 @@
+//! [`FailurePolicy`] — the PR-1 bounded-retry + dead-letter seam (`Option`-gated).
+//!
+//! When the orchestrator ([`crate::run_with_seams`]) is handed `Some(&FailurePolicy)`,
+//! a Mote dispatch error no longer aborts the whole run: a *transient infrastructure*
+//! failure is retried (bounded), and a *terminal* failure (or an exhausted transient)
+//! is journaled as a `Failed` fact so the drive loop can continue **past** the Mote
+//! (dead-letter). With `None` — the canonical demo and every existing caller — a
+//! dispatch error propagates exactly as before (`return Err`), so the deterministic
+//! truth path (digest `a6b5c679…`) is byte-unchanged. This is the proven
+//! `snapshot_sink`/`audit_sink`/`capture_sink` additive-`Option`-seam pattern.
+//!
+//! The policy is the *failsafe foundation* the model-driven re-plan loop (AL2)
+//! builds on: a terminal `Failed` fact is the durable, auditable record a later
+//! re-plan round reads — kortecx never blindly re-runs the same failing Mote
+//! (the user's "no point re-running it"); it records the failure and, in a later
+//! PR, lets the model propose a corrected fresh round.
+
+use std::time::Duration;
+
+use kx_executor::{CommitProtocolError, LifecycleError, MoteExecutorError, ResourceError};
+use kx_journal::FailureReason;
+
+/// How a Mote dispatch failure should be handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FailureClass {
+    /// A transient *infrastructure* error (resource contention, a storage/journal
+    /// hiccup, a broker network blip, a process spawn/timeout) — one that plausibly
+    /// succeeds on a retry. Eligible for bounded retry-with-backoff.
+    TransientInfra,
+    /// A *terminal* logic / permission / validation failure — re-running the
+    /// identical Mote cannot succeed. Dead-letter it (write a `Failed` fact) and
+    /// let the loop continue; a model re-plan (AL2) is the correct recovery, not a
+    /// blind retry.
+    TerminalLogic,
+}
+
+/// Per-run bounded-retry + dead-letter policy. Passed as `Option<&FailurePolicy>`
+/// to [`crate::run_with_seams`]; `None` ⇒ legacy abort-on-failure (digest-invariant).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FailurePolicy {
+    /// Maximum dispatch attempts for a *transient* error before dead-lettering.
+    /// `1` ⇒ no retry (a single attempt, then dead-letter on a transient failure).
+    pub max_attempts: u32,
+    /// Fixed backoff slept between transient retries.
+    pub backoff: Duration,
+}
+
+impl FailurePolicy {
+    /// A policy with `max_attempts` transient attempts and a `backoff` pause.
+    /// `max_attempts` is floored at `1` (every Mote gets at least one attempt).
+    #[must_use]
+    pub fn new(max_attempts: u32, backoff: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            backoff,
+        }
+    }
+
+    /// A sensible local-serve default: 3 transient attempts, 100 ms backoff.
+    #[must_use]
+    pub fn dev_default() -> Self {
+        Self::new(3, Duration::from_millis(100))
+    }
+}
+
+/// Classify a dispatch [`LifecycleError`] as transient-infra (retry) or
+/// terminal-logic (dead-letter).
+///
+/// **Conservative by construction:** only clearly transient *infrastructure*
+/// errors are retried; everything else — including any future/unknown nested
+/// variant — defaults to terminal, so a deterministic failure is never retried in
+/// a storm (fail-safe). The partition mirrors the recovery oracle's
+/// pre-commit-crash (transient) vs terminal split: storage / broker / spawn /
+/// timeout / resource-contention are transient; refusals, validation verdicts, the
+/// R-13 double-fire guard, a non-zero body exit, and unsupported backends are
+/// terminal.
+pub(crate) fn classify_lifecycle_error(err: &LifecycleError) -> FailureClass {
+    use FailureClass::{TerminalLogic, TransientInfra};
+    match err {
+        // A journal append hiccup is transient storage.
+        LifecycleError::JournalAppend(_) => TransientInfra,
+        LifecycleError::ResourceAcquire(e) => classify_resource_error(e),
+        LifecycleError::ExecutorRun(e) => classify_executor_error(e),
+        LifecycleError::CommitProtocol(e) => classify_commit_error(e),
+        // A submission refusal (a permission/construction verdict — R-1..R-9 / widen
+        // / validator type error) or an opaque internal lifecycle error: both are
+        // deterministic, never retried.
+        LifecycleError::Refused(_) | LifecycleError::Internal(_) => TerminalLogic,
+    }
+}
+
+fn classify_resource_error(err: &ResourceError) -> FailureClass {
+    use FailureClass::{TerminalLogic, TransientInfra};
+    match err {
+        // The manager is momentarily saturated — a backoff may free a slot.
+        ResourceError::NoCapacity => TransientInfra,
+        // The Mote's own ceilings are exceeded, or an internal/unknown-slot bug —
+        // deterministic across retries.
+        ResourceError::CpuCapExceeded { .. }
+        | ResourceError::MemCapExceeded { .. }
+        | ResourceError::FdCapExceeded { .. }
+        | ResourceError::UnknownSlot(_)
+        | ResourceError::Internal(_) => TerminalLogic,
+    }
+}
+
+fn classify_executor_error(err: &MoteExecutorError) -> FailureClass {
+    use FailureClass::{TerminalLogic, TransientInfra};
+    match err {
+        // Transient OS / sandbox / timeout conditions that may vary across attempts.
+        MoteExecutorError::ProcessSpawnFailed { .. }
+        | MoteExecutorError::SandboxLoadFailed { .. }
+        | MoteExecutorError::RlimitFailed { .. }
+        | MoteExecutorError::WallClockTimedOut { .. } => TransientInfra,
+        // Deterministic: the backend can't run this class, the rootfs/profile is
+        // bad, or the body itself exited non-zero (an agent *logic* failure → a
+        // model re-plan, never a blind retry).
+        MoteExecutorError::BackendUnsupported { .. }
+        | MoteExecutorError::RootfsExtractFailed { .. }
+        | MoteExecutorError::ProfileSyntaxError { .. }
+        | MoteExecutorError::BodyExited { .. }
+        | MoteExecutorError::Internal { .. } => TerminalLogic,
+    }
+}
+
+fn classify_commit_error(err: &CommitProtocolError) -> FailureClass {
+    use FailureClass::{TerminalLogic, TransientInfra};
+    match err {
+        // Storage / broker / probe transients — the broker's idempotency-key dedup
+        // makes a WM re-dispatch exactly-once, so a bounded retry is safe.
+        CommitProtocolError::BrokerDispatchFailed { .. }
+        | CommitProtocolError::ContentStorePutFailed { .. }
+        | CommitProtocolError::JournalAppendCommittedFailed { .. }
+        | CommitProtocolError::JournalAppendEffectStagedFailed { .. }
+        | CommitProtocolError::ProbeFailed { .. } => TransientInfra,
+        // Deterministic protocol / validation verdicts + the R-13 re-dispatch
+        // refusal (the double-fire guard — MUST NOT be retried).
+        CommitProtocolError::R11ResultRefIncomplete { .. }
+        | CommitProtocolError::R12CommittedNotProofOfValidity { .. }
+        | CommitProtocolError::R13WmReDispatchRefused { .. }
+        | CommitProtocolError::CompensateFailed { .. }
+        | CommitProtocolError::Internal { .. } => TerminalLogic,
+    }
+}
+
+/// The journaled [`FailureReason`] for a dead-lettered Mote of the given class.
+/// Reuses the existing closed enum (no schema bump): an exhausted transient maps
+/// to [`FailureReason::TimedOut`] (it ran out of attempts, i.e. never committed in
+/// budget), a terminal logic failure to [`FailureReason::ExecutorRefused`] (the
+/// executor did not produce a committable result).
+pub(crate) fn reason_for(class: FailureClass) -> FailureReason {
+    match class {
+        FailureClass::TransientInfra => FailureReason::TimedOut,
+        FailureClass::TerminalLogic => FailureReason::ExecutorRefused,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_executor::MoteExecutorError;
+
+    #[test]
+    fn body_exit_is_terminal_not_retried() {
+        // An agent body that exits non-zero is a deterministic logic failure — the
+        // user's "no point re-running it". It must dead-letter, never retry-storm.
+        let e = LifecycleError::ExecutorRun(MoteExecutorError::BodyExited { code: 1 });
+        assert_eq!(classify_lifecycle_error(&e), FailureClass::TerminalLogic);
+        assert_eq!(
+            reason_for(FailureClass::TerminalLogic),
+            FailureReason::ExecutorRefused
+        );
+    }
+
+    #[test]
+    fn resource_no_capacity_is_transient() {
+        let e = LifecycleError::ResourceAcquire(ResourceError::NoCapacity);
+        assert_eq!(classify_lifecycle_error(&e), FailureClass::TransientInfra);
+        assert_eq!(
+            reason_for(FailureClass::TransientInfra),
+            FailureReason::TimedOut
+        );
+    }
+
+    #[test]
+    fn resource_cap_exceeded_is_terminal() {
+        // The Mote asks for more than the ceiling — deterministic, dead-letter.
+        let e = LifecycleError::ResourceAcquire(ResourceError::MemCapExceeded {
+            requested: 1 << 40,
+            cap: 1 << 20,
+        });
+        assert_eq!(classify_lifecycle_error(&e), FailureClass::TerminalLogic);
+    }
+
+    #[test]
+    fn journal_append_hiccup_is_transient() {
+        let e = LifecycleError::JournalAppend("disk busy".into());
+        assert_eq!(classify_lifecycle_error(&e), FailureClass::TransientInfra);
+    }
+
+    #[test]
+    fn internal_lifecycle_error_is_terminal() {
+        let e = LifecycleError::Internal("opaque".into());
+        assert_eq!(classify_lifecycle_error(&e), FailureClass::TerminalLogic);
+    }
+
+    #[test]
+    fn max_attempts_floored_at_one() {
+        assert_eq!(FailurePolicy::new(0, Duration::ZERO).max_attempts, 1);
+        assert_eq!(FailurePolicy::dev_default().max_attempts, 3);
+    }
+}

--- a/crates/kx-runtime/src/lib.rs
+++ b/crates/kx-runtime/src/lib.rs
@@ -63,6 +63,7 @@ pub mod crash;
 pub mod digest;
 pub mod engine;
 pub mod error;
+pub mod failure_policy;
 pub mod migrate;
 pub mod snapshot_sink;
 pub mod topology;
@@ -78,6 +79,7 @@ pub use engine::{
     RunOutcome,
 };
 pub use error::RuntimeError;
+pub use failure_policy::FailurePolicy;
 // Re-export the audit vocabulary so callers (CLI / harness / future gateway) use
 // the runtime facade, mirroring how `CaptureSink` fronts `kx-capture`.
 pub use kx_audit::{AuditEvent, AuditSink, DispatchKind, InMemoryAuditSink, JsonlAuditSink};

--- a/crates/kx-runtime/src/workflow.rs
+++ b/crates/kx-runtime/src/workflow.rs
@@ -148,6 +148,33 @@ impl DemoWorkflow {
     }
 }
 
+/// A flat (shaperless) workflow of independent PURE **root** Motes — one per
+/// `seed`, with no parents so each commits or fails independently (no cascade).
+/// Test-only: the PR-1 failure-policy tests need a DAG where one Mote can be
+/// dead-lettered while its siblings still commit, driven with `shaper: None`.
+#[cfg(test)]
+pub(crate) fn flat_pure_workflow(seeds: &[u8]) -> DemoWorkflow {
+    let cap = ToolName("demo-tool".into());
+    let permissive = permissive_warrant();
+    let motes = seeds
+        .iter()
+        .map(|&seed| WorkflowMote {
+            mote: pure_mote(seed, &[]),
+            warrant: permissive.clone(),
+            capability: cap.clone(),
+        })
+        .collect();
+    // The flat path never consults a shaper (run with `shaper: None`); a sentinel
+    // id fills the struct's crash/shaper fields.
+    let sentinel = pure_mote(0xFF, &[]).id;
+    DemoWorkflow {
+        motes,
+        stc_crash_target: sentinel,
+        vtc_crash_target: sentinel,
+        shaper_id: sentinel,
+    }
+}
+
 /// A permissive warrant — the demo runs in a single trusted process, so every
 /// axis is wide open. (The broker/executor seams still enforce structurally;
 /// the warrant just doesn't narrow anything for the demo.)


### PR DESCRIPTION
## Context

Today a **mid-DAG Mote dispatch error aborts the entire single-process run** (the `?` in the `run_with_seams` drive loop) — no `Failed` fact is even written, no retry, no recovery. This is the live correctness gap surfaced by the agentic-runtime readiness review: the runtime should *record* a failing step and keep going, never blindly re-run it. PR-1 is the **failsafe foundation** the model-driven re-plan loop (AL2) builds on.

## What changed

An **additive, `Option`-gated `FailurePolicy` seam** on `run_with_seams` (the proven `snapshot_sink`/`audit_sink`/`capture_sink` pattern):

- **NEW `kx-runtime/src/failure_policy.rs`** — `FailurePolicy { max_attempts, backoff }` (pub) + a conservative, **exhaustive** `classify_lifecycle_error` over the public `LifecycleError` (storage / broker / spawn / timeout / resource-contention ⇒ **transient**; refusals / validation verdicts / the R-13 double-fire guard / non-zero body-exit / unsupported-backend / opaque-internal ⇒ **terminal**) + `reason_for` (reuses the existing closed `FailureReason` — **no schema bump**).
- **`engine.rs`** — `failure_policy: Option<&FailurePolicy>` on `run_with_seams`; `handle_failure` (folds-then-checks-terminal to avoid double-writing when the commit protocol already journaled a `Failed`; in-memory per-Mote attempt counter); `pick_next` skips terminal Motes; the `Mode::Run` completion gate treats a dead-lettered `Failed` as **terminal**, not `Stalled`.
- The classifier lives in `kx-runtime` off the **public** `LifecycleError`, so the frozen trio is byte-untouched.

When the policy is present: a transient error retries within `max_attempts` (the P0.4 `serve_if_committed` gate guarantees a retry never re-runs committed work); a terminal failure (or exhausted transient) journals one terminal `Failed{reason_class}` and the loop **continues past** the dead-lettered Mote. **kortecx never blindly re-runs a failing Mote** — the durable `Failed` is the auditable record AL2 will read.

## Golden Rule 8 — pre-flight

- **Breaks:** nothing — every existing caller (and the demo) passes `None`, so a dispatch error propagates exactly as the pre-PR-1 `?` did. Frozen-trio (`kx-executor`/`kx-scheduler`/`kx-inference`) **src diff EMPTY**; canonical demo digest **`a6b5c679…` invariant** (proven by `a0_guard`); `Cargo.lock` unchanged.
- **Degrades:** a `Some`-policy run can now end *partially complete* (a dead-lettered `Failed` present) where it previously aborted — the intended improvement. Transient backoff is a `thread::sleep` on the single-process loop (only when a policy opts in).
- **Opens a hole:** none new — no new input/effect/egress surface; the classifier is pure + total; a retry cannot re-run committed work (P0.4 gate). Default-terminal classification is fail-safe (no retry storms on deterministic failures).

## Tests

3 behavior (`terminal_failure_dead_letters_and_run_completes`, `transient_failure_retries_to_budget_then_dead_letters`, `no_policy_aborts_the_run_exactly_as_before`) + 6 classifier units. Local gate: fmt, clippy `-D warnings` (workspace), **`cargo test --workspace` 1757 passed / 0 failed**, doc `-D warnings`, cargo-deny (advisories/bans/licenses/sources ok).

## Roadmap

First step of the agentic-loop track: **PR-1 failsafe foundation** → PR-2 model-driven `TopologyDecision` into serve (AL1) → PR-3 re-plan-on-failure (AL2) → PR-4 tool-call ReAct loop → PR-5 snapshot/replay UX → PR-6 minimal OSS HITL. Each additive, digest-invariant, frozen-trio-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)