### PR TITLE
feat(ui,sdk,gateway): T3.3 — live XYFlow DAG viewer over the live KxGateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ kx submit --demo --wait
 
 # Invoke a PUBLISHED recipe by handle, bound to JSON args — run-to-result.
 kx invoke kx/recipes/echo --args '{"topic":"durable agents"}' --wait
+
+# A multi-node DAG, model-free: root → 3 children → gather (5 Motes, all committed).
+kx invoke kx/recipes/fanout-demo --args '{}' --wait
 ```
 
 **Inspect** any run — its DAG, a committed result, and its event stream:
@@ -170,6 +173,24 @@ Auth is **deny-all by default**: `--dev-allow-local` trusts loopback only; for
 real principals use `--auth-token <token>=<party>` (or `--auth-token-file`), and
 pass `--token`/`--token-file` on the client. Identity is always derived
 server-side — never asserted by the client.
+
+### Web console (live DAG)
+
+A static-hostable React + Vite single-page app ([`ui/`](ui/)) talks **gRPC-web** to
+the same `kx serve` and lets you **watch the Mote DAG execute** in the browser —
+nodes light up as the run commits, edges are the `parents[]` lineage. Build the
+TypeScript SDK, start a CORS-allowed gateway, then the dev server:
+
+```bash
+npm --prefix bindings/typescript ci && npm --prefix bindings/typescript run build
+kx serve --journal /tmp/kx.db --content /tmp/kx-content \
+  --dev-allow-local --cors-origin http://localhost:5173 &
+npm --prefix ui ci && npm --prefix ui run dev   # http://localhost:5173
+```
+
+Connect to `http://127.0.0.1:50151`, then submit `kx/recipes/echo` (one node) or
+`kx/recipes/fanout-demo` (a 5-node graph). See [`ui/README.md`](ui/README.md) for
+the full walkthrough.
 
 ## Run in Docker
 
@@ -426,9 +447,11 @@ Interfaces will change before 1.0 — **pin a commit** if you build on it now.
 
 **Early development, built in the open.** Today (v0.1.0): a durable single-system
 runtime with exactly-once world effects and crash recovery, a gateway server, the
-unified `kx` CLI, a recipe library + prompt templating, an audit trail, and a
-live event stream. Next: TypeScript & Python client SDKs over gRPC, a dashboard,
-audio multi-modal inference, and an opt-in cluster layer for managed multi-node.
+unified `kx` CLI, a recipe library + prompt templating, an audit trail, a live
+event stream, TypeScript & Python client SDKs over gRPC, and a React + Vite **web
+console** that renders the live execution DAG (gRPC-web). Next: event timeline /
+time-travel + multi-modal artifact review in the console, audio multi-modal
+inference, and an opt-in cluster layer for managed multi-node.
 
 ## Contributing
 

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -36,6 +36,9 @@ export {
   isPending,
 } from "./types.js";
 
+export { ParentEdge, edgeKindName } from "./parents.js";
+export type { EdgeKindName } from "./parents.js";
+
 export { WaitState } from "./wait.js";
 export type { WaitOutcome, WaitMode } from "./wait.js";
 

--- a/bindings/typescript/src/parents.ts
+++ b/bindings/typescript/src/parents.ts
@@ -1,0 +1,36 @@
+/**
+ * The parent-edge view — one inbound DAG edge of a Mote (hex parent id + edge
+ * metadata). Kept in its own module so `types.ts` stays a thin aggregator,
+ * mirroring the Rust core's module-per-concern discipline.
+ *
+ * SN-8: the parent id is server-derived; the SDK only *encodes* the bytes to
+ * hex (never computes an id). An out-of-range `EdgeKind` renders `"unknown"` —
+ * never a crash, never a silent mislabel (mirrors `stateName` in `types.ts`).
+ */
+
+import { EdgeKind } from "./gen/kortecx/v1/coordinator_pb.js";
+import type { ParentRef } from "./gen/kortecx/v1/coordinator_pb.js";
+import { encode } from "./hexids.js";
+
+/** A parent edge's semantic kind. `"unknown"` absorbs UNSPECIFIED(0) + any future value. */
+export type EdgeKindName = "data" | "control" | "unknown";
+
+/** Map an `EdgeKind` discriminant to a stable name (`"unknown"` if new). */
+export function edgeKindName(kind: number): EdgeKindName {
+  if (kind === EdgeKind.DATA) return "data";
+  if (kind === EdgeKind.CONTROL) return "control";
+  return "unknown";
+}
+
+/** One inbound edge of a Mote in the projection DAG (hex parent id + edge meta). */
+export class ParentEdge {
+  constructor(
+    readonly parentId: string,
+    readonly edgeKind: EdgeKindName,
+    readonly nonCascade: boolean,
+  ) {}
+
+  static fromProto(p: ParentRef): ParentEdge {
+    return new ParentEdge(encode(p.parentId), edgeKindName(p.edgeKind), p.nonCascade);
+  }
+}

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -16,6 +16,7 @@ import type {
 } from "./gen/kortecx/v1/gateway_pb.js";
 import { MoteSnapshotState } from "./gen/kortecx/v1/gateway_pb.js";
 import { encode } from "./hexids.js";
+import { ParentEdge } from "./parents.js";
 
 const STATE_NAMES: Record<number, string> = {
   [MoteSnapshotState.PENDING]: "PENDING",
@@ -52,6 +53,12 @@ export class MoteView {
     readonly moteDefHash: string,
     readonly committedSeq: number | null,
     readonly anomaly: number | null,
+    /**
+     * Inbound DAG edges (server-derived). Trailing + defaulted so existing
+     * positional callers keep working; deliberately NOT in `toJSON()` (the CLI
+     * `projection --json` shape carries no parents — byte-parity is load-bearing).
+     */
+    readonly parents: readonly ParentEdge[] = [],
   ) {}
 
   static fromProto(m: MoteSnapshot): MoteView {
@@ -65,6 +72,7 @@ export class MoteView {
       encode(m.moteDefHash),
       m.committedSeq !== undefined ? Number(m.committedSeq) : null,
       m.anomaly !== undefined ? m.anomaly : null,
+      m.parents.map((p) => ParentEdge.fromProto(p)),
     );
   }
 

--- a/bindings/typescript/test/parents.test.ts
+++ b/bindings/typescript/test/parents.test.ts
@@ -1,0 +1,82 @@
+/** Parent-edge views (T3.3 DAG edges) — pure, no server. */
+
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+import { EdgeKind, ParentRefSchema } from "../src/gen/kortecx/v1/coordinator_pb.js";
+import { MoteSnapshotSchema, MoteSnapshotState } from "../src/gen/kortecx/v1/gateway_pb.js";
+import { ParentEdge, edgeKindName } from "../src/parents.js";
+import { MoteView } from "../src/types.js";
+
+const fill = (v: number, n: number): Uint8Array => new Uint8Array(n).fill(v);
+
+describe("edgeKindName", () => {
+  it("maps DATA/CONTROL and absorbs unknown", () => {
+    expect(edgeKindName(EdgeKind.DATA)).toBe("data");
+    expect(edgeKindName(EdgeKind.CONTROL)).toBe("control");
+    expect(edgeKindName(EdgeKind.UNSPECIFIED)).toBe("unknown");
+    expect(edgeKindName(99)).toBe("unknown");
+  });
+});
+
+describe("ParentEdge.fromProto", () => {
+  it("hex-encodes the parent id + maps edge meta", () => {
+    const p = create(ParentRefSchema, {
+      parentId: fill(0x06, 32),
+      edgeKind: EdgeKind.CONTROL,
+      nonCascade: true,
+    });
+    const e = ParentEdge.fromProto(p);
+    expect(e.parentId).toBe("06".repeat(32));
+    expect(e.edgeKind).toBe("control");
+    expect(e.nonCascade).toBe(true);
+  });
+});
+
+describe("MoteView parents", () => {
+  it("populates parents from the snapshot", () => {
+    const snap = create(MoteSnapshotSchema, {
+      moteId: fill(0x03, 32),
+      state: MoteSnapshotState.COMMITTED,
+      moteDefHash: fill(0x05, 32),
+      parents: [
+        create(ParentRefSchema, {
+          parentId: fill(0x01, 32),
+          edgeKind: EdgeKind.DATA,
+          nonCascade: false,
+        }),
+        create(ParentRefSchema, {
+          parentId: fill(0x02, 32),
+          edgeKind: EdgeKind.CONTROL,
+          nonCascade: true,
+        }),
+      ],
+    });
+    const mv = MoteView.fromProto(snap);
+    expect(mv.parents).toHaveLength(2);
+    expect(mv.parents[0]).toEqual(new ParentEdge("01".repeat(32), "data", false));
+    expect(mv.parents[1]?.edgeKind).toBe("control");
+    expect(mv.parents[1]?.nonCascade).toBe(true);
+  });
+
+  it("defaults to an empty parents array (a root mote)", () => {
+    const snap = create(MoteSnapshotSchema, {
+      moteId: fill(0x03, 32),
+      state: MoteSnapshotState.SCHEDULED,
+      moteDefHash: fill(0x05, 32),
+    });
+    expect(MoteView.fromProto(snap).parents).toEqual([]);
+    // a positional construction with no parents arg still works (additive/trailing).
+    expect(new MoteView("aa", "S", 2, 1, 1, null, "bb", null, null).parents).toEqual([]);
+  });
+
+  it("toJSON() does NOT include parents (CLI byte-parity guard)", () => {
+    const snap = create(MoteSnapshotSchema, {
+      moteId: fill(0x03, 32),
+      state: MoteSnapshotState.COMMITTED,
+      moteDefHash: fill(0x05, 32),
+      parents: [create(ParentRefSchema, { parentId: fill(0x01, 32), edgeKind: EdgeKind.DATA })],
+    });
+    const json = MoteView.fromProto(snap).toJSON();
+    expect(Object.keys(json)).not.toContain("parents");
+  });
+});

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -73,7 +73,7 @@ pub use error::GatewayError;
 pub use live_tail::LiveTailer;
 pub use provision::{
     DemoLibrary, HostRecipeBinder, HostSignatureCatalog, DEMO_RECIPE_HANDLE, EXEC_RECIPE_HANDLE,
-    MODEL_RECIPE_HANDLE,
+    FANOUT_RECIPE_HANDLE, MODEL_RECIPE_HANDLE,
 };
 pub use server::{serve, start, RunningGateway};
 

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -24,7 +24,7 @@ use kx_gateway_core::{
     SignatureCatalog, SignatureSummaryEntry,
 };
 use kx_invoke::{bind_snapshot, InvokeError, UseWarrantResolver};
-use kx_mote::{ConfigKey, ConfigVal, LogicRef, ModelId, ToolName, PROMPT_KEY};
+use kx_mote::{ConfigKey, ConfigVal, EdgeMeta, LogicRef, ModelId, ToolName, PROMPT_KEY};
 use kx_warrant::{
     ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope, ResourceCeiling, Role,
     WarrantSpec,
@@ -123,6 +123,17 @@ pub const DEMO_RECIPE_HANDLE: &str = "kx/recipes/echo";
 /// (see `real_exec::register_demo_body`); takes no free-params (the
 /// body's input is the Mote's identity). Shared with the e2e test (no drift).
 pub const EXEC_RECIPE_HANDLE: &str = "kx/recipes/exec-demo";
+
+/// The wire handle of the T3.3 deterministic MULTI-NODE demo recipe: a PURE
+/// fan-out → gather DAG (root → N children → gather) that runs model-free on the
+/// embedded storing executor, so a single `Invoke` yields a real multi-node
+/// projection with DATA parent edges — the live-DAG viewer's end-to-end fixture.
+/// Always provisioned. Takes no free-params. Shared with the e2e test (no drift).
+pub const FANOUT_RECIPE_HANDLE: &str = "kx/recipes/fanout-demo";
+
+/// The fan-out width of [`FANOUT_RECIPE_HANDLE`]: root + `FANOUT_WIDTH` children +
+/// gather = `FANOUT_WIDTH + 2` Motes. Three keeps the demo graph legible.
+const FANOUT_WIDTH: u8 = 3;
 
 /// The content-ref of the demo recipe's single typed free-param (`topic`).
 const TOPIC_SCHEMA_REF: [u8; 32] = [0x2b; 32];
@@ -258,6 +269,13 @@ impl DemoLibrary {
                 free_params: topic_contract(),
             },
         ));
