### PR TITLE
fix(sdk): F13 — react invoke(wait) settles via ListReactTurns

### DIFF
--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -40,8 +40,21 @@ from .v1 import gateway_pb2_grpc as _gg
 #: The conventional gateway endpoint (matches ``kx serve`` / the CLI default).
 DEFAULT_ENDPOINT = "http://127.0.0.1:50151"
 
+#: The canonical ReAct recipe handle. A react run has NO statically-known terminal
+#: Mote (the gateway hands back a run-salted turn-0 id that never commits, and the
+#: settled Answer turn isn't known until the model emits it), so ``invoke(wait=True)``
+#: on this handle waits on chain SETTLEMENT via ``ListReactTurns`` instead of a
+#: single terminal Mote (campaign finding F13).
+REACT_RECIPE_HANDLE = "kx/recipes/react"
+
 ArgsType = Union[dict, bytes, bytearray, str]
 IdType = Union[str, bytes]
+
+
+def _is_react_handle(handle: str) -> bool:
+    """True for the ReAct recipe — its ``invoke(wait=True)`` settles via the chain
+    (``ListReactTurns``), not a terminal Mote (F13)."""
+    return handle == REACT_RECIPE_HANDLE
 
 
 # --- shared credential + channel helpers -------------------------------------
@@ -174,7 +187,16 @@ class KxClient:
         run = Run(self, resp.instance_id, resp.terminal_mote_id, resp.recipe_fingerprint)
         if not wait:
             return run
-        result = self._await_terminal(resp.instance_id, resp.terminal_mote_id, timeout, wait_mode)
+        if _is_react_handle(handle):
+            # F13: a react chain settles via ListReactTurns, not a terminal Mote.
+            outcome = _wait.poll_react_result(
+                self._stub, self._md, resp.instance_id, resp.terminal_mote_id, timeout
+            )
+            result = self._finish(outcome)
+        else:
+            result = self._await_terminal(
+                resp.instance_id, resp.terminal_mote_id, timeout, wait_mode
+            )
         if out is not None and result.payload is not None:
             with open(out, "wb") as fh:
                 fh.write(result.payload)
@@ -481,9 +503,16 @@ class AsyncKxClient:
         run = AsyncRun(self, resp.instance_id, resp.terminal_mote_id, resp.recipe_fingerprint)
         if not wait:
             return run
-        result = await self._await_terminal(
-            resp.instance_id, resp.terminal_mote_id, timeout, wait_mode
-        )
+        if _is_react_handle(handle):
+            # F13: a react chain settles via ListReactTurns, not a terminal Mote.
+            outcome = await _wait.apoll_react_result(
+                self._stub, self._md, resp.instance_id, resp.terminal_mote_id, timeout
+            )
+            result = KxClient._finish(outcome)
+        else:
+            result = await self._await_terminal(
+                resp.instance_id, resp.terminal_mote_id, timeout, wait_mode
+            )
         if out is not None and result.payload is not None:
             with open(out, "wb") as fh:
                 fh.write(result.payload)

--- a/bindings/python/src/kortecx/wait.py
+++ b/bindings/python/src/kortecx/wait.py
@@ -109,6 +109,53 @@ def poll_result(stub, md, instance_id, terminal_mote_id, timeout) -> WaitOutcome
         time.sleep(POLL_INTERVAL)
 
 
