### PR TITLE
feat: PR-2 — the model drives the loop (F-4 AL1 + F-7)

### DIFF
--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -59,12 +59,14 @@ pub mod metered;
 pub mod prompt;
 pub mod registration;
 pub mod toolcall;
+pub mod topology_provider;
 pub mod workflows;
 
 pub use broker::{BrokerObserver, ModelBroker};
 pub use executor::ModelExecutor;
 pub use metered::MeteredBackend;
 pub use registration::{register_kortecx, RegistrationError};
+pub use topology_provider::{run_model_loop, LoopBudget, ModelTopologyProvider};
 
 /// The exact quantization of the pinned campaign model, folded into the
 /// [`ModelId`] so a different quant yields a different identity.
@@ -335,6 +337,9 @@ impl Harness {
             &executor,
             &protocol,
             None,
+            // topology_provider (PR-2) — the generic driver runs flat DAGs; a
+            // model-driven topology loop uses `drive_model_loop`.
+            None,
             Some(&sink),
             // capture_sink — off for the harness; the runtime seam captures only
             // the action, and `Full` reasoning/thinking enrichment is M3.2 (D67).
@@ -344,6 +349,35 @@ impl Harness {
             // failure_policy (PR-1) — the harness drives deterministic workflows;
             // `None` keeps legacy abort-on-failure.
             None,
+        )
+    }
+
+    /// PR-2 (F-4) — drive a **model-driven topology loop**. The model computes the
+    /// shaper's [`kx_mote::TopologyDecision`] (via [`ModelTopologyProvider`]), its
+    /// children materialize + execute, and a cold re-fold re-derives byte-identical
+    /// children (R49 — the model's choice is replayed, never re-sampled).
+    ///
+    /// `workflow` is a [`workflows::loop_shaper`]; `recipes` is the vetted
+    /// role→recipe allowlist the proposal lowers through (an unregistered role
+    /// fails closed); `budget` bounds the fan-out. A refused proposal dead-letters
+    /// the shaper and the run completes with no children (PR-1 discipline).
+    pub fn drive_model_loop(
+        &self,
+        config: &RuntimeConfig,
+        workflow: &DemoWorkflow,
+        recipes: Arc<dyn kx_planner::RoleRecipeResolver>,
+        budget: crate::LoopBudget,
+    ) -> Result<RunOutcome, RuntimeError> {
+        let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+        crate::run_model_loop(
+            config,
+            self.store.clone(),
+            self.journal.clone(),
+            self.backend.clone(),
+            registry,
+            recipes,
+            workflow,
+            budget,
         )
     }
 }

