### PR TITLE
feat(profile,llamacpp): PR-2d-0 — profile-harness (Golden Rule 10: measure-and-persist runtime metrics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,11 @@ kx-cloud/
 /docs/analysis/
 # Plan files are private-only (SN-5: plans NEVER land in the public OSS repo).
 /docs/plans/
+# Profiling/benchmark results are private-only (Golden Rule 10 / SN-2): the
+# `just profile` HARNESS is public OSS, but the captured numbers are a corpus
+# trend record that lives only in the private kortecx-core checkout under
+# docs/benchmarks/. Added BEFORE any result file can exist so none leaks.
+/docs/benchmarks/
 # Internal warning/debug log — kept in the private kortecx-core repo only.
 /WARNINGS.md
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-profile"
+version = "0.0.1"
+dependencies = [
+ "kx-gateway",
+ "kx-proto",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tonic-health",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kx-projection"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "crates/kx-invoke",
     "crates/kx-model-store",
     "crates/kx-cli",
+    "crates/kx-profile",
 ]
 exclude = [
     "kx-cloud",

--- a/crates/kx-llamacpp/tests/smoke.rs
+++ b/crates/kx-llamacpp/tests/smoke.rs
@@ -160,6 +160,82 @@ fn smoke_end_to_end_inference() {
     );
 }
 
+/// Golden Rule 10 (M6) — inference-path timing spike: **model warm-up** (GGUF
+/// load), **time-to-first-token** (TTFT = prompt-decode → first greedy sample),
+/// and **decode tokens/sec** over a short greedy generation.
+///
+/// Prints a single greppable line; there are NO hard thresholds (absolute
+/// inference latency is platform/model-sensitive — Metal vs CPU, and the toy
+/// stories260K is not representative of a production model). `just
+/// profile-inference` runs this and the numbers are copied into the PRIVATE
+/// `docs/benchmarks/` trend record (SN-2). It asserts only that generation
+/// makes progress (no divide-by-zero, ≥ 2 tokens) so a broken pipeline still
+/// fails loudly.
+#[test]
+fn smoke_inference_timing() {
+    use std::time::Instant;
+
+    let backend = LlamaBackend::new().expect("backend init");
+
+    // M6a — model warm-up: time the GGUF load (tensor load + KV alloc).
+    let t_load = Instant::now();
+    let params = ModelParams::new().with_n_gpu_layers(0);
+    let model = Model::load_with_params(&backend, MODEL_PATH, &params).expect("load stories260K");
+    let warmup_load_ms = t_load.elapsed().as_secs_f64() * 1000.0;
+
+    let vocab = model.vocab();
+    let prompt = vocab
+        .tokenize("Once upon a time", true, false)
+        .expect("tokenize");
+
+    let mut ctx = Context::new_with_params(
+        &model,
+        &ContextParams::new().with_n_ctx(256).with_n_seq_max(1),
+    )
+    .expect("context");
+
+    // M6b — TTFT: prompt decode → first greedy sample.
+    let mut batch = Batch::with_capacity(prompt.len() as i32, 1);
+    for (i, &t) in prompt.iter().enumerate() {
+        let last = i + 1 == prompt.len();
+        batch.add(t, i as i32, &[0], last);
+    }
+    let t_ttft = Instant::now();
+    ctx.decode(&batch).expect("decode prompt");
+    let mut sampler = Sampler::greedy(&backend).expect("greedy");
+    let mut next = sampler.sample(&mut ctx, -1);
+    let ttft_ms = t_ttft.elapsed().as_secs_f64() * 1000.0;
+
+    // M6c — decode throughput: time a short greedy generation.
+    const GEN: usize = 16;
+    let t_gen = Instant::now();
+    let mut produced = 1usize; // the TTFT token counts as the first
+    for step in 0..GEN {
+        if next.is_eog(&vocab) {
+            break;
+        }
+        let mut step_batch = Batch::with_capacity(1, 1);
+        step_batch.add(next, (prompt.len() + step) as i32, &[0], true);
+        ctx.decode(&step_batch).expect("decode step");
+        next = sampler.sample(&mut ctx, -1);
+        produced += 1;
+    }
+    let gen_s = t_gen.elapsed().as_secs_f64();
+    let decode_tps = if gen_s > 0.0 {
+        produced as f64 / gen_s
+    } else {
+        0.0
+    };
+
+    assert!(produced >= 2, "must generate at least 2 tokens");
+    // One structured, greppable line for `just profile-inference` → private trend.
+    eprintln!(
+        "M6 inference timing | model={desc} | warmup_load_ms={warmup_load_ms:.3} \
+         | ttft_ms={ttft_ms:.3} | decode_tokens_per_s={decode_tps:.2} | tokens={produced}",
+        desc = model.desc(),
+    );
+}
+
 /// KV-cache management round-trip: decode → query positions → seq_keep →
 /// seq_rm → clear. Verifies the cache ops behave as documented.
 ///

--- a/crates/kx-profile/Cargo.toml
+++ b/crates/kx-profile/Cargo.toml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-profile"
+version      = "0.0.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx runtime profiling harness (Golden Rule 10): an FFI-free bin that hosts an in-process gateway, measures warm-up + submit-to-Committed latency, captures an environment-labelled schema-1 JSON report, and is the public half of the measure-and-persist discipline (results live in the private corpus only)."
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "kx-profile"
+path = "src/main.rs"
+
+[dependencies]
+# Host an in-process gateway to measure warm-up + submit→Committed. Default
+# features ON ⇒ the embedded-worker closure; FFI-free (the dep_wall pins it), so
+# the "any contributor can profile their box" claim holds without a C++ toolchain.
+kx-gateway   = { workspace = true }
+# The FROZEN KxGateway client stubs + request/response messages.
+kx-proto     = { workspace = true }
+# gRPC transport for the client + the health probe (warm-up = ready-to-SERVING).
+tonic        = { workspace = true }
+tonic-health = { workspace = true }
+# `time` for the poll backoff (rt-multi-thread/macros/net come from the workspace set).
+tokio        = { workspace = true, features = ["time"] }
+# The structured report (schema-1 JSON) + machine-readable env block.
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+# Ephemeral per-iteration journal/content/catalog roots (already in the lock).
+tempfile     = { workspace = true }
+thiserror    = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/kx-profile/src/env.rs
+++ b/crates/kx-profile/src/env.rs
@@ -1,0 +1,151 @@
+//! Environment capture — the load-bearing label on every profiling record.
+//!
+//! Golden Rule 10: "a number with no environment label is not a record (macOS
+//! fsync ≠ Linux fsync — label or discard)." So [`Environment`] is a required,
+//! fully-populated struct; capture is fallible and aborts the run rather than
+//! emit a partial label.
+//!
+//! Capture is done at **run time** (via std + a few cheap commands), NOT a
+//! `build.rs`, so `kx-profile`'s compiled artifact carries no volatile bytes
+//! and the workspace `check-reproducible` (I1.c byte-determinism) gate is
+//! unaffected.
+
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ProfileError;
+
+/// The machine + toolchain a set of numbers was captured on. Every field is
+/// required: a report cannot serialize without a complete label.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Environment {
+    /// The host name (`hostname`, or the `HOSTNAME`/`COMPUTERNAME` env).
+    pub host: String,
+    /// The target OS (`std::env::consts::OS`).
+    pub os: String,
+    /// The target architecture (`std::env::consts::ARCH`).
+    pub arch: String,
+    /// A human CPU model string (sysctl/`/proc/cpuinfo`, falling back to arch).
+    pub cpu: String,
+    /// The number of logical cores (`available_parallelism`).
+    pub cores: usize,
+    /// The compiler version (`rustc --version`).
+    pub toolchain: String,
+    /// The cargo features `kx-profile` was built with (the profiled build).
+    pub features: Vec<String>,
+}
+
+impl Environment {
+    /// Capture the current environment.
+    ///
+    /// # Errors
+    /// Returns [`ProfileError::Env`] if `rustc --version` cannot be run (the
+    /// toolchain label is mandatory) or the host name cannot be determined.
+    pub fn capture() -> Result<Self, ProfileError> {
+        let host = host_name()
+            .ok_or_else(|| ProfileError::Env("could not determine the host name".to_string()))?;
+        let toolchain = run_cmd("rustc", &["--version"]).ok_or_else(|| {
+            ProfileError::Env("could not run `rustc --version` for the toolchain label".to_string())
+        })?;
+        let cores = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1);
+        Ok(Self {
+            host,
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            cpu: cpu_model(),
+            cores,
+            toolchain,
+            features: enabled_features(),
+        })
+    }
+}
+
+/// Capture the commit the runtime is being profiled at.
+///
+/// # Errors
+/// Returns [`ProfileError::Env`] if `git rev-parse HEAD` cannot be run (the
+/// report's `git_sha` is mandatory — profiling runs inside the repo).
+pub fn capture_git_sha() -> Result<String, ProfileError> {
+    run_cmd("git", &["rev-parse", "HEAD"])
+        .ok_or_else(|| ProfileError::Env("could not run `git rev-parse HEAD`".to_string()))
+}
+
+/// Run a command and return its trimmed stdout, or `None` on any failure.
+fn run_cmd(prog: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new(prog).args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Best-effort host name: the `hostname` command, then common env vars.
+fn host_name() -> Option<String> {
+    run_cmd("hostname", &[])
+        .or_else(|| std::env::var("HOSTNAME").ok())
+        .or_else(|| std::env::var("COMPUTERNAME").ok())
+        .filter(|s| !s.is_empty())
+}
+
+/// A human CPU model string. Falls back to the architecture (always present),
+/// so this never fails — arch is itself a valid CPU descriptor.
+fn cpu_model() -> String {
+    #[cfg(target_os = "macos")]
+    if let Some(brand) = run_cmd("sysctl", &["-n", "machdep.cpu.brand_string"]) {
+        return brand;
+    }
+    #[cfg(target_os = "linux")]
+    if let Ok(info) = std::fs::read_to_string("/proc/cpuinfo") {
+        if let Some(model) = info.lines().find_map(|l| {
+            l.strip_prefix("model name")
+                .and_then(|r| r.split(':').nth(1))
+        }) {
+            let model = model.trim();
+            if !model.is_empty() {
+                return model.to_string();
+            }
+        }
+    }
+    std::env::consts::ARCH.to_string()
+}
+
+/// The cargo features `kx-profile` was compiled with. `kx-profile` is FFI-free
+/// with no optional features today, so this is `["default"]`; a future
+/// `inference`/`hnsw` feature would extend it here so the label tracks the
+/// profiled build.
+fn enabled_features() -> Vec<String> {
+    let features = vec!["default".to_string()];
+    features
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_populates_every_field() {
+        // In CI + locally, rustc + git are on PATH (we are inside the repo).
+        let env = Environment::capture().expect("env capture in the workspace");
+        assert!(!env.host.is_empty(), "host present");
+        assert!(!env.os.is_empty(), "os present");
+        assert!(!env.arch.is_empty(), "arch present");
+        assert!(!env.cpu.is_empty(), "cpu present (≥ arch fallback)");
+        assert!(env.cores >= 1, "at least one core");
+        assert!(env.toolchain.contains("rustc"), "toolchain labelled");
+        assert!(!env.features.is_empty(), "features present");
+    }
+
+    #[test]
+    fn git_sha_is_captured() {
+        let sha = capture_git_sha().expect("git sha in the workspace");
+        assert_eq!(sha.len(), 40, "a full 40-hex HEAD sha");
+    }
+}

--- a/crates/kx-profile/src/error.rs
+++ b/crates/kx-profile/src/error.rs
@@ -1,0 +1,41 @@
+//! The profiling harness error type.
+//!
+//! Profiling is a best-effort *measurement* tool, but the **environment label**
+//! is load-bearing (Golden Rule 10: a number with no environment is not a
+//! record). So environment capture is fallible and surfaces here rather than
+//! being silently defaulted — an incomplete env aborts the run.
+
+use thiserror::Error;
+
+/// Errors raised while capturing the environment, running a spike, or writing a
+/// report. A profiling run aborts on any of these rather than emit a partial or
+/// unlabelled record.
+#[derive(Debug, Error)]
+pub enum ProfileError {
+    /// A required environment field could not be determined (Golden Rule 10:
+    /// fail rather than persist an unlabelled number).
+    #[error("environment capture failed: {0}")]
+    Env(String),
+
+    /// The in-process gateway under measurement failed to start, serve, or
+    /// shut down.
+    #[error("gateway under measurement failed: {0}")]
+    Gateway(String),
+
+    /// A gRPC client call against the gateway under measurement failed.
+    #[error("client call failed: {0}")]
+    Client(String),
+
+    /// The gateway did not reach the expected terminal state within the budget.
+    #[error("timed out waiting for {what} after {elapsed_ms} ms")]
+    Timeout {
+        /// What the harness was waiting for (e.g. "health SERVING").
+        what: String,
+        /// How long it waited before giving up, in milliseconds.
+        elapsed_ms: u64,
+    },
+
+    /// Writing the JSON report to disk failed.
+    #[error("writing the report failed: {0}")]
+    Report(String),
+}

--- a/crates/kx-profile/src/lib.rs
+++ b/crates/kx-profile/src/lib.rs
@@ -1,0 +1,34 @@
+//! kortecx runtime profiling harness (Golden Rule 10).
+//!
+//! The **public half** of the measure-and-persist discipline: an FFI-free
+//! library + bin that hosts an in-process gateway, measures warm-up +
+//! submit→Committed latency, and captures an **environment-labelled, schema-1
+//! JSON** [`Report`]. The captured numbers are a corpus trend record that lives
+//! ONLY in the private repo (`docs/benchmarks/`, gitignored on OSS — SN-2); the
+//! harness here is the reusable, public measurement tool.
+//!
+//! Design constraints (Golden Rule 10 + the workspace invariants):
+//! - **FFI-free** — the default gateway closure has no llama.cpp, so any
+//!   contributor can profile their box without a C++ toolchain.
+//! - **No `build.rs`** — the environment (`git_sha`, toolchain, host, cpu) is
+//!   captured at run time, so the compiled artifact carries no volatile bytes
+//!   and the `check-reproducible` (I1.c) byte-determinism gate is unaffected.
+//! - **Off the hot path** — all timing is at the client/dispatch boundary,
+//!   never inside the sole-writer commit path or the digest fold.
+
+// Test modules host an in-process gateway + assert on captured values; the
+// safety lints (deny in library code) are relaxed for tests per Rule 3.
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)
+)]
+
+pub mod env;
+pub mod error;
+pub mod report;
+pub mod spikes;
+
+pub use env::{capture_git_sha, Environment};
+pub use error::ProfileError;
+pub use report::{Metric, MetricKind, Report, SCHEMA_VERSION};
+pub use spikes::{percentile, LatencySamples};

