### PR TITLE
feat(gateway,coordinator,worker): PR-2c-1 — F-7 assemble-into-serve (live parent context for model Motes)

### DIFF
--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -482,12 +482,20 @@ impl Coordinator for CoordinatorService {
         let (work, instance_id) = self.core.lease_work(worker, executor_class, max).await?;
         let items = work
             .into_iter()
-            .map(|(mote, warrant)| proto::WorkItem {
-                mote: Some(mote.into()),
-                warrant: Some(warrant.into()),
-                // F-7 parent-context resolution is populated in Step 5; empty here keeps
-                // the leaf path byte-identical to the pre-F-7 behavior.
-                parent_results: vec![],
+            .map(|item| proto::WorkItem {
+                mote: Some(item.mote.into()),
+                warrant: Some(item.warrant.into()),
+                // F-7 (assemble-into-serve): the leaf's resolved Data context, resolved
+                // on the sole-writer thread (`lease_ready` → `resolve_parent_context`).
+                // Empty for a Mote with no Data context ⇒ byte-identical to pre-F-7.
+                parent_results: item
+                    .parent_results
+                    .into_iter()
+                    .map(|(parent_mote_id, result_ref)| proto::ParentResult {
+                        parent_mote_id: parent_mote_id.as_bytes().to_vec(),
+                        result_ref: result_ref.as_bytes().to_vec(),
+                    })
+                    .collect(),
             })
             .collect();
         Ok(Response::new(proto::LeaseWorkResponse {

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -19,12 +19,12 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use kx_content::{ContentStore, LocalFsContentStore};
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_journal::{
     FailureReason, IdempotencyClassTag, Journal, JournalEntry, RepudiationReason,
     ResolvedCapabilityRecord, ResolvedKindTag, INSTANCE_ID_LEN,
 };
-use kx_mote::{Mote, MoteDef, MoteId, NdClass};
+use kx_mote::{EdgeKind, Mote, MoteDef, MoteId, NdClass};
 use kx_projection::{MoteState, Projection};
 use kx_refusal::{validate_mote_submission, ToolResolution};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
@@ -71,10 +71,24 @@ pub(crate) struct SubmitOutcome {
     pub(crate) instance_id: Option<[u8; INSTANCE_ID_LEN]>,
 }
 
+/// One unit of leased work: the Mote to run, its warrant, and the **F-7
+/// parent-context** — the committed `(MoteId, ContentRef)` of the leaf's Data
+/// context, resolved on the sole-writer thread from the projection (NO journal
+/// write). The worker forwards these to the executor so a model Mote assembles
+/// real upstream context (`WorkItem.parent_results`, the reserved seam). A Mote
+/// with no Data context (the demo / a root) carries an EMPTY list ⇒ byte-identical
+/// to the pre-F-7 leaf path.
+#[derive(Debug, Clone)]
+pub(crate) struct LeasedItem {
+    pub(crate) mote: Mote,
+    pub(crate) warrant: WarrantSpec,
+    pub(crate) parent_results: Vec<(MoteId, ContentRef)>,
+}
+
 /// Leased work plus the run's `instance_id` (if registered) — the `LeaseWork`
 /// reply shape (M1.2): the worker derives the run-scoped idempotency token from
 /// the `instance_id`.
-type LeasedWork = (Vec<(Mote, WarrantSpec)>, Option<[u8; INSTANCE_ID_LEN]>);
+type LeasedWork = (Vec<LeasedItem>, Option<[u8; INSTANCE_ID_LEN]>);
 
 /// Outcome of a `ReportCommit`: the journal-assigned seq and whether the commit
 /// was newly appended or a dedup-by-key hit (first-wins).
@@ -496,7 +510,7 @@ fn serve_lease<J: Journal>(
     );
     dispatch
         .tracker
-        .record_lease(req.worker, items.iter().map(|(mote, _)| mote.id));
+        .record_lease(req.worker, items.iter().map(|it| it.mote.id));
     // M1.2 (O(1) off-DAG read): the run the leased work belongs to.
     let instance_id = projection.run_registration().map(|(id, _)| id);
     (items, instance_id)
@@ -523,7 +537,7 @@ fn lease_ready(
     worker: WorkerId,
     executor_class: ExecutorClass,
     max: usize,
-) -> Vec<(Mote, WarrantSpec)> {
+) -> Vec<LeasedItem> {
     let placement = LoadAwarePlacement::new(registry, executor_class);
     let mut preferred: Vec<MoteId> = Vec::new();
     let mut rest: Vec<MoteId> = Vec::new();
@@ -575,8 +589,66 @@ fn lease_ready(
         .into_iter()
         .chain(rest)
         .take(max)
-        .filter_map(|id| submitted_defs.get(&id).cloned())
+        .filter_map(|id| {
+            submitted_defs.get(&id).map(|(mote, warrant)| {
+                let parent_results = resolve_parent_context(mote, projection, submitted_defs);
+                LeasedItem {
+                    mote: mote.clone(),
+                    warrant: warrant.clone(),
+                    parent_results,
+                }
+            })
+        })
         .collect()
+}
+
+/// F-7 (assemble-into-serve): resolve, on the sole-writer thread, the committed
+/// `(MoteId, ContentRef)` of `mote`'s **Data context** — the upstream a model Mote
+/// must see to reason. This is a pure projection read (NO journal write, NO edge
+/// mutation — the canonical digest is untouched):
+///
+/// - **direct Data parents** of `mote` (the general rule, mirrors
+///   `kx_context_assembler::assemble`'s parent loop), and
+/// - for a **materialized shaper-child** (whose only parent is a Control edge to
+///   its shaper, PR-2b), the shaper's OWN Data parents — so the run's source/prompt
+///   context flows down to the leaf *without* giving the child a new edge.
+///
+/// A Mote with no resolvable Data context (the canonical demo, a root) ⇒ an EMPTY
+/// list ⇒ the worker assembles an empty leaf context, byte-identical to pre-F-7.
+/// Results are de-duplicated and sorted by `MoteId` so the wire payload (and thus
+/// the assembled prompt and the leaf's content-addressed `result_ref`) is
+/// deterministic across leases and recovery re-folds (R49).
+fn resolve_parent_context(
+    mote: &Mote,
+    projection: &Projection,
+    submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
+) -> Vec<(MoteId, ContentRef)> {
+    let mut out: Vec<(MoteId, ContentRef)> = Vec::new();
+    for parent in &mote.parents {
+        match parent.edge.kind {
+            EdgeKind::Data => {
+                if let Some(result_ref) = projection.result_ref_of(&parent.parent_id) {
+                    out.push((parent.parent_id, result_ref));
+                }
+            }
+            EdgeKind::Control => {
+                // Materialized shaper-child: lift the shaper's Data context one level
+                // (never recursive — the shaper's own Control parents are not followed).
+                if let Some((shaper, _)) = submitted_defs.get(&parent.parent_id) {
+                    for sp in &shaper.parents {
+                        if sp.edge.kind == EdgeKind::Data {
+                            if let Some(result_ref) = projection.result_ref_of(&sp.parent_id) {
+                                out.push((sp.parent_id, result_ref));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+    out.dedup_by(|a, b| a.0 == b.0);
+    out
 }
 
 /// R-13 under distribution (P3.6c): whether a **crash-failed** Mote is safe to *re-dispatch*.

--- a/crates/kx-gateway/src/assemble_serve.rs
+++ b/crates/kx-gateway/src/assemble_serve.rs
@@ -1,0 +1,179 @@
+//! F-7 (assemble-into-serve): render a model Mote's resolved Data context — its
+//! committed `(parent MoteId, result_ref)` pairs, delivered by the worker's
+//! [`kx_worker::ContextSink`] from `WorkItem.parent_results` — into a deterministic
+//! text block prepended to the model prompt.
+//!
+//! **Self-contained + dependency-free** (it deliberately does NOT pull
+//! `kx-context-assembler`): the gateway leaf path is a distinct code path from the
+//! harness assembler, and its completion is content-addressed by its OWN output, so
+//! the only invariant that matters is determinism WITHIN this path — the SAME
+//! parents must always render the SAME block, so the leaf's `result_ref` is stable
+//! across leases and recovery re-folds (R49). To guarantee that:
+//!
+//! - parents are **sorted by `MoteId`** (and de-duplicated) before rendering, and
+//! - the block is **hard-capped at [`WINDOW_BYTES`]**, failing closed on overflow
+//!   (mirroring the assembler's `OverflowDecisionRequired`) so a runaway upstream
+//!   can never silently truncate or blow the model window.
+//!
+//! Empty input ⇒ the empty string ⇒ byte-identical to the pre-F-7 leaf prompt.
+
+use std::fmt;
+
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
+use kx_mote::MoteId;
+
+/// The hard cap on assembled F-7 context bytes prepended to a model prompt. Pinned
+/// (NOT warrant-derived) so the leaf's content-addressed result stays deterministic
+/// and a runaway upstream fails closed rather than silently truncating.
+pub(crate) const WINDOW_BYTES: usize = 32 * 1024;
+
+/// Failure assembling F-7 serve context. Both variants are fail-closed: the model
+/// never runs on partial or unbounded context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AssembleError {
+    /// A declared parent `result_ref` did not resolve in the shared store (a forged,
+    /// or not-yet-replicated, ref). Never run the model on missing context.
+    UpstreamMissing(ContentRef),
+    /// The rendered context exceeded [`WINDOW_BYTES`].
+    Overflow { needed: usize, cap: usize },
+}
+
+impl fmt::Display for AssembleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AssembleError::UpstreamMissing(r) => {
+                write!(
+                    f,
+                    "F-7 upstream context {} not resolvable in store",
+                    r.to_hex()
+                )
+            }
+            AssembleError::Overflow { needed, cap } => {
+                write!(f, "F-7 context {needed}B exceeds window cap {cap}B")
+            }
+        }
+    }
+}
+
+/// Render `parents` into a deterministic, labeled context block. Empty input yields
+/// the empty string (the pre-F-7 leaf prompt). Fails closed on a missing upstream or
+/// a window overflow.
+pub(crate) fn assemble_from_parent_results(
+    parents: &[(MoteId, ContentRef)],
+    store: &LocalFsContentStore,
+) -> Result<String, AssembleError> {
+    if parents.is_empty() {
+        return Ok(String::new());
+    }
+    // Deterministic order, independent of the wire order the coordinator sent.
+    let mut sorted: Vec<(MoteId, ContentRef)> = parents.to_vec();
+    sorted.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+    sorted.dedup_by(|a, b| a.0 == b.0);
+
+    let mut out = String::new();
+    for (_parent_id, result_ref) in &sorted {
+        let bytes = store
+            .get(result_ref)
+            .map_err(|_| AssembleError::UpstreamMissing(*result_ref))?;
+        let label = &result_ref.to_hex()[..16];
+        // Labeled block; UTF-8-lossy so arbitrary content bytes render deterministically.
+        let block = format!(
+            "[context parent.{label}]\n{}\n\n",
+            String::from_utf8_lossy(bytes.as_ref())
+        );
+        let needed = out.len() + block.len();
+        if needed > WINDOW_BYTES {
+            return Err(AssembleError::Overflow {
+                needed,
+                cap: WINDOW_BYTES,
+            });
+        }
+        out.push_str(&block);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_content::ContentStore;
+    use tempfile::TempDir;
+
+    fn store() -> (TempDir, LocalFsContentStore) {
+        let dir = TempDir::new().expect("tempdir");
+        let store = LocalFsContentStore::open(dir.path()).expect("open store");
+        (dir, store)
+    }
+
+    fn mote_id(seed: u8) -> MoteId {
+        MoteId::from_bytes([seed; 32])
+    }
+
+    #[test]
+    fn empty_parents_render_nothing() {
+        let (_dir, store) = store();
+        assert_eq!(
+            assemble_from_parent_results(&[], &store).unwrap(),
+            String::new(),
+            "no Data context ⇒ empty block ⇒ byte-identical to the pre-F-7 leaf prompt"
+        );
+    }
+
+    #[test]
+    fn render_is_deterministic_and_moteid_sorted() {
+        // Two parents inserted in BOTH orders must render byte-identically (sorted by
+        // MoteId), so the leaf's content-addressed result_ref is stable (R49).
+        let (_dir, store) = store();
+        let ref_a = store.put(b"alpha-output").unwrap();
+        let ref_b = store.put(b"beta-output").unwrap();
+        let id_lo = mote_id(0x01);
+        let id_hi = mote_id(0x99);
+
+        let forward =
+            assemble_from_parent_results(&[(id_lo, ref_a), (id_hi, ref_b)], &store).unwrap();
+        let reverse =
+            assemble_from_parent_results(&[(id_hi, ref_b), (id_lo, ref_a)], &store).unwrap();
+        assert_eq!(
+            forward, reverse,
+            "wire order must not change the rendered context"
+        );
+        // The lower MoteId's block comes first.
+        let pos_a = forward.find("alpha-output").unwrap();
+        let pos_b = forward.find("beta-output").unwrap();
+        assert!(pos_a < pos_b, "blocks ordered by ascending MoteId");
+        assert!(forward.contains("[context parent."), "blocks are labeled");
+    }
+
+    #[test]
+    fn duplicate_parents_are_deduped() {
+        let (_dir, store) = store();
+        let r = store.put(b"once").unwrap();
+        let id = mote_id(0x42);
+        let out = assemble_from_parent_results(&[(id, r), (id, r)], &store).unwrap();
+        assert_eq!(
+            out.matches("once").count(),
+            1,
+            "a repeated parent renders once"
+        );
+    }
+
+    #[test]
+    fn missing_upstream_fails_closed() {
+        let (_dir, store) = store();
+        // A result_ref that was never put → not resolvable → fail closed (never run the
+        // model on missing context).
+        let phantom = ContentRef::of(b"never-stored");
+        let err = assemble_from_parent_results(&[(mote_id(1), phantom)], &store).unwrap_err();
+        assert_eq!(err, AssembleError::UpstreamMissing(phantom));
+    }
+
+    #[test]
+    fn overflow_fails_closed() {
+        let (_dir, store) = store();
+        // A single parent larger than the window must fail closed (no silent truncation).
+        let big = vec![b'x'; WINDOW_BYTES + 1];
+        let r = store.put(&big).unwrap();
+        let err = assemble_from_parent_results(&[(mote_id(1), r)], &store).unwrap_err();
+        assert!(matches!(err, AssembleError::Overflow { cap, .. } if cap == WINDOW_BYTES));
+    }
+}

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -51,6 +51,11 @@
 //! convention. The frozen trio (`kx-scheduler` / `kx-executor`) source is
 //! untouched; this crate only *consumes* their public API.
 
+// PR-2c F-7: render a model Mote's resolved Data context (WorkItem.parent_results)
+// into the prompt. Self-contained + FFI-free; shares the `inference` feature with
+// the model executor that consumes it.
+#[cfg(feature = "inference")]
+mod assemble_serve;
 mod auth;
 mod config;
 // T3.7: the host-side Datasets data-plane (the kx-dataset-hnsw-backed DatasetView

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -20,7 +20,7 @@
 
 use std::collections::BTreeSet;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use kx_content::{ContentStore, LocalFsContentStore};
 use kx_executor::{MoteExecutionResult, MoteExecutor, MoteExecutorError, Rootfs};
@@ -33,7 +33,7 @@ use kx_model_validator::{
     RequiredCapabilities, ValidatorOutcome,
 };
 use kx_mote::{
-    ConfigKey, EffectPattern, InferenceParams, LogicRef, ModelId, Mote, NdClass,
+    ConfigKey, EffectPattern, InferenceParams, LogicRef, ModelId, Mote, MoteId, NdClass,
     PromptTemplateHash, RoleId, ToolName, PROMPT_KEY,
 };
 use kx_planner::{
@@ -281,6 +281,10 @@ pub(crate) fn build_serve_backend(
 /// - **leaf model** (`is_model_mote`, AL1): a greedy completion (recomputable) committed
 ///   as content bytes — the shaper's children land here, running their per-child intent.
 ///
+/// A leased Mote's resolved Data context: the committed `(parent MoteId, result_ref)`
+/// pairs the worker delivers via [`kx_worker::ContextSink`] for F-7 assembly.
+type ParentResults = Vec<(MoteId, ContentRef)>;
+
 /// Generic over the backend `B` so a deterministic stub injects in tests; production uses
 /// [`LlamaInferenceBackend`]. The whole module is `#[cfg(feature = "inference")]`.
 pub(crate) struct ModelRouterExecutor<B: InferenceBackend> {
@@ -291,6 +295,12 @@ pub(crate) struct ModelRouterExecutor<B: InferenceBackend> {
     /// the model names a role, the recipe gives the child's vetted identity axes). `None`
     /// ⇒ no shaper support provisioned (a shaper Mote then fails closed, dead-lettered).
     recipes: Option<Arc<dyn RoleRecipeResolver>>,
+    /// F-7 (assemble-into-serve): the per-dispatch context slot the worker fills via
+    /// [`kx_worker::ContextSink`] BEFORE each `run` (the frozen `MoteExecutor::run`
+    /// carries no snapshot). Keyed by `MoteId` so a stale slot can never leak into the
+    /// wrong Mote; consumed (taken) inside `dispatch_model`. The worker runs a lease
+    /// batch sequentially on one thread, so the slot is set-then-consumed with no race.
+    parent_ctx: Mutex<Option<(MoteId, ParentResults)>>,
 }
 
 impl<B: InferenceBackend> ModelRouterExecutor<B> {
@@ -309,6 +319,20 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             backend,
             store,
             recipes,
+            parent_ctx: Mutex::new(None),
+        }
+    }
+
+    /// Take this Mote's F-7 context if the worker delivered any for it (and clear the
+    /// slot). Returns the parents iff the slot matches `mote_id` — a non-matching or
+    /// empty slot yields `None`, so a leaf with no Data context assembles nothing
+    /// (byte-identical to pre-F-7). A poisoned lock degrades to "no context" rather
+    /// than aborting the dispatch.
+    fn take_parent_context(&self, mote_id: MoteId) -> Option<Vec<(MoteId, ContentRef)>> {
+        let mut slot = self.parent_ctx.lock().ok()?;
+        match slot.as_ref() {
+            Some((id, _)) if *id == mote_id => slot.take().map(|(_, parents)| parents),
+            _ => None,
         }
     }
 
@@ -379,6 +403,19 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
     ) -> Result<Vec<u8>, MoteExecutorError> {
         let instruction = prompt_from_config(mote)
             .ok_or_else(|| internal("model Mote lost its prompt config key"))?;
+        // F-7 (assemble-into-serve): prepend this Mote's resolved upstream context (if
+        // the worker delivered any for it) so a corrective/leaf model reasons over its
+        // run's source/parent results, not blind. Empty context ⇒ the prompt is
+        // byte-identical to pre-F-7. A missing/oversized upstream fails closed.
+        let instruction = match self.take_parent_context(mote.id) {
+            Some(parents) if !parents.is_empty() => {
+                let context =
+                    crate::assemble_serve::assemble_from_parent_results(&parents, &self.store)
+                        .map_err(|e| internal(&format!("assemble F-7 context: {e}")))?;
+                format!("{context}{instruction}")
+            }
+            _ => instruction,
+        };
         let input = InferenceInput::text(chatml(&instruction));
         let params = inference_params_from_mote(mote, warrant)
             .map_err(|e| internal(&format!("inference params: {e}")))?;
@@ -436,6 +473,19 @@ impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
         // The model arm leases on the same class as the inner router (the embedded
         // worker's single class); delegate the predicate so behavior is identical.
         self.inner.supports(executor_class)
+    }
+}
+
+/// F-7 (assemble-into-serve): the worker hands this executor a leased Mote's resolved
+/// Data context BEFORE dispatch (the frozen `MoteExecutor::run` carries no snapshot).
+/// The gateway clones ONE `Arc<ModelRouterExecutor>` into both the `MoteExecutor` and
+/// the `ContextSink` role, so the slot the worker fills is the slot `dispatch_model`
+/// consumes. Setting an empty list clears any stale prior slot for safety.
+impl<B: InferenceBackend> kx_worker::ContextSink for ModelRouterExecutor<B> {
+    fn set_parent_results(&self, mote_id: MoteId, parents: Vec<(MoteId, ContentRef)>) {
+        if let Ok(mut slot) = self.parent_ctx.lock() {
+            *slot = Some((mote_id, parents));
+        }
     }
 }
 

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -64,6 +64,15 @@ const POLL_IDLE: Duration = Duration::from_millis(25);
 #[cfg(feature = "embedded-worker")]
 const POLL_ERR: Duration = Duration::from_millis(200);
 
+/// F-7 wiring: the model executor (as the worker's `MoteExecutor`) + the SAME `Arc`
+/// in its `ContextSink` role + the served model id. `None`s ⇒ no model wired.
+#[cfg(feature = "inference")]
+type WiredExecutor = (
+    Arc<dyn MoteExecutor>,
+    Option<Arc<dyn kx_worker::ContextSink>>,
+    Option<kx_mote::ModelId>,
+);
+
 /// The platform-appropriate executor class the embedded worker registers as
 /// (mirrors `kx_executor::default_executor()`'s platform choice). A client's
 /// submitted warrant must name this class for the local worker to lease it.
@@ -436,22 +445,28 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     // dispatches (`kx/recipes/plan`). The shaper arm shares the run's recipe allowlist with
     // the coordinator's role registry (both from `shaper_runtime`). Fail-soft: no model ⇒
     // unchanged behavior. The default (FFI-free) build keeps `serve_model = None`.
+    // F-7 (assemble-into-serve): when the model executor is wired, it is BOTH the
+    // worker's `MoteExecutor` AND its `ContextSink` (one Arc, two roles) so the
+    // coordinator-resolved `parent_results` reach the model prompt. `None` ⇒ no sink
+    // ⇒ the worker dispatch is byte-identical to pre-F-7.
     #[cfg(feature = "inference")]
-    let (executor, serve_model): (Arc<dyn MoteExecutor>, Option<kx_mote::ModelId>) =
-        match shaper_runtime {
-            Some(rt) => {
-                tracing::info!(model = %rt.model_id.0, "AL1+PR-2b: live model + topology loop enabled");
-                let wrapped: Arc<dyn MoteExecutor> =
-                    Arc::new(crate::model_exec::ModelRouterExecutor::new(
-                        executor,
-                        rt.backend,
-                        (*content).clone(),
-                        Some(rt.recipes),
-                    ));
-                (wrapped, Some(rt.model_id))
-            }
-            None => (executor, None),
-        };
+    let (executor, context_sink, serve_model): WiredExecutor = match shaper_runtime {
+        Some(rt) => {
+            tracing::info!(model = %rt.model_id.0, "AL1+PR-2b: live model + topology loop enabled");
+            let model_exec = Arc::new(crate::model_exec::ModelRouterExecutor::new(
+                executor,
+                rt.backend,
+                (*content).clone(),
+                Some(rt.recipes),
+            ));
+            let sink: Arc<dyn kx_worker::ContextSink> = model_exec.clone();
+            let wrapped: Arc<dyn MoteExecutor> = model_exec;
+            (wrapped, Some(sink), Some(rt.model_id))
+        }
+        None => (executor, None, None),
+    };
+    #[cfg(not(feature = "inference"))]
+    let context_sink: Option<Arc<dyn kx_worker::ContextSink>> = None;
     #[cfg(not(feature = "inference"))]
     let serve_model: Option<kx_mote::ModelId> = None;
     let broker: Arc<dyn CapabilityBroker> =
@@ -468,6 +483,11 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     )
     .await
     .map_err(|e| GatewayError::Coordinator(e.to_string()))?;
+    // F-7: attach the model executor as the worker's context sink (if wired).
+    let worker = match context_sink {
+        Some(sink) => worker.with_context_sink(sink),
+        None => worker,
+    };
     // Keep the idle worker live in the registry (background heartbeat) so a run
     // submitted after an idle period leases promptly (no false-death/reschedule).
     let heartbeat_task = worker.spawn_heartbeat(DEFAULT_HEARTBEAT_CADENCE);

--- a/crates/kx-worker/src/context_sink.rs
+++ b/crates/kx-worker/src/context_sink.rs
@@ -1,0 +1,30 @@
+//! F-7 (assemble-into-serve) — the seam by which the worker hands a leased Mote's
+//! resolved Data context (`WorkItem.parent_results`) to its executor.
+//!
+//! The frozen `kx_executor::MoteExecutor::run(&self, mote, warrant, env)` carries
+//! no snapshot, so a model executor that wants to assemble upstream context cannot
+//! receive it through the trait method. Instead the worker sets the context on this
+//! side-channel *before* each dispatch; the gateway's model executor implements
+//! [`ContextSink`] and reads the slot inside `run`. The frozen trait is untouched.
+//!
+//! The worker processes a lease batch sequentially on one thread, so a single slot
+//! keyed by `MoteId` is sufficient and race-free: `set_parent_results` immediately
+//! precedes the executor's `run`, which consumes the slot iff it matches the Mote.
+//! A worker whose executor does not assemble simply holds no sink (`None`).
+
+use kx_content::ContentRef;
+use kx_mote::MoteId;
+
+/// The worker → executor F-7 context side-channel. Implemented by an executor that
+/// assembles upstream context for a model Mote (the gateway's `ModelRouterExecutor`).
+///
+/// `Send + Sync` so the worker can hold an `Arc<dyn ContextSink>` alongside its
+/// `Arc<dyn MoteExecutor>` (the gateway clones ONE `Arc` into both roles).
+pub trait ContextSink: Send + Sync {
+    /// Stash the leased Mote's resolved Data context (its committed
+    /// `(parent MoteId, result_ref)` pairs) for the executor to consume on the next
+    /// `run` of `mote_id`. An empty list (the common case for a non-model or
+    /// no-Data-context Mote) is delivered too, so a stale prior slot can never leak
+    /// into the wrong Mote.
+    fn set_parent_results(&self, mote_id: MoteId, parents: Vec<(MoteId, ContentRef)>);
+}

--- a/crates/kx-worker/src/lib.rs
+++ b/crates/kx-worker/src/lib.rs
@@ -73,6 +73,7 @@ pub use kx_proto::proto;
 
 mod client;
 mod commit_builder;
+mod context_sink;
 mod error;
 mod read_model;
 mod run;
@@ -80,5 +81,6 @@ mod run_wm;
 mod worker;
 
 pub use client::WorkerClient;
+pub use context_sink::ContextSink;
 pub use error::WorkerError;
 pub use worker::{Worker, DEFAULT_HEARTBEAT_CADENCE};

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use kx_capability::{CapabilityBroker, INSTANCE_ID_LEN};
-use kx_content::{ContentStore, LocalFsContentStore};
+use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_executor::{LocalResourceManager, MoteExecutor};
 use kx_mote::{Mote, MoteId, NdClass};
 use kx_proto::proto;
@@ -13,6 +13,7 @@ use kx_warrant::{ExecutorClass, WarrantSpec};
 use tokio::task::JoinHandle;
 
 use crate::client::WorkerClient;
+use crate::context_sink::ContextSink;
 use crate::error::{classify_worker_failure, FailureClass, WorkerError};
 use crate::read_model::ReadModel;
 use crate::{commit_builder, run, run_wm};
@@ -66,6 +67,11 @@ pub struct Worker {
     /// entry. A worker restart resets it harmlessly — the bound is a sanity ceiling, not
     /// durable state (the coordinator's terminal `Failed` is the durable truth).
     attempts: std::collections::HashMap<MoteId, u32>,
+    /// F-7 (assemble-into-serve): the optional side-channel that hands a leased Mote's
+    /// resolved Data context (`WorkItem.parent_results`) to the executor *before* each
+    /// dispatch (the frozen `MoteExecutor::run` carries no snapshot). `None` for a worker
+    /// whose executor does not assemble — its dispatch is byte-identical to pre-F-7.
+    context_sink: Option<Arc<dyn ContextSink>>,
 }
 
 impl Worker {
@@ -104,7 +110,19 @@ impl Worker {
             max_lease,
             in_flight: Arc::new(AtomicU32::new(0)),
             attempts: std::collections::HashMap::new(),
+            context_sink: None,
         })
+    }
+
+    /// Attach an F-7 [`ContextSink`] (assemble-into-serve): before each dispatch the
+    /// worker hands the leased Mote's resolved Data context to `sink`, which the model
+    /// executor consumes inside `run`. The gateway clones ONE `Arc` into both the
+    /// `MoteExecutor` and the `ContextSink` role, so the slot is shared. Additive —
+    /// a worker without a sink behaves byte-identically to pre-F-7.
+    #[must_use]
+    pub fn with_context_sink(mut self, sink: Arc<dyn ContextSink>) -> Self {
+        self.context_sink = Some(sink);
+        self
     }
 
     /// The coordinator-assigned worker id.
@@ -172,6 +190,24 @@ impl Worker {
                 .warrant
                 .ok_or(WorkerError::MissingField("warrant"))?
                 .try_into()?;
+
+            // F-7 (assemble-into-serve): hand the executor this Mote's resolved Data
+            // context BEFORE dispatch (the frozen `MoteExecutor::run` carries no
+            // snapshot). Always set — including an empty list — so a prior Mote's
+            // context can never leak into this one. Malformed wire entries are dropped;
+            // a missing parent the model needs surfaces fail-closed in the assembler.
+            if let Some(sink) = &self.context_sink {
+                let parents: Vec<(MoteId, ContentRef)> = item
+                    .parent_results
+                    .iter()
+                    .filter_map(|pr| {
+                        let id: [u8; 32] = pr.parent_mote_id.as_slice().try_into().ok()?;
+                        let r: [u8; 32] = pr.result_ref.as_slice().try_into().ok()?;
+                        Some((MoteId::from_bytes(id), ContentRef::from_bytes(r)))
+                    })
+                    .collect();
+                sink.set_parent_results(mote.id, parents);
+            }
 
             // PURE recomputes locally through the hosted executor (verbatim, D40 — a
             // throwaway journal). Non-PURE (WORLD-MUTATING / READ-ONLY-NONDET) drives


### PR DESCRIPTION
## What

The live `kx serve` model loop's first agentic-maturity piece: a leased model Mote now reasons over its **committed upstream context** instead of running blind. This is the foundation both re-plan-live and critic-live build on.

- **kx-coordinator** — `lease_ready` resolves each leased Mote's Data context on the sole-writer thread (its own Data parents + a materialized child's shaper's Data parents) into the **reserved `WorkItem.parent_results`** seam. **No edge-graph mutation** ⇒ the canonical projection digest `7d22d4bd…` is invariant *by construction*. A Mote with no Data context carries an empty list ⇒ byte-identical to pre-F-7.
- **kx-worker** — a `ContextSink` seam hands the resolved context to the executor **before** each dispatch (the frozen `MoteExecutor::run` carries no snapshot, so context enters via the executor struct, not the trait method). No sink ⇒ byte-identical to pre-F-7.
- **kx-gateway** — `ModelRouterExecutor` implements `ContextSink`; `dispatch_model` prepends a **deterministic, MoteId-sorted, window-capped** (`WINDOW_BYTES`) context block to the model prompt. Self-contained assembler (no `kx-context-assembler` dep), **fail-closed** on a missing upstream or a window overflow.

## Golden Rule 8 — pre-flight

- **Breaks / digest:** the naive F-7 (giving children a Data edge) would have **moved `7d22d4bd`** — `encode_state` serializes the edge graph, and the canonical 8-Mote workflow materializes a shaper child. This PR is **edge-free** (resolves the shaper's *existing* Data parents), so the digest is invariant. Verified: `a0_guard` + `audit_trail` green.
- **Perf:** per-lease resolution is O(k) map lookups + per-parent `store.get`, off the fold path → `scale-smoke` unaffected. Window hard-capped.
- **Security (SN-8):** parent context is content-addressed (`result_ref`); a forged ref fails closed. Prompt-injection note: parent bytes are model outputs within the granted warrant — SN-8 contains the *action* surface (no capability escalation); for this PR gateway Motes are PURE with empty `tool_contract`, so the blast radius is content-only.
- **Fwd/back-compat:** `parent_results` was already a reserved additive proto field — old worker ignores it (empty leaf context); old coordinator emits none. **Proto unchanged**, zero new deps (`Cargo.lock` unchanged), frozen trio untouched.

## Scope

**F-7 only.** Re-plan-live and critic-live (the rest of PR-2c) are deferred to focused follow-up PRs: ground-truth analysis showed crash-safe coordinator-materialized re-plan needs a **new durable replan-round fact** (recovery re-derives materialized children only from committed `TopologyDecision` facts; the `Committed` journal entry stores only `mote_def_hash`, not the def) — a durability-spine-adjacent change that merits its own review.

## Tests

F-7 assembler unit tests (determinism / MoteId-sort / dedup / overflow / missing-upstream fail-closed); coordinator/worker/gateway suites green; digest invariant + FFI dep-wall + build-no-inference + scale-smoke green; clippy `-D warnings`, fmt, deny, doc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)