--- a/crates/kx-model-harness/src/topology_provider.rs
+++ b/crates/kx-model-harness/src/topology_provider.rs
@@ -1,0 +1,445 @@
+//! PR-2 (F-4) — **the model drives the loop.** A real model computes a topology
+//! shaper's [`kx_mote::TopologyDecision`] (the next-step fan-out), replacing the
+//! hardcoded `demo_topology_decision()`. This is the D111 home of the
+//! "model-runs-once → decode → lower → read-the-plan-back" wiring: `kx-planner`
+//! stays a pure lowering library; the runtime stays free of any model type; the
+//! orchestration seam ([`kx_runtime::TopologyProvider`]) is implemented HERE.
+//!
+//! ## Flow ([`run_model_loop`])
+//!
+//! 1. [`ModelTopologyProvider::decide`] assembles the shaper's context (D78 —
+//!    reusing the crate's `context::model_input` / `assemble` wiring), runs the model ONCE,
+//!    decodes the completion **fail-closed** via [`kx_planner::decode_loop_proposal`],
+//!    enforces the per-decision child budget, and lowers it through *vetted
+//!    recipes* ([`kx_planner::lower_loop_to_topology_decision`]) into a
+//!    `TopologyDecision` (SN-8: the model proposes role *names*; identity axes +
+//!    warrant narrowing are the runtime's).
+//! 2. The decision's canonical bytes are staged as the shaper's effect (a
+//!    [`kx_runtime::broker::DemoBroker`] response), so the shaper's committed
+//!    `result_ref` IS the decision hash — a captured fact the
+//!    `DefaultTopologyMaterializer` + the engine both decode (one source of truth).
+//! 3. `run_with_seams` drives the run: the shaper commits the decision, its
+//!    children materialize + execute, and a cold re-fold re-derives byte-identical
+//!    children (R49 — the model's choice is replayed, never re-sampled).
+//!
+//! ## Fail-closed (composes with PR-1)
+//!
+//! A malformed / oversized / un-grantable / over-budget proposal makes `decide`
+//! return [`TopologyProviderError`]; [`run_model_loop`] then **dead-letters** the
+//! shaper with a terminal `Failed` fact (never a panic) and the run completes
+//! PAST it with no children — exactly the PR-1 "a failing Mote is recorded, never
+//! blindly re-run" discipline.
+//!
+//! ## Bounded (the OSS "bounded additive" guarantee)
+//!
+//! Three layered bounds: the byte cap ([`kx_planner::max_plan_bytes`], enforced
+//! before parse), the structural per-round cap (`MAX_LOOP_STEPS` in decode), and
+//! the run-policy [`LoopBudget`] (`max_rounds` across rounds + `max_children` per
+//! decision). The unbounded durable-loop topology stays cloud (D126 cat-B).
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_content::ContentStore;
+use kx_executor::{LocalResourceManager, StandardCommitProtocol};
+use kx_inference::{inference_params_from_mote, InferenceBackend};
+use kx_journal::{FailureReason, Journal, JournalEntry, SqliteJournal};
+use kx_mote::{Mote, MoteDef, MoteId, RoleId, TopologyDecision};
+use kx_planner::{
+    decode_loop_proposal, lower_loop_to_topology_decision, max_plan_bytes, RoleRecipeResolver,
+};
+use kx_projection::{
+    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, Projection,
+    Snapshot, TopologyMaterializer,
+};
+use kx_runtime::broker::DemoBroker;
+use kx_runtime::topology::encode_topology_decision;
+use kx_runtime::{
+    run_with_seams, DemoWorkflow, FailurePolicy, RunOutcome, RuntimeConfig, RuntimeError,
+    SnapshotSink, TopologyProvider, TopologyProviderError,
+};
+use kx_tool_registry::ToolRegistry;
+use kx_warrant::{Role, RoleRegistry, WarrantSpec};
+
+use crate::{context, prompt, ModelExecutor};
+
+/// A [`RoleRegistry`] that grants EVERY proposed role the shaper's own warrant, so
+/// the materializer's `intersect(shaper.warrant, role.spec)` narrowing is a no-op:
+/// children inherit the shaper's authority — never wider (SN-8 narrowing-only).
+/// The role ALLOWLIST is the [`RoleRecipeResolver`] (an unregistered role fails
+/// closed at `lower_loop_to_topology_decision` before the materializer is ever
+/// consulted); per-role *restriction* (tighter child warrants) arrives with the
+/// PR-4 tool-call warrants. This keeps PR-2's foundation correct + bounded without
+/// a workflow author pre-registering a parallel role catalog.
+struct InheritShaperWarrantRoles {
+    shaper_warrant: WarrantSpec,
+}
+
+impl RoleRegistry for InheritShaperWarrantRoles {
+    fn resolve(&self, role_id: &RoleId) -> Option<Role> {
+        Some(Role {
+            name: role_id.0.clone(),
+            version: 1,
+            spec: self.shaper_warrant.clone(),
+            description: String::new(),
+        })
+    }
+}
+
+/// Reporter id stamped on a dead-lettered shaper's terminal `Failed` entry — a
+/// fixed, UUID-shaped provenance marker (never identity or dedup input, D19),
+/// distinct from the engine's `RUNTIME_REPORTER_ID` and the coordinator's `0`.
+const TOPOLOGY_PROVIDER_REPORTER_ID: u128 = 0x6b78_5f74_6f70_6f6c_6f67_7900_0000_0001;
+
+/// The per-run bound on a model-driven loop — the OSS "bounded additive" cap (the
+/// unbounded durable-loop / recursion topology stays cloud, D126 cat-B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoopBudget {
+    /// Max replan rounds per run the provider will honour (shaper invocations).
+    /// The `(max_rounds + 1)`-th [`ModelTopologyProvider::decide`] returns
+    /// [`TopologyProviderError`] ⇒ the shaper dead-letters ⇒ the run completes
+    /// bounded. (One round in PR-2's single-shaper foundation; exercised across
+    /// rounds by PR-3 re-plan.)
+    pub max_rounds: u32,
+    /// Max children a single decision may spawn — the run-policy fan-out cap,
+    /// enforced AFTER decode's structural `MAX_LOOP_STEPS` cap (typically tighter).
+    pub max_children: usize,
+}
+
+impl Default for LoopBudget {
+    fn default() -> Self {
+        Self {
+            max_rounds: 4,
+            max_children: 8,
+        }
+    }
+}
+
+/// A [`TopologyProvider`] that computes a shaper's decision from a real model.
+///
+/// Generic over the backend + store so the live campaign uses
+/// [`crate::MeteredBackend`]`<`[`kx_inference::LlamaInferenceBackend`]`>` while a
+/// deterministic test uses a stub backend (no GGUF needed). Shares the backend
+/// `Arc` with the run's [`ModelExecutor`] so the dispatch count aggregates.
+pub struct ModelTopologyProvider<B: InferenceBackend, S: ContentStore> {
+    backend: Arc<B>,
+    store: Arc<S>,
+    registry: Arc<dyn ToolRegistry>,
+    recipes: Arc<dyn RoleRecipeResolver>,
+    budget: LoopBudget,
+    /// Rounds consumed so far (off the truth path — a crash re-folds the committed
+    /// prefix and the counter restarts harmlessly; it only ever *limits* fresh
+    /// rounds, never affects a committed shaper's already-materialized children).
+    round: AtomicU32,
+}
+
+impl<B: InferenceBackend, S: ContentStore> std::fmt::Debug for ModelTopologyProvider<B, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModelTopologyProvider")
+            .field("budget", &self.budget)
+            .field("round", &self.round.load(Ordering::SeqCst))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: InferenceBackend, S: ContentStore> ModelTopologyProvider<B, S> {
+    /// Build a provider over a shared backend + content store + tool registry +
+    /// vetted role-recipe resolver, bounded by `budget`.
+    #[must_use]
+    pub fn new(
+        backend: Arc<B>,
+        store: Arc<S>,
+        registry: Arc<dyn ToolRegistry>,
+        recipes: Arc<dyn RoleRecipeResolver>,
+        budget: LoopBudget,
+    ) -> Self {
+        Self {
+            backend,
+            store,
+            registry,
+            recipes,
+            budget,
+            round: AtomicU32::new(0),
+        }
+    }
+}
+
+impl<B, S> TopologyProvider for ModelTopologyProvider<B, S>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    fn decide(
+        &self,
+        shaper: &Mote,
+        shaper_warrant: &WarrantSpec,
+        snapshot: &Snapshot,
+    ) -> Result<TopologyDecision, TopologyProviderError> {
+        // (0) Round budget — fail-closed once exhausted (the run dead-letters the
+        //     shaper; bounded additive). `fetch_add` returns the pre-increment
+        //     count, so `max_rounds` rounds (0..max_rounds) are honoured.
+        let round = self.round.fetch_add(1, Ordering::SeqCst);
+        if round >= self.budget.max_rounds {
+            return Err(TopologyProviderError(format!(
+                "loop budget exhausted: {} of max {} replan rounds used",
+                round, self.budget.max_rounds
+            )));
+        }
+
+        // (1) Assemble the shaper's context (D78) + ChatML-wrap the planning
+        //     instruction. Reuses the executor's exact wiring (assemble against
+        //     the snapshot; a parentless shaper yields an empty context, so the
+        //     input is `chatml(instruction)` — byte-identical to the leaf path).
+        let instruction = prompt::raw_prompt(shaper).ok_or_else(|| {
+            TopologyProviderError("topology shaper carries no planning prompt".to_string())
+        })?;
+        let sink = SnapshotSink::new();
+        sink.publish(snapshot.clone());
+        let input = context::model_input(
+            shaper,
+            shaper_warrant,
+            &instruction,
+            &sink,
+            &*self.store,
+            &*self.registry,
+        )
+        .map_err(|e| TopologyProviderError(format!("context assembly: {e}")))?;
+
+        // (2) Run the model ONCE (params verbatim from the identity-bearing
+        //     `mote.def.inference_params`, the sole permitted constructor — D50).
+        let params = inference_params_from_mote(shaper, shaper_warrant)
+            .map_err(|e| TopologyProviderError(format!("inference params: {e}")))?;
+        let out = self
+            .backend
+            .dispatch(&shaper.def.model_id, &input, &params, shaper_warrant)
+            .map_err(|e| TopologyProviderError(format!("model dispatch: {e}")))?;
+
+        // (3) Decode the proposal FAIL-CLOSED (the untrusted-bytes trust boundary:
+        //     size-cap-before-parse, `deny_unknown_fields`, `<think>`-strip,
+        //     versioned). The byte cap is the warrant's output ceiling.
+        let proposal = decode_loop_proposal(&out.bytes, max_plan_bytes(shaper_warrant))
+            .map_err(|e| TopologyProviderError(format!("decode loop proposal: {e}")))?;
+
+        // (4) Run-policy fan-out cap (after decode's structural cap).
+        if proposal.next_steps.len() > self.budget.max_children {
+            return Err(TopologyProviderError(format!(
+                "decision proposes {} children, exceeding max_children {}",
+                proposal.next_steps.len(),
+                self.budget.max_children
+            )));
+        }
+
+        // (5) Lower through VETTED recipes — role identity axes (logic_ref /
+        //     nd_class / effect_pattern) come from the recipe, never model output
+        //     (SN-8 / IMP-5 / D70). An unregistered role fails closed.
+        lower_loop_to_topology_decision(&proposal, &*self.recipes)
+            .map_err(|e| TopologyProviderError(format!("lower: {e}")))
+    }
+
+    fn materializer(
+        &self,
+        shaper_def: &MoteDef,
+        shaper_warrant: &WarrantSpec,
+    ) -> Box<dyn TopologyMaterializer> {
+        // Resolve the model's proposed roles (the recipe allowlist already gated
+        // them at `lower`) and narrow each child trivially against the shaper's
+        // own warrant. Reuses the SHARED store (the run's), so the committed
+        // decision + warrant bytes the fold reads are the ones the run wrote.
+        let def_registry = InMemoryMoteDefRegistry::new();
+        def_registry.register(shaper_def.clone());
+        Box::new(DefaultTopologyMaterializer::new(
+            self.store.clone(),
+            Arc::new(def_registry),
+            Arc::new(InheritShaperWarrantRoles {
+                shaper_warrant: shaper_warrant.clone(),
+            }),
+            InheritFromShaperResolver,
+        ))
+    }
+}
+
+/// Drive a model-driven topology loop end-to-end through the real orchestrator.
+///
+/// Shared by the live campaign ([`crate::Harness::drive_model_loop`]) and the
+/// deterministic CI test (a stub backend), so there is ONE eager-decide → stage →
+/// drive path. `workflow` must be a single topology-shaper [`DemoWorkflow`] (see
+/// [`crate::workflows::loop_shaper`]); `shaper_id` selects the shaper.
+///
+/// PR-2 computes the (parentless) shaper's decision **eagerly** — once, before the
+/// run, against an empty initial snapshot — then stages it as the shaper's effect.
+/// PR-3 re-plan will compute lazily per round through the same provider seam.
+///
+/// # Errors
+/// Propagates store / journal / orchestrator failures. A *refused model proposal*
+/// is NOT an error: the shaper is dead-lettered (terminal `Failed`) and the run
+/// completes with no children — the returned [`RunOutcome`] reflects that.
+// Each argument is a distinct injected seam (config / store / journal / backend /
+// registry / recipes / workflow / budget) — mirrors `run_with_seams`'s own allow.
+#[allow(clippy::too_many_arguments)]
+pub fn run_model_loop<B, S>(
+    config: &RuntimeConfig,
+    store: Arc<S>,
+    journal: Arc<SqliteJournal>,
+    backend: Arc<B>,
+    registry: Arc<dyn ToolRegistry>,
+    recipes: Arc<dyn RoleRecipeResolver>,
+    workflow: &DemoWorkflow,
+    budget: LoopBudget,
+) -> Result<RunOutcome, RuntimeError>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    let rm = LocalResourceManager::dev_defaults();
+    // Bounded additive (PR-1): a refused proposal / failing child is recorded as a
+    // terminal `Failed` and the run continues past it — never an abort, never a
+    // blind re-run. `max_attempts = 1` ⇒ a (deterministic) refusal dead-letters at
+    // once rather than pointlessly re-running the model.
+    let failure_policy = FailurePolicy::new(1, Duration::ZERO);
+
+    let shaper_wm = workflow
+        .motes
+        .iter()
+        .find(|w| w.mote.id == workflow.shaper_id)
+        .cloned()
+        .ok_or_else(|| {
+            RuntimeError::Config("model-loop workflow is missing its topology shaper".to_string())
+        })?;
+
+    let provider = ModelTopologyProvider::new(
+        backend.clone(),
+        store.clone(),
+        registry.clone(),
+        recipes,
+        budget,
+    );
+
+    // EAGER decide: the parentless shaper's decision is computed once, before the
+    // run, against an empty initial snapshot (no parents committed yet ⇒ empty
+    // assembled context). PR-3 re-plan computes lazily per round.
+    let initial_snapshot = Projection::new().snapshot();
+    let decision = match provider.decide(&shaper_wm.mote, &shaper_wm.warrant, &initial_snapshot) {
+        Ok(decision) => decision,
+        Err(e) => {
+            // FAIL-CLOSED: record a terminal `Failed` for the shaper (dead-letter)
+            // and run — the engine skips the now-terminal shaper, no children
+            // materialize, and the run completes (PR-1 discipline). `register_mote`
+            // only sets declared info, so this folded `Failed` state survives the
+            // scheduler's submit (verified) and `pick_next` skips it.
+            tracing::warn!(
+                error = %e,
+                shaper = ?workflow.shaper_id,
+                "topology provider refused the model proposal — dead-lettering the shaper"
+            );
+            journal.append(JournalEntry::Failed {
+                mote_id: workflow.shaper_id,
+                idempotency_key: *workflow.shaper_id.as_bytes(),
+                seq: 0, // journal assigns
+                reason_class: FailureReason::ExecutorRefused,
+                reporter_id: TOPOLOGY_PROVIDER_REPORTER_ID,
+            })?;
+            return drive_dead_lettered(
+                config,
+                &store,
+                journal,
+                backend,
+                registry,
+                workflow,
+                &rm,
+                &failure_policy,
+                &shaper_wm,
+                &provider,
+            );
+        }
+    };
+
+    // The model's lowered decision becomes the shaper's committed effect: stage its
+    // canonical bytes so the committed `result_ref` is the decision hash — the
+    // exact bytes the materializer + the engine's fact-driven derivation decode.
+    let mut responses: BTreeMap<MoteId, Vec<u8>> = BTreeMap::new();
+    responses.insert(workflow.shaper_id, encode_topology_decision(&decision)?);
+
+    let sink = SnapshotSink::new();
+    let executor = ModelExecutor::new(backend, store.clone(), sink.clone(), registry);
+    let broker = Arc::new(DemoBroker::new(
+        store.clone(),
+        responses,
+        config.crash_at,
+        Some(workflow.stc_crash_target),
+    ));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+
+    run_with_seams(
+        config,
+        workflow,
+        store,
+        journal,
+        &rm,
+        &executor,
+        &protocol,
+        // The shaper arg supplies the workflow Mote + the (decided) topology; with
+        // `topology_provider = Some` below, the engine derives children from the
+        // COMMITTED fact, so this decision is the staged-and-committed one anyway.
+        Some((&shaper_wm, &decision)),
+        Some(&provider),
+        Some(&sink),
+        None, // capture_sink — off for the loop foundation
+        None, // audit_sink (R4) — off for the loop foundation
+        Some(&failure_policy),
+    )
+}
+
+/// Drive a run whose shaper has already been dead-lettered (a refused proposal):
+/// no decision is staged, the engine skips the terminal shaper, and the run
+/// completes with no children. Split out so the borrow of the eager `provider`
+/// outlives `run_with_seams` (the `Some(&provider)` arg).
+#[allow(clippy::too_many_arguments)]
+fn drive_dead_lettered<B, S>(
+    config: &RuntimeConfig,
+    store: &Arc<S>,
+    journal: Arc<SqliteJournal>,
+    backend: Arc<B>,
+    registry: Arc<dyn ToolRegistry>,
+    workflow: &DemoWorkflow,
+    rm: &LocalResourceManager,
+    failure_policy: &FailurePolicy,
+    shaper_wm: &kx_runtime::workflow::WorkflowMote,
+    provider: &ModelTopologyProvider<B, S>,
+) -> Result<RunOutcome, RuntimeError>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    let sink = SnapshotSink::new();
+    let executor = ModelExecutor::new(backend, store.clone(), sink.clone(), registry);
+    let broker = Arc::new(DemoBroker::new(
+        store.clone(),
+        BTreeMap::new(),
+        config.crash_at,
+        Some(workflow.stc_crash_target),
+    ));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    // A throwaway decision satisfies the `shaper` arg's type; it is never used —
+    // `topology_provider = Some` selects fact-driven derivation, and the shaper is
+    // already terminal so no children derive.
+    let unused = kx_mote::TopologyDecision {
+        children: Vec::new(),
+    };
+    run_with_seams(
+        config,
+        workflow,
+        store.clone(),
+        journal,
+        rm,
+        &executor,
+        &protocol,
+        Some((shaper_wm, &unused)),
+        Some(provider),
+        Some(&sink),
+        None,
+        None,
+        Some(failure_policy),
+    )
+}

