### PR TITLE
PR-3 — re-plan-on-failure (AL2 + 3-way router)

### DIFF
--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -66,7 +66,10 @@ pub use broker::{BrokerObserver, ModelBroker};
 pub use executor::ModelExecutor;
 pub use metered::MeteredBackend;
 pub use registration::{register_kortecx, RegistrationError};
-pub use topology_provider::{run_model_loop, LoopBudget, ModelTopologyProvider};
+pub use topology_provider::{
+    run_model_loop, run_replan_loop, LoopBudget, ModelTopologyProvider, ReplanLoopOutcome,
+    ReplanOutcome,
+};
 
 /// The exact quantization of the pinned campaign model, folded into the
 /// [`ModelId`] so a different quant yields a different identity.
@@ -370,6 +373,33 @@ impl Harness {
     ) -> Result<RunOutcome, RuntimeError> {
         let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
         crate::run_model_loop(
+            config,
+            self.store.clone(),
+            self.journal.clone(),
+            self.backend.clone(),
+            registry,
+            recipes,
+            workflow,
+            budget,
+        )
+    }
+
+    /// PR-3 (AL2) — drive a **bounded model-driven re-plan-on-failure loop**. The
+    /// initial plan runs; if a step dead-letters, the model sees WHY (the read-side
+    /// [`kx_projection::Snapshot::failure_reason_of`]) and proposes a correction or
+    /// escalates — bounded by `budget`, every round a replayable committed fact (R49).
+    ///
+    /// `workflow` is a round-0 [`workflows::loop_shaper`]; the corrective rounds use
+    /// [`workflows::replan_shaper`] internally. See [`run_replan_loop`].
+    pub fn drive_replan_loop(
+        &self,
+        config: &RuntimeConfig,
+        workflow: &DemoWorkflow,
+        recipes: Arc<dyn kx_planner::RoleRecipeResolver>,
+        budget: crate::LoopBudget,
+    ) -> Result<ReplanLoopOutcome, RuntimeError> {
+        let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+        crate::run_replan_loop(
             config,
             self.store.clone(),
             self.journal.clone(),

--- a/crates/kx-model-harness/src/topology_provider.rs
+++ b/crates/kx-model-harness/src/topology_provider.rs
@@ -38,6 +38,7 @@
 //! decision). The unbounded durable-loop topology stays cloud (D126 cat-B).
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,11 +49,12 @@ use kx_inference::{inference_params_from_mote, InferenceBackend};
 use kx_journal::{FailureReason, Journal, JournalEntry, SqliteJournal};
 use kx_mote::{Mote, MoteDef, MoteId, RoleId, TopologyDecision};
 use kx_planner::{
-    decode_loop_proposal, lower_loop_to_topology_decision, max_plan_bytes, RoleRecipeResolver,
+    decode_loop_proposal, decode_replan_proposal, lower_loop_to_topology_decision, max_plan_bytes,
+    ReplanProposal, RoleRecipeResolver,
 };
 use kx_projection::{
-    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, Projection,
-    Snapshot, TopologyMaterializer,
+    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
+    Projection, Snapshot, TopologyMaterializer,
 };
 use kx_runtime::broker::DemoBroker;
 use kx_runtime::topology::encode_topology_decision;
@@ -133,6 +135,13 @@ pub struct ModelTopologyProvider<B: InferenceBackend, S: ContentStore> {
     /// prefix and the counter restarts harmlessly; it only ever *limits* fresh
     /// rounds, never affects a committed shaper's already-materialized children).
     round: AtomicU32,
+    /// **PR-3 (AL2).** A SHARED, accumulating shaper-def registry. PR-2 has one
+    /// shaper per run; a re-plan loop ([`run_replan_loop`]) chains MANY (one per
+    /// round). Each round's [`Self::materializer`] registers its shaper def here
+    /// (idempotent), so a SINGLE materializer folding the journal re-derives EVERY
+    /// committed round's children (the def is looked up by `def_hash`). With one
+    /// shaper (PR-2) the registry holds exactly that def — byte-identical behavior.
+    def_registry: Arc<InMemoryMoteDefRegistry>,
 }
 
 impl<B: InferenceBackend, S: ContentStore> std::fmt::Debug for ModelTopologyProvider<B, S> {
@@ -162,24 +171,23 @@ impl<B: InferenceBackend, S: ContentStore> ModelTopologyProvider<B, S> {
             recipes,
             budget,
             round: AtomicU32::new(0),
+            def_registry: Arc::new(InMemoryMoteDefRegistry::new()),
         }
     }
-}
 
-impl<B, S> TopologyProvider for ModelTopologyProvider<B, S>
-where
-    B: InferenceBackend,
-    S: ContentStore + Send + Sync + 'static,
-{
-    fn decide(
+    /// **PR-3 (AL2).** Assemble this shaper's context (D78) and run the model ONCE,
+    /// returning the raw completion bytes. Shared by [`TopologyProvider::decide`]
+    /// (the initial round) and [`Self::replan`] (a re-plan round) so there is ONE
+    /// model-runs-once boundary; the two differ only in how they DECODE the bytes.
+    /// Enforces the cross-round budget first (fail-closed once exhausted).
+    fn run_model_once(
         &self,
         shaper: &Mote,
         shaper_warrant: &WarrantSpec,
         snapshot: &Snapshot,
-    ) -> Result<TopologyDecision, TopologyProviderError> {
-        // (0) Round budget — fail-closed once exhausted (the run dead-letters the
-        //     shaper; bounded additive). `fetch_add` returns the pre-increment
-        //     count, so `max_rounds` rounds (0..max_rounds) are honoured.
+    ) -> Result<Vec<u8>, TopologyProviderError> {
+        // (0) Round budget — fail-closed once exhausted. `fetch_add` returns the
+        //     pre-increment count, so rounds `0..max_rounds` are honoured.
         let round = self.round.fetch_add(1, Ordering::SeqCst);
         if round >= self.budget.max_rounds {
             return Err(TopologyProviderError(format!(
@@ -188,10 +196,8 @@ where
             )));
         }
 
-        // (1) Assemble the shaper's context (D78) + ChatML-wrap the planning
-        //     instruction. Reuses the executor's exact wiring (assemble against
-        //     the snapshot; a parentless shaper yields an empty context, so the
-        //     input is `chatml(instruction)` — byte-identical to the leaf path).
+        // (1) Assemble the shaper's (corrected) instruction + upstream context (D78),
+        //     reusing the executor's exact wiring.
         let instruction = prompt::raw_prompt(shaper).ok_or_else(|| {
             TopologyProviderError("topology shaper carries no planning prompt".to_string())
         })?;
@@ -215,11 +221,79 @@ where
             .backend
             .dispatch(&shaper.def.model_id, &input, &params, shaper_warrant)
             .map_err(|e| TopologyProviderError(format!("model dispatch: {e}")))?;
+        Ok(out.bytes)
+    }
+
+    /// **PR-3 (AL2).** A model-driven RE-PLAN round: run the model once against the
+    /// live snapshot (which now carries the prior round's failure — the shaper's
+    /// instruction is the failure-corrected prompt the driver built), decode the
+    /// 3-way `{"replan": …}` envelope FAIL-CLOSED ([`decode_replan_proposal`]), and
+    /// either lower a corrective fan-out through vetted recipes
+    /// ([`ReplanOutcome::Topology`]) or surface an escalation
+    /// ([`ReplanOutcome::FlagHuman`]). SN-8: a permission-adapt proposes a role; the
+    /// runtime narrows authority downstream (`intersect`), never widens.
+    ///
+    /// # Errors
+    /// [`TopologyProviderError`] for an exhausted budget / malformed-or-over-budget
+    /// proposal / unknown role — the caller dead-letters the shaper (PR-1 discipline).
+    pub fn replan(
+        &self,
+        shaper: &Mote,
+        shaper_warrant: &WarrantSpec,
+        snapshot: &Snapshot,
+    ) -> Result<ReplanOutcome, TopologyProviderError> {
+        let bytes = self.run_model_once(shaper, shaper_warrant, snapshot)?;
+        match decode_replan_proposal(&bytes, max_plan_bytes(shaper_warrant))
+            .map_err(|e| TopologyProviderError(format!("decode replan proposal: {e}")))?
+        {
+            ReplanProposal::Topology(proposal) => {
+                if proposal.next_steps.len() > self.budget.max_children {
+                    return Err(TopologyProviderError(format!(
+                        "replan proposes {} children, exceeding max_children {}",
+                        proposal.next_steps.len(),
+                        self.budget.max_children
+                    )));
+                }
+                let td = lower_loop_to_topology_decision(&proposal, &*self.recipes)
+                    .map_err(|e| TopologyProviderError(format!("lower: {e}")))?;
+                Ok(ReplanOutcome::Topology(td))
+            }
+            ReplanProposal::FlagHuman(reason) => Ok(ReplanOutcome::FlagHuman(reason)),
+        }
+    }
+}
+
+/// **PR-3 (AL2).** The lowered form of a re-plan round's 3-way decision (the
+/// runtime-side counterpart of [`kx_planner::ReplanProposal`]). `Topology` is a
+/// vetted-recipe-lowered corrective fan-out (corrected-context / permission-adapt,
+/// both narrowing-only); `FlagHuman` is a clean terminal escalation (the failed
+/// step stays a durable dead-lettered fact; the active HITL handshake is a later PR).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplanOutcome {
+    /// Spawn this corrective topology next (the re-plan continues).
+    Topology(TopologyDecision),
+    /// Escalate to a human — stop the loop, leave the failure dead-lettered.
+    FlagHuman(String),
+}
+
+impl<B, S> TopologyProvider for ModelTopologyProvider<B, S>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    fn decide(
+        &self,
+        shaper: &Mote,
+        shaper_warrant: &WarrantSpec,
+        snapshot: &Snapshot,
+    ) -> Result<TopologyDecision, TopologyProviderError> {
+        // (0-2) Budget + assemble + run the model ONCE (shared with `replan`).
+        let bytes = self.run_model_once(shaper, shaper_warrant, snapshot)?;
 
         // (3) Decode the proposal FAIL-CLOSED (the untrusted-bytes trust boundary:
         //     size-cap-before-parse, `deny_unknown_fields`, `<think>`-strip,
         //     versioned). The byte cap is the warrant's output ceiling.
-        let proposal = decode_loop_proposal(&out.bytes, max_plan_bytes(shaper_warrant))
+        let proposal = decode_loop_proposal(&bytes, max_plan_bytes(shaper_warrant))
             .map_err(|e| TopologyProviderError(format!("decode loop proposal: {e}")))?;
 
         // (4) Run-policy fan-out cap (after decode's structural cap).
@@ -243,15 +317,19 @@ where
         shaper_def: &MoteDef,
         shaper_warrant: &WarrantSpec,
     ) -> Box<dyn TopologyMaterializer> {
-        // Resolve the model's proposed roles (the recipe allowlist already gated
-        // them at `lower`) and narrow each child trivially against the shaper's
-        // own warrant. Reuses the SHARED store (the run's), so the committed
-        // decision + warrant bytes the fold reads are the ones the run wrote.
-        let def_registry = InMemoryMoteDefRegistry::new();
-        def_registry.register(shaper_def.clone());
+        // PR-3: register THIS round's shaper def into the SHARED accumulating
+        // registry (idempotent), then build a materializer over it — so a single
+        // fold of the journal re-derives EVERY committed round's children (lookup
+        // by `def_hash`). With one shaper (PR-2) the registry holds exactly this
+        // def — byte-identical to the prior fresh-registry behavior. Reuses the
+        // SHARED store (the run's), so the committed decision + warrant bytes the
+        // fold reads are the ones the run wrote. All rounds share the caller's
+        // warrant, so a single `InheritShaperWarrantRoles` narrows every shaper's
+        // children trivially (`intersect(shaper.warrant, role.spec=shaper.warrant)`).
+        self.def_registry.register(shaper_def.clone());
         Box::new(DefaultTopologyMaterializer::new(
             self.store.clone(),
-            Arc::new(def_registry),
+            self.def_registry.clone(),
             Arc::new(InheritShaperWarrantRoles {
                 shaper_warrant: shaper_warrant.clone(),
             }),
@@ -442,4 +520,419 @@ where
         None,
         Some(failure_policy),
     )
+}
+
+// ===========================================================================
+// PR-3 (AL2) — the bounded re-plan-on-failure loop.
+// ===========================================================================
+
+/// The outcome of a bounded re-plan loop ([`run_replan_loop`]).
+#[derive(Debug, Clone)]
+pub struct ReplanLoopOutcome {
+    /// The final round's [`RunOutcome`]. Its `digest` is the WHOLE-journal replay
+    /// surface (every committed Mote across every round), so a different process
+    /// cold-folding the journal reproduces it (R49).
+    pub run: RunOutcome,
+    /// How many shaper rounds were driven. `1` ⇒ the initial plan needed no
+    /// correction; `n` ⇒ `n-1` re-plan rounds followed the first failure.
+    pub rounds_used: u32,
+    /// `Some(reason)` iff the model chose flag-a-human: the loop stopped and the
+    /// failed step remains a durable dead-lettered fact. The active operator
+    /// handshake (resume/inject) is a later PR / the cloud tier; PR-3 only records.
+    pub escalation: Option<String>,
+}
+
+/// **PR-3 (AL2) — run a bounded model-driven RE-PLAN-ON-FAILURE loop.**
+///
+/// Drives the initial plan ([`ModelTopologyProvider::decide`], round 0). If a
+/// non-shaper step then dead-letters (a terminal `Failed` fact, via PR-1), the
+/// driver folds the journal, reads WHY each step failed
+/// ([`kx_projection::Snapshot::failure_reason_of`]), builds a failure-corrected
+/// instruction, and asks the model for the next round
+/// ([`ModelTopologyProvider::replan`]) — the 3-way router: a corrective
+/// [`ReplanOutcome::Topology`] (corrected-context / permission-adapt, narrowing-only)
+/// spawns the next round's steps; a [`ReplanOutcome::FlagHuman`] stops the loop and
+/// records the escalation. The prior round's COMMITTED steps are never touched
+/// (D76 append-only); each round is a NEW committed ROND shaper fact, so a crash
+/// between rounds resumes by re-folding and a cold re-fold reproduces the exact
+/// chain (R49). Bounded by [`LoopBudget`] (`max_rounds` × `max_children`); the
+/// unbounded durable loop stays cloud (D126 cat-B).
+///
+/// `workflow` is the round-0 [`crate::workflows::loop_shaper`]. Composes with PR-1:
+/// `max_attempts = 1` ⇒ a refused/failing step dead-letters at once, never a blind
+/// re-run.
+///
+/// # Errors
+/// Propagates store / journal / orchestrator failures. A refused proposal, a failing
+/// step, budget exhaustion, and an escalation are NOT errors — they are reflected in
+/// the returned [`ReplanLoopOutcome`].
+// `Arc`-by-value params mirror `run_model_loop`'s public signature (the run owns
+// them for its whole lifetime); `run_with_seams` allows the same lint.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+pub fn run_replan_loop<B, S>(
+    config: &RuntimeConfig,
+    store: Arc<S>,
+    journal: Arc<SqliteJournal>,
+    backend: Arc<B>,
+    registry: Arc<dyn ToolRegistry>,
+    recipes: Arc<dyn RoleRecipeResolver>,
+    workflow: &DemoWorkflow,
+    budget: LoopBudget,
+) -> Result<ReplanLoopOutcome, RuntimeError>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    let rm = LocalResourceManager::dev_defaults();
+    // PR-1: a refused proposal / failing step is a terminal `Failed` (no retry).
+    let failure_policy = FailurePolicy::new(1, Duration::ZERO);
+    let provider = ModelTopologyProvider::new(
+        backend.clone(),
+        store.clone(),
+        registry.clone(),
+        recipes,
+        budget,
+    );
+
+    let shaper0 = workflow
+        .motes
+        .iter()
+        .find(|w| w.mote.id == workflow.shaper_id)
+        .cloned()
+        .ok_or_else(|| {
+            RuntimeError::Config("replan-loop workflow is missing its topology shaper".to_string())
+        })?;
+    let model_id = shaper0.mote.def.model_id.clone();
+    let warrant = shaper0.warrant.clone();
+    let base_prompt = prompt::raw_prompt(&shaper0.mote).ok_or_else(|| {
+        RuntimeError::Config("replan-loop shaper carries no planning prompt".to_string())
+    })?;
+
+    let mut escalation: Option<String> = None;
+
+    let mut round: u32 = 0;
+    let mut current_wf: DemoWorkflow = workflow.clone();
+    let mut current_shaper = shaper0;
+
+    // The loop ALWAYS drives round 0, then re-plans while THIS round's own steps
+    // keep failing and the budget allows — every exit `break`s with the round's
+    // `RunOutcome` (whose `digest` is the whole-journal replay surface).
+    let run: RunOutcome = loop {
+        // Fold the journal (skip-committed guard + the snapshot for decide/replan).
+        let proj = fold_for_inspection(&provider, &current_shaper, &warrant, &journal)?;
+        let shaper_state = proj.state_of(&current_shaper.mote.id);
+
+        // Resolve this round's staged decision. `None` ⇒ serve a committed fact
+        // (R49 replay), or stop (a refused/escalated/already-dead-lettered shaper).
+        let (staged, stop): (Option<TopologyDecision>, bool) = match shaper_state {
+            // R49 replay: the decision is already a committed fact — serve it
+            // (the materializer re-derives children), NEVER re-sample the model.
+            MoteState::Committed => (None, false),
+            // Already dead-lettered (a prior refused round) — drive to a clean stop.
+            MoteState::Failed => (None, true),
+            // Fresh round: round 0 plans (`decide`); a re-plan round corrects or
+            // escalates (`replan`) against the live snapshot (its prompt carries the
+            // failure). A refusal / escalation dead-letters the shaper and stops.
+            _ => {
+                let snapshot = proj.snapshot();
+                if round == 0 {
+                    match provider.decide(&current_shaper.mote, &warrant, &snapshot) {
+                        Ok(td) => (Some(td), false),
+                        Err(e) => {
+                            tracing::warn!(error = %e, shaper = ?current_shaper.mote.id, "initial plan refused — dead-lettering the shaper");
+                            dead_letter_shaper(&journal, current_shaper.mote.id)?;
+                            (None, true)
+                        }
+                    }
+                } else {
+                    match provider.replan(&current_shaper.mote, &warrant, &snapshot) {
+                        Ok(ReplanOutcome::Topology(td)) => (Some(td), false),
+                        Ok(ReplanOutcome::FlagHuman(reason)) => {
+                            tracing::warn!(reason = %reason, shaper = ?current_shaper.mote.id, "model escalated (flag-a-human) — stopping the loop");
+                            dead_letter_shaper(&journal, current_shaper.mote.id)?;
+                            escalation = Some(reason);
+                            (None, true)
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, shaper = ?current_shaper.mote.id, "re-plan refused — dead-lettering the shaper");
+                            dead_letter_shaper(&journal, current_shaper.mote.id)?;
+                            (None, true)
+                        }
+                    }
+                }
+            }
+        };
+
+        let outcome = drive_one_round(
+            config,
+            &store,
+            &journal,
+            &backend,
+            &registry,
+            &rm,
+            &failure_policy,
+            &current_wf,
+            &current_shaper,
+            staged.as_ref(),
+            &provider,
+        )?;
+
+        if stop {
+            break outcome; // a refused / escalated / already-dead-lettered shaper stops the loop.
+        }
+
+        // Did any of THIS round's OWN steps (its shaper's children) dead-letter?
+        // Scoping to this round's children — not all-time `Failed` motes — is what
+        // makes the loop CONVERGE: a prior round's failed step stays a durable
+        // `Failed` fact forever (D76), but it was already addressed by the round
+        // that corrected it; only a fresh failure warrants another re-plan.
+        let post = fold_for_inspection(&provider, &current_shaper, &warrant, &journal)?;
+        let mut failures: Vec<(MoteId, Option<kx_journal::FailureReason>)> = post
+            .children_of(&current_shaper.mote.id)
+            .into_iter()
+            .map(|(id, _)| id)
+            .filter(|id| post.state_of(id) == MoteState::Failed)
+            .map(|id| (id, post.failure_reason_of(&id)))
+            .collect();
+        // Deterministic order (replay-stable corrected prompt → replay-stable shaper).
+        failures.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+
+        if failures.is_empty() {
+            break outcome; // success — the round's steps all committed.
+        }
+        if round + 1 >= budget.max_rounds {
+            break outcome; // budget exhausted — leave the failure dead-lettered (bounded additive).
+        }
+
+        // Build the next re-plan round (a NEW, round-distinct shaper).
+        round += 1;
+        let corrected = corrected_prompt(&base_prompt, &failures);
+        current_wf = crate::workflows::replan_shaper(&model_id, &warrant, &corrected, round);
+        current_shaper = current_wf.motes[0].clone();
+    };
+
+    Ok(ReplanLoopOutcome {
+        run,
+        rounds_used: round + 1,
+        escalation,
+    })
+}
+
+/// Fold the journal into an inspection [`Projection`] through the provider's
+/// (accumulating) materializer — so every committed round's children are
+/// re-derived and the snapshot reflects the true cross-round state (incl. each
+/// step's terminal `FailureReason`).
+fn fold_for_inspection<B, S>(
+    provider: &ModelTopologyProvider<B, S>,
+    shaper_wm: &kx_runtime::workflow::WorkflowMote,
+    warrant: &WarrantSpec,
+    journal: &Arc<SqliteJournal>,
+) -> Result<Projection, RuntimeError>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    let materializer = provider.materializer(&shaper_wm.mote.def, warrant);
+    Ok(Projection::from_journal_with_materializer(
+        &**journal,
+        materializer,
+    )?)
+}
+
+/// Stage `staged` (a fresh round's decision) as the shaper's effect, then drive ONE
+/// round through `run_with_seams`. `None` ⇒ the shaper is already committed (R49
+/// replay) or dead-lettered ⇒ an empty broker (the materializer derives children
+/// from the committed fact, or the terminal shaper derives none).
+#[allow(clippy::too_many_arguments)]
+fn drive_one_round<B, S>(
+    config: &RuntimeConfig,
+    store: &Arc<S>,
+    journal: &Arc<SqliteJournal>,
+    backend: &Arc<B>,
+    registry: &Arc<dyn ToolRegistry>,
+    rm: &LocalResourceManager,
+    failure_policy: &FailurePolicy,
+    round_wf: &DemoWorkflow,
+    round_shaper: &kx_runtime::workflow::WorkflowMote,
+    staged: Option<&TopologyDecision>,
+    provider: &ModelTopologyProvider<B, S>,
+) -> Result<RunOutcome, RuntimeError>
+where
+    B: InferenceBackend,
+    S: ContentStore + Send + Sync + 'static,
+{
+    let mut responses: BTreeMap<MoteId, Vec<u8>> = BTreeMap::new();
+    if let Some(td) = staged {
+        responses.insert(round_shaper.mote.id, encode_topology_decision(td)?);
+    }
+    let sink = SnapshotSink::new();
+    let executor = ModelExecutor::new(
+        backend.clone(),
+        store.clone(),
+        sink.clone(),
+        registry.clone(),
+    );
+    let broker = Arc::new(DemoBroker::new(
+        store.clone(),
+        responses,
+        config.crash_at,
+        Some(round_wf.stc_crash_target),
+    ));
+    let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+    let dummy = TopologyDecision {
+        children: Vec::new(),
+    };
+    let decision_ref = staged.unwrap_or(&dummy);
+    run_with_seams(
+        config,
+        round_wf,
+        store.clone(),
+        journal.clone(),
+        rm,
+        &executor,
+        &protocol,
+        Some((round_shaper, decision_ref)),
+        Some(provider),
+        Some(&sink),
+        None,
+        None,
+        Some(failure_policy),
+    )
+}
+
+/// Journal a terminal `Failed` for a shaper whose round was refused / escalated —
+/// the same dead-letter fact PR-1 + [`run_model_loop`] write (a durable, auditable
+/// record; the engine then skips the now-terminal shaper).
+fn dead_letter_shaper(journal: &Arc<SqliteJournal>, shaper_id: MoteId) -> Result<(), RuntimeError> {
+    journal.append(JournalEntry::Failed {
+        mote_id: shaper_id,
+        idempotency_key: *shaper_id.as_bytes(),
+        seq: 0, // journal assigns
+        reason_class: FailureReason::ExecutorRefused,
+        reporter_id: TOPOLOGY_PROVIDER_REPORTER_ID,
+    })?;
+    Ok(())
+}
+
+/// A STABLE, rename-and-reorder-proof token for a [`kx_journal::FailureReason`].
+///
+/// **Load-bearing for R49.** This token is threaded into the re-plan shaper's
+/// [`corrected_prompt`], which is identity-bearing (`config_subset` → `MoteDef::hash`
+/// → the shaper's `MoteId`). Derived `Debug` is explicitly NOT a Rust stability
+/// contract, so a future variant rename would silently shift the shaper's identity
+/// and a cold re-fold of an OLD journal on the NEW binary would derive a DIFFERENT
+/// chain (breaking replay). Keying off the canonical `as_u8()` (the `#[repr(u8)]`
+/// discriminant — the journal's own on-disk reason encoding) makes the token
+/// rename-proof; the `failure_reason_token_is_frozen` test pins the mapping so any
+/// reorder/renumber that would shift identity bytes fails CI. `Debug` stays for
+/// human-facing `tracing` ONLY — never for bytes that enter a `MoteId`.
+fn failure_reason_token(reason: Option<kx_journal::FailureReason>) -> &'static str {
+    match reason.map(kx_journal::FailureReason::as_u8) {
+        Some(0) => "timed-out",
+        Some(1) => "executor-refused",
+        Some(2) => "validator-rejected",
+        Some(3) => "worker-crashed",
+        Some(4) => "upstream-repudiated",
+        Some(5) => "unsafe-world-mutating-construction",
+        Some(6) => "compensated-at-least-once",
+        Some(7) => "quarantined-at-least-once",
+        // A None (transient/pre-commit-crash → no retained terminal reason) or any
+        // future, not-yet-tokenized variant maps to a fixed sentinel — still stable.
+        _ => "transient-or-unknown",
+    }
+}
+
+/// Build the next round's failure-corrected planning instruction (deterministic —
+/// `failures` is pre-sorted and each reason renders via the STABLE
+/// [`failure_reason_token`], so a cold re-fold reconstructs the SAME prompt ⇒ the
+/// SAME re-plan shaper identity, R49). The reasons are the low-entropy
+/// [`kx_journal::FailureReason`] enum only (never result bytes / secrets — SN-8).
+fn corrected_prompt(
+    base: &str,
+    failures: &[(MoteId, Option<kx_journal::FailureReason>)],
+) -> String {
+    let mut s = String::from(base);
+    s.push_str(
+        "\n\nThe previous attempt left failed step(s). Respond with a `replan` envelope: \
+         either `next_steps` that retry or replace them (corrected context / a role whose \
+         authority fits), or `flag_human` with a reason if you cannot fix it within your \
+         authority. Failed step(s):",
+    );
+    for (id, reason) in failures {
+        let label = failure_reason_token(*reason);
+        let _ = write!(s, "\n- step {id} failed (reason: {label})");
+    }
+    s
+}
+
+#[cfg(test)]
+mod replan_unit_tests {
+    use super::*;
+    use kx_journal::FailureReason;
+
+    #[test]
+    fn failure_reason_token_is_frozen() {
+        // PINS the identity-bearing token for every FailureReason. Keyed off the
+        // canonical `as_u8()` (the on-disk reason encoding), so a variant RENAME
+        // can NEVER shift a re-plan shaper's MoteId (R49 forward-compat). Any
+        // reorder/renumber that changes a token here is a deliberate, CI-caught
+        // identity change.
+        assert_eq!(failure_reason_token(None), "transient-or-unknown");
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::TimedOut)),
+            "timed-out"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::ExecutorRefused)),
+            "executor-refused"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::ValidatorRejected)),
+            "validator-rejected"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::WorkerCrashed)),
+            "worker-crashed"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::UpstreamRepudiated)),
+            "upstream-repudiated"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::UnsafeWorldMutatingConstruction)),
+            "unsafe-world-mutating-construction"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::CompensatedAtLeastOnce)),
+            "compensated-at-least-once"
+        );
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::QuarantinedAtLeastOnce)),
+            "quarantined-at-least-once"
+        );
+    }
+
+    #[test]
+    fn corrected_prompt_is_deterministic_and_reason_stable() {
+        let base = "plan";
+        let f = [(
+            MoteId::from_bytes([3; 32]),
+            Some(FailureReason::ExecutorRefused),
+        )];
+        let a = corrected_prompt(base, &f);
+        let b = corrected_prompt(base, &f);
+        assert_eq!(
+            a, b,
+            "same inputs ⇒ byte-identical prompt (identity-stable)"
+        );
+        assert!(a.contains("executor-refused"), "stable token, not Debug");
+        assert!(
+            !a.contains("ExecutorRefused"),
+            "Debug spelling never enters identity"
+        );
+    }
 }