+
+        // (fanout-demo) the T3.3 PURE multi-node recipe — a fan-out → gather DAG that
+        // runs model-free on the storing executor (see `seed_fanout_demo`). Always
+        // seeded; no free-params.
+        recipes.push(seed_fanout_demo(
+            &versions, &bodies, &grants, &owner, parties, exec_class,
+        )?);
 
         // (exec-demo) the PR-9b real-exec recipe — step logic_ref == the located
         // body's content ref, a sandbox warrant, no free-params. Seeded only when
@@ -502,6 +520,77 @@ fn demo_handle() -> Result<AssetPath, GatewayError> {
 fn exec_handle() -> Result<AssetPath, GatewayError> {
     parse_handle(EXEC_RECIPE_HANDLE)
         .ok_or_else(|| GatewayError::Catalog("invalid exec recipe handle".into()))
+}
+
+fn fanout_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(FANOUT_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid fanout recipe handle".into()))
+}
+
+/// Seed the T3.3 PURE multi-node `fanout-demo` recipe and return its
+/// `(handle, meta)` for the binder's recipe table. Factored out of
+/// [`DemoLibrary::seed`] so the orchestrator stays within the line budget and each
+/// recipe reads as a self-contained unit.
+fn seed_fanout_demo(
+    versions: &SqliteVersionLedger,
+    bodies: &SqliteBodyLedger,
+    grants: &SqliteGrantLedger,
+    owner: &PartyId,
+    parties: &[String],
+    exec_class: ExecutorClass,
+) -> Result<(AssetPath, RecipeMeta), GatewayError> {
+    let warrant = demo_warrant(exec_class);
+    let handle = fanout_handle()?;
+    let body = multinode_recipe_body(&warrant)?;
+    seed_recipe(
+        versions, bodies, grants, owner, parties, &handle, body, &warrant,
+    )?;
+    Ok((
+        handle,
+        RecipeMeta {
+            owner_root: warrant,
+            free_params: FreeParamContract::new(),
+        },
+    ))
+}
+
+/// A PURE, deterministic MULTI-step recipe body: a root that fans out to
+/// [`FANOUT_WIDTH`] PURE children which a gather step joins
+/// (`root → {c1..cN} → gather`, all DATA edges). Every step is a PURE `transform`
+/// carrying `warrant` (== the demo warrant), so bind's narrowing `intersect` is a
+/// no-op and each Mote leases on the embedded storing executor — yielding a real
+/// multi-node projection with parent edges WITHOUT a model. The terminal is the
+/// gather step (added last). Distinct `logic_ref`s give the steps distinct
+/// identities (the storing executor ignores `logic_ref`).
+fn multinode_recipe_body(warrant: &WarrantSpec) -> Result<WorkflowDef, GatewayError> {
+    let edge_err =
+        |e: kx_workflow::CompileError| GatewayError::Catalog(format!("fanout edge: {e}"));
+    // Seed "fano" so the body is stable + idempotent across restarts.
+    let mut wf = WorkflowDef::new(u32::from_le_bytes(*b"fano"));
+    let model_id = warrant.model_route.model_id.clone();
+    let step = |tag: u8| {
+        transform(
+            LogicRef::from_bytes([tag; 32]),
+            model_id.clone(),
+            warrant.clone(),
+            ToolName("fanout-demo".into()),
+        )
+    };
+
+    let root = wf.add_step(step(0x40));
+    let mut children = Vec::with_capacity(FANOUT_WIDTH as usize);
+    for i in 0..FANOUT_WIDTH {
+        let child = wf.add_step(step(0x41 + i)); // 0x41, 0x42, 0x43 — distinct identities
+        wf.add_edge(root, child, EdgeMeta::data())
+            .map_err(edge_err)?;
+        children.push(child);
+    }
+    let gather = wf.add_step(step(0x50));
+    for child in children {
+        wf.add_edge(child, gather, EdgeMeta::data())
+            .map_err(edge_err)?;
+    }
+    Ok(wf)
 }
 
 /// A PURE recipe body: a single content-addressed step with `step_logic_ref` as
@@ -823,6 +912,31 @@ mod tests {
             assert_eq!(w.executor_class, ExecutorClass::Bwrap);
             assert!(w.model_route.max_calls <= 3);
         }
+    }
+
+    #[tokio::test]
+    async fn bind_fanout_demo_is_a_multinode_dag() {
+        let dir = tempfile::tempdir().unwrap();
+        let binder = demo_lib(dir.path());
+        let bound = binder
+            .bind("alice@acme", FANOUT_RECIPE_HANDLE, b"{}")
+            .await
+            .unwrap();
+        // root + FANOUT_WIDTH children + gather = a genuine multi-node DAG.
+        assert_eq!(bound.motes.len(), FANOUT_WIDTH as usize + 2);
+        // Every step stays PURE on the worker's executor_class (so it leases on the
+        // embedded storing executor — the model-free multi-node path).
+        for (_, w) in &bound.motes {
+            assert_eq!(w.executor_class, ExecutorClass::Bwrap);
+            assert_eq!(w.mote_class, MoteClass::Pure);
+        }
+        // Idempotent: identical (empty) args → identical terminal identity.
+        let again = binder
+            .bind("alice@acme", FANOUT_RECIPE_HANDLE, b"{}")
+            .await
+            .unwrap();
+        assert_eq!(bound.terminal_mote_id, again.terminal_mote_id);
+        assert_eq!(bound.recipe_fingerprint, again.recipe_fingerprint);
     }
 
     #[tokio::test]

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,29 +1,40 @@
-# @kortecx/ui — runtime console (T3.2 shell)
+# @kortecx/ui — runtime console (live DAG)
 
 A static-hostable **React + Vite** single-page app over the frozen `KxGateway`
 contract, talking **gRPC-web** to a running `kx serve` via the existing
 [`@kortecx/sdk`](../bindings/typescript) browser client. No server tier: the
 journal is the source of truth and the client is stateless (D119).
 
-This is the **shell** (milestone T3.2 on the OSS UI critical path): connect to a
-gateway, submit a run, and **watch its Motes transition live** in a status table
-that the gateway is polled for. The next milestone (T3.3) swaps that table for an
-interactive XYFlow DAG — reusing this exact data layer unchanged.
+Connect to a gateway, submit a recipe, and **watch its Motes execute** — as a live
+**XYFlow (reactflow) DAG** (nodes = Motes colored by state/`nd_class`, edges =
+`parents[]`) or a status table, both polled live from `GetProjection`. This is the
+T3.3 milestone on the OSS UI critical path (the live-DAG viewer over the T3.2 shell).
 
 ## Architecture
 
 - **Routing/state:** TanStack Router (typed routes + search params) + TanStack
   Query (server-state, polling, caching, retry).
 - **Live updates:** poll `GetProjection` over gRPC-web on an interval (TanStack
-  Query `refetchInterval`); polling stops once every Mote is terminal. This is the
-  verified, secure path (same CORS + bearer + TLS surface as every other RPC; no
-  second port, no plaintext `ws://`). Lower-latency WS/delta streaming is a
-  documented scale-path follow-on.
-- **Data layer (`src/kx/`)** is the forward seam: the run-detail route consumes one
-  hook, `useProjection(instanceId)`. T3.3 changes only the *view* it feeds.
+  Query `refetchInterval`). Polling stops authoritatively when the recipe's
+  **terminal (sink) Mote** commits — its id is threaded from the `Invoke` response
+  through the route (`?terminal=…`) — so a multi-node run keeps updating while its
+  Mote set is still growing (a naïve "all visible Motes terminal" check stops too
+  early). A direct-URL navigation (no terminal id) falls back to frontier stability
+  (all-terminal + `current_seq` unchanged). Same CORS + bearer + TLS surface as every
+  other RPC; no second port, no plaintext `ws://`.
+- **The DAG (`src/components/dag/`):** pure modules — `dag-graph` (projection →
+  nodes/edges + a topology hash), `layout` (dagre), `edges` (DATA solid / CONTROL
+  dashed / non-cascade dimmed), `flow` (reactflow adapters) — and thin React wrappers
+  (`MoteNode`, `MoteDag`). Layout is memoized on the topology hash, so a state-only
+  poll re-colors nodes in place without a relayout; new nodes (dynamic shaper
+  children) animate in. reactflow + dagre are **code-split** into the run-detail route.
+- **Data layer (`src/kx/`)** is the seam both views share: `useProjection`. The
+  Graph/Table toggle, `?atSeq` time-travel, and Refresh are all view-agnostic. Above
+  500 Motes the DAG falls back to the table (the scale surface).
 - **Security:** the bearer token lives in **memory only** (never `localStorage` /
-  the bundle). CORS is enforced server-side (deny-by-default). The shell renders
-  enum labels + hex ids only — never arbitrary Mote content (no XSS surface).
+  the bundle). CORS is enforced server-side (deny-by-default). The console renders
+  enum labels + server-derived hex ids only — never arbitrary Mote content (SN-8;
+  no XSS surface).
 
 ## Prerequisites
 
@@ -35,20 +46,15 @@ npm --prefix ../bindings/typescript ci
 npm --prefix ../bindings/typescript run build
 ```
 
-(Run from this `ui/` directory the paths are `../bindings/typescript`; from the repo
-root drop the `../`.)
+(From this `ui/` directory the path is `../bindings/typescript`; from the repo root
+drop the `../`.)
 
-## Develop
+## Run it locally
 
-```sh
-npm ci                 # install (after the SDK dist/ exists)
-npm run dev            # Vite dev server on http://localhost:5173
-```
-
-Run a gateway that allows the dev origin (deny-by-default CORS — name it exactly):
+**1. Start a gateway** that allows the dev origin (deny-by-default CORS — name it
+exactly), from the repo root:
 
 ```sh
-# from the repo root
 cargo build -p kx-cli
 target/debug/kx serve \
   --journal /tmp/kx.db --content /tmp/kx-blobs \