+#: The branches a ReAct turn settles to (vs the live "pending"/"tool" states).
+_REACT_ANSWER = "answer"
+_REACT_DEAD = "dead_lettered"
+
+
+def _list_react_turns(stub, md, instance_id: bytes):
+    try:
+        resp = stub.ListReactTurns(
+            _g.ListReactTurnsRequest(instance_id=instance_id), metadata=md
+        )
+        return list(resp.turns)
+    except grpc.RpcError as e:
+        raise from_rpc_error(e) from e
+
+
+def _projection_result_ref(stub, md, instance_id: bytes, mote_id: bytes) -> Optional[bytes]:
+    view = _get_projection(stub, md, instance_id)
+    m = next((x for x in view.motes if x.mote_id == mote_id), None)
+    return _snapshot_result_ref(m) if m is not None else None
+
+
+def poll_react_result(stub, md, instance_id, terminal_mote_id, timeout) -> WaitOutcome:
+    """Wait for a ReAct CHAIN to settle (the ``invoke`` react path).
+
+    A react chain has no statically-known terminal Mote: the run-salted turn-0 id
+    the gateway hands back never matches the committed turn id, and the settled
+    Answer turn isn't known until the model emits it. So completion is observed via
+    ``ListReactTurns`` — the chain is done when a turn settles to ``answer`` (the
+    final answer; resolve its committed content) or ``dead_lettered`` (terminal
+    failure). This is the durable, server-derived signal (the runtime's own
+    "resume with get_projection / events" hint, made the default for react).
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        turns = _list_react_turns(stub, md, instance_id)
+        answer = next((t for t in turns if t.branch == _REACT_ANSWER), None)
+        if answer is not None:
+            rr = _projection_result_ref(stub, md, instance_id, answer.turn_mote_id)
+            return _committed_outcome(stub, md, instance_id, answer.turn_mote_id, rr)
+        dead = next((t for t in turns if t.branch == _REACT_DEAD), None)
+        if dead is not None:
+            return _terminal(instance_id, dead.turn_mote_id, WaitState.FAILED)
+        if time.monotonic() >= deadline:
+            return _terminal(instance_id, terminal_mote_id, WaitState.RUNNING)
+        time.sleep(POLL_INTERVAL)
+
+
 def poll_any(stub, md, instance_id, timeout) -> WaitOutcome:
     """Poll until ANY Mote commits (the ``submit`` path — no terminal id)."""
     deadline = time.monotonic() + timeout
@@ -210,6 +257,40 @@ async def apoll_result(stub, md, instance_id, terminal_mote_id, timeout) -> Wait
                 )
             if not types.is_pending(m.state):
                 return _terminal(instance_id, terminal_mote_id, WaitState.FAILED)
+        if loop.time() >= deadline:
+            return _terminal(instance_id, terminal_mote_id, WaitState.RUNNING)
+        await asyncio.sleep(POLL_INTERVAL)
+
+
+async def _alist_react_turns(stub, md, instance_id: bytes):
+    try:
+        resp = await stub.ListReactTurns(
+            _g.ListReactTurnsRequest(instance_id=instance_id), metadata=md
+        )
+        return list(resp.turns)
+    except grpc.RpcError as e:
+        raise from_rpc_error(e) from e
+
+
+async def _aprojection_result_ref(stub, md, instance_id: bytes, mote_id: bytes) -> Optional[bytes]:
+    view = await _aget_projection(stub, md, instance_id)
+    m = next((x for x in view.motes if x.mote_id == mote_id), None)
+    return _snapshot_result_ref(m) if m is not None else None
+
+
+async def apoll_react_result(stub, md, instance_id, terminal_mote_id, timeout) -> WaitOutcome:
+    """Async mirror of :func:`poll_react_result` (the react ``invoke`` path)."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while True:
+        turns = await _alist_react_turns(stub, md, instance_id)
+        answer = next((t for t in turns if t.branch == _REACT_ANSWER), None)
+        if answer is not None:
+            rr = await _aprojection_result_ref(stub, md, instance_id, answer.turn_mote_id)
+            return await _acommitted_outcome(stub, md, instance_id, answer.turn_mote_id, rr)
+        dead = next((t for t in turns if t.branch == _REACT_DEAD), None)
+        if dead is not None:
+            return _terminal(instance_id, dead.turn_mote_id, WaitState.FAILED)
         if loop.time() >= deadline:
             return _terminal(instance_id, terminal_mote_id, WaitState.RUNNING)
         await asyncio.sleep(POLL_INTERVAL)

--- a/bindings/python/src/kortecx/wait.py
+++ b/bindings/python/src/kortecx/wait.py
@@ -116,9 +116,7 @@ _REACT_DEAD = "dead_lettered"
 
 def _list_react_turns(stub, md, instance_id: bytes):
     try:
-        resp = stub.ListReactTurns(
-            _g.ListReactTurnsRequest(instance_id=instance_id), metadata=md
-        )
+        resp = stub.ListReactTurns(_g.ListReactTurnsRequest(instance_id=instance_id), metadata=md)
         return list(resp.turns)
     except grpc.RpcError as e:
         raise from_rpc_error(e) from e

--- a/bindings/python/tests/test_unit.py
+++ b/bindings/python/tests/test_unit.py
@@ -238,3 +238,82 @@ def test_result_binary_payload_has_no_utf8():
     )
     r = Result.from_outcome(out)
     assert r.text is None and "result_utf8" not in r.to_dict()
+
+
+# --- F13: react invoke(wait=True) settles via ListReactTurns ------------------
+
+
+class _FakeReactStub:
+    """A minimal stub for the react-wait path: ListReactTurns drives settlement,
+    GetProjection resolves the settled turn's result_ref, GetContent its bytes.
+    Models the F13 reality — the gateway's returned terminal_mote_id never commits;
+    the settled answer turn (a DIFFERENT, run-salted id) carries the answer."""
+
+    def __init__(self, turns, answer_mote=None, answer_ref=None, payload=b""):
+        self._turns = turns
+        self._answer_mote = answer_mote
+        self._answer_ref = answer_ref
+        self._payload = payload
+
+    def ListReactTurns(self, req, metadata=None):  # noqa: N802 (gRPC stub name)
+        return g.ListReactTurnsResponse(turns=self._turns, has_more=False)
+
+    def GetProjection(self, req, metadata=None):  # noqa: N802
+        motes = []
+        if self._answer_mote is not None:
+            m = g.MoteSnapshot(
+                mote_id=self._answer_mote,
+                state=g.MoteSnapshotState.MOTE_SNAPSHOT_STATE_COMMITTED,
+            )
+            if self._answer_ref is not None:
+                m.result_ref = self._answer_ref
+            motes.append(m)
+        return g.ProjectionView(instance_id=req.instance_id, motes=motes)
+
+    def GetContent(self, req, metadata=None):  # noqa: N802
+        return g.ContentBlob(payload=self._payload)
+
+
+def test_react_wait_settles_on_answer_via_list_react_turns():
+    from kortecx.wait import poll_react_result
+
+    inst = b"\x07" * 16
+    seed = b"\x99" * 32  # the gateway's returned terminal — NEVER commits (F13)
+    answer = b"\x42" * 32  # the run-salted settled answer turn id
+    stub = _FakeReactStub(
+        turns=[
+            g.ReactTurnSummary(turn=0, turn_mote_id=answer, branch="answer"),
+            g.ReactTurnSummary(turn=0, turn_mote_id=answer, branch="pending"),
+        ],
+        answer_mote=answer,
+        answer_ref=b"\x03" * 32,
+        payload=b"the final answer",
+    )
+    out = poll_react_result(stub, [], inst, seed, timeout=5)
+    assert out.state == WaitState.COMMITTED
+    assert out.terminal_mote_id == answer  # NOT the never-committing seed
+    assert out.payload == b"the final answer"
+
+
+def test_react_wait_dead_letter_is_failed():
+    from kortecx.wait import poll_react_result
+
+    inst = b"\x07" * 16
+    seed = b"\x99" * 32
+    dead = b"\x55" * 32
+    stub = _FakeReactStub(
+        turns=[g.ReactTurnSummary(turn=2, turn_mote_id=dead, branch="dead_lettered")]
+    )
+    out = poll_react_result(stub, [], inst, seed, timeout=5)
+    assert out.state == WaitState.FAILED
+    assert out.terminal_mote_id == dead
+
+
+def test_react_wait_times_out_while_pending():
+    from kortecx.wait import poll_react_result
+
+    inst = b"\x07" * 16
+    seed = b"\x99" * 32
+    stub = _FakeReactStub(turns=[g.ReactTurnSummary(turn=0, turn_mote_id=seed, branch="pending")])
+    out = poll_react_result(stub, [], inst, seed, timeout=0.01)
+    assert out.state == WaitState.RUNNING  # still in progress (resumable), no false commit

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -27,7 +27,22 @@ import { type RunPage, RunSummary } from "./runs.js";
 import { TeamMembers, type TeamSummary, teamsFromProto } from "./teams.js";
 import { type Args, encodeArgs } from "./transport.js";
 import { type Delta, Projection, SignatureSummary } from "./types.js";