--- a/crates/kx-model-harness/src/workflows.rs
+++ b/crates/kx-model-harness/src/workflows.rs
@@ -431,6 +431,66 @@ pub fn loop_shaper(
     }
 }
 
+/// **PR-3 (AL2) — a re-plan round's topology shaper.** Like [`loop_shaper`], but
+/// its identity is derived from the `round` index (a 32-byte blake3 namespace),
+/// NOT a single seed byte — so each re-plan round's shaper has a DISTINCT,
+/// deterministic, replay-stable `MoteId` that can never collide with the round-0
+/// [`loop_shaper`] or a sibling round (the [`crate::run_replan_loop`] crash-safety
+/// precondition: a re-plan round's shaper is a pure function of the round, so a
+/// cold re-fold reconstructs the SAME chain). `planning_prompt` is the
+/// failure-corrected instruction the driver builds from the prior round's
+/// dead-lettered step(s); it is carried in `config_subset` (identity-bearing), so
+/// the corrective intent is part of the committed shaper fact.
+#[must_use]
+pub fn replan_shaper(
+    model_id: &ModelId,
+    warrant: &WarrantSpec,
+    planning_prompt: &str,
+    round: u32,
+) -> DemoWorkflow {
+    // Round-namespaced 32-byte identity material — deterministic + distinct per
+    // round, and cryptographically distinct from a `loop_shaper` `[seed; 32]`.
+    let mut material = b"kx-replan-round".to_vec();
+    material.extend_from_slice(&round.to_le_bytes());
+    let id_bytes = *blake3::hash(&material).as_bytes();
+
+    let mut config_subset = BTreeMap::new();
+    prompt::put_prompt(&mut config_subset, planning_prompt);
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes(id_bytes),
+        model_id: model_id.clone(),
+        prompt_template_hash: PromptTemplateHash::from_bytes(id_bytes),
+        tool_contract: BTreeMap::new(),
+        // ROND + shaper (R-14: a shaper is never WM); the COMMITTED decision is
+        // the served fact (R49), greedy so a live decode stays reproducible.
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: true,
+        inference_params: greedy(128),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    let shaper = Mote::new(
+        def,
+        InputDataId::from_bytes(id_bytes),
+        GraphPosition(id_bytes.to_vec()),
+        SmallVec::new(),
+    );
+    let shaper_id = shaper.id;
+    DemoWorkflow {
+        motes: vec![WorkflowMote {
+            mote: shaper,
+            warrant: warrant.clone(),
+            capability: ToolName(CAPABILITY.to_string()),
+        }],
+        stc_crash_target: sentinel_shaper(),
+        vtc_crash_target: sentinel_shaper(),
+        shaper_id,
+    }
+}
+
 /// **M6 — run a planner-produced DAG.** Map a `kx_planner::compile_plan` result
 /// (`CompiledMote { mote, warrant, capability }`) 1:1 to a flat (shaperless)
 /// [`DemoWorkflow`], so it drives through `run_with_seams` with NO new execution

