### PR TITLE
feat(ui): T3.2 — React+Vite dashboard shell over the live KxGateway (gRPC-web)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,6 +559,90 @@ jobs:
         run: npx vitest run
 
   # ---------------------------------------------------------------------------
+  # ui — the React/Vite dashboard shell (ui/). Builds the FFI-free `kx`, builds the
+  # TS SDK (the UI depends on its dist/ via a `file:` dependency), then lints
+  # (biome), type-checks (tsc), runs the unit/component/contract suites (vitest —
+  # the contract test drives a real `kx serve`), builds the production bundle, and
+  # runs the browser E2E (Playwright/chromium against a real CORS-enabled gateway,
+  # deterministic no-model echo path). Pure gRPC-web client — NO submodules, NO C++.
+  # NON-REQUIRED: a new context, not in branch protection (promote once green via a
+  # separate authorized change). Mirrors sdk-typescript / verify-quickstart.
+  # ---------------------------------------------------------------------------
+  ui:
+    name: ui (React/Vite dashboard shell — biome + tsc + vitest + build + Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (NO submodules — the UI is pure gRPC-web, FFI-free)
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: cargo --version
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-ui-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-ui-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Build the FFI-free kx (serve) for the contract + E2E tests
+        run: cargo build -p kx-cli
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build the TS SDK (the UI depends on its built dist via a file dependency)
+        working-directory: bindings/typescript
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install the UI (clean, from the committed lockfile)
+        working-directory: ui
+        run: npm ci
+
+      - name: Lint + format + type-check (biome + tsc)
+        working-directory: ui
+        run: |
+          npx biome ci .
+          npx tsc --noEmit
+
+      - name: Unit + component + contract tests (vitest; contract vs a real `kx serve`)
+        working-directory: ui
+        env:
+          KX_BIN: ${{ github.workspace }}/target/debug/kx
+        run: npx vitest run
+
+      - name: Production build (proves the SPA bundles)
+        working-directory: ui
+        run: npm run build
+
+      - name: Install the Playwright browser (chromium only)
+        working-directory: ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser E2E (deterministic no-model echo path, CORS-enabled serve)
+        working-directory: ui
+        env:
+          KX_BIN: ${{ github.workspace }}/target/debug/kx
+        run: npx playwright test
+
+      - name: Upload the Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: ui/playwright-report
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
   # reproducible — byte-determinism check (I1.c). Runs `just check-reproducible`
   # which performs two clean release builds and diffs the output. Expensive
   # (~6+ minutes) but the load-bearing reproducibility gate.

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+coverage/
+playwright-report/
+test-results/
+.vite/
+*.tsbuildinfo

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,87 @@
+# @kortecx/ui — runtime console (T3.2 shell)
+
+A static-hostable **React + Vite** single-page app over the frozen `KxGateway`
+contract, talking **gRPC-web** to a running `kx serve` via the existing
+[`@kortecx/sdk`](../bindings/typescript) browser client. No server tier: the
+journal is the source of truth and the client is stateless (D119).
+
+This is the **shell** (milestone T3.2 on the OSS UI critical path): connect to a
+gateway, submit a run, and **watch its Motes transition live** in a status table
+that the gateway is polled for. The next milestone (T3.3) swaps that table for an
+interactive XYFlow DAG — reusing this exact data layer unchanged.
+
+## Architecture
+
+- **Routing/state:** TanStack Router (typed routes + search params) + TanStack
+  Query (server-state, polling, caching, retry).
+- **Live updates:** poll `GetProjection` over gRPC-web on an interval (TanStack
+  Query `refetchInterval`); polling stops once every Mote is terminal. This is the
+  verified, secure path (same CORS + bearer + TLS surface as every other RPC; no
+  second port, no plaintext `ws://`). Lower-latency WS/delta streaming is a
+  documented scale-path follow-on.
+- **Data layer (`src/kx/`)** is the forward seam: the run-detail route consumes one
+  hook, `useProjection(instanceId)`. T3.3 changes only the *view* it feeds.
+- **Security:** the bearer token lives in **memory only** (never `localStorage` /
+  the bundle). CORS is enforced server-side (deny-by-default). The shell renders
+  enum labels + hex ids only — never arbitrary Mote content (no XSS surface).
+
+## Prerequisites
+
+The UI depends on the SDK's built `dist/` (via a `file:` dependency). **Build the
+SDK first:**
+
+```sh
+npm --prefix ../bindings/typescript ci
+npm --prefix ../bindings/typescript run build
+```
+
+(Run from this `ui/` directory the paths are `../bindings/typescript`; from the repo
+root drop the `../`.)
+
+## Develop
+
+```sh
+npm ci                 # install (after the SDK dist/ exists)
+npm run dev            # Vite dev server on http://localhost:5173
+```
+
+Run a gateway that allows the dev origin (deny-by-default CORS — name it exactly):
+
+```sh
+# from the repo root
+cargo build -p kx-cli
+target/debug/kx serve \
+  --journal /tmp/kx.db --content /tmp/kx-blobs \
+  --listen 127.0.0.1:50151 --dev-allow-local \
+  --cors-origin http://localhost:5173
+```
+
+Then open the dev server, connect to `http://127.0.0.1:50151`, submit a run (the
+built-in `kx/recipes/echo` recipe is pre-filled), and watch the Mote flip to
+`COMMITTED`.
+
+## Test
+
+```sh
+npm run lint           # biome
+npm run typecheck      # tsc --noEmit
+KX_BIN="$PWD/../target/debug/kx" npm test   # vitest: unit + component + contract
+npm run build          # vite build → dist/
+npm run test:e2e       # Playwright (chromium) — builds + previews + drives a real gateway
+```
+
+- **Unit/component** tests mock the client and cover every Mote state/nd_class,
+  error → UI mapping, the poll re-render seam, and the "token is never persisted"
+  invariant.
+- **Contract** test (`// @vitest-environment node`, gated on `KX_BIN`) drives a real
+  `kx serve` and asserts byte-parity with the `kx` CLI + the auth/permission edges.
+- **E2E** (Playwright) proves the real browser gRPC-web + CORS path end to end.
+
+The agentic-shaper-children path needs on-device inference (Metal) and is exercised
+**locally** only; CI uses the deterministic, no-model `kx/recipes/echo` path (SN-7).
+
+## Scale note
+
+The shell renders a plain (unvirtualized) table — comfortable to ~5k Motes, degrades
+beyond. The runtime proves 25k-Mote *folding* (`scale-smoke`); windowing the table
+(and then the DAG) with `@tanstack/react-virtual` lands in T3.3.

--- a/ui/biome.json
+++ b/ui/biome.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": { "enabled": false },
+  "files": {
+    "ignoreUnknown": true,
+    "ignore": [
+      "dist/**",
+      "coverage/**",
+      "node_modules/**",
+      "playwright-report/**",
+      "test-results/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "organizeImports": { "enabled": true },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "useNodejsImportProtocol": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  }
+}

--- a/ui/e2e/connect-submit-poll.spec.ts
+++ b/ui/e2e/connect-submit-poll.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("connect → submit echo → watch a Mote reach COMMITTED (real gRPC-web + CORS)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+
+  await page.goto("/connect");
+  await expect(page.getByRole("heading", { name: /connect to a gateway/i })).toBeVisible();
+
+  const endpoint = page.getByLabel(/gateway endpoint/i);
+  await endpoint.fill(gw.endpoint);
+  await expect(endpoint).toHaveValue(gw.endpoint);
+  await page.getByRole("button", { name: /^connect$/i }).click();
+
+  // Lands on /runs (the echo handle is prefilled)
+  await expect(page.getByRole("heading", { name: /run a recipe/i })).toBeVisible();
+  await page.getByRole("button", { name: /submit run/i }).click();
+
+  // Run-detail: the DAG table appears and a Mote pill flips to COMMITTED via the poll loop.
+  await expect(page.getByTestId("mote-table")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).first()).toBeVisible(
+    { timeout: 30_000 },
+  );
+});

--- a/ui/e2e/connection-drop.spec.ts
+++ b/ui/e2e/connection-drop.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("a gateway drop mid-session surfaces a clear, retryable error (no hang/crash)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+
+  await page.goto("/connect");
+  const endpoint = page.getByLabel(/gateway endpoint/i);
+  await endpoint.fill(gw.endpoint);
+  await expect(endpoint).toHaveValue(gw.endpoint);
+  await page.getByRole("button", { name: /^connect$/i }).click();
+  await page.getByRole("button", { name: /submit run/i }).click();
+  await expect(page.getByTestId("mote-table")).toBeVisible({ timeout: 30_000 });
+
+  // The gateway disappears.
+  gw.stop();
+  gw = undefined;
+
+  // A manual refresh now hits an unreachable gateway → a clear error notice with a Retry
+  // affordance (the durability property: the UI degrades gracefully, it does not hang).
+  await page.getByRole("button", { name: /refresh/i }).click();
+  await expect(page.getByTestId("error-notice")).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole("button", { name: /retry/i })).toBeVisible();
+});