--- a/crates/kx-profile/src/main.rs
+++ b/crates/kx-profile/src/main.rs
@@ -1,0 +1,135 @@
+//! `kx-profile` — capture an environment-labelled runtime profile (Golden Rule
+//! 10).
+//!
+//! Hosts a fresh in-process gateway per iteration, measures warm-up
+//! (`start` → health `SERVING`) and submit→Committed latency over the FFI-free
+//! echo demo, and writes a schema-1 JSON [`Report`] to `target/profile/`
+//! (gitignored). `just profile` runs this + re-runs the existing scale/ceiling
+//! spikes; the captured JSON is then copied into the PRIVATE
+//! `docs/benchmarks/` trend record (never committed to OSS — SN-2).
+//!
+//! Usage: `kx-profile [--iterations N] [--out PATH]` (default `N = 8`).
+
+use std::path::PathBuf;
+
+use kx_profile::{capture_git_sha, percentile, spikes, Environment, Metric, ProfileError, Report};
+
+#[tokio::main]
+async fn main() {
+    // Surface the gateway-under-measurement's tracing (best-effort; ignore an
+    // already-installed global subscriber).
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .try_init();
+
+    if let Err(e) = run().await {
+        eprintln!("kx-profile: {e}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), ProfileError> {
+    let args = Args::parse(std::env::args().skip(1));
+
+    // Capture the load-bearing labels FIRST — abort before any work if the
+    // environment can't be fully described (Golden Rule 10).
+    let git_sha = capture_git_sha()?;
+    let env = Environment::capture()?;
+    eprintln!(
+        "kx-profile: profiling {sha} on {host} ({cores} cores, {os}/{arch}) — {n} iteration(s)",
+        sha = short_sha(&git_sha),
+        host = env.host,
+        cores = env.cores,
+        os = env.os,
+        arch = env.arch,
+        n = args.iterations,
+    );
+
+    let samples = spikes::measure(args.iterations).await?;
+    let metrics = vec![
+        Metric::spike(
+            "warmup_to_serving_p50",
+            percentile(&samples.warmup_ms, 50),
+            "ms",
+        ),
+        Metric::spike(
+            "submit_to_committed_p50",
+            percentile(&samples.submit_ms, 50),
+            "ms",
+        ),
+        Metric::spike(
+            "submit_to_committed_p99",
+            percentile(&samples.submit_ms, 99),
+            "ms",
+        ),
+    ];
+
+    let report = Report::new(git_sha.clone(), env, metrics);
+    let json = report
+        .to_json()
+        .map_err(|e| ProfileError::Report(e.to_string()))?;
+
+    let out = args.out.unwrap_or_else(|| default_out(&git_sha));
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| ProfileError::Report(format!("create {}: {e}", parent.display())))?;
+    }
+    std::fs::write(&out, format!("{json}\n"))
+        .map_err(|e| ProfileError::Report(format!("write {}: {e}", out.display())))?;
+    eprintln!("kx-profile: wrote {}", out.display());
+
+    // The JSON also goes to stdout so `just profile` can tee it into the
+    // private trend record.
+    println!("{json}");
+    Ok(())
+}
+
+/// Parsed CLI arguments (hand-rolled, no clap — the FFI-free `kx` convention).
+struct Args {
+    iterations: usize,
+    out: Option<PathBuf>,
+}
+
+impl Args {
+    fn parse(mut argv: impl Iterator<Item = String>) -> Self {
+        let mut iterations = 8usize;
+        let mut out = None;
+        while let Some(flag) = argv.next() {
+            match flag.as_str() {
+                "--iterations" | "-n" => {
+                    if let Some(v) = argv.next() {
+                        if let Ok(n) = v.parse::<usize>() {
+                            iterations = n.max(1);
+                        } else {
+                            eprintln!("kx-profile: invalid --iterations {v:?}; using {iterations}");
+                        }
+                    }
+                }
+                "--out" | "-o" => {
+                    out = argv.next().map(PathBuf::from);
+                }
+                other => {
+                    eprintln!("kx-profile: ignoring unrecognized argument {other:?}");
+                }
+            }
+        }
+        Self { iterations, out }
+    }
+}
+
+/// The first 12 hex of a commit sha (for human log lines / file names).
+fn short_sha(sha: &str) -> &str {
+    let end = sha.len().min(12);
+    &sha[..end]
+}
+
+/// Default output path: `target/profile/profile-<sha12>.json` (`target/` is
+/// already gitignored).
+fn default_out(git_sha: &str) -> PathBuf {
+    PathBuf::from("target")
+        .join("profile")
+        .join(format!("profile-{}.json", short_sha(git_sha)))
+}