--- a/crates/kx-model-harness/src/workflows.rs
+++ b/crates/kx-model-harness/src/workflows.rs
@@ -376,6 +376,61 @@ pub fn planner_mote(
     wrap(vec![planner], warrant, sentinel_shaper(), planner_id)
 }
 
+/// **PR-2 (F-4) — the model-driven topology shaper.** A single READ-ONLY-NONDET
+/// *model* Mote with `is_topology_shaper = true`, carrying `planning_prompt`. The
+/// model's lowered [`kx_mote::TopologyDecision`] commits as the shaper's
+/// `result_ref` (a captured fact, D76); the `DefaultTopologyMaterializer` spawns
+/// its children, which execute and cold-refold to byte-identical `MoteId`s (R49 —
+/// the model's choice is replayed, never re-sampled). `shaper_id` is the shaper
+/// itself (NOT the sentinel), so `run_with_seams` takes the topology-materializing
+/// path. Drive it through [`crate::topology_provider::run_model_loop`].
+///
+/// GREEDY params: the committed decision is served (not re-sampled) on recovery
+/// regardless, but greedy keeps a live decode reproducible for the campaign.
+#[must_use]
+pub fn loop_shaper(
+    model_id: &ModelId,
+    warrant: &WarrantSpec,
+    planning_prompt: &str,
+    seed: u8,
+) -> DemoWorkflow {
+    let mut config_subset = BTreeMap::new();
+    prompt::put_prompt(&mut config_subset, planning_prompt);
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([seed; 32]),
+        model_id: model_id.clone(),
+        prompt_template_hash: PromptTemplateHash::from_bytes([seed; 32]),
+        tool_contract: BTreeMap::new(),
+        // ROND: the planner samples a plan; the COMMITTED decision is the fact
+        // (served, not re-sampled, on replay). R-14: a shaper is never WM.
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: true,
+        inference_params: greedy(128),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    let shaper = Mote::new(
+        def,
+        InputDataId::from_bytes([seed; 32]),
+        GraphPosition(vec![seed]),
+        SmallVec::new(),
+    );
+    let shaper_id = shaper.id;
+    DemoWorkflow {
+        motes: vec![WorkflowMote {
+            mote: shaper,
+            warrant: warrant.clone(),
+            capability: ToolName(CAPABILITY.to_string()),
+        }],
+        stc_crash_target: sentinel_shaper(),
+        vtc_crash_target: sentinel_shaper(),
+        shaper_id,
+    }
+}
+
 /// **M6 — run a planner-produced DAG.** Map a `kx_planner::compile_plan` result
 /// (`CompiledMote { mote, warrant, capability }`) 1:1 to a flat (shaperless)
 /// [`DemoWorkflow`], so it drives through `run_with_seams` with NO new execution

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -246,6 +246,7 @@ fn drive(workflow: &DemoWorkflow, dir: &Path) -> (Result<RunOutcome, RuntimeErro
         &executor,
         &protocol,
         None,
+        None, // topology_provider (PR-2) — flat assemble-wiring DAG
         Some(&sink),
         None, // capture_sink (D67) — off for this assemble-wiring test
         None, // audit_sink (R4) — off for this assemble-wiring test
@@ -453,6 +454,7 @@ fn image_parent_routes_child_to_multimodal_input() {
         &executor,
         &protocol,
         None,
+        None, // topology_provider (PR-2) — flat assemble-wiring DAG
         Some(&sink),
         None,
         None, // audit_sink (R4)

--- a/crates/kx-model-harness/tests/mcp_http_e2e.rs
+++ b/crates/kx-model-harness/tests/mcp_http_e2e.rs
@@ -310,6 +310,7 @@ fn drive(
         &executor,
         &protocol,
         None,
+        None, // topology_provider (PR-2) — flat tool-call DAG
         Some(&sink),
         None, // capture_sink (D67) — off for this MCP HTTP e2e test
         None, // audit_sink (R4) — off for this MCP HTTP e2e test

--- a/crates/kx-model-harness/tests/mcp_model_driven.rs
+++ b/crates/kx-model-harness/tests/mcp_model_driven.rs
@@ -210,6 +210,7 @@ fn drive(
         &executor,
         &protocol,
         None,
+        None, // topology_provider (PR-2) — flat tool-call DAG
         Some(&sink),
         None, // capture_sink (D67) — off for this MCP model-driven test
         None, // audit_sink (R4) — off for this MCP model-driven test

--- a/crates/kx-model-harness/tests/model_loop_e2e.rs
+++ b/crates/kx-model-harness/tests/model_loop_e2e.rs
@@ -1,0 +1,399 @@
+//! PR-2 (F-4) — "the model drives the loop", deterministically (NO GGUF).
+//!
+//! A stub backend stands in for the model, returning a fixed completion for every
+//! dispatch. Drives the REAL orchestrator + the shipped materializer through
+//! [`kx_model_harness::run_model_loop`] to prove, without a model:
+//!
+//! - **the model computes the topology** — a stub `{"loop_proposal": …}` is decoded
+//!   (`decode_loop_proposal`), lowered through vetted recipes, committed as the
+//!   shaper's `result_ref` fact, materialized into children that execute;
+//! - **determinism / R49** — a cold re-fold over the committed journal re-derives
+//!   byte-identical child `MoteId`s (the model's choice is replayed, never
+//!   re-sampled — served from the fact, the materializer never calls the backend);
+//! - **fail-closed (PR-1)** — a malformed / over-budget / unknown-role proposal
+//!   dead-letters the shaper (terminal `Failed`) and the run completes with no
+//!   children, never a panic;
+//! - **`<think>`-stripping** — a Qwen3 reasoning preamble is stripped before decode.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kx_content::LocalFsContentStore;
+use kx_inference::{
+    InferenceBackend, InferenceError, InferenceInput, InferenceOutput, InferenceParams,
+};
+use kx_journal::SqliteJournal;
+use kx_model_harness::workflows;
+use kx_model_harness::{run_model_loop, LoopBudget};
+use kx_mote::{
+    EffectPattern, LogicRef, ModelId, MoteDef, NdClass, PromptTemplateHash, RoleId, ToolName,
+};
+use kx_planner::{InMemoryRoleRecipes, RoleRecipe, RoleRecipeResolver};
+use kx_projection::{
+    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
+    Projection,
+};
+use kx_runtime::{DemoWorkflow, Mode, RunOutcome, RuntimeConfig, RuntimeError};
+use kx_tool_registry::{InMemoryToolRegistry, ToolRegistry};
+use kx_warrant::{
+    ExecutorClass, FsScope, InMemoryRoleRegistry, ModelRoute, MoteClass, NetScope, ResourceCeiling,
+    Role, WarrantSpec,
+};
+
+const MODEL: &str = "stub-loop-model:test:0";
+const PLAN_PROMPT: &str = "Propose the next steps as a loop_proposal envelope.";
+const SHAPER_SEED: u8 = 0x71;
+
+fn model_id() -> ModelId {
+    ModelId(MODEL.into())
+}
+
+/// A stub backend returning a fixed `reply` for every dispatch, counting calls so
+/// a test can assert "served from the committed fact, never re-sampled".
+struct StubBackend {
+    reply: Vec<u8>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl InferenceBackend for StubBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(InferenceOutput {
+            bytes: self.reply.clone(),
+            output_tokens: 1,
+            backend_name: "stub",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(0),
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "stub"
+    }
+}
+
+/// A permissive WORLD-MUTATING warrant routed to [`model_id`] (so a ROND shaper +
+/// its PURE children are admissible; the model route authorises dispatch, D35).
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: model_id(),
+            max_input_tokens: 8192,
+            max_output_tokens: 1024,
+            max_calls: 64,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 1000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+/// The vetted role→recipe allowlist (PURE, no tools) the proposal lowers through.
+fn recipes() -> Arc<dyn RoleRecipeResolver> {
+    let r = InMemoryRoleRecipes::new();
+    for (i, name) in ["reader", "summarizer"].iter().enumerate() {
+        let tag = u8::try_from(i).unwrap();
+        r.register(
+            RoleId((*name).into()),
+            RoleRecipe {
+                logic_ref: LogicRef::from_bytes([0x90 + tag; 32]),
+                model_id: model_id(),
+                prompt_template_hash: PromptTemplateHash::from_bytes([0xA0 + tag; 32]),
+                tool_contract: BTreeMap::new(),
+                capability: ToolName("kx-model".into()),
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                inference_params: InferenceParams::default(),
+                deterministic_check: None,
+            },
+        );
+    }
+    Arc::new(r)
+}
+
+fn config_for(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+        audit_log: None,
+    }
+}
+
+fn loop_wf() -> DemoWorkflow {
+    workflows::loop_shaper(&model_id(), &warrant(), PLAN_PROMPT, SHAPER_SEED)
+}
+
+/// A well-formed two-child proposal naming the allowlisted roles.
+fn two_child_proposal() -> Vec<u8> {
+    br#"{"loop_proposal":{"version":1,"next_steps":[{"role":"reader","intent":"read"},{"role":"summarizer","intent":"sum"}]}}"#.to_vec()
+}
+
+struct Driven {
+    result: Result<RunOutcome, RuntimeError>,
+    calls: usize,
+    store: Arc<LocalFsContentStore>,
+    journal: Arc<SqliteJournal>,
+    workflow: DemoWorkflow,
+}
+
+fn drive(dir: &Path, reply: &[u8], budget: LoopBudget) -> Driven {
+    let config = config_for(dir);
+    let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+    let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+    let calls = Arc::new(AtomicUsize::new(0));
+    let backend = Arc::new(StubBackend {
+        reply: reply.to_vec(),
+        calls: calls.clone(),
+    });
+    let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+    let workflow = loop_wf();
+    let result = run_model_loop(
+        &config,
+        store.clone(),
+        journal.clone(),
+        backend,
+        registry,
+        recipes(),
+        &workflow,
+        budget,
+    );
+    Driven {
+        result,
+        calls: calls.load(Ordering::SeqCst),
+        store,
+        journal,
+        workflow,
+    }
+}
+
+/// Cold re-fold the committed journal through a fresh materializer (resolving the
+/// allowlisted roles) — the SHIPPED recovery path, which decodes the committed
+/// decision fact and NEVER calls a model.
+fn cold_fold(d: &Driven) -> Projection {
+    let shaper_def: MoteDef = d.workflow.motes[0].mote.def.clone();
+    let def_registry = InMemoryMoteDefRegistry::new();
+    def_registry.register(shaper_def);
+    let role_registry = InMemoryRoleRegistry::new();
+    for r in ["reader", "summarizer"] {
+        role_registry.register(
+            RoleId(r.into()),
+            Role {
+                name: r.into(),
+                version: 1,
+                spec: warrant(),
+                description: String::new(),
+            },
+        );
+    }
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        d.store.clone(),
+        Arc::new(def_registry),
+        Arc::new(role_registry),
+        InheritFromShaperResolver,
+    ));
+    Projection::from_journal_with_materializer(&*d.journal, materializer).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_drives_topology_children_materialize_and_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), &two_child_proposal(), LoopBudget::default());
+    let outcome = d.result.as_ref().expect("the run completes");
+
+    // shaper + 2 children, all committed.
+    assert_eq!(outcome.total, 3, "shaper + 2 materialized children");
+    assert_eq!(outcome.committed, 3, "all committed");
+
+    // R49: a cold re-fold reproduces the same committed set + the children's
+    // parent is the shaper — with NO backend (served from the committed fact).
+    let cold = cold_fold(&d);
+    assert_eq!(cold.committed_count(), 3);
+    let shaper_id = d.workflow.shaper_id;
+    assert_eq!(cold.state_of(&shaper_id), MoteState::Committed);
+    let children: Vec<_> = cold
+        .iter_motes()
+        .map(|(id, _)| id)
+        .filter(|id| *id != shaper_id)
+        .collect();
+    assert_eq!(children.len(), 2, "two children re-fold");
+    for c in &children {
+        assert_eq!(
+            cold.parents_of(c)[0].0,
+            shaper_id,
+            "each child's parent is the shaper"
+        );
+    }
+}
+
+#[test]
+fn cold_refold_is_identical_and_serves_the_committed_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), &two_child_proposal(), LoopBudget::default());
+    d.result.as_ref().expect("the run completes");
+
+    // The live run called the backend (the eager plan + the children's dispatch).
+    assert!(d.calls >= 1, "the model was consulted during the live run");
+
+    // Two cold re-folds reproduce byte-identical identities (R49) — the
+    // materializer decodes the committed decision fact, never re-running a model.
+    let a: Vec<_> = cold_fold(&d).iter_motes().map(|(id, _)| id).collect();
+    let b: Vec<_> = cold_fold(&d).iter_motes().map(|(id, _)| id).collect();
+    assert_eq!(
+        a, b,
+        "cold re-folds are identical (R49, served-not-resampled)"
+    );
+    assert_eq!(a.len(), 3);
+}
+
+#[test]
+fn think_preamble_is_stripped_before_decode() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut reply = b"<think>I will spawn a reader and a summarizer.</think>\n".to_vec();
+    reply.extend_from_slice(&two_child_proposal());
+    let d = drive(dir.path(), &reply, LoopBudget::default());
+    let outcome = d
+        .result
+        .as_ref()
+        .expect("the run completes after the think strip");
+    assert_eq!(
+        outcome.committed, 3,
+        "shaper + 2 children despite the preamble"
+    );
+}
+
+#[test]
+fn malformed_proposal_dead_letters_the_shaper() {
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(
+        dir.path(),
+        b"this is not a loop proposal",
+        LoopBudget::default(),
+    );
+    let outcome = d
+        .result
+        .as_ref()
+        .expect("a refused proposal is NOT a run error (PR-1)");
+
+    // No children materialize; the shaper is a terminal Failed fact; run completes.
+    assert_eq!(outcome.committed, 0, "nothing committed");
+    assert_eq!(outcome.total, 1, "only the (dead-lettered) shaper");
+    let cold = cold_fold(&d);
+    assert_eq!(
+        cold.state_of(&d.workflow.shaper_id),
+        MoteState::Failed,
+        "the shaper is dead-lettered, never blindly re-run"
+    );
+    assert_eq!(cold.committed_count(), 0);
+}
+
+#[test]
+fn unknown_role_dead_letters_the_shaper() {
+    let dir = tempfile::tempdir().unwrap();
+    // "ghost" is not in the recipe allowlist → lower fails closed (UnknownRecipe).
+    let reply =
+        br#"{"loop_proposal":{"version":1,"next_steps":[{"role":"ghost","intent":"haunt"}]}}"#;
+    let d = drive(dir.path(), reply, LoopBudget::default());
+    let outcome = d
+        .result
+        .as_ref()
+        .expect("a refused proposal completes the run");
+    assert_eq!(outcome.committed, 0);
+    assert_eq!(
+        cold_fold(&d).state_of(&d.workflow.shaper_id),
+        MoteState::Failed
+    );
+}
+
+#[test]
+fn fan_out_budget_dead_letters_an_over_cap_decision() {
+    let dir = tempfile::tempdir().unwrap();
+    // A 2-child proposal under a max_children = 1 budget → fail-closed dead-letter.
+    let budget = LoopBudget {
+        max_rounds: 4,
+        max_children: 1,
+    };
+    let d = drive(dir.path(), &two_child_proposal(), budget);
+    let outcome = d
+        .result
+        .as_ref()
+        .expect("an over-budget proposal completes the run");
+    assert_eq!(outcome.committed, 0, "the over-cap fan-out is refused");
+    assert_eq!(
+        cold_fold(&d).state_of(&d.workflow.shaper_id),
+        MoteState::Failed
+    );
+}
+
+#[test]
+fn round_budget_is_enforced_at_the_provider() {
+    // The cross-round budget is a provider concern (exercised across rounds by PR-3
+    // re-plan). Drive it directly: a `max_rounds = 2` provider honours 2 `decide`s
+    // then fails closed on the 3rd.
+    use kx_model_harness::ModelTopologyProvider;
+    use kx_projection::Projection as ColdProjection;
+    use kx_runtime::TopologyProvider;
+
+    let store = Arc::new(kx_content::InMemoryContentStore::new());
+    let backend = Arc::new(StubBackend {
+        reply: two_child_proposal(),
+        calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+    let provider = ModelTopologyProvider::new(
+        backend,
+        store,
+        registry,
+        recipes(),
+        LoopBudget {
+            max_rounds: 2,
+            max_children: 8,
+        },
+    );
+    let wf = loop_wf();
+    let shaper = &wf.motes[0].mote;
+    let snapshot = ColdProjection::new().snapshot();
+
+    assert!(
+        provider.decide(shaper, &warrant(), &snapshot).is_ok(),
+        "round 1"
+    );
+    assert!(
+        provider.decide(shaper, &warrant(), &snapshot).is_ok(),
+        "round 2"
+    );
+    assert!(
+        provider.decide(shaper, &warrant(), &snapshot).is_err(),
+        "round 3 exceeds max_rounds → fail-closed"
+    );
+}

--- a/crates/kx-model-harness/tests/model_loop_invariants.rs
+++ b/crates/kx-model-harness/tests/model_loop_invariants.rs
@@ -1,0 +1,187 @@
+//! PR-2 (F-4) — "the model drives the loop" with a REAL GGUF model (run with
+//! `--features with-model`, host + Metal). The live counterpart of
+//! `model_loop_e2e.rs`: a real model produces the `loop_proposal` envelope, which
+//! is decoded + lowered + committed as the shaper's `TopologyDecision` fact and
+//! materialized into children that execute.
+//!
+//! Hard invariants (hold for ANY model output — a cooperative model spawns
+//! children; a model that emits a malformed / un-grantable proposal dead-letters
+//! the shaper fail-closed, PR-1):
+//! - the run **completes** (never a panic / abort / hang);
+//! - the shaper reaches a **terminal** state (Committed with a decision, or Failed
+//!   dead-letter);
+//! - **R49** — two cold re-folds of the committed journal reproduce byte-identical
+//!   `MoteId`s (the model's decision is a captured fact, replayed, never
+//!   re-sampled; the materializer never calls the model).
+
+#![cfg(feature = "with-model")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use kx_journal::SqliteJournal;
+use kx_model_harness::evidence::Evidence;
+use kx_model_harness::{harness_warrant, model_id_for, workflows, Harness, LoopBudget};
+use kx_mote::{
+    EffectPattern, LogicRef, ModelId, MoteDef, NdClass, PromptTemplateHash, RoleId, ToolName,
+};
+use kx_planner::{InMemoryRoleRecipes, RoleRecipe, RoleRecipeResolver};
+use kx_projection::{
+    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
+    Projection,
+};
+use kx_runtime::config::Mode;
+use kx_runtime::RuntimeConfig;
+use kx_warrant::{InMemoryRoleRegistry, Role, WarrantSpec};
+
+/// Roles the planner is instructed to choose from (the recipe allowlist).
+const ROLES: [&str; 2] = ["reader", "writer"];
+const SHAPER_SEED: u8 = 0x73;
+
+const PLAN_PROMPT: &str = "You are a planning agent. Output ONLY one JSON object, \
+no prose, of EXACTLY this shape: \
+{\"loop_proposal\":{\"version\":1,\"next_steps\":[{\"role\":\"reader\",\"intent\":\"read the input\"},{\"role\":\"writer\",\"intent\":\"write a summary\"}]}}. \
+The only allowed role values are \"reader\" and \"writer\". Do not add any other fields.";
+
+fn gguf() -> std::path::PathBuf {
+    kx_model_harness::default_gguf_path()
+}
+
+fn config(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+        audit_log: None,
+    }
+}
+
+fn recipes(model_id: &ModelId) -> Arc<dyn RoleRecipeResolver> {
+    let r = InMemoryRoleRecipes::new();
+    for (i, name) in ROLES.iter().enumerate() {
+        let tag = u8::try_from(i).unwrap();
+        r.register(
+            RoleId((*name).into()),
+            RoleRecipe {
+                logic_ref: LogicRef::from_bytes([0x90 + tag; 32]),
+                model_id: model_id.clone(),
+                prompt_template_hash: PromptTemplateHash::from_bytes([0xA0 + tag; 32]),
+                tool_contract: BTreeMap::new(),
+                capability: ToolName("kx-model".into()),
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                inference_params: kx_mote::InferenceParams::default(),
+                deterministic_check: None,
+            },
+        );
+    }
+    Arc::new(r)
+}
+
+/// Cold re-fold the committed journal through a fresh materializer (resolving the
+/// allowlisted roles) — the shipped recovery path; decodes the committed decision
+/// fact, never calls a model.
+fn cold_fold(cfg: &RuntimeConfig, shaper_def: &MoteDef, warrant: &WarrantSpec) -> Projection {
+    let store = Arc::new(kx_content::LocalFsContentStore::open(&cfg.content_root).unwrap());
+    let journal = SqliteJournal::open(&cfg.journal_path).unwrap();
+    let def_registry = InMemoryMoteDefRegistry::new();
+    def_registry.register(shaper_def.clone());
+    let role_registry = InMemoryRoleRegistry::new();
+    for r in ROLES {
+        role_registry.register(
+            RoleId(r.into()),
+            Role {
+                name: r.into(),
+                version: 1,
+                spec: warrant.clone(),
+                description: String::new(),
+            },
+        );
+    }
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        store,
+        Arc::new(def_registry),
+        Arc::new(role_registry),
+        InheritFromShaperResolver,
+    ));
+    Projection::from_journal_with_materializer(&journal, materializer).unwrap()
+}
+
+#[test]
+fn a_real_model_drives_the_topology_loop() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = config(dir.path());
+    let model_id = model_id_for(&gguf()).unwrap();
+    // Generous output budget (the JSON envelope) + wall-clock for CPU/Metal decode.
+    let warrant = harness_warrant(&model_id, 256, 120_000);
+    let wf = workflows::loop_shaper(&model_id, &warrant, PLAN_PROMPT, SHAPER_SEED);
+    let shaper_def = wf.motes[0].mote.def.clone();
+    let shaper_id = wf.shaper_id;
+
+    let harness = Harness::open(&cfg, &gguf(), model_id).unwrap();
+    let outcome = harness
+        .drive_model_loop(&cfg, &wf, recipes(&harness.model_id), LoopBudget::default())
+        .expect("the model-driven loop completes (a refused proposal dead-letters, never aborts)");
+
+    // The shaper is terminal: it either committed a decision (children spawned) or
+    // was dead-lettered fail-closed. Never a hang.
+    let p1 = cold_fold(&cfg, &shaper_def, &warrant);
+    let shaper_state = p1.state_of(&shaper_id);
+    assert!(
+        matches!(shaper_state, MoteState::Committed | MoteState::Failed),
+        "the shaper is terminal after the model drove the decision: {shaper_state:?}"
+    );
+
+    // R49: a second cold re-fold reproduces byte-identical identities (the model's
+    // choice is a replayed fact, never re-sampled).
+    let p2 = cold_fold(&cfg, &shaper_def, &warrant);
+    let ids1: Vec<_> = p1.iter_motes().map(|(id, _)| id).collect();
+    let ids2: Vec<_> = p2.iter_motes().map(|(id, _)| id).collect();
+    assert_eq!(ids1, ids2, "R49: cold re-folds are identical");
+
+    // When the model cooperated, the children materialized under the shaper.
+    let children: Vec<_> = p1
+        .iter_motes()
+        .map(|(id, _)| id)
+        .filter(|id| *id != shaper_id)
+        .collect();
+    if shaper_state == MoteState::Committed {
+        assert!(!children.is_empty(), "a committed decision spawns ≥1 child");
+        for c in &children {
+            assert_eq!(
+                p1.parents_of(c)[0].0,
+                shaper_id,
+                "child parent = the shaper"
+            );
+        }
+    }
+
+    eprintln!(
+        "model-driven loop: shaper={shaper_state:?}, children={}, committed={}/{}",
+        children.len(),
+        outcome.committed,
+        outcome.total
+    );
+
+    if let Some(stamp) = std::env::var("KX_RUNSTAMP").ok() {
+        if let Ok(ev) = Evidence::open(
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target"),
+            &stamp,
+        ) {
+            let _ = ev.write_str(
+                "F4_model_loop",
+                "outcome.txt",
+                &format!(
+                    "shaper={shaper_state:?}\nchildren={}\ncommitted={}/{}\n",
+                    children.len(),
+                    outcome.committed,
+                    outcome.total
+                ),
+            );
+        }
+    }
+}

