### PR TITLE
feat(gateway,coordinator,projection,refusal): PR-2c-3 — critic-live (native deterministic-critic exit-gate LIVE in kx serve)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "kx-catalog",
  "kx-content",
  "kx-coordinator",
+ "kx-critic",
  "kx-dataset",
  "kx-dataset-hnsw",
  "kx-executor",
@@ -1537,6 +1538,7 @@ dependencies = [
  "kx-mote",
  "kx-planner",
  "kx-proto",
+ "kx-refusal",
  "kx-warrant",
  "kx-worker",
  "kx-workflow",
@@ -1565,10 +1567,12 @@ name = "kx-gateway-core"
 version = "0.0.1"
 dependencies = [
  "kx-content",
+ "kx-critic-types",
  "kx-journal",
  "kx-mote",
  "kx-projection",
  "kx-proto",
+ "kx-refusal",
  "kx-warrant",
  "proptest",
  "smallvec",

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -25,7 +25,7 @@ use kx_journal::{
     ResolvedCapabilityRecord, ResolvedKindTag, INSTANCE_ID_LEN,
 };
 use kx_mote::{ConfigKey, EdgeKind, ModelId, Mote, MoteDef, MoteId, NdClass, PROMPT_KEY};
-use kx_projection::{MoteState, Projection, RegisterMote, ReplanRoundRecord};
+use kx_projection::{ContentStoreVerdicts, MoteState, Projection, RegisterMote, ReplanRoundRecord};
 use kx_refusal::{validate_mote_submission, ToolResolution};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
 use kx_tool_registry::{IdempotencyClass, ToolKind, ToolRegistry, ToolResolutionEvent};
@@ -494,6 +494,7 @@ fn serve_lease<J: Journal>(
     registry: &dyn WorkerRegistry,
     dispatch: &mut Dispatch,
     req: &LeaseReq,
+    store: Option<&LocalFsContentStore>,
 ) -> LeasedWork {
     reap_dead_workers(
         journal,
@@ -510,6 +511,7 @@ fn serve_lease<J: Journal>(
         req.worker,
         req.executor_class,
         req.max,
+        store,
     );
     dispatch
         .tracker
@@ -532,6 +534,27 @@ fn serve_lease<J: Journal>(
 /// ungated. The D55 phantom-ref guard backstops the commit. Placement v2 (D56) then orders them:
 /// `worker`'s placement-preferred Motes come **first**, the rest **fill to `max`**
 /// (starvation-free; double execution stays harmless under dedup, D54).
+/// The lease + `ReadySet` ready set with the **P4.2-3 critic exit-gate**
+/// auto-activated (PR-2c-3 critic-live). A critic-free run takes the byte-identical
+/// `projection.ready_set()` path (zero gate cost). When a critic IS declared, a WM
+/// producer's consumers are withheld until its critic commits `Valid`, read by
+/// content-address from `store`; **`None` store ⇒ fail-closed** (withhold) so the
+/// gate is a pure deterministic fold of the journal, never dependent on a store
+/// handle being wired (B2). Used by BOTH `lease_ready` and the `ReadySet` command
+/// arm so they can never disagree (H4).
+fn gated_ready_set(projection: &Projection, store: Option<&LocalFsContentStore>) -> Vec<MoteId> {
+    match store {
+        Some(s) => {
+            let verdicts = ContentStoreVerdicts::new(s.clone());
+            projection.ready_set_auto(Some(&verdicts))
+        }
+        None => projection.ready_set_auto(None),
+    }
+}
+
+// One more arg than the clippy default (the optional content store for the
+// PR-2c-3 critic exit gate); an internal sole-writer helper, not a public seam.
+#[allow(clippy::too_many_arguments)]
 fn lease_ready(
     projection: &Projection,
     submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
@@ -540,6 +563,7 @@ fn lease_ready(
     worker: WorkerId,
     executor_class: ExecutorClass,
     max: usize,
+    store: Option<&LocalFsContentStore>,
 ) -> Vec<LeasedItem> {
     let placement = LoadAwarePlacement::new(registry, executor_class);
     let mut preferred: Vec<MoteId> = Vec::new();
@@ -557,8 +581,7 @@ fn lease_ready(
     // never re-leased. The ready-set half is NOT gated (those are first dispatches; a
     // StageThenCommit Mote that staged-then-crashed is `Pending`/in the ready-set with the
     // hint present, so it is still offered there).
-    for mote_id in projection
-        .ready_set()
+    for mote_id in gated_ready_set(projection, store)
         .into_iter()
         .chain(
             rescheduleable
@@ -626,6 +649,19 @@ fn resolve_parent_context(
     projection: &Projection,
     submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
 ) -> Vec<(MoteId, ContentRef)> {
+    // PR-2c-3 critic-live (B1): a native deterministic critic evaluates its declared
+    // check over EXACTLY its producer's committed bytes (`critic_for`) — byte-for-byte
+    // the same source the FROZEN `run_native_critic_mote` reads from the journal. So a
+    // critic gets ONLY `[(critic_for, ref)]`, never its other Data parents (if any),
+    // so the live verdict arm can never be fed a different parent's bytes (which would
+    // make a `Valid` verdict promote a producer whose real output was never checked).
+    // Empty (producer not yet committed) ⇒ the arm fails closed.
+    if let Some(producer_id) = mote.def.critic_for {
+        return match projection.result_ref_of(&producer_id) {
+            Some(result_ref) => vec![(producer_id, result_ref)],
+            None => Vec::new(),
+        };
+    }
     let mut out: Vec<(MoteId, ContentRef)> = Vec::new();
     for parent in &mote.parents {
         match parent.edge.kind {
@@ -1110,7 +1146,7 @@ fn handle_command<J: Journal>(
             let _ = reply.send(projection.snapshot().committed_count());
         }
         Command::ReadySet { reply } => {
-            let _ = reply.send(projection.ready_set());
+            let _ = reply.send(gated_ready_set(projection, store));
         }
         Command::LeaseWork {
             worker,
@@ -1129,6 +1165,7 @@ fn handle_command<J: Journal>(
                     executor_class,
                     max,
                 },
+                store,
             );
             let _ = reply.send(leased);
         }

--- a/crates/kx-executor/tests/native_critic.rs
+++ b/crates/kx-executor/tests/native_critic.rs
@@ -278,3 +278,61 @@ fn run_native_critic_rejects_non_pure_mote() {
         "a non-PURE native critic must be refused at execution (run-time R-15)"
     );
 }
+
+/// PR-2c-3 critic-live (Change #3): the shared `native_critic_shape` R-15 gate
+/// MUST agree, case-for-case, with the FROZEN `run_native_critic_mote` inline gate
+/// (kx-executor) — so the live verdict arm (kx-gateway `run_critic`, which calls
+/// `native_critic_shape`) and the submission refusal (`check_r15`, which delegates
+/// to it) can never accept a critic shape the frozen executor would reject, or
+/// vice-versa. A well-formed critic passes BOTH (and, given a committed producer,
+/// the frozen executor proceeds to commit a verdict); each ill-formed shape trips
+/// BOTH.
+#[test]
+#[allow(clippy::type_complexity)]
+fn native_critic_shape_matches_frozen_executor_gate() {
+    use kx_refusal::native_critic_shape;
+
+    // Each case mutates a well-formed critic's def, then asserts the shared shape
+    // predicate and the frozen executor's gate reach the SAME accept/reject verdict.
+    let cases: [(&str, fn(&mut MoteDef), bool); 4] = [
+        ("well_formed", |_d| {}, true),
+        ("non_pure", |d| d.nd_class = NdClass::WorldMutating, false),
+        ("no_critic_for", |d| d.critic_for = None, false),
+        ("topology_shaper", |d| d.is_topology_shaper = true, false),
+    ];
+
+    for (name, mutate, expect_ok) in cases {
+        // Fresh journal+store with the producer committed, so a VALID shape proceeds
+        // PAST the gate to a real commit (proving the gate accepted), while an
+        // INVALID shape is rejected at the gate (step 1, before the producer read).
+        let journal = InMemoryJournal::new();
+        let store = InMemoryContentStore::new();
+        let producer = producer_mote();
+        commit_producer(&journal, &store, &producer, br#"{"ok":true}"#);
+
+        let mut def = critic_mote(producer.id, json_check()).def.clone();
+        mutate(&mut def);
+        let critic = Mote::new(
+            def,
+            InputDataId::from_bytes([20; 32]),
+            GraphPosition("/critic".into()),
+            SmallVec::new(),
+        );
+
+        let shape_ok = native_critic_shape(&critic).is_ok();
+        assert_eq!(
+            shape_ok, expect_ok,
+            "shared shape gate disagreed on `{name}`"
+        );
+
+        let frozen_ok = run_native_critic_mote(&critic, &warrant(), &journal, &store).is_ok();
+        assert_eq!(
+            frozen_ok, expect_ok,
+            "frozen executor gate disagreed on `{name}`"
+        );
+        assert_eq!(
+            shape_ok, frozen_ok,
+            "shared shape gate and frozen executor gate MUST agree on `{name}`"
+        );
+    }
+}

--- a/crates/kx-gateway-core/Cargo.toml
+++ b/crates/kx-gateway-core/Cargo.toml
@@ -30,6 +30,11 @@ kx-warrant    = { workspace = true }
 # The Journal trait + JournalEntry, wrapped by the read-only ReadOnly<J> seam. gateway-core
 # NEVER names append/append_batch — the write path cannot type-check.
 kx-journal    = { workspace = true }
+# PR-2c-3 (critic-live): the whole-DAG submission validator (`validate_submission`) the
+# SubmitRun ingress runs to enforce the CROSS-Mote critic refusals (R-2/R-4/R-5/R-6) the
+# per-Mote live path cannot — a `critic_for` must reference an existing WORLD-MUTATING
+# producer, no producer may carry two critics, etc. (B3). FFI-free; pure validation.
+kx-refusal    = { workspace = true }
 # Async gRPC service (Request/Response/Status/Streaming) + the re-exported async_trait.
 tonic         = { workspace = true }
 # Backs the resumable StreamEvents cursor (tokio_stream::iter over precomputed frames).
@@ -46,6 +51,9 @@ tokio         = { workspace = true }
 proptest      = { workspace = true }
 # TEST-ONLY: build journal `Committed` entries (the parents SmallVec) in fixtures.
 smallvec      = { workspace = true }
+# TEST-ONLY (PR-2c-3 critic-live): the `CheckSpec` to build a native-critic Mote in
+# the SubmitRun B3/H5 admission tests.
+kx-critic-types = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kx-gateway-core/src/service.rs
+++ b/crates/kx-gateway-core/src/service.rs
@@ -377,6 +377,15 @@ pub struct GatewayService {
     /// The `StreamEvents` tailer. Defaults to [`SnapshotTailer`]; the host injects
     /// a live tailer via [`GatewayService::with_event_tailer`].
     tailer: Arc<dyn EventTailer>,
+    /// Whether this serve build can EVALUATE a native deterministic critic
+    /// (PR-2c-3 critic-live, H5). The verdict arm lives in the inference-build
+    /// executor; on a serve that lacks it, a critic Mote would commit echo bytes and
+    /// the P4.2-3 exit gate would withhold the producer's consumers FOREVER. So when
+    /// this is `false`, `SubmitRun` REFUSES a critic-bearing workflow fail-closed
+    /// (rather than admitting a guaranteed deadlock). The host sets it `true` via
+    /// [`GatewayService::with_critics_supported`] only when it wires the critic-capable
+    /// executor. Defaults to `false` (conservative).
+    critics_supported: bool,
 }
 
 impl GatewayService {
@@ -399,7 +408,19 @@ impl GatewayService {
             grants_view: None,
             datasets: None,
             tailer: Arc::new(SnapshotTailer),
+            critics_supported: false,
         }
+    }
+
+    /// Declare that this serve can EVALUATE native deterministic critics (PR-2c-3
+    /// critic-live, H5) — the host has wired a critic-capable executor (the
+    /// inference build's `ModelRouterExecutor`). Until set, `SubmitRun` refuses a
+    /// critic-bearing workflow fail-closed (a critic with no verdict arm deadlocks
+    /// the exit gate).
+    #[must_use]
+    pub fn with_critics_supported(mut self, supported: bool) -> Self {
+        self.critics_supported = supported;
+        self
     }
 
     /// Wire the signature-catalog seam (the host's concrete `kx-catalog`-backed
@@ -484,14 +505,12 @@ impl KxGateway for GatewayService {
             "recipe_fingerprint must be 32 bytes",
         )?;
 
-        // Register first: returns only after the journaled instance_id (never
-        // acks ahead of the journal).
-        let instance_id = self
-            .submitter
-            .register_run(recipe_fp)
-            .await
-            .map_err(submit_status)?;
-
+        // Convert ALL Motes up front (PR-2c-3 critic-live): the cross-Mote critic
+        // admission below needs every Mote of the run together, and converting before
+        // `register_run` means a malformed / refused submission never leaves an orphan
+        // registered run behind.
+        let mut collected: Vec<(kx_mote::Mote, kx_warrant::WarrantSpec, bool)> =
+            Vec::with_capacity(req.motes.len());
         for spec in req.motes {
             let mote_proto = spec
                 .mote
@@ -507,8 +526,56 @@ impl KxGateway for GatewayService {
             let warrant: kx_warrant::WarrantSpec = warrant_proto
                 .try_into()
                 .map_err(|e: kx_proto::ConvertError| Status::invalid_argument(e.to_string()))?;
+            collected.push((mote, warrant, spec.accept_at_least_once));
+        }
+
+        // PR-2c-3 critic-live — cross-Mote critic ADMISSION (only when the run carries a
+        // critic, so a critic-free workflow is byte-for-byte unaffected).
+        if collected
+            .iter()
+            .any(|(m, _, _)| m.def.critic_check.is_some())
+        {
+            // H5: a native critic's verdict is computed ONLY by the inference-build
+            // executor. On a serve that cannot, a critic would commit echo bytes and the
+            // P4.2-3 exit gate would withhold its producer's consumers forever — so we
+            // refuse fail-closed rather than admit a guaranteed deadlock.
+            if !self.critics_supported {
+                return Err(Status::failed_precondition(
+                    "this serve cannot evaluate native deterministic critics (no inference \
+                     executor wired); a critic-bearing workflow is refused",
+                ));
+            }
+            // B3: enforce the CROSS-Mote critic refusals (R-2/R-4/R-5/R-6) the per-Mote
+            // submit path cannot — `critic_for` must reference an existing WORLD-MUTATING
+            // producer, no producer may carry two critics, a critic may not be itself
+            // WORLD-MUTATING, etc. `master_warrant`/`run_id` are not consulted by these
+            // checks, so placeholder values are sound.
+            let motes: std::collections::BTreeMap<kx_mote::MoteId, kx_mote::Mote> = collected
+                .iter()
+                .map(|(m, _, _)| (m.id, m.clone()))
+                .collect();
+            let accept_at_least_once = collected.iter().map(|(m, _, a)| (m.id, *a)).collect();
+            let submission = kx_refusal::WorkflowSubmission {
+                run_id: [0u8; 32],
+                master_warrant: kx_warrant::WarrantSpec::default(),
+                motes,
+                accept_at_least_once,
+            };
+            kx_refusal::validate_submission(&submission).map_err(|e| {
+                Status::failed_precondition(format!("critic admission refused: {e}"))
+            })?;
+        }
+
+        // Register: returns only after the journaled instance_id (never acks ahead of
+        // the journal). Then submit each Mote in order.
+        let instance_id = self
+            .submitter
+            .register_run(recipe_fp)
+            .await
+            .map_err(submit_status)?;
+        for (mote, warrant, accept) in collected {
             self.submitter
-                .submit_mote(mote, warrant, spec.accept_at_least_once)
+                .submit_mote(mote, warrant, accept)
                 .await
                 .map_err(submit_status)?;
         }

--- a/crates/kx-gateway-core/tests/gateway_e2e.rs
+++ b/crates/kx-gateway-core/tests/gateway_e2e.rs
@@ -252,6 +252,99 @@ async fn submit_run_rejects_malformed_recipe_fingerprint() {
     assert_eq!(err.code(), Code::InvalidArgument);
 }
 
+// --- PR-2c-3 critic-live: SubmitRun cross-Mote critic ADMISSION (B3 + H5) ---
+
+/// A native deterministic critic Mote wire-spec (`critic_check` + `critic_for`).
+fn critic_mote_spec(critic_for: [u8; 32]) -> proto::SubmitMoteSpec {
+    use common::{mote_def, sample_warrant};
+    use kx_critic_types::{CheckSpec, SchemaSpec, SchemaTag};
+    use kx_mote::{GraphPosition, InputDataId, Mote, MoteId, NdClass};
+
+    let mut def = mote_def(0xC0, NdClass::Pure);
+    def.critic_check = Some(CheckSpec::Schema(SchemaSpec {
+        expected: SchemaTag::Json,
+    }));
+    def.critic_for = Some(MoteId::from_bytes(critic_for));
+    let mote = Mote::new(
+        def,
+        InputDataId::from_bytes([0x20; 32]),
+        GraphPosition(vec![0xC0]),
+        smallvec::SmallVec::new(),
+    );
+    proto::SubmitMoteSpec {
+        mote: Some(mote.into()),
+        warrant: Some(sample_warrant().into()),
+        accept_at_least_once: false,
+    }
+}
+
+#[tokio::test]
+async fn submit_run_refuses_critic_when_critics_unsupported() {
+    // H5: the default service cannot evaluate critics → a critic-bearing workflow
+    // is refused fail-closed (never admitted into an exit-gate deadlock).
+    let svc = service_from(build_run(), Arc::new(MockSubmitter::default()));
+    let mut client = spawn(svc).await;
+    let err = client
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: RECIPE_FP.to_vec(),
+            motes: vec![critic_mote_spec([0xAA; 32])],
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert!(
+        err.message().contains("critic"),
+        "reason surfaced: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn submit_run_refuses_critic_with_dangling_critic_for() {
+    // B3: with critics supported, the whole-DAG validator still runs — a critic
+    // whose `critic_for` references no submitted Mote trips R-4 (cross-Mote, NOT
+    // enforced by the per-Mote live submit path) and is refused at ingress.
+    let svc =
+        service_from(build_run(), Arc::new(MockSubmitter::default())).with_critics_supported(true);
+    let mut client = spawn(svc).await;
+    let err = client
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: RECIPE_FP.to_vec(),
+            motes: vec![critic_mote_spec([0x77; 32])], // critic_for → a non-existent Mote
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert!(
+        err.message().contains("critic admission"),
+        "reason surfaced: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn submit_run_admits_critic_free_run_unchanged_when_unsupported() {
+    // A critic-free workflow is byte-for-byte unaffected by the admission gate even
+    // on a serve that cannot evaluate critics (the gate only engages on a critic).
+    let mock = MockSubmitter::default();
+    let svc = service_from(build_run(), Arc::new(mock.clone()));
+    let mut client = spawn(svc).await;
+    let handle = client
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: RECIPE_FP.to_vec(),
+            motes: vec![proto::SubmitMoteSpec {
+                mote: Some(sample_mote().into()),
+                warrant: Some(sample_warrant().into()),
+                accept_at_least_once: false,
+            }],
+        })
+        .await
+        .expect("a critic-free run is admitted unchanged")
+        .into_inner();
+    assert_eq!(handle.instance_id, INSTANCE_ID.to_vec());
+    assert!(mock.calls().iter().any(|c| c == "submit_mote"));
+}
+
 // --- SN-8 — the client never computes a MoteId -----------------------------
 
 #[test]

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -44,6 +44,12 @@ bincode         = { workspace = true }
 kx-invoke       = { workspace = true }
 kx-mote         = { workspace = true }
 kx-workflow     = { workspace = true }
+# PR-2c-3 (critic-live): the shared whole-DAG submission validator + the R-15
+# native-critic SHAPE gate (`native_critic_shape`). FFI-free (dep-wall-safe);
+# NON-optional because the SubmitRun ingress runs it in BOTH builds — to enforce
+# the cross-Mote critic refusals live (B3) and to refuse a critic-bearing DAG on a
+# non-inference serve build that cannot compute verdicts (H5, fail-closed).
+kx-refusal      = { workspace = true }
 # Inline parent-edge storage for the demo Mote built by `demo_submit_run_request`
 # (`Mote::new`'s `parents` is a `SmallVec<[ParentRef; 4]>`). Promoted from a dev-dep
 # (R3) so the helper is a NORMAL public library fn. FFI-free (the dep_wall forbids
@@ -74,6 +80,12 @@ kx-model-validator = { workspace = true, optional = true }
 # arm (model proposal → vetted TopologyDecision). FFI-free (dep-wall-safe); behind
 # `inference` so the default build is unaffected.
 kx-planner         = { workspace = true, optional = true }
+# PR-2c-3 (critic-live): the FFI-free deterministic-critic evaluator
+# (`kx_critic::evaluate` + `CriticVerdict`). The live verdict arm in
+# `model_exec.rs::run_critic` mirrors the FROZEN `run_native_critic_mote`; behind
+# `inference` because that arm lives in the inference-gated executor (a critic DAG
+# is refused on a non-inference serve, H5). Pure-Rust — the dep-wall stays green.
+kx-critic          = { workspace = true, optional = true }
 # T3.7: the FFI-free durable vector substrate (the Datasets data-plane). kx-dataset
 # (the RetrievalIndex trait + Hit) + kx-dataset-hnsw (the in-process HNSW ANN index).
 # Both pure-Rust (hnsw_rs / thiserror only) — NO llama.cpp, so the dep-wall holds.
@@ -154,6 +166,7 @@ inference = [
     "dep:kx-model-store",
     "dep:kx-model-validator",
     "dep:kx-planner",
+    "dep:kx-critic",
 ]
 # T3.7: the Datasets data-plane (RAG) read/write surface. The client-provided-vector
 # path is FFI-FREE + deterministic (CI-exercisable on Linux with no model). Pulls only

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -55,6 +55,15 @@ use kx_content::ContentRef;
 /// runaway model cannot materialize an unbounded DAG.
 pub(crate) const SHAPER_MAX_CHILDREN: usize = 8;
 
+/// Fail-closed upper bound on a native critic's producer-output size (PR-2c-3
+/// critic-live, M1). A critic reads the FULL committed producer bytes into memory to
+/// evaluate its check; a pathologically large output is refused (terminal) rather than
+/// risking an allocation blow-up on the lease hot path — and the verdict is NEVER
+/// computed over a truncated input (that would corrupt the gate). 16 MiB comfortably
+/// covers model completions + typical tool outputs; the frozen `run_native_critic_mote`
+/// has no cap, so the byte-for-byte equivalence test pins inputs ≤ this budget.
+pub(crate) const CRITIC_MAX_INPUT_BYTES: usize = 16 * 1024 * 1024;
+
 /// The single demo worker role a shaper fans out to: a PURE (greedy, recomputable) model
 /// step that runs the serve model with the child's per-child `intent` as its prompt.
 pub(crate) const WORKER_ROLE: &str = "worker";
@@ -470,6 +479,88 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             finished_at_epoch_ms: 0,
         })
     }
+
+    /// Run a **native deterministic CRITIC** Mote (PR-2c-3 critic-live) — the live
+    /// `kx serve` mirror of the FROZEN `kx_executor::run_native_critic_mote` (which
+    /// reads the producer from the journal the distributed executor cannot see).
+    ///
+    /// A critic carries no prompt (not a model Mote) and would otherwise fall to the
+    /// inner echo/real-body router, committing the WRONG bytes (no verdict). Instead we
+    /// evaluate the Mote's declared `critic_check` over its producer's (`critic_for`)
+    /// committed bytes — delivered byte-for-byte via the F-7 `parent_results` seam — and
+    /// commit the resulting `CriticVerdict`. The frozen `run_pure_mote` (a critic is
+    /// PURE) then commits the returned `result_ref`; the projection's P4.2-3 exit gate
+    /// withholds the producer's consumers until that verdict decodes `Valid`. A
+    /// behaviour-equivalence test pins `(verdict, result_ref)` byte-identical to the
+    /// frozen executor for the same `(spec, producer_bytes)`.
+    ///
+    /// **Fail-closed on every path** (never promote unvalidated output): a malformed
+    /// shape (R-15) or an oversized input is TERMINAL (dead-letters the critic — a
+    /// misconfigured gate must STALL, not silently pass). A missing producer context is
+    /// also TERMINAL, but it is **unreachable by construction**: a critic enters the
+    /// ready set only after its producer commits (the Data edge), and the coordinator's
+    /// D55 phantom-ref guard proves the producer's bytes are in the store before that
+    /// commit — so `resolve_parent_context` always delivers `[(critic_for, ref)]` and
+    /// `store.get` always resolves. (`MoteExecutorError` lives in the frozen executor and
+    /// has no content-missing variant; a transient-retry path is a deferred follow-on.)
+    fn run_critic(&self, mote: &Mote) -> Result<MoteExecutionResult, MoteExecutorError> {
+        // (1) Shared R-15 SHAPE gate — the identical four-condition predicate the
+        // submission refusal (`check_r15`) and the frozen executor enforce. Terminal.
+        kx_refusal::native_critic_shape(mote)
+            .map_err(|e| internal(&format!("native critic shape (R-15): {e}")))?;
+        // Shape-gated above ⇒ both are present; treat absence as a fail-closed bug.
+        let spec = mote
+            .def
+            .critic_check
+            .as_ref()
+            .ok_or_else(|| internal("critic_check vanished after shape gate"))?;
+        let producer_id = mote
+            .def
+            .critic_for
+            .ok_or_else(|| internal("critic_for vanished after shape gate"))?;
+
+        // (2) The producer's committed bytes via the F-7 seam (B1: EXACTLY `critic_for`,
+        // never another Data parent — `resolve_parent_context` special-cases a critic to
+        // deliver only `[(critic_for, ref)]`, so this find is a defense-in-depth pin).
+        let parents = self.take_parent_context(mote.id).unwrap_or_default();
+        let producer_ref = parents
+            .iter()
+            .find(|(id, _)| *id == producer_id)
+            .map(|(_, r)| *r)
+            .ok_or_else(|| {
+                internal(&format!(
+                    "critic producer {producer_id:?} bytes not delivered via F-7 \
+                     (scheduling/D55 invariant) — withholding fail-closed"
+                ))
+            })?;
+        let producer_bytes = self
+            .store
+            .get(&producer_ref)
+            .map_err(|e| internal(&format!("read critic producer bytes: {e}")))?;
+
+        // (3) Bound the input fail-closed (M1) — never truncate (that corrupts the gate).
+        if producer_bytes.len() > CRITIC_MAX_INPUT_BYTES {
+            return Err(internal(&format!(
+                "critic producer output {} bytes exceeds max {CRITIC_MAX_INPUT_BYTES}",
+                producer_bytes.len()
+            )));
+        }
+
+        // (4) Evaluate IN-PROCESS — pure / total / deterministic. The verdict's content
+        // ref is `blake3(verdict.encode())`, byte-identical to the frozen executor for
+        // the same `(spec, producer_bytes)` (SN-8: exact crypto-equality, integer-only
+        // evidence; the model never decides promotion — the deterministic check does).
+        let verdict = kx_critic::evaluate(spec, &producer_bytes);
+        let result_ref = self
+            .store
+            .put(&verdict.encode())
+            .map_err(|e| internal(&format!("content store put (verdict): {e}")))?;
+        Ok(MoteExecutionResult {
+            result_ref,
+            started_at_epoch_ms: 0,
+            finished_at_epoch_ms: 0,
+        })
+    }
 }
 
 impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
@@ -479,6 +570,13 @@ impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
         warrant: &WarrantSpec,
         env: Option<Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        // Native deterministic CRITIC FIRST (PR-2c-3 critic-live): a critic carries no
+        // prompt (so `is_model_mote` is false) and would otherwise fall to the inner
+        // echo/real-body router, committing the wrong bytes instead of a verdict. Route
+        // it to the in-process check (mirrors the FROZEN `run_native_critic_mote`).
+        if mote.def.critic_check.is_some() {
+            return self.run_critic(mote);
+        }
         // Shaper FIRST (a shaper is also a model Mote — has a prompt): the model proposes
         // topology, lowered + committed as a TopologyDecision. Then leaf-model (greedy
         // completion). Everything else → the inner real-body / PURE-echo router.
@@ -900,5 +998,210 @@ mod tests {
             prompt_from_config(&make(b"raw prompt")).as_deref(),
             Some("raw prompt")
         );
+    }
+
+    // --- critic arm (PR-2c-3 critic-live): verdict == frozen executor + fail-closed ---
+
+    use kx_critic::{CheckSpec, SchemaSpec, SchemaTag};
+    use kx_mote::MoteId;
+
+    fn json_check() -> CheckSpec {
+        CheckSpec::Schema(SchemaSpec {
+            expected: SchemaTag::Json,
+        })
+    }
+
+    /// A WORLD-MUTATING producer Mote (the critic's `critic_for`).
+    fn critic_producer() -> Mote {
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([1u8; 32]),
+            model_id: model_id(),
+            prompt_template_hash: PromptTemplateHash::from_bytes([2u8; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::WorldMutating,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::StageThenCommit,
+            critic_for: None,
+            is_topology_shaper: false,
+            inference_params: InferenceParams::default(),
+            critic_check: None,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([10u8; 32]),
+            GraphPosition(b"/producer".to_vec()),
+            SmallVec::new(),
+        )
+    }
+
+    /// A native deterministic critic for `producer` carrying `check`.
+    fn critic_mote(producer: MoteId, check: CheckSpec) -> Mote {
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([3u8; 32]),
+            model_id: model_id(),
+            prompt_template_hash: PromptTemplateHash::from_bytes([4u8; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::Pure,
+            config_subset: BTreeMap::new(),
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: Some(producer),
+            is_topology_shaper: false,
+            inference_params: InferenceParams::default(),
+            critic_check: Some(check),
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([20u8; 32]),
+            GraphPosition(b"/critic".to_vec()),
+            SmallVec::new(),
+        )
+    }
+
+    /// The verdict ref the FROZEN `kx_executor::run_native_critic_mote` would commit
+    /// for `(producer_bytes, check)` — the byte-for-byte oracle the gateway arm pins to.
+    fn frozen_verdict_ref(producer: &Mote, critic: &Mote, producer_bytes: &[u8]) -> ContentRef {
+        use kx_content::ContentStore as _;
+        use kx_journal::Journal as _;
+        let journal = kx_journal::InMemoryJournal::new();
+        let store = kx_content::InMemoryContentStore::new();
+        let result_ref = store.put(producer_bytes).unwrap();
+        journal
+            .append(kx_journal::JournalEntry::Committed {
+                mote_id: producer.id,
+                idempotency_key: *producer.id.as_bytes(),
+                seq: 0,
+                nondeterminism: NdClass::WorldMutating,
+                result_ref,
+                parents: SmallVec::new(),
+                warrant_ref: kx_warrant::warrant_ref_of(&shaper_warrant(
+                    &model_id(),
+                    ExecutorClass::MacOsSandbox,
+                )),
+                mote_def_hash: producer.def.hash(),
+            })
+            .unwrap();
+        kx_executor::run_native_critic_mote(
+            critic,
+            &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+            &journal,
+            &store,
+        )
+        .unwrap()
+        .result_ref
+    }
+
+    /// Deliver `parents` to the executor's F-7 slot (as the worker's `ContextSink`
+    /// would), then route the critic through `run`.
+    fn run_critic_with_context(
+        exec: &ModelRouterExecutor<StubBackend>,
+        critic: &Mote,
+        parents: Vec<(MoteId, ContentRef)>,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        use kx_worker::ContextSink;
+        exec.set_parent_results(critic.id, parents);
+        exec.run(
+            critic,
+            &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+            None,
+        )
+    }
+
+    #[test]
+    fn run_critic_verdict_is_byte_identical_to_frozen_executor() {
+        for (label, payload) in [
+            ("valid_json", &br#"{"ok":true}"#[..]),
+            ("invalid_json", &b"not json{{{"[..]),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalFsContentStore::open(dir.path()).unwrap();
+            let (exec, _) = executor(&store, b"unused", None);
+
+            let producer = critic_producer();
+            let critic = critic_mote(producer.id, json_check());
+            let producer_ref = store.put(payload).unwrap();
+
+            let out = run_critic_with_context(&exec, &critic, vec![(producer.id, producer_ref)])
+                .unwrap_or_else(|e| panic!("critic runs ({label}): {e:?}"));
+
+            // (1) The committed ref equals the FROZEN executor's verdict ref.
+            assert_eq!(
+                out.result_ref,
+                frozen_verdict_ref(&producer, &critic, payload),
+                "gateway run_critic must commit the SAME verdict ref as the frozen executor ({label})"
+            );
+            // (2) And it decodes to exactly `evaluate(check, producer_bytes)` (SN-8).
+            let bytes = store.get(&out.result_ref).unwrap();
+            let committed = kx_critic::CriticVerdict::decode(&bytes).unwrap();
+            assert_eq!(
+                committed,
+                kx_critic::evaluate(&json_check(), payload),
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    fn run_critic_evaluates_only_the_critic_for_parent() {
+        // B1: even handed an EXTRA (non-`critic_for`) parent, the verdict is computed
+        // over the producer's bytes ONLY — never another parent's.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, _) = executor(&store, b"unused", None);
+
+        let producer = critic_producer();
+        let critic = critic_mote(producer.id, json_check());
+        let producer_ref = store.put(br#"{"ok":true}"#).unwrap(); // VALID
+        let decoy_ref = store.put(b"garbage not json").unwrap(); // would be INVALID
+        let decoy_id = MoteId::from_bytes([0x99; 32]);
+
+        let out = run_critic_with_context(
+            &exec,
+            &critic,
+            vec![(decoy_id, decoy_ref), (producer.id, producer_ref)],
+        )
+        .unwrap();
+        let committed =
+            kx_critic::CriticVerdict::decode(&store.get(&out.result_ref).unwrap()).unwrap();
+        assert!(
+            committed.is_valid(),
+            "the verdict must reflect the critic_for producer's (valid) bytes, not the decoy"
+        );
+    }
+
+    #[test]
+    fn run_critic_fails_closed_on_non_pure_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, _) = executor(&store, b"unused", None);
+        let producer = critic_producer();
+        let mut bad = critic_mote(producer.id, json_check());
+        // An ill-shaped critic (WORLD-MUTATING) must be refused fail-closed (R-15).
+        bad.def.nd_class = NdClass::WorldMutating;
+        let bad = Mote::new(
+            bad.def.clone(),
+            InputDataId::from_bytes([20u8; 32]),
+            GraphPosition(b"/critic".to_vec()),
+            SmallVec::new(),
+        );
+        let producer_ref = store.put(br#"{"ok":true}"#).unwrap();
+        let err = run_critic_with_context(&exec, &bad, vec![(producer.id, producer_ref)])
+            .expect_err("a non-Pure critic is refused (R-15)");
+        assert!(matches!(err, MoteExecutorError::Internal { .. }));
+    }
+
+    #[test]
+    fn run_critic_fails_closed_when_producer_not_delivered() {
+        // No F-7 context delivered ⇒ the producer's bytes are absent ⇒ withhold
+        // fail-closed (terminal), never a silent or empty-input verdict.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, _) = executor(&store, b"unused", None);
+        let producer = critic_producer();
+        let critic = critic_mote(producer.id, json_check());
+        let err = run_critic_with_context(&exec, &critic, vec![])
+            .expect_err("a critic with no delivered producer fails closed");
+        assert!(matches!(err, MoteExecutorError::Internal { .. }));
     }
 }

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -517,6 +517,12 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     //      step warrant uses the embedded worker's executor_class so a bound run
     //      leases (see `provision::demo_warrant`).
     let parties: Vec<String> = cfg.auth_tokens.values().cloned().collect();
+    // PR-2c-3 critic-live (H5): native deterministic critics are evaluated by the
+    // inference build's `ModelRouterExecutor` (which holds `run_critic`). That executor
+    // is wired exactly when a fit serve model resolved (`serve_model.is_some()`), so the
+    // gateway advertises critic support iff it is present — `SubmitRun` refuses a
+    // critic-bearing workflow otherwise (rather than admitting an exit-gate deadlock).
+    let critics_supported = serve_model.is_some();
     let demo = Arc::new(DemoLibrary::open_full(
         &catalog_dir,
         default_executor_class(),
@@ -570,6 +576,7 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         .with_recipe_catalog(recipe_catalog)
         .with_membership_view(membership_view)
         .with_grant_view(grant_view)
+        .with_critics_supported(critics_supported)
         .with_event_tailer(Arc::new(crate::live_tail::LiveTailer::new(
             live_shutdown_rx.clone(),
         )));

--- a/crates/kx-projection/src/critic_gate_tests.rs
+++ b/crates/kx-projection/src/critic_gate_tests.rs
@@ -1,0 +1,243 @@
+//! PR-2c-3 critic-live — `Projection::ready_set_auto` exit-gate tests.
+//!
+//! Builds a real `producer (WORLD-MUTATING) → critic → consumer` DAG through the
+//! public `register_mote` + `fold` surface and asserts the live `kx serve` gate
+//! behaviour end-to-end: a WM producer's consumer is withheld until its critic
+//! commits a `Valid` verdict, the gate is FAIL-CLOSED with no verdict lookup, and a
+//! critic-free run is byte-for-byte the ungated `ready_set` (zero gate cost).
+
+#![cfg(test)]
+
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_critic_types::{CheckKind, CriticReason, CriticVerdict};
+use kx_journal::{JournalEntry, ParentEntry};
+use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+use smallvec::SmallVec;
+
+use crate::promotion::ContentStoreVerdicts;
+use crate::{Projection, RegisterMote};
+
+fn mid(b: u8) -> MoteId {
+    MoteId::from_bytes([b; 32])
+}
+
+fn data_parent(id: MoteId) -> ParentRef {
+    ParentRef {
+        parent_id: id,
+        edge: EdgeMeta::data(),
+    }
+}
+
+fn register(
+    id: MoteId,
+    nd: NdClass,
+    critic_for: Option<MoteId>,
+    parents: &[ParentRef],
+) -> RegisterMote {
+    RegisterMote {
+        mote_id: id,
+        nd_class: nd,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for,
+        is_topology_shaper: false,
+        parents: parents.iter().copied().collect(),
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+    }
+}
+
+fn commit(
+    id: MoteId,
+    seq: u64,
+    nd: NdClass,
+    result_ref: ContentRef,
+    parents: &[ParentRef],
+) -> JournalEntry {
+    let pe: SmallVec<[ParentEntry; 4]> = parents.iter().map(ParentEntry::from_parent_ref).collect();
+    JournalEntry::Committed {
+        mote_id: id,
+        idempotency_key: *id.as_bytes(),
+        seq,
+        nondeterminism: nd,
+        result_ref,
+        parents: pe,
+        warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+        mote_def_hash: MoteDefHash::from_bytes([1u8; 32]),
+    }
+}
+
+fn invalid() -> CriticVerdict {
+    CriticVerdict::Invalid {
+        reason: CriticReason::Unparseable {
+            check: CheckKind::Schema,
+            at_offset: 0,
+        },
+    }
+}
+
+/// Build the `producer(WM) → {critic, consumer}` DAG. The critic commits `verdict`
+/// (its `result_ref` is the encoded verdict bytes in `store`); the consumer is left
+/// Pending (a Data edge to the producer). Returns `(projection, consumer_id)`.
+fn dag_with_critic(store: &InMemoryContentStore, verdict: &CriticVerdict) -> (Projection, MoteId) {
+    let (producer, critic, consumer) = (mid(1), mid(2), mid(3));
+    let mut p = Projection::new();
+    // Producer: WORLD-MUTATING, committed.
+    p.register_mote(register(producer, NdClass::WorldMutating, None, &[]));
+    let producer_out = store.put(b"the producer output").unwrap();
+    p.fold(&commit(
+        producer,
+        1,
+        NdClass::WorldMutating,
+        producer_out,
+        &[],
+    ))
+    .unwrap();
+    // Critic: Pure, critic_for=producer, Data edge to producer, committed verdict.
+    p.register_mote(register(
+        critic,
+        NdClass::Pure,
+        Some(producer),
+        &[data_parent(producer)],
+    ));
+    let verdict_ref = store.put(&verdict.encode()).unwrap();
+    p.fold(&commit(
+        critic,
+        2,
+        NdClass::Pure,
+        verdict_ref,
+        &[data_parent(producer)],
+    ))
+    .unwrap();
+    // Consumer: Pure, Data edge to producer, NOT committed ⇒ Pending.
+    p.register_mote(register(
+        consumer,
+        NdClass::Pure,
+        None,
+        &[data_parent(producer)],
+    ));
+    (p, consumer)
+}
+
+#[test]
+fn valid_verdict_promotes_consumer() {
+    let store = InMemoryContentStore::new();
+    let (p, consumer) = dag_with_critic(&store, &CriticVerdict::Valid);
+    let verdicts = ContentStoreVerdicts::new(store);
+    assert!(
+        p.ready_set_auto(Some(&verdicts)).contains(&consumer),
+        "a Valid critic verdict must PROMOTE the WM producer's consumer"
+    );
+}
+
+#[test]
+fn invalid_verdict_withholds_consumer() {
+    let store = InMemoryContentStore::new();
+    let (p, consumer) = dag_with_critic(&store, &invalid());
+    let verdicts = ContentStoreVerdicts::new(store);
+    assert!(
+        !p.ready_set_auto(Some(&verdicts)).contains(&consumer),
+        "an Invalid critic verdict must WITHHOLD the consumer (fail-closed exit gate)"
+    );
+}
+
+#[test]
+fn no_verdict_lookup_withholds_when_critic_declared() {
+    // B2 fail-closed: a critic is declared, but no content store resolves its
+    // verdict ⇒ the gate withholds (never promotes blind). `None` lookup.
+    let store = InMemoryContentStore::new();
+    let (p, consumer) = dag_with_critic(&store, &CriticVerdict::Valid);
+    assert!(p.has_declared_critic(), "the DAG declares a critic");
+    assert!(
+        !p.ready_set_auto(None).contains(&consumer),
+        "a declared critic with no verdict lookup must WITHHOLD (fail-closed)"
+    );
+}
+
+#[test]
+fn a_pending_critic_is_not_gated_by_its_own_producer() {
+    // Deadlock-avoidance: a critic IS the gate, not a gated consumer. With its WM
+    // producer committed but UNPROMOTED (the verdict is exactly what this critic will
+    // produce), the critic must still be ready — else the producer could never be
+    // promoted. A NON-critic consumer of the same producer stays withheld.
+    let store = InMemoryContentStore::new();
+    let (producer, critic, consumer) = (mid(1), mid(2), mid(3));
+    let mut p = Projection::new();
+    p.register_mote(register(producer, NdClass::WorldMutating, None, &[]));
+    let producer_out = store.put(b"out").unwrap();
+    p.fold(&commit(
+        producer,
+        1,
+        NdClass::WorldMutating,
+        producer_out,
+        &[],
+    ))
+    .unwrap();
+    // Critic: PENDING (registered, not committed), critic_for = producer.
+    p.register_mote(register(
+        critic,
+        NdClass::Pure,
+        Some(producer),
+        &[data_parent(producer)],
+    ));
+    // Non-critic consumer of the producer: PENDING.
+    p.register_mote(register(
+        consumer,
+        NdClass::Pure,
+        None,
+        &[data_parent(producer)],
+    ));
+
+    let verdicts = ContentStoreVerdicts::new(store);
+    let ready = p.ready_set_auto(Some(&verdicts));
+    assert!(
+        ready.contains(&critic),
+        "the producer's own critic must be ready (it is the gate, not a gated consumer)"
+    );
+    assert!(
+        !ready.contains(&consumer),
+        "a non-critic consumer stays withheld until the critic commits Valid"
+    );
+}
+
+#[test]
+fn critic_free_run_is_byte_identical_to_ready_set() {
+    // A WM producer with NO critic: has_declared_critic is false, so ready_set_auto
+    // takes the ungated ready_set path — the consumer is ready, and the result is
+    // identical with Some(verdicts) or None (zero gate cost, digest-invariant).
+    let store = InMemoryContentStore::new();
+    let (producer, consumer) = (mid(1), mid(3));
+    let mut p = Projection::new();
+    p.register_mote(register(producer, NdClass::WorldMutating, None, &[]));
+    let producer_out = store.put(b"output").unwrap();
+    p.fold(&commit(
+        producer,
+        1,
+        NdClass::WorldMutating,
+        producer_out,
+        &[],
+    ))
+    .unwrap();
+    p.register_mote(register(
+        consumer,
+        NdClass::Pure,
+        None,
+        &[data_parent(producer)],
+    ));
+
+    assert!(!p.has_declared_critic(), "no critic declared");
+    let verdicts = ContentStoreVerdicts::new(store);
+    let baseline = p.ready_set();
+    assert!(
+        baseline.contains(&consumer),
+        "ungated: a WM parent with no critic does not withhold"
+    );
+    assert_eq!(
+        p.ready_set_auto(Some(&verdicts)),
+        baseline,
+        "critic-free run: ready_set_auto(Some) must equal ready_set (byte-identical)"
+    );
+    assert_eq!(
+        p.ready_set_auto(None),
+        baseline,
+        "critic-free run: ready_set_auto(None) must equal ready_set (byte-identical)"
+    );
+}

--- a/crates/kx-projection/src/helpers.rs
+++ b/crates/kx-projection/src/helpers.rs
@@ -2,7 +2,7 @@
 //! transitive-consumers BFS walk, ready-set computation, 3c promotion-state
 //! stub.
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use kx_mote::{EdgeKind, MoteId, NdClass};
 
@@ -52,6 +52,16 @@ pub(crate) fn ready_set_impl_with(
     promotion: &dyn Fn(&State, &MoteId) -> PromotionState,
 ) -> Vec<MoteId> {
     let mut out: Vec<MoteId> = Vec::new();
+    // Per-pass promotion memo (PR-2c-3 critic-live, H2/H3). The WORLD-MUTATING
+    // promotion gate is keyed by the PRODUCER, and many pending consumers commonly
+    // share the same producer, so the unmemoized oracle recomputes the same verdict
+    // scan + content-store decode once per consumer (the hot-path waste the red-team
+    // flagged). Computing each producer's promotion state once per `ready_set` pass
+    // makes the cost O(distinct WM producers · M) instead of O(consumers · M); the
+    // result is byte-identical (a committed verdict is an immutable content-addressed
+    // fact), so the demo digest and the P1 contract are untouched. The default
+    // `NotApplicable` stub never even reaches here (it returns before any store read).
+    let mut promo_memo: BTreeMap<MoteId, PromotionState> = BTreeMap::new();
     for (id, info) in &state.motes {
         if state.state_of_id(id) != MoteState::Pending {
             continue;
@@ -71,12 +81,27 @@ pub(crate) fn ready_set_impl_with(
             }
             // WORLD-MUTATING promotion gate (per projection.md §7). In P1 default,
             // promotion_state always returns NotApplicable, so the gate passes
-            // trivially. The check is in the contract so it activates when the
-            // executor (P1.9) wires the MoteDef registry.
+            // trivially. The P4.2-3 verdict-aware oracle (live in `kx serve` as of
+            // PR-2c-3) withholds a consumer until every critic of a WM producer
+            // commits a `Valid` verdict.
+            //
+            // EXCEPT the producer's OWN critic: a critic (`critic_for == p.parent_id`)
+            // IS the gate, not a gated consumer — it must run to PRODUCE the verdict
+            // that promotes the producer. Gating it on the producer's (still-pending)
+            // promotion would deadlock (the producer can never be promoted because its
+            // critic can never run). A critic of a DIFFERENT WM parent stays gated by
+            // that parent. (Live-only effect: under the P1 `NotApplicable` default the
+            // branch is never taken, so the demo digest is byte-unchanged.)
+            if d.critic_for.as_ref() == Some(&p.parent_id) {
+                continue;
+            }
             if let Some(pinfo) = state.motes.get(&p.parent_id) {
                 if let Some(committed) = &pinfo.committed {
                     if committed.nondeterminism == NdClass::WorldMutating {
-                        match promotion(state, &p.parent_id) {
+                        let promo = *promo_memo
+                            .entry(p.parent_id)
+                            .or_insert_with(|| promotion(state, &p.parent_id));
+                        match promo {
                             PromotionState::Promoted | PromotionState::NotApplicable => {}
                             PromotionState::Unpromoted => {
                                 all_wm_parents_promoted = false;
@@ -103,3 +128,94 @@ pub(crate) fn promotion_state_impl(_state: &State, _mote_id: &MoteId) -> Promoti
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use kx_content::ContentRef;
+    use kx_mote::{EdgeMeta, EffectPattern, MoteDefHash, MoteId, NdClass, ParentRef};
+    use smallvec::SmallVec;
+
+    use super::ready_set_impl_with;
+    use crate::enums::PromotionState;
+    use crate::state::{CommittedInfo, DeclaredInfo, MoteInfo, State};
+
+    fn id(b: u8) -> MoteId {
+        MoteId::from_bytes([b; 32])
+    }
+
+    /// PR-2c-3 critic-live (H2/H3): the promotion oracle is memoized PER PASS — many
+    /// pending consumers of one WORLD-MUTATING producer compute its promotion state
+    /// ONCE, not once per consumer. Proves the gate cost is `O(distinct WM producers)`,
+    /// not `O(consumers)`, on the lease hot path (the scalability guarantee), and that
+    /// the memo is behaviour-preserving (every consumer still becomes ready).
+    #[test]
+    fn promotion_oracle_is_memoized_per_pass() {
+        let producer = id(1);
+        let mut state = State::default();
+        // A committed WORLD-MUTATING producer.
+        state.motes.insert(
+            producer,
+            MoteInfo {
+                declared: Some(DeclaredInfo {
+                    nd_class: NdClass::WorldMutating,
+                    effect_pattern: EffectPattern::StageThenCommit,
+                    critic_for: None,
+                    is_topology_shaper: false,
+                    parents: SmallVec::new(),
+                    warrant_ref: ContentRef::from_bytes([0; 32]),
+                }),
+                committed: Some(CommittedInfo {
+                    seq: 1,
+                    result_ref: ContentRef::from_bytes([9; 32]),
+                    nondeterminism: NdClass::WorldMutating,
+                    parents_in_entry: SmallVec::new(),
+                    warrant_ref: ContentRef::from_bytes([0; 32]),
+                    mote_def_hash: MoteDefHash::from_bytes([0; 32]),
+                    repudiated: false,
+                }),
+                ..Default::default()
+            },
+        );
+        // 16 pending consumers, each a Data child of the one producer.
+        let consumers = 16u8;
+        for c in 2..2 + consumers {
+            state.motes.insert(
+                id(c),
+                MoteInfo {
+                    declared: Some(DeclaredInfo {
+                        nd_class: NdClass::Pure,
+                        effect_pattern: EffectPattern::IdempotentByConstruction,
+                        critic_for: None,
+                        is_topology_shaper: false,
+                        parents: SmallVec::from_vec(vec![ParentRef {
+                            parent_id: producer,
+                            edge: EdgeMeta::data(),
+                        }]),
+                        warrant_ref: ContentRef::from_bytes([0; 32]),
+                    }),
+                    committed: None, // Pending
+                    ..Default::default()
+                },
+            );
+        }
+
+        let calls = Cell::new(0u32);
+        let ready = ready_set_impl_with(&state, &|_s, _id| {
+            calls.set(calls.get() + 1);
+            PromotionState::Promoted
+        });
+
+        assert_eq!(
+            calls.get(),
+            1,
+            "the WM producer's promotion is computed ONCE for all {consumers} consumers (memoized)"
+        );
+        assert_eq!(
+            ready.len(),
+            consumers as usize,
+            "every consumer of a Promoted producer becomes ready (behaviour-preserving)"
+        );
+    }
+}

--- a/crates/kx-projection/src/lib.rs
+++ b/crates/kx-projection/src/lib.rs
@@ -120,6 +120,8 @@
 
 mod checkpoint;
 mod child_resolver;
+#[cfg(test)]
+mod critic_gate_tests;
 mod enums;
 mod errors;
 mod helpers;

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -804,6 +804,41 @@ impl Projection {
         })
     }
 
+    /// The ready set with the **P4.2-3 critic exit-gate auto-activated**
+    /// (PR-2c-3 critic-live — the live `kx serve` lease + ReadySet entry point).
+    ///
+    /// - **No critic declared in the run** ⇒ exactly [`Self::ready_set`] (the P1
+    ///   `NotApplicable` default): a critic-free DAG NEVER pays the verdict scan, so
+    ///   the canonical demo + every critic-free run are byte-for-byte unchanged.
+    /// - **A critic IS declared, `Some(verdicts)`** ⇒ [`Self::ready_set_promoted`]
+    ///   (the live exit gate, fed by a content-addressed verdict lookup).
+    /// - **A critic IS declared, `None`** ⇒ FAIL-CLOSED: every critic-gated consumer
+    ///   is withheld (a critic exists but no store can resolve its verdict, so the
+    ///   gate cannot prove `Valid`). Gating on the *folded* `has_declared_critic`
+    ///   (not on whether a store handle is present) keeps the ready set a pure,
+    ///   deterministic fold of the journal — it can never fail OPEN (B2).
+    #[must_use]
+    pub fn ready_set_auto(
+        &self,
+        verdicts: Option<&dyn crate::promotion::VerdictLookup>,
+    ) -> Vec<MoteId> {
+        if !self.state.has_declared_critic() {
+            return self.ready_set();
+        }
+        match verdicts {
+            Some(v) => self.ready_set_promoted(v),
+            None => self.ready_set_promoted(&crate::promotion::NoVerdicts),
+        }
+    }
+
+    /// `true` iff any declared Mote is a deterministic critic (`critic_for =
+    /// Some`). Gates [`Self::ready_set_auto`] so a critic-free run pays zero
+    /// exit-gate cost. A pure fold of the journal (PR-2c-3 critic-live).
+    #[must_use]
+    pub fn has_declared_critic(&self) -> bool {
+        self.state.has_declared_critic()
+    }
+
     /// The verdict-resolved promotion state of `producer_id` (P4.2-3). Unlike
     /// [`Self::promotion_state`] (the P1 `NotApplicable` stub), this reads
     /// committed critic verdicts via `verdicts`.

--- a/crates/kx-projection/src/promotion.rs
+++ b/crates/kx-projection/src/promotion.rs
@@ -53,6 +53,21 @@ impl<S: ContentStore> VerdictLookup for ContentStoreVerdicts<S> {
     }
 }
 
+/// A fail-closed [`VerdictLookup`] that resolves NOTHING — every verdict is
+/// treated as missing (⇒ "not Valid" ⇒ withhold). Used by
+/// [`crate::Projection::ready_set_auto`] when a critic IS declared in the run but
+/// no content store is available to resolve its verdict: the gate withholds the
+/// producer's consumers rather than promoting blind. This keeps the exit gate a
+/// deterministic pure fold of the journal — it can never fail OPEN because a store
+/// handle happened to be absent (PR-2c-3 critic-live, B2).
+pub struct NoVerdicts;
+
+impl VerdictLookup for NoVerdicts {
+    fn verdict(&self, _critic_result_ref: &ContentRef) -> Option<CriticVerdict> {
+        None
+    }
+}
+
 /// Compute the [`PromotionState`] of `producer_id` against committed critic
 /// verdicts. Pure over `state` + the verdict lookups.
 ///

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -197,6 +197,16 @@ impl State {
         self.motes.entry(*id).or_default()
     }
 
+    /// `true` iff any declared Mote is a deterministic critic (`critic_for =
+    /// Some`). Gates the P4.2-3 exit gate in `kx serve` so a critic-free run pays
+    /// zero verdict-scan cost (PR-2c-3 critic-live). A pure fold read — `O(M)`,
+    /// consulted once per lease poll, far cheaper than the `O(M²)` it guards.
+    pub(crate) fn has_declared_critic(&self) -> bool {
+        self.motes
+            .values()
+            .any(|i| i.declared.as_ref().is_some_and(|d| d.critic_for.is_some()))
+    }
+
     /// Compute the per-identity state per `projection.md` §4 (v2 derivation
     /// per STEP 5.1 of PR 4.5).
     ///

--- a/crates/kx-refusal/src/lib.rs
+++ b/crates/kx-refusal/src/lib.rs
@@ -37,6 +37,6 @@
 mod refusal;
 
 pub use refusal::{
-    refusal_from_narrowing, validate_mote_submission, validate_submission,
+    native_critic_shape, refusal_from_narrowing, validate_mote_submission, validate_submission,
     validate_submission_with_idempotency, SubmissionRefusal, ToolResolution, WorkflowSubmission,
 };

--- a/crates/kx-refusal/src/refusal.rs
+++ b/crates/kx-refusal/src/refusal.rs
@@ -619,9 +619,26 @@ fn check_r14(mote: &Mote) -> Result<(), SubmissionRefusal> {
     Ok(())
 }
 
-/// **R-15** (D60 / P4.2-2). Refuse a `critic_check`-bearing Mote that is not a
-/// well-formed native critic. See `SubmissionRefusal::R15NativeCheckShape`.
-fn check_r15(mote: &Mote) -> Result<(), SubmissionRefusal> {
+/// **R-15** (D60 / P4.2-2) — the shared native-critic SHAPE gate.
+///
+/// The single predicate the runtime enforces in three places: the submission-time
+/// refusal (`check_r15` → [`validate_mote_submission`]), and — re-landed in
+/// PR-2c-3 critic-live — the live verdict executor in `kx-gateway`'s
+/// `ModelRouterExecutor::run_critic`. A `critic_check`-bearing Mote MUST be
+/// [`NdClass::Pure`], declare `critic_for = Some(_)`, and not be a topology shaper;
+/// a non-critic (`critic_check.is_none()`) trivially passes (returns `Ok`).
+///
+/// This is the non-frozen mirror of the FROZEN `kx_executor::run_native_critic_mote`
+/// inline R-15 guard (kx-executor, which cannot be edited). A behaviour-equivalence
+/// test pins all three call-sites to the identical four-condition shape so the live
+/// path can never accept a critic the frozen executor would reject (and vice-versa).
+///
+/// # Errors
+///
+/// Returns [`SubmissionRefusal::R15NativeCheckShape`] iff `mote` carries a
+/// `critic_check` but is not a well-formed native critic (not `Pure`, missing
+/// `critic_for`, or a topology shaper).
+pub fn native_critic_shape(mote: &Mote) -> Result<(), SubmissionRefusal> {
     if mote.def.critic_check.is_none() {
         return Ok(());
     }
@@ -632,6 +649,12 @@ fn check_r15(mote: &Mote) -> Result<(), SubmissionRefusal> {
         return Err(SubmissionRefusal::R15NativeCheckShape { mote_id: mote.id });
     }
     Ok(())
+}
+
+/// **R-15** (D60 / P4.2-2). Refuse a `critic_check`-bearing Mote that is not a
+/// well-formed native critic. Delegates to the shared [`native_critic_shape`] gate.
+fn check_r15(mote: &Mote) -> Result<(), SubmissionRefusal> {
+    native_critic_shape(mote)
 }
 
 fn check_r9(mote: &Mote, motes: &BTreeMap<MoteId, Mote>) -> Result<(), SubmissionRefusal> {


### PR DESCRIPTION
## What

Wires the runtime's **native deterministic-critic exit-gate** into the live `kx serve` path — the last piece of the PR-2c live-agentic-loop track (after F-7 #163 and re-plan-live #164). A **WORLD-MUTATING producer's** downstream consumers are now withheld until a deterministic **`Valid` `CriticVerdict`** commits, so schema / PII-leak / dedup / stat-bounds checks gate real-world effects before consumers proceed.

The critic mechanism was fully built + tested but only reachable via the `kx-runtime` engine (`run_with_seams`/harness), which live `kx serve` does not use: the worker's `run_pure_mote` never computed a verdict, and the coordinator's `lease_ready` used `ready_set()` (gate inactive). This PR closes both.

## Three changes (Option 1: gate WM producers; refuse critic DAGs on non-inference serve — both user-chosen)

1. **Verdict arm** — `kx-gateway` `ModelRouterExecutor::run_critic`. A critic Mote (`critic_check.is_some()`) is evaluated in-process via `kx_critic::evaluate` over its producer's (`critic_for`) committed bytes — delivered byte-for-byte through the F-7 `parent_results` seam — and commits the verdict (the frozen `run_pure_mote` then commits the ref). Mirrors the **FROZEN** `run_native_critic_mote`, pinned **byte-identical** by an equivalence test. Selects EXACTLY the `critic_for` parent (B1), shape-gated (`native_critic_shape`), size-bounded (M1), fail-closed on every path.
2. **Gate activation** — `kx-coordinator` + `kx-projection`. `lease_ready` AND the `ReadySet` arm use a new `Projection::ready_set_auto`, gated on the folded `has_declared_critic` (a critic-free run is **byte-identical** to `ready_set` — zero cost; B2 fail-closed when no verdict lookup; H4 no lease/ReadySet split-brain). `promotion_state_with` is **memoized per pass** (`O(distinct WM producers)`, not `O(consumers)`; H2/H3). `resolve_parent_context` special-cases a critic to deliver only `[(critic_for, ref)]` (B1). **A critic is never withheld by the promotion of the producer it critiques** (deadlock-avoidance — caught by the existing distributed VTC-cascade test).
3. **Shared R-15 gate** — `kx-refusal` `native_critic_shape`. One predicate the submission refusal (`check_r15`) and the live verdict arm both enforce; a 3-way behaviour-equivalence test pins it to the frozen executor's inline gate.

Plus **B3/H5** (`kx-gateway-core` SubmitRun ingress): a critic-bearing run is refused fail-closed on a serve that can't evaluate critics (H5), and the whole-DAG `validate_submission` enforces the cross-Mote critic refusals (R-2/R-4/R-5/R-6) the per-Mote live path cannot (B3).

## Golden Rule 8 (pre-flight) + invariants

- **Breaks/fwd-back-compat:** no proto / journal / checkpoint change (verdict commits as a normal Pure `Committed`; verdict lookup transient). **Digest `7d22d4bd…` byte-invariant** (demo has no critics; `ready_set_auto ≡ ready_set` with none; the engine baseline already uses the promotion-gated ready set). Frozen trio (`kx-executor`/`kx-scheduler`/`kx-inference`) **src byte-untouched**.
- **Perf/scale:** the `O(M²)` promotion scan is fixed by the per-pass memo + the `has_declared_critic` gate (zero cost on critic-free runs, incl. the 25k scale-smoke). Proven by a memoization test (oracle computed once per producer).
- **Security/SN-8:** exact crypto-equality (content-addressed verdict, strict decode, spec in `MoteId` identity — forgery/spec-swap closed); B3 rejects orphan/misdirected critics; every error path fails **closed** (withhold), never open.
- `Cargo.lock` += dep edges only (`kx-gateway`→`kx-critic`/`kx-refusal`, `kx-gateway-core`→`kx-refusal`/`kx-critic-types`[dev]); no new external crates.

## Tests

- **Equivalence/determinism:** `run_critic` byte-identical to the frozen executor (valid + invalid JSON), `critic_for`-only byte source, fail-closed on bad shape / missing producer.
- **Promotion gating:** `ready_set_auto` valid-promotes / invalid-withholds / no-lookup-fail-closed / critic-free-byte-identical / **pending-critic-not-self-gated** (deadlock-avoidance).
- **Perf:** per-pass memoization (`O(producers)`).
- **Refusal:** 3-way `native_critic_shape` ≡ frozen gate.
- **Ingress (B3/H5):** SubmitRun refuses critic when unsupported, refuses dangling `critic_for`, admits critic-free unchanged.
- Full local gate green: fmt · clippy `-D warnings` (default + inference) · `cargo test --workspace` (1979 passed) · doc · cargo-deny · dep-wall · digest `7d22d4bd` (a0_guard + audit_trail) · frozen-trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)