@@ -56,9 +62,22 @@ target/debug/kx serve \
   --cors-origin http://localhost:5173
 ```
 
-Then open the dev server, connect to `http://127.0.0.1:50151`, submit a run (the
-built-in `kx/recipes/echo` recipe is pre-filled), and watch the Mote flip to
-`COMMITTED`.
+**2. Start the UI** (from `ui/`):
+
+```sh
+npm ci                 # install (after the SDK dist/ exists)
+npm run dev            # Vite dev server on http://localhost:5173
+```
+
+**3. In the browser** open <http://localhost:5173>, connect to
+`http://127.0.0.1:50151`, then run a recipe and watch the DAG execute:
+
+- **`kx/recipes/echo`** (pre-filled, args `{"topic":"hello"}`) — a single COMMITTED node.
+- **`kx/recipes/fanout-demo`** (args `{}`) — a **5-node** fan-out → gather DAG
+  (root → 3 children → gather) that runs model-free and lights up to COMMITTED. The
+  best way to see the graph view.
+
+Toggle **Graph / Table**, or pin a snapshot with `?atSeq=<n>` for time-travel.
 
 ## Test
 
@@ -66,22 +85,26 @@ built-in `kx/recipes/echo` recipe is pre-filled), and watch the Mote flip to
 npm run lint           # biome
 npm run typecheck      # tsc --noEmit
 KX_BIN="$PWD/../target/debug/kx" npm test   # vitest: unit + component + contract
-npm run build          # vite build → dist/
+npm run build          # vite build → dist/ (reactflow/dagre code-split)
 npm run test:e2e       # Playwright (chromium) — builds + previews + drives a real gateway
 ```
 
-- **Unit/component** tests mock the client and cover every Mote state/nd_class,
-  error → UI mapping, the poll re-render seam, and the "token is never persisted"
-  invariant.
+- **Unit/component** tests cover the pure DAG modules across every topology
+  (chain / diamond / fan-out / fan-in / disconnected / control-edge / cycle-guard),
+  the no-relayout-on-state-only-poll invariant, the dynamic-child-appearance path,
+  the >500-node table fallback, error → UI mapping, and the poll-stop logic.
 - **Contract** test (`// @vitest-environment node`, gated on `KX_BIN`) drives a real
-  `kx serve` and asserts byte-parity with the `kx` CLI + the auth/permission edges.
-- **E2E** (Playwright) proves the real browser gRPC-web + CORS path end to end.
+  `kx serve`: echo's empty `parents[]` proves the edge wire end-to-end, `fanout-demo`
+  proves a real multi-node `parents[]` DAG, and byte-parity with the `kx` CLI holds.
+- **E2E** (Playwright) proves the real browser gRPC-web + CORS path: echo reaching
+  COMMITTED in the DAG, and the `fanout-demo` graph rendering all 5 nodes COMMITTED.
 
 The agentic-shaper-children path needs on-device inference (Metal) and is exercised
-**locally** only; CI uses the deterministic, no-model `kx/recipes/echo` path (SN-7).
+**locally** only; CI uses the deterministic, no-model `echo` + `fanout-demo` paths (SN-7).
 
 ## Scale note
 
-The shell renders a plain (unvirtualized) table — comfortable to ~5k Motes, degrades
-beyond. The runtime proves 25k-Mote *folding* (`scale-smoke`); windowing the table
-(and then the DAG) with `@tanstack/react-virtual` lands in T3.3.
+The DAG renders for runs up to **500 Motes** (above that it falls back to the table,
+which is comfortable to ~5k and degrades beyond). The runtime proves 25k-Mote
+*folding* (`scale-smoke`); windowing the table/DAG with `@tanstack/react-virtual` is
+a documented follow-on.

--- a/ui/e2e/connect-submit-poll.spec.ts
+++ b/ui/e2e/connect-submit-poll.spec.ts
@@ -25,9 +25,15 @@ test("connect → submit echo → watch a Mote reach COMMITTED (real gRPC-web + 
   await expect(page.getByRole("heading", { name: /run a recipe/i })).toBeVisible();
   await page.getByRole("button", { name: /submit run/i }).click();
 
-  // Run-detail: the DAG table appears and a Mote pill flips to COMMITTED via the poll loop.
-  await expect(page.getByTestId("mote-table")).toBeVisible({ timeout: 30_000 });
+  // Run-detail defaults to the live DAG: a Mote node appears and flips to COMMITTED
+  // via the projection poll loop (the real reactflow canvas + gRPC-web path).
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("mote-node").first()).toBeVisible({ timeout: 30_000 });
   await expect(page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).first()).toBeVisible(
     { timeout: 30_000 },
   );
+
+  // The table toggle still works (the proven scale + a11y surface stays reachable).
+  await page.getByRole("button", { name: /^table$/i }).click();
+  await expect(page.getByTestId("mote-table")).toBeVisible();
 });

