### PR TITLE
F4 — clean termination of a WM StageThenCommit dispatch failure (dead-letter, no spin)

### DIFF
--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -440,6 +440,19 @@ pub enum FailureReason {
     /// terminal (never re-dispatched) and surfaced via the projection's
     /// `AnomalyKind`/`anomaly_motes` for operator review.
     QuarantinedAtLeastOnce = 7,
+    /// **Engine dead-letter outcome (F4).** The single-process drive loop gave up
+    /// on a Mote: a *transient* infrastructure dispatch error that exhausted the
+    /// [`crate`]-external `FailurePolicy` retry budget, OR a *terminal-logic*
+    /// dispatch failure that cannot succeed on a retry. Classified **terminal** by
+    /// [`is_pre_commit_crash`] (returns `false`), so the projection's `Failed` fold
+    /// sets `terminal_failure_observed` → the Mote becomes terminal `Failed`, is
+    /// never re-dispatched, and the loop terminates cleanly. **Distinct from
+    /// [`TimedOut`](Self::TimedOut)** — `TimedOut` is a *liveness* pre-commit-crash
+    /// (the worker died mid-flight; under an `EffectStaged` it *permits* re-dispatch
+    /// because the broker's tool-boundary idempotency closes the window). Conflating
+    /// the two is the F4 hang: a budget-exhausted dead-letter written as `TimedOut`
+    /// under `EffectStaged` stays re-dispatchable forever (`run_with_seams` spins).
+    DeadLettered = 8,
 }
 
 impl FailureReason {
@@ -462,6 +475,7 @@ impl FailureReason {
             5 => Self::UnsafeWorldMutatingConstruction,
             6 => Self::CompensatedAtLeastOnce,
             7 => Self::QuarantinedAtLeastOnce,
+            8 => Self::DeadLettered,
             _ => return None,
         })
     }
@@ -504,6 +518,8 @@ impl FailureReason {
 /// assert!(!is_pre_commit_crash(FailureReason::ValidatorRejected));
 /// assert!(!is_pre_commit_crash(FailureReason::UpstreamRepudiated));
 /// assert!(!is_pre_commit_crash(FailureReason::UnsafeWorldMutatingConstruction));
+/// // The engine dead-letter (F4) is terminal — the loop gave up, never re-dispatch.
+/// assert!(!is_pre_commit_crash(FailureReason::DeadLettered));
 /// ```
 #[must_use]
 pub const fn is_pre_commit_crash(reason: FailureReason) -> bool {
@@ -2318,7 +2334,12 @@ mod tests {
         }
         assert_eq!(FailureReason::CompensatedAtLeastOnce.as_u8(), 6);
         assert_eq!(FailureReason::QuarantinedAtLeastOnce.as_u8(), 7);
-        assert_eq!(FailureReason::from_u8(8), None);
+        // F4: the engine dead-letter variant is discriminant 8 (terminal), and it
+        // round-trips. The unknown-sentinel boundary moves to 9.
+        assert_eq!(FailureReason::DeadLettered.as_u8(), 8);
+        assert_eq!(FailureReason::from_u8(8), Some(FailureReason::DeadLettered));
+        assert!(!is_pre_commit_crash(FailureReason::DeadLettered));
+        assert_eq!(FailureReason::from_u8(9), None);
     }
 
     #[test]
@@ -2362,6 +2383,9 @@ mod tests {
         assert!(!is_pre_commit_crash(
             FailureReason::UnsafeWorldMutatingConstruction
         ));
+        // F4: the engine dead-letter is terminal — the loop gave up; NEVER
+        // re-dispatch (writing it under EffectStaged must NOT spin the loop).
+        assert!(!is_pre_commit_crash(FailureReason::DeadLettered));
     }
 
     #[test]

--- a/crates/kx-journal/tests/proptest_entry.rs
+++ b/crates/kx-journal/tests/proptest_entry.rs
@@ -75,6 +75,7 @@ fn arb_failure_reason() -> impl Strategy<Value = FailureReason> {
         Just(FailureReason::WorkerCrashed),
         Just(FailureReason::UpstreamRepudiated),
         Just(FailureReason::UnsafeWorldMutatingConstruction),
+        Just(FailureReason::DeadLettered),
     ]
 }
 

--- a/crates/kx-model-harness/src/topology_provider.rs
+++ b/crates/kx-model-harness/src/topology_provider.rs
@@ -840,6 +840,10 @@ fn failure_reason_token(reason: Option<kx_journal::FailureReason>) -> &'static s
         Some(5) => "unsafe-world-mutating-construction",
         Some(6) => "compensated-at-least-once",
         Some(7) => "quarantined-at-least-once",
+        // F4: the engine dead-letter (a budget-exhausted transient or a terminal-logic
+        // dispatch failure the loop gave up on). Distinct from `timed-out` (a liveness
+        // pre-commit-crash) so the AL2 re-plan reads an accurate signal.
+        Some(8) => "dead-lettered",
         // A None (transient/pre-commit-crash → no retained terminal reason) or any
         // future, not-yet-tokenized variant maps to a fixed sentinel — still stable.
         _ => "transient-or-unknown",