--- a/ui/e2e/cors-denied.spec.ts
+++ b/ui/e2e/cors-denied.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import { type Gateway, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("a deny-by-default gateway (origin not allowed) fails the connect probe cleanly", async ({
+  page,
+}) => {
+  // No --cors-origin → the SPA's browser origin is NOT allowed → the gRPC-web call is blocked.
+  gw = await spawnGateway();
+
+  await page.goto("/connect");
+  const endpoint = page.getByLabel(/gateway endpoint/i);
+  await endpoint.fill(gw.endpoint);
+  await expect(endpoint).toHaveValue(gw.endpoint);
+  await page.getByRole("button", { name: /^connect$/i }).click();
+
+  // A clear error notice appears and we stay on the connect screen (no hang, no crash).
+  await expect(page.getByTestId("error-notice")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole("heading", { name: /connect to a gateway/i })).toBeVisible();
+  await expect(page.getByTestId("conn-status")).toHaveAttribute("data-status", "disconnected");
+});

--- a/ui/e2e/fixtures/serve.ts
+++ b/ui/e2e/fixtures/serve.ts
@@ -1,0 +1,130 @@
+/**
+ * Spawn a real `kx serve` for the browser E2E. The gateway is given an explicit
+ * `--cors-origin` so the SPA (served at the pinned preview origin) can make gRPC-web
+ * calls — proving the real browser CORS + gRPC-web path end to end. Readiness is
+ * probed with the Node client (the test browser uses the web client).
+ */
+
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { KxClient } from "@kortecx/sdk/node";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// ui/e2e/fixtures → up 3 = repo root.
+export const REPO_ROOT = path.resolve(HERE, "../../..");
+
+let cachedBin: string | null = null;
+
+function findOrBuildKx(): string {
+  if (cachedBin) {
+    return cachedBin;
+  }
+  const env = process.env.KX_BIN;
+  if (env && existsSync(env)) {
+    cachedBin = env;
+    return env;
+  }
+  for (const rel of ["target/release/kx", "target/debug/kx"]) {
+    const cand = path.join(REPO_ROOT, rel);
+    if (existsSync(cand)) {
+      cachedBin = cand;
+      return cand;
+    }
+  }
+  execFileSync("cargo", ["build", "--release", "-p", "kx-cli"], {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+  cachedBin = path.join(REPO_ROOT, "target/release/kx");
+  return cachedBin;
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function waitReady(endpoint: string, proc: ChildProcess, timeoutMs = 40_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const probe = new KxClient(endpoint);
+  try {
+    while (Date.now() < deadline) {
+      if (proc.exitCode !== null) {
+        throw new Error(`kx serve exited early (code ${proc.exitCode})`);
+      }
+      try {
+        await probe.listSignatures();
+        return;
+      } catch (e) {
+        const code = (e as { code?: string }).code;
+        if (code === "unavailable" || code === "connect") {
+          await sleep(100);
+        } else {
+          return;
+        }
+      }
+    }
+    throw new Error("kx serve did not become ready in time");
+  } finally {
+    probe.close();
+  }
+}
+
+export interface Gateway {
+  endpoint: string;
+  stop(): void;
+}
+
+export interface SpawnOpts {
+  /** Allowed browser origin (omit to test deny-by-default). */
+  corsOrigin?: string;
+}
+
+export async function spawnGateway(opts: SpawnOpts = {}): Promise<Gateway> {
+  const kxBin = findOrBuildKx();
+  const [port, wsPort] = await Promise.all([freePort(), freePort()]);
+  const tmp = await mkdtemp(path.join(tmpdir(), "kxe2e-"));
+  const endpoint = `http://127.0.0.1:${port}`;
+  const args = [
+    "serve",
+    "--journal",
+    path.join(tmp, "kx.db"),
+    "--content",
+    path.join(tmp, "blobs"),
+    "--listen",
+    `127.0.0.1:${port}`,
+    "--ws-listen",
+    `127.0.0.1:${wsPort}`,
+    "--dev-allow-local",
+  ];
+  if (opts.corsOrigin) {
+    args.push("--cors-origin", opts.corsOrigin);
+  }
+  const proc = spawn(kxBin, args, { stdio: ["ignore", "pipe", "pipe"] });
+  let stopped = false;
+  const stop = () => {
+    if (!stopped) {
+      stopped = true;
+      proc.kill("SIGTERM");
+    }
+  };
+  await waitReady(endpoint, proc);
+  return { endpoint, stop };
+}
+
+/** The pinned origin the SPA is served from (must match playwright webServer). */
+export const SPA_ORIGIN = "http://localhost:4173";

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>kortecx — runtime console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,4403 @@
+{
+  "name": "@kortecx/ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@kortecx/ui",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@kortecx/sdk": "file:../bindings/typescript",
+        "@tanstack/react-query": "^5.59.0",
+        "@tanstack/react-router": "^1.58.0",
+        "framer-motion": "^11.5.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@playwright/test": "^1.47.0",
+        "@testing-library/jest-dom": "^6.5.0",
+        "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^22.0.0",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "@vitest/coverage-v8": "^2.1.0",
+        "jsdom": "^25.0.0",
+        "typescript": "^5.6.0",
+        "vite": "^5.4.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "../bindings/typescript": {
+      "name": "@kortecx/sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0",
+        "@connectrpc/connect-web": "^2.0.0"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "1.9.4",
+        "@bufbuild/buf": "^1.47.0",
+        "@bufbuild/protoc-gen-es": "^2.2.0",
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ws": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kortecx/sdk": {
+      "resolved": "../bindings/typescript",
+      "link": true
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/history": {
+      "version": "1.162.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.162.0.tgz",
+      "integrity": "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.170.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.15.tgz",
+      "integrity": "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/history": "1.162.0",
+        "@tanstack/react-store": "^0.9.3",
+        "@tanstack/router-core": "1.171.13",
+        "isbot": "^5.1.22"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+      "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.9.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.171.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.13.tgz",
+      "integrity": "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/history": "1.162.0",
+        "cookie-es": "^3.0.0",
+        "seroval": "^1.5.4",
+        "seroval-plugins": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.368",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
+      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isbot": {
+      "version": "5.1.41",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.41.tgz",
+      "integrity": "sha512-9WFV/Vhh0FEj6CQ7MoHweEL9/vLKPjeoD2I2htbAjX7kbW7VJs3OCpWOVyd+JraNTWVU6/DRx2MZy2KaUNXHcg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
+      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
+      "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@kortecx/ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "kortecx runtime console — a static-hostable React+Vite SPA over the frozen KxGateway (gRPC-web). T3.2 shell.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173 --strictPort",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome ci .",
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@kortecx/sdk": "file:../bindings/typescript",
+    "@tanstack/react-query": "^5.59.0",
+    "@tanstack/react-router": "^1.58.0",
+    "framer-motion": "^11.5.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "1.9.4",
+    "@playwright/test": "^1.47.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^22.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^2.1.0",
+    "jsdom": "^25.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0",
+    "vitest": "^2.1.0"
+  },
+  "homepage": "https://github.com/Kortecx/kortecx",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kortecx/kortecx.git",
+    "directory": "ui"
+  }
+}

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// The SPA is served (production bundle) at a PINNED origin so each test's
+// `kx serve` can allow exactly `http://localhost:4173` in its deny-by-default
+// `--cors-origin` allowlist. The gateway port is random per test (fixtures), but
+// the browser Origin is always the preview origin.
+export default defineConfig({
+  testDir: "e2e",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 120_000,
+  expect: { timeout: 30_000 },
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // Serves the built dist/ — run `npm run build` first (CI + `verify` do).
+    command: "npm run preview",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/ui/src/app/motion.ts
+++ b/ui/src/app/motion.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared framer-motion variants (single source). Page-level fade/slide for route
+ * transitions; a one-shot pulse a {@link StatePill} replays when a Mote's state
+ * changes. `prefers-reduced-motion` is honored globally via `<MotionConfig
+ * reducedMotion="user">` in the providers.
+ */
+
+import type { Transition } from "framer-motion";
+
+export const pageFade = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -8 },
+  transition: { duration: 0.18 } as Transition,
+};
+
+export const statePulse = {
+  initial: { scale: 0.85, opacity: 0.5 },
+  animate: { scale: 1, opacity: 1 },
+  transition: { duration: 0.25 } as Transition,
+};

--- a/ui/src/app/providers.tsx
+++ b/ui/src/app/providers.tsx
@@ -1,0 +1,23 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { MotionConfig } from "framer-motion";
+import { type ReactNode, useState } from "react";
+import { type ClientFactory, KxConnectionProvider } from "../kx/connection-context";
+import { makeQueryClient } from "./query-client";
+
+export interface AppProvidersProps {
+  children: ReactNode;
+  /** Injectable client builder (tests pass a node-client or mock factory). */
+  createClient?: ClientFactory;
+}
+
+/** Composes the server-state, connection, and motion providers. */
+export function AppProviders({ children, createClient }: AppProvidersProps) {
+  const [queryClient] = useState(() => makeQueryClient());
+  return (
+    <QueryClientProvider client={queryClient}>
+      <KxConnectionProvider createClient={createClient}>
+        <MotionConfig reducedMotion="user">{children}</MotionConfig>
+      </KxConnectionProvider>
+    </QueryClientProvider>
+  );
+}

--- a/ui/src/app/query-client.ts
+++ b/ui/src/app/query-client.ts
@@ -1,0 +1,28 @@
+/**
+ * The TanStack Query client. Retry policy is keyed on the stable error kind: never
+ * retry auth/permission/not-found/not-wired/bad-input (retrying cannot help and
+ * would hammer the gateway); retry transient transport errors with capped backoff.
+ */
+
+import { QueryClient } from "@tanstack/react-query";
+import { toUiError } from "../kx/errors";
+
+export function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: (failureCount, error) => {
+          const ui = toUiError(error);
+          if (!ui.retryable) {
+            return false;
+          }
+          return failureCount < 3;
+        },
+        retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
+        refetchOnWindowFocus: false,
+        staleTime: 0,
+      },
+      mutations: { retry: false },
+    },
+  });
+}

--- a/ui/src/components/AnomalyBadge.tsx
+++ b/ui/src/components/AnomalyBadge.tsx
@@ -1,0 +1,14 @@
+import { anomalyLabel } from "../lib/colors";
+
+/** A Mote anomaly warning (renders nothing for a healthy Mote). */
+export function AnomalyBadge({ anomaly }: { anomaly: number | null }) {
+  const label = anomalyLabel(anomaly);
+  if (label === null) {
+    return null;
+  }
+  return (
+    <output className="badge badge--anomaly" data-testid="anomaly-badge" title="Mote anomaly">
+      ⚠ {label}
+    </output>
+  );
+}

--- a/ui/src/components/ConnectGate.tsx
+++ b/ui/src/components/ConnectGate.tsx
@@ -1,0 +1,14 @@
+import { Link } from "@tanstack/react-router";
+
+/** Shown by protected screens when the app is not connected to a gateway. */
+export function ConnectGate() {
+  return (
+    <div className="empty-state" data-testid="connect-gate">
+      <p className="empty-state__title">Not connected</p>
+      <p className="empty-state__detail">Connect to a running gateway to continue.</p>
+      <Link to="/connect" className="btnlink">
+        Go to Connect
+      </Link>
+    </div>
+  );
+}

--- a/ui/src/components/ConnectionForm.tsx
+++ b/ui/src/components/ConnectionForm.tsx
@@ -1,0 +1,70 @@
+import { type FormEvent, useState } from "react";
+import { isNonloopbackPlaintext, validateEndpoint } from "../lib/endpoint";
+
+export interface ConnectionFormProps {
+  initialEndpoint: string;
+  connecting: boolean;
+  onConnect: (endpoint: string, token: string | undefined) => void;
+}
+
+/**
+ * Endpoint + optional bearer token. The token is held in local component state
+ * (memory) and handed to `onConnect`; it is NEVER persisted. A cleartext warning
+ * shows when a token would cross plaintext http:// to a non-loopback host.
+ */
+export function ConnectionForm({ initialEndpoint, connecting, onConnect }: ConnectionFormProps) {
+  const [endpoint, setEndpoint] = useState(initialEndpoint);
+  const [token, setToken] = useState("");
+  const endpointError = validateEndpoint(endpoint);
+  const plaintextWarning = token.trim() !== "" && isNonloopbackPlaintext(endpoint.trim());
+
+  function submit(e: FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    if (endpointError !== null) {
+      return;
+    }
+    const t = token.trim();
+    onConnect(endpoint.trim(), t === "" ? undefined : t);
+  }
+
+  return (
+    <form className="connect-form" onSubmit={submit} data-testid="connection-form">
+      <label htmlFor="endpoint">Gateway endpoint</label>
+      <input
+        id="endpoint"
+        name="endpoint"
+        type="text"
+        value={endpoint}
+        onChange={(e) => setEndpoint(e.target.value)}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      {endpointError !== null ? (
+        <p className="field-error" role="alert">
+          {endpointError}
+        </p>
+      ) : null}
+
+      <label htmlFor="token">Bearer token (optional)</label>
+      <input
+        id="token"
+        name="token"
+        type="password"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        autoComplete="off"
+        placeholder="blank for --dev-allow-local"
+      />
+      {plaintextWarning ? (
+        <output className="field-warning" data-testid="plaintext-warning">
+          ⚠ This token would travel in cleartext to a non-loopback host. Use an https:// endpoint
+          (TLS) for remote gateways.
+        </output>
+      ) : null}
+
+      <button type="submit" disabled={connecting || endpointError !== null}>
+        {connecting ? "Connecting…" : "Connect"}
+      </button>
+    </form>
+  );
+}

--- a/ui/src/components/EmptyState.tsx
+++ b/ui/src/components/EmptyState.tsx
@@ -1,0 +1,14 @@
+export interface EmptyStateProps {
+  title: string;
+  detail?: string;
+}
+
+/** A neutral empty/placeholder panel. */
+export function EmptyState({ title, detail }: EmptyStateProps) {
+  return (
+    <div className="empty-state" data-testid="empty-state">
+      <p className="empty-state__title">{title}</p>
+      {detail ? <p className="empty-state__detail">{detail}</p> : null}
+    </div>
+  );
+}

