### PR TITLE
feat(dataset-hnsw): DP3 (T2.3) — opt-in hnsw_rs ANN scale backend behind RetrievalIndex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,16 +24,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anndists"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8396b473aa0bceed68fb32462505387ea39fa47c7029417e0a49f10592b036"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -150,6 +217,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -389,6 +465,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +501,16 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -461,6 +563,31 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -519,6 +646,41 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -730,6 +892,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -759,6 +923,31 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hnsw_rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5258f079b97bf2e8311ff9579e903c899dcbac0d9a138d62e9a066778bd07"
+dependencies = [
+ "anndists",
+ "anyhow",
+ "bincode 1.3.3",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "lazy_static",
+ "log",
+ "mmap-rs",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+]
 
 [[package]]
 name = "http"
@@ -1003,6 +1192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1222,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,7 +1267,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1063,7 +1282,7 @@ dependencies = [
  "proptest",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1081,7 +1300,7 @@ dependencies = [
 name = "kx-catalog"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-content",
  "kx-dataset",
@@ -1094,7 +1313,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1111,7 +1330,7 @@ dependencies = [
  "kx-runtime",
  "kx-warrant",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -1126,7 +1345,7 @@ dependencies = [
  "kx-runtime",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tonic-health",
@@ -1145,7 +1364,7 @@ dependencies = [
  "rkyv",
  "serde",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1154,7 +1373,7 @@ dependencies = [
 name = "kx-context-assembler"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "bytes",
  "kx-content",
@@ -1167,7 +1386,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1190,7 +1409,7 @@ dependencies = [
  "kx-worker",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -1214,12 +1433,12 @@ dependencies = [
 name = "kx-critic-types"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "proptest",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1231,14 +1450,25 @@ dependencies = [
  "kx-mote",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "kx-dataset-hnsw"
+version = "0.0.1"
+dependencies = [
+ "hnsw_rs",
+ "kx-content",
+ "kx-dataset",
+ "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "kx-executor"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "bytes",
  "kx-capability",
@@ -1256,12 +1486,12 @@ dependencies = [
  "kx-tool-registry",
  "kx-warrant",
  "libc",
- "nix",
+ "nix 0.29.0",
  "proptest",
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1270,7 +1500,7 @@ dependencies = [
 name = "kx-fleet"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-catalog",
  "kx-mote",
@@ -1280,7 +1510,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1288,7 +1518,7 @@ dependencies = [
 name = "kx-gateway"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "futures-util",
  "kx-capability",
  "kx-catalog",
@@ -1308,13 +1538,13 @@ dependencies = [
  "kx-warrant",
  "kx-worker",
  "kx-workflow",
- "nix",
+ "nix 0.29.0",
  "rcgen",
  "serde",
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -1339,7 +1569,7 @@ dependencies = [
  "kx-warrant",
  "proptest",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1366,7 +1596,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1388,7 +1618,7 @@ dependencies = [
  "proptest",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -1398,7 +1628,7 @@ dependencies = [
 name = "kx-journal"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-content",
  "kx-mote",
@@ -1407,7 +1637,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1420,7 +1650,7 @@ dependencies = [
  "proptest",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -1447,7 +1677,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "ureq",
  "url",
@@ -1464,7 +1694,7 @@ dependencies = [
  "proptest",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1473,7 +1703,7 @@ dependencies = [
 name = "kx-model-harness"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-capability",
  "kx-capture",
@@ -1501,7 +1731,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "ureq",
 ]
@@ -1516,7 +1746,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1527,7 +1757,7 @@ dependencies = [
  "kx-mote",
  "proptest",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1536,13 +1766,13 @@ dependencies = [
 name = "kx-mote"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-critic-types",
  "proptest",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1555,7 +1785,7 @@ dependencies = [
  "kx-mote",
  "proptest",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1573,14 +1803,14 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "kx-projection"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "criterion",
  "kx-content",
@@ -1592,7 +1822,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1601,7 +1831,7 @@ dependencies = [
 name = "kx-proto"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "kx-content",
  "kx-critic-types",
  "kx-mote",
@@ -1610,7 +1840,7 @@ dependencies = [
  "prost",
  "protoc-bin-vendored",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tonic-build",
@@ -1626,14 +1856,14 @@ dependencies = [
  "kx-warrant",
  "proptest",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "kx-runtime"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-audit",
  "kx-capability",
@@ -1649,7 +1879,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1666,7 +1896,7 @@ dependencies = [
  "kx-warrant",
  "proptest",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1679,7 +1909,7 @@ dependencies = [
  "kx-mote",
  "kx-projection",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1687,7 +1917,7 @@ dependencies = [
 name = "kx-tool-registry"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-content",
  "kx-mote",
@@ -1695,7 +1925,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1704,14 +1934,14 @@ dependencies = [
 name = "kx-warrant"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-content",
  "kx-mote",
  "proptest",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1730,7 +1960,7 @@ dependencies = [
  "kx-warrant",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -1740,7 +1970,7 @@ dependencies = [
 name = "kx-workflow"
 version = "0.0.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "blake3",
  "kx-content",
  "kx-critic-types",
@@ -1755,7 +1985,7 @@ dependencies = [
  "proptest",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1810,10 +2040,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1860,6 +2108,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmap-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecce9d566cb9234ae3db9e249c8b55665feaaf32b0859ff1e27e310d2beb3d8"
+dependencies = [
+ "bitflags",
+ "combine",
+ "libc",
+ "mach2",
+ "nix 0.30.1",
+ "sysctl",
+ "thiserror 2.0.18",
+ "widestring",
+ "windows",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2155,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1932,10 +2209,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -1948,6 +2241,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pem"
@@ -2006,6 +2322,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2310,6 +2641,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2671,15 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2530,6 +2890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +3096,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,7 +3128,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2756,6 +3145,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3121,7 +3521,7 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -3199,6 +3599,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -3384,12 +3790,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3404,7 +3847,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3418,19 +3861,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3440,9 +3904,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3458,9 +3934,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3470,9 +3958,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/kx-chaos",
     "crates/kx-workflow",
     "crates/kx-dataset",
+    "crates/kx-dataset-hnsw",
     "crates/kx-critic-types",
     "crates/kx-critic",
     "crates/kx-capture",
@@ -91,6 +92,13 @@ rcgen              = { version = "0.13", default-features = false, features = ["
 criterion          = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 rkyv               = "0.8"
 rusqlite           = { version = "0.32", features = ["bundled"] }
+# DP3 (T2.3): pure-Rust HNSW (Malkov-Yashunin) ANN for the opt-in kx-dataset-hnsw
+# scale backend. Apache-2.0/MIT; `default-features = false` keeps the SIMD
+# (`simdeez_f`, x86) + nightly (`stdsimd`) features OFF in the default build — the
+# index is correct without them. No C/C++ toolchain (unlike usearch). The full
+# transitive tree (anndists/mmap-rs/rayon/hashbrown/…) is permissive; cargo-deny
+# (all-features) gates it.
+hnsw_rs            = { version = "0.3", default-features = false }
 # Workspace member path-deps carry an explicit `version = "0.0.1"` matching
 # each member's `[package].version`. Without it, cargo-deny flags path-only
 # deps as wildcards (the version constraint is unconstrained). The version
@@ -132,6 +140,11 @@ kx-workflow          = { path = "crates/kx-workflow",          version = "0.0.1"
 # The data-management seam (P4.1c) — typed (tensor/vector/blob/multi-modal)
 # DataStore/Dataset/RetrievalIndex over committed content; journal-authoritative.
 kx-dataset           = { path = "crates/kx-dataset",           version = "0.0.1" }
+# The opt-in SCALE retrieval backend (DP3, T2.3) — a file-backed in-process HNSW
+# index implementing kx-dataset::RetrievalIndex via the pure-Rust hnsw_rs crate.
+# Off the truth path (SN-8); the exact InMemory index stays the reproducible
+# default. Consumed only behind an opt-in feature (kx-gateway's `hnsw`, T3.7).
+kx-dataset-hnsw      = { path = "crates/kx-dataset-hnsw",      version = "0.0.1" }
 # Deterministic-critic vocabulary (P4.2) — CriticVerdict / CriticReason / CheckSpec.
 # Parser-free + dataset-free so kx-mote can embed a CheckSpec in MoteDef without a
 # dependency cycle or inheriting regex/serde_json.

--- a/crates/kx-dataset-hnsw/Cargo.toml
+++ b/crates/kx-dataset-hnsw/Cargo.toml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-dataset-hnsw"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx opt-in SCALE retrieval backend (DP3, T2.3) — a file-backed, in-process HNSW (approximate-nearest-neighbour) index implementing kx-dataset::RetrievalIndex via the pure-Rust hnsw_rs crate, for corpora too large for the default exact brute-force scan. Off the truth path (SN-8): similarity stays inside the retrieval Mote; only the ordered neighbour-ref SET is committed. The on-disk form is a REBUILDABLE CACHE of (ContentRef, vector) records — the HNSW graph is rebuilt on open, so a format break is recovered by replay (D40), never a migration. The exact InMemoryRetrievalIndex stays the reproducible DEFAULT; this is the opt-in scale path."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The RetrievalIndex trait + Hit this backend implements (the shared seam), and
+# InMemoryRetrievalIndex for parity tests. FFI-free leaf.
+kx-dataset = { workspace = true }
+# Content-addressed identity the vectors are keyed by (the sidecar map + the
+# cache records are keyed by 32-byte ContentRef).
+kx-content = { workspace = true }
+# Pure-Rust HNSW (Malkov-Yashunin); Apache-2.0/MIT, `default = []` (no SIMD/nightly
+# features) so the default build pulls no x86-simd / nightly std::simd surface.
+hnsw_rs    = { workspace = true }
+thiserror  = { workspace = true }
+
+[dev-dependencies]
+# Durability / corrupt-file / path-traversal integration tests write a cache file.
+tempfile   = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-dataset-hnsw/src/error.rs
+++ b/crates/kx-dataset-hnsw/src/error.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Errors for the HNSW retrieval backend.
+
+/// An error opening, persisting, or decoding the HNSW cache.
+///
+/// The cache is a rebuildable projection (D40), so callers recover from
+/// `Corrupt` / `Io` by rebuilding the index from the journal — never by trusting
+/// a partially-decoded file.
+#[derive(Debug, thiserror::Error)]
+pub enum HnswError {
+    /// An I/O error reading or writing the cache file.
+    #[error("hnsw cache i/o: {0}")]
+    Io(#[from] std::io::Error),
+    /// The cache file is malformed (bad header, truncation, or trailing bytes);
+    /// rebuild the index from the journal.
+    #[error("corrupt hnsw cache: {0}")]
+    Corrupt(&'static str),
+    /// The cache path contained a parent-dir (`..`) traversal component and was
+    /// refused.
+    #[error("hnsw cache path rejected: parent-dir (`..`) component")]
+    PathTraversal,
+}

--- a/crates/kx-dataset-hnsw/src/index.rs
+++ b/crates/kx-dataset-hnsw/src/index.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The HNSW retrieval index — an approximate-nearest-neighbour `RetrievalIndex`.
+
+use std::collections::HashMap;
+
+use hnsw_rs::prelude::{DistCosine, Hnsw};
+use kx_content::ContentRef;
+use kx_dataset::{Hit, RetrievalIndex};
+
+/// Construction + search parameters for the HNSW graph.
+///
+/// The defaults target a 10k–1M-vector single-node corpus. Raise
+/// `max_nb_connection` / `ef_construction` for higher build recall (at the cost
+/// of build time + memory), and `ef_search` for higher query recall.
+#[derive(Clone, Copy, Debug)]
+pub struct HnswParams {
+    /// `M` — maximum neighbour links per node per layer (graph degree).
+    pub max_nb_connection: usize,
+    /// `efConstruction` — candidate-list width during insertion (build recall).
+    pub ef_construction: usize,
+    /// Maximum graph layer count (Malkov-Yashunin `mL`).
+    pub max_layer: usize,
+    /// Expected element count — a graph-sizing hint; inserting beyond it is allowed.
+    pub capacity_hint: usize,
+    /// `ef` — candidate-list width during search (query recall). Clamped up to `k`.
+    pub ef_search: usize,
+}
+
+impl Default for HnswParams {
+    fn default() -> Self {
+        Self {
+            max_nb_connection: 16,
+            ef_construction: 200,
+            max_layer: 16,
+            capacity_hint: 10_000,
+            ef_search: 64,
+        }
+    }
+}
+
+/// A file-backed, in-process approximate-nearest-neighbour index over embedding
+/// vectors, implementing the shared `RetrievalIndex` seam via `hnsw_rs`.
+///
+/// **SN-8.** Like every `RetrievalIndex`, this is used ONLY inside the
+/// ReadOnlyNondet retrieval Mote: similarity stays inside, and only the ordered
+/// neighbour-ref SET is committed (matched downstream by exact hash). The
+/// approximate, build-order-sensitive nature of HNSW is therefore safe — a score
+/// never reaches a `MoteId`. For reproducible-by-reference corpora the exact
+/// `InMemoryRetrievalIndex` remains the default; this is the opt-in scale path.
+///
+/// **Content-addressed inserts.** Because ids are content refs (D17), the same
+/// ref always carries the same vector, so `insert` is idempotent by ref (a repeat
+/// is a no-op). A single embedding dimension is assumed per index; a
+/// dimension-mismatched insert is skipped.
+pub struct HnswRetrievalIndex {
+    hnsw: Hnsw<'static, f32, DistCosine>,
+    params: HnswParams,
+    /// `DataId` (the index into this Vec) -> the content ref it stands for.
+    ids: Vec<ContentRef>,
+    /// Content ref -> `DataId`, for idempotent-by-ref inserts.
+    by_ref: HashMap<ContentRef, usize>,
+    /// `DataId` -> the raw vector, retained so the index persists as a rebuildable
+    /// cache (the HNSW graph itself is never serialized).
+    vectors: Vec<Vec<f32>>,
+    /// The fixed embedding dimension, set by the first insert.
+    dim: Option<usize>,
+}
+
+impl HnswRetrievalIndex {
+    /// Create an empty index with default parameters.
+    pub fn new() -> Self {
+        Self::with_params(HnswParams::default())
+    }
+
+    /// Create an empty index with explicit parameters.
+    pub fn with_params(params: HnswParams) -> Self {
+        let hnsw: Hnsw<'static, f32, DistCosine> = Hnsw::new(
+            params.max_nb_connection,
+            params.capacity_hint.max(1),
+            params.max_layer,
+            params.ef_construction,
+            DistCosine,
+        );
+        Self {
+            hnsw,
+            params,
+            ids: Vec::new(),
+            by_ref: HashMap::new(),
+            vectors: Vec::new(),
+            dim: None,
+        }
+    }
+
+    /// The embedding dimension once known (after the first insert).
+    pub fn dim(&self) -> Option<usize> {
+        self.dim
+    }
+
+    /// Snapshot for persistence: the dimension + the `(ref, vector)` records in
+    /// `DataId` order. The HNSW graph is intentionally NOT exported — it is
+    /// rebuilt from these records on `open`.
+    pub(crate) fn snapshot(&self) -> (u32, &[ContentRef], &[Vec<f32>]) {
+        let dim = u32::try_from(self.dim.unwrap_or(0)).unwrap_or(u32::MAX);
+        (dim, &self.ids, &self.vectors)
+    }
+}
+
+impl Default for HnswRetrievalIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RetrievalIndex for HnswRetrievalIndex {
+    fn insert(&mut self, id: ContentRef, vector: Vec<f32>) {
+        // Content-addressed: a known ref already carries this exact vector → no-op.
+        if self.by_ref.contains_key(&id) {
+            return;
+        }
+        // One embedding dimension per index; the first insert fixes it.
+        match self.dim {
+            None => self.dim = Some(vector.len()),
+            Some(d) if d == vector.len() => {}
+            Some(_) => return, // skip a dimension-mismatched insert
+        }
+        let data_id = self.ids.len();
+        self.hnsw.insert((vector.as_slice(), data_id));
+        self.by_ref.insert(id, data_id);
+        self.ids.push(id);
+        self.vectors.push(vector);
+    }
+
+    fn query(&self, query: &[f32], k: usize) -> Vec<Hit> {
+        if k == 0 || self.ids.is_empty() {
+            return Vec::new();
+        }
+        // A wrong-dimension query has no meaningful neighbours in this index.
+        if self.dim.is_none_or(|d| d != query.len()) {
+            return Vec::new();
+        }
+        let ef = self.params.ef_search.max(k);
+        let neighbours = self.hnsw.search(query, k, ef);
+        let mut hits: Vec<Hit> = neighbours
+            .iter()
+            .filter_map(|n| {
+                self.ids.get(n.get_origin_id()).map(|&id| Hit {
+                    id,
+                    // DistCosine distance == 1 - cosine_similarity → similarity == 1 - distance.
+                    score: 1.0 - n.get_distance(),
+                })
+            })
+            .collect();
+        // Deterministic order for the committed ordered-ref fact: score desc, then
+        // ascending content ref — mirrors InMemoryRetrievalIndex's stable tiebreak.
+        hits.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.id.as_bytes().cmp(b.id.as_bytes()))
+        });
+        hits.truncate(k);
+        hits
+    }
+
+    fn len(&self) -> usize {
+        self.ids.len()
+    }
+}

--- a/crates/kx-dataset-hnsw/src/lib.rs
+++ b/crates/kx-dataset-hnsw/src/lib.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-dataset-hnsw` — the opt-in SCALE retrieval backend (DP3, T2.3).
+//!
+//! A file-backed, in-process approximate-nearest-neighbour (HNSW) index that
+//! implements `kx_dataset::RetrievalIndex` via the pure-Rust `hnsw_rs` crate, for
+//! corpora too large for the default exact brute-force scan.
+//!
+//! # Boundaries (load-bearing)
+//!
+//! - **SN-8.** Used ONLY inside the ReadOnlyNondet retrieval Mote. Similarity
+//!   stays inside; only the ordered neighbour-ref SET is committed, matched
+//!   downstream by exact hash. The approximate, build-order-sensitive nature of
+//!   HNSW never reaches a `MoteId` — so ANN non-determinism is safe here.
+//! - **Journal-authoritative.** The on-disk form is a REBUILDABLE CACHE of
+//!   `(ContentRef, vector)` records; the HNSW graph is rebuilt from them on
+//!   `open`. The `hnsw_rs` internal dump format is intentionally NOT used, so the
+//!   cache is decoupled from it: a format break or corrupt file is recovered by
+//!   rebuild-from-journal (D40), never a migration.
+//! - **Off the default path.** The exact `InMemoryRetrievalIndex` stays the
+//!   reproducible default; this crate is consumed only behind an opt-in feature,
+//!   so the frozen execution kernel + the default build stay byte-unchanged.
+#![forbid(unsafe_code)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )
+)]
+
+mod error;
+mod index;
+mod open;
+mod persist;
+
+pub use error::HnswError;
+pub use index::{HnswParams, HnswRetrievalIndex};
+pub use open::{dump, open, open_with_params};
+
+#[cfg(test)]
+mod tests;

--- a/crates/kx-dataset-hnsw/src/open.rs
+++ b/crates/kx-dataset-hnsw/src/open.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Operator-facing persistence: open an index from a cache file (rebuilding the
+//! HNSW graph from records) and dump it back.
+//!
+//! Path validation rejects `..` traversal; the cache is a rebuildable projection,
+//! so an absent file degrades to an empty index and a malformed file degrades to
+//! a graceful error (the caller rebuilds from the journal) — never a panic.
+
+use std::path::{Component, Path};
+
+use kx_dataset::RetrievalIndex;
+
+use crate::error::HnswError;
+use crate::index::{HnswParams, HnswRetrievalIndex};
+use crate::persist::{decode_records, encode_records};
+
+/// Reject any path containing a parent-dir (`..`) component. Defence-in-depth:
+/// the cache path is operator-configured, not request-derived, but the backend
+/// refuses to follow a traversal regardless.
+fn reject_traversal(path: &Path) -> Result<(), HnswError> {
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(HnswError::PathTraversal);
+    }
+    Ok(())
+}
+
+/// Open an index from `path` with default parameters. An absent file yields an
+/// empty index (first run); a malformed file is a `Corrupt` error (the caller
+/// rebuilds from the journal).
+pub fn open(path: &Path) -> Result<HnswRetrievalIndex, HnswError> {
+    open_with_params(path, HnswParams::default())
+}
+
+/// Open an index from `path` with explicit parameters. The graph is rebuilt by
+/// re-inserting the cached records; the sizing hint is widened to the record
+/// count for graph quality.
+pub fn open_with_params(path: &Path, params: HnswParams) -> Result<HnswRetrievalIndex, HnswError> {
+    reject_traversal(path)?;
+    if !path.exists() {
+        return Ok(HnswRetrievalIndex::with_params(params));
+    }
+    let bytes = std::fs::read(path)?;
+    let (_dim, records) = decode_records(&bytes)?;
+    let mut build = params;
+    build.capacity_hint = records.len().max(params.capacity_hint).max(1);
+    let mut index = HnswRetrievalIndex::with_params(build);
+    for (id, vector) in records {
+        index.insert(id, vector);
+    }
+    Ok(index)
+}
+
+/// Persist `index` to `path` as a rebuildable cache (records only; the graph is
+/// rebuilt on open). Overwrites any existing file.
+pub fn dump(index: &HnswRetrievalIndex, path: &Path) -> Result<(), HnswError> {
+    reject_traversal(path)?;
+    let (dim, ids, vectors) = index.snapshot();
+    let bytes = encode_records(dim, ids, vectors);
+    std::fs::write(path, bytes)?;
+    Ok(())
+}

--- a/crates/kx-dataset-hnsw/src/persist.rs
+++ b/crates/kx-dataset-hnsw/src/persist.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The on-disk cache format: a flat, deterministic, little-endian encoding of the
+//! `(content-ref, vector)` records.
+//!
+//! This is a REBUILDABLE CACHE, never a source of truth — the HNSW graph is
+//! rebuilt from these records on open, so the format is decoupled from
+//! `hnsw_rs`'s internal dump format and a break is recovered by replay (D40), not
+//! a migration. The decoder is total + panic-free over arbitrary bytes and
+//! treats the file as untrusted input (bounded allocation, fail-closed).
+
+use kx_content::ContentRef;
+
+use crate::error::HnswError;
+
+/// Magic + format-version header. Bump the trailing digits on a format change.
+pub(crate) const MAGIC: [u8; 8] = *b"KXHNSW01";
+
+/// Decoded cache payload: one `(content-ref, embedding)` record per indexed row.
+pub(crate) type Records = Vec<(ContentRef, Vec<f32>)>;
+
+/// Encode the records into the flat cache form:
+/// `MAGIC | dim:u32le | count:u32le | (ref:32B | f32le * dim) * count`.
+pub(crate) fn encode_records(dim: u32, ids: &[ContentRef], vectors: &[Vec<f32>]) -> Vec<u8> {
+    let count = u32::try_from(ids.len()).unwrap_or(u32::MAX);
+    let mut out = Vec::with_capacity(16 + ids.len() * (32 + dim as usize * 4));
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&dim.to_le_bytes());
+    out.extend_from_slice(&count.to_le_bytes());
+    for (id, vector) in ids.iter().zip(vectors.iter()) {
+        out.extend_from_slice(id.as_bytes());
+        for x in vector {
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+    out
+}
+
+/// A reading cursor that never indexes out of bounds (fail-closed loader).
+fn take<'a>(bytes: &'a [u8], off: &mut usize, n: usize) -> Result<&'a [u8], HnswError> {
+    let end = off
+        .checked_add(n)
+        .ok_or(HnswError::Corrupt("length overflow"))?;
+    let slice = bytes
+        .get(*off..end)
+        .ok_or(HnswError::Corrupt("truncated"))?;
+    *off = end;
+    Ok(slice)
+}
+
+/// Decode the flat cache form. Total + panic-free over arbitrary bytes: any
+/// malformed input is a graceful `Corrupt` error, never a panic, and allocation
+/// is bounded by the actual byte length (a hostile `count`/`dim` cannot OOM).
+pub(crate) fn decode_records(bytes: &[u8]) -> Result<(u32, Records), HnswError> {
+    let mut off = 0usize;
+    if take(bytes, &mut off, 8)? != MAGIC {
+        return Err(HnswError::Corrupt("bad magic"));
+    }
+    let dim = u32::from_le_bytes(
+        take(bytes, &mut off, 4)?
+            .try_into()
+            .map_err(|_| HnswError::Corrupt("dim"))?,
+    );
+    let count = u32::from_le_bytes(
+        take(bytes, &mut off, 4)?
+            .try_into()
+            .map_err(|_| HnswError::Corrupt("count"))?,
+    );
+    let dim_usize = dim as usize;
+    let count_usize = count as usize;
+    // Bound the pre-allocation by the remaining bytes — a record is at least 32
+    // bytes (the ref), so the file cannot declare more records than it can hold.
+    let mut out = Vec::with_capacity(count_usize.min(bytes.len() / 32));
+    for _ in 0..count_usize {
+        let id_bytes: [u8; 32] = take(bytes, &mut off, 32)?
+            .try_into()
+            .map_err(|_| HnswError::Corrupt("ref"))?;
+        let id = ContentRef::from_bytes(id_bytes);
+        let mut vector = Vec::with_capacity(dim_usize.min(bytes.len() / 4));
+        for _ in 0..dim_usize {
+            let f = f32::from_le_bytes(
+                take(bytes, &mut off, 4)?
+                    .try_into()
+                    .map_err(|_| HnswError::Corrupt("vector element"))?,
+            );
+            vector.push(f);
+        }
+        out.push((id, vector));
+    }
+    // Reject trailing garbage — the cache must be exactly the declared records.
+    if off != bytes.len() {
+        return Err(HnswError::Corrupt("trailing bytes"));
+    }
+    Ok((dim, out))
+}

--- a/crates/kx-dataset-hnsw/src/tests.rs
+++ b/crates/kx-dataset-hnsw/src/tests.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Unit tests: query correctness, parity with the exact index, determinism,
+//! idempotency, dimension handling, and the cache codec round-trip.
+
+use kx_content::ContentRef;
+use kx_dataset::{InMemoryRetrievalIndex, RetrievalIndex};
+
+use crate::index::HnswRetrievalIndex;
+use crate::persist::{decode_records, encode_records};
+
+fn cref(tag: u8) -> ContentRef {
+    ContentRef::from_bytes([tag; 32])
+}
+
+/// A pure one-hot vector — orthogonal across `hot`, so cosine top-1 is unambiguous.
+fn onehot(dim: usize, hot: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; dim];
+    if let Some(slot) = v.get_mut(hot) {
+        *slot = 1.0;
+    }
+    v
+}
+
+#[test]
+fn nearest_is_matching_onehot() {
+    let mut idx = HnswRetrievalIndex::new();
+    for h in 0..8usize {
+        idx.insert(cref(h as u8), onehot(8, h));
+    }
+    let hits = idx.query(&onehot(8, 3), 1);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, cref(3));
+}
+
+#[test]
+fn top1_parity_with_inmemory() {
+    let mut hnsw = HnswRetrievalIndex::new();
+    let mut exact = InMemoryRetrievalIndex::new();
+    for h in 0..16usize {
+        hnsw.insert(cref(h as u8), onehot(16, h));
+        exact.insert(cref(h as u8), onehot(16, h));
+    }
+    for h in 0..16usize {
+        let q = onehot(16, h);
+        let a = hnsw.query(&q, 1);
+        let b = exact.query(&q, 1);
+        assert_eq!(a[0].id, b[0].id, "top-1 mismatch at {h}");
+    }
+}
+
+#[test]
+fn deterministic_repeat_query_on_fixed_graph() {
+    let mut idx = HnswRetrievalIndex::new();
+    for h in 0..32usize {
+        idx.insert(cref(h as u8), onehot(32, h));
+    }
+    let q = onehot(32, 7);
+    // A fixed graph is deterministic across repeated queries (the committed
+    // ordered-ref fact is stable for a given index state).
+    assert_eq!(idx.query(&q, 5), idx.query(&q, 5));
+}
+
+#[test]
+fn idempotent_duplicate_insert() {
+    let mut idx = HnswRetrievalIndex::new();
+    idx.insert(cref(1), onehot(4, 0));
+    idx.insert(cref(1), onehot(4, 0));
+    assert_eq!(idx.len(), 1);
+}
+
+#[test]
+fn dim_mismatch_insert_skipped_and_query_empty() {
+    let mut idx = HnswRetrievalIndex::new();
+    idx.insert(cref(1), onehot(4, 0));
+    idx.insert(cref(2), onehot(8, 0)); // wrong dim → skipped
+    assert_eq!(idx.len(), 1);
+    assert!(idx.query(&onehot(8, 0), 1).is_empty()); // wrong-dim query → empty
+}
+
+#[test]
+fn empty_index_and_k_zero_are_empty() {
+    let empty = HnswRetrievalIndex::new();
+    assert!(empty.is_empty());
+    assert!(empty.query(&onehot(4, 0), 3).is_empty());
+
+    let mut one = HnswRetrievalIndex::new();
+    one.insert(cref(1), onehot(4, 0));
+    assert!(one.query(&onehot(4, 0), 0).is_empty());
+}
+
+#[test]
+fn query_respects_k_and_len_bounds() {
+    let mut idx = HnswRetrievalIndex::new();
+    for h in 0..8usize {
+        idx.insert(cref(h as u8), onehot(8, h));
+    }
+    let q = onehot(8, 2);
+    // k larger than the corpus: never returns more than is indexed, and the
+    // exact-present vector is the nearest (recall@1 — distance 0 is the global min).
+    let many = idx.query(&q, 100);
+    assert!(!many.is_empty());
+    assert!(many.len() <= idx.len());
+    assert_eq!(many[0].id, cref(2));
+    // k smaller than the result set: the output is truncated to k.
+    let few = idx.query(&q, 2);
+    assert!(few.len() <= 2);
+    assert_eq!(few[0].id, cref(2));
+}
+
+#[test]
+fn record_codec_roundtrip() {
+    let ids = vec![cref(1), cref(2)];
+    let vectors = vec![vec![1.0f32, 2.0, 3.0], vec![4.0, 5.0, 6.0]];
+    let bytes = encode_records(3, &ids, &vectors);
+    let (dim, recs) = decode_records(&bytes).unwrap();
+    assert_eq!(dim, 3);
+    assert_eq!(
+        recs,
+        vec![
+            (cref(1), vec![1.0, 2.0, 3.0]),
+            (cref(2), vec![4.0, 5.0, 6.0]),
+        ]
+    );
+}
+
+#[test]
+fn codec_rejects_garbage_and_truncation() {
+    assert!(decode_records(b"nope").is_err());
+    let bytes = encode_records(2, &[cref(1)], &[vec![1.0f32, 2.0]]);
+    let mut truncated = bytes.clone();
+    truncated.truncate(bytes.len() - 1);
+    assert!(decode_records(&truncated).is_err());
+    let mut trailing = bytes;
+    trailing.push(0xFF);
+    assert!(decode_records(&trailing).is_err());
+}

--- a/crates/kx-dataset-hnsw/tests/persistence.rs
+++ b/crates/kx-dataset-hnsw/tests/persistence.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Durability + fail-closed integration tests for the HNSW cache: dump → drop →
+//! reopen preserves the corpus + its nearest neighbours; absent files open empty;
+//! corrupt files and path-traversal are rejected.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::cast_precision_loss)]
+
+use std::path::PathBuf;
+
+use kx_content::ContentRef;
+use kx_dataset::{InMemoryRetrievalIndex, RetrievalIndex};
+use kx_dataset_hnsw::{dump, open, HnswRetrievalIndex};
+use tempfile::tempdir;
+
+fn cref(tag: u64) -> ContentRef {
+    let mut b = [0u8; 32];
+    b[..8].copy_from_slice(&tag.to_le_bytes());
+    ContentRef::from_bytes(b)
+}
+
+/// Graded 2-D angular embeddings → an unambiguous cosine nearest neighbour
+/// (graph-structure-independent), so durability can be asserted via recall.
+fn angle_vec(h: u64) -> Vec<f32> {
+    let t = h as f32 * 0.21;
+    vec![t.cos(), t.sin()]
+}
+
+#[test]
+fn dump_then_open_preserves_corpus_and_nearest() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("corpus.hnsw");
+
+    let mut idx = HnswRetrievalIndex::new();
+    let mut exact = InMemoryRetrievalIndex::new();
+    for h in 0..24u64 {
+        let v = angle_vec(h);
+        idx.insert(cref(h), v.clone());
+        exact.insert(cref(h), v);
+    }
+    dump(&idx, &path).unwrap();
+    drop(idx);
+
+    let reopened = open(&path).unwrap();
+    assert_eq!(reopened.len(), 24);
+    // The reloaded index returns the same exact nearest neighbour as the
+    // brute-force baseline (data + queryability survived the round-trip).
+    for h in [0u64, 5, 11, 23] {
+        let q = angle_vec(h);
+        assert_eq!(
+            reopened.query(&q, 1)[0].id,
+            exact.query(&q, 1)[0].id,
+            "nearest mismatch after reload at {h}"
+        );
+    }
+}
+
+#[test]
+fn open_absent_path_is_empty() {
+    let dir = tempdir().unwrap();
+    let idx = open(&dir.path().join("missing.hnsw")).unwrap();
+    assert!(idx.is_empty());
+}
+
+#[test]
+fn open_corrupt_file_is_err() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("bad.hnsw");
+    std::fs::write(&path, b"not a valid kx hnsw cache file").unwrap();
+    assert!(open(&path).is_err());
+}
+
+#[test]
+fn path_traversal_is_rejected_on_open_and_dump() {
+    let traversal = PathBuf::from("../escape.hnsw");
+    assert!(open(&traversal).is_err());
+    let idx = HnswRetrievalIndex::new();
+    assert!(dump(&idx, &traversal).is_err());
+}

--- a/crates/kx-dataset-hnsw/tests/scale.rs
+++ b/crates/kx-dataset-hnsw/tests/scale.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scale-smoke: a 25k-vector HNSW must answer queries materially faster than the
+//! exact O(n) brute-force scan — the whole point of the opt-in DP3 backend.
+//! `#[ignore]`; run by `just scale-smoke` in `--release`.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation
+)]
+
+use std::time::Instant;
+
+use kx_content::ContentRef;
+use kx_dataset::{InMemoryRetrievalIndex, RetrievalIndex};
+use kx_dataset_hnsw::HnswRetrievalIndex;
+
+/// Cheap deterministic pseudo-vectors via xorshift — no `rand` dependency.
+fn vec_for(seed: u64, dim: usize) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    (0..dim)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            // top 24 bits → [0, 1) → [-0.5, 0.5)
+            (s >> 40) as f32 / 16_777_216.0 - 0.5
+        })
+        .collect()
+}
+
+fn cref(i: u64) -> ContentRef {
+    let mut b = [0u8; 32];
+    b[..8].copy_from_slice(&i.to_le_bytes());
+    ContentRef::from_bytes(b)
+}
+
+#[test]
+#[ignore = "scale-smoke; run via `just scale-smoke` in --release"]
+fn hnsw_25k_query_beats_brute_force() {
+    const N: u64 = 25_000;
+    const DIM: usize = 64;
+
+    let mut hnsw = HnswRetrievalIndex::new();
+    let mut exact = InMemoryRetrievalIndex::new();
+    for i in 0..N {
+        let v = vec_for(i, DIM);
+        hnsw.insert(cref(i), v.clone());
+        exact.insert(cref(i), v);
+    }
+    let q = vec_for(7_777, DIM);
+
+    let t = Instant::now();
+    for _ in 0..50 {
+        let _ = hnsw.query(&q, 10);
+    }
+    let ann = t.elapsed() / 50;
+
+    let t = Instant::now();
+    for _ in 0..5 {
+        let _ = exact.query(&q, 10);
+    }
+    let brute = t.elapsed() / 5;
+
+    println!("hnsw scale-smoke: N={N} dim={DIM} ann={ann:?} brute={brute:?}");
+    assert!(
+        ann < brute,
+        "ANN query ({ann:?}) must beat exact brute-force ({brute:?}) at {N} vectors"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -401,6 +401,7 @@ scale-smoke:
     cargo test -p kx-fleet --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-gateway-core --release --test scale -- --ignored --nocapture --test-threads=1
     cargo test -p kx-workflow --release --test stress_fanout -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-dataset-hnsw --release --test scale -- --ignored --nocapture --test-threads=1
 
 # IMP-4 (D116) single-writer scale-readiness measurement spike — publish the
 # single-writer journal commit ceiling + the projection-fold curve so a real number


### PR DESCRIPTION
## DP3 (T2.3) — opt-in `hnsw_rs` ANN scale backend behind `RetrievalIndex`

The third PR of the RAG/Datasets data-plane track (DP1 embedding seam ✅ → DP2 `rag_pipeline` ✅ → **DP3 scale backend**). Adds a new crate `kx-dataset-hnsw`: a file-backed, in-process HNSW (approximate-nearest-neighbour) index implementing the existing `kx_dataset::RetrievalIndex` trait via the pure-Rust `hnsw_rs` crate, for corpora too large for the default exact brute-force scan.

**Purely additive** — `kx-dataset-hnsw` is not wired into any binary yet (that's T3.7, under an opt-in `kx-gateway` `hnsw` feature). No proto change. The exact `InMemoryRetrievalIndex` stays the reproducible **default**.

### Backend choice (Golden Rule 8 — tech-stack decision)

The original roadmap pick was "LanceDB embedded." A web-verified, adversarially-checked research pass disqualified it (and Qdrant) on hard grounds, and selected `hnsw_rs`:

| Candidate | Verdict | Why |
|---|---|---|
| **LanceDB** | ❌ reject | `lancedb 0.30 → lance-namespace 7.0` **force-pulls `rustls + aws-lc-rs`** (lance-namespace #240, PR #242 unresolved). `aws-lc-sys` carries a compound SPDX incl. `MIT-0` + vendored OpenSSL/SSLeay-licensed C — **non-feature-flaggable under our `deny.toml all-features=true` permissive-only gate**. Its columnar/Delta value is also nullified by our journal-authoritative model. |
| **Qdrant** | ❌ reject | Not embeddable — the `qdrant` crate is a `v0.0.0` placeholder (`has_lib:false`); the engine is a server; "Qdrant Edge" is unpublished private beta. |
| **`hnsw_rs`** | ✅ **chosen** | Pure-Rust, **fully sync** (drops into the sync trait with no `block_on`/tokio bridge), Apache/MIT, `default-features=false` (no x86 `simdeez_f` / nightly `stdsimd`), no C/C++ toolchain. **Full transitive tree clears `cargo-deny` with ZERO `deny.toml` exceptions.** |
| `usearch` | fallback | Battle-tested, native mmap-view, but adds a second C++ FFI build + a `u64↔ContentRef` sidecar. |

### Persistence design (a GR8 improvement over the original plan)

Instead of `hnsw_rs`'s native mmap dump, this crate **persists its own flat little-endian `(ContentRef, vector)` records and rebuilds the HNSW graph on `open`**. Reasons:

- `hnsw_rs`'s `HnswIo::load_hnsw` returns an `Hnsw` that **borrows the `HnswIo`** (`'a: 'b`, for mmap) — holding both in one struct would be self-referential.
- Records + rebuild **decouples the cache from `hnsw_rs`'s on-disk format**: a format break or corrupt file is recovered by rebuild-from-journal (D40), never a migration — exactly the journal-authoritative model.
- The decoder is total + panic-free with **bounded allocation** (a hostile `count`/`dim` cannot OOM); `open`/`dump` reject `..` path traversal.

### SN-8

Similarity stays inside the retrieval Mote; only the ordered neighbour-ref **set** is committed (matched downstream by exact hash). Results are sorted score-desc / ref-asc to mirror `InMemoryRetrievalIndex`'s deterministic tiebreak, so the committed ordered-ref fact is stable for a given index state. ANN approximation never reaches a `MoteId`.

### Golden Rule 8 — pre-flight risk analysis

- **(a) Breaks live / fwd-back-compat:** none. Opt-in crate off the truth path; digest invariant; the index is a rebuildable cache (no journal/wire/identity schema change). Frozen trio diff-proven.
- **(b) Performance:** ANN replaces the default O(n) brute-force scan *only when opted in* — a strict improvement at scale (scale-smoke: 25k vectors, **ANN ~140µs vs brute ~1.7ms ≈ 12×**). No hot-path allocation churn.
- **(c) Security:** new surface = embedding-vector ingest + cache deserialization → loader is **fail-closed**, treats the cache as untrusted (bounded alloc), rejects path traversal. SN-8 preserved (scores display-only). No new egress/secret surface.

### Tests + gates

- **9 unit:** recall@1, top-1 parity vs `InMemory`, deterministic repeat-query, idempotent-by-ref insert, dim/k/empty bounds, cache codec round-trip + corrupt/truncation/trailing rejection.
- **4 integration:** dump→drop→reopen preserves the corpus + nearest; absent→empty; corrupt→err; path-traversal rejected.
- **scale-smoke:** a 25k-vector retrieval-latency test wired into `just scale-smoke`.
- ✅ **Full `just ci` green** — fmt-check · clippy `-D warnings` · test · **deny (full tree, no exceptions)** · doc `-D warnings` · ffi-link · build-no-inference · check-reproducible · scale-smoke.
- ✅ **Frozen trio** (`kx-executor`/`kx-scheduler` + `kx-inference/dispatcher.rs`) **0 files changed**.
- ✅ **Canonical projection digest `7d22d4bd…` invariant** (a0_guard).
- ✅ `Cargo.lock` += only the `hnsw_rs` edges.

### Next

T3.7 (PR-B): wire `kx-dataset-hnsw` into `kx-gateway` under an opt-in `hnsw` feature + a `DatasetView`/`HostDatasetView` seam + 3 additive RPCs (`ListDatasets`/`IngestDocuments`/`QueryDataset`, scores display-only) + TS/Py SDK + the Datasets UI panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