--- a/crates/kx-model-harness/tests/planner_e2e.rs
+++ b/crates/kx-model-harness/tests/planner_e2e.rs
@@ -229,6 +229,7 @@ fn drive(
         &executor,
         &protocol,
         None,
+        None, // topology_provider (PR-2) — static plan, not a model-driven loop
         Some(&sink),
         None,
         None, // audit_sink (R4)

--- a/crates/kx-planner/src/decode.rs
+++ b/crates/kx-planner/src/decode.rs
@@ -13,7 +13,8 @@
 use kx_warrant::WarrantSpec;
 
 use crate::error::PlanError;
-use crate::plan::{Envelope, Plan};
+use crate::lower::LoopProposal;
+use crate::plan::{Envelope, LoopEnvelope, Plan};
 
 /// Hard structural cap on declared steps — a `DoS` bound independent of the byte
 /// cap. A plan with more steps is refused before lowering touches the graph.
@@ -21,6 +22,14 @@ pub const MAX_PLAN_STEPS: usize = 256;
 
 /// Hard structural cap on declared edges (`DoS` bound).
 pub const MAX_PLAN_EDGES: usize = 1024;
+
+/// Hard structural cap on a single agentic-loop round's proposed steps — a `DoS`
+/// bound independent of the byte cap, and DISTINCT from the cross-run round
+/// budget (`kx_model_harness::LoopBudget::max_rounds`, enforced where the model
+/// runs). A round proposing more children than this is refused before lowering.
+/// Tighter than [`MAX_PLAN_STEPS`]: one re-plan round fans out far less than a
+/// full authored plan.
+pub const MAX_LOOP_STEPS: usize = 64;
 
 /// The per-plan byte cap, derived from the warrant's output ceiling
 /// (`max_output_tokens · 4` — the model produced the plan, so its output budget
@@ -113,4 +122,70 @@ pub fn decode_plan(bytes: &[u8], max_plan_bytes: usize) -> Result<Plan, PlanErro
     }
 
     Ok(plan)