@@ -913,6 +917,12 @@ mod replan_unit_tests {
         assert_eq!(
             failure_reason_token(Some(FailureReason::QuarantinedAtLeastOnce)),
             "quarantined-at-least-once"
+        );
+        // F4: the engine dead-letter token (discriminant 8). Existing tokens 0..=7
+        // stay byte-frozen above, so adding this cannot shift any committed identity.
+        assert_eq!(
+            failure_reason_token(Some(FailureReason::DeadLettered)),
+            "dead-lettered"
         );
     }
 

--- a/crates/kx-model-harness/tests/react_loop_e2e.rs
+++ b/crates/kx-model-harness/tests/react_loop_e2e.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use kx_capability::{CapabilityBroker, LocalCapabilityBroker, INSTANCE_ID_LEN};
 use kx_content::LocalFsContentStore;
 use kx_inference::{InferenceBackend, InferenceError, InferenceInput, InferenceOutput};
-use kx_journal::SqliteJournal;
+use kx_journal::{Journal, SqliteJournal};
 use kx_mcp::{McpCapability, McpTransport, TransportError};
 use kx_model_harness::{
     harness_warrant, run_react_loop, workflows, ReactBudget, ReactLoopOutcome, ReactStop,
@@ -685,16 +685,101 @@ fn cold_refold_reproduces_committed_set() {
     );
 }
 
