### PR TITLE
fix(gateway): F9 — durable run_meta so serve-path capture stamps the run instance across poll ticks

### DIFF
--- a/crates/kx-gateway/src/capture.rs
+++ b/crates/kx-gateway/src/capture.rs
@@ -44,7 +44,9 @@ use kx_gateway_core::GatewayError as CoreError;
 /// The capture-projection schema version. A bump (or any decode failure) makes
 /// the load path drop-and-rebuild from the journal — capture is a cache, so
 /// there is NEVER a migration, only a rebuild.
-const SCHEMA_VERSION: i64 = 1;
+// v2: the durable `run_meta` instance-id row (the multi-tick stamping fix —
+// an old v1 sidecar drops-and-rebuilds with correct stamping; capture is a cache).
+const SCHEMA_VERSION: i64 = 2;
 
 /// The durable schema (idempotent). `capture_records` is the action projection;
 /// `react_turns` is the incremental turn→branch join source; `meta` holds the
@@ -67,7 +69,12 @@ CREATE TABLE IF NOT EXISTS react_turns (
     branch       TEXT NOT NULL,
     seq          INTEGER NOT NULL
 );
-CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value INTEGER NOT NULL);";
+CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value INTEGER NOT NULL);
+-- The run instance id (single-node: one RunRegistered per journal) is DURABLE
+-- across fold ticks, so an action committed in a LATER tick is still stamped
+-- even though RunRegistered (seq=1) folded in an EARLIER tick. A blob, so it
+-- cannot live in `meta` (INTEGER values).
+CREATE TABLE IF NOT EXISTS run_meta (id INTEGER PRIMARY KEY CHECK (id = 0), instance_id BLOB NOT NULL);";
 
 /// The closed `nd_class` wire vocabulary (the `ReactTurnSummary.branch` style:
 /// a string, so a future class is additive on the wire).
