### PR TITLE
feat(inference,llamacpp): DP1 — embedding seam (EmbeddingBackend sub-trait)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,20 @@ jobs:
         run: cargo fmt --all -- --check
 
   # ---------------------------------------------------------------------------
-  # frozen-trio — the thesis-test guard. The single-node execution kernel
-  # (kx-scheduler / kx-executor / kx-inference) is the stable spine: layers added
-  # ON TOP (distribution, gateway/AL1, SDKs, Docker) must NOT reach down and edit
-  # it. This job FAILS a PR whose diff touches the trio's `src/`. Touching the
-  # kernel is a deliberate, signed-off act of kernel evolution (e.g. a dedicated
-  # inference PR for continuous batching / GBNF) — such a PR updates THIS guard in
-  # the same change. Cheap (no toolchain); pull_request-only (needs a base to diff).
+  # frozen-trio — the thesis-test guard. The single-node EXECUTION kernel
+  # (kx-scheduler / kx-executor) is the stable spine: layers added ON TOP
+  # (distribution, gateway/AL1, SDKs, Docker) — and even a dedicated capability
+  # PR — must NOT reach down and edit it. kx-inference's dispatch CONTROL FLOW
+  # (`dispatcher.rs` — the D35 routing, byte-stable since D50) is frozen for the
+  # same reason. The ONE sanctioned exception (D108.2) is kx-inference's
+  # CAPABILITY seams — the backend traits, the llama.cpp backend impl + model
+  # cache, and additive input/output types: a dedicated inference PR MAY evolve
+  # them (multimodal, embedding, future GBNF / continuous batching). Such a PR is
+  # a deliberate, signed-off act of kernel evolution; the unchanged-EXECUTION-
+  # behaviour invariant is then enforced by the a0_guard canonical-digest test
+  # (`7d22d4bd…`), not a blanket kx-inference/src freeze. This job FAILS a PR whose
+  # diff touches the execution kernel or the dispatch control flow. Cheap (no
+  # toolchain); pull_request-only (needs a base to diff).
   # ---------------------------------------------------------------------------
   frozen-trio:
     name: frozen-trio (kernel src unchanged)
@@ -72,22 +79,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Assert kx-inference / kx-executor / kx-scheduler src is unchanged
+      - name: Assert kx-executor / kx-scheduler src + kx-inference dispatch control-flow are unchanged
         run: |
           set -euo pipefail
           BASE="${{ github.base_ref }}"
           git fetch --no-tags origin "$BASE"
           CHANGED="$(git diff --name-only "origin/$BASE...HEAD" -- \
-            crates/kx-inference/src crates/kx-executor/src crates/kx-scheduler/src)"
+            crates/kx-executor/src crates/kx-scheduler/src \
+            crates/kx-inference/src/dispatcher.rs)"
           if [ -n "$CHANGED" ]; then
-            echo "::error::Frozen-trio source changed (thesis test). The kernel" \
-                 "(kx-inference/kx-executor/kx-scheduler) must not be edited by a" \
-                 "layer-on-top PR. If this is deliberate kernel evolution, update" \
+            echo "::error::Frozen kernel source changed (thesis test). The execution" \
+                 "kernel (kx-executor/kx-scheduler) and the kx-inference dispatch" \
+                 "control flow (dispatcher.rs) must not be edited by a layer-on-top" \
+                 "or capability PR. A sanctioned kx-inference CAPABILITY change" \
+                 "(D108.2) must stay OUT of dispatcher.rs and keep the a0_guard" \
+                 "digest invariant; if this is deliberate kernel evolution, update" \
                  "this guard in the same PR."
             echo "Changed files:"; echo "$CHANGED"
             exit 1
           fi
-          echo "frozen trio unchanged ✓"
+          echo "frozen execution kernel + dispatch control-flow unchanged ✓"
 
   # ---------------------------------------------------------------------------
   # clippy — needs the full build graph (build scripts + bindgen output).

--- a/crates/kx-inference/src/backend.rs
+++ b/crates/kx-inference/src/backend.rs
@@ -12,7 +12,10 @@
 use kx_mote::ModelId;
 use kx_warrant::WarrantSpec;
 
-use crate::types::{InferenceError, InferenceInput, InferenceOutput, InferenceParams};
+use crate::types::{
+    EmbeddingOutput, EmbeddingPooling, InferenceError, InferenceInput, InferenceOutput,
+    InferenceParams,
+};
 
 /// A single dispatch request, packaged as a reference-tuple so
 /// `batch_dispatch` doesn't force clones.