-// NOTE (deferred follow-on, NOT in PR-4 scope): a tool *dispatch* failure (e.g. an
-// MCP transport/network error) under StageThenCommit does NOT yet cleanly terminate
-// the engine drive loop — `run_with_seams` can spin on the EffectStaged redispatch
-// path rather than dead-lettering after the failure budget. That is an ENGINE / PR-1
-// failure-classification concern (frozen trio), tied to the corpus's deferred F4
-// "worker terminal-failure / dead-letter" item — it is out of this harness-only PR's
-// scope and must NOT be papered over with a driver-side hack. PR-4 owns the
-// PARSE-time fail-closed paths (malformed / ungranted / oversize), proven above; the
-// observation-commit-failure path (driver tool-committed guard, react.rs) is correct
-// once the engine returns. Tracked for the F4 engine PR.
+/// An MCP transport that is hard-down: every `round_trip` fails. Stands in for an
+/// unreachable MCP server / a dropped network. A tool dispatch over it fails the
+/// broker (`CommitProtocolError::BrokerDispatchFailed` → `TransientInfra`).
+struct FailingTransport;
+
+impl McpTransport for FailingTransport {
+    fn round_trip(
+        &self,
+        _request: &[u8],
+        _max: usize,
+        _ms: u64,
+        _idempotency_key: Option<&[u8; 32]>,
+    ) -> Result<Vec<u8>, TransportError> {
+        Err(TransportError::Unreachable(
+            "injected: MCP server down".into(),
+        ))
+    }
+}
+
+#[test]
+fn tool_dispatch_failure_dead_letters_and_loop_returns() {
+    // **F4 — the regression this PR fixes.** The model proposes a tool call, but the
+    // MCP transport is hard-down. The observation Mote is a WM `StageThenCommit`, so
+    // its commit protocol stages `EffectStaged` BEFORE the (failing) broker dispatch.
+    // PRE-FIX, the budget-exhausted dead-letter was written as `TimedOut` (a
+    // pre-commit-crash), which under `EffectStaged` stayed re-dispatchable forever →
+    // `run_with_seams` SPUN (the original test hung 60s+ and was removed). POST-FIX
+    // the dead-letter is the terminal `DeadLettered`, so the engine RETURNS, the
+    // driver sees the non-committed observation, and the loop stops cleanly with
+    // `ReactStop::DeadLettered`.
+    //
+    // We run the drive on a worker thread with a HARD 10s deadline so a regression of
+    // the F4 spin FAILS CI (a timeout) rather than hanging the whole suite.
+    let (tx, rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let dir = tempfile::tempdir().unwrap();
+        let (outcome, _backend, journal) = drive_full(
+            dir.path(),
+            vec![
+                envelope("mcp-tool", "1", "investigate"),
+                // A fallback final answer — it must NOT be reached (the loop stops at
+                // the dead-letter), but a script entry guards against an accidental
+                // extra turn silently exhausting the script.
+                b"fallback answer (should be unreached)".to_vec(),
+            ],
+            Box::new(FailingTransport),
+            &warrant_granting(),
+            ReactBudget {
+                max_turns: 5,
+                max_tool_calls: 5,
+            },
+        );
+        let outcome = outcome.expect("the loop RETURNS, never hangs (F4: no EffectStaged spin)");
+        // Reduce to Send primitives before crossing the channel (SqliteJournal is not
+        // Send): the stop reason, the tool-call count, the failed-Mote count, and the
+        // total journal length (the anti-spin bound).
+        let failed = failed_count(&journal);
+        let total = journal.current_seq().unwrap();
+        let _ = tx.send((outcome.outcome, outcome.tool_calls, failed, total));
+    });
+
+    let (stop, tool_calls, failed, total) = match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "F4 REGRESSION: the ReAct loop did not terminate within 10s — \
+                    `run_with_seams` is spinning the EffectStaged-redispatch path again"
+            );
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            // The worker panicked (e.g. the loop returned Err) — surface that panic.
+            worker.join().unwrap();
+            unreachable!("worker disconnected without sending");
+        }
+    };
+    worker.join().unwrap();
+
+    assert_eq!(
+        stop,
+        ReactStop::DeadLettered,
+        "a failed tool dispatch dead-letters the observation and stops the loop"
+    );
+    assert_eq!(
+        tool_calls, 0,
+        "a dead-lettered observation is NOT counted as a successful tool call"
+    );
+    assert!(
+        failed >= 1,
+        "the observation Mote dead-lettered (terminal Failed), not committed"
+    );
+    assert!(
+        total < 25,
+        "the journal stayed bounded ({total} entries) — no unbounded EffectStaged-redispatch spin"
+    );
+}
 
 // ---------------------------------------------------------------------------
 // Safety: a context-window overflow surfaces a TYPED error, never a panic.

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -829,9 +829,11 @@ mod tests {
         {
             // PR-3: a terminal-failure mote carries a retained `failure_reason`, so
             // the round-trip proves the v1→v2 format preserves it (the bump's point).
+            // F4: use the canonical engine dead-letter reason `DeadLettered` (the new
+            // discriminant 8), so the checkpoint serde is proven to round-trip it.
             let m = s.moteinfo_mut(&mid(22));
             m.terminal_failure_observed = true;
-            m.failure_reason = Some(kx_journal::FailureReason::ExecutorRefused);
+            m.failure_reason = Some(kx_journal::FailureReason::DeadLettered);
         }
         s.moteinfo_mut(&mid(23)).inconsistent = true;
         s.last_seq = 4;

--- a/crates/kx-projection/tests/cross_product.rs
+++ b/crates/kx-projection/tests/cross_product.rs
@@ -254,6 +254,32 @@ fn cell_5_terminal_failure_under_effect_staged_unsafe_wm_construction() {
     assert!(!p.can_redispatch_world_effect(&mid));
 }
 
+#[test]
+fn cell_5_terminal_failure_under_effect_staged_dead_lettered() {
+    // **F4 regression (the projection-level proof the hang is closed).** A WM
+    // `StageThenCommit` Mote whose dispatch repeatedly failed gets dead-lettered by
+    // the engine with `FailureReason::DeadLettered`. Because `DeadLettered` is
+    // terminal (NOT a pre-commit-crash), this MUST land in cell 5 (Failed, no
+    // redispatch) — NOT cell 3 (Pending in-flight, redispatch permitted). If this
+    // ever regressed to redispatch-permitted, `run_with_seams` would spin forever.
+    let mid = MoteId::from_bytes([13u8; 32]);
+    let (p, _) = projection_from_entries(vec![
+        effect_staged(mid, 0),
+        failed(mid, 0, FailureReason::DeadLettered),
+    ]);
+    assert_eq!(
+        p.state_of(&mid),
+        MoteState::Failed,
+        "F4: DeadLettered under EffectStaged MUST be terminal Failed (not Pending)"
+    );
+    assert!(
+        !p.can_redispatch_world_effect(&mid),
+        "F4: DeadLettered forbids redispatch — the loop terminates instead of spinning"
+    );
+    // A clean dead-letter is NOT an anomaly (distinct from the quarantine path).
+    assert!(p.anomaly_motes().is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Cell 5 — EffectStaged + Committed
 // ---------------------------------------------------------------------------

--- a/crates/kx-projection/tests/proptest_fold.rs
+++ b/crates/kx-projection/tests/proptest_fold.rs
@@ -695,6 +695,7 @@ fn arbitrary_failure_reason() -> impl Strategy<Value = FailureReason> {
         Just(FailureReason::WorkerCrashed),
         Just(FailureReason::UpstreamRepudiated),
         Just(FailureReason::UnsafeWorldMutatingConstruction),
+        Just(FailureReason::DeadLettered),
     ]
 }
 

--- a/crates/kx-runtime/src/engine.rs
+++ b/crates/kx-runtime/src/engine.rs
@@ -1323,13 +1323,14 @@ mod failure_tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use kx_capability::{BrokerError, BrokerHandle, CapabilityBroker, EffectRequest};
     use kx_content::LocalFsContentStore;
     use kx_executor::{
         LocalResourceManager, MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs,
         StandardCommitProtocol, TestMoteExecutor,
     };
-    use kx_journal::SqliteJournal;
-    use kx_mote::Mote;
+    use kx_journal::{FailureReason, Journal, SqliteJournal};
+    use kx_mote::{Mote, ToolName};
     use kx_projection::{MoteState, Projection};
     use kx_warrant::{ExecutorClass, WarrantSpec};
 
@@ -1338,7 +1339,7 @@ mod failure_tests {
     use crate::config::{Mode, RuntimeConfig};
     use crate::error::RuntimeError;
     use crate::failure_policy::FailurePolicy;
-    use crate::workflow::flat_pure_workflow;
+    use crate::workflow::{flat_pure_workflow, flat_wm_stc_workflow};
 
     /// A `MoteExecutor` that fails a chosen Mote and delegates the rest to a real
     /// deterministic stub, counting how many times the chosen Mote is dispatched.
@@ -1463,6 +1464,13 @@ mod failure_tests {
             MoteState::Committed,
             "its sibling still commits"
         );
+        // F4: every engine dead-letter records the dedicated terminal `DeadLettered`
+        // reason (was the loosely-reused `ExecutorRefused` pre-F4).
+        assert_eq!(
+            projection.failure_reason_of(&target),
+            Some(FailureReason::DeadLettered),
+            "the dead-letter reason is the dedicated terminal DeadLettered"
+        );
         // Terminal logic failure ⇒ dispatched exactly once, never retried.
         assert_eq!(calls, 1, "a terminal failure is not retried");
     }
@@ -1483,6 +1491,12 @@ mod failure_tests {
         let projection = projection.unwrap();
         assert_eq!(projection.state_of(&target), MoteState::Failed);
         assert_eq!(projection.state_of(&sibling), MoteState::Committed);
+        assert_eq!(
+            projection.failure_reason_of(&target),
+            Some(FailureReason::DeadLettered),
+            "an exhausted transient dead-letters with the terminal DeadLettered (NOT \
+             the pre-commit-crash TimedOut, which under EffectStaged would spin)"
+        );
         // A transient error is retried up to `max_attempts` dispatches, then dead-lettered.
         assert_eq!(calls, 3, "transient retried to the 3-attempt budget");
     }
@@ -1497,6 +1511,344 @@ mod failure_tests {
         assert!(
             matches!(result, Err(RuntimeError::Lifecycle(_))),
             "without a policy a failing Mote aborts the run"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // F4 — clean termination of a WM `StageThenCommit` DISPATCH failure.
+    //
+    // The PURE tests above CANNOT reproduce F4: a PURE Mote never stages an
+    // `EffectStaged`, so its dead-letter (`Failed{DeadLettered}`) is terminal via
+    // the `failed_pending_reattempt` branch. F4 is specific to a WORLD-MUTATING
+    // `StageThenCommit` Mote, whose commit protocol writes `EffectStaged` BEFORE the
+    // broker dispatch. Under the pre-F4 mapping (`reason_for(TransientInfra) =
+    // TimedOut`, a pre-commit-crash), a budget-exhausted dead-letter stayed
+    // re-dispatchable forever (`effect_staged_observed` masks the terminal branch) →
+    // `run_with_seams` spun, growing the journal without bound (the 60s+ hang). These
+    // tests drive a flat WM `StageThenCommit` workflow through a FAILING BROKER and
+    // assert the run TERMINATES (bounded re-dispatch → terminal `DeadLettered`).
+    // -----------------------------------------------------------------------
+
+    /// A `CapabilityBroker` that fails `dispatch` for a chosen WM Mote the first
+    /// `fail_times` calls, then delegates to the real [`DemoBroker`]. Counts target
+    /// dispatches. `fail_times == u32::MAX` ⇒ always fail (the repeated-failure /
+    /// hang case); a finite value ⇒ the transient-then-success case. A broker
+    /// `dispatch` error becomes `CommitProtocolError::BrokerDispatchFailed`, which
+    /// `classify_lifecycle_error` maps to `TransientInfra` (retry-then-dead-letter).
+    struct FailingBroker {
+        inner: DemoBroker<LocalFsContentStore>,
+        target: kx_mote::MoteId,
+        fail_times: u32,
+        target_calls: Arc<AtomicUsize>,
+    }
+
+    impl CapabilityBroker for FailingBroker {
+        fn dispatch(
+            &self,
+            mote: &Mote,
+            warrant: &WarrantSpec,
+            capability: &ToolName,
+            request: EffectRequest,
+        ) -> Result<BrokerHandle, BrokerError> {
+            if mote.id == self.target {
+                // `fetch_add` returns the PRE-increment count → the 1st call sees 0.
+                let prior = self.target_calls.fetch_add(1, Ordering::SeqCst);
+                if u32::try_from(prior).unwrap_or(u32::MAX) < self.fail_times {
+                    return Err(BrokerError::StageWriteFailed {
+                        capability: capability.clone(),
+                        diagnostic: "injected: MCP transport unreachable".into(),
+                    });
+                }
+            }
+            self.inner.dispatch(mote, warrant, capability, request)
+        }
+
+        fn probe_readback(
+            &self,
+            mote: &Mote,
+            warrant: &WarrantSpec,
+            capability: &ToolName,
+            probe: EffectRequest,
+        ) -> Result<Option<BrokerHandle>, BrokerError> {
+            self.inner.probe_readback(mote, warrant, capability, probe)
+        }
+    }
+
+    /// Drive a flat 2-Mote WM `StageThenCommit` workflow whose SECOND Mote's broker
+    /// dispatch fails `fail_times` times, under `policy`. Returns the run result, the
+    /// (target, sibling) ids, the re-folded projection, the target's dispatch count,
+    /// and the canonical projection digest (committed-set only — `Failed` excluded).
+    fn drive_wm(
+        fail_times: u32,
+        policy: Option<&FailurePolicy>,
+    ) -> (
+        Result<RunOutcome, RuntimeError>,
+        kx_mote::MoteId,
+        kx_mote::MoteId,
+        Projection,
+        usize,
+        String,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_for(dir.path());
+        let workflow = flat_wm_stc_workflow(&[0x20, 0x21]);
+        let sibling = workflow.motes[0].mote.id;
+        let target = workflow.motes[1].mote.id;
+
+        let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+        let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+        let rm = LocalResourceManager::dev_defaults();
+        let target_calls = Arc::new(AtomicUsize::new(0));
+        let broker = Arc::new(FailingBroker {
+            inner: DemoBroker::new(store.clone(), BTreeMap::new(), None, None),
+            target,
+            fail_times,
+            target_calls: target_calls.clone(),
+        });
+        let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+        // WM Motes dispatch through the BROKER, not the executor; the deterministic
+        // stub satisfies the param and is never called on a WM Mote.
+        let executor = TestMoteExecutor::deterministic();
+
+        let result = run_with_seams(
+            &config,
+            &workflow,
+            store,
+            journal.clone(),
+            &rm,
+            &executor,
+            &protocol,
+            None, // shaper — flat DAG
+            None, // topology_provider
+            None, // snapshot_sink
+            None, // capture_sink
+            None, // audit_sink
+            policy,
+        );
+
+        let projection = Projection::from_journal(&*journal).unwrap();
+        let digest = crate::digest::digest_journal(&*journal).unwrap().to_hex();
+        (
+            result,
+            target,
+            sibling,
+            projection,
+            target_calls.load(Ordering::SeqCst),
+            digest,
+        )
+    }
+
+    #[test]
+    fn failing_stage_then_commit_wm_dead_letters_within_budget_and_run_completes() {
+        // THE F4 REGRESSION. Pre-fix this HANGS (unbounded EffectStaged re-stage).
+        let policy = FailurePolicy::new(3, Duration::ZERO);
+        let (result, target, sibling, projection, calls, _digest) =
+            drive_wm(u32::MAX, Some(&policy));
+
+        let outcome = result.expect("the run COMPLETES — F4: no spin on EffectStaged redispatch");
+        assert_eq!(outcome.total, 2);
+        assert_eq!(
+            outcome.committed, 1,
+            "the sibling commits; the target dead-letters"
+        );
+
+        assert_eq!(
+            projection.state_of(&target),
+            MoteState::Failed,
+            "a repeatedly-failing WM StageThenCommit Mote becomes TERMINAL Failed"
+        );
+        assert!(
+            !projection.can_redispatch_world_effect(&target),
+            "terminal dead-letter forbids redispatch — the loop stops instead of spinning"
+        );
+        assert_eq!(
+            projection.failure_reason_of(&target),
+            Some(FailureReason::DeadLettered),
+        );
+        assert_eq!(projection.state_of(&sibling), MoteState::Committed);
+        // The anti-spin proof: bounded by `max_attempts`, NOT unbounded.
+        assert_eq!(calls, 3, "dispatch is bounded by the FailurePolicy budget");
+    }
+
+    #[test]
+    fn wm_dispatch_failure_max_attempts_one_dead_letters_immediately() {
+        // max_attempts = 1 ⇒ a single attempt, then dead-letter (no retry).
+        let policy = FailurePolicy::new(1, Duration::ZERO);
+        let (result, target, _sibling, projection, calls, _digest) =
+            drive_wm(u32::MAX, Some(&policy));
+        result.expect("the run completes");
+        assert_eq!(projection.state_of(&target), MoteState::Failed);
+        assert_eq!(
+            projection.failure_reason_of(&target),
+            Some(FailureReason::DeadLettered)
+        );
+        assert_eq!(calls, 1, "max_attempts=1 ⇒ exactly one dispatch");
+    }
+
+    #[test]
+    fn wm_dispatch_failure_does_not_grow_journal_unbounded() {
+        // The DIRECT anti-spin gate: the on-disk journal stays bounded. Pre-fix this
+        // grows without bound (each loop iteration appends Proposed+EffectStaged+
+        // Failed) until the test times out.
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_for(dir.path());
+        let workflow = flat_wm_stc_workflow(&[0x40, 0x41]);
+        let target = workflow.motes[1].mote.id;
+        let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+        let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+        let rm = LocalResourceManager::dev_defaults();
+        let policy = FailurePolicy::new(3, Duration::ZERO);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let broker = Arc::new(FailingBroker {
+            inner: DemoBroker::new(store.clone(), BTreeMap::new(), None, None),
+            target,
+            fail_times: u32::MAX,
+            target_calls: calls.clone(),
+        });
+        let protocol = StandardCommitProtocol::new(store.clone(), journal.clone(), broker);
+        let executor = TestMoteExecutor::deterministic();
+        run_with_seams(
+            &config,
+            &workflow,
+            store,
+            journal.clone(),
+            &rm,
+            &executor,
+            &protocol,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&policy),
+        )
+        .expect("completes");
+        // Per target attempt: at most Proposed + EffectStaged + (a final) Failed; the
+        // sibling adds a small constant. Far below any "spin" signature.
+        let total = journal.current_seq().unwrap();
+        assert!(
+            total < 20,
+            "journal stayed bounded (got {total}) — no EffectStaged-redispatch spin"
+        );
+    }
+
+    #[test]
+    fn wm_transient_then_success_commits_within_budget_digest_invariant() {
+        // A flaky broker that fails twice then succeeds (within a 3-attempt budget)
+        // must COMMIT — NOT dead-letter — and produce the SAME canonical digest as a
+        // clean run (the committed result_ref is content-addressed; the transient
+        // failures leave no committed trace).
+        let policy = FailurePolicy::new(3, Duration::ZERO);
+        let (r_ok, target, sibling, p_ok, calls_ok, digest_baseline) = drive_wm(0, Some(&policy));
+        r_ok.expect("clean run completes");
+        assert_eq!(p_ok.state_of(&target), MoteState::Committed);
+        assert_eq!(p_ok.state_of(&sibling), MoteState::Committed);
+        assert_eq!(calls_ok, 1, "clean: target dispatched once");
+
+        let (r_flaky, t2, s2, p_flaky, calls_flaky, digest_flaky) = drive_wm(2, Some(&policy));
+        r_flaky.expect("flaky run completes");
+        assert_eq!(t2, target, "deterministic ids across runs (same seeds)");
+        assert_eq!(s2, sibling);
+        assert_eq!(
+            p_flaky.state_of(&target),
+            MoteState::Committed,
+            "transient-then-success COMMITS, never dead-letters"
+        );
+        assert_eq!(
+            p_flaky.failure_reason_of(&target),
+            None,
+            "a committed Mote carries no terminal failure reason"
+        );
+        assert_eq!(calls_flaky, 3, "failed twice (n=0,1), succeeded on the 3rd");
+        assert_eq!(
+            digest_flaky, digest_baseline,
+            "digest invariant: the committed set is identical regardless of transient retries"
+        );
+    }
+
+    #[test]
+    fn wm_dead_letter_is_durable_across_restart_and_never_redispatched() {
+        // Crash-resume (R49): a dead-lettered WM Mote stays terminal across a restart
+        // and is NEVER re-dispatched. Run 2 = a fresh `run_with_seams` on the SAME
+        // journal (a fresh in-memory attempt counter, exactly like a process restart).
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_for(dir.path());
+        let workflow = flat_wm_stc_workflow(&[0x30, 0x31]);
+        let target = workflow.motes[1].mote.id;
+        let store = Arc::new(LocalFsContentStore::open(&config.content_root).unwrap());
+        let journal = Arc::new(SqliteJournal::open(&config.journal_path).unwrap());
+        let rm = LocalResourceManager::dev_defaults();
+        let policy = FailurePolicy::new(2, Duration::ZERO);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let executor = TestMoteExecutor::deterministic();
+        let new_broker = || {
+            Arc::new(FailingBroker {
+                inner: DemoBroker::new(store.clone(), BTreeMap::new(), None, None),
+                target,
+                fail_times: u32::MAX,
+                target_calls: calls.clone(),
+            })
+        };
+
+        // Run 1: retries to the 2-attempt budget then dead-letters the target.
+        let p1 = StandardCommitProtocol::new(store.clone(), journal.clone(), new_broker());
+        run_with_seams(
+            &config,
+            &workflow,
+            store.clone(),
+            journal.clone(),
+            &rm,
+            &executor,
+            &p1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&policy),
+        )
+        .expect("run 1 completes (dead-letters, no spin)");
+        let calls_after_1 = calls.load(Ordering::SeqCst);
+        assert_eq!(
+            calls_after_1, 2,
+            "target retried to budget then dead-lettered"
+        );
+        assert_eq!(
+            Projection::from_journal(&*journal)
+                .unwrap()
+                .state_of(&target),
+            MoteState::Failed
+        );
+
+        // Run 2 (restart on the same journal): the target is already terminal →
+        // skipped → the broker is NEVER called again; the run completes at once.
+        let p2 = StandardCommitProtocol::new(store.clone(), journal.clone(), new_broker());
+        run_with_seams(
+            &config,
+            &workflow,
+            store.clone(),
+            journal.clone(),
+            &rm,
+            &executor,
+            &p2,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&policy),
+        )
+        .expect("run 2 (restart) completes immediately");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            calls_after_1,
+            "a dead-lettered Mote is NEVER re-dispatched on restart (R49)"
+        );
+        assert_eq!(
+            Projection::from_journal(&*journal)
+                .unwrap()
+                .state_of(&target),
+            MoteState::Failed
         );
     }
 }