--- a/crates/kx-profile/src/report.rs
+++ b/crates/kx-profile/src/report.rs
@@ -1,0 +1,136 @@
+//! The structured profiling report (schema-1 JSON).
+//!
+//! A [`Report`] is the durable, comparable record Golden Rule 10 mandates:
+//! `git_sha` + a fully-populated [`Environment`] + a flat list of
+//! [`Metric`]s. The [`Environment`] is a **required, non-`Option`** field, so a
+//! report literally cannot serialize without its environment label
+//! (make-illegal-states-unrepresentable, Rule 5.2) — there is no code path that
+//! emits an unlabelled number.
+
+use serde::{Deserialize, Serialize};
+
+use crate::env::Environment;
+
+/// The report schema version. Bump on any breaking change to the JSON shape so
+/// the private trend record can discriminate old captures.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Whether a metric is a CI regression *gate* (a ratio that holds across
+/// substrates) or a measurement-only *spike* (an absolute latency/throughput
+/// captured for the trend but never a flaky CI assertion). Golden Rule 10(d).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    /// A ratio-expressible regression gate (e.g. fold linearity).
+    Gate,
+    /// A measurement-only spike (absolute latency / throughput).
+    Spike,
+}
+
+/// One captured measurement: a stable id, a numeric value, its unit, and its
+/// gate-vs-spike classification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Metric {
+    /// A stable identifier (e.g. `warmup_to_serving_p50`).
+    pub id: String,
+    /// The measured value.
+    pub value: f64,
+    /// The unit (e.g. `ms`, `commits_per_s`, `us_per_entry`).
+    pub unit: String,
+    /// Gate (ratio regression guard) vs spike (measurement-only).
+    pub kind: MetricKind,
+}
+
+impl Metric {
+    /// Construct a measurement-only spike metric.
+    #[must_use]
+    pub fn spike(id: impl Into<String>, value: f64, unit: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            value,
+            unit: unit.into(),
+            kind: MetricKind::Spike,
+        }
+    }
+}
+
+/// The full profiling report. Serializes to the schema-1 JSON the private
+/// `docs/benchmarks/` trend record consumes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Report {
+    /// The report schema version ([`SCHEMA_VERSION`]).
+    pub schema: u32,
+    /// The commit the runtime was profiled at (`git rev-parse HEAD`).
+    pub git_sha: String,
+    /// The machine + toolchain the numbers were captured on. REQUIRED — a
+    /// report cannot exist without it (Golden Rule 10).
+    pub env: Environment,
+    /// The captured metrics.
+    pub metrics: Vec<Metric>,
+}
+
+impl Report {
+    /// Assemble a schema-1 report from a captured environment + metrics.
+    #[must_use]
+    pub fn new(git_sha: String, env: Environment, metrics: Vec<Metric>) -> Self {
+        Self {
+            schema: SCHEMA_VERSION,
+            git_sha,
+            env,
+            metrics,
+        }
+    }
+
+    /// Render the report as pretty JSON.
+    ///
+    /// # Errors
+    /// Returns [`serde_json::Error`] only if a metric value is a non-finite
+    /// float (`serde_json` rejects `NaN`/`Inf`) — the spikes never produce one,
+    /// but the error is surfaced rather than panicked.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::env::Environment;
+
+    fn sample_env() -> Environment {
+        Environment {
+            host: "test-host".into(),
+            os: "macos".into(),
+            arch: "aarch64".into(),
+            cpu: "Apple M-series".into(),
+            cores: 10,
+            toolchain: "rustc 1.x".into(),
+            features: vec!["default".into()],
+        }
+    }
+
+    #[test]
+    fn report_serializes_schema_1_with_env() {
+        let r = Report::new(
+            "deadbeef".into(),
+            sample_env(),
+            vec![Metric::spike("warmup_to_serving_p50", 12.5, "ms")],
+        );
+        let v: serde_json::Value = serde_json::from_str(&r.to_json().unwrap()).unwrap();
+        assert_eq!(v["schema"], 1);
+        assert_eq!(v["git_sha"], "deadbeef");
+        // The env block is present and fully populated.
+        assert_eq!(v["env"]["host"], "test-host");
+        assert_eq!(v["env"]["cores"], 10);
+        assert_eq!(v["metrics"][0]["kind"], "spike");
+        assert_eq!(v["metrics"][0]["unit"], "ms");
+    }
+
+    #[test]
+    fn report_roundtrips() {
+        let r = Report::new("sha".into(), sample_env(), vec![]);
+        let back: Report = serde_json::from_str(&r.to_json().unwrap()).unwrap();
+        assert_eq!(r, back);
+    }
+}