--- a/crates/kx-model-harness/tests/replan_loop_e2e.rs
+++ b/crates/kx-model-harness/tests/replan_loop_e2e.rs
@@ -1,0 +1,576 @@
+//! PR-3 (AL2) — "the model re-plans on failure", deterministically (NO GGUF).
+//!
+//! A [`ScriptedBackend`] returns a fixed, *call-indexed* sequence of completions
+//! (and injected failures) so a re-plan loop is fully reproducible without a model.
+//! It drives the REAL orchestrator + the shipped materializer through
+//! [`kx_model_harness::run_replan_loop`] to prove, without a model:
+//!
+//! - **corrected-context re-plan** — round 0 spawns a step that dead-letters; the
+//!   driver reads WHY (`failure_reason_of`), the model proposes a corrected round,
+//!   and the prior round's committed steps are NEVER touched (D76);
+//! - **durability / R49** — re-running the driver over the SAME committed journal
+//!   reconstructs the SAME chain, serving every committed round's decision from the
+//!   fact (the model is NOT re-sampled — the skip-already-committed-round guard);
+//! - **bounded** — a step that keeps failing exhausts `max_rounds` and the loop
+//!   stops with the failure dead-lettered (never an infinite loop);
+//! - **flag-a-human** — an escalation stops the loop and records the reason;
+//! - **fail-closed** — a malformed re-plan round dead-letters that round's shaper.
+//!
+//! The call sequence per round is deterministic: the driver calls the model ONCE
+//! for the round's plan (`decide`/`replan`), the shaper's effect is the staged
+//! decision (broker-served, NO model call), then each PURE child dispatches through
+//! the model once. So for a 1-child round: `[plan, child]`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use kx_content::LocalFsContentStore;
+use kx_inference::{
+    InferenceBackend, InferenceError, InferenceInput, InferenceOutput, InferenceParams,
+};
+use kx_journal::SqliteJournal;
+use kx_model_harness::{run_replan_loop, workflows, LoopBudget, ReplanLoopOutcome};
+use kx_mote::{EffectPattern, LogicRef, ModelId, NdClass, PromptTemplateHash, RoleId, ToolName};
+use kx_planner::{InMemoryRoleRecipes, RoleRecipe, RoleRecipeResolver};
+use kx_projection::{MoteState, Projection};
+use kx_runtime::{DemoWorkflow, Mode, RuntimeConfig};
+use kx_tool_registry::{InMemoryToolRegistry, ToolRegistry};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+const MODEL: &str = "stub-replan-model:test:0";
+const PLAN_PROMPT: &str = "Propose the next steps as a loop_proposal envelope.";
+const SHAPER_SEED: u8 = 0x71;
+
+fn model_id() -> ModelId {
+    ModelId(MODEL.into())
+}
+
+/// One scripted backend response, keyed by global dispatch index.
+#[derive(Clone)]
+enum Reply {
+    /// Return these completion bytes.
+    Ok(Vec<u8>),
+    /// Return a backend failure (→ the dispatching Mote dead-letters terminally
+    /// with `FailureReason::ExecutorRefused`).
+    Fail,
+}
+
+/// A backend that replays a fixed `Reply` sequence by call index (trailing calls
+/// get a benign `b"done"`). Records every call so a test can assert "served from
+/// the committed fact, never re-sampled".
+struct ScriptedBackend {
+    replies: Mutex<std::vec::IntoIter<Reply>>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl ScriptedBackend {
+    fn new(replies: Vec<Reply>, calls: Arc<AtomicUsize>) -> Self {
+        Self {
+            replies: Mutex::new(replies.into_iter()),
+            calls,
+        }
+    }
+}
+
+impl InferenceBackend for ScriptedBackend {
+    fn dispatch(
+        &self,
+        model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let bytes = match self.replies.lock().unwrap().next() {
+            Some(Reply::Ok(b)) => b,
+            None => b"done".to_vec(), // trailing calls succeed benignly
+            Some(Reply::Fail) => {
+                return Err(InferenceError::ModelNotFound {
+                    model_id: model_id.0.clone(),
+                })
+            }
+        };
+        Ok(InferenceOutput {
+            bytes,
+            output_tokens: 1,
+            backend_name: "scripted",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(0),
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "scripted"
+    }
+}
+
+/// A permissive WORLD-MUTATING warrant routed to [`model_id`].
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: model_id(),
+            max_input_tokens: 8192,
+            max_output_tokens: 1024,
+            max_calls: 64,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 1000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+/// The vetted role→recipe allowlist (PURE, no tools) every round lowers through.
+fn recipes() -> Arc<dyn RoleRecipeResolver> {
+    let r = InMemoryRoleRecipes::new();
+    for (i, name) in ["reader", "summarizer"].iter().enumerate() {
+        let tag = u8::try_from(i).unwrap();
+        r.register(
+            RoleId((*name).into()),
+            RoleRecipe {
+                logic_ref: LogicRef::from_bytes([0x90 + tag; 32]),
+                model_id: model_id(),
+                prompt_template_hash: PromptTemplateHash::from_bytes([0xA0 + tag; 32]),
+                tool_contract: BTreeMap::new(),
+                capability: ToolName("kx-model".into()),
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                inference_params: InferenceParams::default(),
+                deterministic_check: None,
+            },
+        );
+    }
+    Arc::new(r)
+}
+
+fn config_for(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+        audit_log: None,
+    }
+}
+
+fn loop_wf() -> DemoWorkflow {
+    workflows::loop_shaper(&model_id(), &warrant(), PLAN_PROMPT, SHAPER_SEED)
+}
+
+fn one_child_loop_proposal(role: &str) -> Vec<u8> {
+    format!(
+        r#"{{"loop_proposal":{{"version":1,"next_steps":[{{"role":"{role}","intent":"go"}}]}}}}"#
+    )
+    .into_bytes()
+}
+
+fn one_child_replan(role: &str) -> Vec<u8> {
+    format!(r#"{{"replan":{{"version":1,"next_steps":[{{"role":"{role}","intent":"retry"}}]}}}}"#)
+        .into_bytes()
+}
+
+fn flag_human_replan(reason: &str) -> Vec<u8> {
+    format!(r#"{{"replan":{{"version":1,"flag_human":"{reason}"}}}}"#).into_bytes()
+}
+
+struct Driven {
+    result: ReplanLoopOutcome,
+    journal: Arc<SqliteJournal>,
+}
+
+/// Drive [`run_replan_loop`] over a fresh store+journal in `dir` with a scripted
+/// backend. `dir` persists, so [`redrive`] can simulate a process restart.
+fn drive(dir: &Path, replies: Vec<Reply>, budget: LoopBudget) -> Driven {
+    let config = config_for(dir);
+    let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+    let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+    let calls = Arc::new(AtomicUsize::new(0));
+    let backend = Arc::new(ScriptedBackend::new(replies, calls));
+    let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+    let result = run_replan_loop(
+        &config,
+        store,
+        journal.clone(),
+        backend,
+        registry,
+        recipes(),
+        &loop_wf(),
+        budget,
+    )
+    .expect("the re-plan loop completes (a failing step is not a run error)");
+    Driven { result, journal }
+}
+
+/// Re-drive over the SAME persisted `dir` (a fresh process / fresh provider, with a
+/// fresh `replies` script) — a process-restart simulation. A committed round serves
+/// its decision from the fact (NO model call); only an UNCOMMITTED tail consumes
+/// `replies`. Returns the outcome + the number of model calls the replay made
+/// (`0` ⇒ a complete journal fully served from facts; `>0` ⇒ a mid-chain resume
+/// only re-sampled the incomplete tail, never a committed round).
+fn redrive(dir: &Path, replies: Vec<Reply>, budget: LoopBudget) -> (ReplanLoopOutcome, usize) {
+    let config = config_for(dir);
+    let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+    let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+    let calls = Arc::new(AtomicUsize::new(0));
+    let backend = Arc::new(ScriptedBackend::new(replies, calls.clone()));
+    let registry: Arc<dyn ToolRegistry> = Arc::new(InMemoryToolRegistry::with_builtins());
+    let out = run_replan_loop(
+        &config,
+        store,
+        journal,
+        backend,
+        registry,
+        recipes(),
+        &loop_wf(),
+        budget,
+    )
+    .expect("replay completes");
+    (out, calls.load(Ordering::SeqCst))
+}
+
+/// Plain fold of `dir`'s journal — for asserting the final committed/failed set
+/// after a [`redrive`] (a fresh process re-opens the persisted journal).
+fn fold_dir(dir: &Path) -> Projection {
+    Projection::from_journal(&SqliteJournal::open(&config_for(dir).journal_path).unwrap()).unwrap()
+}
+
+/// Plain fold (no materializer) — each Mote's state from its own journal entries.
+fn fold(d: &Driven) -> Projection {
+    Projection::from_journal(&*d.journal).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_round_replan_corrected_context_appends_and_cold_refolds() {
+    // Round 0: plan one "reader" child → it FAILS at dispatch (Reply::Fail).
+    // Round 1: re-plan one "reader" child → it succeeds.
+    // Calls: [plan0, child0=FAIL, replan1, child1=ok].
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Fail,
+        Reply::Ok(one_child_replan("reader")),
+        Reply::Ok(b"done".to_vec()),
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), replies, LoopBudget::default());
+
+    assert_eq!(
+        d.result.rounds_used, 2,
+        "one initial round + one re-plan round"
+    );
+    assert!(d.result.escalation.is_none(), "no escalation");
+
+    let p = fold(&d);
+    // 2 shapers + the round-1 child commit; the round-0 child stays dead-lettered.
+    assert_eq!(p.committed_count(), 3, "2 shapers + the corrected child");
+    assert_eq!(
+        p.failed_count(),
+        1,
+        "the round-0 step is a durable Failed fact"
+    );
+    // The round-0 shaper (a fact) and its committed-prefix are intact (D76).
+    assert_eq!(
+        p.state_of(&loop_wf().shaper_id),
+        MoteState::Committed,
+        "round-0 shaper committed; its decision is never re-touched"
+    );
+
+    // R49: re-running over the SAME (complete) journal serves every committed round
+    // from the fact through the SHIPPED recovery fold (the driver's
+    // `from_journal_with_materializer`), so the model is NEVER re-sampled.
+    let (replay, replay_calls) = redrive(dir.path(), vec![], LoopBudget::default());
+    assert_eq!(
+        replay_calls, 0,
+        "no model call on replay — the whole multi-round chain served from facts"
+    );
+    assert_eq!(replay.rounds_used, 2, "the chain reconstructs identically");
+    let rp = fold_dir(dir.path());
+    assert_eq!(
+        rp.committed_count(),
+        3,
+        "replay reproduces the committed set (R49)"
+    );
+    assert_eq!(rp.failed_count(), 1);
+}
+
+#[test]
+fn mid_chain_crash_resumes_and_corrects_without_resampling_round_0() {
+    // The NON-NEGOTIABLE durability gate: a crash BETWEEN rounds resumes by
+    // re-folding. Simulate it by capping round 0 (`max_rounds = 1`) so the run
+    // stops with round-0's step dead-lettered and NO round 1 — a journal frozen
+    // mid-chain. Then "restart" (a fresh process via `redrive`) with more budget +
+    // the round-1 correction: the driver must SERVE round 0 from the fact (NOT
+    // re-sample it) and resume at round 1.
+    let dir = tempfile::tempdir().unwrap();
+    let _ = drive(
+        dir.path(),
+        vec![Reply::Ok(one_child_loop_proposal("reader")), Reply::Fail],
+        LoopBudget {
+            max_rounds: 1,
+            max_children: 8,
+        },
+    );
+    // After the cap: round-0 shaper committed, round-0 child dead-lettered, no round 1.
+    let mid = fold_dir(dir.path());
+    assert_eq!(
+        mid.committed_count(),
+        1,
+        "only the round-0 shaper committed"
+    );
+    assert_eq!(
+        mid.failed_count(),
+        1,
+        "round-0 step is a durable Failed fact"
+    );
+
+    // Restart with budget for the correction. The redrive script supplies ONLY the
+    // round-1 plan + child — round 0 is served from the journal, never re-sampled.
+    let (resumed, calls) = redrive(
+        dir.path(),
+        vec![
+            Reply::Ok(one_child_replan("reader")),
+            Reply::Ok(b"done".to_vec()),
+        ],
+        LoopBudget::default(),
+    );
+    assert_eq!(
+        resumed.rounds_used, 2,
+        "resume reconstructs round 0 (served) then drives the round-1 correction"
+    );
+    // Exactly the round-1 plan + child were sampled — round 0's plan was NOT
+    // re-run (else `calls` would be 3+ and round 0 would be re-sampled).
+    assert_eq!(
+        calls, 2,
+        "only the uncommitted tail (round-1 plan + child) called the model"
+    );
+    let after = fold_dir(dir.path());
+    assert_eq!(
+        after.committed_count(),
+        3,
+        "2 shapers + the corrected child after the resume"
+    );
+    assert_eq!(
+        after.failed_count(),
+        1,
+        "the original round-0 failure persists (D76)"
+    );
+    assert_eq!(
+        after.state_of(&loop_wf().shaper_id),
+        MoteState::Committed,
+        "the round-0 decision survived the crash, served not re-sampled (R49)"
+    );
+}
+
+#[test]
+fn round_budget_exhaustion_fails_closed() {
+    // Every round's child FAILS; max_rounds = 2 → the loop drives exactly 2 rounds
+    // then stops with the last failure dead-lettered (bounded additive, no infinite loop).
+    // Calls: [plan0, child0=FAIL, replan1, child1=FAIL].
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Fail,
+        Reply::Ok(one_child_replan("reader")),
+        Reply::Fail,
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let budget = LoopBudget {
+        max_rounds: 2,
+        max_children: 8,
+    };
+    let d = drive(dir.path(), replies, budget);
+
+    assert_eq!(d.result.rounds_used, 2, "stops after exactly max_rounds");
+    assert!(d.result.escalation.is_none());
+    let p = fold(&d);
+    assert_eq!(p.committed_count(), 2, "both shapers committed");
+    assert_eq!(p.failed_count(), 2, "both rounds' steps stay dead-lettered");
+}
+
+#[test]
+fn flag_human_stops_the_loop_and_records_a_durable_reason() {
+    // Round 0: a child fails. Round 1: the model escalates (flag_human).
+    // Calls: [plan0, child0=FAIL, replan1=flag_human].
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Fail,
+        Reply::Ok(flag_human_replan("needs a credential I cannot grant")),
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), replies, LoopBudget::default());
+
+    assert_eq!(
+        d.result.escalation.as_deref(),
+        Some("needs a credential I cannot grant"),
+        "the escalation reason is surfaced"
+    );
+    let p = fold(&d);
+    // round-0 shaper committed; round-0 child Failed; round-1 shaper dead-lettered.
+    assert_eq!(
+        p.state_of(&loop_wf().shaper_id),
+        MoteState::Committed,
+        "round-0 plan stands"
+    );
+    assert!(
+        p.failed_count() >= 1,
+        "the failed step remains a durable record"
+    );
+    assert_eq!(
+        p.committed_count(),
+        1,
+        "only the round-0 shaper; nothing forced through"
+    );
+}
+
+#[test]
+fn no_failure_means_no_replan() {
+    // The initial plan's child succeeds → the loop ends after round 0 (PR-2 parity).
+    // Calls: [plan0, child0=ok].
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Ok(b"done".to_vec()),
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), replies, LoopBudget::default());
+    assert_eq!(d.result.rounds_used, 1, "no correction needed");
+    assert!(d.result.escalation.is_none());
+    let p = fold(&d);
+    assert_eq!(p.committed_count(), 2, "shaper + child");
+    assert_eq!(p.failed_count(), 0);
+}
+
+#[test]
+fn two_failures_in_one_round_are_replanned_once() {
+    // Round 0 spawns TWO children, both FAIL → ONE re-plan round addresses them.
+    // Calls: [plan0, child0a=FAIL, child0b=FAIL, replan1, child1=ok].
+    let two = br#"{"loop_proposal":{"version":1,"next_steps":[{"role":"reader","intent":"a"},{"role":"summarizer","intent":"b"}]}}"#.to_vec();
+    let replies = vec![
+        Reply::Ok(two),
+        Reply::Fail,
+        Reply::Fail,
+        Reply::Ok(one_child_replan("reader")),
+        Reply::Ok(b"done".to_vec()),
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), replies, LoopBudget::default());
+    assert_eq!(
+        d.result.rounds_used, 2,
+        "one re-plan addresses BOTH failures"
+    );
+    let p = fold(&d);
+    assert_eq!(p.failed_count(), 2, "both round-0 steps stay dead-lettered");
+    assert_eq!(
+        p.committed_count(),
+        3,
+        "2 shapers + the one corrected child"
+    );
+}
+
+#[test]
+fn malformed_replan_round_dead_letters_that_shaper() {
+    // Round 0: a child fails. Round 1: the model returns garbage → the round-1
+    // shaper dead-letters fail-closed; the run completes; prior steps untouched.
+    // Calls: [plan0, child0=FAIL, replan1=garbage].
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Fail,
+        Reply::Ok(b"this is not a replan envelope".to_vec()),
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), replies, LoopBudget::default());
+    assert!(d.result.escalation.is_none());
+    let p = fold(&d);
+    assert_eq!(
+        p.state_of(&loop_wf().shaper_id),
+        MoteState::Committed,
+        "round-0 plan stands"
+    );
+    // round-0 child Failed + round-1 shaper dead-lettered = 2 Failed; nothing forced.
+    assert!(
+        p.failed_count() >= 2,
+        "the refused round-1 shaper is a Failed fact too"
+    );
+    assert_eq!(p.committed_count(), 1, "only the round-0 shaper committed");
+}
+
+#[test]
+fn replan_proposing_an_unknown_role_dead_letters_that_round() {
+    // Round 0: a child fails. Round 1: the model proposes a role NOT in the recipe
+    // allowlist → `lower` fails closed (UnknownRecipe) inside `replan` → the round-1
+    // shaper dead-letters (SN-8: an unvetted role never materializes). The run
+    // completes; the round-0 committed prefix is untouched.
+    // Calls: [plan0, child0=FAIL, replan1=ghost-role].
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Fail,
+        Reply::Ok(one_child_replan("ghost")), // "ghost" ∉ recipes()
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(dir.path(), replies, LoopBudget::default());
+    assert!(d.result.escalation.is_none());
+    let p = fold(&d);
+    assert_eq!(
+        p.state_of(&loop_wf().shaper_id),
+        MoteState::Committed,
+        "round-0 plan stands"
+    );
+    assert!(
+        p.failed_count() >= 2,
+        "round-0 child + the unvetted round-1 shaper both dead-letter"
+    );
+    assert_eq!(
+        p.committed_count(),
+        1,
+        "no unvetted child ever materialized (SN-8)"
+    );
+}
+
+#[test]
+fn replan_over_max_children_dead_letters_that_round() {
+    // Round 0: a child fails. Round 1: the model proposes MORE children than the
+    // per-decision fan-out cap → `replan` fails closed → the round-1 shaper
+    // dead-letters (bounded additive). max_children = 1, round-1 proposes 2.
+    let two_replan = br#"{"replan":{"version":1,"next_steps":[{"role":"reader","intent":"a"},{"role":"summarizer","intent":"b"}]}}"#.to_vec();
+    let replies = vec![
+        Reply::Ok(one_child_loop_proposal("reader")),
+        Reply::Fail,
+        Reply::Ok(two_replan),
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let d = drive(
+        dir.path(),
+        replies,
+        LoopBudget {
+            max_rounds: 4,
+            max_children: 1,
+        },
+    );
+    let p = fold(&d);
+    assert!(
+        p.failed_count() >= 2,
+        "the over-cap round-1 fan-out is refused fail-closed"
+    );
+    assert_eq!(p.committed_count(), 1, "only the round-0 shaper committed");
+}

--- a/crates/kx-model-harness/tests/replan_loop_invariants.rs
+++ b/crates/kx-model-harness/tests/replan_loop_invariants.rs
@@ -1,0 +1,144 @@
+//! PR-3 (AL2) — "the model re-plans on failure" with a REAL GGUF model (run with
+//! `--features with-model`, host + Metal). The live counterpart of
+//! `replan_loop_e2e.rs`. A real model's steps commit normally, so this exercises
+//! the re-plan DRIVER on the no-correction path (`rounds_used == 1`, equivalent to
+//! the PR-2 single round) end-to-end through `drive_replan_loop`; the
+//! failure → correction → budget → escalate paths are covered DETERMINISTICALLY in
+//! `replan_loop_e2e.rs` (a real-model child failure cannot be injected reproducibly).
+//!
+//! Hard invariants (hold for ANY model output):
+//! - the loop **completes** (never a panic / abort / hang) and `rounds_used >= 1`;
+//! - the round-0 shaper reaches a **terminal** state (Committed or Failed);
+//! - **R49** — two cold re-folds of the committed journal reproduce byte-identical
+//!   `MoteId`s (the model's decision is a replayed fact, never re-sampled).
+
+#![cfg(feature = "with-model")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use kx_journal::SqliteJournal;
+use kx_model_harness::{harness_warrant, model_id_for, workflows, Harness, LoopBudget};
+use kx_mote::{
+    EffectPattern, LogicRef, ModelId, MoteDef, NdClass, PromptTemplateHash, RoleId, ToolName,
+};
+use kx_planner::{InMemoryRoleRecipes, RoleRecipe, RoleRecipeResolver};
+use kx_projection::{
+    DefaultTopologyMaterializer, InMemoryMoteDefRegistry, InheritFromShaperResolver, MoteState,
+    Projection,
+};
+use kx_runtime::config::Mode;
+use kx_runtime::RuntimeConfig;
+use kx_warrant::{InMemoryRoleRegistry, Role, WarrantSpec};
+
+const ROLES: [&str; 2] = ["reader", "writer"];
+const SHAPER_SEED: u8 = 0x77;
+
+const PLAN_PROMPT: &str = "You are a planning agent. Output ONLY one JSON object, \
+no prose, of EXACTLY this shape: \
+{\"loop_proposal\":{\"version\":1,\"next_steps\":[{\"role\":\"reader\",\"intent\":\"read the input\"}]}}. \
+The only allowed role values are \"reader\" and \"writer\". Do not add any other fields.";
+
+fn gguf() -> std::path::PathBuf {
+    kx_model_harness::default_gguf_path()
+}
+
+fn config(dir: &Path) -> RuntimeConfig {
+    RuntimeConfig {
+        journal_path: dir.join("j.sqlite"),
+        content_root: dir.join("c"),
+        mode: Mode::Run,
+        crash_at: None,
+        checkpoint_every: None,
+        audit_log: None,
+    }
+}
+
+fn recipes(model_id: &ModelId) -> Arc<dyn RoleRecipeResolver> {
+    let r = InMemoryRoleRecipes::new();
+    for (i, name) in ROLES.iter().enumerate() {
+        let tag = u8::try_from(i).unwrap();
+        r.register(
+            RoleId((*name).into()),
+            RoleRecipe {
+                logic_ref: LogicRef::from_bytes([0x90 + tag; 32]),
+                model_id: model_id.clone(),
+                prompt_template_hash: PromptTemplateHash::from_bytes([0xA0 + tag; 32]),
+                tool_contract: BTreeMap::new(),
+                capability: ToolName("kx-model".into()),
+                nd_class: NdClass::Pure,
+                effect_pattern: EffectPattern::IdempotentByConstruction,
+                inference_params: kx_mote::InferenceParams::default(),
+                deterministic_check: None,
+            },
+        );
+    }
+    Arc::new(r)
+}
+
+/// Cold re-fold the committed journal through a fresh materializer — the shipped
+/// recovery path; decodes the committed decision fact, never calls a model.
+fn cold_fold(cfg: &RuntimeConfig, shaper_def: &MoteDef, warrant: &WarrantSpec) -> Projection {
+    let store = Arc::new(kx_content::LocalFsContentStore::open(&cfg.content_root).unwrap());
+    let journal = SqliteJournal::open(&cfg.journal_path).unwrap();
+    let def_registry = InMemoryMoteDefRegistry::new();
+    def_registry.register(shaper_def.clone());
+    let role_registry = InMemoryRoleRegistry::new();
+    for r in ROLES {
+        role_registry.register(
+            RoleId(r.into()),
+            Role {
+                name: r.into(),
+                version: 1,
+                spec: warrant.clone(),
+                description: String::new(),
+            },
+        );
+    }
+    let materializer = Box::new(DefaultTopologyMaterializer::new(
+        store,
+        Arc::new(def_registry),
+        Arc::new(role_registry),
+        InheritFromShaperResolver,
+    ));
+    Projection::from_journal_with_materializer(&journal, materializer).unwrap()
+}
+
+#[test]
+fn a_real_model_drives_the_replan_loop() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = config(dir.path());
+    let model_id = model_id_for(&gguf()).unwrap();
+    let warrant = harness_warrant(&model_id, 256, 120_000);
+    let wf = workflows::loop_shaper(&model_id, &warrant, PLAN_PROMPT, SHAPER_SEED);
+    let shaper_def = wf.motes[0].mote.def.clone();
+    let shaper_id = wf.shaper_id;
+
+    let harness = Harness::open(&cfg, &gguf(), model_id).unwrap();
+    let outcome = harness
+        .drive_replan_loop(&cfg, &wf, recipes(&harness.model_id), LoopBudget::default())
+        .expect("the re-plan loop completes (a refused proposal dead-letters, never aborts)");
+
+    assert!(outcome.rounds_used >= 1, "at least the initial round ran");
+
+    // The round-0 shaper is terminal (committed a decision, or dead-lettered).
+    let p1 = cold_fold(&cfg, &shaper_def, &warrant);
+    let shaper_state = p1.state_of(&shaper_id);
+    assert!(
+        matches!(shaper_state, MoteState::Committed | MoteState::Failed),
+        "round-0 shaper terminal: {shaper_state:?}"
+    );
+
+    // R49: a second cold re-fold reproduces byte-identical identities.
+    let p2 = cold_fold(&cfg, &shaper_def, &warrant);
+    let ids1: Vec<_> = p1.iter_motes().map(|(id, _)| id).collect();
+    let ids2: Vec<_> = p2.iter_motes().map(|(id, _)| id).collect();
+    assert_eq!(ids1, ids2, "R49: cold re-folds are identical");
+
+    eprintln!(
+        "replan loop: rounds_used={}, shaper={shaper_state:?}, escalation={:?}, committed={}/{}",
+        outcome.rounds_used, outcome.escalation, outcome.run.committed, outcome.run.total
+    );
+}