--- a/crates/kx-runtime/src/failure_policy.rs
+++ b/crates/kx-runtime/src/failure_policy.rs
@@ -144,14 +144,25 @@ fn classify_commit_error(err: &CommitProtocolError) -> FailureClass {
 }
 
 /// The journaled [`FailureReason`] for a dead-lettered Mote of the given class.
-/// Reuses the existing closed enum (no schema bump): an exhausted transient maps
-/// to [`FailureReason::TimedOut`] (it ran out of attempts, i.e. never committed in
-/// budget), a terminal logic failure to [`FailureReason::ExecutorRefused`] (the
-/// executor did not produce a committable result).
+///
+/// **Both classes map to the dedicated terminal [`FailureReason::DeadLettered`]**
+/// (F4). This is load-bearing for correctness, not cosmetic: the projection's
+/// `Failed` fold sets `terminal_failure_observed` only when the reason is NOT a
+/// pre-commit-crash ([`kx_journal::is_pre_commit_crash`]). The pre-F4 mapping wrote
+/// [`FailureReason::TimedOut`] for an exhausted transient — but `TimedOut` IS a
+/// pre-commit-crash (a worker that died mid-flight, *re-dispatchable* under an
+/// `EffectStaged`). So a budget-exhausted WORLD-MUTATING `StageThenCommit`
+/// dead-letter stayed re-dispatchable forever and `run_with_seams` spun the
+/// EffectStaged-redispatch path without ever terminating (the F4 hang). Writing the
+/// terminal `DeadLettered` makes the Mote terminal `Failed`, so the drive loop skips
+/// it and the run completes. Mapping the *terminal-logic* class to the same variant
+/// (vs the old [`FailureReason::ExecutorRefused`] reuse — a submission-time verdict,
+/// not an engine dead-letter) gives the AL2 re-plan one unambiguous "the engine gave
+/// up on this step" signal. No schema bump beyond the additive `DeadLettered`
+/// variant; `Failed` entries are not folded into the canonical digest.
 pub(crate) fn reason_for(class: FailureClass) -> FailureReason {
     match class {
-        FailureClass::TransientInfra => FailureReason::TimedOut,
-        FailureClass::TerminalLogic => FailureReason::ExecutorRefused,
+        FailureClass::TransientInfra | FailureClass::TerminalLogic => FailureReason::DeadLettered,
     }
 }
 