--- a/crates/kx-profile/src/spikes.rs
+++ b/crates/kx-profile/src/spikes.rs
@@ -1,0 +1,215 @@
+//! In-process gateway spikes: **warm-up** (`start` → health `SERVING`) and
+//! **submit→Committed** latency.
+//!
+//! Each iteration hosts a *fresh* in-process gateway over an ephemeral journal,
+//! so neither metric is perturbed by cross-run dedup (a fresh journal ⇒ a fresh
+//! echo run every time). All timing is at the **client/dispatch boundary** —
+//! never inside the sole-writer commit path or the digest fold (Golden Rule
+//! 10(b) / Rule 8 Pass-A perf). FFI-free: the default gateway closure has no
+//! llama.cpp, so any contributor can profile their box.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use tonic::transport::Channel;
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+use kx_gateway::{demo_submit_run_request, start, GatewayConfig};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+
+use crate::error::ProfileError;
+
+const POLL: Duration = Duration::from_millis(10);
+const ACCEPT_TRIES: u32 = 500; // ≤ 5 s for the listener to accept
+const SERVING_TRIES: u32 = 500; // ≤ 5 s to report SERVING
+const COMMIT_POLL: Duration = Duration::from_millis(20);
+const COMMIT_TRIES: u32 = 500; // ≤ 10 s for the echo Mote to commit
+
+/// Raw per-iteration latency samples (milliseconds).
+#[derive(Debug, Clone)]
+pub struct LatencySamples {
+    /// Time from `start` to health `SERVING`, per iteration.
+    pub warmup_ms: Vec<f64>,
+    /// Time from `SubmitRun` to the echo Mote reaching `Committed`, per iteration.
+    pub submit_ms: Vec<f64>,
+}
+
+/// Measure warm-up + submit→Committed over `iterations` fresh in-process
+/// gateways.
+///
+/// # Errors
+/// Returns [`ProfileError`] if a gateway fails to start/serve/shutdown, a
+/// client call fails, or a stage times out.
+pub async fn measure(iterations: usize) -> Result<LatencySamples, ProfileError> {
+    let mut warmup_ms = Vec::with_capacity(iterations);
+    let mut submit_ms = Vec::with_capacity(iterations);
+
+    for _ in 0..iterations {
+        let dir = TempDir::new().map_err(|e| ProfileError::Gateway(e.to_string()))?;
+
+        // M1 — warm-up: start → accepting → SERVING.
+        let t0 = Instant::now();
+        let running = start(config(dir.path())?)
+            .await
+            .map_err(|e| ProfileError::Gateway(e.to_string()))?;
+        let addr = running.local_addr();
+        let channel = connect(addr).await?;
+        wait_for_serving(&channel).await?;
+        warmup_ms.push(elapsed_ms(t0));
+
+        // M2 — submit→Committed of the FFI-free echo demo.
+        let t1 = Instant::now();
+        let instance = submit_demo(&channel).await?;
+        wait_for_committed(&channel, &instance).await?;
+        submit_ms.push(elapsed_ms(t1));
+
+        running
+            .shutdown()
+            .await
+            .map_err(|e| ProfileError::Gateway(e.to_string()))?;
+    }
+
+    Ok(LatencySamples {
+        warmup_ms,
+        submit_ms,
+    })
+}
+
+/// An ephemeral loopback, dev-auth gateway config rooted at `dir`.
+fn config(dir: &Path) -> Result<GatewayConfig, ProfileError> {
+    let parse = |s: &str| -> Result<SocketAddr, ProfileError> {
+        s.parse()
+            .map_err(|e| ProfileError::Gateway(format!("bad listen addr {s}: {e}")))
+    };
+    Ok(GatewayConfig {
+        listen: parse("127.0.0.1:0")?,
+        ws_listen: parse("127.0.0.1:0")?,
+        journal_path: dir.join("kx.db"),
+        content_root: dir.join("blobs"),
+        max_lease: 16,
+        dev_allow_local: true,
+        auth_tokens: HashMap::new(),
+        catalog_dir: None,
+        tls: None,
+        cors_origins: Vec::new(),
+    })
+}
+
+/// Wait for the listener to accept, then build a channel.
+async fn connect(addr: SocketAddr) -> Result<Channel, ProfileError> {
+    for _ in 0..ACCEPT_TRIES {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            let uri = format!("http://{addr}");
+            return Channel::from_shared(uri)
+                .map_err(|e| ProfileError::Client(e.to_string()))?
+                .connect()
+                .await
+                .map_err(|e| ProfileError::Client(e.to_string()));
+        }
+        tokio::time::sleep(POLL).await;
+    }
+    Err(ProfileError::Timeout {
+        what: format!("{addr} to accept connections"),
+        elapsed_ms: u64::from(ACCEPT_TRIES) * 10,
+    })
+}
+
+/// Poll the `grpc.health.v1` overall status until `SERVING` (warm-up signal —
+/// matches `kx health`).
+async fn wait_for_serving(channel: &Channel) -> Result<(), ProfileError> {
+    let mut health = HealthClient::new(channel.clone());
+    for _ in 0..SERVING_TRIES {
+        if let Ok(resp) = health
+            .check(HealthCheckRequest {
+                service: String::new(),
+            })
+            .await
+        {
+            if resp.into_inner().status() == ServingStatus::Serving {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(POLL).await;
+    }
+    Err(ProfileError::Timeout {
+        what: "health SERVING".to_string(),
+        elapsed_ms: u64::from(SERVING_TRIES) * 10,
+    })
+}
+
+/// Submit the FFI-free echo demo run; return its journaled `instance_id`.
+async fn submit_demo(channel: &Channel) -> Result<Vec<u8>, ProfileError> {
+    let mut client = KxGatewayClient::new(channel.clone());
+    let handle = client
+        .submit_run(demo_submit_run_request())
+        .await
+        .map_err(|s| ProfileError::Client(s.to_string()))?
+        .into_inner();
+    Ok(handle.instance_id)
+}
+
+/// Poll the projection until any Mote of the run is `Committed`.
+async fn wait_for_committed(channel: &Channel, instance_id: &[u8]) -> Result<(), ProfileError> {
+    let mut client = KxGatewayClient::new(channel.clone());
+    let committed = proto::MoteSnapshotState::Committed as i32;
+    for _ in 0..COMMIT_TRIES {
+        let view = client
+            .get_projection(proto::GetProjectionRequest {
+                instance_id: instance_id.to_vec(),
+                at_seq: None,
+            })
+            .await
+            .map_err(|s| ProfileError::Client(s.to_string()))?
+            .into_inner();
+        if view.motes.iter().any(|m| m.state == committed) {
+            return Ok(());
+        }
+        tokio::time::sleep(COMMIT_POLL).await;
+    }
+    Err(ProfileError::Timeout {
+        what: "a Committed Mote".to_string(),
+        elapsed_ms: u64::from(COMMIT_TRIES) * 20,
+    })
+}
+
+/// Milliseconds elapsed since `t`, as an `f64` (no integer cast).
+fn elapsed_ms(t: Instant) -> f64 {
+    t.elapsed().as_secs_f64() * 1000.0
+}
+
+/// Nearest-rank percentile `p` (1..=100) of `samples`, computed with integer
+/// rank arithmetic (no float cast on the sample count). Empty ⇒ `0.0`.
+#[must_use]
+pub fn percentile(samples: &[f64], p: usize) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let n = sorted.len();
+    // 1-based ceil(p/100 * n), clamped into [0, n-1].
+    let rank = (p * n).div_ceil(100);
+    let idx = rank.saturating_sub(1).min(n - 1);
+    sorted[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_nearest_rank() {
+        let s = vec![10.0, 20.0, 30.0, 40.0, 50.0];
+        assert_eq!(percentile(&s, 50), 30.0);
+        assert_eq!(percentile(&s, 99), 50.0);
+        assert_eq!(percentile(&s, 100), 50.0);
+        assert_eq!(percentile(&[], 50), 0.0);
+        assert_eq!(percentile(&[42.0], 99), 42.0);
+    }
+}

--- a/crates/kx-profile/tests/gitignore_guard.rs
+++ b/crates/kx-profile/tests/gitignore_guard.rs
@@ -1,0 +1,51 @@
+//! SN-2 / Golden Rule 10 guard (mirrors the `dep_wall.rs` manifest-scan
+//! pattern). The `just profile` HARNESS is public OSS, but the captured numbers
+//! are a private corpus trend record. Two independent proofs that no result
+//! file can leak into the public repo:
+//!  1. the workspace `.gitignore` covers `/docs/benchmarks/`, and
+//!  2. `git ls-files docs/benchmarks/` tracks nothing (the tripwire).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The repo root = this crate's manifest dir, two levels up (`crates/kx-profile`).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+#[test]
+fn gitignore_covers_docs_benchmarks() {
+    // include_str! embeds at compile time — robust against the test's CWD.
+    let gitignore = include_str!("../../../.gitignore");
+    assert!(
+        gitignore.lines().any(|l| l.trim() == "/docs/benchmarks/"),
+        "the workspace .gitignore must cover /docs/benchmarks/ so profiling \
+         results (Golden Rule 10 trend record) never leak into the public OSS repo"
+    );
+}
+
+#[test]
+fn no_benchmark_result_is_tracked() {
+    // `git ls-files` lists only TRACKED files; nothing under docs/benchmarks/
+    // may be committed to OSS. Skip if git is unavailable (the include_str!
+    // scan above is the load-bearing gate).
+    let output = Command::new("git")
+        .args(["ls-files", "docs/benchmarks/"])
+        .current_dir(repo_root())
+        .output();
+    let Ok(output) = output else {
+        return; // git not available in this sandbox — the scan above still gates
+    };
+    if !output.status.success() {
+        return;
+    }
+    let tracked = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        tracked.trim().is_empty(),
+        "no benchmark result may be tracked in the OSS repo (SN-2); found:\n{tracked}"
+    );
+}

--- a/crates/kx-profile/tests/spike_smoke.rs
+++ b/crates/kx-profile/tests/spike_smoke.rs
@@ -1,0 +1,29 @@
+//! End-to-end witness that the profiling harness runs against a REAL in-process
+//! gateway: one iteration produces one finite warm-up + one finite
+//! submit→Committed sample. (Mirrors the `kx-cli` client e2e shape — hosts the
+//! gateway in-process, drives it over the gRPC client.)
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_profile::spikes;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn measure_produces_finite_samples() {
+    let samples = spikes::measure(1)
+        .await
+        .expect("one profiling iteration over a fresh in-process gateway");
+
+    assert_eq!(samples.warmup_ms.len(), 1, "one warm-up sample");
+    assert_eq!(samples.submit_ms.len(), 1, "one submit→Committed sample");
+
+    let warmup = samples.warmup_ms[0];
+    let submit = samples.submit_ms[0];
+    assert!(
+        warmup.is_finite() && warmup >= 0.0,
+        "warm-up {warmup} is sane"
+    );
+    assert!(
+        submit.is_finite() && submit >= 0.0,
+        "submit {submit} is sane"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -417,6 +417,31 @@ bench-ceiling:
     cargo test -p kx-coordinator --release --test ceiling_e2e -- --ignored --nocapture --test-threads=1
     cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1
 
+# Golden Rule 10 — the runtime profiling harness. NON-GATING (not part of `just
+# ci`): captures an environment-labelled, schema-1 JSON report of the FFI-free
+# runtime's client-observable costs, then re-runs the existing throughput spikes
+# so a single invocation prints the full single-node picture. The `kx-profile`
+# JSON lands in `target/profile/` (gitignored); COPY it into the PRIVATE
+# `docs/benchmarks/YYYY-MM-DD-<topic>.json` trend record (never committed to OSS
+# — SN-2). Absolute latencies are platform-sensitive (macOS fsync ≠ Linux) — the
+# report's `env` block labels every number. `--release` is REQUIRED for honest
+# numbers. M1 warm-up (start→SERVING) + M2 submit→Committed come from kx-profile;
+# M3 fold curve + M4 commit ceiling + M5 catalog discovery come from the spikes.
+profile iterations="8":
+    cargo run --release -p kx-profile -- --iterations {{iterations}}
+    cargo test -p kx-coordinator --release --test ceiling_e2e -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-projection --release --test fold_curve_scale -- --ignored --nocapture --test-threads=1
+    cargo test -p kx-catalog --release --test scale -- --ignored --nocapture --test-threads=1
+
+# Golden Rule 10 — inference-path profiling (M6: model warm-up + TTFT +
+# tokens/sec). Requires the `model-smoke-test` GGUF (auto-downloaded, ~1.2 MB,
+# SHA-verified) + the llama.cpp FFI; LOCAL-only (Metal on Apple Silicon for real
+# numbers — in-container CPU inference is not representative, D135). Prints the
+# timing the standard smoke test now captures; copy the numbers into the private
+# trend record alongside the kx-profile JSON.
+profile-inference:
+    cargo test -p kx-llamacpp --release --features model-smoke-test -- --nocapture
+
 # ============================================================================
 # Preflight diagnostic
 # ============================================================================


### PR DESCRIPTION
## PR-2d-0 — profile-harness (first of the PR-2d ReAct-live sequence)

Stands up the **measure-and-persist** profiling discipline (Golden Rule 10) so the
upcoming PR-2d-1/2 (ReAct-live) are the first features profiled under it, and captures a
runtime baseline. **No runtime behavior change.**

### What ships
- **NEW FFI-free `kx-profile` bin** — hosts an in-process gateway and measures:
  - **M1 warm-up** = `start` → `grpc.health.v1` SERVING (matches `kx health`)
  - **M2 submit→Committed** p50/p99 over the echo demo
  - over a **fresh in-process gateway per iteration** (no cross-run dedup), all timing at
    the client/dispatch boundary — never the sole-writer commit path or the digest fold.
  - Emits an **environment-labelled schema-1 JSON** report to `target/profile/` (gitignored).
    The `env` block is a required, fully-populated struct (illegal-states-unrepresentable) —
    a report can't serialize without a complete `{host, os, arch, cpu, cores, toolchain, features}`
    label. Env is captured at **run time** (no `build.rs`) so the compiled artifact carries no
    volatile bytes (I1.c byte-determinism unaffected).
- **`just profile` / `just profile-inference`** (siblings of `bench-ceiling`) — reuse the
  existing `ceiling_e2e` / `fold_curve_scale` / catalog `scale` spikes (M3–M5) and extend
  `kx-llamacpp` `smoke.rs` with an **additive M6 timing test** (model warm-up, TTFT,
  tokens/sec) — there was no inference timing before.
- **SN-2**: `/docs/benchmarks/` is now gitignored on OSS **before any result file can exist**,
  guarded by a `dep_wall`-style test + a `git ls-files` tripwire. The harness is public OSS;
  the captured numbers live only in the private corpus.

### Captured baseline (this PR's commit, Apple M3)
| metric | value |
|---|---|
| warmup_to_serving_p50 | ~229 ms |
| submit_to_committed_p50 | ~26 ms |
| submit_to_committed_p99 | ~51 ms |

### Invariants
- frozen-trio (`kx-scheduler`/`kx-executor`/`kx-inference`) `src` diff-**EMPTY**
- canonical projection digest `7d22d4bd` **unaffected** (no journal/projection/checkpoint change)
- `Cargo.lock` **edge-only** — one new `kx-profile` node, **no new external crate**
- **FFI-free** — `kx-cli` / `kx-runtime` closures intact (`build-no-inference` green)
- I1.c byte-determinism **PASS** (two clean release builds bit-identical)

### Local gate
fmt ✓ · clippy `--workspace --all-targets -D warnings` ✓ · `test --workspace` ✓ · doc `-D warnings` ✓ ·
deny ✓ · build-no-inference ✓ · check-reproducible (I1.c) ✓ · inference smoke-test compiles ✓.
scale-smoke / ffi-link unaffected (no change to those crates) — CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)