--- a/crates/kx-planner/src/decode.rs
+++ b/crates/kx-planner/src/decode.rs
@@ -13,8 +13,8 @@
 use kx_warrant::WarrantSpec;
 
 use crate::error::PlanError;
-use crate::lower::LoopProposal;
-use crate::plan::{Envelope, LoopEnvelope, Plan};
+use crate::lower::{LoopProposal, ReplanProposal};
+use crate::plan::{Envelope, LoopEnvelope, Plan, ReplanEnvelope};
 
 /// Hard structural cap on declared steps — a `DoS` bound independent of the byte
 /// cap. A plan with more steps is refused before lowering touches the graph.
@@ -30,6 +30,11 @@ pub const MAX_PLAN_EDGES: usize = 1024;
 /// Tighter than [`MAX_PLAN_STEPS`]: one re-plan round fans out far less than a
 /// full authored plan.
 pub const MAX_LOOP_STEPS: usize = 64;
+
+/// Hard cap on a `flag_human` escalation reason (bytes) — defense-in-depth on top
+/// of the overall `max_bytes` proposal cap, so the operator-facing reason can
+/// never be an unbounded model-authored blob (PR-3 / AL2).
+pub const MAX_FLAG_HUMAN_BYTES: usize = 1024;
 
 /// The per-plan byte cap, derived from the warrant's output ceiling
 /// (`max_output_tokens · 4` — the model produced the plan, so its output budget