--- a/ui/src/components/ErrorNotice.tsx
+++ b/ui/src/components/ErrorNotice.tsx
@@ -1,0 +1,37 @@
+import type { UiError } from "../kx/errors";
+
+export interface ErrorNoticeProps {
+  error: UiError;
+  onRetry?: () => void;
+  onReauth?: () => void;
+}
+
+/** Render a {@link UiError} with the affordance its kind implies. */
+export function ErrorNotice({ error, onRetry, onReauth }: ErrorNoticeProps) {
+  return (
+    <div
+      className={`notice notice--${error.kind}`}
+      role="alert"
+      data-testid="error-notice"
+      data-kind={error.kind}
+    >
+      <div className="notice__head">
+        <strong className="notice__title">{error.title}</strong>
+        <code className="notice__code">[{error.code}]</code>
+      </div>
+      <p className="notice__message">{error.message}</p>
+      <div className="notice__actions">
+        {error.kind === "reauth" && onReauth ? (
+          <button type="button" onClick={onReauth}>
+            Re-enter token
+          </button>
+        ) : null}
+        {error.retryable && onRetry ? (
+          <button type="button" onClick={onRetry}>
+            Retry
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/MoteRow.tsx
+++ b/ui/src/components/MoteRow.tsx
@@ -1,0 +1,46 @@
+import { memo } from "react";
+import type { MoteVM } from "../kx/use-projection";
+import { promotionIsNotable, promotionLabel } from "../lib/colors";
+import { formatSeq, shortHex } from "../lib/format";
+import { AnomalyBadge } from "./AnomalyBadge";
+import { NdClassBadge } from "./NdClassBadge";
+import { StatePill } from "./StatePill";
+
+function MoteRowImpl({ mote }: { mote: MoteVM }) {
+  return (
+    <tr data-testid="mote-row" data-mote={mote.moteId} data-state={mote.stateCode}>
+      <td className="mono" title={mote.moteId}>
+        {shortHex(mote.moteId)}
+      </td>
+      <td>
+        <StatePill stateCode={mote.stateCode} />
+      </td>
+      <td>
+        <NdClassBadge ndClass={mote.ndClass} />
+      </td>
+      <td>{promotionIsNotable(mote.promotion) ? promotionLabel(mote.promotion) : ""}</td>
+      <td className="num">{formatSeq(mote.committedSeq)}</td>
+      <td className="mono">{mote.resultRef ? shortHex(mote.resultRef) : ""}</td>
+      <td>
+        <AnomalyBadge anomaly={mote.anomaly} />
+      </td>
+    </tr>
+  );
+}
+
+// Re-render a row only when a field that affects its display changes. With the
+// data layer's structural sharing the prop reference is usually already stable;
+// this comparator is the belt-and-braces guarantee the perf budget relies on.
+export const MoteRow = memo(MoteRowImpl, (prev, next) => {
+  const a = prev.mote;
+  const b = next.mote;
+  return (
+    a.moteId === b.moteId &&
+    a.stateCode === b.stateCode &&
+    a.ndClass === b.ndClass &&
+    a.promotion === b.promotion &&
+    a.resultRef === b.resultRef &&
+    a.committedSeq === b.committedSeq &&
+    a.anomaly === b.anomaly
+  );
+});

--- a/ui/src/components/MoteTable.tsx
+++ b/ui/src/components/MoteTable.tsx
@@ -1,0 +1,42 @@
+import { memo } from "react";
+import type { ProjectionVM } from "../kx/use-projection";
+import { EmptyState } from "./EmptyState";
+import { MoteRow } from "./MoteRow";
+
+/**
+ * The run's Motes as a status table. This is the T3.3 forward seam: the live DAG
+ * viewer will replace this view (keeping the same `ProjectionVM` input). Memoized so
+ * an unchanged poll (stable `projection` reference via structural sharing) is a no-op.
+ */
+function MoteTableImpl({ projection }: { projection: ProjectionVM }) {
+  if (projection.motes.length === 0) {
+    return (
+      <EmptyState
+        title="No Motes yet"
+        detail="This run has no Motes at the current frontier — they appear as the run executes."
+      />
+    );
+  }
+  return (
+    <table className="mote-table" data-testid="mote-table">
+      <thead>
+        <tr>
+          <th scope="col">Mote</th>
+          <th scope="col">State</th>
+          <th scope="col">nd_class</th>
+          <th scope="col">Promotion</th>
+          <th scope="col">Committed</th>
+          <th scope="col">Result</th>
+          <th scope="col">Anomaly</th>
+        </tr>
+      </thead>
+      <tbody>
+        {projection.motes.map((m) => (
+          <MoteRow key={m.moteId} mote={m} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export const MoteTable = memo(MoteTableImpl);

--- a/ui/src/components/NdClassBadge.tsx
+++ b/ui/src/components/NdClassBadge.tsx
@@ -1,0 +1,16 @@
+import { ndClassVisual } from "../lib/colors";
+
+/** The Mote's nondeterminism class (PURE / READ_ONLY_NONDET / WORLD_MUTATING). */
+export function NdClassBadge({ ndClass }: { ndClass: number }) {
+  const { label, tone } = ndClassVisual(ndClass);
+  return (
+    <span
+      className={`badge badge--${tone}`}
+      data-testid="nd-badge"
+      data-tone={tone}
+      title={`nd_class: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/ui/src/components/ProjectionSummary.tsx
+++ b/ui/src/components/ProjectionSummary.tsx
@@ -1,0 +1,31 @@
+import type { ProjectionVM } from "../kx/use-projection";
+import { countSummary, formatSeq, shortHex } from "../lib/format";
+
+const COMMITTED = 3; // MoteSnapshotState.COMMITTED
+
+export function ProjectionSummary({
+  projection,
+  polling,
+}: {
+  projection: ProjectionVM;
+  polling: boolean;
+}) {
+  const committed = projection.motes.filter((m) => m.stateCode === COMMITTED).length;
+  const total = projection.motes.length;
+  return (
+    <div className="proj-summary" data-testid="projection-summary">
+      <span>seq {formatSeq(projection.currentSeq)}</span>
+      <span className="mono" title={projection.recipeFingerprint}>
+        recipe {shortHex(projection.recipeFingerprint)}
+      </span>
+      <span>{countSummary(committed, total, "committed")}</span>
+      {polling ? (
+        <span className="pulse" aria-live="polite" data-testid="polling-indicator">
+          ● live
+        </span>
+      ) : (
+        <span data-testid="at-rest-indicator">○ at rest</span>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/StatePill.tsx
+++ b/ui/src/components/StatePill.tsx
@@ -1,0 +1,21 @@
+import { motion } from "framer-motion";
+import { statePulse } from "../app/motion";
+import { stateVisual } from "../lib/colors";
+
+/** A Mote state as a colored pill that pulses when the state changes (key remount). */
+export function StatePill({ stateCode }: { stateCode: number }) {
+  const { label, tone } = stateVisual(stateCode);
+  return (
+    <motion.span
+      key={stateCode}
+      className={`pill pill--${tone}`}
+      data-testid="state-pill"
+      data-tone={tone}
+      initial={statePulse.initial}
+      animate={statePulse.animate}
+      transition={statePulse.transition}
+    >
+      {label}
+    </motion.span>
+  );
+}

--- a/ui/src/kx/connection-context.tsx
+++ b/ui/src/kx/connection-context.tsx
@@ -1,0 +1,125 @@
+/**
+ * The gateway connection. Holds the live {@link KxClientBase} (or null) plus the
+ * connect/disconnect machine.
+ *
+ * SECURITY: the bearer token is held ONLY inside the constructed client instance
+ * (in memory). It is never written to storage, never placed in the bundle, and the
+ * context never hands it back out. Only the (non-secret) endpoint is persisted.
+ */
+
+import { DEFAULT_ENDPOINT, KxClient } from "@kortecx/sdk/web";
+import type { KxClientBase } from "@kortecx/sdk/web";
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
+import { type UiError, toUiError } from "./errors";
+
+/** Build a client for an endpoint + optional token. Injectable for tests. */
+export type ClientFactory = (endpoint: string, opts: { token?: string }) => KxClientBase;
+
+const defaultFactory: ClientFactory = (endpoint, opts) => new KxClient(endpoint, opts);
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+export interface ConnectionState {
+  readonly status: ConnectionStatus;
+  readonly endpoint: string;
+  readonly client: KxClientBase | null;
+  readonly error: UiError | null;
+  /** Connect + probe; resolves `true` on success, `false` on a surfaced error. */
+  connect(endpoint: string, token?: string): Promise<boolean>;
+  disconnect(): void;
+}
+
+const ENDPOINT_KEY = "kortecx.ui.endpoint";
+
+/** Exported so tests can provide a connected state directly (DI). */
+export const ConnectionContext = createContext<ConnectionState | null>(null);
+
+export interface KxConnectionProviderProps {
+  children: ReactNode;
+  /** Injectable client builder; defaults to the gRPC-web browser client. */
+  createClient?: ClientFactory;
+  /** Initial endpoint (defaults to the persisted value, then the SDK default). */
+  initialEndpoint?: string;
+}
+
+function loadEndpoint(fallback: string): string {
+  try {
+    return localStorage.getItem(ENDPOINT_KEY) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function persistEndpoint(endpoint: string): void {
+  try {
+    localStorage.setItem(ENDPOINT_KEY, endpoint);
+  } catch {
+    /* best-effort; storage may be unavailable (private mode / SSR) */
+  }
+}
+
+export function KxConnectionProvider({
+  children,
+  createClient = defaultFactory,
+  initialEndpoint,
+}: KxConnectionProviderProps) {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<ConnectionStatus>("disconnected");
+  const [endpoint, setEndpoint] = useState<string>(
+    () => initialEndpoint ?? loadEndpoint(DEFAULT_ENDPOINT),
+  );
+  const [client, setClient] = useState<KxClientBase | null>(null);
+  const [error, setError] = useState<UiError | null>(null);
+
+  const connect = useCallback(
+    async (ep: string, token?: string): Promise<boolean> => {
+      setStatus("connecting");
+      setError(null);
+      // The token is passed straight into the client (memory only) and dropped here.
+      const candidate = createClient(ep, token ? { token } : {});
+      try {
+        // Cheap unary probe. A real gRPC answer (even UNIMPLEMENTED) = reachable + authorized.
+        await candidate.listSignatures();
+      } catch (e) {
+        const ui = toUiError(e);
+        if (ui.kind !== "not-wired") {
+          candidate.close();
+          setClient(null);
+          setStatus("disconnected");
+          setError(ui);
+          return false;
+        }
+      }
+      setClient(candidate);
+      setEndpoint(ep);
+      setStatus("connected");
+      persistEndpoint(ep);
+      return true;
+    },
+    [createClient],
+  );
+
+  const disconnect = useCallback((): void => {
+    client?.close();
+    setClient(null);
+    setStatus("disconnected");
+    setError(null);
+    queryClient.clear(); // drop any cached projections from the old endpoint
+  }, [client, queryClient]);
+
+  const value = useMemo<ConnectionState>(
+    () => ({ status, endpoint, client, error, connect, disconnect }),
+    [status, endpoint, client, error, connect, disconnect],
+  );
+
+  return <ConnectionContext.Provider value={value}>{children}</ConnectionContext.Provider>;
+}
+
+export function useConnection(): ConnectionState {
+  const ctx = useContext(ConnectionContext);
+  if (ctx === null) {
+    throw new Error("useConnection must be used within <KxConnectionProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/kx/errors.ts
+++ b/ui/src/kx/errors.ts
@@ -1,0 +1,120 @@
+/**
+ * Map any thrown error (a typed SDK {@link KxError} or a raw Connect/gRPC error)
+ * into a UI-facing shape the components render. Branch on the stable `ErrorCode`,
+ * never on a human message (the SDK guarantees the codes are cross-surface stable).
+ */
+
+import { ErrorCode, fromRpcError } from "@kortecx/sdk/web";
+
+export type UiErrorKind =
+  | "reauth"
+  | "forbidden"
+  | "not-found"
+  | "not-wired"
+  | "bad-input"
+  | "retry"
+  | "generic";
+
+export interface UiError {
+  readonly code: string;
+  readonly kind: UiErrorKind;
+  readonly title: string;
+  readonly message: string;
+  readonly retryable: boolean;
+}
+
+/**
+ * Read the stable error code by DUCK-TYPING `.code` rather than `instanceof`. The
+ * SDK bundles its `web` and `node` entry points standalone, so the `KxError` class
+ * identity differs across entry points — `instanceof` would silently miss. Any
+ * SDK error (web or node) carries a string `.code`; a raw Connect/gRPC error is
+ * normalized through `fromRpcError`.
+ */
+function errorCode(err: unknown): string {
+  if (err !== null && typeof err === "object" && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") {
+      return c;
+    }
+  }
+  return fromRpcError(err).code;
+}
+
+export function toUiError(err: unknown): UiError {
+  const code = errorCode(err);
+  const message = err instanceof Error ? err.message : String(err);
+  switch (code) {
+    case ErrorCode.Unauthenticated:
+      return {
+        code,
+        kind: "reauth",
+        title: "Authentication required",
+        message: message || "This gateway requires a valid bearer token.",
+        retryable: false,
+      };
+    case ErrorCode.PermissionDenied:
+      // Uniform by design — no existence oracle (a wrong instance id and an
+      // unauthorized one are indistinguishable). Say so honestly.
+      return {
+        code,
+        kind: "forbidden",
+        title: "Not found or not authorized",
+        message: message || "This run does not exist, or this token cannot access it.",
+        retryable: false,
+      };
+    case ErrorCode.NotFound:
+      return {
+        code,
+        kind: "not-found",
+        title: "Not found",
+        message: message || "No such resource.",
+        retryable: false,
+      };
+    case ErrorCode.Unimplemented:
+      return {
+        code,
+        kind: "not-wired",
+        title: "Not available here",
+        message: message || "This capability is not wired on the connected gateway.",
+        retryable: false,
+      };
+    case ErrorCode.InvalidArgument:
+    case ErrorCode.Usage:
+    case ErrorCode.FailedPrecondition:
+      return {
+        code,
+        kind: "bad-input",
+        title: "Invalid request",
+        message: message || "The request was rejected as invalid.",
+        retryable: false,
+      };
+    case ErrorCode.Unavailable:
+    case ErrorCode.Connect:
+    case ErrorCode.CatchupRequired:
+    case ErrorCode.WaitTimeout:
+      return {
+        code,
+        kind: "retry",
+        title: "Gateway unreachable",
+        message:
+          message || "Could not reach the gateway — check the endpoint and that `kx serve` is up.",
+        retryable: true,
+      };
+    case ErrorCode.RunFailed:
+      return {
+        code,
+        kind: "generic",
+        title: "Run failed",
+        message: message || "The run's terminal Mote failed.",
+        retryable: false,
+      };
+    default:
+      return {
+        code,
+        kind: "generic",
+        title: "Something went wrong",
+        message: message || "Unexpected error.",
+        retryable: true,
+      };
+  }
+}

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -1,0 +1,11 @@
+/**
+ * Query keys are ENDPOINT-SCOPED so switching gateways never serves a stale
+ * cross-endpoint cache. `atSeq` distinguishes a pinned time-travel snapshot from
+ * the live ("live") view.
+ */
+
+export const queryKeys = {
+  signatures: (endpoint: string) => ["kx", endpoint, "signatures"] as const,
+  projection: (endpoint: string, instanceId: string, atSeq?: number) =>
+    ["kx", endpoint, "projection", instanceId, atSeq ?? "live"] as const,
+};

--- a/ui/src/kx/use-invoke.ts
+++ b/ui/src/kx/use-invoke.ts
@@ -1,0 +1,28 @@
+/**
+ * Start a run by invoking a published recipe handle with JSON args. Returns the
+ * run's hex instance id (no wait) so the caller can route to the live run-detail
+ * view and watch it execute. The built-in `kx/recipes/echo` recipe makes this work
+ * against a plain `kx serve` with no extra wiring.
+ */
+
+import type { Run } from "@kortecx/sdk/web";
+import { useMutation } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+
+export interface InvokeVars {
+  handle: string;
+  args: Record<string, unknown>;
+}
+
+export function useInvoke() {
+  const { client } = useConnection();
+  return useMutation<string, unknown, InvokeVars>({
+    mutationFn: async ({ handle, args }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      const run = (await client.invoke(handle, args)) as Run;
+      return run.instanceId; // hex (16B)
+    },
+  });
+}

--- a/ui/src/kx/use-projection.ts
+++ b/ui/src/kx/use-projection.ts
@@ -1,0 +1,94 @@
+/**
+ * The run-projection poll — the data layer's centerpiece and the T3.3 forward seam.
+ * The run-detail view consumes only this hook; T3.3 swaps the *view* (table → DAG)
+ * without touching the data layer. When T3.3 exposes `parents[]` on the SDK's
+ * `MoteView`, `toProjectionVM` gains a `parents` field and nothing else changes.
+ *
+ * We poll `GetProjection` (unary gRPC-web) and stop once the run is at rest. We map
+ * the SDK's `Projection` *class* into a PLAIN view-model so TanStack Query's
+ * structural sharing keeps a stable reference across unchanged polls (memoized rows
+ * then skip re-render).
+ */
+
+import type { Projection } from "@kortecx/sdk/web";
+import { useQuery } from "@tanstack/react-query";
+import { isTerminalState } from "../lib/colors";
+import { useConnection } from "./connection-context";
+import { queryKeys } from "./query-keys";
+
+const POLL_MS = 1000;
+
+/** A plain, serializable Mote view-model (no class methods → clean structural sharing). */
+export interface MoteVM {
+  readonly moteId: string;
+  readonly stateCode: number;
+  readonly ndClass: number;
+  readonly promotion: number;
+  readonly resultRef: string | null;
+  readonly committedSeq: number | null;
+  readonly anomaly: number | null;
+}
+
+export interface ProjectionVM {
+  readonly instanceId: string;
+  readonly recipeFingerprint: string;
+  readonly currentSeq: number;
+  readonly motes: MoteVM[];
+}
+
+/** Map the SDK's `Projection` (class) to the plain VM the views consume. */
+export function toProjectionVM(p: Projection): ProjectionVM {
+  return {
+    instanceId: p.instanceId,
+    recipeFingerprint: p.recipeFingerprint,
+    currentSeq: p.currentSeq,
+    motes: p.motes.map((m) => ({
+      moteId: m.moteId,
+      stateCode: m.stateCode,
+      ndClass: m.ndClass,
+      promotion: m.promotion,
+      resultRef: m.resultRef,
+      committedSeq: m.committedSeq,
+      anomaly: m.anomaly,
+    })),
+  };
+}
+
+/** A run is "at rest" when it has Motes and they are all terminal (stop polling). */
+export function allTerminal(p: ProjectionVM): boolean {
+  return p.motes.length > 0 && p.motes.every((m) => isTerminalState(m.stateCode));
+}
+
+export interface UseProjectionOptions {
+  atSeq?: number;
+}
+
+export function useProjection(instanceId: string | undefined, opts: UseProjectionOptions = {}) {
+  const { client, endpoint, status } = useConnection();
+  const atSeq = opts.atSeq;
+  return useQuery({
+    queryKey: queryKeys.projection(endpoint, instanceId ?? "", atSeq),
+    enabled: status === "connected" && client !== null && Boolean(instanceId),
+    queryFn: async (): Promise<ProjectionVM> => {
+      if (!client || !instanceId) {
+        throw new Error("not connected");
+      }
+      const view = await client.getProjection(
+        instanceId,
+        atSeq != null ? { atSeq: BigInt(atSeq) } : {},
+      );
+      return toProjectionVM(view);
+    },
+    refetchInterval: (query) => {
+      if (atSeq != null) {
+        return false; // a pinned-seq snapshot is static
+      }
+      const data = query.state.data;
+      if (!data) {
+        return POLL_MS; // still loading
+      }
+      return allTerminal(data) ? false : POLL_MS; // stop once the run is at rest
+    },
+    refetchIntervalInBackground: false,
+  });
+}

--- a/ui/src/kx/use-signatures.ts
+++ b/ui/src/kx/use-signatures.ts
@@ -1,0 +1,24 @@
+/**
+ * The published recipe catalog (read-only). Tolerant of an empty catalog and of a
+ * gateway that has not wired the catalog read path (UNIMPLEMENTED → the query errors
+ * and the UI shows a "not available here" notice; the rest of the shell stays usable).
+ */
+
+import type { SignatureSummary } from "@kortecx/sdk/web";
+import { useQuery } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { queryKeys } from "./query-keys";
+
+export function useSignatures() {
+  const { client, endpoint, status } = useConnection();
+  return useQuery({
+    queryKey: queryKeys.signatures(endpoint),
+    enabled: status === "connected" && client !== null,
+    queryFn: async (): Promise<SignatureSummary[]> => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.listSignatures();
+    },
+  });
+}

--- a/ui/src/lib/colors.ts
+++ b/ui/src/lib/colors.ts
@@ -1,0 +1,90 @@
+/**
+ * Exhaustive Mote enum → visual mappings, with an UNKNOWN fallback for ANY value
+ * (including UNSPECIFIED=0 and future server discriminants). Mirrors the SDK's
+ * `stateName` philosophy (bindings/typescript/src/types.ts): never crash, never
+ * mislabel a new enum value.
+ *
+ * The integer values are the FROZEN gateway-proto discriminants
+ * (crates/kx-proto/proto/kortecx/v1/{gateway,coordinator}.proto). The proto is
+ * additive-only, so an unseen value safely renders as UNKNOWN rather than breaking.
+ *
+ * `tone` names a CSS custom property family in styles/app.css — themes restyle by
+ * editing the variables, never this logic (single source of truth).
+ */
+
+export type StateTone =
+  | "pending"
+  | "scheduled"
+  | "committed"
+  | "failed"
+  | "repudiated"
+  | "inconsistent"
+  | "unknown";
+
+export type NdTone = "pure" | "read-only-nondet" | "world-mutating" | "unknown";
+
+export interface Visual<T extends string> {
+  readonly label: string;
+  readonly tone: T;
+}
+
+// MoteSnapshotState (gateway.proto:40) — 1..6; 0/UNSPECIFIED + unseen → UNKNOWN.
+const STATE: Readonly<Record<number, Visual<StateTone>>> = {
+  1: { label: "PENDING", tone: "pending" },
+  2: { label: "SCHEDULED", tone: "scheduled" },
+  3: { label: "COMMITTED", tone: "committed" },
+  4: { label: "FAILED", tone: "failed" },
+  5: { label: "REPUDIATED", tone: "repudiated" },
+  6: { label: "INCONSISTENT", tone: "inconsistent" },
+};
+const STATE_UNKNOWN: Visual<StateTone> = { label: "UNKNOWN", tone: "unknown" };
+
+export function stateVisual(code: number): Visual<StateTone> {
+  return STATE[code] ?? STATE_UNKNOWN;
+}
+
+/**
+ * A Mote whose state will not transition further under normal flow
+ * (COMMITTED/FAILED/REPUDIATED/INCONSISTENT). PENDING/SCHEDULED are in-flight.
+ * Used to stop the projection poll once a run is at rest (see use-projection).
+ */
+const TERMINAL: ReadonlySet<number> = new Set([3, 4, 5, 6]);
+export function isTerminalState(code: number): boolean {
+  return TERMINAL.has(code);
+}
+
+// NdClass (coordinator.proto) — 1..3; 0/UNSPECIFIED + unseen → UNKNOWN.
+const ND: Readonly<Record<number, Visual<NdTone>>> = {
+  1: { label: "PURE", tone: "pure" },
+  2: { label: "READ_ONLY_NONDET", tone: "read-only-nondet" },
+  3: { label: "WORLD_MUTATING", tone: "world-mutating" },
+};
+const ND_UNKNOWN: Visual<NdTone> = { label: "UNKNOWN", tone: "unknown" };
+
+export function ndClassVisual(code: number): Visual<NdTone> {
+  return ND[code] ?? ND_UNKNOWN;
+}
+
+// PromotionState (gateway.proto:51).
+const PROMOTION: Readonly<Record<number, string>> = {
+  1: "NOT_APPLICABLE",
+  2: "UNPROMOTED",
+  3: "PROMOTED",
+};
+export function promotionLabel(code: number): string {
+  return PROMOTION[code] ?? "UNKNOWN";
+}
+/** UNSPECIFIED(0)/NOT_APPLICABLE(1) carry no signal worth a badge. */
+export function promotionIsNotable(code: number): boolean {
+  return code === 2 || code === 3;
+}
+
+// MoteAnomaly (gateway.proto:59) — null/absent when healthy.
+const ANOMALY: Readonly<Record<number, string>> = {
+  1: "EFFECT_STAGED_THEN_REPUDIATED",
+  2: "QUARANTINED_AT_LEAST_ONCE_EFFECT",
+};
+export function anomalyLabel(code: number | null): string | null {
+  if (code == null || code === 0) return null;
+  return ANOMALY[code] ?? "UNKNOWN_ANOMALY";
+}

--- a/ui/src/lib/endpoint.ts
+++ b/ui/src/lib/endpoint.ts
@@ -1,0 +1,25 @@
+/**
+ * Endpoint validation for the connection form. The cleartext-token warning is the
+ * SDK's `isNonloopbackPlaintext` (re-exported so the UI and SDK agree exactly).
+ */
+
+import { isNonloopbackPlaintext } from "@kortecx/sdk/web";
+
+export { isNonloopbackPlaintext };
+
+/** Return a human error message for an invalid endpoint, or `null` if it is valid. */
+export function validateEndpoint(endpoint: string): string | null {
+  const e = endpoint.trim();
+  if (e === "") {
+    return "endpoint is required";
+  }
+  if (!/^https?:\/\//.test(e)) {
+    return "endpoint must start with http:// or https://";
+  }
+  try {
+    new URL(e);
+  } catch {
+    return "endpoint is not a valid URL";
+  }
+  return null;
+}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure display formatting. The runtime's ids are 16B/32B lowercase hex strings
+ * (server-derived, SN-8); we only ever shorten them for display, never compute one.
+ */
+
+/** Shorten a long hex id to `head…tail` (returns the input unchanged if short). */
+export function shortHex(hex: string, head = 8, tail = 4): string {
+  if (hex.length <= head + tail + 1) {
+    return hex;
+  }
+  return `${hex.slice(0, head)}…${hex.slice(-tail)}`;
+}
+
+/** Render an optional journal sequence as `#<n>` (or an em dash when absent). */
+export function formatSeq(seq: number | null | undefined): string {
+  return seq == null ? "—" : `#${seq}`;
+}
+
+/** A stable count summary like "3/5 committed". */
+export function countSummary(done: number, total: number, noun: string): string {
+  return `${done}/${total} ${noun}`;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,19 @@
+import { RouterProvider } from "@tanstack/react-router";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { AppProviders } from "./app/providers";
+import { router } from "./router/router";
+import "./styles/app.css";
+
+const rootEl = document.getElementById("root");
+if (rootEl === null) {
+  throw new Error("missing #root element");
+}
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <AppProviders>
+      <RouterProvider router={router} />
+    </AppProviders>
+  </StrictMode>,
+);

--- a/ui/src/router/router.tsx
+++ b/ui/src/router/router.tsx
@@ -1,0 +1,19 @@
+import { createRouter } from "@tanstack/react-router";
+import { rootRoute } from "./routes/__root";
+import { connectRoute } from "./routes/connect";
+import { indexRoute } from "./routes/index";
+import { runDetailRoute } from "./routes/run-detail";
+import { runsRoute } from "./routes/runs";
+
+const routeTree = rootRoute.addChildren([indexRoute, connectRoute, runsRoute, runDetailRoute]);
+
+export const router = createRouter({
+  routeTree,
+  defaultPreload: "intent",
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/ui/src/router/routes/__root.tsx
+++ b/ui/src/router/routes/__root.tsx
@@ -1,0 +1,64 @@
+import { Link, Outlet, createRootRoute, useRouterState } from "@tanstack/react-router";
+import { AnimatePresence, motion } from "framer-motion";
+import { pageFade } from "../../app/motion";
+import { useConnection } from "../../kx/connection-context";
+
+function RootLayout() {
+  const { status, endpoint, disconnect } = useConnection();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  return (
+    <div className="app">
+      <header className="app__nav">
+        <span className="app__brand">kortecx</span>
+        <nav className="app__links">
+          <Link
+            to="/runs"
+            className="navlink"
+            activeProps={{ className: "navlink navlink--active" }}
+          >
+            Runs
+          </Link>
+          <Link
+            to="/connect"
+            className="navlink"
+            activeProps={{ className: "navlink navlink--active" }}
+          >
+            Connect
+          </Link>
+        </nav>
+        <span className="app__conn" data-testid="conn-status" data-status={status}>
+          {status === "connected" ? (
+            <>
+              <span className="dot dot--ok" />
+              <span className="mono">{endpoint}</span>
+              <button type="button" className="linkbtn" onClick={disconnect}>
+                disconnect
+              </button>
+            </>
+          ) : (
+            <>
+              <span className="dot dot--off" />
+              not connected
+            </>
+          )}
+        </span>
+      </header>
+      <main className="app__main">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={pathname}
+            initial={pageFade.initial}
+            animate={pageFade.animate}
+            exit={pageFade.exit}
+            transition={pageFade.transition}
+          >
+            <Outlet />
+          </motion.div>
+        </AnimatePresence>
+      </main>
+    </div>
+  );
+}
+
+export const rootRoute = createRootRoute({ component: RootLayout });

--- a/ui/src/router/routes/connect.tsx
+++ b/ui/src/router/routes/connect.tsx
@@ -1,0 +1,37 @@
+import { createRoute, useNavigate } from "@tanstack/react-router";
+import { ConnectionForm } from "../../components/ConnectionForm";
+import { ErrorNotice } from "../../components/ErrorNotice";
+import { useConnection } from "../../kx/connection-context";
+import { rootRoute } from "./__root";
+
+function ConnectScreen() {
+  const { status, endpoint, error, connect } = useConnection();
+  const navigate = useNavigate();
+
+  return (
+    <section className="screen">
+      <h1>Connect to a gateway</h1>
+      <p className="muted">
+        Point at a running <code>kx serve</code>. The bearer token is kept in memory only — never
+        stored.
+      </p>
+      {error ? <ErrorNotice error={error} /> : null}
+      <ConnectionForm
+        initialEndpoint={endpoint}
+        connecting={status === "connecting"}
+        onConnect={async (ep, token) => {
+          const ok = await connect(ep, token);
+          if (ok) {
+            navigate({ to: "/runs" });
+          }
+        }}
+      />
+    </section>
+  );
+}
+
+export const connectRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/connect",
+  component: ConnectScreen,
+});

--- a/ui/src/router/routes/index.tsx
+++ b/ui/src/router/routes/index.tsx
@@ -1,0 +1,14 @@
+import { Navigate, createRoute } from "@tanstack/react-router";
+import { useConnection } from "../../kx/connection-context";
+import { rootRoute } from "./__root";
+
+function IndexRedirect() {
+  const { status } = useConnection();
+  return <Navigate to={status === "connected" ? "/runs" : "/connect"} />;
+}
+
+export const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: IndexRedirect,
+});

--- a/ui/src/router/routes/run-detail.tsx
+++ b/ui/src/router/routes/run-detail.tsx
@@ -1,0 +1,81 @@
+import { createRoute, useParams, useSearch } from "@tanstack/react-router";
+import { ConnectGate } from "../../components/ConnectGate";
+import { EmptyState } from "../../components/EmptyState";
+import { ErrorNotice } from "../../components/ErrorNotice";
+import { MoteTable } from "../../components/MoteTable";
+import { ProjectionSummary } from "../../components/ProjectionSummary";
+import { useConnection } from "../../kx/connection-context";
+import { toUiError } from "../../kx/errors";
+import { allTerminal, useProjection } from "../../kx/use-projection";
+import { shortHex } from "../../lib/format";
+import { rootRoute } from "./__root";
+
+const ROUTE_ID = "/runs/$instanceId";
+
+interface RunSearch {
+  atSeq?: number;
+}
+
+function RunDetailScreen() {
+  const { status } = useConnection();
+  if (status !== "connected") {
+    return <ConnectGate />;
+  }
+  return <RunDetailContent />;
+}
+
+function RunDetailContent() {
+  const { instanceId } = useParams({ from: ROUTE_ID });
+  const { atSeq } = useSearch({ from: ROUTE_ID });
+  const projection = useProjection(instanceId, atSeq != null ? { atSeq } : {});
+  const data = projection.data;
+  const polling = atSeq == null && data != null && !allTerminal(data);
+
+  return (
+    <section className="screen">
+      <div className="screen__head">
+        <h1>
+          Run{" "}
+          <code className="mono" title={instanceId}>
+            {shortHex(instanceId)}
+          </code>
+        </h1>
+        <button
+          type="button"
+          className="linkbtn"
+          onClick={() => void projection.refetch()}
+          disabled={projection.isFetching}
+        >
+          Refresh
+        </button>
+      </div>
+      {atSeq != null ? (
+        <p className="muted">Pinned snapshot at seq #{atSeq} (live polling paused).</p>
+      ) : null}
+      {projection.isLoading ? <EmptyState title="Loading projection…" /> : null}
+      {projection.error ? (
+        <ErrorNotice
+          error={toUiError(projection.error)}
+          onRetry={() => void projection.refetch()}
+        />
+      ) : null}
+      {data ? (
+        <>
+          <ProjectionSummary projection={data} polling={polling} />
+          <MoteTable projection={data} />
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+export const runDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_ID,
+  validateSearch: (search: Record<string, unknown>): RunSearch => {
+    const raw = search.atSeq;
+    const n = typeof raw === "string" ? Number(raw) : typeof raw === "number" ? raw : Number.NaN;
+    return Number.isFinite(n) && n >= 0 ? { atSeq: Math.floor(n) } : {};
+  },
+  component: RunDetailScreen,
+});

--- a/ui/src/router/routes/runs.tsx
+++ b/ui/src/router/routes/runs.tsx
@@ -1,0 +1,124 @@
+import { createRoute, useNavigate } from "@tanstack/react-router";
+import { type FormEvent, useState } from "react";
+import { ConnectGate } from "../../components/ConnectGate";
+import { EmptyState } from "../../components/EmptyState";
+import { ErrorNotice } from "../../components/ErrorNotice";
+import { useConnection } from "../../kx/connection-context";
+import { toUiError } from "../../kx/errors";
+import { useInvoke } from "../../kx/use-invoke";
+import { useSignatures } from "../../kx/use-signatures";
+import { shortHex } from "../../lib/format";
+import { rootRoute } from "./__root";
+
+const DEFAULT_HANDLE = "kx/recipes/echo";
+const DEFAULT_ARGS = '{\n  "topic": "hello"\n}';
+
+function RunsScreen() {
+  const { status } = useConnection();
+  if (status !== "connected") {
+    return <ConnectGate />;
+  }
+  return <RunsContent />;
+}
+
+function RunsContent() {
+  const navigate = useNavigate();
+  const signatures = useSignatures();
+  const invoke = useInvoke();
+  const [handle, setHandle] = useState(DEFAULT_HANDLE);
+  const [argsText, setArgsText] = useState(DEFAULT_ARGS);
+  const [argsError, setArgsError] = useState<string | null>(null);
+
+  function submit(e: FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    let args: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(argsText);
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("args must be a JSON object");
+      }
+      args = parsed as Record<string, unknown>;
+    } catch (err) {
+      setArgsError((err as Error).message);
+      return;
+    }
+    setArgsError(null);
+    invoke.mutate(
+      { handle: handle.trim(), args },
+      { onSuccess: (instanceId) => navigate({ to: "/runs/$instanceId", params: { instanceId } }) },
+    );
+  }
+
+  const invokeError = invoke.error ? toUiError(invoke.error) : null;
+
+  return (
+    <section className="screen">
+      <h1>Run a recipe</h1>
+      <p className="muted">
+        The built-in <code>kx/recipes/echo</code> recipe works against any <code>kx serve</code> —
+        submit it to watch a run execute.
+      </p>
+
+      <form className="invoke-form" onSubmit={submit}>
+        <label htmlFor="handle">Recipe handle</label>
+        <input
+          id="handle"
+          value={handle}
+          onChange={(e) => setHandle(e.target.value)}
+          spellCheck={false}
+          autoComplete="off"
+        />
+        <label htmlFor="args">Args (JSON object)</label>
+        <textarea
+          id="args"
+          value={argsText}
+          onChange={(e) => setArgsText(e.target.value)}
+          rows={5}
+          spellCheck={false}
+        />
+        {argsError ? (
+          <p className="field-error" role="alert">
+            {argsError}
+          </p>
+        ) : null}
+        <button type="submit" disabled={invoke.isPending}>
+          {invoke.isPending ? "Submitting…" : "Submit run"}
+        </button>
+      </form>
+      {invokeError ? <ErrorNotice error={invokeError} onRetry={() => invoke.reset()} /> : null}
+
+      <h2>Published recipes</h2>
+      {signatures.isLoading ? <EmptyState title="Loading recipes…" /> : null}
+      {signatures.error ? (
+        <ErrorNotice
+          error={toUiError(signatures.error)}
+          onRetry={() => void signatures.refetch()}
+        />
+      ) : null}
+      {signatures.data && signatures.data.length === 0 ? (
+        <EmptyState
+          title="No published recipes"
+          detail="The built-in kx/recipes/echo recipe still works above."
+        />
+      ) : null}
+      {signatures.data && signatures.data.length > 0 ? (
+        <ul className="sig-list">
+          {signatures.data.map((s) => (
+            <li key={s.signatureId}>
+              <button type="button" className="linkbtn" onClick={() => setHandle(s.name)}>
+                {s.name}
+              </button>
+              <code className="mono">{shortHex(s.signatureId)}</code>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+export const runsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/runs",
+  component: RunsScreen,
+});

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1,0 +1,386 @@
+/*
+ * Design tokens + minimal component styling (no CSS framework). Mote state/nd_class
+ * colors are CSS custom properties keyed by the `tone` from lib/colors.ts — the
+ * single styling source. Restyle by editing variables, never the logic.
+ */
+
+:root {
+  color-scheme: dark;
+  --bg: #0b0e14;
+  --bg-elev: #131722;
+  --bg-input: #0e121b;
+  --border: #232a39;
+  --fg: #d8dee9;
+  --fg-muted: #8a93a6;
+  --accent: #5aa9ff;
+  --accent-fg: #04101f;
+
+  /* Mote state tones */
+  --t-pending: #5b6573;
+  --t-scheduled: #d8a23a;
+  --t-committed: #3fb950;
+  --t-failed: #f0506e;
+  --t-repudiated: #e8833a;
+  --t-inconsistent: #b15be8;
+  --t-unknown: #4a5160;
+
+  /* nd_class tones */
+  --t-pure: #4f9dde;
+  --t-read-only-nondet: #36b3a8;
+  --t-world-mutating: #e85b9e;
+
+  /* notice tones */
+  --n-retry: #d8a23a;
+  --n-reauth: #5aa9ff;
+  --n-forbidden: #f0506e;
+  --n-bad-input: #e8833a;
+  --n-not-wired: #8a93a6;
+  --n-not-found: #8a93a6;
+  --n-generic: #f0506e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.mono {
+  font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+/* ---- layout / nav ---- */
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.app__nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+}
+.app__brand {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.app__links {
+  display: flex;
+  gap: 0.75rem;
+}
+.navlink {
+  color: var(--fg-muted);
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+}
+.navlink--active {
+  color: var(--fg);
+  background: var(--bg-input);
+}
+.app__conn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--fg-muted);
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.dot--ok {
+  background: var(--t-committed);
+}
+.dot--off {
+  background: var(--t-failed);
+}
+.app__main {
+  flex: 1;
+  padding: 1.5rem;
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* ---- screens / forms ---- */
+.screen h1 {
+  font-size: 1.4rem;
+  margin: 0 0 0.25rem;
+}
+.screen h2 {
+  font-size: 1.05rem;
+  margin: 1.75rem 0 0.5rem;
+}
+.screen__head {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+.muted {
+  color: var(--fg-muted);
+  margin: 0 0 1rem;
+}
+.connect-form,
+.invoke-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-width: 540px;
+  margin-top: 0.5rem;
+}
+label {
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  margin-top: 0.5rem;
+}
+input,
+textarea {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+}
+textarea {
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  resize: vertical;
+}
+button {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 0.9rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 0.75rem;
+  align-self: flex-start;
+}
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.linkbtn {
+  background: none;
+  color: var(--accent);
+  padding: 0;
+  margin: 0;
+  font-weight: 500;
+}
+.btnlink {
+  display: inline-block;
+  margin-top: 0.75rem;
+  color: var(--accent);
+  text-decoration: none;
+}
+.field-error {
+  color: var(--t-failed);
+  margin: 0.1rem 0 0;
+  font-size: 0.85rem;
+}
+.field-warning {
+  display: block;
+  color: var(--t-scheduled);
+  margin: 0.1rem 0 0;
+  font-size: 0.85rem;
+}
+
+/* ---- pills / badges ---- */
+.pill {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #04101f;
+  background: var(--t-unknown);
+}
+.pill--pending {
+  background: var(--t-pending);
+  color: #fff;
+}
+.pill--scheduled {
+  background: var(--t-scheduled);
+}
+.pill--committed {
+  background: var(--t-committed);
+}
+.pill--failed {
+  background: var(--t-failed);
+}
+.pill--repudiated {
+  background: var(--t-repudiated);
+}
+.pill--inconsistent {
+  background: var(--t-inconsistent);
+  color: #fff;
+}
+.pill--unknown {
+  background: var(--t-unknown);
+  color: #fff;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.05rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.badge--pure {
+  color: var(--t-pure);
+  border-color: var(--t-pure);
+}
+.badge--read-only-nondet {
+  color: var(--t-read-only-nondet);
+  border-color: var(--t-read-only-nondet);
+}
+.badge--world-mutating {
+  color: var(--t-world-mutating);
+  border-color: var(--t-world-mutating);
+}
+.badge--unknown {
+  color: var(--fg-muted);
+  border-color: var(--border);
+}
+.badge--anomaly {
+  color: #fff;
+  background: var(--t-failed);
+}
+
+/* ---- table ---- */
+.mote-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.75rem;
+}
+.mote-table th,
+.mote-table td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
+.mote-table th {
+  color: var(--fg-muted);
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+.mote-table .num {
+  text-align: right;
+}
+
+/* ---- projection summary ---- */
+.proj-summary {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  color: var(--fg-muted);
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+.pulse {
+  color: var(--t-committed);
+}
+
+/* ---- notice ---- */
+.notice {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--n-generic);
+  background: var(--bg-elev);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  margin: 0.75rem 0;
+  max-width: 640px;
+}
+.notice--retry {
+  border-left-color: var(--n-retry);
+}
+.notice--reauth {
+  border-left-color: var(--n-reauth);
+}
+.notice--forbidden {
+  border-left-color: var(--n-forbidden);
+}
+.notice--bad-input {
+  border-left-color: var(--n-bad-input);
+}
+.notice--not-wired {
+  border-left-color: var(--n-not-wired);
+}
+.notice--not-found {
+  border-left-color: var(--n-not-found);
+}
+.notice--generic {
+  border-left-color: var(--n-generic);
+}
+.notice__head {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.notice__code {
+  color: var(--fg-muted);
+}
+.notice__message {
+  margin: 0.35rem 0 0;
+  color: var(--fg);
+}
+.notice__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+.notice__actions button {
+  margin-top: 0.5rem;
+}
+
+/* ---- empty / sig list ---- */
+.empty-state {
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+  text-align: center;
+  color: var(--fg-muted);
+  margin-top: 0.75rem;
+}
+.empty-state__title {
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+.empty-state__detail {
+  margin: 0.35rem 0 0;
+}
+.sig-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.sig-list li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/ui/test/component/ConnectionForm.test.tsx
+++ b/ui/test/component/ConnectionForm.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectionForm } from "../../src/components/ConnectionForm";
+
+const LOOPBACK = "http://127.0.0.1:50151";
+const REMOTE = "http://example.com:50151";
+
+describe("ConnectionForm", () => {
+  it("submits endpoint + token to onConnect (token stays in memory)", () => {
+    const onConnect = vi.fn();
+    render(<ConnectionForm initialEndpoint={LOOPBACK} connecting={false} onConnect={onConnect} />);
+    fireEvent.change(screen.getByLabelText(/bearer token/i), { target: { value: "s3cr3t" } });
+    fireEvent.click(screen.getByRole("button", { name: /^connect$/i }));
+    expect(onConnect).toHaveBeenCalledWith(LOOPBACK, "s3cr3t");
+  });
+
+  it("a blank token connects with undefined", () => {
+    const onConnect = vi.fn();
+    render(<ConnectionForm initialEndpoint={LOOPBACK} connecting={false} onConnect={onConnect} />);
+    fireEvent.click(screen.getByRole("button", { name: /^connect$/i }));
+    expect(onConnect).toHaveBeenCalledWith(LOOPBACK, undefined);
+  });
+
+  it("warns when a token would cross plaintext http to a remote host", () => {
+    render(<ConnectionForm initialEndpoint={REMOTE} connecting={false} onConnect={vi.fn()} />);
+    expect(screen.queryByTestId("plaintext-warning")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/bearer token/i), { target: { value: "s3cr3t" } });
+    expect(screen.getByTestId("plaintext-warning")).toBeInTheDocument();
+  });
+
+  it("does not warn for a loopback endpoint", () => {
+    render(<ConnectionForm initialEndpoint={LOOPBACK} connecting={false} onConnect={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/bearer token/i), { target: { value: "s3cr3t" } });
+    expect(screen.queryByTestId("plaintext-warning")).not.toBeInTheDocument();
+  });
+
+  it("disables connect on an invalid endpoint", () => {
+    render(<ConnectionForm initialEndpoint="" connecting={false} onConnect={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /^connect$/i })).toBeDisabled();
+  });
+});

--- a/ui/test/component/ErrorNotice.test.tsx
+++ b/ui/test/component/ErrorNotice.test.tsx
@@ -1,0 +1,44 @@
+import {
+  KxInvalidArgument,
+  KxUnauthenticated,
+  KxUnavailable,
+  KxUnimplemented,
+} from "@kortecx/sdk/web";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorNotice } from "../../src/components/ErrorNotice";
+import { toUiError } from "../../src/kx/errors";
+
+describe("ErrorNotice", () => {
+  it("reauth → a re-enter-token button that fires onReauth", () => {
+    const onReauth = vi.fn();
+    render(<ErrorNotice error={toUiError(new KxUnauthenticated("x"))} onReauth={onReauth} />);
+    fireEvent.click(screen.getByRole("button", { name: /re-enter token/i }));
+    expect(onReauth).toHaveBeenCalledOnce();
+  });
+
+  it("retryable → a retry button that fires onRetry", () => {
+    const onRetry = vi.fn();
+    render(<ErrorNotice error={toUiError(new KxUnavailable("x"))} onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("not-wired → no action buttons (retrying cannot help)", () => {
+    render(
+      <ErrorNotice
+        error={toUiError(new KxUnimplemented("x"))}
+        onRetry={vi.fn()}
+        onReauth={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("error-notice")).toHaveAttribute("data-kind", "not-wired");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("bad-input → no retry button", () => {
+    render(<ErrorNotice error={toUiError(new KxInvalidArgument("x"))} onRetry={vi.fn()} />);
+    expect(screen.getByTestId("error-notice")).toHaveAttribute("data-kind", "bad-input");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/ui/test/component/MoteTable.test.tsx
+++ b/ui/test/component/MoteTable.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MoteTable } from "../../src/components/MoteTable";
+import { toProjectionVM } from "../../src/kx/use-projection";
+import {
+  allStatesProjection,
+  largeProjection,
+  mote,
+  projection,
+} from "../mocks/projection-fixtures";
+
+describe("MoteTable", () => {
+  it("renders one row per Mote across all states", () => {
+    render(<MoteTable projection={toProjectionVM(allStatesProjection())} />);
+    expect(screen.getAllByTestId("mote-row")).toHaveLength(7);
+  });
+
+  it("empty projection shows an empty state, not a table", () => {
+    render(<MoteTable projection={toProjectionVM(projection([]))} />);
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("mote-table")).not.toBeInTheDocument();
+  });
+
+  it("a single Mote renders one row", () => {
+    render(<MoteTable projection={toProjectionVM(projection([mote({ stateCode: 3 })]))} />);
+    expect(screen.getAllByTestId("mote-row")).toHaveLength(1);
+  });
+
+  it("maps each state code to its pill tone (incl. UNKNOWN for out-of-range)", () => {
+    const vm = toProjectionVM(projection([mote({ stateCode: 3 }), mote({ stateCode: 99 })]));
+    render(<MoteTable projection={vm} />);
+    const pills = screen.getAllByTestId("state-pill");
+    expect(pills[0]).toHaveAttribute("data-tone", "committed");
+    expect(pills[1]).toHaveAttribute("data-tone", "unknown");
+  });
+
+  it("surfaces an anomaly badge only for an anomalous Mote", () => {
+    const vm = toProjectionVM(
+      projection([mote({ stateCode: 6, anomaly: 2 }), mote({ stateCode: 3, anomaly: null })]),
+    );
+    render(<MoteTable projection={vm} />);
+    expect(screen.getAllByTestId("anomaly-badge")).toHaveLength(1);
+  });
+
+  it("renders 5000 Motes within the perf budget", () => {
+    const vm = toProjectionVM(largeProjection(5000));
+    const t0 = performance.now();
+    render(<MoteTable projection={vm} />);
+    const elapsed = performance.now() - t0;
+    expect(screen.getAllByTestId("mote-row")).toHaveLength(5000);
+    // Generous jsdom budget — guards against accidental O(n^2) work in the table.
+    expect(elapsed).toBeLessThan(4000);
+  });
+});

--- a/ui/test/component/StatePill.test.tsx
+++ b/ui/test/component/StatePill.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatePill } from "../../src/components/StatePill";
+
+describe("StatePill", () => {
+  it.each([
+    [1, "pending", "PENDING"],
+    [2, "scheduled", "SCHEDULED"],
+    [3, "committed", "COMMITTED"],
+    [4, "failed", "FAILED"],
+    [5, "repudiated", "REPUDIATED"],
+    [6, "inconsistent", "INCONSISTENT"],
+    [0, "unknown", "UNKNOWN"],
+    [99, "unknown", "UNKNOWN"],
+  ])("state %i renders tone %s", (code, tone, label) => {
+    render(<StatePill stateCode={code} />);
+    const pill = screen.getByTestId("state-pill");
+    expect(pill).toHaveAttribute("data-tone", tone);
+    expect(pill).toHaveTextContent(label);
+  });
+});

--- a/ui/test/component/badges.test.tsx
+++ b/ui/test/component/badges.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AnomalyBadge } from "../../src/components/AnomalyBadge";
+import { NdClassBadge } from "../../src/components/NdClassBadge";
+
+describe("NdClassBadge", () => {
+  it.each([
+    [1, "pure", "PURE"],
+    [2, "read-only-nondet", "READ_ONLY_NONDET"],
+    [3, "world-mutating", "WORLD_MUTATING"],
+    [0, "unknown", "UNKNOWN"],
+    [77, "unknown", "UNKNOWN"],
+  ])("nd_class %i → tone %s", (code, tone, label) => {
+    render(<NdClassBadge ndClass={code} />);
+    const badge = screen.getByTestId("nd-badge");
+    expect(badge).toHaveAttribute("data-tone", tone);
+    expect(badge).toHaveTextContent(label);
+  });
+});
+
+describe("AnomalyBadge", () => {
+  it("renders nothing for a healthy Mote", () => {
+    const { container } = render(<AnomalyBadge anomaly={null} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId("anomaly-badge")).not.toBeInTheDocument();
+  });
+  it("renders nothing for UNSPECIFIED (0)", () => {
+    render(<AnomalyBadge anomaly={0} />);
+    expect(screen.queryByTestId("anomaly-badge")).not.toBeInTheDocument();
+  });
+  it.each([
+    [1, "EFFECT_STAGED_THEN_REPUDIATED"],
+    [2, "QUARANTINED_AT_LEAST_ONCE_EFFECT"],
+    [99, "UNKNOWN_ANOMALY"],
+  ])("anomaly %i shows a warning badge", (code, label) => {
+    render(<AnomalyBadge anomaly={code} />);
+    expect(screen.getByTestId("anomaly-badge")).toHaveTextContent(label);
+  });
+});

--- a/ui/test/component/connection.test.tsx
+++ b/ui/test/component/connection.test.tsx
@@ -1,0 +1,94 @@
+import { KxUnauthenticated } from "@kortecx/sdk/web";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ClientFactory,
+  KxConnectionProvider,
+  useConnection,
+} from "../../src/kx/connection-context";
+import { makeTestQueryClient } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+const EP = "http://127.0.0.1:50151";
+
+function realWrapper(factory: ClientFactory) {
+  const qc = makeTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <KxConnectionProvider createClient={factory}>{children}</KxConnectionProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("connection machine", () => {
+  it("connects after a successful probe", async () => {
+    const { client } = makeMockClient({ listSignatures: async () => [] });
+    const factory = vi.fn(() => client);
+    const { result } = renderHook(() => useConnection(), { wrapper: realWrapper(factory) });
+
+    await act(async () => {
+      const ok = await result.current.connect(EP);
+      expect(ok).toBe(true);
+    });
+    expect(result.current.status).toBe("connected");
+    expect(result.current.client).toBe(client);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces an auth failure and stays disconnected", async () => {
+    const { client, close } = makeMockClient({
+      listSignatures: async () => {
+        throw new KxUnauthenticated("no token");
+      },
+    });
+    const { result } = renderHook(() => useConnection(), { wrapper: realWrapper(() => client) });
+
+    await act(async () => {
+      const ok = await result.current.connect(EP, "bad-token");
+      expect(ok).toBe(false);
+    });
+    expect(result.current.status).toBe("disconnected");
+    expect(result.current.error?.kind).toBe("reauth");
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("NEVER persists the bearer token (only the endpoint)", async () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const { client } = makeMockClient({ listSignatures: async () => [] });
+    const { result } = renderHook(() => useConnection(), { wrapper: realWrapper(() => client) });
+
+    const TOKEN = "super-secret-token-value";
+    await act(async () => {
+      await result.current.connect(EP, TOKEN);
+    });
+
+    // The endpoint is persisted; the token never is.
+    const persistedValues = setItem.mock.calls.map((c) => String(c[1]));
+    expect(persistedValues).toContain(EP);
+    expect(persistedValues.some((v) => v.includes(TOKEN))).toBe(false);
+    expect(JSON.stringify(localStorage)).not.toContain(TOKEN);
+  });
+
+  it("disconnect tears down the client and clears state", async () => {
+    const { client, close } = makeMockClient({ listSignatures: async () => [] });
+    const { result } = renderHook(() => useConnection(), { wrapper: realWrapper(() => client) });
+    await act(async () => {
+      await result.current.connect(EP);
+    });
+    act(() => {
+      result.current.disconnect();
+    });
+    expect(result.current.status).toBe("disconnected");
+    expect(result.current.client).toBeNull();
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/ui/test/component/use-invoke.test.tsx
+++ b/ui/test/component/use-invoke.test.tsx
@@ -1,0 +1,38 @@
+import { KxUnimplemented } from "@kortecx/sdk/web";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useInvoke } from "../../src/kx/use-invoke";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+const INSTANCE = "ab".repeat(16);
+
+describe("useInvoke", () => {
+  it("invokes a recipe and returns the hex instance id", async () => {
+    const { client, invoke } = makeMockClient({
+      // Mirrors the SDK's `Run` (instanceId is a hex getter).
+      invoke: async () => ({ instanceId: INSTANCE }),
+    });
+    const { result } = renderHook(() => useInvoke(), { wrapper: connectedWrapper(client) });
+    let id = "";
+    await act(async () => {
+      id = await result.current.mutateAsync({ handle: "kx/recipes/echo", args: { topic: "x" } });
+    });
+    expect(id).toBe(INSTANCE);
+    expect(invoke).toHaveBeenCalledWith("kx/recipes/echo", { topic: "x" });
+  });
+
+  it("propagates an UNIMPLEMENTED invoke (no catalog) for the UI to surface", async () => {
+    const { client } = makeMockClient({
+      invoke: async () => {
+        throw new KxUnimplemented("invoke not wired");
+      },
+    });
+    const { result } = renderHook(() => useInvoke(), { wrapper: connectedWrapper(client) });
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ handle: "x/y/z", args: {} }),
+      ).rejects.toBeInstanceOf(KxUnimplemented);
+    });
+  });
+});

--- a/ui/test/component/use-projection.test.tsx
+++ b/ui/test/component/use-projection.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { allTerminal, toProjectionVM, useProjection } from "../../src/kx/use-projection";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+import { mote, projection } from "../mocks/projection-fixtures";
+
+const INSTANCE = "ab".repeat(16);
+
+describe("toProjectionVM", () => {
+  it("maps every field the views need", () => {
+    const vm = toProjectionVM(
+      projection(
+        [mote({ moteId: "11".repeat(32), stateCode: 4, ndClass: 3, committedSeq: 7, anomaly: 1 })],
+        {
+          currentSeq: 9,
+        },
+      ),
+    );
+    expect(vm.currentSeq).toBe(9);
+    expect(vm.motes).toHaveLength(1);
+    expect(vm.motes[0]).toMatchObject({
+      moteId: "11".repeat(32),
+      stateCode: 4,
+      ndClass: 3,
+      committedSeq: 7,
+      anomaly: 1,
+    });
+  });
+});
+
+describe("allTerminal", () => {
+  it("false for an empty projection", () => {
+    expect(allTerminal(toProjectionVM(projection([])))).toBe(false);
+  });
+  it("false while any Mote is in-flight", () => {
+    const vm = toProjectionVM(projection([mote({ stateCode: 3 }), mote({ stateCode: 2 })]));
+    expect(allTerminal(vm)).toBe(false);
+  });
+  it("true once every Mote is terminal", () => {
+    const vm = toProjectionVM(projection([mote({ stateCode: 3 }), mote({ stateCode: 4 })]));
+    expect(allTerminal(vm)).toBe(true);
+  });
+});
+
+describe("useProjection", () => {
+  it("loads a projection from the gateway", async () => {
+    const { client, getProjection } = makeMockClient({
+      getProjection: async () => projection([mote({ stateCode: 3 })], { currentSeq: 5 }),
+    });
+    const { result } = renderHook(() => useProjection(INSTANCE), {
+      wrapper: connectedWrapper(client),
+    });
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+    expect(result.current.data?.currentSeq).toBe(5);
+    expect(getProjection).toHaveBeenCalled();
+  });
+
+  it("keeps a stable data reference across an unchanged poll (no re-render churn)", async () => {
+    const { client } = makeMockClient({
+      // New Projection instance each call, but identical content.
+      getProjection: async () =>
+        projection([mote({ moteId: "aa".repeat(32), stateCode: 2 })], { currentSeq: 5 }),
+    });
+    const { result } = renderHook(() => useProjection(INSTANCE), {
+      wrapper: connectedWrapper(client),
+    });
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+    const first = result.current.data;
+    await act(async () => {
+      await result.current.refetch();
+    });
+    // Structural sharing returns the prior reference when content is unchanged.
+    expect(result.current.data).toBe(first);
+  });
+
+  it("reflects an advancing frontier (a Mote flips SCHEDULED → COMMITTED)", async () => {
+    const frames = [
+      projection([mote({ moteId: "bb".repeat(32), stateCode: 2 })], { currentSeq: 5 }),
+      projection([mote({ moteId: "bb".repeat(32), stateCode: 3 })], { currentSeq: 6 }),
+    ];
+    let i = 0;
+    const { client, getProjection } = makeMockClient({
+      getProjection: async () => frames[Math.min(i++, frames.length - 1)],
+    });
+    const { result } = renderHook(() => useProjection(INSTANCE), {
+      wrapper: connectedWrapper(client),
+    });
+    await waitFor(() => expect(result.current.data?.currentSeq).toBe(5));
+    const first = result.current.data;
+    await act(async () => {
+      await result.current.refetch();
+    });
+    await waitFor(() => expect(result.current.data?.currentSeq).toBe(6));
+    expect(getProjection.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(result.current.data?.motes[0]?.stateCode).toBe(3);
+    // Content changed → structural sharing yields a fresh reference.
+    expect(result.current.data).not.toBe(first);
+  });
+});

--- a/ui/test/contract/projection.e2e.test.ts
+++ b/ui/test/contract/projection.e2e.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+/**
+ * Contract test: drive a REAL `kx serve` and prove the UI's data-layer assumptions
+ * hold against the actual runtime (echo works, projection carries the states the UI
+ * maps, byte-parity with the CLI, and the auth/permission edges surface correctly).
+ * Uses the Node client; the browser gRPC-web + CORS path is proven by the Playwright
+ * E2E. Gated on a buildable `kx` (KX_BIN in CI).
+ */
+
+import { execFileSync } from "node:child_process";
+import { KxClient, KxPermissionDenied, KxUnauthenticated } from "@kortecx/sdk/node";
+import type { Result } from "@kortecx/sdk/node";
+import { afterAll, describe, expect, it } from "vitest";
+import { toUiError } from "../../src/kx/errors";
+import { toProjectionVM } from "../../src/kx/use-projection";
+import { ECHO_HANDLE, authServer, devServer, findOrBuildKx, stopAllServers } from "./serve";
+
+function cli(endpoint: string, ...argv: string[]): Record<string, unknown> {
+  const out = execFileSync(findOrBuildKx(), [...argv, "--json", "--endpoint", endpoint], {
+    encoding: "utf-8",
+  });
+  return JSON.parse(out);
+}
+
+afterAll(async () => {
+  await stopAllServers();
+});
+
+describe("UI data path against a real kx serve", () => {
+  it("invoke echo → projection shows a COMMITTED terminal Mote the table can render", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    const result = (await kx.invoke(
+      ECHO_HANDLE,
+      { topic: "ui-contract" },
+      { wait: true },
+    )) as Result;
+    expect(result.ok).toBe(true);
+    const proj = await kx.getProjection(result.instanceId);
+    kx.close();
+
+    const vm = toProjectionVM(proj);
+    expect(vm.instanceId).toBe(result.instanceId);
+    const terminal = vm.motes.find((m) => m.moteId === result.terminalMoteId);
+    expect(terminal, "terminal Mote present in projection").toBeTruthy();
+    expect(terminal?.stateCode).toBe(3); // COMMITTED
+    expect(terminal?.resultRef).toBeTruthy();
+    expect(typeof terminal?.ndClass).toBe("number");
+  });
+
+  it("byte-parity: the SDK projection equals the CLI projection (the UI reads the same truth)", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    const result = (await kx.invoke(ECHO_HANDLE, { topic: "parity" }, { wait: true })) as Result;
+    const proj = await kx.getProjection(result.instanceId);
+    kx.close();
+    const cliProj = cli(s.endpoint, "projection", "--instance", result.instanceId);
+    expect(proj.toJSON()).toEqual(cliProj);
+  });
+
+  it("auth: no token → Unauthenticated → the UI shows a re-auth prompt", async () => {
+    const s = await authServer();
+    const kx = new KxClient(s.endpoint); // no token
+    const err = await kx
+      .listSignatures()
+      .then(() => null)
+      .catch((e: unknown) => e);
+    kx.close();
+    expect(err).toBeInstanceOf(KxUnauthenticated);
+    expect(toUiError(err).kind).toBe("reauth");
+  });
+
+  it("auth: the correct token connects", async () => {
+    const s = await authServer();
+    const kx = new KxClient(s.endpoint, { token: s.token });
+    const sigs = await kx.listSignatures();
+    kx.close();
+    expect(Array.isArray(sigs)).toBe(true);
+  });
+
+  it("a bogus instance id is a uniform permission_denied → the UI shows forbidden", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    const err = await kx
+      .getProjection("00".repeat(16))
+      .then(() => null)
+      .catch((e: unknown) => e);
+    kx.close();
+    expect(err).toBeInstanceOf(KxPermissionDenied);
+    expect(toUiError(err).kind).toBe("forbidden");
+  });
+
+  it("listSignatures returns an array (catalog read path is wired, not UNIMPLEMENTED)", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    const sigs = await kx.listSignatures();
+    kx.close();
+    expect(Array.isArray(sigs)).toBe(true);
+  });
+});

--- a/ui/test/contract/serve.ts
+++ b/ui/test/contract/serve.ts
@@ -1,0 +1,145 @@
+/**
+ * Spin up a real `kx serve` gateway for the contract test (adapted from the SDK's
+ * fixtures). The `kx` binary is located via `KX_BIN`, then `target/release/kx`,
+ * then `target/debug/kx`; if none exist it is built FFI-free. The contract test
+ * uses the Node client (guaranteed under Node); the browser gRPC-web + CORS path is
+ * proven separately by the Playwright E2E.
+ */
+
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { KxClient } from "@kortecx/sdk/node";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// ui/test/contract → up 3 = repo root.
+export const REPO_ROOT = path.resolve(HERE, "../../..");
+export const ECHO_HANDLE = "kx/recipes/echo";
+
+let cachedBin: string | null = null;
+
+export function findOrBuildKx(): string {
+  if (cachedBin) {
+    return cachedBin;
+  }
+  const env = process.env.KX_BIN;
+  if (env && existsSync(env)) {
+    cachedBin = env;
+    return env;
+  }
+  for (const rel of ["target/release/kx", "target/debug/kx"]) {
+    const cand = path.join(REPO_ROOT, rel);
+    if (existsSync(cand)) {
+      cachedBin = cand;
+      return cand;
+    }
+  }
+  execFileSync("cargo", ["build", "--release", "-p", "kx-cli"], {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+  cachedBin = path.join(REPO_ROOT, "target/release/kx");
+  return cachedBin;
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export class Server {
+  constructor(
+    readonly endpoint: string,
+    readonly proc: ChildProcess,
+    public token?: string,
+  ) {}
+
+  stop(): void {
+    this.proc.kill("SIGTERM");
+  }
+}
+
+async function waitReady(endpoint: string, proc: ChildProcess, timeoutMs = 40_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const probe = new KxClient(endpoint);
+  try {
+    while (Date.now() < deadline) {
+      if (proc.exitCode !== null) {
+        throw new Error(`kx serve exited early (code ${proc.exitCode})`);
+      }
+      try {
+        await probe.listSignatures();
+        return;
+      } catch (e) {
+        const code = (e as { code?: string }).code;
+        if (code === "unavailable" || code === "connect") {
+          await sleep(100);
+        } else {
+          return; // any real gRPC answer means the server is up
+        }
+      }
+    }
+    throw new Error("kx serve did not become ready in time");
+  } finally {
+    probe.close();
+  }
+}
+
+const SERVERS: Server[] = [];
+
+export async function spawnServer(...extra: string[]): Promise<Server> {
+  const kxBin = findOrBuildKx();
+  const [port, wsPort] = await Promise.all([freePort(), freePort()]);
+  const tmp = await mkdtemp(path.join(tmpdir(), "kxui-"));
+  const endpoint = `http://127.0.0.1:${port}`;
+  const proc = spawn(
+    kxBin,
+    [
+      "serve",
+      "--journal",
+      path.join(tmp, "kx.db"),
+      "--content",
+      path.join(tmp, "blobs"),
+      "--listen",
+      `127.0.0.1:${port}`,
+      "--ws-listen",
+      `127.0.0.1:${wsPort}`,
+      ...extra,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const server = new Server(endpoint, proc);
+  SERVERS.push(server);
+  await waitReady(endpoint, proc);
+  return server;
+}
+
+export function devServer(): Promise<Server> {
+  return spawnServer("--dev-allow-local");
+}
+
+export async function authServer(): Promise<Server> {
+  const s = await spawnServer("--auth-token", "s3cr3t=alice");
+  s.token = "s3cr3t";
+  return s;
+}
+
+export async function stopAllServers(): Promise<void> {
+  for (const s of SERVERS.splice(0)) {
+    s.stop();
+  }
+  await sleep(50);
+}

--- a/ui/test/mocks/harness.tsx
+++ b/ui/test/mocks/harness.tsx
@@ -1,0 +1,36 @@
+/** Test wrappers: a connected connection context + a query client. */
+
+import type { KxClientBase } from "@kortecx/sdk/web";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+import { ConnectionContext, type ConnectionState } from "../../src/kx/connection-context";
+
+export function makeTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+/** A wrapper that presents the app as already CONNECTED to `client`. */
+export function connectedWrapper(client: KxClientBase, endpoint = "http://127.0.0.1:50151") {
+  const qc = makeTestQueryClient();
+  const value: ConnectionState = {
+    status: "connected",
+    endpoint,
+    client,
+    error: null,
+    connect: vi.fn(async () => true),
+    disconnect: vi.fn(),
+  };
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ConnectionContext.Provider value={value}>{children}</ConnectionContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+}

--- a/ui/test/mocks/kx-client.ts
+++ b/ui/test/mocks/kx-client.ts
@@ -1,0 +1,43 @@
+/** A fake KxClientBase whose methods are vi.fn()s, for component/hook tests. */
+
+import type { KxClientBase } from "@kortecx/sdk/web";
+import { vi } from "vitest";
+
+export interface MockClientImpl {
+  listSignatures?: () => Promise<unknown>;
+  getProjection?: (...args: unknown[]) => Promise<unknown>;
+  invoke?: (...args: unknown[]) => Promise<unknown>;
+  getContent?: (...args: unknown[]) => Promise<unknown>;
+}
+
+export function makeMockClient(impl: MockClientImpl = {}) {
+  const listSignatures = vi.fn(impl.listSignatures ?? (async () => []));
+  const getProjection = vi.fn(
+    impl.getProjection ??
+      (async () => {
+        throw new Error("getProjection not stubbed");
+      }),
+  );
+  const invoke = vi.fn(
+    impl.invoke ??
+      (async () => {
+        throw new Error("invoke not stubbed");
+      }),
+  );
+  const getContent = vi.fn(impl.getContent ?? (async () => new Uint8Array()));
+  const close = vi.fn();
+  const client = {
+    listSignatures,
+    getProjection,
+    invoke,
+    getContent,
+    close,
+    submitRun: vi.fn(),
+    getSignature: vi.fn(),
+    registerSignature: vi.fn(),
+    streamEvents: vi.fn(),
+    wsEvents: vi.fn(),
+    endpoint: "http://127.0.0.1:50151",
+  } as unknown as KxClientBase;
+  return { client, listSignatures, getProjection, invoke, getContent, close };
+}

--- a/ui/test/mocks/projection-fixtures.ts
+++ b/ui/test/mocks/projection-fixtures.ts
@@ -1,0 +1,59 @@
+/** Builders for `Projection` / `MoteView` (the real SDK classes) used by tests. */
+
+import { MoteView, Projection } from "@kortecx/sdk/web";
+
+let counter = 0;
+
+export interface MoteOpts {
+  moteId?: string;
+  stateCode?: number;
+  ndClass?: number;
+  promotion?: number;
+  resultRef?: string | null;
+  moteDefHash?: string;
+  committedSeq?: number | null;
+  anomaly?: number | null;
+}
+
+export function mote(opts: MoteOpts = {}): MoteView {
+  const id = opts.moteId ?? (counter++).toString(16).padStart(64, "0");
+  return new MoteView(
+    id,
+    "STATE", // display name — unused by the VM (it reads stateCode)
+    opts.stateCode ?? 3,
+    opts.ndClass ?? 1,
+    opts.promotion ?? 1,
+    opts.resultRef ?? null,
+    opts.moteDefHash ?? "cd".repeat(32),
+    opts.committedSeq ?? null,
+    opts.anomaly ?? null,
+  );
+}
+
+export interface ProjectionOpts {
+  instanceId?: string;
+  recipeFingerprint?: string;
+  currentSeq?: number;
+}
+
+export function projection(motes: MoteView[], opts: ProjectionOpts = {}): Projection {
+  return new Projection(
+    opts.instanceId ?? "ab".repeat(16),
+    opts.recipeFingerprint ?? "ef".repeat(32),
+    opts.currentSeq ?? motes.length,
+    motes,
+  );
+}
+
+/** One Mote in each state code 0..6 (covers all states + UNSPECIFIED). */
+export function allStatesProjection(): Projection {
+  return projection([0, 1, 2, 3, 4, 5, 6].map((s) => mote({ stateCode: s })));
+}
+
+/** A large projection for the render perf budget. */
+export function largeProjection(n: number): Projection {
+  const motes = Array.from({ length: n }, (_, i) =>
+    mote({ moteId: i.toString(16).padStart(64, "0"), stateCode: (i % 6) + 1 }),
+  );
+  return projection(motes, { currentSeq: n });
+}

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -1,0 +1,63 @@
+import React from "react";
+import { vi } from "vitest";
+
+// Stub framer-motion: render plain DOM elements (motion-only props stripped) so
+// component tests are fast + deterministic and the perf budget measures OUR table,
+// not framer-motion's jsdom cost. Real animation is exercised by the browser E2E.
+// Top-level + harmless when framer-motion isn't imported (e.g. the node contract test).
+const MOTION_PROPS = new Set([
+  "initial",
+  "animate",
+  "exit",
+  "transition",
+  "variants",
+  "whileHover",
+  "whileTap",
+  "whileInView",
+  "whileFocus",
+  "layout",
+  "layoutId",
+  "drag",
+]);
+
+function strip(props: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(props)) {
+    if (!MOTION_PROPS.has(k)) {
+      out[k] = props[k];
+    }
+  }
+  return out;
+}
+
+vi.mock("framer-motion", () => {
+  const cache = new Map<string, (props: Record<string, unknown>) => unknown>();
+  const motion = new Proxy(
+    {},
+    {
+      get: (_t, tag: string) => {
+        if (!cache.has(tag)) {
+          cache.set(tag, (props: Record<string, unknown>) =>
+            React.createElement(tag, strip(props)),
+          );
+        }
+        return cache.get(tag);
+      },
+    },
+  );
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: unknown }) => children,
+    MotionConfig: ({ children }: { children: unknown }) => children,
+  };
+});
+
+// DOM-only setup (jsdom). Skipped in the node-environment contract test.
+if (typeof document !== "undefined") {
+  await import("@testing-library/jest-dom/vitest");
+  const { cleanup } = await import("@testing-library/react");
+  const { afterEach } = await import("vitest");
+  afterEach(() => {
+    cleanup();
+  });
+}

--- a/ui/test/unit/colors.test.ts
+++ b/ui/test/unit/colors.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  anomalyLabel,
+  isTerminalState,
+  ndClassVisual,
+  promotionIsNotable,
+  promotionLabel,
+  stateVisual,
+} from "../../src/lib/colors";
+
+describe("stateVisual", () => {
+  it.each([
+    [1, "pending", "PENDING"],
+    [2, "scheduled", "SCHEDULED"],
+    [3, "committed", "COMMITTED"],
+    [4, "failed", "FAILED"],
+    [5, "repudiated", "REPUDIATED"],
+    [6, "inconsistent", "INCONSISTENT"],
+    [0, "unknown", "UNKNOWN"],
+    [7, "unknown", "UNKNOWN"],
+    [-1, "unknown", "UNKNOWN"],
+    [999, "unknown", "UNKNOWN"],
+  ])("state %i → tone %s / label %s", (code, tone, label) => {
+    const v = stateVisual(code);
+    expect(v.tone).toBe(tone);
+    expect(v.label).toBe(label);
+  });
+
+  it("never returns undefined for ANY integer", () => {
+    for (let i = -10; i < 100; i++) {
+      const v = stateVisual(i);
+      expect(v.tone).toBeTruthy();
+      expect(v.label).toBeTruthy();
+    }
+  });
+});
+
+describe("isTerminalState", () => {
+  it("COMMITTED/FAILED/REPUDIATED/INCONSISTENT are terminal", () => {
+    for (const c of [3, 4, 5, 6]) {
+      expect(isTerminalState(c)).toBe(true);
+    }
+  });
+  it("PENDING/SCHEDULED/UNSPECIFIED/unknown are not terminal", () => {
+    for (const c of [0, 1, 2, 7, 99]) {
+      expect(isTerminalState(c)).toBe(false);
+    }
+  });
+});
+
+describe("ndClassVisual", () => {
+  it.each([
+    [1, "pure", "PURE"],
+    [2, "read-only-nondet", "READ_ONLY_NONDET"],
+    [3, "world-mutating", "WORLD_MUTATING"],
+    [0, "unknown", "UNKNOWN"],
+    [42, "unknown", "UNKNOWN"],
+  ])("nd_class %i → %s / %s", (code, tone, label) => {
+    const v = ndClassVisual(code);
+    expect(v.tone).toBe(tone);
+    expect(v.label).toBe(label);
+  });
+});
+
+describe("promotion", () => {
+  it("labels", () => {
+    expect(promotionLabel(1)).toBe("NOT_APPLICABLE");
+    expect(promotionLabel(2)).toBe("UNPROMOTED");
+    expect(promotionLabel(3)).toBe("PROMOTED");
+    expect(promotionLabel(0)).toBe("UNKNOWN");
+    expect(promotionLabel(99)).toBe("UNKNOWN");
+  });
+  it("only PROMOTED/UNPROMOTED are notable", () => {
+    expect(promotionIsNotable(2)).toBe(true);
+    expect(promotionIsNotable(3)).toBe(true);
+    expect(promotionIsNotable(0)).toBe(false);
+    expect(promotionIsNotable(1)).toBe(false);
+  });
+});
+
+describe("anomalyLabel", () => {
+  it("absent/healthy → null", () => {
+    expect(anomalyLabel(null)).toBeNull();
+    expect(anomalyLabel(0)).toBeNull();
+  });
+  it("known anomalies → label", () => {
+    expect(anomalyLabel(1)).toBe("EFFECT_STAGED_THEN_REPUDIATED");
+    expect(anomalyLabel(2)).toBe("QUARANTINED_AT_LEAST_ONCE_EFFECT");
+  });
+  it("unseen anomaly → UNKNOWN_ANOMALY (never crash)", () => {
+    expect(anomalyLabel(99)).toBe("UNKNOWN_ANOMALY");
+  });
+});

--- a/ui/test/unit/endpoint.test.ts
+++ b/ui/test/unit/endpoint.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isNonloopbackPlaintext, validateEndpoint } from "../../src/lib/endpoint";
+
+describe("validateEndpoint", () => {
+  it("rejects empty", () => {
+    expect(validateEndpoint("")).toMatch(/required/);
+    expect(validateEndpoint("   ")).toMatch(/required/);
+  });
+  it("rejects a missing scheme", () => {
+    expect(validateEndpoint("127.0.0.1:50151")).toMatch(/http/);
+  });
+  it("accepts a valid http/https endpoint", () => {
+    expect(validateEndpoint("http://127.0.0.1:50151")).toBeNull();
+    expect(validateEndpoint("https://gw.example.com")).toBeNull();
+  });
+});
+
+describe("isNonloopbackPlaintext (SDK re-export)", () => {
+  it("loopback http is not flagged", () => {
+    expect(isNonloopbackPlaintext("http://127.0.0.1:50151")).toBe(false);
+    expect(isNonloopbackPlaintext("http://localhost:50151")).toBe(false);
+  });
+  it("remote http IS flagged", () => {
+    expect(isNonloopbackPlaintext("http://example.com:50151")).toBe(true);
+    expect(isNonloopbackPlaintext("http://10.0.0.5")).toBe(true);
+  });
+  it("https is never flagged", () => {
+    expect(isNonloopbackPlaintext("https://example.com")).toBe(false);
+  });
+});

--- a/ui/test/unit/errors.test.ts
+++ b/ui/test/unit/errors.test.ts
@@ -1,0 +1,44 @@
+import {
+  type ErrorCode,
+  KxError,
+  KxInvalidArgument,
+  KxNotFound,
+  KxPermissionDenied,
+  KxRunFailed,
+  KxUnauthenticated,
+  KxUnavailable,
+  KxUnimplemented,
+  KxUsage,
+} from "@kortecx/sdk/web";
+import { describe, expect, it } from "vitest";
+import { toUiError } from "../../src/kx/errors";
+
+describe("toUiError", () => {
+  it.each([
+    [new KxUnauthenticated("x"), "reauth", false],
+    [new KxPermissionDenied("x"), "forbidden", false],
+    [new KxNotFound("x"), "not-found", false],
+    [new KxUnimplemented("x"), "not-wired", false],
+    [new KxInvalidArgument("x"), "bad-input", false],
+    [new KxUsage("x"), "bad-input", false],
+    [new KxUnavailable("x"), "retry", true],
+    [new KxRunFailed("x"), "generic", false],
+  ])("maps %o to kind/retryable", (err, kind, retryable) => {
+    const ui = toUiError(err);
+    expect(ui.kind).toBe(kind);
+    expect(ui.retryable).toBe(retryable);
+    expect(ui.title).toBeTruthy();
+    expect(ui.code).toBeTruthy();
+  });
+
+  it("an unknown future ErrorCode falls back to generic", () => {
+    const ui = toUiError(new KxError("weird", { code: "brand_new_code" as ErrorCode }));
+    expect(ui.kind).toBe("generic");
+  });
+
+  it("a raw (non-Kx) error is normalized via fromRpcError", () => {
+    const ui = toUiError(new Error("boom"));
+    expect(ui.code).toBeTruthy();
+    expect(ui.kind).toBeTruthy();
+  });
+});

--- a/ui/test/unit/format.test.ts
+++ b/ui/test/unit/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { countSummary, formatSeq, shortHex } from "../../src/lib/format";
+
+describe("shortHex", () => {
+  it("shortens a long hex id to head…tail", () => {
+    const id = "ab".repeat(32); // 64 chars
+    expect(shortHex(id)).toBe(`${id.slice(0, 8)}…${id.slice(-4)}`);
+  });
+  it("returns short input unchanged", () => {
+    expect(shortHex("abcd")).toBe("abcd");
+    expect(shortHex("")).toBe("");
+  });
+  it("honors custom head/tail", () => {
+    const id = "0123456789abcdef".repeat(2);
+    expect(shortHex(id, 4, 2)).toBe(`${id.slice(0, 4)}…${id.slice(-2)}`);
+  });
+});
+
+describe("formatSeq", () => {
+  it("null/undefined → em dash", () => {
+    expect(formatSeq(null)).toBe("—");
+    expect(formatSeq(undefined)).toBe("—");
+  });
+  it("number → #n", () => {
+    expect(formatSeq(0)).toBe("#0");
+    expect(formatSeq(42)).toBe("#42");
+  });
+});
+
+describe("countSummary", () => {
+  it("formats done/total noun", () => {
+    expect(countSummary(3, 5, "committed")).toBe("3/5 committed");
+  });
+});

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node", "vite/client"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "test", "e2e", "vite.config.ts", "playwright.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest/config" />
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+// One config drives the dev server, the production build, AND vitest. The dev
+// (5173) / preview (4173) ports are pinned + strict so the gateway's deny-by-default
+// `--cors-origin` allowlist can name them exactly (a flaky CORS mismatch otherwise).
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173, strictPort: true },
+  preview: { port: 4173, strictPort: true },
+  test: {
+    // Component/unit tests run in jsdom; the contract test opts into the node
+    // environment per-file (`// @vitest-environment node`) so it gets real
+    // `child_process`/`net` + undici fetch against a live `kx serve`.
+    environment: "jsdom",
+    globals: false,
+    setupFiles: ["./test/setup.ts"],
+    include: ["test/**/*.test.{ts,tsx}"],
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
+    // The contract test builds the FFI-free `kx` on a cold cache + spawns it, so
+    // the budgets mirror the SDK suite's tolerance.
+    testTimeout: 120_000,
+    hookTimeout: 180_000,
+    // One gateway per file keeps the run-instance-per-recipe rule simple.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## What

The first PR on the OSS **UI critical path** (`R9.5 ✅ → shell → live DAG`). A greenfield, static-hostable **React + Vite SPA** under a new top-level `ui/`, talking **gRPC-web** to a running `kx serve` via the existing `@kortecx/sdk/web` client. Connect to a gateway, submit the built-in `kx/recipes/echo` recipe, and **watch its Motes transition live** in a projection-polled status table.

This is the **shell** (T3.2). The next PR (T3.3) swaps the table for an interactive XYFlow DAG, reusing this exact data layer unchanged.

## Decisions (confirmed)
- **TanStack Router + TanStack Query** (SPA; not TanStack Start / Next.js) — typed URL state (`instanceId`/`atSeq`) + server-state polling/caching.
- **Live updates = poll `GetProjection`** over gRPC-web (verified, secure: same CORS+bearer+TLS surface; no second port; no plaintext `ws://`). WS/delta streaming is a documented scale-path follow-on.
- **Greenfield `ui/`** top-level dir; consumes the SDK's built `dist/` via a `file:` dependency.

## Architecture
- **`src/kx/` data layer = the T3.3 forward seam.** The run-detail view consumes one hook, `useProjection`, which polls `GetProjection` and stops once the run is at rest. The SDK `Projection` is mapped to a plain view-model so TanStack Query structural sharing keeps a stable reference across unchanged polls (memoized rows skip re-render).
- **Security:** bearer token in memory only (never `localStorage`/bundle — tested); CORS is server-side deny-by-default (E2E-proven); renders enum labels + hex ids only (no XSS surface). **Production dependency audit: 0 vulnerabilities.**
- **Robustness fix:** `toUiError` duck-types the stable `.code` rather than `instanceof KxError` — the SDK bundles its web/node entry points standalone, so class identity differs across entry points and `instanceof` would silently miss.

## Tests — 97 vitest (all green) + 3 Playwright
- **unit:** every Mote state / nd_class / anomaly enum incl. UNKNOWN fallback; error→UI mapping for every `ErrorCode`; endpoint/plaintext checks.
- **component:** `MoteTable` (all states, empty, **5000-Mote render budget**), pills/badges, `ErrorNotice` affordances, `ConnectionForm` (**token never persisted**), the poll re-render seam, connect/disconnect machine.
- **contract (vs a real `kx serve`):** echo→projection→`COMMITTED`, **byte-parity with the CLI**, auth postures, uniform `permission_denied`.
- **E2E (Playwright/chromium, real gateway):** connect→submit→watch `COMMITTED` over real gRPC-web+CORS; deny-by-default origin fails cleanly; graceful, retryable error on gateway drop.

## Golden Rule 8
**Zero Rust change** (the gateway already serves everything post-R9.5) → `frozen-trio` trivially empty, digest `7d22d4bd…` trivially invariant; no proto/wire/journal change. New **non-required `ui` CI job** mirrors `sdk-typescript` (FFI-free). Agentic-shaper-children path needs on-device inference (Metal) → exercised locally; CI uses the deterministic no-model echo path (SN-7).

**Pass B follow-ups (named, deferred):** code-split the bundle; `@tanstack/react-virtual` for >5k Motes (T3.3); bump vite (dev-only esbuild advisory); add `osv-scanner` to the `ui` job; `wss://`/SSO/multi-user = cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)