@@ -96,6 +99,65 @@ pub trait InferenceBackend: Send + Sync {
         items
             .iter()
             .map(|item| self.dispatch(item.model_id, item.input, item.params, item.warrant))
+            .collect()
+    }
+}
+
+/// The **embedding capability seam** (DP1 / T2.1, the D108.2-sanctioned
+/// `kx-inference` capability addition).
+///
+/// A *separate* trait — NOT a method on [`InferenceBackend`] — so that trait's
+/// source stays byte-stable and every existing backend remains valid without
+/// edit. A backend that can produce embeddings opts in by also implementing
+/// this; the default methods return `Err(Unsupported)`, so the seam is exercised
+/// (and degrades gracefully) even for backends that don't.
+///
+/// The `: InferenceBackend` supertrait bound keeps the dispatcher's existing
+/// `dyn InferenceBackend` set unaffected: a caller that wants embeddings holds an
+/// `&dyn EmbeddingBackend` (or the concrete backend) and calls
+/// [`Self::dispatch_embedding`] directly — embeddings are an ingest-time act, not
+/// a scheduler/executor `dispatch_mote` path, so the frozen control flow is
+/// untouched.
+pub trait EmbeddingBackend: InferenceBackend {
+    /// Embed `text` for `model_id` under `pooling`, enforcing the warrant's
+    /// model route (the backend MUST refuse a model the warrant did not
+    /// authorise, exactly like [`InferenceBackend::dispatch`]).
+    ///
+    /// # Errors
+    /// Returns [`InferenceError::Unsupported`] by default (a backend without the
+    /// embedding capability). A capable backend returns
+    /// [`InferenceError::WarrantDeniesModel`] when the model id does not match
+    /// the warrant route, [`InferenceError::ModelNotFound`] when it cannot serve
+    /// the model, [`InferenceError::Timeout`] on wall-clock expiry, and
+    /// [`InferenceError::BackendFailure`] on any backend-internal failure (incl.
+    /// an empty / untokenizable input).
+    fn dispatch_embedding(
+        &self,
+        model_id: &ModelId,
+        text: &str,
+        pooling: EmbeddingPooling,
+        warrant: &WarrantSpec,
+    ) -> Result<EmbeddingOutput, InferenceError> {
+        let _ = (model_id, text, pooling, warrant);
+        Err(InferenceError::Unsupported {
+            reason: "embedding not supported by this backend",
+        })
+    }
+
+    /// Embed a batch of texts under one `pooling` + `model_id`. The default maps
+    /// [`Self::dispatch_embedding`] per item; a future backend overrides this to
+    /// exploit a single multi-sequence decode (the seam, mirroring
+    /// [`InferenceBackend::batch_dispatch`], is what's load-bearing).
+    fn dispatch_embedding_batch(
+        &self,
+        model_id: &ModelId,
+        texts: &[&str],
+        pooling: EmbeddingPooling,
+        warrant: &WarrantSpec,
+    ) -> Vec<Result<EmbeddingOutput, InferenceError>> {
+        texts
+            .iter()
+            .map(|text| self.dispatch_embedding(model_id, text, pooling, warrant))
             .collect()
     }
 }

--- a/crates/kx-inference/src/cache.rs
+++ b/crates/kx-inference/src/cache.rs
@@ -40,13 +40,15 @@ use std::time::{Duration, Instant};
 use kx_content::ContentRef;
 use kx_llamacpp::{
     Bitmap, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, ModelWithProjector,
-    Mtmd, Sampler, Vocab,
+    Mtmd, PoolingType, Sampler, Vocab,
 };
 use kx_mote::{InferenceParams, ModelId};
 use smallvec::SmallVec;
 
 use crate::llama::BACKEND_NAME;
-use crate::types::{InferenceError, InferenceOutput, MEDIA_MARKER};
+use crate::types::{
+    EmbeddingOutput, EmbeddingPooling, InferenceError, InferenceOutput, MEDIA_MARKER,
+};
 
 /// Default number of distinct models kept loaded at once. Small because models
 /// are heavyweight; enough for one active model plus a swap.
@@ -96,11 +98,55 @@ struct Job {
     reply: Sender<Result<InferenceOutput, InferenceError>>,
 }
 
+/// One embedding request handed to the owner thread (DP1). All fields are
+/// `Send`. Distinct from [`Job`] because embedding produces a dense `Vec<f32>`,
+/// not completion bytes, and uses no sampler / generation loop — but it shares
+/// the SAME owner thread + loaded-model LRU, so an embedding reuses an
+/// already-cached model and never reloads it.
+struct EmbedJob {
+    /// Loaded-model cache key (the same identity used by [`Job`]).
+    identity: ContentRef,
+    /// Where to load the model from on a cache miss.
+    path: PathBuf,
+    /// Echoed back into `EmbeddingOutput.model_id`.
+    model_id: ModelId,
+    /// The text to embed.
+    text: String,
+    /// Pooling strategy for the per-sequence vector.
+    pooling: EmbeddingPooling,
+    /// Wall-clock ceiling in milliseconds (`warrant.resource_ceiling`).
+    wall_clock_ms: u64,
+    /// Where the owner thread sends the result.
+    reply: Sender<Result<EmbeddingOutput, InferenceError>>,
+}
+
+/// The owner thread serves both completion and embedding jobs over one channel
+/// so a single loaded-model LRU backs both (an embedding reuses the cached
+/// generation model). Boxed variants keep the enum small (the completion `Job`
+/// is heavyweight).
+enum OwnerJob {
+    /// A completion / generation request (text or multimodal).
+    Generate(Box<Job>),
+    /// An embedding request (DP1).
+    Embed(Box<EmbedJob>),
+}
+
+/// Map the FFI-free [`EmbeddingPooling`] seam type to `kx-llamacpp`'s
+/// `PoolingType`. Only single-vector poolings exist on `EmbeddingPooling`, so
+/// this is total and never produces `None`/`Rank`.
+fn map_pooling(pooling: EmbeddingPooling) -> PoolingType {
+    match pooling {
+        EmbeddingPooling::Mean => PoolingType::Mean,
+        EmbeddingPooling::Cls => PoolingType::Cls,
+        EmbeddingPooling::Last => PoolingType::Last,
+    }
+}
+
 /// `Send + Sync` handle to the model-cache owner thread. Cheap to clone (clones
 /// share one worker + the load counters).
 #[derive(Clone, Debug)]
 pub(crate) struct ModelCache {
-    tx: Sender<Job>,
+    tx: Sender<OwnerJob>,
     /// Number of cold `Model::load`s performed — the observable proof that a
     /// cache hit did NOT reload (and the ops metric for "the reload is gone").
     loads: Arc<AtomicU64>,
@@ -116,7 +162,7 @@ impl ModelCache {
     /// every `ModelCache` clone (and thus every `Sender`) is dropped, at which
     /// point `recv` errors and it exits cleanly.
     pub(crate) fn spawn(capacity: usize) -> Self {
-        let (tx, rx) = mpsc::channel::<Job>();
+        let (tx, rx) = mpsc::channel::<OwnerJob>();
         let loads = Arc::new(AtomicU64::new(0));
         let mmproj_loads = Arc::new(AtomicU64::new(0));
         let worker_loads = Arc::clone(&loads);
@@ -172,7 +218,7 @@ impl ModelCache {
             reply: reply_tx,
         };
         self.tx
-            .send(job)
+            .send(OwnerJob::Generate(Box::new(job)))
             .map_err(|_| InferenceError::BackendFailure {
                 backend: BACKEND_NAME,
                 message: "model-cache owner thread is gone (send failed)".to_string(),
@@ -184,19 +230,67 @@ impl ModelCache {
                 message: "model-cache owner thread died mid-job (recv failed)".to_string(),
             })?
     }
+
+    /// Submit an embedding job and block until the owner thread replies (DP1).
+    /// Shares the loaded-model LRU with [`Self::dispatch`], so embedding reuses
+    /// an already-cached generation model.
+    pub(crate) fn dispatch_embedding(
+        &self,
+        identity: ContentRef,
+        path: PathBuf,
+        model_id: ModelId,
+        text: String,
+        pooling: EmbeddingPooling,
+        wall_clock_ms: u64,
+    ) -> Result<EmbeddingOutput, InferenceError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let job = EmbedJob {
+            identity,
+            path,
+            model_id,
+            text,
+            pooling,
+            wall_clock_ms,
+            reply: reply_tx,
+        };
+        self.tx.send(OwnerJob::Embed(Box::new(job))).map_err(|_| {
+            InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: "model-cache owner thread is gone (send failed)".to_string(),
+            }
+        })?;
+        reply_rx
+            .recv()
+            .map_err(|_| InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: "model-cache owner thread died mid-job (recv failed)".to_string(),
+            })?
+    }
 }
 
 /// The owner thread's loop. Owns the (`!Send`) backend and the loaded-model LRU
 /// as thread-locals; serves jobs until the channel closes.