-import { type WaitMode, type WaitOutcome, eventsResult, pollAny, pollResult } from "./wait.js";
+import {
+  type WaitMode,
+  type WaitOutcome,
+  eventsResult,
+  pollAny,
+  pollReactResult,
+  pollResult,
+} from "./wait.js";
+
+/**
+ * The canonical ReAct recipe handle. A react run has NO statically-known terminal
+ * Mote (the gateway returns a run-salted turn-0 id that never commits, and the
+ * settled Answer turn isn't known until the model emits it), so `invoke({ wait })`
+ * on this handle settles via `ListReactTurns` instead of a terminal Mote (F13).
+ */
+export const REACT_RECIPE_HANDLE = "kx/recipes/react";
 
 /** An id argument: hex string OR raw server-derived bytes. */
 export type Id = string | Uint8Array;
@@ -82,12 +97,23 @@ export abstract class KxClientBase {
     const resp = await rpc(this.grpc.invoke({ handle, args: argBytes }));
     const run = new Run(this, resp.instanceId, resp.terminalMoteId, resp.recipeFingerprint);
     if (!opts.wait) return run;
-    const result = await this._awaitTerminal(
-      resp.instanceId,
-      resp.terminalMoteId,
-      opts.timeoutMs ?? 120_000,
-      opts.waitMode ?? "poll",
-    );
+    const result =
+      handle === REACT_RECIPE_HANDLE
+        ? // F13: a react chain settles via ListReactTurns, not a terminal Mote.
+          this._finish(
+            await pollReactResult(
+              this.grpc,
+              resp.instanceId,
+              resp.terminalMoteId,
+              opts.timeoutMs ?? 120_000,
+            ),
+          )
+        : await this._awaitTerminal(
+            resp.instanceId,
+            resp.terminalMoteId,
+            opts.timeoutMs ?? 120_000,
+            opts.waitMode ?? "poll",
+          );
     if (opts.out !== undefined && result.payload !== null) {
       await this.writeOut(opts.out, result.payload);
     }

--- a/bindings/typescript/src/wait.ts
+++ b/bindings/typescript/src/wait.ts
@@ -112,6 +112,46 @@ export async function pollResult(
   }
 }
 
