### PR TITLE
R9.5 — grpc-web/CORS shim so browsers can call unary RPCs (kx-gateway)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,8 @@ dependencies = [
  "tokio-tungstenite",
  "tonic",
  "tonic-health",
+ "tonic-web",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2954,6 +2956,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-web"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,6 +3005,22 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,14 @@ tonic              = "0.12"
 # A2: the standard `grpc.health.v1.Health` service + client (liveness/readiness),
 # version-locked to tonic 0.12. FFI-free (pure Rust over the same prost/tonic).
 tonic-health       = "0.12"
+# R9.5: the gRPC-web shim for the gateway listener so a browser SPA can make unary
+# RPCs (tonic is HTTP/2-only otherwise). Version-locked to tonic 0.12; FFI-free,
+# MIT; in the `kx-gateway` binary only (the dep wall keeps kx-gateway-core passive).
+tonic-web          = "0.12"
+# R9.5: the deny-by-default CORS middleware for the gRPC-web shim. `cors` feature
+# only; `tower`/`http`/`hyper` are already locked transitively via tonic, so this
+# adds the CORS layer alone. MIT. In the `kx-gateway` binary only.
+tower-http         = { version = "0.5", features = ["cors"] }
 prost              = "0.13"
 tokio              = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 # Server-streaming adapter for the KxGateway `StreamEvents` RPC (M8/D120). Already

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -24,8 +24,10 @@ usage: kx <command> [args]
   server:
     kx serve --journal <path> --content <dir> [--listen <addr:port>] [--ws-listen <addr:port>]
              [--dev-allow-local] [--auth-token <tok>=<party>]... [--auth-token-file <path>]
-             [--max-lease N] [--catalog-dir <dir>]
-             (--listen defaults to 127.0.0.1:50151; --ws-listen — the live-event WebSocket — to :50152)
+             [--max-lease N] [--catalog-dir <dir>] [--tls-cert <p> --tls-key <p>]
+             [--cors-origin <scheme://host[:port]>]...
+             (--listen defaults to 127.0.0.1:50151; --ws-listen — the live-event WebSocket — to :50152;
+              --cors-origin enables the gRPC-web browser shim for the listed origins, deny-by-default)
 
   client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --tls-ca <path> --json):
     kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>]
@@ -268,7 +270,9 @@ kx run|replay|digest --journal <path> --content <dir> [--crash-at <pt>] [--check
 kx serve --journal <path> --content <dir> [--listen <addr:port>] [--ws-listen <addr:port>] [--dev-allow-local] ...
   Hosts the embedded single-system gateway. --listen (gRPC) defaults to 127.0.0.1:50151;
   --ws-listen (the R5 live-event WebSocket bridge) defaults to 127.0.0.1:50152.
-  Deny-all by default: pass --dev-allow-local (loopback only) or --auth-token(-file)."
+  Deny-all by default: pass --dev-allow-local (loopback only) or --auth-token(-file).
+  Browser SPAs: --cors-origin <scheme://host[:port]> (repeatable, deny-by-default) enables the
+  gRPC-web shim for the listed origins (pair with --tls-cert/--tls-key for https)."
             .into(),
         "invoke" => "\
 kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>] [client flags]

--- a/crates/kx-cli/tests/common/mod.rs
+++ b/crates/kx-cli/tests/common/mod.rs
@@ -37,6 +37,7 @@ pub fn gateway_config(
         auth_tokens,
         catalog_dir: None,
         tls: None,
+        cors_origins: Vec::new(),
     }
 }
 

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -76,6 +76,14 @@ tonic              = { workspace = true, features = ["tls"] }
 # gRPC listener, alongside the KxGateway service (NOT behind the auth interceptor —
 # a health probe is unauthenticated by design).
 tonic-health       = { workspace = true }