+}
+
+/// Decode a model-proposed **agentic-loop round**, fail-closed.
+///
+/// Returns `Ok(LoopProposal)` only for a strict, size-bounded
+/// `{"loop_proposal": {"version": 1, "next_steps": [ … ]}}` envelope with
+/// `1..=MAX_LOOP_STEPS` steps. Returns `Err` for everything else — oversized
+/// bytes, non-JSON / non-object / truncated / trailing-garbage / unexpected-key
+/// payloads, an unknown version, an empty round, or an over-cap step count. A
+/// leading `<think>…</think>` block (Qwen3 reasoning) is stripped before the
+/// strict parse.
+///
+/// This is the loop counterpart of [`decode_plan`] and shares its exact
+/// untrusted-bytes discipline (IMP-5): size-check BEFORE parse (so a hostile
+/// model cannot force a large parse allocation), decode into fixed flat structs
+/// (never a dynamic `serde_json::Value`, so no float/NaN/unbounded-recursion
+/// path), and `deny_unknown_fields` on every struct (closing the "smuggle an
+/// extra field" vector — a `confidence` channel can never reach the runtime, D77).
+/// `max_bytes` is the warrant-derived output ceiling (`max_plan_bytes(warrant)`
+/// — the model produced the proposal, so its output budget bounds it).
+///
+/// Total + panic-free over arbitrary `bytes`.
+pub fn decode_loop_proposal(bytes: &[u8], max_bytes: usize) -> Result<LoopProposal, PlanError> {
+    // (1) Size cap BEFORE parse — on the ORIGINAL bytes, so the `<think>` strip
+    //     below can only ever shrink the parsed text.
+    if bytes.len() > max_bytes {
+        return Err(PlanError::Oversize {
+            got: bytes.len(),
+            max: max_bytes,
+        });
+    }
+
+    // (2) UTF-8 (a proposal is mandatory — no `Ok(None)` arm), strip a leading
+    //     Qwen3 `<think>…</think>` block, then parse strictly into fixed flat
+    //     structs. `deny_unknown_fields` makes any unexpected key a hard refusal.
+    let text = std::str::from_utf8(bytes).map_err(|_| PlanError::Malformed {
+        diagnostic: "model output was not valid UTF-8".to_string(),
+    })?;
+    let stripped = strip_reasoning_preamble(text);
+    let envelope: LoopEnvelope =
+        serde_json::from_str(stripped).map_err(|e| PlanError::Malformed {
+            diagnostic: e.to_string(),
+        })?;
+    let wire = envelope.loop_proposal;
+
+    // (3) Envelope invariants — fail closed on each. Reuse the closed PlanError
+    //     vocabulary (Oversize / Malformed / UnknownVersion / EmptyPlan /
+    //     TooManySteps): a loop round is a plan with no edges and a tighter cap.
+    if wire.version != 1 {
+        return Err(PlanError::UnknownVersion {
+            version: wire.version,
+        });
+    }
+    if wire.next_steps.is_empty() {
+        return Err(PlanError::EmptyPlan);
+    }
+    if wire.next_steps.len() > MAX_LOOP_STEPS {
+        return Err(PlanError::TooManySteps {
+            got: wire.next_steps.len(),
+            max: MAX_LOOP_STEPS,
+        });
+    }
+
+    Ok(LoopProposal {
+        next_steps: wire.next_steps,
+    })
 }