@@ -136,6 +143,7 @@ impl CaptureLedger {
             conn.execute_batch(
                 "DROP TABLE IF EXISTS capture_records;
                  DROP TABLE IF EXISTS react_turns;
+                 DROP TABLE IF EXISTS run_meta;
                  DROP TABLE IF EXISTS meta;",
             )
             .map_err(|e| GatewayError::Catalog(format!("capture rebuild: {e}")))?;
@@ -226,9 +234,11 @@ impl CaptureLedger {
         };
         let mut inserted = 0usize;
         // The serve session's instance id (single-node: one RunRegistered per
-        // journal). Seeded from a prior fold if present; updated if this range
-        // carries the registration. Every action row is stamped with it.
-        let mut instance: Option<Vec<u8>> = Self::known_instance(&tx).ok().flatten();
+        // journal). Seeded from the DURABLE run_meta row — so an action committed
+        // in a later tick is stamped even though RunRegistered (seq=1) folded in
+        // an earlier tick (the bug the installed-runtime sweep caught: relying on
+        // a same-tick registration left every later action's instance empty).
+        let mut instance: Option<Vec<u8>> = Self::run_instance(&tx).ok().flatten();
         // The react facts seen THIS tick (turn_mote_id → highest-seq turn/branch),
         // applied to both new and already-captured rows after the inserts.
         let mut react_updates: HashMap<[u8; 32], (i64, String)> = HashMap::new();
@@ -236,6 +246,11 @@ impl CaptureLedger {
             match entry {
                 JournalEntry::RunRegistered { instance_id, .. } => {
                     instance = Some(instance_id.to_vec());
+                    // Persist it DURABLY so later ticks stamp without re-seeing it.
+                    let _ = tx.execute(
+                        "INSERT OR REPLACE INTO run_meta(id, instance_id) VALUES (0, ?1)",
+                        params![instance_id.to_vec()],
+                    );
                 }
                 JournalEntry::Committed {
                     mote_id,
@@ -318,13 +333,12 @@ impl CaptureLedger {
         inserted
     }
 
-    /// The serve session's instance id, if any captured row already carries one.
-    fn known_instance(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<Option<Vec<u8>>> {
-        tx.query_row(
-            "SELECT instance_id FROM capture_records WHERE length(instance_id) = 16 LIMIT 1",
-            [],
-            |r| r.get(0),
-        )
+    /// The serve session's instance id from the DURABLE `run_meta` row (set when
+    /// `RunRegistered` first folds), or `None` before any run registered.
+    fn run_instance(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<Option<Vec<u8>>> {
+        tx.query_row("SELECT instance_id FROM run_meta WHERE id = 0", [], |r| {
+            r.get(0)
+        })
         .map(Some)
         .or_else(|e| match e {
             rusqlite::Error::QueryReturnedNoRows => Ok(None),
@@ -474,6 +488,92 @@ mod tests {
         // Stamped with the run instance; newest-first by seq.
         assert!(records.iter().all(|r| r.instance_id == [5; 16]));
         assert!(records[0].seq > records[1].seq);
+    }
+
+    /// A test-only [`JournalReader`] whose contents GROW between reads — modeling
+    /// a live journal that the background poller folds incrementally across ticks.
+    /// (We cannot reuse `ReadOnly<InMemoryJournal>`: the seam deliberately exposes
+    /// no write surface, and `InMemoryJournal` is not `Clone`, so there is no way
+    /// to append to the folded handle between ticks. This reader stays a pure test
+    /// fixture — no production seam is weakened for the test's sake.)
+    struct GrowableReader {
+        entries: std::sync::RwLock<Vec<JournalEntry>>,
+    }
+
+    impl GrowableReader {
+        fn new() -> Self {
+            Self {
+                entries: std::sync::RwLock::new(Vec::new()),
+            }
+        }
+
+        fn push(&self, entry: JournalEntry) {
+            self.entries.write().unwrap().push(entry);
+        }
+    }
+
+    impl JournalReader for GrowableReader {
+        fn read_entries_by_seq(
+            &self,
+            range: std::ops::Range<u64>,
+        ) -> Result<Box<dyn Iterator<Item = JournalEntry> + '_>, kx_journal::JournalError> {
+            let hit: Vec<JournalEntry> = self
+                .entries
+                .read()
+                .unwrap()
+                .iter()
+                .filter(|e| range.contains(&e.seq()))
+                .cloned()
+                .collect();
+            Ok(Box::new(hit.into_iter()))
+        }
+
+        fn current_seq(&self) -> Result<u64, kx_journal::JournalError> {
+            Ok(self
+                .entries
+                .read()
+                .unwrap()
+                .iter()
+                .map(JournalEntry::seq)
+                .max()
+                .unwrap_or(0))
+        }
+    }
+
+    #[test]
+    fn instance_is_stamped_across_separate_fold_ticks() {
+        // The installed-runtime-sweep regression (F9): in a real serve the
+        // RunRegistered fact (seq=1) folds in an EARLY tick, before any action
+        // commits. A later tick that folds a Committed action must STILL stamp
+        // it with the run instance — via the durable run_meta row, not a
+        // same-tick registration.
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger = CaptureLedger::open(dir.path()).unwrap();
+        let reader = GrowableReader::new();
+        // Tick 1: only the registration is in the journal.
+        reader.push(JournalEntry::RunRegistered {
+            instance_id: [7; 16],
+            recipe_fingerprint: [6; 32],
+            ts: 0,
+            seq: 1,
+        });
+        assert_eq!(
+            ledger.fold(&reader),
+            0,
+            "registration tick captures no action"
+        );
+        // Tick 2: an action commits LATER (the registration is already past the
+        // watermark, so the run instance comes only from the durable run_meta row).
+        reader.push(committed(2, 0x10, 0x20));
+        assert_eq!(ledger.fold(&reader), 1);
+
+        let (records, _) = ledger.list(10, Some([7; 16])).unwrap();
+        assert_eq!(
+            records.len(),
+            1,
+            "the later action is stamped with the run instance from a PRIOR tick"
+        );
+        assert_eq!(records[0].instance_id, [7; 16]);
     }
 
     #[test]

--- a/crates/kx-gateway/tests/capture_e2e.rs
+++ b/crates/kx-gateway/tests/capture_e2e.rs
@@ -120,6 +120,51 @@ async fn captured_actions_reconcile_with_the_projection() {
 }
 
 #[tokio::test]
+async fn a_later_action_is_stamped_from_the_durable_run_meta() {
+    // The installed-runtime-sweep regression (F9), end-to-end. The original
+    // reconcile test drives the WHOLE run before the first 250 ms poll, so
+    // RunRegistered (seq=1) and every Committed action fold in ONE tick — where
+    // same-tick stamping happened to work. A real serve trickles actions in over
+    // many ticks: an action committed AFTER the watermark has already advanced
+    // past the registration must STILL be stamped (from the durable run_meta
+    // row). This forces that ordering: await the first capture (advancing the
+    // watermark past RunRegistered), THEN submit a second action and prove the
+    // later fold tick — whose range no longer contains RunRegistered — stamps it.
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let instance = common::submit_pure_run(&mut c, 0x44).await;
+    let first = await_captures(&mut c, Some(instance.clone()), 1).await;
+    assert!(first.iter().all(|r| r.instance_id == instance));
+
+    // A second Mote JOINS the same single-node run (F4: RunRegistered is seq=1,
+    // idempotent) and commits LATER — its fold range starts past the watermark,
+    // so RunRegistered is NOT in it. Stamping can only come from run_meta.
+    let _ = common::submit_pure_run(&mut c, 0x45).await;
+    let after = await_captures(&mut c, Some(instance.clone()), first.len() + 1).await;
+    assert!(
+        after.len() > first.len(),
+        "the second action was captured in a later poll tick"
+    );
+    for r in &after {
+        assert_eq!(
+            r.instance_id, instance,
+            "a later-tick action is stamped from the durable run_meta row, not zeros"
+        );
+        assert_ne!(
+            r.instance_id,
+            vec![0u8; 16],
+            "instance must never be all-zeros (the F9 bug)"
+        );
+    }
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
 async fn capture_survives_restart_and_rebuilds_from_the_journal() {
     let dir = tempfile::TempDir::new().unwrap();
     let captured_first: Vec<Vec<u8>>;


### PR DESCRIPTION
## What

The clean-install verification campaign's **installed-runtime sweep** (Batch 4) caught the Morphic Data Engine stamping every captured action's `instance_id` as all-zeros in a *real* `kx serve`.

**Root cause.** The capture poller folds the read-only journal into `capture.db` every ~250ms. `RunRegistered` (seq=1) folds in an **early** tick, before any action commits, but `fold()` seeded the run instance ONLY from a *same-tick* registration. Every action committed in a **later** tick was therefore stamped `00…00`. The Batch-2 e2e missed this because `submit_pure_run` drives the whole run to completion before the first poll — collapsing `RunRegistered` + all `Committed` actions into a single tick (where same-tick stamping happened to work).

**Fix.** A durable `run_meta(id=0, instance_id)` row (`capture.db` schema **v1→v2**). The fold seeds the instance from that durable row, persists it on `RunRegistered`, and stamps any later-tick action from it — order-robust. Capture is a rebuildable cache, so an old v1 sidecar simply **drops-and-rebuilds** (no migration); the schema-bump drop now clears `run_meta` too for a fully clean rebuild.

## Tests

- **unit** `instance_is_stamped_across_separate_fold_ticks` — deterministic, via a pure **test-local** growable `JournalReader`. Deliberately **not** via a new `ReadOnly::inner()`: that would expose a writable `&J` and break the read-only seam's documented no-write-surface guarantee (Golden Rule 1).
- **e2e** `a_later_action_is_stamped_from_the_durable_run_meta` — forces a genuinely separate poll tick through a real serve and asserts the later action's `instance_id` is the run instance, never all-zeros.

## Risk / compat (Golden Rule 8)

- **Off the truth path.** Canonical projection digest `7d22d4bd…` invariant (`verify-quickstart` green), frozen trio untouched, no journal/checkpoint change, additive-only.
- **Fwd/back-compat.** `capture.db` is a journal-derived rebuildable cache (D40): a v1 sidecar written by the old binary drops-and-rebuilds under the new one with correct stamping — a deliberate, self-healing cache reset, not a data loss (the journal is truth).
- **Perf/security.** Read-side only, one extra single-row query per fold tick; no new untrusted input or egress surface.

Full `just ci` green (fmt, clippy -D warnings both feature sets, tests, deny, doc, ffi-link, byte-determinism I1.c, scale-smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)