+# R9.5: the gRPC-web shim (GrpcWebLayer) so a browser SPA can make unary RPCs over
+# HTTP/1.1 (tonic is HTTP/2-only otherwise). Binary-only; FFI-free; the native h2
+# gRPC path is unchanged (accept_http1 is additive).
+tonic-web          = { workspace = true }
+# R9.5: the deny-by-default CORS layer for the gRPC-web shim (`--cors-origin`
+# allowlist; never a wildcard). `cors` feature only; tower/http already locked via
+# tonic. Outermost layer so OPTIONS preflight is answered before the auth interceptor.
+tower-http         = { workspace = true }
 # Additive feature bump over the workspace tokio (rt-multi-thread/macros/net):
 # `signal` for graceful Ctrl-C shutdown, `time` for the worker poll/backoff +
 # connect-retry + the R5 live-tail poll interval, `sync` for the R5 per-subscriber

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -49,6 +49,13 @@ pub struct GatewayConfig {
     /// the given PEM cert + key; `None` ⇒ plaintext (the default). `--tls-cert` and
     /// `--tls-key` are given together or not at all.
     pub tls: Option<TlsPaths>,
+    /// Browser cross-origin allowlist for the gRPC-web shim (R9.5). Each entry is
+    /// an explicit origin (`scheme://host[:port]`), parsed from `--cors-origin`
+    /// (repeatable). **Empty ⇒ deny-by-default**: no CORS layer is installed, so a
+    /// browser gets no cross-origin grant (native/`curl` clients are unaffected —
+    /// CORS is a browser same-origin-policy mechanism). A wildcard (`*`) is refused
+    /// at parse time — the allowlist is always explicit (SN-8 fail-closed posture).
+    pub cors_origins: Vec<String>,
 }
 
 /// PEM paths for the gRPC listener's server TLS (A1). The embedded loopback
@@ -83,7 +90,7 @@ pub const USAGE: &str =
     "usage: kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
 [--ws-listen <addr:port>] [--max-lease <N>] [--dev-allow-local] \
 [--auth-token <token>=<party>]... [--auth-token-file <path>] [--catalog-dir <dir>] \
-[--tls-cert <path> --tls-key <path>]\n       \
+[--tls-cert <path> --tls-key <path>] [--cors-origin <scheme://host[:port]>]...\n       \
 kx-gateway --help | --version";
 
 impl Cli {
@@ -120,6 +127,7 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
     let mut catalog_dir: Option<PathBuf> = None;
     let mut tls_cert: Option<PathBuf> = None;
     let mut tls_key: Option<PathBuf> = None;
+    let mut cors_origins: Vec<String> = Vec::new();
 
     while let Some(flag) = args.next() {
         let mut take_value = |name: &str| -> Result<String, GatewayError> {
@@ -170,6 +178,10 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
             "--catalog-dir" => catalog_dir = Some(PathBuf::from(take_value("--catalog-dir")?)),
             "--tls-cert" => tls_cert = Some(PathBuf::from(take_value("--tls-cert")?)),
             "--tls-key" => tls_key = Some(PathBuf::from(take_value("--tls-key")?)),
+            "--cors-origin" => {
+                let v = take_value("--cors-origin")?;
+                cors_origins.push(validate_cors_origin(&v)?);
+            }
             other => return Err(GatewayError::Config(format!("unknown flag {other:?}"))),
         }
     }
@@ -188,20 +200,7 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
         ));
     }
 
-    // TLS cert + key are given together or not at all (a half-configured TLS would
-    // silently fall back to plaintext — fail closed instead).
-    let tls = match (tls_cert, tls_key) {
-        (Some(cert_path), Some(key_path)) => Some(TlsPaths {
-            cert_path,
-            key_path,
-        }),
-        (None, None) => None,
-        _ => {
-            return Err(GatewayError::Config(
-                "--tls-cert and --tls-key must be given together".into(),
-            ))
-        }
-    };
+    let tls = pair_tls(tls_cert, tls_key)?;
 
     Ok(GatewayConfig {
         listen,
@@ -213,7 +212,64 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
         auth_tokens,
         catalog_dir,
         tls,
+        cors_origins,
     })
