### PR TITLE
feat(workflow,model-harness): DP2 — the RAG Morphic recipe + ingest/query glue

### DIFF
--- a/crates/kx-model-harness/src/lib.rs
+++ b/crates/kx-model-harness/src/lib.rs
@@ -57,6 +57,7 @@ pub mod evidence;
 pub mod executor;
 pub mod metered;
 pub mod prompt;
+pub mod rag;
 pub mod react;
 pub mod registration;
 pub mod toolcall;
@@ -66,6 +67,7 @@ pub mod workflows;
 pub use broker::{BrokerObserver, ModelBroker};
 pub use executor::ModelExecutor;
 pub use metered::MeteredBackend;
+pub use rag::{encode_vector_le, ingest_corpus, query_corpus, Embedder, RagError};
 pub use react::{run_react_loop, ReactBudget, ReactLoopOutcome, ReactStop};
 pub use registration::{register_kortecx, RegistrationError};
 pub use topology_provider::{

--- a/crates/kx-model-harness/src/rag.rs
+++ b/crates/kx-model-harness/src/rag.rs
@@ -1,0 +1,157 @@
+//! RAG ingest + query glue (DP2) — the executable side of the `rag_pipeline`
+//! recipe ([`kx_workflow::rag_pipeline`]).
+//!
+//! The recipe *structure* is pure data in `kx-workflow` (no FFI). The *execution*
+//! — actually embedding a corpus, populating a [`RetrievalIndex`], and running a
+//! query — lives HERE because it needs the FFI + dataset deps `kx-workflow` must
+//! not carry (`kx-workflow` deps `kx-dataset` but NOT `kx-inference`/`kx-llamacpp`).
+//! This mirrors how `synthesis_pipeline` (structure) is separate from
+//! `ModelExecutor`/`ModelBroker` (execution).
+//!
+//! # SN-8 boundary
+//!
+//! [`query_corpus`] returns the committed-fact ref ([`kx_workflow::retrieval_result_ref`]
+//! — the ORDERED content refs, **scores excluded**) AND the raw [`Hit`]s (scores
+//! included). The scores are for the CALLER's display / ranking only — they never
+//! enter the committed fact, a `MoteId`, or memoization. Downstream steps consume
+//! the retrieved content by EXACT hash.
+
+use kx_content::ContentRef;
+use kx_dataset::{ContentSchema, DataError, DataStore, Dataset, Hit, RetrievalIndex};
+use kx_inference::{EmbeddingBackend, EmbeddingOutput, EmbeddingPooling, InferenceError};
+use kx_mote::{ModelId, MoteId};
+use kx_warrant::WarrantSpec;
+use kx_workflow::retrieval_result_ref;
+use thiserror::Error;
+
+/// Failure modes of the RAG ingest/query glue.
+#[derive(Debug, Error)]
+pub enum RagError {
+    /// The embedding backend failed (or does not support embeddings).
+    #[error("embedding: {0}")]
+    Embedding(#[from] InferenceError),
+    /// The data store failed (poisoned lock).
+    #[error("data store: {0}")]
+    Store(#[from] DataError),
+}
+
+/// Canonical **little-endian f32** encoding of an embedding vector — the
+/// reproducible content-addressed form.
+///
+/// `kx-dataset` content-addresses (blake3) the RAW bytes passed to `put_typed`;
+/// `ContentSchema::Vector{dim}` is only a type tag and performs NO
+/// canonicalization. So the encoding MUST be fixed here, or the same embedding
+/// would hash differently across machines / endiannesses and break `DatasetId`
+/// reproducibility.
+#[must_use]
+pub fn encode_vector_le(vector: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vector.len() * 4);
+    for v in vector {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+/// The embedding context: a backend + the model route + warrant + pooling that
+/// travel together for every embed call. Bundling them keeps [`ingest_corpus`] /
+/// [`query_corpus`] to a small, clear signature and pins the
+/// reproducibility-bearing axes (`model_id` + `pooling`) in one place.
+pub struct Embedder<'a> {
+    backend: &'a dyn EmbeddingBackend,
+    model_id: &'a ModelId,
+    warrant: &'a WarrantSpec,
+    pooling: EmbeddingPooling,
+}
+
+impl<'a> Embedder<'a> {
+    /// Bind a backend + model route + warrant + pooling for the corpus.
+    #[must_use]
+    pub fn new(
+        backend: &'a dyn EmbeddingBackend,
+        model_id: &'a ModelId,
+        warrant: &'a WarrantSpec,
+        pooling: EmbeddingPooling,
+    ) -> Self {
+        Self {
+            backend,
+            model_id,
+            warrant,
+            pooling,
+        }
+    }
+
+    /// Embed `text` under this context (route-gated by the backend).
+    ///
+    /// # Errors
+    /// Whatever [`EmbeddingBackend::dispatch_embedding`] returns.
+    pub fn embed(&self, text: &str) -> Result<EmbeddingOutput, InferenceError> {
+        self.backend
+            .dispatch_embedding(self.model_id, text, self.pooling, self.warrant)
+    }
+}
+
+/// Embed + store + index a corpus, returning the reproducible [`Dataset`].
+///
+/// For each document, in order:
+/// 1. embed it ([`EmbeddingBackend::dispatch_embedding`], under `pooling`);
+/// 2. store the SOURCE TEXT as a `ContentSchema::Text` row — the retrievable
+///    payload AND the index key (so retrieval returns refs a caller can fetch);
+/// 3. store the embedding as a canonical-LE `ContentSchema::Vector{dim}` row;
+/// 4. `index.insert(text_ref, vector)`.
+///
+/// Content-addressed dedup is free: a duplicate document → the same `text_ref` →
+/// an idempotent `put_typed` + an overwriting `insert`, so the index holds one
+/// entry per DISTINCT document.
+///
+/// The returned [`Dataset`] rows interleave (text, vector) per document, so its
+/// [`DatasetId`](kx_dataset::DatasetId) is a pure function of the source text AND
+/// the embeddings: pin the [`Embedder`]'s `model_id` + `pooling` and the same
+/// corpus re-ingests to a byte-identical `DatasetId` on any machine. `lineage`
+/// records the Motes (if any) whose committed output produced the corpus — pass
+/// `&[]` for a direct ingest.
+///
+/// # Errors
+/// [`RagError::Embedding`] if a document fails to embed; [`RagError::Store`] on a
+/// store failure.
+pub fn ingest_corpus(
+    store: &dyn DataStore,
+    index: &mut dyn RetrievalIndex,
+    embedder: &Embedder<'_>,
+    docs: &[&str],
+    lineage: &[MoteId],
+) -> Result<Dataset, RagError> {
+    let mut rows = Vec::with_capacity(docs.len().saturating_mul(2));
+    for doc in docs {
+        let out = embedder.embed(doc)?;
+        let vec_bytes = encode_vector_le(&out.vector);
+        let text_ref = store.put_typed(doc.as_bytes(), ContentSchema::Text)?;
+        let vec_ref = store.put_typed(&vec_bytes, ContentSchema::Vector { dim: out.dim })?;
+        index.insert(text_ref.content_ref, out.vector);
+        rows.push(text_ref);
+        rows.push(vec_ref);
+    }
+    Ok(Dataset::new(rows, lineage.to_vec()))
+}
+
+/// Embed a query and retrieve the top-`k` nearest documents from the index.
+///
+/// Returns the SN-8-safe committed-fact ref ([`retrieval_result_ref`] — the
+/// ordered content refs, **scores excluded**) AND the raw [`Hit`]s (scores
+/// included, for DISPLAY / ranking only — never on a commit path). For a fixed
+/// index state + query + pooling the `fact_ref` is stable (the exact `InMemory`
+/// backend is deterministic), so a downstream Mote that consumes it has a
+/// reproducible identity.
+///
+/// # Errors
+/// [`RagError::Embedding`] if the query fails to embed.
+pub fn query_corpus(
+    index: &dyn RetrievalIndex,
+    embedder: &Embedder<'_>,
+    query: &str,
+    k: usize,
+) -> Result<(ContentRef, Vec<Hit>), RagError> {
+    let out = embedder.embed(query)?;
+    let hits = index.query(&out.vector, k);
+    let fact_ref = retrieval_result_ref(&hits);
+    Ok((fact_ref, hits))
+}

--- a/crates/kx-model-harness/tests/rag_e2e.rs
+++ b/crates/kx-model-harness/tests/rag_e2e.rs
@@ -1,0 +1,234 @@
+//! DP2 — the RAG ingest/query glue, end-to-end with SYNTHETIC vectors (no model).
+//!
+//! A deterministic keyword embedder makes retrieval predictable + assertable
+//! without a GGUF, so this runs in the default `cargo test` pass. It proves the
+//! whole `ingest_corpus` → `query_corpus` path: relevance ranking, the SN-8
+//! scores-excluded fact, `DatasetId` reproducibility, content-addressed dedup,
+//! and the empty/oversize-k edges. Real-model embedding numerics are covered by
+//! the `kx-llamacpp` smoke (`embed_with`); a model-gated end-to-end belongs to a
+//! `with-model` test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use kx_content::ContentRef;
+use kx_dataset::{InMemoryDataStore, InMemoryRetrievalIndex, RetrievalIndex};
+use kx_inference::{
+    EmbeddingBackend, EmbeddingOutput, EmbeddingPooling, InferenceBackend, InferenceError,
+    InferenceInput, InferenceOutput, InferenceParams,
+};
+use kx_model_harness::{encode_vector_le, ingest_corpus, query_corpus, Embedder};
+use kx_mote::ModelId;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, WarrantSpec,
+};
+use kx_workflow::retrieval_result_ref;
+
+fn model() -> ModelId {
+    ModelId("local".into())
+}
+
+fn warrant() -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::Pure,
+        nd_class: MoteClass::Pure,
+        fs_scope: FsScope {
+            mounts: BTreeMap::new(),
+        },
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef([0u8; 32]),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: model(),
+            max_input_tokens: 2048,
+            max_output_tokens: 2048,
+            max_calls: 100,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 1000,
+            mem_bytes: 1 << 30,
+            wall_clock_ms: 60_000,
+            fd_count: 64,
+            disk_bytes: 1 << 28,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+/// A deterministic keyword embedder: a 3-dim one-hot over {apple, banana, cherry}
+/// by substring presence, so a query about apples retrieves the apple document.
+struct KeywordEmbed;
+
+impl InferenceBackend for KeywordEmbed {
+    fn dispatch(
+        &self,
+        _model_id: &ModelId,
+        _input: &InferenceInput,
+        _params: &InferenceParams,
+        _warrant: &WarrantSpec,
+    ) -> Result<InferenceOutput, InferenceError> {
+        Err(InferenceError::Unsupported {
+            reason: "stub: embeddings only",
+        })
+    }
+    fn supports(&self, _model_id: &ModelId) -> bool {
+        true
+    }
+    fn name(&self) -> &'static str {
+        "keyword-embed"
+    }
+}
+
+impl EmbeddingBackend for KeywordEmbed {
+    fn dispatch_embedding(
+        &self,
+        model_id: &ModelId,
+        text: &str,
+        _pooling: EmbeddingPooling,
+        _warrant: &WarrantSpec,
+    ) -> Result<EmbeddingOutput, InferenceError> {
+        let l = text.to_lowercase();
+        let vector = vec![
+            f32::from(u8::from(l.contains("apple"))),
+            f32::from(u8::from(l.contains("banana"))),
+            f32::from(u8::from(l.contains("cherry"))),
+        ];
+        Ok(EmbeddingOutput {
+            vector,
+            dim: 3,
+            backend_name: "keyword-embed",
+            model_id: model_id.clone(),
+            elapsed: Duration::from_millis(0),
+        })
+    }
+}
+
+const APPLE: &str = "I baked an apple pie";
+const BANANA: &str = "a banana split for dessert";
+const CHERRY: &str = "fresh cherry tart";
+
+#[test]
+fn ingest_then_query_retrieves_the_relevant_doc() {
+    let store = InMemoryDataStore::new();
+    let mut index = InMemoryRetrievalIndex::new();
+    let backend = KeywordEmbed;
+    let (m, w) = (model(), warrant());
+    let embedder = Embedder::new(&backend, &m, &w, EmbeddingPooling::Mean);
+
+    let docs = [APPLE, BANANA, CHERRY];
+    let ds = ingest_corpus(&store, &mut index, &embedder, &docs, &[]).unwrap();
+    // 3 docs × (text row + vector row) = 6 rows; index holds one vector per doc.
+    assert_eq!(ds.len(), 6, "two rows per document");
+    assert_eq!(index.len(), 3);
+
+    let (_fact, hits) =
+        query_corpus(&index, &embedder, "what apple recipe should I try", 1).unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].id,
+        ContentRef::of(APPLE.as_bytes()),
+        "the apple document is the nearest neighbour"
+    );
+    assert!(hits[0].score > 0.99, "cosine ~1 for the matching one-hot");
+}
+
+#[test]
+fn result_fact_excludes_scores_and_is_stable() {
+    let store = InMemoryDataStore::new();
+    let mut index = InMemoryRetrievalIndex::new();
+    let backend = KeywordEmbed;
+    let (m, w) = (model(), warrant());
+    let embedder = Embedder::new(&backend, &m, &w, EmbeddingPooling::Mean);
+    ingest_corpus(&store, &mut index, &embedder, &[APPLE, BANANA, CHERRY], &[]).unwrap();
+
+    let (fact_a, hits_a) = query_corpus(&index, &embedder, "apple", 2).unwrap();
+    let (fact_b, _hits_b) = query_corpus(&index, &embedder, "apple", 2).unwrap();
+    assert_eq!(fact_a, fact_b, "the same query yields the same exact fact");
+    // The fact is purely the ordered refs — scores excluded (SN-8).
+    assert_eq!(
+        fact_a,
+        retrieval_result_ref(&hits_a),
+        "fact = retrieval_result_ref(hits) = ordered refs, no scores"
+    );
+}
+
+#[test]
+fn dataset_id_is_reproducible_across_two_ingests() {
+    let docs = [APPLE, BANANA, CHERRY];
+    let backend = KeywordEmbed;
+    let (m, w) = (model(), warrant());
+    let embedder = Embedder::new(&backend, &m, &w, EmbeddingPooling::Mean);
+
+    let id1 = {
+        let store = InMemoryDataStore::new();
+        let mut index = InMemoryRetrievalIndex::new();
+        ingest_corpus(&store, &mut index, &embedder, &docs, &[])
+            .unwrap()
+            .id()
+    };
+    let id2 = {
+        let store = InMemoryDataStore::new();
+        let mut index = InMemoryRetrievalIndex::new();
+        ingest_corpus(&store, &mut index, &embedder, &docs, &[])
+            .unwrap()
+            .id()
+    };
+    assert_eq!(id1, id2, "same corpus + model + pooling → same DatasetId");
+}
+
+#[test]
+fn duplicate_docs_dedup_in_the_index() {
+    let store = InMemoryDataStore::new();
+    let mut index = InMemoryRetrievalIndex::new();
+    let backend = KeywordEmbed;
+    let (m, w) = (model(), warrant());
+    let embedder = Embedder::new(&backend, &m, &w, EmbeddingPooling::Mean);
+    let ds = ingest_corpus(&store, &mut index, &embedder, &[APPLE, APPLE, BANANA], &[]).unwrap();
+    // The Dataset records every ingest row (6), but the content-addressed index
+    // holds ONE entry per DISTINCT document.
+    assert_eq!(ds.len(), 6);
+    assert_eq!(index.len(), 2, "content-addressed dedup → 2 distinct docs");
+}
+
+#[test]
+fn k_larger_than_corpus_truncates_to_available() {
+    let store = InMemoryDataStore::new();
+    let mut index = InMemoryRetrievalIndex::new();
+    let backend = KeywordEmbed;
+    let (m, w) = (model(), warrant());
+    let embedder = Embedder::new(&backend, &m, &w, EmbeddingPooling::Mean);
+    ingest_corpus(&store, &mut index, &embedder, &[APPLE, BANANA], &[]).unwrap();
+    let (_fact, hits) = query_corpus(&index, &embedder, "apple", 10).unwrap();
+    assert_eq!(hits.len(), 2, "k is clamped to the corpus size");
+}
+
+#[test]
+fn empty_corpus_query_returns_no_hits() {
+    let index = InMemoryRetrievalIndex::new();
+    let backend = KeywordEmbed;
+    let (m, w) = (model(), warrant());
+    let embedder = Embedder::new(&backend, &m, &w, EmbeddingPooling::Mean);
+    let (fact, hits) = query_corpus(&index, &embedder, "apple", 5).unwrap();
+    assert!(hits.is_empty());
+    assert_eq!(
+        fact,
+        retrieval_result_ref(&[]),
+        "empty fact is well-defined"
+    );
+}
+
+#[test]
+fn vector_row_uses_canonical_le_encoding() {
+    // The stored Vector row's bytes are exactly the little-endian f32 sequence —
+    // the reproducible content-addressed form the DatasetId depends on.
+    let v = [1.0f32, -0.5, 2.25];
+    let bytes = encode_vector_le(&v);
+    assert_eq!(bytes.len(), 12);
+    assert_eq!(&bytes[0..4], &1.0f32.to_le_bytes());
+    assert_eq!(&bytes[4..8], &(-0.5f32).to_le_bytes());
+    assert_eq!(&bytes[8..12], &2.25f32.to_le_bytes());
+}