--- a/ui/e2e/connection-drop.spec.ts
+++ b/ui/e2e/connection-drop.spec.ts
@@ -19,7 +19,7 @@ test("a gateway drop mid-session surfaces a clear, retryable error (no hang/cras
   await expect(endpoint).toHaveValue(gw.endpoint);
   await page.getByRole("button", { name: /^connect$/i }).click();
   await page.getByRole("button", { name: /submit run/i }).click();
-  await expect(page.getByTestId("mote-table")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
 
   // The gateway disappears.
   gw.stop();

--- a/ui/e2e/fanout-dag.spec.ts
+++ b/ui/e2e/fanout-dag.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("submit fanout-demo → the live DAG renders the whole fan-out → gather graph (COMMITTED)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+
+  await page.goto("/connect");
+  await page.getByLabel(/gateway endpoint/i).fill(gw.endpoint);
+  await page.getByRole("button", { name: /^connect$/i }).click();
+
+  await expect(page.getByRole("heading", { name: /run a recipe/i })).toBeVisible();
+  // Focus then type the handle/args (pressSequentially fires per-keystroke input
+  // events the React controlled inputs catch; a bulk fill() can leave state stale).
+  const handle = page.getByLabel(/recipe handle/i);
+  await handle.click();
+  await handle.fill("");
+  await handle.pressSequentially("kx/recipes/fanout-demo");
+  const args = page.getByLabel(/args \(json/i);
+  await args.click();
+  await args.fill("");
+  await args.pressSequentially("{}");
+  await page.getByRole("button", { name: /submit run/i }).click();
+
+  // The live DAG materializes the entire graph: root + 3 children + gather = 5 nodes.
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect.poll(() => page.getByTestId("mote-node").count(), { timeout: 30_000 }).toBe(5);
+
+  // Every Mote reaches COMMITTED (the gather joins all three children) — the headline
+  // "watch the DAG execute" beat, driven model-free through a real gRPC-web gateway.
+  await expect
+    .poll(() => page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).count(), {
+      timeout: 30_000,
+    })
+    .toBe(5);
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@dagrejs/dagre": "^1.1.8",
         "@kortecx/sdk": "file:../bindings/typescript",
         "@tanstack/react-query": "^5.59.0",
         "@tanstack/react-router": "^1.58.0",
+        "@xyflow/react": "^12.11.0",
         "framer-motion": "^11.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -690,6 +692,24 @@
       "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.8.tgz",
+      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1577,7 +1597,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
       "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.101.0"
       },
@@ -1594,7 +1613,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.15.tgz",
       "integrity": "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "@tanstack/react-store": "^0.9.3",
@@ -1636,7 +1654,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.13.tgz",
       "integrity": "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "cookie-es": "^3.0.0",
@@ -1803,6 +1820,55 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1825,14 +1891,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1844,7 +1910,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -2016,6 +2082,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -2221,6 +2329,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2314,9 +2428,114 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -4398,6 +4617,34 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,9 +20,11 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.8",
     "@kortecx/sdk": "file:../bindings/typescript",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-router": "^1.58.0",
+    "@xyflow/react": "^12.11.0",
     "framer-motion": "^11.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/ui/src/components/dag/MoteDag.tsx
+++ b/ui/src/components/dag/MoteDag.tsx
@@ -1,0 +1,117 @@
+import { Background, Controls, ReactFlow, ReactFlowProvider, useReactFlow } from "@xyflow/react";
+import { useEffect, useMemo } from "react";
+import type { ProjectionVM } from "../../kx/use-projection";
+import { EmptyState } from "../EmptyState";
+import { MoteTable } from "../MoteTable";
+import { MoteNode } from "./MoteNode";
+import { buildEdges, topologyHash } from "./dag-graph";
+import { buildFlowEdges, buildFlowNodes } from "./flow";
+import { layoutGraph } from "./layout";
+
+/**
+ * Above this many Motes the DAG falls back to the table. All nodes within the cap
+ * render (no viewport culling — that mis-culls un-measured nodes and is needless
+ * below the cap); the cap itself bounds the dagre layout + reactflow DOM/SVG cost.
+ * The 25k-Mote M2.1 ceiling is the table's domain (the scale surface); the DAG is
+ * the human-scale legibility surface.
+ */
+export const MAX_DAG_NODES = 500;
+
+// Module-level (stable reference) — an inline object re-registers node types every
+// render, a known reactflow performance footgun.
+const nodeTypes = { mote: MoteNode };
+
+function DagFlow({ projection }: { projection: ProjectionVM }) {
+  const motes = projection.motes;
+  const topoHash = useMemo(() => topologyHash(motes), [motes]);
+
+  // Relayout ONLY when the topology hash changes; a state-only poll reuses the
+  // cached positions (the no-thrash invariant — see dag-graph.topologyHash).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: relayout is intentionally keyed on the topology hash only — a state-only poll must NOT relayout.
+  const positions = useMemo(
+    () =>
+      layoutGraph(
+        motes.map((m) => m.moteId),
+        buildEdges(motes),
+      ),
+    [topoHash],
+  );
+  // Edges are topology — recompute only on a topology change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: edges depend on topology only (same justification as positions).
+  const edges = useMemo(() => buildFlowEdges(motes), [topoHash]);
+  // Node DATA (state/anomaly) re-merges every poll WITHOUT relayout.
+  const nodes = useMemo(() => buildFlowNodes(motes, positions), [motes, positions]);
+
+  // Refit the viewport when the topology grows (dynamic children appear). Guarded
+  // so a headless/jsdom flow (no measured viewport) is a harmless no-op.
+  const { fitView } = useReactFlow();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: topoHash is an intentional re-fit trigger (refit when the graph grows), not read in the body.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      try {
+        void fitView({ padding: 0.2, duration: 200 });
+      } catch {
+        /* no measured viewport (headless) — ignore */
+      }
+    }, 0);
+    return () => clearTimeout(t);
+  }, [topoHash, fitView]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      fitView
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      proOptions={{ hideAttribution: true }}
+      minZoom={0.1}
+      maxZoom={1.5}
+    >
+      <Background gap={20} />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+}
+
+/**
+ * The run's Motes as a live execution DAG (nodes = Motes colored by state/nd_class,
+ * edges = `parents[]`). Consumes the same `ProjectionVM` as the table, so the poll
+ * seam, `?atSeq` time-travel, and Refresh are all view-agnostic. Replaces the table
+ * as the default run view (T3.3); the table stays as a toggle + the >MAX fallback.
+ */
+export function MoteDag({ projection }: { projection: ProjectionVM }) {
+  if (projection.motes.length === 0) {
+    return (
+      <EmptyState
+        title="No Motes yet"
+        detail="This run has no Motes at the current frontier — they appear as the run executes."
+      />
+    );
+  }
+  if (projection.motes.length > MAX_DAG_NODES) {
+    return (
+      <div data-testid="dag-fallback">
+        <p className="muted">
+          Graph hidden for {projection.motes.length} Motes — showing the table (the DAG renders for
+          runs up to {MAX_DAG_NODES} Motes).
+        </p>
+        <MoteTable projection={projection} />
+      </div>
+    );
+  }
+  return (
+    <div
+      className="dag-canvas"
+      data-testid="mote-dag"
+      role="img"
+      aria-label={`Execution DAG of ${projection.motes.length} Motes`}
+    >
+      <ReactFlowProvider>
+        <DagFlow projection={projection} />
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/ui/src/components/dag/MoteNode.tsx
+++ b/ui/src/components/dag/MoteNode.tsx
@@ -1,0 +1,47 @@
+import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import { motion } from "framer-motion";
+import { memo } from "react";
+import { statePulse } from "../../app/motion";
+import { stateVisual } from "../../lib/colors";
+import { shortHex } from "../../lib/format";
+import { AnomalyBadge } from "../AnomalyBadge";
+import { NdClassBadge } from "../NdClassBadge";
+import { StatePill } from "../StatePill";
+import type { MoteFlowNode } from "./flow";
+
+/**
+ * One Mote as a DAG node: id + state pill + nd_class badge (+ anomaly). Reuses
+ * the table's visual vocabulary (`StatePill`/`NdClassBadge`/`stateVisual`) so the
+ * two surfaces never diverge. A newly-mounted node (a dynamic shaper child) plays
+ * the one-shot enter pulse; persistent nodes keep their instance (no re-pulse).
+ */
+function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
+  const { mote } = data;
+  const { tone } = stateVisual(mote.stateCode);
+  return (
+    <motion.div
+      className={`dag-node dag-node--${tone}`}
+      data-testid="mote-node"
+      data-mote={mote.moteId}
+      data-state={mote.stateCode}
+      initial={statePulse.initial}
+      animate={statePulse.animate}
+      transition={statePulse.transition}
+      aria-label={`Mote ${shortHex(mote.moteId)}`}
+    >
+      <Handle type="target" position={Position.Top} className="dag-handle" />
+      <div className="dag-node__id mono" title={mote.moteId}>
+        {shortHex(mote.moteId)}
+      </div>
+      <div className="dag-node__row">
+        <StatePill stateCode={mote.stateCode} />
+        <NdClassBadge ndClass={mote.ndClass} />
+      </div>
+      <AnomalyBadge anomaly={mote.anomaly} />
+      <Handle type="source" position={Position.Bottom} className="dag-handle" />
+    </motion.div>
+  );
+}
+
+export const MoteNode = memo(MoteNodeImpl);

--- a/ui/src/components/dag/dag-graph.ts
+++ b/ui/src/components/dag/dag-graph.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure projection → DAG-graph transform (no React, no reactflow). The single
+ * source of the live graph's structure; kept isolated so every topology can be
+ * exhaustively unit-tested without rendering. Mirrors the Rust core's
+ * pure/total/testable discipline.
+ */
+
+import type { MoteVM, ParentEdgeVM } from "../../kx/use-projection";
+
+/** A directed edge in the projection DAG (parent → child). */
+export interface GraphEdge {
+  readonly id: string;
+  readonly source: string; // parent mote id (hex)
+  readonly target: string; // child mote id (hex)
+  readonly edgeKind: ParentEdgeVM["edgeKind"];
+  readonly nonCascade: boolean;
+}
+
+/**
+ * Build the DAG edges from each Mote's `parents[]`. An edge whose parent is NOT
+ * present at the current frontier is DROPPED — a child can surface a poll before
+ * its parent; never render a dangling edge, it materializes on the next poll.
+ */
+export function buildEdges(motes: readonly MoteVM[]): GraphEdge[] {
+  const present = new Set(motes.map((m) => m.moteId));
+  const edges: GraphEdge[] = [];
+  for (const m of motes) {
+    for (const p of m.parents) {
+      if (!present.has(p.parentId)) {
+        continue; // drop dangling — parent not at this frontier yet
+      }
+      edges.push({
+        id: `${p.parentId}->${m.moteId}`,
+        source: p.parentId,
+        target: m.moteId,
+        edgeKind: p.edgeKind,
+        nonCascade: p.nonCascade,
+      });
+    }
+  }
+  return edges;
+}
+
+/**
+ * A stable hash of the DAG *topology* — the sorted node-id set + sorted edge set.
+ * Deliberately EXCLUDES mote state/anomaly so a poll that only flips a state
+ * yields an identical hash (→ no dagre relayout; cached positions are reused).
+ * This is the load-bearing no-thrash invariant.
+ */
+export function topologyHash(motes: readonly MoteVM[]): string {
+  const ids = motes.map((m) => m.moteId).sort();
+  const edges = buildEdges(motes)
+    .map((e) => `${e.source}>${e.target}:${e.edgeKind}${e.nonCascade ? "!" : ""}`)
+    .sort();
+  return `${ids.join(",")}|${edges.join(",")}`;
+}

--- a/ui/src/components/dag/edges.ts
+++ b/ui/src/components/dag/edges.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure DAG-edge → reactflow-edge visual mapping (no React). DATA edges are solid;
+ * CONTROL edges are dashed; a non-cascade CONTROL edge is dimmed (it does not
+ * propagate failure to its child). Isolated so the styling is unit-testable.
+ */
+
+import { MarkerType } from "@xyflow/react";
+import type { Edge } from "@xyflow/react";
+import type { GraphEdge } from "./dag-graph";
+
+/** Map one DAG edge to its styled reactflow edge. */
+export function toRfEdge(e: GraphEdge): Edge {
+  const isControl = e.edgeKind === "control";
+  return {
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    className: `dag-edge dag-edge--${e.edgeKind}${e.nonCascade ? " dag-edge--noncascade" : ""}`,
+    markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14 },
+    style: {
+      strokeDasharray: isControl ? "5 4" : undefined,
+      opacity: e.nonCascade ? 0.4 : 0.85,
+    },
+    data: { edgeKind: e.edgeKind, nonCascade: e.nonCascade },
+  };
+}

--- a/ui/src/components/dag/flow.ts
+++ b/ui/src/components/dag/flow.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure adapters that assemble reactflow `nodes`/`edges` from the projection +
+ * the memoized layout (no React). Keeping this out of `MoteDag.tsx` lets the
+ * node/edge construction be unit-tested directly and keeps the component thin.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+import type { MoteVM } from "../../kx/use-projection";
+import { buildEdges } from "./dag-graph";
+import { toRfEdge } from "./edges";
+import type { XY } from "./layout";
+
+/** The data a `MoteNode` renders. The index signature satisfies reactflow's `Node<T>`. */
+export interface MoteNodeData {
+  readonly mote: MoteVM;
+  readonly [key: string]: unknown;
+}
+
+export type MoteFlowNode = Node<MoteNodeData, "mote">;
+
+/** Positioned reactflow nodes (positions come from the memoized dagre layout). */
+export function buildFlowNodes(
+  motes: readonly MoteVM[],
+  positions: ReadonlyMap<string, XY>,
+): MoteFlowNode[] {
+  return motes.map((m) => ({
+    id: m.moteId,
+    type: "mote",
+    position: positions.get(m.moteId) ?? { x: 0, y: 0 },
+    data: { mote: m },
+    draggable: false,
+  }));
+}
+
+/** Styled reactflow edges from the Motes' parent links (dangling dropped). */
+export function buildFlowEdges(motes: readonly MoteVM[]): Edge[] {
+  return buildEdges(motes).map(toRfEdge);
+}

--- a/ui/src/components/dag/layout.ts
+++ b/ui/src/components/dag/layout.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure dagre directed-graph layout (no React). Isolated so it can be tested in
+ * isolation and memoized by the caller on a topology hash (state-only polls must
+ * never relayout).
+ */
+
+import dagre from "@dagrejs/dagre";
+import type { GraphEdge } from "./dag-graph";
+
+export interface XY {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** Fixed node box used for layout (matches the `.dag-node` CSS footprint). */
+export const NODE_W = 184;
+export const NODE_H = 72;
+
+/**
+ * Lay the graph out top-to-bottom and return each node's TOP-LEFT position
+ * (reactflow's coordinate origin; dagre reports centers). Tolerant of cycles
+ * (dagre breaks back-edges via a greedy feedback-arc set) and of empty graphs.
+ */
+export function layoutGraph(
+  nodeIds: readonly string[],
+  edges: readonly GraphEdge[],
+): Map<string, XY> {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: "TB", nodesep: 44, ranksep: 64, marginx: 16, marginy: 16 });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const id of nodeIds) {
+    g.setNode(id, { width: NODE_W, height: NODE_H });
+  }
+  for (const e of edges) {
+    // Defensive: buildEdges already drops dangling, but never edge to a missing node.
+    if (g.hasNode(e.source) && g.hasNode(e.target)) {
+      g.setEdge(e.source, e.target);
+    }
+  }
+
+  dagre.layout(g);
+
+  const positions = new Map<string, XY>();
+  for (const id of nodeIds) {
+    const n = g.node(id);
+    positions.set(id, {
+      x: (n?.x ?? 0) - NODE_W / 2,
+      y: (n?.y ?? 0) - NODE_H / 2,
+    });
+  }
+  return positions;
+}

--- a/ui/src/kx/use-invoke.ts
+++ b/ui/src/kx/use-invoke.ts
@@ -1,8 +1,9 @@
 /**
  * Start a run by invoking a published recipe handle with JSON args. Returns the
- * run's hex instance id (no wait) so the caller can route to the live run-detail
- * view and watch it execute. The built-in `kx/recipes/echo` recipe makes this work
- * against a plain `kx serve` with no extra wiring.
+ * run's hex instance id + terminal (sink) Mote id (no wait) so the caller can route
+ * to the live run-detail view, watch it execute, and stop polling authoritatively
+ * when the terminal Mote commits. The built-in `kx/recipes/echo` recipe makes this
+ * work against a plain `kx serve` with no extra wiring.
  */
 
 import type { Run } from "@kortecx/sdk/web";
@@ -14,15 +15,21 @@ export interface InvokeVars {
   args: Record<string, unknown>;
 }
 