+}
+
+/// Pair the TLS cert + key: both given (TLS) or neither (plaintext). A
+/// half-configured TLS would silently fall back to plaintext — fail closed instead.
+fn pair_tls(
+    tls_cert: Option<PathBuf>,
+    tls_key: Option<PathBuf>,
+) -> Result<Option<TlsPaths>, GatewayError> {
+    match (tls_cert, tls_key) {
+        (Some(cert_path), Some(key_path)) => Ok(Some(TlsPaths {
+            cert_path,
+            key_path,
+        })),
+        (None, None) => Ok(None),
+        _ => Err(GatewayError::Config(
+            "--tls-cert and --tls-key must be given together".into(),
+        )),
+    }
+}
+
+/// Validate a `--cors-origin` value fail-closed: it must be a concrete origin
+/// (`scheme://host[:port]`), never a wildcard. The allowlist is always explicit so
+/// a browser can never be granted blanket cross-origin access (the gRPC-web shim's
+/// security posture mirrors the deny-all auth default). Returns the trimmed origin.
+///
+/// We reject `*` and `null` (the two blanket/opaque grants) and require a
+/// `scheme://` prefix; the exact host is matched verbatim at request time by the
+/// CORS layer, so we keep parsing minimal (no scheme/host allowlist beyond the
+/// shape) — a typo yields a benign no-match (the browser is simply denied), never
+/// an over-broad grant.
+fn validate_cors_origin(value: &str) -> Result<String, GatewayError> {
+    let v = value.trim();
+    if v.is_empty() {
+        return Err(GatewayError::Config(
+            "--cors-origin requires a non-empty origin".into(),
+        ));
+    }
+    if v == "*" || v.eq_ignore_ascii_case("null") {
+        return Err(GatewayError::Config(format!(
+            "--cors-origin must be an explicit origin, not a wildcard, got {v:?} \
+             (the allowlist is deny-by-default — list each browser origin explicitly)"
+        )));
+    }
+    // Require a scheme://host shape so an accidental bare host is caught early
+    // rather than silently never matching.
+    let Some((scheme, rest)) = v.split_once("://") else {
+        return Err(GatewayError::Config(format!(
+            "--cors-origin expects <scheme://host[:port]>, got {v:?}"
+        )));
+    };
+    if scheme.is_empty() || rest.is_empty() {
+        return Err(GatewayError::Config(format!(
+            "--cors-origin expects <scheme://host[:port]>, got {v:?}"
+        )));
+    }
+    Ok(v.to_string())
 }
 
 /// Split a `token=party` spec on the LAST `=` (so a base64 token with `=`