--- a/crates/kx-planner/src/lib.rs
+++ b/crates/kx-planner/src/lib.rs
@@ -63,7 +63,10 @@ mod lower;
 mod plan;
 mod role;
 
-pub use decode::{decode_plan, max_plan_bytes, MAX_PLAN_EDGES, MAX_PLAN_STEPS};
+pub use decode::{
+    decode_loop_proposal, decode_plan, max_plan_bytes, MAX_LOOP_STEPS, MAX_PLAN_EDGES,
+    MAX_PLAN_STEPS,
+};
 pub use error::PlanError;
 pub use lower::{
     compile_plan, lower_loop_to_topology_decision, lower_plan, seed_from_plan_bytes, LoopProposal,

--- a/crates/kx-planner/src/plan.rs
+++ b/crates/kx-planner/src/plan.rs
@@ -19,6 +19,34 @@ pub(crate) struct Envelope {
     pub plan: Plan,
 }
 
+/// The strict outer envelope for a model-proposed agentic-loop round:
+/// `{ "loop_proposal": { … } }`. `deny_unknown_fields` rejects any sibling key,
+/// so a payload that merely *contains* a proposal (or smuggles a sibling field)
+/// is refused — the same fail-closed boundary as [`Envelope`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LoopEnvelope {
+    pub loop_proposal: LoopProposalWire,
+}
+
+/// The wire form of a [`crate::LoopProposal`]: a versioned, strict list of the
+/// next round's steps. Decoded into the public `LoopProposal` (which carries no
+/// `version` — that is an envelope concern, validated then dropped) only after
+/// the envelope invariants pass. Reuses [`PlanStep`] verbatim — the same minimal
+/// trust surface (role name + intent, `deny_unknown_fields`, no score channel →
+/// D77 holds for free).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LoopProposalWire {
+    /// Envelope schema version. Only `1` is accepted; any other value is refused
+    /// as [`crate::PlanError::UnknownVersion`] (forward-compatible fail-closed,
+    /// mirroring [`Plan::version`]).
+    pub version: u32,
+    /// The next round's steps, in author/intent order. Each lowers to a
+    /// [`kx_mote::ChildDescriptor`] via [`crate::lower_loop_to_topology_decision`].
+    pub next_steps: Vec<PlanStep>,
+}
+
 /// A model-proposed plan: an ordered list of steps plus the dependency edges
 /// between them. Compiled (after role resolution) into a [`kx_workflow::WorkflowDef`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/kx-planner/src/tests.rs