+/** The server-derived handles for a started run (both hex; the client never derives an id). */
+export interface StartedRun {
+  instanceId: string;
+  terminalMoteId: string;
+}
+
 export function useInvoke() {
   const { client } = useConnection();
-  return useMutation<string, unknown, InvokeVars>({
+  return useMutation<StartedRun, unknown, InvokeVars>({
     mutationFn: async ({ handle, args }) => {
       if (!client) {
         throw new Error("not connected");
       }
       const run = (await client.invoke(handle, args)) as Run;
-      return run.instanceId; // hex (16B)
+      return { instanceId: run.instanceId, terminalMoteId: run.terminalMoteId };
     },
   });
 }

--- a/ui/src/kx/use-projection.ts
+++ b/ui/src/kx/use-projection.ts
@@ -12,11 +12,19 @@
 
 import type { Projection } from "@kortecx/sdk/web";
 import { useQuery } from "@tanstack/react-query";
+import { useRef } from "react";
 import { isTerminalState } from "../lib/colors";
 import { useConnection } from "./connection-context";
 import { queryKeys } from "./query-keys";
 
 const POLL_MS = 1000;
+
+/** One inbound DAG edge (server-derived hex parent id + edge meta). */
+export interface ParentEdgeVM {
+  readonly parentId: string;
+  readonly edgeKind: "data" | "control" | "unknown";
+  readonly nonCascade: boolean;
+}
 
 /** A plain, serializable Mote view-model (no class methods → clean structural sharing). */
 export interface MoteVM {
@@ -27,6 +35,8 @@ export interface MoteVM {
   readonly resultRef: string | null;
   readonly committedSeq: number | null;
   readonly anomaly: number | null;
+  /** Inbound DAG edges — the source of the live graph's links (empty for a root). */
+  readonly parents: readonly ParentEdgeVM[];
 }
 
 export interface ProjectionVM {
@@ -50,6 +60,11 @@ export function toProjectionVM(p: Projection): ProjectionVM {
       resultRef: m.resultRef,
       committedSeq: m.committedSeq,
       anomaly: m.anomaly,
+      parents: m.parents.map((e) => ({
+        parentId: e.parentId,
+        edgeKind: e.edgeKind,
+        nonCascade: e.nonCascade,
+      })),
     })),
   };
 }
@@ -59,13 +74,50 @@ export function allTerminal(p: ProjectionVM): boolean {
   return p.motes.length > 0 && p.motes.every((m) => isTerminalState(m.stateCode));
 }
 
+/**
+ * Whether the run has settled — the cosmetic "live / at rest" signal. When the
+ * recipe's terminal (sink) Mote id is known, it reaching a terminal state is
+ * authoritative; otherwise fall back to "all visible Motes terminal".
+ */
+export function runSettled(p: ProjectionVM, terminalMoteId?: string): boolean {
+  if (terminalMoteId) {
+    return p.motes.some((m) => m.moteId === terminalMoteId && isTerminalState(m.stateCode));
+  }
+  return allTerminal(p);
+}
+
+/**
+ * Whether polling can stop. The terminal (sink) Mote committing is authoritative —
+ * it commits only AFTER the whole DAG does, so this is correct even while children
+ * are still registering (incremental materialization / dynamic shaper children),
+ * which a naive "all currently-visible Motes terminal" check gets wrong (it can
+ * fire when only the root is present). Without a terminal id (a direct-URL nav),
+ * fall back to a frontier-stability heuristic: every visible Mote terminal AND the
+ * journal frontier (`current_seq`) did not advance this poll.
+ */
+export function isRunAtRest(
+  data: ProjectionVM,
+  terminalMoteId: string | undefined,
+  prevSeq: number,
+): boolean {
+  if (terminalMoteId) {
+    return runSettled(data, terminalMoteId);
+  }
+  return allTerminal(data) && data.currentSeq === prevSeq;
+}
+
 export interface UseProjectionOptions {
   atSeq?: number;
+  /** The recipe's terminal (sink) Mote id — the authoritative run-complete signal. */
+  terminalMoteId?: string;
 }
 
 export function useProjection(instanceId: string | undefined, opts: UseProjectionOptions = {}) {
   const { client, endpoint, status } = useConnection();
   const atSeq = opts.atSeq;
+  const terminalMoteId = opts.terminalMoteId;
+  // Tracks the journal frontier across polls for the fallback stop heuristic.
+  const frontier = useRef<{ key: string; lastSeq: number }>({ key: "", lastSeq: -1 });
   return useQuery({
     queryKey: queryKeys.projection(endpoint, instanceId ?? "", atSeq),
     enabled: status === "connected" && client !== null && Boolean(instanceId),
@@ -87,7 +139,15 @@ export function useProjection(instanceId: string | undefined, opts: UseProjectio
       if (!data) {
         return POLL_MS; // still loading
       }
-      return allTerminal(data) ? false : POLL_MS; // stop once the run is at rest
+      const key = `${endpoint}|${instanceId ?? ""}`;
+      const f = frontier.current;
+      if (f.key !== key) {
+        f.key = key; // a different run — reset frontier tracking
+        f.lastSeq = -1;
+      }
+      const prevSeq = f.lastSeq;
+      f.lastSeq = data.currentSeq;
+      return isRunAtRest(data, terminalMoteId, prevSeq) ? false : POLL_MS;
     },
     refetchIntervalInBackground: false,
   });

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AppProviders } from "./app/providers";
 import { router } from "./router/router";
+import "@xyflow/react/dist/style.css";
 import "./styles/app.css";
 
 const rootEl = document.getElementById("root");

--- a/ui/src/router/routes/run-detail.tsx
+++ b/ui/src/router/routes/run-detail.tsx
@@ -1,4 +1,5 @@
 import { createRoute, useParams, useSearch } from "@tanstack/react-router";
+import { Suspense, lazy, useState } from "react";
 import { ConnectGate } from "../../components/ConnectGate";
 import { EmptyState } from "../../components/EmptyState";
 import { ErrorNotice } from "../../components/ErrorNotice";
@@ -6,14 +7,55 @@ import { MoteTable } from "../../components/MoteTable";
 import { ProjectionSummary } from "../../components/ProjectionSummary";
 import { useConnection } from "../../kx/connection-context";
 import { toUiError } from "../../kx/errors";
-import { allTerminal, useProjection } from "../../kx/use-projection";
+import { type ProjectionVM, runSettled, useProjection } from "../../kx/use-projection";
 import { shortHex } from "../../lib/format";
 import { rootRoute } from "./__root";