@@ -419,6 +475,82 @@ mod tests {
         assert!(base(&["--tls-key", "/tmp/key.pem"]).is_err());
         // Neither → None (plaintext default).
         assert!(serve(base(&[]).unwrap()).tls.is_none());
+    }
+
+    #[test]
+    fn cors_origin_parses_repeatable_and_defaults_empty() {
+        // Default: no --cors-origin ⇒ empty ⇒ deny-by-default (no CORS layer).
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+            ])
+            .unwrap(),
+        );
+        assert!(
+            c.cors_origins.is_empty(),
+            "deny-by-default: no browser origin is granted unless listed"
+        );
+
+        // Repeatable: each --cors-origin appends, in order.
+        let c = serve(
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+                "--cors-origin",
+                "http://localhost:5173",
+                "--cors-origin",
+                "https://app.example.com",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(
+            c.cors_origins,
+            vec![
+                "http://localhost:5173".to_string(),
+                "https://app.example.com".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn cors_origin_rejects_wildcard_and_malformed() {
+        let base = |origin: &str| {
+            Cli::from_args([
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+                "--cors-origin",
+                origin,
+            ])
+        };
+        // A wildcard / opaque grant is refused fail-closed (no blanket access).
+        assert!(base("*").is_err(), "wildcard origin must be refused");
+        assert!(
+            base("null").is_err(),
+            "opaque 'null' origin must be refused"
+        );
+        assert!(base("NULL").is_err(), "case-insensitive 'null' refused");
+        // A bare host (no scheme) is caught early rather than silently never matching.
+        assert!(base("app.example.com").is_err());
+        assert!(base("https://").is_err());
+        assert!(base("").is_err());
+        // A concrete origin is accepted.
+        assert!(base("https://app.example.com").is_ok());
     }
 
     #[test]

--- a/crates/kx-gateway/src/main.rs
+++ b/crates/kx-gateway/src/main.rs
@@ -5,9 +5,14 @@
 //!
 //! ```text
 //! kx-gateway serve --listen <addr:port> --journal <path> --content <dir> \
-//!                  [--max-lease <N>] [--dev-allow-local]
+//!                  [--max-lease <N>] [--dev-allow-local] \
+//!                  [--cors-origin <scheme://host[:port]>]...
 //! kx-gateway --help | --version
 //! ```
+//!
+//! `--cors-origin` (R9.5, repeatable, deny-by-default) enables the gRPC-web shim
+//! for the listed browser origins so a SPA can make unary RPCs; omit it and
+//! browsers get no cross-origin grant (native clients are unaffected).
 //!
 //! `serve` brings up an embedded single-system runtime (coordinator + local
 //! worker) and hosts the FROZEN `KxGateway` gRPC service over it, so a client

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -45,7 +45,13 @@ use {
     kx_warrant::ExecutorClass,
     kx_worker::{Worker, WorkerClient, DEFAULT_HEARTBEAT_CADENCE},
     std::path::{Path, PathBuf},
+    // R9.5: the gRPC-web shim + deny-by-default CORS for browser unary RPCs. The
+    // `http` types ride tonic's re-export (no new direct `http`/`tower` dep — both
+    // are already locked transitively via tonic).
+    tonic::codegen::http::{HeaderName, HeaderValue, Method},
     tonic::transport::Server,
+    tonic_web::GrpcWebLayer,
+    tower_http::cors::{AllowOrigin, CorsLayer},
 };
 
 /// Backoff when a `run_once` lease found no ready work (keeps an idle server off
@@ -560,15 +566,34 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     health_reporter
         .set_service_status("", tonic_health::ServingStatus::Serving)
         .await;
+    // R9.5: the deny-by-default CORS layer for the gRPC-web shim. Built BEFORE the
+    // spawn so a malformed `--cors-origin` fails `start` loudly (mirrors the TLS
+    // fail-fast). An empty allowlist installs a layer that matches no origin ⇒ a
+    // browser is never granted cross-origin access (deny-by-default); a native
+    // client carries no `Origin` header and is unaffected.
+    let cors = build_cors_layer(&cfg.cors_origins)?;
+    if !cfg.cors_origins.is_empty() {
+        tracing::info!(
+            origins = ?cfg.cors_origins,
+            "gRPC-web CORS enabled for the listed browser origins"
+        );
+    }
     let (shutdown, shutdown_rx) = oneshot::channel::<()>();
     let gateway = tokio::spawn(async move {
-        let mut builder = Server::builder();
+        // `accept_http1(true)` lets the listener also speak HTTP/1.1 (gRPC-web rides
+        // it); native HTTP/2 gRPC clients are detected by the h2 preface and are
+        // UNCHANGED. CORS is the outermost layer (it answers an OPTIONS preflight
+        // before the gRPC-web translation + the auth interceptor), then GrpcWebLayer
+        // translates gRPC-web frames to gRPC for the KxGateway/health services.
+        let mut builder = Server::builder().accept_http1(true);
         if let Some(tls) = tls_config {
             builder = builder
                 .tls_config(tls)
                 .map_err(|e| GatewayError::Tls(e.to_string()))?;
         }
         builder
+            .layer(cors)
+            .layer(GrpcWebLayer::new())
             .add_service(health_service)
             .add_service(svc)
             .serve_with_shutdown(local_addr, async move {
@@ -695,6 +720,51 @@ async fn resolve_listen(listen: SocketAddr) -> Result<SocketAddr, GatewayError> 
         .map_err(|e| GatewayError::Bind(e.to_string()))?;
     drop(probe);
     Ok(addr)
+}
+
+/// Build the gRPC-web CORS layer (R9.5) from the parsed `--cors-origin` allowlist.
+///
+/// **Deny-by-default**: an empty `origins` yields an [`AllowOrigin::list`] that
+/// matches no origin, so a browser is never granted cross-origin access — and a
+/// non-browser client (no `Origin` header) is untouched, so the native gRPC path is
+/// unchanged. The allowlist is ALWAYS explicit (never [`AllowOrigin::any`]); the
+/// `*`/`null` wildcards are already rejected at parse time
+/// ([`crate::config`]'s `validate_cors_origin`), so reaching here with a bad shape
+/// is impossible — the only residual failure is a header-value encoding error,
+/// surfaced as a fail-closed config error before the port binds.
+///
+/// Allowed request headers cover the gRPC-web client surface (`content-type`,
+/// `x-grpc-web`, `x-user-agent`, `grpc-timeout`) plus `authorization` (the bearer
+/// token); exposed response headers carry the gRPC trailers the browser client
+/// reads (`grpc-status`/`grpc-message`/`grpc-status-details-bin`). Credentials are
+/// NOT enabled — the token rides the `Authorization` header, not a cookie.
+#[cfg(feature = "embedded-worker")]
+fn build_cors_layer(origins: &[String]) -> Result<CorsLayer, GatewayError> {
+    let parsed: Vec<HeaderValue> = origins
+        .iter()
+        .map(|o| {
+            HeaderValue::from_str(o).map_err(|e| {
+                GatewayError::Config(format!(
+                    "--cors-origin {o:?} is not a valid header value: {e}"
+                ))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(CorsLayer::new()
+        .allow_origin(AllowOrigin::list(parsed))
+        .allow_methods([Method::POST, Method::OPTIONS])
+        .allow_headers([
+            HeaderName::from_static("content-type"),
+            HeaderName::from_static("x-grpc-web"),
+            HeaderName::from_static("x-user-agent"),
+            HeaderName::from_static("grpc-timeout"),
+            HeaderName::from_static("authorization"),
+        ])
+        .expose_headers([
+            HeaderName::from_static("grpc-status"),
+            HeaderName::from_static("grpc-message"),
+            HeaderName::from_static("grpc-status-details-bin"),
+        ]))
 }
 
 #[cfg(all(test, unix))]

--- a/crates/kx-gateway/tests/common/mod.rs
+++ b/crates/kx-gateway/tests/common/mod.rs
@@ -113,6 +113,7 @@ pub fn gateway_config(
         auth_tokens,
         catalog_dir: None,
         tls: None,
+        cors_origins: Vec::new(),
     }
 }
 

--- a/crates/kx-gateway/tests/grpc_web_e2e.rs
+++ b/crates/kx-gateway/tests/grpc_web_e2e.rs
@@ -1,0 +1,300 @@
+//! R9.5 — gRPC-web shim + deny-by-default CORS, end-to-end.
+//!
+//! Proves the browser-facing wire over a real `kx serve` gateway:
+//!   1. a gRPC-web unary RPC (HTTP/1.1, `application/grpc-web+proto`) round-trips
+//!      through the `GrpcWebLayer` to a real RPC and returns `grpc-status: 0`;
+//!   2. CORS is **deny-by-default** — an unlisted origin (and the no-`--cors-origin`
+//!      default) gets NO `access-control-allow-origin`, a listed origin gets it
+//!      echoed back (never `*`);
+//!   3. an `OPTIONS` preflight is answered by the CORS layer WITHOUT the bearer
+//!      auth interceptor (a preflight is not an auth oracle), even on a deny-all
+//!      gateway;
+//!   4. native HTTP/2 gRPC clients are UNAFFECTED (`accept_http1(true)` is
+//!      additive) — a full `SubmitRun → Committed` still works through the layers.
+//!
+//! The gRPC-web/CORS requests are issued as raw HTTP/1.1 over a `TcpStream` (no new
+//! client dep): the 5-byte gRPC length-prefixed frame is trivial for the
+//! empty-request `ListSignatures` RPC, and the response is asserted on the status
+//! line + CORS headers + the gRPC trailer.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use kx_gateway::{start, GatewayConfig};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+mod common;
+
+/// The unary RPC we exercise over gRPC-web: an EMPTY request, so its gRPC frame is
+/// just the 5-byte header `00 00 00 00 00` (flag 0 + big-endian length 0).
+const LIST_SIGNATURES_PATH: &str = "/kortecx.v1.KxGateway/ListSignatures";
+
+/// A dev-allow-local gateway config rooted at `dir`, with the given CORS allowlist.
+fn cfg_with_cors(dir: &TempDir, cors_origins: Vec<String>) -> GatewayConfig {
+    let mut cfg = common::gateway_config(dir, true, HashMap::new());
+    cfg.cors_origins = cors_origins;
+    cfg
+}
+
+/// Send one raw HTTP/1.1 request to `addr` and return the full response bytes.
+///
+/// Reads until the peer half-closes or a short inter-read timeout elapses (hyper
+/// keep-alive holds the socket open, so the timeout is what bounds a single
+/// response). Adequate for the small gRPC-web / preflight responses asserted here.
+async fn http1_request(addr: SocketAddr, request: &[u8]) -> Vec<u8> {
+    // `start()` returns before the listener binds (the serve task spawns), so retry
+    // the connect briefly — mirrors `common::connect_client`.
+    let mut stream = {
+        let mut last = None;
+        for _ in 0..200 {
+            match TcpStream::connect(addr).await {
+                Ok(s) => {
+                    last = Some(s);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+        last.expect("connect to gateway (server bound)")
+    };
+    stream.write_all(request).await.expect("write request");
+    stream.flush().await.expect("flush");
+
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match tokio::time::timeout(Duration::from_millis(400), stream.read(&mut chunk)).await {
+            Ok(Ok(0)) => break,                              // peer closed
+            Ok(Ok(n)) => buf.extend_from_slice(&chunk[..n]), // got bytes, keep reading
+            Ok(Err(e)) => panic!("read error: {e}"),
+            Err(_) => break, // inter-read timeout: the response is complete
+        }
+        // A complete grpc-web/preflight response is small; cap to avoid a runaway.
+        if buf.len() > 1 << 20 {
+            break;
+        }
+    }
+    buf
+}
+
+/// Build a raw HTTP/1.1 request: ASCII headers + an optional binary body.
+fn http1_message(
+    method: &str,
+    path: &str,
+    addr: SocketAddr,
+    headers: &[(&str, &str)],
+    body: &[u8],
+) -> Vec<u8> {
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n");
+    for (k, v) in headers {
+        req.push_str(&format!("{k}: {v}\r\n"));
+    }
+    req.push_str(&format!("Content-Length: {}\r\n\r\n", body.len()));
+    let mut bytes = req.into_bytes();
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+/// Lowercase the header block (everything up to the first blank line) for
+/// case-insensitive header assertions; the body is asserted separately.
+fn lower(resp: &[u8]) -> String {
+    String::from_utf8_lossy(resp).to_lowercase()
+}
+
+#[tokio::test]
+async fn grpc_web_unary_round_trips() {
+    let dir = TempDir::new().unwrap();
+    let running = start(cfg_with_cors(&dir, vec!["http://localhost:5173".into()]))
+        .await
+        .unwrap();
+    let addr = running.local_addr();
+
+    // The empty ListSignatures request: one gRPC frame, header-only (length 0).
+    let frame = [0u8, 0, 0, 0, 0];
+    let req = http1_message(
+        "POST",
+        LIST_SIGNATURES_PATH,
+        addr,
+        &[
+            ("content-type", "application/grpc-web+proto"),
+            ("x-grpc-web", "1"),
+        ],
+        &frame,
+    );
+    let resp = http1_request(addr, &req).await;
+    let text = lower(&resp);
+
+    assert!(
+        text.starts_with("http/1.1 200"),
+        "gRPC-web unary returns HTTP 200; got:\n{text}"
+    );
+    assert!(
+        text.contains("content-type: application/grpc-web"),
+        "the response is gRPC-web framed; got:\n{text}"
+    );
+    // A successful RPC carries the gRPC trailer grpc-status:0 (tonic-web encodes
+    // trailers in a trailer frame as ASCII). Normalize spaces before matching.
+    let normalized = text.replace(' ', "");
+    assert!(
+        normalized.contains("grpc-status:0"),
+        "the RPC succeeded end-to-end (grpc-status:0); got:\n{text}"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn cors_allows_a_listed_origin() {
+    let dir = TempDir::new().unwrap();
+    let origin = "http://localhost:5173";
+    let running = start(cfg_with_cors(&dir, vec![origin.into()]))
+        .await
+        .unwrap();
+    let addr = running.local_addr();
+
+    let req = http1_message(
+        "OPTIONS",
+        LIST_SIGNATURES_PATH,
+        addr,
+        &[
+            ("origin", origin),
+            ("access-control-request-method", "POST"),
+            (
+                "access-control-request-headers",
+                "content-type,x-grpc-web,authorization",
+            ),
+        ],
+        &[],
+    );
+    let text = lower(&http1_request(addr, &req).await);
+
+    assert!(
+        text.contains(&format!("access-control-allow-origin: {origin}")),
+        "a listed origin is echoed in the preflight grant; got:\n{text}"
+    );
+    // Never a wildcard.
+    assert!(
+        !text.contains("access-control-allow-origin: *"),
+        "the grant is the explicit origin, never a wildcard; got:\n{text}"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn cors_denies_an_unlisted_origin() {
+    let dir = TempDir::new().unwrap();
+    // Allowlist one origin; request from a DIFFERENT one.
+    let running = start(cfg_with_cors(&dir, vec!["http://localhost:5173".into()]))
+        .await
+        .unwrap();
+    let addr = running.local_addr();
+
+    let req = http1_message(
+        "OPTIONS",
+        LIST_SIGNATURES_PATH,
+        addr,
+        &[
+            ("origin", "https://evil.example.com"),
+            ("access-control-request-method", "POST"),
+        ],
+        &[],
+    );
+    let text = lower(&http1_request(addr, &req).await);
+
+    assert!(
+        !text.contains("access-control-allow-origin"),
+        "an unlisted origin gets NO cross-origin grant; got:\n{text}"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn cors_deny_by_default_when_allowlist_empty() {
+    let dir = TempDir::new().unwrap();
+    // No --cors-origin at all (the default posture).
+    let running = start(cfg_with_cors(&dir, Vec::new())).await.unwrap();
+    let addr = running.local_addr();
+
+    let req = http1_message(
+        "OPTIONS",
+        LIST_SIGNATURES_PATH,
+        addr,
+        &[
+            ("origin", "http://localhost:5173"),
+            ("access-control-request-method", "POST"),
+        ],
+        &[],
+    );
+    let text = lower(&http1_request(addr, &req).await);
+
+    assert!(
+        !text.contains("access-control-allow-origin"),
+        "deny-by-default: with no allowlist, no browser origin is granted; got:\n{text}"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn preflight_is_not_an_auth_oracle() {
+    // A DENY-ALL gateway (no --dev-allow-local, no tokens): every real RPC is
+    // refused, but a CORS preflight must still be answered by the CORS layer
+    // (outermost, before the auth interceptor) — proving the preflight cannot be
+    // used to probe authentication state.
+    let dir = TempDir::new().unwrap();
+    let origin = "http://localhost:5173";
+    let mut cfg = common::gateway_config(&dir, false, HashMap::new()); // deny-all
+    cfg.cors_origins = vec![origin.into()];
+    let running = start(cfg).await.unwrap();
+    let addr = running.local_addr();
+
+    let req = http1_message(
+        "OPTIONS",
+        LIST_SIGNATURES_PATH,
+        addr,
+        &[
+            ("origin", origin),
+            ("access-control-request-method", "POST"),
+        ],
+        &[],
+    );
+    let text = lower(&http1_request(addr, &req).await);
+
+    // The preflight is granted (2xx) and carries the allow-origin — it never went
+    // through the bearer interceptor, so it is not a 401/identity oracle.
+    assert!(
+        text.starts_with("http/1.1 2"),
+        "the preflight is answered by CORS (2xx), not the auth interceptor; got:\n{text}"
+    );
+    assert!(
+        text.contains(&format!("access-control-allow-origin: {origin}")),
+        "the preflight grant is independent of auth; got:\n{text}"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn native_h2_grpc_still_works_through_the_layers() {
+    // Back-compat: `accept_http1(true)` + the gRPC-web/CORS layers must not break a
+    // native HTTP/2 tonic client. A full SubmitRun → Committed still works.
+    let dir = TempDir::new().unwrap();
+    let running = start(cfg_with_cors(&dir, vec!["http://localhost:5173".into()]))
+        .await
+        .unwrap();
+    let addr = running.local_addr();
+
+    let mut client = common::connect_client(addr).await;
+    let instance_id = common::submit_pure_run(&mut client, 0x42).await;
+    let (_mote_id, _result_ref) = common::await_committed(&mut client, &instance_id).await;
+
+    running.shutdown().await.unwrap();
+}


### PR DESCRIPTION
## What & why

`tonic` is HTTP/2-only, so **no browser SPA can make a unary gRPC call** to `kx serve` today — the UI could only consume the plaintext WebSocket live-tail (read-only). **R9.5** is the minimal, OSS-clean unblocker on the UI critical path:

> **R9.5 (this PR) → React+Vite shell → live DAG viewer** = a demoable interface over the already-functioning runtime.

It touches only `kx-gateway` (+ `kx-cli` docs) — off the truth path, never links the frozen trio.

## How

- `Server::builder().accept_http1(true)` + `tonic_web::GrpcWebLayer` translate gRPC-web frames to gRPC for the `KxGateway` + health services. **Native HTTP/2 gRPC clients are UNAFFECTED** (`accept_http1` is additive) — a full `SubmitRun → Committed` still works through the layers.
- `tower_http::CorsLayer` is the **outermost** layer, **deny-by-default**: a repeatable `--cors-origin <scheme://host[:port]>` allowlist (**never a wildcard** — `*`/`null` refused at parse time). An empty allowlist grants no browser origin; native (`curl`/CLI) clients carry no `Origin` header and are unaffected. A CORS preflight (`OPTIONS`) is answered **before** the bearer auth interceptor, so it can't be an auth oracle; real RPCs still pass deny-all/bearer auth (SN-8 — identity from the token, never the origin). Pairs with the existing A1 TLS.

## Golden Rule 8 pre-flight
- **Breaks / compat:** none on the default path; native h2 clients unchanged; **no proto/journal/wire change** → no SDK regen, **digest `7d22d4bd…` invariant** (a0_guard green), **frozen-trio src diff EMPTY**. `Cargo.lock` gains `tonic-web` + `tower-http` — the new deps *are* the PR (D111); both pure-Rust/MIT, `cargo deny` clean, and stay out of the FFI-free `kx-cli`/`kx-runtime` closure.
- **Degrades:** per-request middleware on the external listener only; embedded loopback coordinator/worker untouched.
- **Opens a hole:** the CORS surface, closed deny-by-default + explicit-allowlist + preflight-before-auth.
- **Deferred (own PR / backlog):** `wss://` for the WS bridge + mTLS.

## Tests
- **Config units:** `--cors-origin` parses one/many/none; `*`/`null`/bare-host refused fail-closed.
- **`grpc_web_e2e.rs`:** gRPC-web unary round-trips (`grpc-status:0`); CORS allows a listed origin (echoed, never `*`); denies an unlisted origin; deny-by-default with no allowlist; **preflight is not an auth oracle** (a deny-all gateway still answers OPTIONS without the bearer interceptor); **native h2 `SubmitRun → Committed` back-compat** through the layers.

## Local gate
`cargo test --workspace` 0 failed · clippy `--workspace --all-targets -D warnings` · fmt · `cargo deny` · doc `-D warnings` · a0_guard digest `7d22d4bd…` ✓ · frozen-trio src EMPTY · FFI-free closure intact (0 `kx-llamacpp` in `kx-cli`/`kx-runtime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)