@@ -166,9 +177,12 @@ mod tests {
         // user's "no point re-running it". It must dead-letter, never retry-storm.
         let e = LifecycleError::ExecutorRun(MoteExecutorError::BodyExited { code: 1 });
         assert_eq!(classify_lifecycle_error(&e), FailureClass::TerminalLogic);
+        // F4: every engine dead-letter is the dedicated terminal `DeadLettered`
+        // reason (NOT pre-commit-crash → sets terminal_failure_observed → the loop
+        // never re-dispatches it).
         assert_eq!(
             reason_for(FailureClass::TerminalLogic),
-            FailureReason::ExecutorRefused
+            FailureReason::DeadLettered
         );
     }
 
@@ -176,9 +190,11 @@ mod tests {
     fn resource_no_capacity_is_transient() {
         let e = LifecycleError::ResourceAcquire(ResourceError::NoCapacity);
         assert_eq!(classify_lifecycle_error(&e), FailureClass::TransientInfra);
+        // F4: an exhausted-transient dead-letter is terminal `DeadLettered`, NOT the
+        // pre-commit-crash `TimedOut` (which under EffectStaged stays redispatchable).
         assert_eq!(
             reason_for(FailureClass::TransientInfra),
-            FailureReason::TimedOut
+            FailureReason::DeadLettered
         );
     }
 

--- a/crates/kx-runtime/src/workflow.rs
+++ b/crates/kx-runtime/src/workflow.rs
@@ -175,6 +175,41 @@ pub(crate) fn flat_pure_workflow(seeds: &[u8]) -> DemoWorkflow {
     }
 }
 