+++ b/crates/kx-planner/src/tests.rs
@@ -18,8 +18,9 @@ use kx_warrant::{
 use proptest::prelude::*;
 
 use crate::{
-    compile_plan, decode_plan, lower_loop_to_topology_decision, lower_plan, seed_from_plan_bytes,
-    InMemoryRoleRecipes, LoopProposal, PlanError, PlanStep, PlanStepKind, RoleRecipe,
+    compile_plan, decode_loop_proposal, decode_plan, lower_loop_to_topology_decision, lower_plan,
+    seed_from_plan_bytes, InMemoryRoleRecipes, LoopProposal, PlanError, PlanStep, PlanStepKind,
+    RoleRecipe,
 };
 
 const SYSCALL: [u8; 32] = [7; 32];
@@ -283,6 +284,179 @@ proptest! {
         let mut s = String::from(r#"{"plan":{"version":1,"steps":"#);
         s.push_str(&"[".repeat(depth));
         let r = decode_plan(s.as_bytes(), 1 << 20);
+        prop_assert!(r.is_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// decode_loop_proposal (IMP-5) — the agentic-loop round trust boundary.
+// Mirrors the decode_plan suite: same fail-closed discipline, distinct envelope.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn well_formed_loop_proposal_decodes() {
+    let bytes = json(
+        r#"{"loop_proposal":{"version":1,"next_steps":[{"role":"reader","intent":"again"},{"role":"summarizer","intent":"again"}]}}"#,
+    );
+    let proposal = decode_loop_proposal(&bytes, 8192).expect("a valid proposal decodes");
+    assert_eq!(proposal.next_steps.len(), 2);
+    assert_eq!(proposal.next_steps[0].role, "reader");
+    assert_eq!(proposal.next_steps[0].kind, PlanStepKind::Plain);
+}
+
+#[test]
+fn think_preamble_then_loop_proposal_decodes() {
+    // Qwen3 thinking-mode: a reasoning block precedes the proposal JSON.
+    let bytes = json(
+        "<think>I should spawn a reader next.</think>\n{\"loop_proposal\":{\"version\":1,\"next_steps\":[{\"role\":\"reader\",\"intent\":\"again\"}]}}",
+    );
+    let proposal = decode_loop_proposal(&bytes, 8192).expect("a proposal after a think block");
+    assert_eq!(proposal.next_steps.len(), 1);
+}
+
+#[test]
+fn unclosed_think_loop_is_malformed() {
+    // An unterminated reasoning block strips to "" ⇒ a proposal is mandatory ⇒ Err.
+    assert!(matches!(
+        decode_loop_proposal(b"<think>reasoning with no closing tag", 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn oversize_loop_with_think_still_oversize_on_original_bytes() {
+    // The size cap is on the ORIGINAL bytes — a giant `<think>` block cannot
+    // sneak past the budget by being stripped before the length check.
+    let mut s = String::from("<think>");
+    s.push_str(&"x".repeat(10_240));
+    s.push_str("</think>{\"loop_proposal\":{\"version\":1,\"next_steps\":[{\"role\":\"r\",\"intent\":\"i\"}]}}");
+    assert!(matches!(
+        decode_loop_proposal(s.as_bytes(), 64),
+        Err(PlanError::Oversize { .. })
+    ));
+}
+
+#[test]
+fn oversize_loop_is_refused_before_parse() {
+    let big = vec![b'{'; 10_240];
+    assert!(matches!(
+        decode_loop_proposal(&big, 4),
+        Err(PlanError::Oversize {
+            got: 10_240,
+            max: 4
+        })
+    ));
+}
+
+#[test]
+fn malformed_loop_inputs_fail_closed() {
+    // truncated
+    assert!(matches!(
+        decode_loop_proposal(br#"{"loop_proposal":{"version":1,"next_steps":["#, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // not an object
+    assert!(matches!(
+        decode_loop_proposal(b"[]", 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // missing the `loop_proposal` envelope key (e.g. a bare plan smuggled in)
+    assert!(matches!(
+        decode_loop_proposal(br#"{"plan":{"version":1,"steps":[]}}"#, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // trailing garbage after a valid envelope
+    assert!(matches!(
+        decode_loop_proposal(
+            br#"{"loop_proposal":{"version":1,"next_steps":[{"role":"r","intent":"i"}]}} then prose"#,
+            8192
+        ),
+        Err(PlanError::Malformed { .. })
+    ));
+    // non-UTF-8
+    assert!(matches!(
+        decode_loop_proposal(&[0xff, 0xfe, 0x00], 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn unknown_field_in_loop_step_refused_no_confidence_channel_d77() {
+    // deny_unknown_fields on the reused PlanStep: a smuggled "confidence" on a
+    // proposed step is refused — a loop round offers NO score channel either.
+    let bytes = json(
+        r#"{"loop_proposal":{"version":1,"next_steps":[{"role":"reader","intent":"i","confidence":0.99}]}}"#,
+    );
+    assert!(matches!(
+        decode_loop_proposal(&bytes, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // a smuggled sibling on the envelope itself is equally refused
+    let bytes2 = json(
+        r#"{"loop_proposal":{"version":1,"next_steps":[{"role":"r","intent":"i"}]},"score":1.0}"#,
+    );
+    assert!(matches!(
+        decode_loop_proposal(&bytes2, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn unknown_version_empty_and_cap_refused_loop() {
+    assert!(matches!(
+        decode_loop_proposal(
+            br#"{"loop_proposal":{"version":2,"next_steps":[{"role":"r","intent":"i"}]}}"#,
+            8192
+        ),
+        Err(PlanError::UnknownVersion { version: 2 })
+    ));
+    assert!(matches!(
+        decode_loop_proposal(br#"{"loop_proposal":{"version":1,"next_steps":[]}}"#, 8192),
+        Err(PlanError::EmptyPlan)
+    ));
+    // > MAX_LOOP_STEPS steps.
+    let mut steps = String::new();
+    for _ in 0..=crate::MAX_LOOP_STEPS {
+        steps.push_str(r#"{"role":"r","intent":"i"},"#);
+    }
+    steps.pop(); // trailing comma
+    let bytes = json(&format!(
+        r#"{{"loop_proposal":{{"version":1,"next_steps":[{steps}]}}}}"#
+    ));
+    assert!(matches!(
+        decode_loop_proposal(&bytes, 1 << 20),
+        Err(PlanError::TooManySteps { .. })
+    ));
+}
+
+#[test]
+fn loop_proposal_decodes_then_lowers_to_topology_decision() {
+    // End-to-end of the pure path: model bytes → decode → lower → a content-
+    // addressed TopologyDecision (the exact fact a ROND shaper commits).
+    let (_roles, recipes) = standard_registries();
+    let bytes = json(
+        r#"{"loop_proposal":{"version":1,"next_steps":[{"role":"reader","intent":"again"},{"role":"summarizer","intent":"again"}]}}"#,
+    );
+    let proposal = decode_loop_proposal(&bytes, 8192).expect("decodes");
+    let td = lower_loop_to_topology_decision(&proposal, &recipes).expect("lowers");
+    assert_eq!(td.children.len(), 2);
+    assert_eq!(&td.children[0].role_id.0, "reader");
+    assert_eq!(td.hash(), td.hash()); // deterministic content address
+}
+
+proptest! {
+    /// decode_loop_proposal is total + panic-free over arbitrary bytes.
+    #[test]
+    fn decode_loop_proposal_never_panics_on_arbitrary_bytes(bytes: Vec<u8>) {
+        let _ = decode_loop_proposal(&bytes, 4096);
+    }
+
+    /// Deeply-nested input is a bounded `Err`, never a stack overflow.
+    #[test]
+    fn loop_deep_nesting_is_bounded_err(depth in 1usize..50_000) {
+        let mut s = String::from(r#"{"loop_proposal":{"version":1,"next_steps":"#);
+        s.push_str(&"[".repeat(depth));
+        let r = decode_loop_proposal(s.as_bytes(), 1 << 20);
         prop_assert!(r.is_err());
     }
 }

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -41,7 +41,7 @@ use crate::digest::{digest_projection, ProjectionDigest};
 use crate::error::RuntimeError;
 use crate::failure_policy::{classify_lifecycle_error, reason_for, FailureClass, FailurePolicy};
 use crate::snapshot_sink::SnapshotSink;
-use crate::topology;
+use crate::topology::{self, TopologyProvider};
 use crate::workflow::{DemoWorkflow, WorkflowMote};
 
 /// The result of driving the workflow to a stopping point.
@@ -194,6 +194,10 @@ pub fn run_with_capture(
         &executor,
         &protocol,
         Some((&shaper_wm, &topology_decision)),
+        // No model drives the demo's topology — the decision is the hardcoded
+        // `demo_topology_decision()`, supplied directly. `None` keeps arg-based
+        // child derivation (byte-identical truth path).
+        None,
         // The deterministic demo assembles no context: `None` ⇒ no snapshot is
         // ever published ⇒ the truth path (digest `a6b5c679…`) is byte-unchanged.
         None,
@@ -219,6 +223,17 @@ pub fn run_with_capture(
 /// `shaper` carries the topology shaper + its decision when the workflow has one
 /// (the canonical demo); pass `None` for a flat DAG (the harness's A–J workflows),
 /// in which case the topology materializer + child re-derivation are skipped.
+///
+/// `topology_provider` is the PR-2 (F-4) "model drives the loop" seam. When `Some`,
+/// the shaper's [`TopologyDecision`] was produced by a model (a
+/// [`TopologyProvider`], lowered + committed as the shaper's `result_ref`), so the
+/// engine derives the shaper's runnable children from that **committed fact**
+/// (decoding the `result_ref`) rather than the caller-supplied `shaper` decision —
+/// guaranteeing the runnable set equals the materializer-registered set (one source
+/// of truth). When `None` (the canonical demo + every existing caller), children are
+/// derived from the supplied decision exactly as before — the deterministic truth
+/// path (digest `a6b5c679…`) is byte-unchanged. (The provider is invoked eagerly by
+/// the harness in PR-2; PR-3 re-plan will invoke it lazily per round — same seam.)
 ///
 /// `snapshot_sink` is the D78 context-publishing seam: when `Some`, the
 /// orchestrator publishes the current committed-state [`kx_projection::Snapshot`]
@@ -257,6 +272,7 @@ pub fn run_with_seams<S, E, CP>(
     executor: &E,
     protocol: &CP,
     shaper: Option<(&WorkflowMote, &TopologyDecision)>,
+    topology_provider: Option<&dyn TopologyProvider>,
     snapshot_sink: Option<&SnapshotSink>,
     capture_sink: Option<&CaptureSink>,
     audit_sink: Option<&RuntimeAuditSink>,
@@ -293,8 +309,16 @@ where
     let recovery_start = Instant::now();
     let (mut projection, recovery_outcome) = if let Some((shaper_wm, _)) = shaper {
         store.put(&topology::encode_warrant(&shaper_wm.warrant)?)?;
-        let materializer =
-            topology::build_materializer(store.clone(), &shaper_wm.mote.def, &shaper_wm.warrant);
+        // PR-2 (F-4): a model-driven loop supplies its own materializer (resolving
+        // the model's proposed roles); the demo uses the hardcoded `demo-worker`
+        // registry. Both read `store` (the provider's materializer is contracted to
+        // use the run's store). `None` ⇒ byte-identical demo path.
+        let materializer = match topology_provider {
+            Some(provider) => provider.materializer(&shaper_wm.mote.def, &shaper_wm.warrant),
+            None => {
+                topology::build_materializer(store.clone(), &shaper_wm.mote.def, &shaper_wm.warrant)
+            }
+        };
         Projection::from_journal_with_checkpoint_with_materializer_reported(
             &*journal,
             materializer,
@@ -363,14 +387,29 @@ where
         // the children remain break first, orphaning the shaper's decision.
         if !children_derived {
             if let Some((shaper_wm, topology_decision)) = shaper {
-                children_derived = derive_shaper_children(
-                    workflow,
-                    shaper_wm,
-                    topology_decision,
-                    &projection,
-                    &mut runnable,
-                    &mut child_ids,
-                );
+                // PR-2 (F-4): a model-driven shaper derives children from the
+                // COMMITTED decision fact (`topology_provider` is `Some`); the demo
+                // + every existing caller (`None`) derive from the supplied decision,
+                // byte-for-byte as before — the digest `a6b5c679…` path is untouched.
+                children_derived = if topology_provider.is_some() {
+                    derive_shaper_children_from_fact(
+                        workflow,
+                        shaper_wm,
+                        &projection,
+                        &*store,
+                        &mut runnable,
+                        &mut child_ids,
+                    )?
+                } else {
+                    derive_shaper_children(
+                        workflow,
+                        shaper_wm,
+                        topology_decision,
+                        &projection,
+                        &mut runnable,
+                        &mut child_ids,
+                    )
+                };
                 // R4: the committed shaper just materialized its children into the
                 // runnable set. Echo the shaper id + child count off the truth path.
                 if children_derived {
@@ -810,6 +849,56 @@ fn derive_shaper_children(
     child_ids.extend(children.iter().map(|c| c.mote.id));
     runnable.extend(children);
     true
+}
+
+/// Like [`derive_shaper_children`], but the [`TopologyDecision`] comes from the
+/// shaper's **committed `result_ref`** (the model's lowered decision, decoded from
+/// the content store) rather than a caller-supplied value. This is the PR-2 (F-4)
+/// fact-driven path, selected when a [`topology::TopologyProvider`] produced the
+/// topology: the engine trusts the journal fact, so its runnable children are
+/// provably the SAME set the `DefaultTopologyMaterializer` registered (both decode
+/// one committed payload — a single source of truth; no pre-staged-arg vs fact
+/// divergence). Pure over the committed entry, so a fresh recovery re-derives the
+/// same children (R49 — replay the model's decision, never re-decide).
+///
+/// `Ok(false)` while the shaper is uncommitted; `Ok(true)` once children derive;
+/// `Err` only if the committed payload is missing or not a decodable
+/// `TopologyDecision` — corruption, since the model-proposal decode boundary
+/// (`kx_planner::decode_loop_proposal`) ran BEFORE the decision was committed.
+fn derive_shaper_children_from_fact<S>(
+    workflow: &DemoWorkflow,
+    shaper_wm: &WorkflowMote,
+    projection: &Projection,
+    store: &S,
+    runnable: &mut Vec<WorkflowMote>,
+    child_ids: &mut Vec<MoteId>,
+) -> Result<bool, RuntimeError>
+where
+    S: ContentStore + ?Sized,
+{
+    if projection.state_of(&workflow.shaper_id) != MoteState::Committed {
+        return Ok(false);
+    }
+    let Some(shaper_result_ref) = projection.result_ref_of(&workflow.shaper_id) else {
+        return Ok(false);
+    };
+    let payload = store.get(&shaper_result_ref).map_err(|_| {
+        RuntimeError::Decode(format!(
+            "shaper {:?} committed result_ref {shaper_result_ref:?} has no payload",
+            workflow.shaper_id
+        ))
+    })?;
+    let decision = topology::decode_topology_decision(&payload)?;
+    let children = topology::derive_child_motes(
+        &shaper_wm.mote,
+        shaper_result_ref,
+        &decision,
+        &shaper_wm.warrant,
+        &shaper_wm.capability,
+    );
+    child_ids.extend(children.iter().map(|c| c.mote.id));
+    runnable.extend(children);
+    Ok(true)
 }
 
 fn pick_next(
@@ -1331,6 +1420,7 @@ mod failure_tests {
             &executor,
             &protocol,
             None, // shaper — flat DAG
+            None, // topology_provider — no model-driven topology
             None, // snapshot_sink
             None, // capture_sink
             None, // audit_sink

--- a/crates/kx-runtime/src/error.rs
+++ b/crates/kx-runtime/src/error.rs
@@ -38,6 +38,15 @@ pub enum RuntimeError {
     #[error("canonical encode: {0}")]
     Encode(String),
 
+    /// Canonical-bincode decoding of a committed shaper `result_ref` back into a
+    /// `TopologyDecision` failed (the engine's fact-driven child derivation,
+    /// PR-2). Reachable only on a corrupt / non-decision payload at a shaper's
+    /// committed `result_ref`; the model-proposal decode boundary
+    /// (`kx_planner::decode_loop_proposal`) runs BEFORE commit, so a well-formed
+    /// run never reaches this — it is surfaced (not `expect`-ed) as corruption.
+    #[error("canonical decode: {0}")]
+    Decode(String),
+
     /// CLI / config error (bad argument, missing path).
     #[error("config: {0}")]
     Config(String),

--- a/crates/kx-runtime/src/lib.rs
+++ b/crates/kx-runtime/src/lib.rs
@@ -85,4 +85,5 @@ pub use failure_policy::FailurePolicy;
 pub use kx_audit::{AuditEvent, AuditSink, DispatchKind, InMemoryAuditSink, JsonlAuditSink};
 pub use migrate::migrate_and_verify;
 pub use snapshot_sink::SnapshotSink;
+pub use topology::{decode_topology_decision, TopologyProvider, TopologyProviderError};
 pub use workflow::DemoWorkflow;

--- a/crates/kx-runtime/src/topology.rs
+++ b/crates/kx-runtime/src/topology.rs
@@ -18,13 +18,89 @@ use kx_mote::{
 };
 use kx_projection::{
     ChildResolver, DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver,
-    TopologyMaterializer,
+    Snapshot, TopologyMaterializer,
 };
 use kx_warrant::{InMemoryRoleRegistry, Role, WarrantSpec};
 use smallvec::SmallVec;
+use thiserror::Error;
 
 use crate::error::RuntimeError;
 use crate::workflow::WorkflowMote;
+
+/// The PR-2 (F-4) seam: a **model** computes a topology shaper's
+/// [`TopologyDecision`] at dispatch time, replacing the hardcoded
+/// [`demo_topology_decision`]. This is "the model drives the loop": the shaper's
+/// committed `result_ref` is the *model's* lowered decision, a captured fact the
+/// projection materializer re-derives children from on every fold (incl. replay).
+///
+/// Object-safe (`&dyn TopologyProvider`) and `Send + Sync` so the engine can hold
+/// `Option<&dyn TopologyProvider>`. It carries **no** model/inference type — the
+/// concrete provider lives in `kx-model-harness` (the dependency arrow points
+/// down; `kx-runtime` never depends on the harness/inference). It receives only
+/// what the engine already holds at the shaper-dispatch point: the shaper `Mote`,
+/// its `WarrantSpec`, and the current committed-state [`Snapshot`].
+///
+/// SN-8: the provider **proposes** (the model output is untrusted — the concrete
+/// impl decodes it fail-closed and lowers role names through *vetted recipes*);
+/// the **runtime decides** authority — each materialized child's warrant is
+/// `intersect(shaper.warrant, role)` (narrowing-only) downstream. A fail-closed
+/// provider (malformed / oversized / un-grantable proposal, or an exhausted
+/// budget) returns [`TopologyProviderError`]; the caller dead-letters the shaper
+/// (composing with the PR-1 failure policy), never panics, never re-runs it.
+///
+/// PR-2 invokes this **eagerly** in the harness (the single parentless shaper is
+/// computed once, before the run, then served as the shaper's effect). PR-3
+/// (re-plan) will have the engine invoke it **lazily** per round against the live
+/// snapshot — the same seam, no signature change.
+pub trait TopologyProvider: Send + Sync {
+    /// Compute this shaper's [`TopologyDecision`] from the model's proposal,
+    /// assembled against `snapshot`. The caller encodes the returned decision
+    /// (canonical bincode) and commits it as the shaper's `result_ref`, so a cold
+    /// re-fold re-materializes byte-identical children (R49). Returns
+    /// [`TopologyProviderError`] for any fail-closed refusal.
+    fn decide(
+        &self,
+        shaper: &Mote,
+        shaper_warrant: &WarrantSpec,
+        snapshot: &Snapshot,
+    ) -> Result<TopologyDecision, TopologyProviderError>;
+
+    /// Build the topology materializer the runtime folds through while THIS
+    /// provider drives the loop. The demo's [`build_materializer`] only resolves
+    /// the `demo-worker` role; a model-driven decision proposes arbitrary roles,
+    /// so the provider supplies a materializer whose role registry resolves every
+    /// role its [`decide`](Self::decide) can emit (still `intersect(shaper.warrant,
+    /// role)`-narrowing — SN-8). The runtime calls this once, at projection build,
+    /// in place of `build_materializer` whenever a provider is present; the
+    /// returned materializer MUST read the SAME content store the run commits to
+    /// (so the committed decision + warrant bytes resolve).
+    fn materializer(
+        &self,
+        shaper_def: &MoteDef,
+        shaper_warrant: &WarrantSpec,
+    ) -> Box<dyn TopologyMaterializer>;
+}
+
+/// Why a [`TopologyProvider`] could not produce a decision. Opaque to the engine
+/// (a `String` payload keeps `kx-runtime` free of a `kx-planner`/inference dep —
+/// the harness formats its `PlanError` / backend error into it). The caller
+/// dead-letters the shaper on this; it is never a panic and never a silent skip.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("topology provider could not produce a decision: {0}")]
+pub struct TopologyProviderError(pub String);
+
+/// Decode the canonical-bincode bytes a topology shaper committed as its
+/// `result_ref` back into a [`TopologyDecision`] — the exact inverse of
+/// [`encode_topology_decision`], and the identical decode the
+/// `DefaultTopologyMaterializer` performs. Used by the engine's fact-driven child
+/// derivation so its runnable children are provably the SAME set the materializer
+/// registers (both decode one committed fact — a single source of truth).
+pub fn decode_topology_decision(bytes: &[u8]) -> Result<TopologyDecision, RuntimeError> {
+    let (td, _) =
+        bincode::serde::decode_from_slice::<TopologyDecision, _>(bytes, canonical_config())
+            .map_err(|e| RuntimeError::Decode(format!("topology decision: {e}")))?;
+    Ok(td)
+}
 
 /// The `RoleId` every demo worker child takes.
 pub const DEMO_WORKER_ROLE: &str = "demo-worker";


### PR DESCRIPTION
## PR-2 — The model drives the loop (F-4 AL1 + F-7), Foundation scope

The next step on the **agentic-loop track** (PR-1 failsafe `#146` opened it). The
13-agent readiness verdict: *the failsafe spine is strong; the agent LOOP on top is
the gap* — dynamic spawning was **built-but-unwired** (`demo_topology_decision()`
hardcoded; **no model computes the `TopologyDecision`**). This closes that gap.

The **model now computes the `TopologyDecision`** (the next-step fan-out), end-to-end
through the proven `run_with_seams` + `kx-model-harness` path, behind an
`Option<&dyn TopologyProvider>` seam:

> model completion → `decode_loop_proposal` (fail-closed) → `lower_loop_to_topology_decision`
> (vetted recipes) → committed as the shaper's `result_ref` **fact** →
> `DefaultTopologyMaterializer` spawns children → **cold re-fold reproduces identical
> `MoteId`s (R49)** — the model's choice is replayed, never re-sampled.

**Scope decision (user-confirmed): Foundation.** The live `kx serve` gateway wiring
(coordinator materialization + scheduler routing + snapshot plumbing + planner recipe)
is a separate PR (**PR-2b**) because it touches the sole-writer recovery path.

### What changed
- **`kx-planner` (pure):** `decode_loop_proposal` + `MAX_LOOP_STEPS` — mirrors
  `decode_plan` exactly (size-cap-before-parse, `<think>`-strip, `deny_unknown_fields`,
  versioned envelope, reuses the closed `PlanError`). **No new deps** (D111 ban intact).
- **`kx-runtime`:** object-safe `TopologyProvider` trait (`decide` + `materializer`) +
  `TopologyProviderError` + `decode_topology_decision`; `run_with_seams` gains an
  `Option<&dyn TopologyProvider>`. When present, the engine derives shaper children from
  the **committed fact** (engine-runnable == materializer-registered == one source of
  truth), and the provider supplies the materializer resolving the model's roles.
  Default `None` ⇒ **byte-identical demo path**.
- **`kx-model-harness`:** `ModelTopologyProvider` (the D111 model-runs-once home) +
  `LoopBudget` (`max_rounds` / `max_children`) + `run_model_loop` +
  `Harness::drive_model_loop` + `workflows::loop_shaper`. A refused proposal
  **dead-letters** the shaper (terminal `Failed`) and the run completes past it
  (composes with PR-1).

### Load-bearing invariants ✅
- **Frozen trio** (`kx-executor` / `kx-scheduler` / `kx-inference`) `src` **byte-empty diff**.
- **Digest `a6b5c679…` invariant** (`a0_guard`) — the new seam defaults to `None`.
- **D111** `kx-planner` dependency-ban intact (no new deps; `Cargo.lock` unchanged).
- **SN-8** — the model proposes role *names*; identity axes from vetted recipes; per-child
  warrant `intersect(shaper.warrant, role)` narrowing-only.
- **Bounded additive** — three layered bounds (byte cap / structural `MAX_LOOP_STEPS` /
  run-policy `max_rounds`+`max_children`); unbounded durable-loop stays cloud (D126 cat-B).

### Tests (deep)
- `kx-planner`: `decode_loop_proposal` unit + property suite (total/panic-free;
  `confidence`-smuggle refused = D77; oversize-before-parse; `<think>`; caps).
- **`model_loop_e2e.rs`** (deterministic, no-GGUF, **7/7**): model-drives-topology
  (3/3 committed); R49 cold-refold + serve-not-resample; fail-closed dead-letters
  (malformed / unknown-role / over-budget); `<think>`-strip; provider round budget.
- **`model_loop_invariants.rs`** (`with-model`, host-Metal): real-model integration +
  fail-closed + R49 — **validated on Metal** (qwen3-0.6b → fail-closed dead-letter +
  R49; a capable campaign model also exercises the happy path).
- `cargo test --workspace` **1803/0**; clippy `-D warnings`, fmt, doc `-D warnings` clean;
  cargo-deny ok.

### Golden Rule 8 — two passes
**(A) Defensive.** *Breaks:* decision-source ambiguity mitigated by deriving children
from the committed fact (R49); interface drift = one `None` arg at every existing caller
(a0_guard/planner_e2e/failure_tests net); round counter in-memory (crash re-folds the
committed prefix; only gates fresh rounds). *Degrades:* **no new clones on the demo path**
(`None` ⇒ no snapshot publish); materializer keeps its O(1) non-shaper fast-path; the
per-dispatch snapshot clone (model path only, pre-existing) flagged as a scalability
watch-item. *Security (model output untrusted):* `decode_loop_proposal` is the trust
boundary (size-cap, `deny_unknown_fields`, fixed flat structs, `<think>`-strip); three
budget layers bound fan-out/DoS; SN-8 + D77 hold; assembled context is model-input-only
(never identity/journal, D64).

**(B) Forward.** A stochastic model choice becomes a **replayable durable fact** — the
runtime's "re-read what it did, never re-run it" guarantee now covers model-driven
topology. The seam is the shared on-ramp to PR-3 re-plan + the cloud unbounded loop.
*Flagged (not silently done):* copy-on-write `Snapshot` if loop fan-out grows;
unify `decode_plan`/`decode_loop_proposal` only if a third proposal type appears;
per-child intent threading (needs a `ChildDescriptor` core-type change → its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