--- a/crates/kx-workflow/src/lib.rs
+++ b/crates/kx-workflow/src/lib.rs
@@ -63,8 +63,8 @@ pub use def::{CompiledMote, CompiledWorkflow, StepDef, StepEdge, StepRef, StepRo
 pub use error::CompileError;
 pub use prompt::{put_rendered_prompt, render_prompts, PromptTemplate, TEMPLATE_KEY};
 pub use recipes::{
-    fan_out_gather, image_batch_describe_reduce, map_reduce, react_tool_loop, retry_until_critic,
-    WorkerKind, IMAGE_REF_KEY,
+    fan_out_gather, image_batch_describe_reduce, map_reduce, rag_pipeline, react_tool_loop,
+    retry_until_critic, WorkerKind, IMAGE_REF_KEY,
 };
 pub use retrieval::{encode_retrieval_fact, retrieval, retrieval_result_ref};
 pub use share::{Manifest, ManifestId};

--- a/crates/kx-workflow/src/recipes.rs
+++ b/crates/kx-workflow/src/recipes.rs
@@ -35,6 +35,7 @@ use kx_mote::{ConfigKey, ConfigVal, EdgeMeta, LogicRef, ModelId, ToolName, ToolV
 
 use crate::def::WorkflowDef;
 use crate::error::CompileError;
+use crate::retrieval::retrieval;
 use crate::synthesis::{deterministic_critic, generator, permissive_warrant, transform};
 
 /// Which builder a fan-out leaf step uses.
@@ -153,6 +154,67 @@ pub fn fan_out_gather(
         worker_logics,
         gather_logic,
     )
+}
+
+/// **RAG (retrieval-augmented generation).** A corpus of `doc_logics` — one
+/// ingest/embed step per document (READ-ONLY-NONDET `generator`s: they read the
+/// world/model to embed + populate a [`kx_dataset::RetrievalIndex`], cached by
+/// ROND identity) → a single `retrieval` query step (ROND, the SN-8 boundary —
+/// its committed fact is the ordered content refs, scores excluded) → a PURE
+/// `assemble` step that grounds an answer in the retrieved top-k content
+/// (consumed by exact hash). Static width (`doc_logics.len()`); `k` is the
+/// authored retrieval width baked into the query step's logic.
+///
+/// Wiring: every `ingest_i ──data──> query` (so the query reads an index
+/// populated from the committed ingest facts) and `query ──data──> assemble`
+/// (the top-k fact is a Data-edge parent the assemble step reads via
+/// `assemble()`). The execution glue that actually embeds + indexes + queries
+/// lives in `kx-model-harness::rag` (it needs the FFI + dataset deps `kx-workflow`
+/// must not carry); this builder is the pure-data structure.
+///
+/// # Errors
+///
+/// [`CompileError::EmptyRecipe`] if `doc_logics` is empty; propagates any edge
+/// error from [`WorkflowDef::add_edge`](crate::WorkflowDef::add_edge).
+pub fn rag_pipeline(
+    seed: u32,
+    model_id: ModelId,
+    capability: ToolName,
+    doc_logics: &[LogicRef],
+    query_logic: LogicRef,
+    assemble_logic: LogicRef,
+) -> Result<WorkflowDef, CompileError> {
+    if doc_logics.is_empty() {
+        return Err(CompileError::EmptyRecipe);
+    }
+    let warrant = permissive_warrant(model_id.clone());
+    let mut wf = WorkflowDef::new(seed);
+
+    // N ingest/embed steps — ROND (read the world/model, StageThenCommit, cached).
+    let mut ingests = Vec::with_capacity(doc_logics.len());
+    for logic in doc_logics {
+        ingests.push(wf.add_step(generator(
+            *logic,
+            model_id.clone(),
+            warrant.clone(),
+            capability.clone(),
+        )));
+    }
+    // The retrieval query step — ROND; the SN-8 boundary (similarity in, exact fact out).
+    let query = wf.add_step(retrieval(
+        query_logic,
+        model_id.clone(),
+        warrant.clone(),
+        capability.clone(),
+    ));
+    // Each ingest feeds the query (its index is populated from the committed ingest facts).
+    for &ingest in &ingests {
+        wf.add_edge(ingest, query, EdgeMeta::data())?;
+    }
+    // The PURE assemble step — grounds an answer in the retrieved top-k (exact refs).
+    let assemble = wf.add_step(transform(assemble_logic, model_id, warrant, capability));
+    wf.add_edge(query, assemble, EdgeMeta::data())?;
+    Ok(wf)
 }
 
 /// **retry-until-critic (bounded best-of-N).** `N` independent attempt steps

--- a/crates/kx-workflow/tests/recipes.rs
+++ b/crates/kx-workflow/tests/recipes.rs
@@ -19,8 +19,8 @@ use kx_content::ContentRef;
 use kx_critic_types::{CheckSpec, SchemaSpec, SchemaTag};
 use kx_mote::{ConfigKey, LogicRef, ModelId, NdClass, ToolName, ToolVersion};
 use kx_workflow::{
-    compile, fan_out_gather, image_batch_describe_reduce, map_reduce, react_tool_loop,
-    retry_until_critic, CompileError, WorkerKind, IMAGE_REF_KEY,
+    compile, fan_out_gather, image_batch_describe_reduce, map_reduce, rag_pipeline,
+    react_tool_loop, retry_until_critic, CompileError, WorkerKind, IMAGE_REF_KEY,
 };
 
 fn model() -> ModelId {
@@ -274,6 +274,101 @@ fn react_tool_loop_wires_reason_act_observe_with_tool_contract() {
     assert!(reason.mote.parents.is_empty(), "reason is the turn root");
     assert_eq!(act.mote.parents.len(), 1, "act depends on reason");
     assert_eq!(observe.mote.parents.len(), 1, "observe depends on act");
+}
+
+// ── rag_pipeline (DP2 — retrieval-augmented generation) ─────────────────────
+
+#[test]
+fn rag_pipeline_wires_n_ingest_then_query_then_assemble() {
+    let docs = [logic(1), logic(2), logic(3)];
+    let query = logic(50);
+    let assemble = logic(60);
+    let wf = rag_pipeline(7, model(), cap(), &docs, query, assemble).unwrap();
+    assert_eq!(ids(&wf), ids(&wf), "recipe compile must be deterministic");
+    let out = compile(&wf).unwrap();
+    assert_eq!(
+        out.motes.len(),
+        docs.len() + 2,
+        "N ingest + 1 query + 1 assemble"
+    );
+
+    // The ingest steps are READ-ONLY-NONDET (they embed + populate the index).
+    for d in &docs {
+        let ingest = out
+            .motes
+            .iter()
+            .find(|m| m.mote.def.logic_ref == *d)
+            .expect("ingest present");
+        assert_eq!(
+            ingest.mote.def.nd_class,
+            NdClass::ReadOnlyNondet,
+            "ingest/embed steps sample"
+        );
+        assert!(ingest.mote.parents.is_empty(), "ingest is a corpus root");
+    }
+
+    // The query (retrieval) step is ROND and parents EVERY ingest.
+    let q = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == query)
+        .expect("query present");
+    assert_eq!(
+        q.mote.def.nd_class,
+        NdClass::ReadOnlyNondet,
+        "retrieval is a nondet read of the index"
+    );
+    assert_eq!(
+        q.mote.parents.len(),
+        docs.len(),
+        "the query reads an index populated by every ingest"
+    );
+
+    // The assemble step is PURE and depends only on the query's top-k fact.
+    let a = out
+        .motes
+        .iter()
+        .find(|m| m.mote.def.logic_ref == assemble)
+        .expect("assemble present");
+    assert_eq!(
+        a.mote.def.nd_class,
+        NdClass::Pure,
+        "assemble folds the retrieved refs deterministically"
+    );
+    assert_eq!(
+        a.mote.parents.len(),
+        1,
+        "assemble depends on the query fact"
+    );
+    assert_eq!(
+        a.mote.parents[0].parent_id, q.mote.id,
+        "assemble's parent is the query step"
+    );
+}
+
+#[test]
+fn rag_pipeline_single_doc_is_three_motes() {
+    let out = compile(&rag_pipeline(0, model(), cap(), &[logic(1)], logic(50), logic(60)).unwrap())
+        .unwrap();
+    assert_eq!(out.motes.len(), 3, "1 ingest + query + assemble");
+}
+
+#[test]
+fn rag_pipeline_seed_changes_identity() {
+    let docs = [logic(1), logic(2)];
+    let a = ids(&rag_pipeline(1, model(), cap(), &docs, logic(50), logic(60)).unwrap());
+    let b = ids(&rag_pipeline(2, model(), cap(), &docs, logic(50), logic(60)).unwrap());
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert_ne!(x, y, "every MoteId shifts with the seed");
+    }
+}
+
+#[test]
+fn rag_pipeline_empty_corpus_is_empty_recipe() {
+    assert_eq!(
+        rag_pipeline(0, model(), cap(), &[], logic(50), logic(60)).unwrap_err(),
+        CompileError::EmptyRecipe
+    );
 }
 
 // ── image_batch_describe_reduce (multi-modal capstone) ──────────────────────