+/** The branches a ReAct turn settles to (vs the live "pending"/"tool" states). */
+const REACT_ANSWER = "answer";
+const REACT_DEAD = "dead_lettered";
+
+/**
+ * Wait for a ReAct CHAIN to settle (the `invoke` react path).
+ *
+ * A react chain has no statically-known terminal Mote: the run-salted turn-0 id
+ * the gateway hands back never matches the committed turn id, and the settled
+ * Answer turn isn't known until the model emits it. So completion is observed via
+ * `ListReactTurns` — done when a turn settles to `answer` (resolve its committed
+ * content) or `dead_lettered` (terminal failure). Mirrors the runtime's own
+ * "resume with get_projection / events" hint (campaign finding F13).
+ */
+export async function pollReactResult(
+  gw: Gateway,
+  instance: Uint8Array,
+  terminal: Uint8Array,
+  timeoutMs: number,
+): Promise<WaitOutcome> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const resp = await rpc(gw.listReactTurns({ instanceId: instance }));
+    const answer = resp.turns.find((t) => t.branch === REACT_ANSWER);
+    if (answer !== undefined) {
+      const view = await rpc(gw.getProjection({ instanceId: instance }));
+      const m = view.motes.find((x) => eq(x.moteId, answer.turnMoteId));
+      return committedOutcome(gw, instance, answer.turnMoteId, m?.resultRef);
+    }
+    const dead = resp.turns.find((t) => t.branch === REACT_DEAD);
+    if (dead !== undefined) {
+      return { instanceId: instance, terminalMoteId: dead.turnMoteId, state: WaitState.Failed };
+    }
+    if (Date.now() >= deadline) {
+      return { instanceId: instance, terminalMoteId: terminal, state: WaitState.Running };
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
 /** Poll until ANY Mote commits (the `submit` path — no terminal id). */
 export async function pollAny(
   gw: Gateway,

--- a/bindings/typescript/test/unit.test.ts
+++ b/bindings/typescript/test/unit.test.ts
@@ -31,7 +31,7 @@ import {
   warnIfPlaintext,
 } from "../src/transport.js";
 import { Delta, MoteView, Projection, isCommitted, isPending, stateName } from "../src/types.js";
-import type { WaitOutcome } from "../src/wait.js";
+import { type WaitOutcome, WaitState, pollReactResult } from "../src/wait.js";
 
 const fill = (v: number, n: number): Uint8Array => new Uint8Array(n).fill(v);
 const dec = (b: Uint8Array): string => new TextDecoder().decode(b);
@@ -252,5 +252,63 @@ describe("Result", () => {
     const r = Result.fromOutcome(o);
     expect(r.text).toBeNull();
     expect(r.toJSON().result_utf8).toBeUndefined();
+  });
+});
+
+// --- F13: react invoke(wait) settles via ListReactTurns ----------------------
+
+describe("pollReactResult (F13 — react wait via ListReactTurns)", () => {
+  // A minimal fake gateway: ListReactTurns drives settlement, GetProjection
+  // resolves the settled turn's resultRef, GetContent its bytes. Models F13 — the
+  // returned terminal_mote_id (seed) never commits; the run-salted answer turn does.
+  const fakeGateway = (
+    turns: Array<{ branch: string; turnMoteId: Uint8Array }>,
+    ans?: {
+      moteId: Uint8Array;
+      resultRef: Uint8Array;
+      payload: Uint8Array;
+    },
+  ) =>
+    ({
+      listReactTurns: (_req: unknown) => Promise.resolve({ turns, hasMore: false }),
+      getProjection: (_req: unknown) =>
+        Promise.resolve({
+          motes: ans
+            ? [{ moteId: ans.moteId, state: MoteSnapshotState.COMMITTED, resultRef: ans.resultRef }]
+            : [],
+        }),
+      getContent: (_req: unknown) =>
+        Promise.resolve({ payload: ans?.payload ?? new Uint8Array(0) }),
+    }) as unknown as Parameters<typeof pollReactResult>[0];
+
+  it("settles COMMITTED on an answer branch, resolving the run-salted turn's content", async () => {
+    const seed = fill(0x99, 32); // gateway's returned terminal — never commits
+    const answer = fill(0x42, 32); // the run-salted settled answer turn
+    const gw = fakeGateway(
+      [
+        { branch: "answer", turnMoteId: answer },
+        { branch: "pending", turnMoteId: answer },
+      ],
+      { moteId: answer, resultRef: fill(0x03, 32), payload: new TextEncoder().encode("final") },
+    );
+    const out = await pollReactResult(gw, fill(0x07, 16), seed, 5_000);
+    expect(out.state).toBe(WaitState.Committed);
+    expect(encode(out.terminalMoteId)).toBe(encode(answer)); // NOT the seed
+    expect(dec(out.payload as Uint8Array)).toBe("final");
+  });
+
+  it("settles FAILED on a dead_lettered branch", async () => {
+    const dead = fill(0x55, 32);
+    const gw = fakeGateway([{ branch: "dead_lettered", turnMoteId: dead }]);
+    const out = await pollReactResult(gw, fill(0x07, 16), fill(0x99, 32), 5_000);
+    expect(out.state).toBe(WaitState.Failed);
+    expect(encode(out.terminalMoteId)).toBe(encode(dead));
+  });
+
+  it("returns RUNNING (resumable) while only pending — no false commit", async () => {
+    const seed = fill(0x99, 32);
+    const gw = fakeGateway([{ branch: "pending", turnMoteId: seed }]);
+    const out = await pollReactResult(gw, fill(0x07, 16), seed, 10);
+    expect(out.state).toBe(WaitState.Running);
   });
 });


### PR DESCRIPTION
See commit. SDK-only F13 fix: react invoke(wait) settles via ListReactTurns (no terminal-mote wait). Python+TS + 6 unit tests; verified live (~5-6s, was 180s timeout). No rust/proto/digest change.