+/// A flat (shaperless) workflow of independent WORLD-MUTATING `StageThenCommit`
+/// **root** Motes — one per `seed`, no parents. Test-only: the F4 dead-letter
+/// tests need the WM `StageThenCommit` shape (the only one whose commit protocol
+/// writes `EffectStaged` *before* the broker dispatch — the precise condition under
+/// which a budget-exhausted dead-letter must be terminal, not redispatchable) where
+/// one Mote can dead-letter while its siblings still commit. Driven with
+/// `shaper: None` (a flat DAG, like [`flat_pure_workflow`]).
+#[cfg(test)]
+pub(crate) fn flat_wm_stc_workflow(seeds: &[u8]) -> DemoWorkflow {
+    let cap = ToolName("demo-tool".into());
+    let permissive = permissive_warrant();
+    let motes = seeds
+        .iter()
+        .map(|&seed| WorkflowMote {
+            mote: nondet_mote(
+                seed,
+                NdClass::WorldMutating,
+                EffectPattern::StageThenCommit,
+                None,
+                &[],
+            ),
+            warrant: permissive.clone(),
+            capability: cap.clone(),
+        })
+        .collect();
+    // The flat path never consults a shaper; a sentinel id fills the crash fields.
+    let sentinel = pure_mote(0xFF, &[]).id;
+    DemoWorkflow {
+        motes,
+        stc_crash_target: sentinel,
+        vtc_crash_target: sentinel,
+        shaper_id: sentinel,
+    }
+}
+
 /// A permissive warrant — the demo runs in a single trusted process, so every
 /// axis is wide open. (The broker/executor seams still enforce structurally;
 /// the warrant just doesn't narrow anything for the demo.)