@@ -188,4 +193,85 @@ pub fn decode_loop_proposal(bytes: &[u8], max_bytes: usize) -> Result<LoopPropos
     Ok(LoopProposal {
         next_steps: wire.next_steps,
     })
+}
+
+/// Decode a model-proposed **re-plan round** (PR-3 / AL2), fail-closed — the 3-way
+/// router's trust boundary.
+///
+/// Returns `Ok(ReplanProposal::Topology(..))` for a strict, size-bounded
+/// `{"replan": {"version": 1, "next_steps": [ … ]}}` envelope (the corrective
+/// fan-out — corrected-context / permission-adapt), or
+/// `Ok(ReplanProposal::FlagHuman(reason))` for `{"replan": {"version": 1,
+/// "flag_human": "…"}}` (escalate). Exactly ONE of `next_steps` / `flag_human` may
+/// be present: both, or neither, is an `Err`.
+///
+/// A SEPARATE boundary from [`decode_loop_proposal`] (the PR-2 initial-round
+/// decode, kept byte-frozen) — but the IDENTICAL untrusted-bytes discipline
+/// (IMP-5): size-check BEFORE parse, a leading `<think>` strip, decode into fixed
+/// flat structs (never a dynamic `Value`), `deny_unknown_fields` on every struct
+/// (no `confidence`/score smuggle — D77). The escalation reason is bounded by
+/// [`MAX_FLAG_HUMAN_BYTES`]. `max_bytes` is the warrant-derived output ceiling.
+///
+/// Total + panic-free over arbitrary `bytes`.
+pub fn decode_replan_proposal(bytes: &[u8], max_bytes: usize) -> Result<ReplanProposal, PlanError> {
+    // (1) Size cap BEFORE parse — on the ORIGINAL bytes.
+    if bytes.len() > max_bytes {
+        return Err(PlanError::Oversize {
+            got: bytes.len(),
+            max: max_bytes,
+        });
+    }
+
+    // (2) UTF-8, strip a leading `<think>…</think>`, then strict flat-struct parse.
+    let text = std::str::from_utf8(bytes).map_err(|_| PlanError::Malformed {
+        diagnostic: "model output was not valid UTF-8".to_string(),
+    })?;
+    let stripped = strip_reasoning_preamble(text);
+    let envelope: ReplanEnvelope =
+        serde_json::from_str(stripped).map_err(|e| PlanError::Malformed {
+            diagnostic: e.to_string(),
+        })?;
+    let wire = envelope.replan;
+
+    // (3) Version — fail closed on anything but 1.
+    if wire.version != 1 {
+        return Err(PlanError::UnknownVersion {
+            version: wire.version,
+        });
+    }
+
+    // (4) The 3-way router: exactly one of next_steps / flag_human.
+    let has_steps = !wire.next_steps.is_empty();
+    match (has_steps, wire.flag_human) {
+        // Corrective fan-out (corrected-context / permission-adapt).
+        (true, None) => {
+            if wire.next_steps.len() > MAX_LOOP_STEPS {
+                return Err(PlanError::TooManySteps {
+                    got: wire.next_steps.len(),
+                    max: MAX_LOOP_STEPS,
+                });
+            }
+            Ok(ReplanProposal::Topology(LoopProposal {
+                next_steps: wire.next_steps,
+            }))
+        }
+        // Escalate (flag-a-human) — bounded reason.
+        (false, Some(reason)) => {
+            if reason.len() > MAX_FLAG_HUMAN_BYTES {
+                return Err(PlanError::Oversize {
+                    got: reason.len(),
+                    max: MAX_FLAG_HUMAN_BYTES,
+                });
+            }
+            Ok(ReplanProposal::FlagHuman(reason))
+        }
+        // Neither: a round that proposes nothing is refused (empty), mirroring
+        // `decode_loop_proposal`'s empty-round refusal.
+        (false, None) => Err(PlanError::EmptyPlan),
+        // Both: ambiguous — a re-plan round corrects OR escalates, never both.
+        (true, Some(_)) => Err(PlanError::Malformed {
+            diagnostic: "a re-plan round must propose next_steps OR flag_human, not both"
+                .to_string(),
+        }),
+    }
 }