### PR DESCRIPTION
## DP2 (T2.2) — end-to-end RAG: the recipe + the ingest/query glue

Second PR of the **RAG / Datasets data-plane** track (DP1 ✅ #159 → **DP2** → DP3 LanceDB → T3.7 UI). The retrieval-augmented loop the runtime (and later the UI) can drive: *corpus → N embed/ingest Motes → populate a `RetrievalIndex` → retrieval query Mote → PURE assemble grounded in the exact top-k refs*.

### Design split (load-bearing)
`kx-workflow` deps `kx-dataset` but **NOT** `kx-inference`/`kx-llamacpp`. So:
- **Recipe structure** (pure data) lives in `kx-workflow/src/recipes.rs`: `rag_pipeline(seed, model_id, capability, doc_logics, query_logic, assemble_logic)` composes N `generator` ingest steps (ROND) + 1 `retrieval` query step (ROND — reuses the existing SN-8 retrieval Mote) + 1 PURE `transform` assemble; wires `ingest_i ──data──> query` and `query ──data──> assemble`; `EmptyRecipe` guard. Mirrors `map_reduce`/`fan_out_gather`.
- **Execution glue** (FFI) lives in NEW `kx-model-harness/src/rag.rs`: an `Embedder` (bundles backend + model route + warrant + pooling), `ingest_corpus` (embed each doc → store the source text + a canonical-LE `Vector` row → `index.insert`; returns a reproducible `Dataset`) and `query_corpus` (embed the query → `index.query` → `retrieval_result_ref`).

### SN-8
`query_corpus` returns the **scores-excluded** committed fact (`retrieval_result_ref` — ordered refs only) AND the raw `Hit`s (scores for DISPLAY/ranking only — never on a commit path / in a `MoteId`). Downstream consumes the retrieved content by exact hash.

### ★ The f32→ContentRef canonical-encoding gotcha (found in DP1)
`kx-dataset` content-addresses (blake3) the RAW bytes; `ContentSchema::Vector{dim}` is just a tag — NO auto-canonicalization. `encode_vector_le` fixes the little-endian f32 form, so the same embedding → the same `ContentRef` → a reproducible `DatasetId` across machines.

### Golden Rule 8
- **Breaks live?** No. Frozen-trio (scheduler/executor/inference) `src` **diff-EMPTY**; digest `7d22d4bd…` invariant (a0_guard 8/8 — a new recipe, the demo path is untouched). `Cargo.lock` unchanged (no new deps — both crates already had every dep).
- **Compat:** `DatasetId` reproducible (pin model+pooling); the retrieval query is ROND but the commit excludes scores → journal/digest deterministic.
- **Perf:** `InMemoryRetrievalIndex` is brute-force O(n·d) — fine for the demo corpus; DP3 (LanceDB) gives sub-linear ANN. Ingest/embed steps are ROND → memoized (re-ingest is a cache hit).
- **Security:** ingest/query text is untrusted but embedded locally (no egress); the warrant route is gated by the backend (DP1).

### Tests
- 4 `rag_pipeline` recipe tests in `kx-workflow/tests/recipes.rs` (DAG shape: N ingest ROND + query ROND + assemble PURE, edges; single-doc; seed-shifts-identity; `EmptyRecipe`).
- 7 synthetic-vector glue e2e in `kx-model-harness/tests/rag_e2e.rs` (a deterministic keyword embedder — no model): relevance ranking, scores-excluded + stable fact, reproducible `DatasetId` across two ingests, content-addressed dedup, k > corpus, empty corpus, canonical LE encoding.
- Full `cargo test --workspace` green; clippy `-D warnings`, fmt, doc `-D warnings`, build-no-inference all green. Real-model embedding numerics covered by the `kx-llamacpp` smoke (DP1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)