### PR DESCRIPTION
## Context

PR-4 (the tool-call ReAct loop, #149) surfaced an **enterprise-critical engine defect**: when a WORLD-MUTATING (WM) `StageThenCommit` Mote's capability dispatch *repeatedly* fails (e.g. an MCP transport/network error), `run_with_seams` does **not terminate** — it spins forever, growing the journal without bound (the test hung 60s+ and was removed). F4 is the prerequisite for productionizing the agentic loop (PR-2b): tool/network failures are inevitable at enterprise scale and the runtime must dead-letter them cleanly.

## Root cause (verified end-to-end)

A WM `StageThenCommit` dispatch writes `EffectStaged` **before** the broker call. When the broker fails, the budget-exhausted dead-letter was journaled as `FailureReason::TimedOut` — but `is_pre_commit_crash(TimedOut) == true` (its legitimate meaning is "worker died mid-flight, re-dispatch is safe"). Under an `EffectStaged` entry the projection therefore never set `terminal_failure_observed`, the Mote stayed `Pending`/redispatchable, `pick_next` re-selected it every iteration, and each pass appended another `Proposed+EffectStaged+Failed{TimedOut}` (`Failed` is not dedup-by-key) → unbounded growth.

PURE Motes never stage an effect, so they already dead-lettered cleanly — the bug is **specific to WM/ROND `StageThenCommit`**.

## Fix (minimal — Option A)

Add a dedicated **terminal** `FailureReason::DeadLettered = 8` and map every engine dead-letter (`reason_for`, both `TransientInfra` and `TerminalLogic`) to it. `is_pre_commit_crash(DeadLettered) == false`, so the `Failed` fold sets `terminal_failure_observed` → the Mote becomes terminal `Failed` → `pick_next`/`ready_set` skip it and `run_with_seams` returns cleanly with `ReactStop::DeadLettered`. No engine control-flow change — the fix flows entirely through `reason_for`. Also resolves the deferred `ExecutorRefused`-reuse semantic nit (the engine now writes one unambiguous "the loop gave up" reason for AL2).

## Tests

- **`kx-model-harness` e2e** — re-added the removed transport-failure test: a `FailingTransport` (`Err(Unreachable)`) → bounded retries → terminal `DeadLettered` → loop returns `ReactStop::DeadLettered`, **no hang**. Runs on a worker thread with a **hard 10s deadline** so a spin regression *fails CI* instead of hanging.
- **`kx-runtime` engine** — a `FailingBroker` on a `flat_wm_stc_workflow`: dead-letter-within-budget + run completes; `max_attempts=1` immediate dead-letter; **transient-then-success commits + digest-invariant**; **restart idempotency** (a dead-lettered Mote is never re-dispatched on restart, R49); **no-unbounded-journal-growth** anti-spin gate.
- **`kx-projection`** — cross_product F4 cell test (`EffectStaged + Failed{DeadLettered}` ⇒ terminal, no redispatch, not an anomaly) + proptest + checkpoint round-trip coverage.

## Golden Rule 8 — pre-flight analysis

- **(a) breaks?** Nothing. Frozen-trio `src` diff **EMPTY** (the trio only constructs `FailureReason`, never exhaustively matches it); `from_u8` additive; `is_pre_commit_crash` body unchanged; R49 tokens `0..=7` byte-frozen.
- **(b) degrades?** Nothing — the fix **removes** the unbounded spin (net availability/latency win). Digest unchanged.
- **(c) security?** Nothing new — `DeadLettered` is a journaled audit fact (not identity, not deduped, not a digest input); it can only make a failing Mote terminal (the safe direction). SN-8 preserved (AL2 renders only the low-entropy reason token).

## Invariants
- Frozen-trio (`kx-executor`/`kx-scheduler`/`kx-inference`) `src` diff **EMPTY**
- Canonical digest **`a6b5c679…` invariant** (a0_guard green; `Failed` is excluded from `digest_projection`)
- `Cargo.lock` **unchanged** (D111)
- `cargo test --workspace` **1843/0**; fmt / clippy `-D warnings` / doc `-D warnings` / cargo-deny / scale-smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)