--- a/crates/kx-planner/src/lib.rs
+++ b/crates/kx-planner/src/lib.rs
@@ -64,13 +64,13 @@ mod plan;
 mod role;
 
 pub use decode::{
-    decode_loop_proposal, decode_plan, max_plan_bytes, MAX_LOOP_STEPS, MAX_PLAN_EDGES,
-    MAX_PLAN_STEPS,
+    decode_loop_proposal, decode_plan, decode_replan_proposal, max_plan_bytes,
+    MAX_FLAG_HUMAN_BYTES, MAX_LOOP_STEPS, MAX_PLAN_EDGES, MAX_PLAN_STEPS,
 };
 pub use error::PlanError;
 pub use lower::{
     compile_plan, lower_loop_to_topology_decision, lower_plan, seed_from_plan_bytes, LoopProposal,
-    PLAN_PROMPT_KEY,
+    ReplanProposal, PLAN_PROMPT_KEY,
 };
 pub use plan::{Plan, PlanEdge, PlanStep, PlanStepKind};
 pub use role::{InMemoryRoleRecipes, RoleRecipe, RoleRecipeResolver};

--- a/crates/kx-planner/src/lower.rs
+++ b/crates/kx-planner/src/lower.rs
@@ -235,6 +235,22 @@ pub struct LoopProposal {
     pub next_steps: Vec<PlanStep>,
 }
 
+/// A model-proposed **re-plan round** decision (PR-3 / AL2) — the decoded form of
+/// the 3-way router. `Topology` carries the corrective fan-out
+/// (corrected-context / permission-adapt, lowered identically through vetted
+/// recipes); `FlagHuman` carries the escalation reason (flag-a-human). The runtime
+/// treats `Topology` exactly as a normal proposal (`intersect` narrows authority,
+/// so a permission-adapt can never widen — SN-8) and treats `FlagHuman` as a clean
+/// terminal stop (the failed step stays a durable dead-lettered fact; the active
+/// HITL handshake is a later PR / cloud).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplanProposal {
+    /// Spawn these corrective steps next (the re-plan continues).
+    Topology(LoopProposal),
+    /// The model cannot fix this within its authority — escalate to a human.
+    FlagHuman(String),
+}
+
 /// Lower an agentic-loop proposal into a [`TopologyDecision`] a ROND shaper
 /// commits (D76). Each next-step becomes a [`ChildDescriptor`] whose
 /// `role_id` / `logic_ref` / `nd_class` / `effect_pattern` come from the vetted

--- a/crates/kx-planner/src/plan.rs
+++ b/crates/kx-planner/src/plan.rs
@@ -47,6 +47,41 @@ pub(crate) struct LoopProposalWire {
     pub next_steps: Vec<PlanStep>,
 }
 
+/// The strict outer envelope for a model-proposed **re-plan round** (PR-3 / AL2):
+/// `{ "replan": { … } }`. Distinct from [`LoopEnvelope`] so [`crate::decode_loop_proposal`]
+/// (the PR-2 initial-round boundary) stays byte-frozen — this is the SEPARATE
+/// trust boundary a re-plan-on-failure round decodes through. `deny_unknown_fields`
+/// rejects any sibling key (the same fail-closed discipline).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReplanEnvelope {
+    pub replan: ReplanWire,
+}
+
+/// The wire form of a re-plan round's 3-way decision. Exactly ONE of `next_steps`
+/// (a non-empty corrective fan-out — corrected-context / permission-adapt) or
+/// `flag_human` (escalate) is present; both-or-neither is refused. `next_steps`
+/// reuses [`PlanStep`] verbatim, so a corrective round lowers through the SAME
+/// vetted-recipe path as an initial round (SN-8). `flag_human` carries an opaque,
+/// bounded human-readable reason (never parsed for enforcement; surfaced to the
+/// operator). No score channel anywhere → D77 holds for free.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReplanWire {
+    /// Envelope schema version. Only `1` is accepted; any other value is refused
+    /// as [`crate::PlanError::UnknownVersion`] (forward-compatible fail-closed).
+    pub version: u32,
+    /// The corrective round's steps (empty ⇒ the model is escalating, not
+    /// re-planning). `#[serde(default)]` + `deny_unknown_fields` keeps the
+    /// either/or shape strict.
+    #[serde(default)]
+    pub next_steps: Vec<PlanStep>,
+    /// An escalation reason — present iff the model chose flag-a-human (the third
+    /// route). Bounded by `MAX_FLAG_HUMAN_BYTES` in the decoder.
+    #[serde(default)]
+    pub flag_human: Option<String>,
+}
+
 /// A model-proposed plan: an ordered list of steps plus the dependency edges
 /// between them. Compiled (after role resolution) into a [`kx_workflow::WorkflowDef`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/kx-planner/src/tests.rs