-fn owner_loop(rx: &Receiver<Job>, capacity: usize, loads: &AtomicU64, mmproj_loads: &AtomicU64) {
+fn owner_loop(
+    rx: &Receiver<OwnerJob>,
+    capacity: usize,
+    loads: &AtomicU64,
+    mmproj_loads: &AtomicU64,
+) {
     let backend = match LlamaBackend::new() {
         Ok(b) => b,
         Err(e) => {
-            // Backend init failed: reply the same error to every queued job so
-            // callers fail fast instead of hanging.
+            // Backend init failed: reply the same error to every queued job (of
+            // either kind) so callers fail fast instead of hanging.
             let err = map_llama_err(e);
-            while let Ok(job) = rx.recv() {
-                let _ = job.reply.send(Err(err.clone()));
+            while let Ok(owner_job) = rx.recv() {
+                match owner_job {
+                    OwnerJob::Generate(job) => {
+                        let _ = job.reply.send(Err(err.clone()));
+                    }
+                    OwnerJob::Embed(job) => {
+                        let _ = job.reply.send(Err(err.clone()));
+                    }
+                }
             }
             return;
         }
@@ -207,12 +301,21 @@ fn owner_loop(rx: &Receiver<Job>, capacity: usize, loads: &AtomicU64, mmproj_loa
     // function, so the borrow is valid for the whole loop and `lru` is dropped
     // before `backend`. Within a bundle the projector is dropped before its
     // model (declaration order); across the `lru`, eviction drops a whole bundle.
+    // Both completion and embedding jobs share this one LRU.
     let mut lru: Vec<(ContentRef, ModelWithProjector<'_>)> = Vec::with_capacity(capacity);
 
-    while let Ok(job) = rx.recv() {
-        let result = run_job(&backend, &mut lru, capacity, loads, mmproj_loads, &job);
+    while let Ok(owner_job) = rx.recv() {
         // A dropped reply receiver (caller gave up) is not our problem.
-        let _ = job.reply.send(result);
+        match owner_job {
+            OwnerJob::Generate(job) => {
+                let result = run_job(&backend, &mut lru, capacity, loads, mmproj_loads, &job);
+                let _ = job.reply.send(result);
+            }
+            OwnerJob::Embed(job) => {
+                let result = run_embed_job(&backend, &mut lru, capacity, loads, &job);
+                let _ = job.reply.send(result);
+            }
+        }
     }
 }
 
@@ -246,6 +349,37 @@ fn run_job<'b>(
     Ok(InferenceOutput {
         bytes,
         output_tokens,
+        backend_name: BACKEND_NAME,
+        model_id: job.model_id.clone(),
+        elapsed: start.elapsed(),
+    })
+}
+
+/// Resolve-or-load the model (reusing the SHARED LRU, so an embedding never
+/// reloads a model a prior generation already cached), then embed `job.text`
+/// under its pooling (DP1). One synchronous `embed_with` — no sampler, no token
+/// loop — so the wall-clock ceiling is checked once before the (fast) decode.
+fn run_embed_job<'b>(
+    backend: &'b LlamaBackend,
+    lru: &mut Vec<(ContentRef, ModelWithProjector<'b>)>,
+    capacity: usize,
+    loads: &AtomicU64,
+    job: &EmbedJob,
+) -> Result<EmbeddingOutput, InferenceError> {
+    let start = Instant::now();
+    let timeout = Duration::from_millis(job.wall_clock_ms);
+    let entry = get_or_load(backend, lru, capacity, loads, job.identity, &job.path)
+        .map_err(map_llama_err)?;
+    check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
+
+    let vector = entry
+        .model()
+        .embed_with(&job.text, map_pooling(job.pooling))
+        .map_err(map_llama_err)?;
+    let dim = u32::try_from(vector.len()).unwrap_or(u32::MAX);
+    Ok(EmbeddingOutput {
+        vector,
+        dim,
         backend_name: BACKEND_NAME,
         model_id: job.model_id.clone(),
         elapsed: start.elapsed(),

--- a/crates/kx-inference/src/lib.rs
+++ b/crates/kx-inference/src/lib.rs
@@ -50,11 +50,11 @@ mod cache;
 mod llama;
 mod types;
 
-pub use backend::{BatchItem, InferenceBackend};
+pub use backend::{BatchItem, EmbeddingBackend, InferenceBackend};
 pub use dispatcher::{DispatchOutcome, Dispatcher, DispatcherConfig};
 #[cfg(feature = "llamacpp")]
 pub use llama::{ContentFetcher, LlamaInferenceBackend};
 pub use types::{
-    inference_params_from_mote, Grammar, InferenceError, InferenceInput, InferenceOutput,
-    InferenceParams, MEDIA_MARKER,
+    inference_params_from_mote, EmbeddingOutput, EmbeddingPooling, Grammar, InferenceError,
+    InferenceInput, InferenceOutput, InferenceParams, MEDIA_MARKER,
 };

--- a/crates/kx-inference/src/llama.rs
+++ b/crates/kx-inference/src/llama.rs
@@ -29,10 +29,11 @@ use kx_mote::ModelId;
 use kx_warrant::WarrantSpec;
 use smallvec::SmallVec;
 
-use crate::backend::InferenceBackend;
+use crate::backend::{EmbeddingBackend, InferenceBackend};
 use crate::cache::{ModelCache, DEFAULT_CACHE_CAPACITY};
 use crate::types::{
-    check_within, InferenceError, InferenceInput, InferenceOutput, InferenceParams,
+    check_within, EmbeddingOutput, EmbeddingPooling, InferenceError, InferenceInput,
+    InferenceOutput, InferenceParams,
 };
 
 /// Object-safe byte fetcher that erases [`ContentStore`]'s associated `Payload`
@@ -363,6 +364,12 @@ impl InferenceBackend for LlamaInferenceBackend {
                     warrant.resource_ceiling.wall_clock_ms,
                 )
             }
+            // The completion path produces no embedding; embeddings ride the
+            // separate `EmbeddingBackend::dispatch_embedding` seam.
+            InferenceInput::TextForEmbedding { .. } => Err(InferenceError::Unsupported {
+                reason: "embedding input on the completion path; use \
+                         EmbeddingBackend::dispatch_embedding",
+            }),
         }
     }
 
@@ -372,5 +379,50 @@ impl InferenceBackend for LlamaInferenceBackend {
 
     fn name(&self) -> &'static str {
         BACKEND_NAME
+    }
+}
+
+impl EmbeddingBackend for LlamaInferenceBackend {
+    /// Embed `text` for `model_id` under `pooling` (DP1). Authorizes the model
+    /// route BEFORE touching the model (SN-8 / D35), resolves the descriptor,
+    /// and runs the embed on the shared model-cache owner thread (reusing an
+    /// already-loaded model). There is no `max_output_tokens` axis to narrow
+    /// (an embedding emits no tokens), so the only quantitative ceiling is the
+    /// warrant's wall-clock.
+    fn dispatch_embedding(
+        &self,
+        model_id: &ModelId,
+        text: &str,
+        pooling: EmbeddingPooling,
+        warrant: &WarrantSpec,
+    ) -> Result<EmbeddingOutput, InferenceError> {
+        // ---- Warrant gate (D35) — the route MUST authorize this model id ----
+        if model_id != &warrant.model_route.model_id {
+            return Err(InferenceError::WarrantDeniesModel {
+                model_id: model_id.0.clone(),
+                route: warrant.model_route.model_id.0.clone(),
+            });
+        }
+
+        // ---- Resolve the model descriptor (paths) ---------------------------
+        let descriptor =
+            self.resolver
+                .resolve(model_id)
+                .ok_or_else(|| InferenceError::ModelNotFound {
+                    model_id: model_id.0.clone(),
+                })?;
+
+        let cache = self
+            .cache
+            .get_or_init(|| ModelCache::spawn(self.cache_capacity));
+
+        cache.dispatch_embedding(
+            descriptor.identity_digest,
+            descriptor.gguf_path.clone(),
+            model_id.clone(),
+            text.to_string(),
+            pooling,
+            warrant.resource_ceiling.wall_clock_ms,
+        )
     }
 }

--- a/crates/kx-inference/src/types.rs
+++ b/crates/kx-inference/src/types.rs
@@ -40,6 +40,7 @@ use smallvec::SmallVec;
 /// match prompt {
 ///     InferenceInput::Text(s) => assert_eq!(s, "Hello, world!"),
 ///     InferenceInput::Multimodal { .. } => unreachable!(),
+///     InferenceInput::TextForEmbedding { .. } => unreachable!(),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,6 +58,39 @@ pub enum InferenceInput {
         /// `kx-content`.
         content_refs: SmallVec<[ContentRef; 4]>,
     },
+    /// Text to be embedded into a single dense vector — the RAG /
+    /// agent-memory payload (DP1 / T2.1). Handled only by backends that
+    /// implement [`crate::EmbeddingBackend`]; a backend's `dispatch`
+    /// (completion) path is NOT expected to handle it (it produces no
+    /// completion bytes), so a backend without the embedding capability
+    /// returns `Err(Unsupported)`.
+    ///
+    /// **Never serialized to the journal / wire.** Like `Multimodal`, this
+    /// value is constructed in-process at ingest time and consumed
+    /// immediately by `dispatch_embedding`; it is not part of `MoteDef` and
+    /// creates no on-disk / on-wire compatibility surface.
+    TextForEmbedding {
+        /// The text to embed.
+        text: String,
+        /// How per-token hidden states are pooled into one vector.
+        pooling: EmbeddingPooling,
+    },
+}
+
+/// Pooling strategy for a [`InferenceInput::TextForEmbedding`] request — the
+/// FFI-free mirror of `kx_llamacpp::PoolingType`'s single-vector variants
+/// (defined here so the seam carries no FFI dependency under
+/// `--no-default-features`). Only single-vector poolings are exposed; per-token
+/// (`None`) and rerank (`Rank`) are intentionally absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum EmbeddingPooling {
+    /// HF-shaped average over all token hidden states (the default).
+    #[default]
+    Mean,
+    /// The first / CLS token's hidden state (BERT-style embedders).
+    Cls,
+    /// The final token's hidden state (decoder-style embedders).
+    Last,
 }
 
 /// The media placeholder that marks, inside a [`InferenceInput::Multimodal`]
@@ -78,7 +112,7 @@ impl InferenceInput {
     pub fn text_len(&self) -> usize {
         match self {
             Self::Text(s) => s.len(),
-            Self::Multimodal { text, .. } => text.len(),
+            Self::Multimodal { text, .. } | Self::TextForEmbedding { text, .. } => text.len(),
         }
     }
 
@@ -181,6 +215,34 @@ pub struct InferenceOutput {
 
     /// Wall-clock time spent inside the backend's dispatch. Excludes
     /// dispatcher overhead (validator / memoizer / scope checks).
+    pub elapsed: Duration,
+}
+
+/// Result of a single embedding dispatch ([`crate::EmbeddingBackend`]).
+///
+/// Distinct from [`InferenceOutput`] because an embedding is a dense `Vec<f32>`,
+/// not completion `bytes`. It is **not** identity-bearing on its own — when an
+/// embedding is ingested into a dataset the identity comes from the
+/// content-addressed `kx-dataset` row, not from this transient struct (hence no
+/// `Eq`: floats have no total equality).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbeddingOutput {
+    /// The dense embedding vector (length == `dim`).
+    pub vector: Vec<f32>,
+
+    /// Dimensionality of `vector` (its length), surfaced for quick schema
+    /// checks without walking the vector.
+    pub dim: u32,
+
+    /// Backend identity that produced this embedding (e.g. `"kx-llamacpp"`).
+    /// Audit-trail field, mirrors [`InferenceOutput::backend_name`].
+    pub backend_name: &'static str,
+
+    /// The model id that produced this embedding. Echoed back so callers can
+    /// confirm the dispatcher routed to the expected model.
+    pub model_id: ModelId,
+
+    /// Wall-clock time spent inside the backend's embedding dispatch.
     pub elapsed: Duration,
 }
 

--- a/crates/kx-inference/tests/embedding_seam.rs
+++ b/crates/kx-inference/tests/embedding_seam.rs
@@ -1,0 +1,261 @@
+//! DP1 — the `EmbeddingBackend` capability seam (model-free).
+//!
+//! Proves the seam WITHOUT a real GGUF, mirroring `model_cache.rs`:
+//!   - a backend that does NOT implement embeddings gets the default
+//!     `Err(Unsupported)` (so the seam degrades gracefully);
+//!   - a backend that DOES implement it returns an `EmbeddingOutput` and
+//!     enforces the warrant route (the SN-8 / D35 authorize-before-work rule);
+//!   - the real `LlamaInferenceBackend` wires `dispatch_embedding` through the
+//!     warrant gate → resolver → owner-thread cache, reaching the load-failure /
+//!     not-found / denied paths without a real model.
+//!
+//! Real-model embedding numerics are proven by `kx-llamacpp`'s
+//! `smoke_embed_with_pooling_matches_mean_and_is_total` (CI smoke-test-with-model)
+//! and exercised end-to-end by the DP2 RAG harness.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use kx_content::ContentRef;
+use kx_inference::{
+    EmbeddingBackend, EmbeddingOutput, EmbeddingPooling, InferenceBackend, InferenceError,
+    InferenceInput, InferenceOutput, InferenceParams,
+};
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+
+fn warrant(model_id: ModelId) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id,
+            max_input_tokens: 2048,
+            max_output_tokens: 2048,
+            max_calls: 100,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+/// A completion-only backend that does NOT opt into embeddings: it implements
+/// `InferenceBackend` and takes `EmbeddingBackend`'s DEFAULT methods.
+struct NoEmbedBackend;
+
+impl InferenceBackend for NoEmbedBackend {
+    fn dispatch(
+        &self,
+        _model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        Err(InferenceError::Unsupported {
+            reason: "stub: no completion",
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "no-embed-backend"
+    }
+}
+impl EmbeddingBackend for NoEmbedBackend {}
+
+/// A backend that DOES embed: it enforces the warrant route exactly like the
+/// real backend, then returns a deterministic canned vector derived from the
+/// text length (so the test can assert the value plumbs through).
+struct CapableEmbedBackend;
+
+impl InferenceBackend for CapableEmbedBackend {
+    fn dispatch(
+        &self,
+        _model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        Err(InferenceError::Unsupported {
+            reason: "stub: embeddings only",
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "capable-embed-backend"
+    }
+}
+impl EmbeddingBackend for CapableEmbedBackend {
+    fn dispatch_embedding(
+        &self,
+        model_id: &ModelId,
+        text: &str,
+        _pooling: EmbeddingPooling,
+        warrant: &WarrantSpec,
+    ) -> Result<EmbeddingOutput, InferenceError> {
+        if model_id != &warrant.model_route.model_id {
+            return Err(InferenceError::WarrantDeniesModel {
+                model_id: model_id.0.clone(),
+                route: warrant.model_route.model_id.0.clone(),
+            });
+        }
+        let vector = vec![text.len() as f32, 0.5, -0.5];
+        Ok(EmbeddingOutput {
+            vector,
+            dim: 3,
+            backend_name: "capable-embed-backend",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(1),
+        })
+    }
+}
+
+#[test]
+fn default_embedding_capability_is_unsupported() {
+    let id = ModelId("m".into());
+    let w = warrant(id.clone());
+    let err = NoEmbedBackend
+        .dispatch_embedding(&id, "hello", EmbeddingPooling::Mean, &w)
+        .expect_err("a non-embedding backend must report Unsupported");
+    assert!(matches!(err, InferenceError::Unsupported { .. }));
+}
+
+#[test]
+fn default_embedding_batch_is_all_unsupported() {
+    let id = ModelId("m".into());
+    let w = warrant(id.clone());
+    let out =
+        NoEmbedBackend.dispatch_embedding_batch(&id, &["a", "b", "c"], EmbeddingPooling::Mean, &w);
+    assert_eq!(out.len(), 3);
+    assert!(out
+        .iter()
+        .all(|r| matches!(r, Err(InferenceError::Unsupported { .. }))));
+}
+
+#[test]
+fn capable_backend_returns_embedding() {
+    let id = ModelId("m".into());
+    let w = warrant(id.clone());
+    let out = CapableEmbedBackend
+        .dispatch_embedding(&id, "hello", EmbeddingPooling::Mean, &w)
+        .expect("capable backend embeds");
+    assert_eq!(out.dim, 3);
+    assert_eq!(out.vector.len(), 3);
+    assert_eq!(out.vector[0], 5.0, "text len plumbs through");
+    assert_eq!(out.model_id, id);
+}
+
+#[test]
+fn capable_backend_enforces_warrant_route() {
+    let asked = ModelId("asked".into());
+    // Warrant authorises a DIFFERENT model than the one requested.
+    let w = warrant(ModelId("authorised".into()));
+    let err = CapableEmbedBackend
+        .dispatch_embedding(&asked, "hello", EmbeddingPooling::Mean, &w)
+        .expect_err("route mismatch must be denied");
+    assert!(matches!(err, InferenceError::WarrantDeniesModel { .. }));
+}
+
+#[test]
+fn capable_backend_batch_maps_per_item() {
+    let id = ModelId("m".into());
+    let w = warrant(id.clone());
+    let out = CapableEmbedBackend.dispatch_embedding_batch(
+        &id,
+        &["x", "yy", "zzz"],
+        EmbeddingPooling::Cls,
+        &w,
+    );
+    let lens: Vec<f32> = out
+        .into_iter()
+        .map(|r| r.expect("each embeds").vector[0])
+        .collect();
+    assert_eq!(lens, vec![1.0, 2.0, 3.0], "per-item text lengths");
+}
+
+#[test]
+fn embedding_pooling_default_is_mean() {
+    assert_eq!(EmbeddingPooling::default(), EmbeddingPooling::Mean);
+}
+
+#[test]
+fn text_for_embedding_reports_its_text_len() {
+    let input = InferenceInput::TextForEmbedding {
+        text: "hello".into(),
+        pooling: EmbeddingPooling::Mean,
+    };
+    assert_eq!(input.text_len(), 5);
+}
+
+// ---- Real backend wiring (llama.cpp feature; no real GGUF needed) -----------
+
+#[cfg(feature = "llamacpp")]
+mod real_backend {
+    use super::{warrant, EmbeddingPooling};
+    use kx_inference::{EmbeddingBackend, InferenceError, LlamaInferenceBackend};
+    use kx_mote::ModelId;
+    use std::path::PathBuf;
+
+    #[test]
+    fn dispatch_embedding_denies_unauthorised_route() {
+        let asked = ModelId("asked".into());
+        let backend =
+            LlamaInferenceBackend::with_model(asked.clone(), PathBuf::from("/tmp/whatever.gguf"));
+        // Warrant routes to a different model: the gate fires BEFORE any FFI.
+        let w = warrant(ModelId("authorised".into()));
+        let err = backend
+            .dispatch_embedding(&asked, "hi", EmbeddingPooling::Mean, &w)
+            .expect_err("unauthorised route must be denied before touching the model");
+        assert!(matches!(err, InferenceError::WarrantDeniesModel { .. }));
+    }
+
+    #[test]
+    fn dispatch_embedding_reports_model_not_found() {
+        let id = ModelId("missing".into());
+        // A backend with NO registered models; the warrant authorises `id`.
+        let backend = LlamaInferenceBackend::new();
+        let w = warrant(id.clone());
+        let err = backend
+            .dispatch_embedding(&id, "hi", EmbeddingPooling::Mean, &w)
+            .expect_err("unresolved model must be ModelNotFound");
+        assert!(matches!(err, InferenceError::ModelNotFound { .. }));
+    }
+
+    #[test]
+    fn dispatch_embedding_wires_through_to_a_typed_load_failure() {
+        let id = ModelId("m".into());
+        // Resolvable id, but the path does not exist: the request must travel the
+        // full path (warrant gate → resolve → owner-thread cache → Model::load)
+        // and surface a typed BackendFailure, never a panic or hang.
+        let backend = LlamaInferenceBackend::with_model(
+            id.clone(),
+            PathBuf::from("/nonexistent/definitely/not/a/model.gguf"),
+        );
+        let w = warrant(id.clone());
+        let err = backend
+            .dispatch_embedding(&id, "hi", EmbeddingPooling::Mean, &w)
+            .expect_err("a missing model file must be a typed BackendFailure");
+        assert!(matches!(err, InferenceError::BackendFailure { .. }));
+    }
+}

--- a/crates/kx-llamacpp/src/model.rs
+++ b/crates/kx-llamacpp/src/model.rs
@@ -207,25 +207,50 @@ impl<'b> Model<'b> {
     /// # Determinism
     /// `embed(x)` is deterministic for fixed `x` and fixed model — proved by
     /// `smoke_embed_one_shot_determinism` in `tests/smoke.rs`.
-    #[tracing::instrument(level = "info", skip(self), fields(text_len = text.len()))]
     pub fn embed(&self, text: &str) -> Result<Vec<f32>, LlamaError> {
+        self.embed_with(text, PoolingType::Mean)
+    }
+
+    /// **Embedding with an explicit pooling strategy** — the general form of
+    /// [`Self::embed`] (which is `embed_with(text, PoolingType::Mean)`).
+    ///
+    /// `pooling` selects how the per-token hidden states are reduced to one
+    /// sequence vector: [`PoolingType::Mean`] (the HF-shaped average),
+    /// [`PoolingType::Cls`] (the first / CLS token), or [`PoolingType::Last`]
+    /// (the final token, for decoder-style embedders). [`PoolingType::None`]
+    /// and [`PoolingType::Rank`] are not single-vector poolings and should not
+    /// be passed here (they yield no per-sequence vector).
+    ///
+    /// # Errors
+    /// - [`LlamaError::TokenizeFailed`] if tokenization fails (incl. empty input).
+    /// - [`LlamaError::ContextCreationFailed`] if a fresh context cannot be allocated.
+    /// - [`LlamaError::DecodeFailed`] if the decode pass fails.
+    /// - [`LlamaError::EmbeddingsUnavailable`] if pooling didn't produce a vector
+    ///   (model lacks the necessary metadata).
+    ///
+    /// # Determinism
+    /// `embed_with(x, p)` is deterministic for fixed `x`, model, and pooling `p`
+    /// — the `Mean` case is proved by `smoke_embed_one_shot_determinism` in
+    /// `tests/smoke.rs`.
+    #[tracing::instrument(level = "info", skip(self), fields(text_len = text.len()))]
+    pub fn embed_with(&self, text: &str, pooling: PoolingType) -> Result<Vec<f32>, LlamaError> {
         let vocab = self.vocab();
         let tokens = vocab.tokenize(text, /* add_special */ true, false)?;
         if tokens.is_empty() {
             return Err(LlamaError::TokenizeFailed(0));
         }
 
-        // Embedding-mode context, mean-pool across the sequence.
+        // Embedding-mode context, pooled across the sequence per `pooling`.
         let params = ContextParams::new()
             .with_n_ctx(tokens.len().max(8) as u32 * 2)
             .with_n_batch(tokens.len() as u32)
             .with_n_ubatch(tokens.len() as u32)
             .with_n_seq_max(1)
             .with_embeddings(true)
-            .with_pooling_type(PoolingType::Mean);
+            .with_pooling_type(pooling);
         let mut ctx = Context::new_with_params(self, &params)?;
 
-        // Decode the prompt; mean-pool reads from all positions, so every
+        // Decode the prompt; pooling reads from all positions, so every
         // position needs compute_logits = true.
         let mut batch = Batch::with_capacity(tokens.len() as i32, 1);
         for (i, &t) in tokens.iter().enumerate() {
@@ -233,7 +258,7 @@ impl<'b> Model<'b> {
         }
         ctx.decode(&batch)?;
 
-        // Read the pooled vector. Mean pooling produces one vector per
+        // Read the pooled vector. Non-`None` pooling produces one vector per
         // sequence; we own seq 0.
         let pooled = ctx.embeddings_seq(0)?;
         Ok(pooled.to_vec())

--- a/crates/kx-llamacpp/tests/smoke.rs
+++ b/crates/kx-llamacpp/tests/smoke.rs
@@ -795,6 +795,47 @@ fn smoke_embed_one_shot_determinism() {
     );
 }
 
+/// DP1: `embed_with(text, pooling)` is the general form of `embed`.
+///
+/// The load-bearing invariant the DP1 refactor must preserve: `embed` is exactly
+/// `embed_with(text, PoolingType::Mean)`, so the two MUST be byte-identical.
+/// Also proves `embed_with` is deterministic and that the alternate single-vector
+/// poolings (`Cls`/`Last`) are total — they either return an `n_embd`-length
+/// vector or a typed error, never a panic.
+#[test]
+fn smoke_embed_with_pooling_matches_mean_and_is_total() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let model = Model::load(&backend, MODEL_PATH).expect("load");
+
+    // `embed` == `embed_with(_, Mean)` — the refactor invariant.
+    let via_embed = model.embed("hello world").expect("embed");
+    let via_with = model
+        .embed_with("hello world", PoolingType::Mean)
+        .expect("embed_with(Mean)");
+    assert_eq!(
+        via_embed, via_with,
+        "embed(text) must equal embed_with(text, Mean) byte-for-byte"
+    );
+
+    // Determinism on the general surface.
+    let again = model
+        .embed_with("hello world", PoolingType::Mean)
+        .expect("embed_with(Mean) again");
+    assert_eq!(via_with, again, "embed_with must be deterministic");
+
+    // Cls / Last are total: an n_embd vector or a typed Err — never a panic.
+    for pooling in [PoolingType::Cls, PoolingType::Last] {
+        match model.embed_with("hello world", pooling) {
+            Ok(v) => assert_eq!(
+                v.len() as i32,
+                model.n_embd(),
+                "pooled vector length must equal n_embd for {pooling:?}"
+            ),
+            Err(e) => eprintln!("embed_with(_, {pooling:?}) → typed Err (acceptable): {e}"),
+        }
+    }
+}
+
 /// HF-shaped chat-template support: `Model::chat_template(None)` returns the
 /// model's default template if it has one, else `None`. `apply_chat_template`
 /// is a pure-string transformation, so it's deterministic by construction.

--- a/crates/kx-model-harness/tests/assemble_wiring.rs
+++ b/crates/kx-model-harness/tests/assemble_wiring.rs
@@ -68,7 +68,8 @@ impl InferenceBackend for RecordingBackend {
     ) -> Result<InferenceOutput, InferenceError> {
         let text = match input {
             InferenceInput::Text(s) => s.clone(),
-            InferenceInput::Multimodal { text, .. } => text.clone(),
+            InferenceInput::Multimodal { text, .. }
+            | InferenceInput::TextForEmbedding { text, .. } => text.clone(),
         };
         self.inputs.lock().unwrap().push(text);
         Ok(InferenceOutput {
@@ -485,6 +486,9 @@ fn image_parent_routes_child_to_multimodal_input() {
             );
         }
         InferenceInput::Text(t) => panic!("child must get a Multimodal input, got Text({t:?})"),
+        InferenceInput::TextForEmbedding { .. } => {
+            panic!("child must get a Multimodal input, got an embedding request")
+        }
     }
 }
 

--- a/crates/kx-model-harness/tests/planner_e2e.rs
+++ b/crates/kx-model-harness/tests/planner_e2e.rs
@@ -80,7 +80,8 @@ impl InferenceBackend for StubBackend {
         self.calls.fetch_add(1, Ordering::SeqCst);
         let text = match input {
             InferenceInput::Text(s) => s.clone(),
-            InferenceInput::Multimodal { text, .. } => text.clone(),
+            InferenceInput::Multimodal { text, .. }
+            | InferenceInput::TextForEmbedding { text, .. } => text.clone(),
         };
         self.inputs.lock().unwrap().push(text);
         Ok(InferenceOutput {

--- a/crates/kx-model-harness/tests/react_loop_e2e.rs
+++ b/crates/kx-model-harness/tests/react_loop_e2e.rs
@@ -100,7 +100,8 @@ impl InferenceBackend for ScriptedBackend {
     ) -> Result<InferenceOutput, InferenceError> {
         let text = match input {
             InferenceInput::Text(s) => s.clone(),
-            InferenceInput::Multimodal { text, .. } => text.clone(),
+            InferenceInput::Multimodal { text, .. }
+            | InferenceInput::TextForEmbedding { text, .. } => text.clone(),
         };
         self.inputs.lock().unwrap().push(text);
         let idx = self.calls.fetch_add(1, Ordering::SeqCst);

--- a/crates/kx-model-harness/tests/replan_loop_e2e.rs
+++ b/crates/kx-model-harness/tests/replan_loop_e2e.rs
@@ -602,7 +602,8 @@ impl InferenceBackend for RecordingBackend {
         self.calls.fetch_add(1, Ordering::SeqCst);
         let text = match input {
             InferenceInput::Text(s) => s.clone(),
-            InferenceInput::Multimodal { text, .. } => text.clone(),
+            InferenceInput::Multimodal { text, .. }
+            | InferenceInput::TextForEmbedding { text, .. } => text.clone(),
         };
         self.inputs.lock().unwrap().push(text);
         let bytes = match self.replies.lock().unwrap().next() {


### PR DESCRIPTION
## DP1 (T2.1) — the embedding seam: the RAG / agent-memory unlock

First PR of the **RAG / Datasets data-plane** track (DP1 → DP2 recipe → DP3 LanceDB → T3.7 UI). Wires llama.cpp embeddings *through the runtime* as an **additive capability seam**, so DP2 can populate a `RetrievalIndex` from a corpus.

### ⚠️ Reviewer note — frozen-trio guard scoped (signed-off kernel evolution)
DP1 edits `kx-inference/src` (the **D108.2-sanctioned** capability work). Per the `frozen-trio` guard's *own* protocol ("a dedicated inference PR … updates THIS guard in the same change"), this PR **scopes the guard** to:
- the **execution kernel** — `kx-executor/src` + `kx-scheduler/src` (always diff-EMPTY for capability PRs), **and**
- the **inference dispatch control-flow** — `kx-inference/src/dispatcher.rs` (byte-stable since D50, untouched by every multimodal PR and by DP1).

…and documents that kx-inference **capability seams** (backend traits, the llama.cpp impl + model cache, additive types) are the sanctioned exception. The unchanged-**execution-behaviour** invariant is enforced by the **a0_guard canonical-digest test (`7d22d4bd…`)**, which this PR holds (8/8). This matches the corpus framing used by every prior capability PR ("kx-scheduler/src + kx-executor/src diff-EMPTY"). The guard was only added in #145 (after the multimodal PRs), so this is the first PR to exercise its update protocol.

### What changed
- **`kx-llamacpp`** — additive `Model::embed_with(text, pooling)`; `embed` delegates with `Mean` (behaviour-preserving, smoke-proven).
- **`kx-inference`** (the D108.2 capability addition):
  - `InferenceInput::TextForEmbedding { text, pooling }` — constructed in-process at ingest, **never journaled/wired**.
  - `EmbeddingPooling { Mean, Cls, Last }` (FFI-free), `EmbeddingOutput`.
  - **`EmbeddingBackend: InferenceBackend`** sub-trait (default `Unsupported`) — a *separate* trait so `InferenceBackend` source stays byte-stable; backends opt in.
  - `LlamaInferenceBackend` impl + an embedding job routed through the **same model-cache owner thread** (reuses an already-loaded model, no reload).
- Embedding is an **ingest-time** call, **not** a Mote dispatch — the scheduler/executor never dispatch an embedding, so the frozen control flow is untouched.

### Golden Rule 8 (pre-flight risk + compat)
- **Breaks live?** No. `kx-scheduler/src` + `kx-executor/src` + `dispatcher.rs` **diff-EMPTY**; projection digest `7d22d4bd…` **invariant** (a0_guard 8/8). `Cargo.lock` unchanged.
- **Fwd/back-compat:** `TextForEmbedding` is never serialized to journal/wire → no on-disk/wire compat surface. `embed_with(Mean) == embed` byte-identical.
- **Perf:** embedding reuses the cached model (no reload); a `dispatch_embedding_batch` seam is left for single-decode batching later.
- **Security:** warrant model-route authorized **before** any model work; local-only (no egress); SN-8 untouched (no similarity on the commit path here).

### Tests
- 10 model-free seam tests in `kx-inference/tests/embedding_seam.rs` (default `Unsupported`, capable stub, warrant-route gate, real-backend wiring to load-failure / not-found / denied).
- `embed_with == embed(Mean)` invariance + Cls/Last totality in `kx-llamacpp` smoke (CI `smoke-test-with-model`).
- Full `cargo test --workspace` green; clippy `-D warnings`, fmt, doc `-D warnings`, build-no-inference, deny all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)