+
+// Code-split: reactflow + dagre (~250 kB gzip) load only when a run's graph is
+// actually viewed — the connect/runs screens stay lightweight.
+const MoteDag = lazy(() =>
+  import("../../components/dag/MoteDag").then((m) => ({ default: m.MoteDag })),
+);
 
 const ROUTE_ID = "/runs/$instanceId";
 
 interface RunSearch {
   atSeq?: number;
+  /** The recipe's terminal (sink) Mote id (hex) — the authoritative poll-stop signal. */
+  terminal?: string;
+}
+
+type RunView = "dag" | "table";
+
+/** The Motes as a live DAG (default) or a status table — both read the same VM. */
+function RunBody({
+  projection,
+  view,
+  onView,
+}: {
+  projection: ProjectionVM;
+  view: RunView;
+  onView: (v: RunView) => void;
+}) {
+  return (
+    <>
+      <fieldset className="view-toggle" aria-label="Run view">
+        <button type="button" aria-pressed={view === "dag"} onClick={() => onView("dag")}>
+          Graph
+        </button>
+        <button type="button" aria-pressed={view === "table"} onClick={() => onView("table")}>
+          Table
+        </button>
+      </fieldset>
+      {view === "dag" ? (
+        <Suspense fallback={<EmptyState title="Loading graph…" />}>
+          <MoteDag projection={projection} />
+        </Suspense>
+      ) : (
+        <MoteTable projection={projection} />
+      )}
+    </>
+  );
 }
 
 function RunDetailScreen() {
@@ -26,10 +68,14 @@ function RunDetailScreen() {
 
 function RunDetailContent() {
   const { instanceId } = useParams({ from: ROUTE_ID });
-  const { atSeq } = useSearch({ from: ROUTE_ID });
-  const projection = useProjection(instanceId, atSeq != null ? { atSeq } : {});
+  const { atSeq, terminal } = useSearch({ from: ROUTE_ID });
+  const projection = useProjection(instanceId, {
+    ...(atSeq != null ? { atSeq } : {}),
+    ...(terminal ? { terminalMoteId: terminal } : {}),
+  });
   const data = projection.data;
-  const polling = atSeq == null && data != null && !allTerminal(data);
+  const polling = atSeq == null && data != null && !runSettled(data, terminal);
+  const [view, setView] = useState<RunView>("dag");
 
   return (
     <section className="screen">
@@ -62,7 +108,7 @@ function RunDetailContent() {
       {data ? (
         <>
           <ProjectionSummary projection={data} polling={polling} />
-          <MoteTable projection={data} />
+          <RunBody projection={data} view={view} onView={setView} />
         </>
       ) : null}
     </section>
@@ -73,9 +119,17 @@ export const runDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: ROUTE_ID,
   validateSearch: (search: Record<string, unknown>): RunSearch => {
+    const out: RunSearch = {};
     const raw = search.atSeq;
     const n = typeof raw === "string" ? Number(raw) : typeof raw === "number" ? raw : Number.NaN;
-    return Number.isFinite(n) && n >= 0 ? { atSeq: Math.floor(n) } : {};
+    if (Number.isFinite(n) && n >= 0) {
+      out.atSeq = Math.floor(n);
+    }
+    // The terminal Mote id is a 32-byte (64 hex char) server-derived id.
+    if (typeof search.terminal === "string" && /^[0-9a-f]{64}$/.test(search.terminal)) {
+      out.terminal = search.terminal;
+    }
+    return out;
   },
   component: RunDetailScreen,
 });

--- a/ui/src/router/routes/runs.tsx
+++ b/ui/src/router/routes/runs.tsx
@@ -45,7 +45,14 @@ function RunsContent() {
     setArgsError(null);
     invoke.mutate(
       { handle: handle.trim(), args },
-      { onSuccess: (instanceId) => navigate({ to: "/runs/$instanceId", params: { instanceId } }) },
+      {
+        onSuccess: ({ instanceId, terminalMoteId }) =>
+          navigate({
+            to: "/runs/$instanceId",
+            params: { instanceId },
+            search: { terminal: terminalMoteId },
+          }),
+      },
     );
   }
 

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -291,6 +291,92 @@ button:disabled {
   text-align: right;
 }
 
+/* ---- view toggle (DAG / table) ---- */
+.view-toggle {
+  display: inline-flex;
+  gap: 0;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  min-inline-size: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.view-toggle button {
+  background: var(--bg-input);
+  color: var(--fg-muted);
+  border: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0.3rem 0.7rem;
+  font-weight: 500;
+}
+.view-toggle button[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+/* ---- live DAG ---- */
+.dag-canvas {
+  height: 520px;
+  margin-top: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+  overflow: hidden;
+}
+.dag-node {
+  width: 184px;
+  min-height: 72px;
+  padding: 0.5rem 0.6rem;
+  border-radius: 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--t-unknown);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.dag-node--pending {
+  border-left-color: var(--t-pending);
+}
+.dag-node--scheduled {
+  border-left-color: var(--t-scheduled);
+}
+.dag-node--committed {
+  border-left-color: var(--t-committed);
+}
+.dag-node--failed {
+  border-left-color: var(--t-failed);
+}
+.dag-node--repudiated {
+  border-left-color: var(--t-repudiated);
+}
+.dag-node--inconsistent {
+  border-left-color: var(--t-inconsistent);
+}
+.dag-node__id {
+  color: var(--fg-muted);
+}
+.dag-node__row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.dag-handle {
+  width: 6px;
+  height: 6px;
+  background: var(--fg-muted);
+  border: none;
+}
+.dag-edge--control {
+  stroke: var(--fg-muted);
+}
+.dag-edge--noncascade {
+  stroke-dasharray: 5 4;
+}
+
 /* ---- projection summary ---- */
 .proj-summary {
   display: flex;

--- a/ui/test/component/dag/MoteDag.test.tsx
+++ b/ui/test/component/dag/MoteDag.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * MoteDag wiring + branching. The real reactflow canvas is covered by the browser
+ * E2E (jsdom can't measure a viewport); here we stub `@xyflow/react` with a probe
+ * that records the nodes/edges it receives, so MoteDag's logic is asserted
+ * deterministically: counts, empty state, the >MAX table fallback, and the
+ * no-relayout-on-state-only-poll invariant.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlow: ({ nodes, edges }: { nodes: unknown[]; edges: unknown[] }) => (
+    <div data-testid="rf" data-nodes={nodes.length} data-edges={edges.length} />
+  ),
+  ReactFlowProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Background: () => null,
+  Controls: () => null,
+  useReactFlow: () => ({ fitView: () => {} }),
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom" },
+  MarkerType: { ArrowClosed: "arrowclosed" },
+}));
+
+import { MAX_DAG_NODES, MoteDag } from "../../../src/components/dag/MoteDag";
+import * as layout from "../../../src/components/dag/layout";
+import { toProjectionVM } from "../../../src/kx/use-projection";
+import {
+  diamondProjection,
+  growsBetweenPolls,
+  largeProjection,
+  projection,
+} from "../../mocks/projection-fixtures";
+
+const vm = (p: ReturnType<typeof projection>) => toProjectionVM(p);
+
+describe("MoteDag", () => {
+  it("renders the canvas with one node per Mote + one edge per parent (diamond)", () => {
+    render(<MoteDag projection={vm(diamondProjection())} />);
+    expect(screen.getByTestId("mote-dag")).toHaveAttribute("role", "img");
+    const rf = screen.getByTestId("rf");
+    expect(rf).toHaveAttribute("data-nodes", "4");
+    expect(rf).toHaveAttribute("data-edges", "4");
+  });
+
+  it("empty projection → empty state, no canvas", () => {
+    render(<MoteDag projection={vm(projection([]))} />);
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("mote-dag")).not.toBeInTheDocument();
+  });
+
+  it("renders the DAG at the node-count boundary (MAX)", () => {
+    render(<MoteDag projection={vm(largeProjection(MAX_DAG_NODES))} />);
+    expect(screen.getByTestId("mote-dag")).toBeInTheDocument();
+    expect(screen.getByTestId("rf")).toHaveAttribute("data-nodes", String(MAX_DAG_NODES));
+  });
+
+  it("falls back to the table beyond MAX nodes", () => {
+    render(<MoteDag projection={vm(largeProjection(MAX_DAG_NODES + 1))} />);
+    expect(screen.getByTestId("dag-fallback")).toBeInTheDocument();
+    expect(screen.getByTestId("mote-table")).toBeInTheDocument();
+    expect(screen.queryByTestId("mote-dag")).not.toBeInTheDocument();
+  });
+
+  it("does NOT relayout on a state-only poll (no dagre thrash)", () => {
+    const spy = vi.spyOn(layout, "layoutGraph");
+    const [, grown, stateOnly] = growsBetweenPolls();
+    const { rerender } = render(<MoteDag projection={vm(grown)} />);
+    const afterFirst = spy.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+    rerender(<MoteDag projection={vm(stateOnly)} />); // children flip COMMITTED — same topology
+    expect(spy.mock.calls.length).toBe(afterFirst);
+    spy.mockRestore();
+  });
+
+  it("relayouts when the topology grows (a dynamic child appears)", () => {
+    const spy = vi.spyOn(layout, "layoutGraph");
+    const [rootOnly, grown] = growsBetweenPolls();
+    const { rerender } = render(<MoteDag projection={vm(rootOnly)} />);
+    const afterFirst = spy.mock.calls.length;
+    rerender(<MoteDag projection={vm(grown)} />); // two children appear
+    expect(spy.mock.calls.length).toBeGreaterThan(afterFirst);
+    spy.mockRestore();
+  });
+});

--- a/ui/test/component/use-invoke.test.tsx
+++ b/ui/test/component/use-invoke.test.tsx
@@ -6,19 +6,20 @@ import { connectedWrapper } from "../mocks/harness";
 import { makeMockClient } from "../mocks/kx-client";
 
 const INSTANCE = "ab".repeat(16);
+const TERMINAL = "cd".repeat(32);
 
 describe("useInvoke", () => {
-  it("invokes a recipe and returns the hex instance id", async () => {
+  it("invokes a recipe and returns the run's instance + terminal Mote ids", async () => {
     const { client, invoke } = makeMockClient({
-      // Mirrors the SDK's `Run` (instanceId is a hex getter).
-      invoke: async () => ({ instanceId: INSTANCE }),
+      // Mirrors the SDK's `Run` (instanceId/terminalMoteId are hex getters).
+      invoke: async () => ({ instanceId: INSTANCE, terminalMoteId: TERMINAL }),
     });
     const { result } = renderHook(() => useInvoke(), { wrapper: connectedWrapper(client) });
-    let id = "";
+    let run = { instanceId: "", terminalMoteId: "" };
     await act(async () => {
-      id = await result.current.mutateAsync({ handle: "kx/recipes/echo", args: { topic: "x" } });
+      run = await result.current.mutateAsync({ handle: "kx/recipes/echo", args: { topic: "x" } });
     });
-    expect(id).toBe(INSTANCE);
+    expect(run).toEqual({ instanceId: INSTANCE, terminalMoteId: TERMINAL });
     expect(invoke).toHaveBeenCalledWith("kx/recipes/echo", { topic: "x" });
   });
 

--- a/ui/test/component/use-projection.test.tsx
+++ b/ui/test/component/use-projection.test.tsx
@@ -1,11 +1,18 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { allTerminal, toProjectionVM, useProjection } from "../../src/kx/use-projection";
+import {
+  allTerminal,
+  isRunAtRest,
+  runSettled,
+  toProjectionVM,
+  useProjection,
+} from "../../src/kx/use-projection";
 import { connectedWrapper } from "../mocks/harness";
 import { makeMockClient } from "../mocks/kx-client";
 import { mote, projection } from "../mocks/projection-fixtures";
 
 const INSTANCE = "ab".repeat(16);
+const TERMINAL = "ee".repeat(32);
 
 describe("toProjectionVM", () => {
   it("maps every field the views need", () => {
@@ -27,6 +34,26 @@ describe("toProjectionVM", () => {
       anomaly: 1,
     });
   });
+
+  it("maps parent edges (the DAG links) and defaults to [] for a root", () => {
+    const vm = toProjectionVM(
+      projection([
+        mote({ moteId: "00".repeat(32) }),
+        mote({
+          moteId: "01".repeat(32),
+          parents: [
+            { parentId: "00".repeat(32), edgeKind: "data" },
+            { parentId: "00".repeat(32), edgeKind: "control", nonCascade: true },
+          ],
+        }),
+      ]),
+    );
+    expect(vm.motes[0]?.parents).toEqual([]); // a root
+    expect(vm.motes[1]?.parents).toEqual([
+      { parentId: "00".repeat(32), edgeKind: "data", nonCascade: false },
+      { parentId: "00".repeat(32), edgeKind: "control", nonCascade: true },
+    ]);
+  });
 });
 
 describe("allTerminal", () => {
@@ -40,6 +67,50 @@ describe("allTerminal", () => {
   it("true once every Mote is terminal", () => {
     const vm = toProjectionVM(projection([mote({ stateCode: 3 }), mote({ stateCode: 4 })]));
     expect(allTerminal(vm)).toBe(true);
+  });
+});
+
+describe("isRunAtRest (the poll-stop signal)", () => {
+  it("with a terminal id: stays live until the terminal Mote commits (even while children register)", () => {
+    // Only the root is visible + committed and the frontier is stable — but the
+    // terminal (sink) Mote has not appeared yet → keep polling (the bug a naive
+    // all-terminal check hits: it would stop here at one node).
+    const early = toProjectionVM(
+      projection([mote({ moteId: "aa".repeat(32), stateCode: 3 })], { currentSeq: 3 }),
+    );
+    expect(isRunAtRest(early, TERMINAL, 3)).toBe(false);
+
+    // Terminal Mote present + COMMITTED → at rest.
+    const done = toProjectionVM(
+      projection(
+        [mote({ moteId: "aa".repeat(32), stateCode: 3 }), mote({ moteId: TERMINAL, stateCode: 3 })],
+        { currentSeq: 11 },
+      ),
+    );
+    expect(isRunAtRest(done, TERMINAL, 11)).toBe(true);
+
+    // Terminal Mote present but still SCHEDULED → keep polling.
+    const running = toProjectionVM(projection([mote({ moteId: TERMINAL, stateCode: 2 })]));
+    expect(isRunAtRest(running, TERMINAL, 9)).toBe(false);
+  });
+
+  it("without a terminal id: frontier-stability fallback (all terminal + seq unchanged)", () => {
+    const vm = toProjectionVM(projection([mote({ stateCode: 3 })], { currentSeq: 7 }));
+    expect(isRunAtRest(vm, undefined, 7)).toBe(true); // settled
+    expect(isRunAtRest(vm, undefined, 6)).toBe(false); // frontier advanced this poll → keep polling
+    const inFlight = toProjectionVM(projection([mote({ stateCode: 2 })], { currentSeq: 7 }));
+    expect(isRunAtRest(inFlight, undefined, 7)).toBe(false); // a Mote still in flight
+  });
+
+  it("runSettled prefers the terminal-Mote signal over all-terminal", () => {
+    const vm = toProjectionVM(
+      projection([
+        mote({ moteId: "aa".repeat(32), stateCode: 3 }),
+        mote({ moteId: TERMINAL, stateCode: 2 }), // the gather is still scheduled
+      ]),
+    );
+    expect(allTerminal(vm)).toBe(false);
+    expect(runSettled(vm, TERMINAL)).toBe(false);
   });
 });
 

--- a/ui/test/contract/projection.e2e.test.ts
+++ b/ui/test/contract/projection.e2e.test.ts
@@ -13,7 +13,14 @@ import type { Result } from "@kortecx/sdk/node";
 import { afterAll, describe, expect, it } from "vitest";
 import { toUiError } from "../../src/kx/errors";
 import { toProjectionVM } from "../../src/kx/use-projection";
-import { ECHO_HANDLE, authServer, devServer, findOrBuildKx, stopAllServers } from "./serve";
+import {
+  ECHO_HANDLE,
+  FANOUT_HANDLE,
+  authServer,
+  devServer,
+  findOrBuildKx,
+  stopAllServers,
+} from "./serve";
 
 function cli(endpoint: string, ...argv: string[]): Record<string, unknown> {
   const out = execFileSync(findOrBuildKx(), [...argv, "--json", "--endpoint", endpoint], {
@@ -46,6 +53,46 @@ describe("UI data path against a real kx serve", () => {
     expect(terminal?.stateCode).toBe(3); // COMMITTED
     expect(terminal?.resultRef).toBeTruthy();
     expect(typeof terminal?.ndClass).toBe("number");
+  });
+
+  it("echo terminal Mote exposes an empty parents[] (the DAG-edge wire is live end-to-end)", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    const result = (await kx.invoke(ECHO_HANDLE, { topic: "edges" }, { wait: true })) as Result;
+    const proj = await kx.getProjection(result.instanceId);
+    kx.close();
+    const terminal = toProjectionVM(proj).motes.find((m) => m.moteId === result.terminalMoteId);
+    // The SDK→VM `parents` field is present and, for a single-node recipe, empty.
+    expect(Array.isArray(terminal?.parents)).toBe(true);
+    expect(terminal?.parents).toEqual([]);
+  });
+
+  it("fanout-demo → a multi-node projection whose parents[] form a real DAG", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    const result = (await kx.invoke(FANOUT_HANDLE, {}, { wait: true })) as Result;
+    expect(result.ok).toBe(true);
+    const proj = await kx.getProjection(result.instanceId);
+    kx.close();
+
+    const vm = toProjectionVM(proj);
+    // root + 3 children + gather, all driven to COMMITTED model-free.
+    expect(vm.motes).toHaveLength(5);
+    expect(vm.motes.every((m) => m.stateCode === 3)).toBe(true);
+
+    const ids = new Set(vm.motes.map((m) => m.moteId));
+    const edges = vm.motes.flatMap((m) => m.parents.map((p) => ({ child: m.moteId, ...p })));
+    // Referential integrity: every parent id resolves to a node in the projection.
+    expect(edges.every((e) => ids.has(e.parentId))).toBe(true);
+    // 3 fan-out edges (root→child) + 3 fan-in edges (child→gather) = 6 DATA edges.
+    expect(edges).toHaveLength(6);
+    expect(edges.every((e) => e.edgeKind === "data")).toBe(true);
+
+    // Exactly one root (no parents) and the terminal gather joins all three children.
+    const roots = vm.motes.filter((m) => m.parents.length === 0);
+    expect(roots).toHaveLength(1);
+    const gather = vm.motes.find((m) => m.moteId === result.terminalMoteId);
+    expect(gather?.parents).toHaveLength(3);
   });
 
   it("byte-parity: the SDK projection equals the CLI projection (the UI reads the same truth)", async () => {

--- a/ui/test/contract/serve.ts
+++ b/ui/test/contract/serve.ts
@@ -19,6 +19,8 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 // ui/test/contract → up 3 = repo root.
 export const REPO_ROOT = path.resolve(HERE, "../../..");
 export const ECHO_HANDLE = "kx/recipes/echo";
+/** The T3.3 deterministic multi-node demo recipe (root → 3 children → gather). */
+export const FANOUT_HANDLE = "kx/recipes/fanout-demo";
 
 let cachedBin: string | null = null;
 

--- a/ui/test/mocks/projection-fixtures.ts
+++ b/ui/test/mocks/projection-fixtures.ts
@@ -1,8 +1,19 @@
 /** Builders for `Projection` / `MoteView` (the real SDK classes) used by tests. */
 
-import { MoteView, Projection } from "@kortecx/sdk/web";
+import { MoteView, ParentEdge, Projection } from "@kortecx/sdk/web";
 
 let counter = 0;
+
+/** A deterministic 32-byte hex id from a small integer (stable across a test run). */
+export function nid(n: number): string {
+  return n.toString(16).padStart(64, "0");
+}
+
+export interface ParentOpt {
+  parentId: string;
+  edgeKind?: "data" | "control" | "unknown";
+  nonCascade?: boolean;
+}
 
 export interface MoteOpts {
   moteId?: string;
@@ -13,10 +24,14 @@ export interface MoteOpts {
   moteDefHash?: string;
   committedSeq?: number | null;
   anomaly?: number | null;
+  parents?: ParentOpt[];
 }
 
 export function mote(opts: MoteOpts = {}): MoteView {
-  const id = opts.moteId ?? (counter++).toString(16).padStart(64, "0");
+  const id = opts.moteId ?? nid(counter++);
+  const parents = (opts.parents ?? []).map(
+    (p) => new ParentEdge(p.parentId, p.edgeKind ?? "data", p.nonCascade ?? false),
+  );
   return new MoteView(
     id,
     "STATE", // display name — unused by the VM (it reads stateCode)
@@ -27,6 +42,7 @@ export function mote(opts: MoteOpts = {}): MoteView {
     opts.moteDefHash ?? "cd".repeat(32),
     opts.committedSeq ?? null,
     opts.anomaly ?? null,
+    parents,
   );
 }
 
@@ -53,7 +69,97 @@ export function allStatesProjection(): Projection {
 /** A large projection for the render perf budget. */
 export function largeProjection(n: number): Projection {
   const motes = Array.from({ length: n }, (_, i) =>
-    mote({ moteId: i.toString(16).padStart(64, "0"), stateCode: (i % 6) + 1 }),
+    mote({ moteId: nid(i), stateCode: (i % 6) + 1 }),
   );
   return projection(motes, { currentSeq: n });
+}
+
+// ---- Multi-node DAG topologies (T3.3) ---------------------------------------
+
+/** A linear chain a → b → c → … of `n` Motes (deep-chain layout). */
+export function chainProjection(n: number): Projection {
+  const motes = Array.from({ length: n }, (_, i) =>
+    mote({ moteId: nid(i), parents: i === 0 ? [] : [{ parentId: nid(i - 1) }] }),
+  );
+  return projection(motes);
+}
+
+/** A diamond a → {b, c} → d (the classic relayout / fan-out-then-join shape). */
+export function diamondProjection(): Projection {
+  const a = mote({ moteId: nid(0) });
+  const b = mote({ moteId: nid(1), parents: [{ parentId: nid(0) }] });
+  const c = mote({ moteId: nid(2), parents: [{ parentId: nid(0) }] });
+  const d = mote({ moteId: nid(3), parents: [{ parentId: nid(1) }, { parentId: nid(2) }] });
+  return projection([a, b, c, d]);
+}
+
+/** One root fanning out to `n` leaves. */
+export function fanOutProjection(n: number): Projection {
+  const root = mote({ moteId: nid(0) });
+  const leaves = Array.from({ length: n }, (_, i) =>
+    mote({ moteId: nid(i + 1), parents: [{ parentId: nid(0) }] }),
+  );
+  return projection([root, ...leaves]);
+}
+
+/** `n` roots converging on one gather Mote. */
+export function fanInProjection(n: number): Projection {
+  const roots = Array.from({ length: n }, (_, i) => mote({ moteId: nid(i) }));
+  const gather = mote({
+    moteId: nid(n),
+    parents: roots.map((_, i) => ({ parentId: nid(i) })),
+  });
+  return projection([...roots, gather]);
+}
+
+/** Two independent subgraphs (multi-root layout): a→b and c→d. */
+export function disconnectedProjection(): Projection {
+  return projection([
+    mote({ moteId: nid(0) }),
+    mote({ moteId: nid(1), parents: [{ parentId: nid(0) }] }),
+    mote({ moteId: nid(2) }),
+    mote({ moteId: nid(3), parents: [{ parentId: nid(2) }] }),
+  ]);
+}
+
+/** A child with one DATA, one CONTROL, and one non-cascade CONTROL parent. */
+export function controlEdgeProjection(): Projection {
+  return projection([
+    mote({ moteId: nid(0) }),
+    mote({ moteId: nid(1) }),
+    mote({ moteId: nid(2) }),
+    mote({
+      moteId: nid(3),
+      parents: [
+        { parentId: nid(0), edgeKind: "data" },
+        { parentId: nid(1), edgeKind: "control" },
+        { parentId: nid(2), edgeKind: "control", nonCascade: true },
+      ],
+    }),
+  ]);
+}
+
+/**
+ * A run that GROWS between polls (the PR-2b dynamic-shaper-child beat):
+ *  - frame 0: root SCHEDULED, alone;
+ *  - frame 1: root COMMITTED + two PENDING children appear (topology grows);
+ *  - frame 2: children COMMITTED (state-only change — no new topology).
+ */
+export function growsBetweenPolls(): [Projection, Projection, Projection] {
+  const root = (state: number) => mote({ moteId: nid(0), stateCode: state });
+  const child = (i: number, state: number) =>
+    mote({ moteId: nid(i), stateCode: state, parents: [{ parentId: nid(0) }] });
+  return [
+    projection([root(2)], { currentSeq: 1 }),
+    projection([root(3), child(1, 1), child(2, 1)], { currentSeq: 3 }),
+    projection([root(3), child(1, 3), child(2, 3)], { currentSeq: 5 }),
+  ];
+}
+
+/** A defensive malformed input: a 2-cycle a↔b. The DAG must render (no hang). */
+export function cycleProjection(): Projection {
+  return projection([
+    mote({ moteId: nid(0), parents: [{ parentId: nid(1) }] }),
+    mote({ moteId: nid(1), parents: [{ parentId: nid(0) }] }),
+  ]);
 }

--- a/ui/test/unit/dag-edges.test.ts
+++ b/ui/test/unit/dag-edges.test.ts
@@ -1,0 +1,45 @@
+/** Pure DAG-edge → reactflow-edge visual mapping. */
+
+import { describe, expect, it } from "vitest";
+import { buildEdges } from "../../src/components/dag/dag-graph";
+import { toRfEdge } from "../../src/components/dag/edges";
+import { toProjectionVM } from "../../src/kx/use-projection";
+import { controlEdgeProjection, nid } from "../mocks/projection-fixtures";
+
+describe("toRfEdge", () => {
+  const edges = buildEdges(toProjectionVM(controlEdgeProjection()).motes);
+  const by = (kind: string, nonCascade: boolean) => {
+    const e = edges.find((x) => x.edgeKind === kind && x.nonCascade === nonCascade);
+    if (e === undefined) {
+      throw new Error(`no ${kind}${nonCascade ? " non-cascade" : ""} edge in fixture`);
+    }
+    return toRfEdge(e);
+  };
+
+  it("DATA edge: solid, full opacity, data class", () => {
+    const rf = by("data", false);
+    expect(rf.className).toContain("dag-edge--data");
+    expect(rf.style?.strokeDasharray).toBeUndefined();
+    expect(rf.style?.opacity).toBe(0.85);
+  });
+
+  it("CONTROL edge: dashed, control class", () => {
+    const rf = by("control", false);
+    expect(rf.className).toContain("dag-edge--control");
+    expect(rf.style?.strokeDasharray).toBe("5 4");
+  });
+
+  it("non-cascade CONTROL edge: dimmed + noncascade class", () => {
+    const rf = by("control", true);
+    expect(rf.className).toContain("dag-edge--noncascade");
+    expect(rf.style?.opacity).toBe(0.4);
+  });
+
+  it("preserves id/source/target + carries an arrow marker", () => {
+    const rf = by("data", false);
+    expect(rf.source).toBe(nid(0));
+    expect(rf.target).toBe(nid(3));
+    expect(rf.id).toContain("->");
+    expect(rf.markerEnd).toBeTruthy();
+  });
+});

--- a/ui/test/unit/dag-flow.test.ts
+++ b/ui/test/unit/dag-flow.test.ts
@@ -1,0 +1,36 @@
+/** Pure reactflow adapters: positioned nodes + styled edges from the projection. */
+
+import { describe, expect, it } from "vitest";
+import { buildFlowEdges, buildFlowNodes } from "../../src/components/dag/flow";
+import { toProjectionVM } from "../../src/kx/use-projection";
+import { diamondProjection, nid } from "../mocks/projection-fixtures";
+
+describe("buildFlowNodes", () => {
+  const motes = toProjectionVM(diamondProjection()).motes;
+  const positions = new Map(motes.map((m, i) => [m.moteId, { x: i * 10, y: i * 20 }]));
+  const nodes = buildFlowNodes(motes, positions);
+
+  it("one node per mote, typed + positioned + non-draggable", () => {
+    expect(nodes).toHaveLength(4);
+    expect(nodes[0]?.type).toBe("mote");
+    expect(nodes[0]?.draggable).toBe(false);
+    expect(nodes[1]?.position).toEqual({ x: 10, y: 20 });
+  });
+
+  it("carries the mote VM as node data", () => {
+    expect(nodes[0]?.data.mote.moteId).toBe(nid(0));
+  });
+
+  it("a node with no layout position falls back to the origin", () => {
+    const fallback = buildFlowNodes(motes, new Map());
+    expect(fallback[0]?.position).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("buildFlowEdges", () => {
+  it("delegates to buildEdges + toRfEdge (diamond → 4 styled edges)", () => {
+    const edges = buildFlowEdges(toProjectionVM(diamondProjection()).motes);
+    expect(edges).toHaveLength(4);
+    expect(edges[0]?.className).toContain("dag-edge");
+  });
+});

--- a/ui/test/unit/dag-graph.test.ts
+++ b/ui/test/unit/dag-graph.test.ts
@@ -1,0 +1,86 @@
+/** Pure DAG-graph transform: edges from parents[], dangling-drop, topology hash. */
+
+import { describe, expect, it } from "vitest";
+import { buildEdges, topologyHash } from "../../src/components/dag/dag-graph";
+import { toProjectionVM } from "../../src/kx/use-projection";
+import {
+  chainProjection,
+  controlEdgeProjection,
+  cycleProjection,
+  diamondProjection,
+  disconnectedProjection,
+  fanInProjection,
+  fanOutProjection,
+  growsBetweenPolls,
+  mote,
+  nid,
+  projection,
+} from "../mocks/projection-fixtures";
+
+const motesOf = (p: ReturnType<typeof projection>) => toProjectionVM(p).motes;
+
+describe("buildEdges", () => {
+  it("chain a→b→c yields parent→child edges", () => {
+    const edges = buildEdges(motesOf(chainProjection(3)));
+    expect(edges.map((e) => `${e.source.slice(-1)}>${e.target.slice(-1)}`)).toEqual(["0>1", "1>2"]);
+  });
+
+  it("diamond a→{b,c}→d yields four edges", () => {
+    expect(buildEdges(motesOf(diamondProjection()))).toHaveLength(4);
+  });
+
+  it("fan-out / fan-in edge counts", () => {
+    expect(buildEdges(motesOf(fanOutProjection(5)))).toHaveLength(5);
+    expect(buildEdges(motesOf(fanInProjection(4)))).toHaveLength(4);
+  });
+
+  it("disconnected subgraphs keep their own edges", () => {
+    expect(buildEdges(motesOf(disconnectedProjection()))).toHaveLength(2);
+  });
+
+  it("carries edge kind + non-cascade", () => {
+    const edges = buildEdges(motesOf(controlEdgeProjection()));
+    const byKind = edges.map((e) => `${e.edgeKind}${e.nonCascade ? "!" : ""}`).sort();
+    expect(byKind).toEqual(["control", "control!", "data"]);
+  });
+
+  it("DROPS a dangling edge whose parent is absent at the frontier", () => {
+    const orphan = projection([mote({ moteId: nid(5), parents: [{ parentId: nid(99) }] })]);
+    expect(buildEdges(motesOf(orphan))).toEqual([]);
+  });
+
+  it("keeps both edges of a 2-cycle (defensive — no crash)", () => {
+    expect(buildEdges(motesOf(cycleProjection()))).toHaveLength(2);
+  });
+});
+
+describe("topologyHash", () => {
+  it("is identical for the same topology with different STATE (no-thrash invariant)", () => {
+    const [, grown, stateOnly] = growsBetweenPolls();
+    // `grown` and `stateOnly` share ids+edges; only the children's state differs.
+    expect(topologyHash(motesOf(stateOnly))).toBe(topologyHash(motesOf(grown)));
+  });
+
+  it("CHANGES when the topology grows (a dynamic child appears)", () => {
+    const [rootOnly, grown] = growsBetweenPolls();
+    expect(topologyHash(motesOf(grown))).not.toBe(topologyHash(motesOf(rootOnly)));
+  });
+
+  it("CHANGES when an edge's kind/cascade differs", () => {
+    const dataOnly = projection([
+      mote({ moteId: nid(0) }),
+      mote({ moteId: nid(1), parents: [{ parentId: nid(0), edgeKind: "data" }] }),
+    ]);
+    const control = projection([
+      mote({ moteId: nid(0) }),
+      mote({ moteId: nid(1), parents: [{ parentId: nid(0), edgeKind: "control" }] }),
+    ]);
+    expect(topologyHash(motesOf(dataOnly))).not.toBe(topologyHash(motesOf(control)));
+  });
+
+  it("is order-independent (sorted ids + edges)", () => {
+    const a = projection([mote({ moteId: nid(0) }), mote({ moteId: nid(1) })]);
+    const b = projection([mote({ moteId: nid(1) }), mote({ moteId: nid(0) })]);
+    expect(topologyHash(motesOf(a))).toBe(topologyHash(motesOf(b)));
+  });
+});

--- a/ui/test/unit/dag-layout.test.ts
+++ b/ui/test/unit/dag-layout.test.ts
@@ -1,0 +1,56 @@
+/** Pure dagre layout: positions all nodes, top-down, cycle/empty tolerant. */
+
+import { describe, expect, it } from "vitest";
+import { buildEdges } from "../../src/components/dag/dag-graph";
+import { layoutGraph } from "../../src/components/dag/layout";
+import { toProjectionVM } from "../../src/kx/use-projection";
+import {
+  chainProjection,
+  cycleProjection,
+  diamondProjection,
+  mote,
+  nid,
+  projection,
+} from "../mocks/projection-fixtures";
+
+const layoutOf = (p: ReturnType<typeof projection>) => {
+  const motes = toProjectionVM(p).motes;
+  return layoutGraph(
+    motes.map((m) => m.moteId),
+    buildEdges(motes),
+  );
+};
+
+describe("layoutGraph", () => {
+  it("returns a position for every node", () => {
+    const pos = layoutOf(diamondProjection());
+    expect(pos.size).toBe(4);
+    for (let i = 0; i < 4; i++) {
+      expect(pos.get(nid(i))).toMatchObject({ x: expect.any(Number), y: expect.any(Number) });
+    }
+  });
+
+  it("empty graph → empty positions", () => {
+    expect(layoutGraph([], []).size).toBe(0);
+  });
+
+  it("lays a chain out top-to-bottom (child below parent)", () => {
+    const pos = layoutOf(chainProjection(3));
+    const y = (i: number) => pos.get(nid(i))?.y ?? 0;
+    expect(y(1)).toBeGreaterThan(y(0));
+    expect(y(2)).toBeGreaterThan(y(1));
+  });
+
+  it("a 2-cycle is laid out without hanging (positions both nodes)", () => {
+    const pos = layoutOf(cycleProjection());
+    expect(pos.size).toBe(2);
+    expect(pos.get(nid(0))).toBeDefined();
+    expect(pos.get(nid(1))).toBeDefined();
+  });
+
+  it("a single root has a finite position", () => {
+    const pos = layoutOf(projection([mote({ moteId: nid(0) })]));
+    expect(Number.isFinite(pos.get(nid(0))?.x)).toBe(true);
+    expect(Number.isFinite(pos.get(nid(0))?.y)).toBe(true);
+  });
+});


### PR DESCRIPTION
## T3.3 — live XYFlow DAG viewer (+ deterministic multi-node demo recipe)

The headline agentic beat — **watch the Mote DAG execute**. Run-detail now defaults to a reactflow + dagre canvas: nodes = Motes (colored by state/nd_class, reusing `StatePill`/`NdClassBadge`), edges = `parents[]`, live-patched by polling `GetProjection`. A **Graph/Table toggle** keeps the table as the scale + a11y surface and the >500-node fallback.

### What's in it
- **SDK (additive, no proto/regen):** new focused `parents.ts` (`ParentEdge` + `EdgeKindName`) threaded onto `MoteView.parents` (trailing, defaulted). `toJSON()` left **byte-identical** (the CLI `projection --json` carries no parents) so the SDK⇄CLI byte-parity contract holds.
- **Gateway (additive, frozen-trio EMPTY):** a deterministic, **model-free multi-node demo recipe** `kx/recipes/fanout-demo` (PURE fan-out→gather: root→3 children→gather) that runs on the embedded storing executor — a single `Invoke` yields a real multi-node projection with DATA parent edges. The live-DAG's end-to-end fixture.
- **Correctness fix (surfaced by the multi-node e2e):** the projection poll-stop was `allTerminal(visible motes)`, which fires prematurely while the Mote set is still growing (and would break PR-2b dynamic shaper children). Now stops on the recipe's **terminal (sink) Mote committing** — threaded from the Invoke response through navigation — with a frontier-stability fallback for direct-URL nav.
- **Modularity:** pure DAG logic isolated into `dag-graph`/`layout`/`edges`/`flow`; reactflow + dagre **code-split** into the run-detail route.

### Golden Rule 8 (pre-flight)
- **Breaks/compat:** SDK field additive + trailing; `toJSON()` byte-parity preserved; **frozen-trio src EMPTY**; proto unchanged; **digest `7d22d4bd…` invariant** (a0_guard + kill-and-replay); `Cargo.lock` unchanged.
- **Perf:** dagre layout memoized by a topology hash (no relayout on state-only polls); ≤500-node cap with table fallback.
- **Security:** read-only over ownership-authz'd `GetProjection`; `parentId` server-derived hex (SN-8); new deps `@xyflow/react` + `@dagrejs/dagre` are MIT + **0 prod-audit vulns**.

### Tests
24 SDK · **133 UI** (unit/component/contract over a real `kx serve`, incl. the multi-node `parents[]` DAG + the new poll-stop logic) · **4 Playwright** (real-browser gRPC-web, incl. the fanout DAG reaching COMMITTED). biome ci + tsc clean; workspace clippy `-D warnings` clean.

### Backlog (spun out)
CLI `projection --json` parents (deliberate compat PR) · PR-2c re-plan-live + F-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)