+++ b/crates/kx-planner/src/tests.rs
@@ -18,9 +18,9 @@ use kx_warrant::{
 use proptest::prelude::*;
 
 use crate::{
-    compile_plan, decode_loop_proposal, decode_plan, lower_loop_to_topology_decision, lower_plan,
-    seed_from_plan_bytes, InMemoryRoleRecipes, LoopProposal, PlanError, PlanStep, PlanStepKind,
-    RoleRecipe,
+    compile_plan, decode_loop_proposal, decode_plan, decode_replan_proposal,
+    lower_loop_to_topology_decision, lower_plan, seed_from_plan_bytes, InMemoryRoleRecipes,
+    LoopProposal, PlanError, PlanStep, PlanStepKind, ReplanProposal, RoleRecipe,
 };
 
 const SYSCALL: [u8; 32] = [7; 32];
@@ -458,6 +458,136 @@ proptest! {
         s.push_str(&"[".repeat(depth));
         let r = decode_loop_proposal(s.as_bytes(), 1 << 20);
         prop_assert!(r.is_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// decode_replan_proposal (PR-3 / AL2) — the re-plan-round 3-way router boundary.
+// A SEPARATE envelope (`replan`) keeps decode_loop_proposal byte-frozen; identical
+// fail-closed discipline + a strict next_steps XOR flag_human shape.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replan_corrected_context_decodes_to_topology() {
+    let bytes = json(
+        r#"{"replan":{"version":1,"next_steps":[{"role":"reader","intent":"retry via the mirror source"}]}}"#,
+    );
+    match decode_replan_proposal(&bytes, 8192).expect("a valid corrective round decodes") {
+        ReplanProposal::Topology(p) => {
+            assert_eq!(p.next_steps.len(), 1);
+            assert_eq!(p.next_steps[0].role, "reader");
+        }
+        ReplanProposal::FlagHuman(_) => panic!("expected Topology"),
+    }
+}
+
+#[test]
+fn replan_flag_human_decodes_to_escalation() {
+    let bytes =
+        json(r#"{"replan":{"version":1,"flag_human":"needs a credential I cannot grant"}}"#);
+    match decode_replan_proposal(&bytes, 8192).expect("a valid escalation decodes") {
+        ReplanProposal::FlagHuman(reason) => {
+            assert_eq!(reason, "needs a credential I cannot grant");
+        }
+        ReplanProposal::Topology(_) => panic!("expected FlagHuman"),
+    }
+}
+
+#[test]
+fn replan_think_preamble_then_decodes() {
+    let bytes = json(
+        "<think>the fetch failed; try a fallback</think>\n{\"replan\":{\"version\":1,\"next_steps\":[{\"role\":\"reader\",\"intent\":\"fallback\"}]}}",
+    );
+    assert!(matches!(
+        decode_replan_proposal(&bytes, 8192),
+        Ok(ReplanProposal::Topology(_))
+    ));
+}
+
+#[test]
+fn replan_both_or_neither_is_refused() {
+    // both next_steps AND flag_human → ambiguous → Malformed.
+    let both = json(
+        r#"{"replan":{"version":1,"next_steps":[{"role":"r","intent":"i"}],"flag_human":"x"}}"#,
+    );
+    assert!(matches!(
+        decode_replan_proposal(&both, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // neither → empty round → EmptyPlan.
+    let neither = json(r#"{"replan":{"version":1}}"#);
+    assert!(matches!(
+        decode_replan_proposal(&neither, 8192),
+        Err(PlanError::EmptyPlan)
+    ));
+}
+
+#[test]
+fn replan_unknown_field_and_version_and_oversize_fail_closed() {
+    // a smuggled confidence/score on the envelope is refused (D77).
+    let smuggle =
+        json(r#"{"replan":{"version":1,"next_steps":[{"role":"r","intent":"i"}],"score":0.9}}"#);
+    assert!(matches!(
+        decode_replan_proposal(&smuggle, 8192),
+        Err(PlanError::Malformed { .. })
+    ));
+    // unknown version fails closed.
+    assert!(matches!(
+        decode_replan_proposal(br#"{"replan":{"version":2,"flag_human":"x"}}"#, 8192),
+        Err(PlanError::UnknownVersion { version: 2 })
+    ));
+    // size cap is BEFORE parse.
+    let big = vec![b'{'; 10_240];
+    assert!(matches!(
+        decode_replan_proposal(&big, 4),
+        Err(PlanError::Oversize {
+            got: 10_240,
+            max: 4
+        })
+    ));
+    // missing the `replan` envelope key (a loop_proposal smuggled in) is refused.
+    assert!(matches!(
+        decode_replan_proposal(
+            br#"{"loop_proposal":{"version":1,"next_steps":[{"role":"r","intent":"i"}]}}"#,
+            8192
+        ),
+        Err(PlanError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn replan_flag_human_reason_is_bounded() {
+    let huge = "x".repeat(crate::MAX_FLAG_HUMAN_BYTES + 1);
+    let bytes = json(&format!(
+        r#"{{"replan":{{"version":1,"flag_human":"{huge}"}}}}"#
+    ));
+    assert!(matches!(
+        decode_replan_proposal(&bytes, 1 << 20),
+        Err(PlanError::Oversize { .. })
+    ));
+}
+
+#[test]
+fn replan_corrected_context_lowers_to_topology_decision() {
+    // The corrective round lowers through the SAME vetted-recipe path as an
+    // initial round (SN-8): role names → recipe identity axes.
+    let (_roles, recipes) = standard_registries();
+    let bytes = json(
+        r#"{"replan":{"version":1,"next_steps":[{"role":"reader","intent":"again"},{"role":"summarizer","intent":"again"}]}}"#,
+    );
+    let ReplanProposal::Topology(p) = decode_replan_proposal(&bytes, 8192).expect("decodes") else {
+        panic!("expected Topology");
+    };
+    let td = lower_loop_to_topology_decision(&p, &recipes).expect("lowers");
+    assert_eq!(td.children.len(), 2);
+    assert_eq!(&td.children[0].role_id.0, "reader");
+}
+
+proptest! {
+    /// decode_replan_proposal is total + panic-free over arbitrary bytes.
+    #[test]
+    fn decode_replan_proposal_never_panics_on_arbitrary_bytes(bytes: Vec<u8>) {
+        let _ = decode_replan_proposal(&bytes, 4096);
     }
 }
 

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -47,7 +47,7 @@
 use std::collections::BTreeMap;
 
 use kx_content::ContentRef;
-use kx_journal::{ParentEntry, ResolvedCapabilityRecord, INSTANCE_ID_LEN};
+use kx_journal::{FailureReason, ParentEntry, ResolvedCapabilityRecord, INSTANCE_ID_LEN};
 use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -59,7 +59,10 @@ use crate::state::{
 /// The on-disk format version. Bump on **any** change to the envelope layout or
 /// the `CheckpointState` payload encoding — old checkpoints then fail
 /// [`FoldCheckpoint::from_bytes`] and recovery falls back to a full fold (self-healing).
-pub const CURRENT_FORMAT_VERSION: u16 = 1;
+///
+/// `2` (PR-3, AL2): `MoteInfoDto` gained `failure_reason` so a checkpoint-seeded
+/// recovery preserves the terminal `FailureReason` a model-driven re-plan reads.
+pub const CURRENT_FORMAT_VERSION: u16 = 2;
 
 /// Payload codec tag. `0` = canonical-bincode (LE + fixed-int, the house
 /// [`kx_mote::canonical_config`]). Reserved for a future rkyv zero-copy payload
@@ -436,6 +439,7 @@ struct MoteInfoDto {
     terminal_failure_observed: bool,
     inconsistent: bool,
     quarantined: bool,
+    failure_reason: Option<FailureReason>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -514,6 +518,7 @@ impl From<&MoteInfo> for MoteInfoDto {
             terminal_failure_observed,
             inconsistent,
             quarantined,
+            failure_reason,
         } = mi;
         Self {
             declared: declared.as_ref().map(DeclaredInfoDto::from),
@@ -524,6 +529,7 @@ impl From<&MoteInfo> for MoteInfoDto {
             terminal_failure_observed: *terminal_failure_observed,
             inconsistent: *inconsistent,
             quarantined: *quarantined,
+            failure_reason: *failure_reason,
         }
     }
 }
@@ -649,6 +655,7 @@ impl TryFrom<MoteInfoDto> for MoteInfo {
             terminal_failure_observed,
             inconsistent,
             quarantined,
+            failure_reason,
         } = dto;
         Ok(MoteInfo {
             declared: declared.map(DeclaredInfo::from),
@@ -659,6 +666,7 @@ impl TryFrom<MoteInfoDto> for MoteInfo {
             terminal_failure_observed,
             inconsistent,
             quarantined,
+            failure_reason,
         })
     }
 }
@@ -818,7 +826,13 @@ mod tests {
         // the remaining per-flag motes
         s.moteinfo_mut(&mid(20)).has_proposed = true;
         s.moteinfo_mut(&mid(21)).failed_pending_reattempt = true;
-        s.moteinfo_mut(&mid(22)).terminal_failure_observed = true;
+        {
+            // PR-3: a terminal-failure mote carries a retained `failure_reason`, so
+            // the round-trip proves the v1→v2 format preserves it (the bump's point).
+            let m = s.moteinfo_mut(&mid(22));
+            m.terminal_failure_observed = true;
+            m.failure_reason = Some(kx_journal::FailureReason::ExecutorRefused);
+        }
         s.moteinfo_mut(&mid(23)).inconsistent = true;
         s.last_seq = 4;
         s.run_registration = Some(RunRegistration {

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -3,7 +3,7 @@
 //! in `seq` order; query via the 7-method read API.
 
 use kx_content::ContentRef;
-use kx_journal::{Journal, JournalEntry};
+use kx_journal::{FailureReason, Journal, JournalEntry};
 use kx_mote::{EdgeMeta, MoteId, NdClass};
 use smallvec::SmallVec;
 
@@ -473,6 +473,14 @@ impl Projection {
                     // `is_pre_commit_crash` is the single source of class truth.
                     if !kx_journal::is_pre_commit_crash(*reason_class) {
                         info.terminal_failure_observed = true;
+                        // **PR-3 (AL2).** Retain the terminal reason (first-wins,
+                        // prefix-monotonic) so a model-driven re-plan can read WHY
+                        // a step dead-lettered. Pure read-side: off-digest, off-id,
+                        // off-DAG (the demo never folds a terminal Failed, so this
+                        // stays None and the canonical digest is byte-unchanged).
+                        if info.failure_reason.is_none() {
+                            info.failure_reason = Some(*reason_class);
+                        }
                     }
                     // **v6 (M2.3b, D105.4).** A recovery-time quarantine of a
                     // staged-uncommitted at-most-once effect: mark it so
@@ -716,6 +724,20 @@ impl Projection {
             .motes
             .get(mote_id)
             .and_then(|i| i.committed.as_ref().map(|c| c.nondeterminism))
+    }
+
+    /// The Mote's terminal [`FailureReason`] if it dead-lettered (a TERMINAL
+    /// `Failed` was folded — not a pre-commit-crash); `None` otherwise (incl. a
+    /// never-failed or a committed Mote, and a pre-commit-crash `Failed`).
+    ///
+    /// **PR-3 (AL2).** The minimal read-side surface a model-driven re-plan reads
+    /// to learn WHY a step failed (corrected-context), and an operator reads for
+    /// triage. Mirrors [`Projection::result_ref_of`] — a pure O(1) lookup. Returns
+    /// ONLY the closed, low-entropy reason enum: never the failed Mote's result
+    /// bytes or warrant secrets (a safe action-selection input, SN-8 / D77).
+    #[must_use]
+    pub fn failure_reason_of(&self, mote_id: &MoteId) -> Option<FailureReason> {
+        self.state.motes.get(mote_id).and_then(|i| i.failure_reason)
     }
 
     /// Motes whose parents are all `Committed-and-not-Repudiated` AND whose

--- a/crates/kx-projection/src/snapshot.rs
+++ b/crates/kx-projection/src/snapshot.rs
@@ -3,6 +3,7 @@
 //! semantics.
 
 use kx_content::ContentRef;
+use kx_journal::FailureReason;
 use kx_mote::{EdgeMeta, MoteId, NdClass};
 use smallvec::SmallVec;
 
@@ -143,6 +144,15 @@ impl Snapshot {
             .motes
             .get(mote_id)
             .and_then(|i| i.committed.as_ref().map(|c| c.nondeterminism))
+    }
+
+    /// Terminal [`FailureReason`] of a dead-lettered Mote. See
+    /// [`crate::Projection::failure_reason_of`]. PR-3 (AL2): the read-side a
+    /// model-driven re-plan consumes (against this immutable snapshot) to learn
+    /// WHY a step failed.
+    #[must_use]
+    pub fn failure_reason_of(&self, mote_id: &MoteId) -> Option<FailureReason> {
+        self.state.motes.get(mote_id).and_then(|i| i.failure_reason)
     }
 
     /// Committed-entry `seq`. See [`crate::Projection::committed_seq_of`].

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 
 use kx_content::ContentRef;
-use kx_journal::ParentEntry;
+use kx_journal::{FailureReason, ParentEntry};
 use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
 use smallvec::SmallVec;
 
@@ -83,6 +83,17 @@ pub(crate) struct MoteInfo {
     /// terminal `Failed` (via `terminal_failure_observed`), surfaced via
     /// [`crate::AnomalyKind::QuarantinedAtLeastOnceEffect`].
     pub(crate) quarantined: bool,
+    /// **PR-3 (AL2).** The journaled [`FailureReason`] of the FIRST *terminal*
+    /// `Failed` folded for this MoteId (i.e. NOT a pre-commit-crash per
+    /// [`kx_journal::is_pre_commit_crash`]) — retained so a model-driven re-plan
+    /// (and an operator) can read WHY a step dead-lettered, not merely THAT it did.
+    /// **Prefix-monotonic** (first-terminal-reason-wins; set in the same `Failed`
+    /// arm that sets `terminal_failure_observed`, never reset). Pure read-side
+    /// annotation: it is NEVER an input to identity, `digest_projection`,
+    /// `ready_set`, or any commit — the canonical demo never folds a `Failed`
+    /// entry, so it stays `None` there and the digest is byte-unchanged. Surfaced
+    /// via [`crate::Projection::failure_reason_of`] / [`crate::Snapshot::failure_reason_of`].
+    pub(crate) failure_reason: Option<FailureReason>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/kx-projection/src/tests.rs
+++ b/crates/kx-projection/src/tests.rs
@@ -91,6 +91,70 @@ fn failed_then_proposed_resets_to_scheduled() {
     assert_eq!(p.state_of(&mid(1)), MoteState::Scheduled);
 }
 
+// PR-3 (AL2): the read-side failure-reason channel a model-driven re-plan reads.
+fn failed_entry_with_reason(mote_byte: u8, seq: u64, reason: FailureReason) -> JournalEntry {
+    JournalEntry::Failed {
+        mote_id: mid(mote_byte),
+        idempotency_key: [mote_byte; 32],
+        seq,
+        reason_class: reason,
+        reporter_id: 0,
+    }
+}
+
+#[test]
+fn failure_reason_of_exposes_terminal_reason_and_defaults_none() {
+    let mut p = Projection::new();
+    // A terminal-logic dead-letter (NOT a pre-commit-crash) retains its reason.
+    p.fold(&proposed_entry(1, 1)).unwrap();
+    p.fold(&failed_entry_with_reason(
+        1,
+        2,
+        FailureReason::ExecutorRefused,
+    ))
+    .unwrap();
+    assert_eq!(p.state_of(&mid(1)), MoteState::Failed);
+    assert_eq!(
+        p.failure_reason_of(&mid(1)),
+        Some(FailureReason::ExecutorRefused)
+    );
+
+    // A pre-commit-crash reason (TimedOut/WorkerCrashed) is NOT a terminal
+    // dead-letter reason — it stays None (matches `terminal_failure_observed`).
+    p.fold(&proposed_entry(2, 3)).unwrap();
+    p.fold(&failed_entry_with_reason(2, 4, FailureReason::TimedOut))
+        .unwrap();
+    assert_eq!(p.failure_reason_of(&mid(2)), None);
+
+    // A never-failed / unknown Mote is None; a committed Mote is None.
+    assert_eq!(p.failure_reason_of(&mid(9)), None);
+    p.fold(&committed_entry(3, 5, NdClass::Pure)).unwrap();
+    assert_eq!(p.failure_reason_of(&mid(3)), None);
+}
+
+#[test]
+fn failure_reason_is_prefix_monotonic_first_terminal_wins() {
+    // Two terminal Failed entries: the FIRST terminal reason is retained.
+    let mut p = Projection::new();
+    p.fold(&proposed_entry(1, 1)).unwrap();
+    p.fold(&failed_entry_with_reason(
+        1,
+        2,
+        FailureReason::ExecutorRefused,
+    ))
+    .unwrap();
+    p.fold(&failed_entry_with_reason(
+        1,
+        3,
+        FailureReason::ValidatorRejected,
+    ))
+    .unwrap();
+    assert_eq!(
+        p.failure_reason_of(&mid(1)),
+        Some(FailureReason::ExecutorRefused)
+    );
+}
+
 #[test]
 fn repudiated_only_applies_when_target_committed_seq_matches() {
     let mut p = Projection::new();

--- a/crates/kx-runtime/src/topology.rs
+++ b/crates/kx-runtime/src/topology.rs
@@ -48,10 +48,16 @@ use crate::workflow::WorkflowMote;
 /// budget) returns [`TopologyProviderError`]; the caller dead-letters the shaper
 /// (composing with the PR-1 failure policy), never panics, never re-runs it.
 ///
-/// PR-2 invokes this **eagerly** in the harness (the single parentless shaper is
-/// computed once, before the run, then served as the shaper's effect). PR-3
-/// (re-plan) will have the engine invoke it **lazily** per round against the live
-/// snapshot — the same seam, no signature change.
+/// PR-2 invokes `decide` **eagerly** in the harness (the single parentless shaper
+/// is computed once, before the run, then served as the shaper's effect). PR-3
+/// (re-plan) drives a **bounded loop in the harness driver**
+/// (`kx_model_harness::run_replan_loop`): the engine stays UNCHANGED and is called
+/// once per round, while the driver invokes the provider per round against the live
+/// snapshot (`decide` for round 0, `replan` for a correction). Each round is a NEW
+/// committed ROND shaper fact, so a cold re-fold reproduces the whole chain (R49).
+/// The driver — not the engine — owns the loop because the engine assumes a SINGLE
+/// shaper and has no mid-loop stage-then-commit path; keeping iteration in the
+/// driver holds this seam, the frozen trio, and the digest invariant intact.
 pub trait TopologyProvider: Send + Sync {
     /// Compute this shaper's [`TopologyDecision`] from the model's proposal,
     /// assembled against `snapshot`. The caller encodes the returned decision


### PR DESCRIPTION
## What & why

Agentic-loop track, **PR 3 of 6** (builds on PR-2 #147 + PR-1 #146). On a **mid-DAG step failure**, the **model** now re-plans — one of three routes: **corrected-context** / **permission-adapt** / **flag-a-human** — bounded by `LoopBudget`. kortecx stays the *failsafe, durable substrate*: each round is a **new committed ROND topology-shaper fact**, so a crash between rounds resumes by re-folding and a cold re-fold reproduces the exact chain (R49). The unbounded durable loop stays cloud (D126 cat-B).

The loop lives in the **harness driver** (`run_replan_loop`); `run_with_seams` + the **frozen trio are UNCHANGED** (the engine assumes a single shaper and has no mid-loop stage-then-commit path, so an engine hook would be a large, frozen-trio-adjacent change for no durability gain).

## Changes
- **kx-projection** — `MoteInfo.failure_reason` + `Projection`/`Snapshot::failure_reason_of` (the read-side so the model sees *why* a step failed); set in the existing `Failed` fold arm when terminal (**off-digest**); checkpoint round-trips it (format v1→2, self-healing).
- **kx-planner** — `decode_replan_proposal`, a **separate `replan` envelope** that keeps `decode_loop_proposal` byte-frozen — `next_steps` XOR `flag_human` + `MAX_FLAG_HUMAN_BYTES`; `ReplanProposal`.
- **kx-model-harness** — `run_replan_loop` + `ReplanLoopOutcome` + `Harness::drive_replan_loop`; `ModelTopologyProvider` gains `replan()`/`ReplanOutcome` + a **shared accumulating def-registry** (one materializer re-derives every round's children); `workflows::replan_shaper` (round-namespaced identity); a **stable failure-reason token** on the identity path (R49 rename/reorder-proof).
- **kx-runtime** — doc-comment only.

## Golden Rule 8 — both passes
- **A (breaks/degrades/holes):** digest `a6b5c679` invariant; frozen-trio diff **EMPTY**; Cargo.lock unchanged (D111). *Breaks* mitigated: round-distinct identity (round-namespaced shaper), the **fold-before-each-round skip-already-committed guard** (crash-safe, tested), the stable identity token. *Degrades:* O(R·journal) per-round rebuild bounded by `max_rounds`; `failure_reason_of` O(1); flagged scale watch-items. *Holes:* `failure_reason` exposes only the closed low-entropy enum (no result bytes/secrets); untrusted model text stays inside the fail-closed decode boundary; SN-8 — `intersect` narrows every round, never widens.
- **B (forward):** the run→fail→re-plan→succeed loop inherits exactly-once + R49 **for free**; `failure_reason_of` closes a real observability gap; the seam is the on-ramp to PR-2b (live serve) + the cloud unbounded loop.

## Tests
`replan_loop_e2e` **9/9** (corrected-context + R49 replay, **mid-chain crash/resume**, budget-exhaustion, flag_human, no-failure, two-failures-one-round, malformed, unknown-role, over-budget) · `decode_replan_proposal` unit+proptest · projection `failure_reason` + checkpoint round-trip units · `failure_reason_token` frozen-mapping · gated with-model `replan_loop_invariants` · PR-2 regression green. **`cargo test --workspace` 1824/0**; clippy `-D warnings` / fmt / doc / deny clean.

## Pre-merge review
11-agent adversarial review (durability / security-SN8 / invariants / test-adequacy + verify): **0 confirmed correctness or security holes**. The one REAL_MEDIUM (Debug-of-`FailureReason` on the shaper-identity path → a variant rename would break cross-version R49) is **fixed in-PR** with a stable `as_u8`-keyed token + a frozen-mapping test. Deferred follow-ons (non-blocking): a single-fold external multi-round recovery test (the driver-rewalk path is proven), a termination proptest, durable flag_human reason (→ PR-6 active HITL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)