### PR TITLE
chore(release): v0.1.1 — version bump + CHANGELOG (F9 capture + F13 react invoke-wait)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ development; interfaces may change before 1.0 — pin a commit if you build on i
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-06-10
+
+A patch release from the clean-install verification campaign — two bugs caught
+by testing the **installed** runtime end-to-end across all four surfaces (CLI,
+Python SDK, TypeScript SDK, UI).
+
+### Fixed
+
+- **Morphic Data Engine: capture records are now correctly stamped with the run
+  instance** (was all-zeros in a real `kx serve`). The serve-path capture poller
+  folds the journal in ~250 ms ticks; the run instance is now persisted durably
+  (`capture.db` `run_meta`, schema v1→v2) so an action committed in any later tick
+  is stamped, not only one folded in the same tick as `RunRegistered`. `capture.db`
+  is a rebuildable cache, so an old sidecar drops-and-rebuilds on first open.
+  (gateway; OSS #172)
+- **SDKs: `invoke(wait=True)` on `kx/recipes/react` no longer spuriously times
+  out.** A ReAct chain has no statically-known terminal Mote (the run-salted
+  turn-0 id is server-derived), so both SDKs now wait on chain **settlement via
+  `ListReactTurns`** (answer → committed, dead-lettered → failed). Drive a react
+  run's completion from a client/UI via `ListReactTurns`/events. (Python +
+  TypeScript SDKs; OSS #173)
+
 ## [0.1.0] — 2026-06-10
 
 The first public release: a single-system durable agentic-execution runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "kx-audit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-mote",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "kx-capability"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "kx-content",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "kx-capture"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-mote",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "kx-catalog"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kx-chaos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "kx-capability",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "kx-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-gateway",
  "kx-proto",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "kx-content"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "kx-context-assembler"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "kx-coordinator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "getrandom 0.3.4",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "kx-critic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "kx-critic-types",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "kx-critic-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "kx-dataset"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "kx-content",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "kx-dataset-hnsw"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hnsw_rs",
  "kx-content",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "kx-executor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "kx-fleet"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "kx-gateway"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "futures-util",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "kx-gateway-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-critic-types",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "kx-inference"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "kx-content",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "kx-invoke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-catalog",
  "kx-content",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "kx-journal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "kx-llamacpp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-llamacpp-sys",
  "proptest",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "kx-llamacpp-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "kx-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-capability",
  "kx-content",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "kx-memoizer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-journal",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "kx-model-harness"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "kx-model-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "kx-content",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "kx-model-validator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-mote",
  "proptest",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "kx-mote"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "kx-normalizer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "kx-mote",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "kx-planner"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "kx-content",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "kx-profile"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-capability",
  "kx-content",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "kx-projection"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "kx-proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "kx-content",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "kx-refusal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-mote",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "kx-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "kx-scheduler"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-executor",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "kx-tiering"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-journal",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "kx-tool-registry"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "kx-toolcall"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-content",
  "kx-mote",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "kx-warrant"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "kx-worker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kx-capability",
  "kx-content",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "kx-workflow"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode 2.0.1",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,23 +107,23 @@ hnsw_rs            = { version = "0.3", default-features = false }
 # field also takes effect on `cargo publish` — replacing the path during
 # publish with the version requirement here. All paths point under
 # `crates/` per the workspace's parent-folder layout convention.
-kx-mote              = { path = "crates/kx-mote",              version = "0.1.0" }
-kx-content           = { path = "crates/kx-content",           version = "0.1.0" }
-kx-journal           = { path = "crates/kx-journal",           version = "0.1.0" }
-kx-projection        = { path = "crates/kx-projection",        version = "0.1.0" }
-kx-llamacpp-sys      = { path = "crates/kx-llamacpp-sys",      version = "0.1.0" }
-kx-llamacpp          = { path = "crates/kx-llamacpp",          version = "0.1.0" }
-kx-model-validator   = { path = "crates/kx-model-validator",   version = "0.1.0" }
-kx-warrant           = { path = "crates/kx-warrant",           version = "0.1.0" }
+kx-mote              = { path = "crates/kx-mote",              version = "0.1.1" }
+kx-content           = { path = "crates/kx-content",           version = "0.1.1" }
+kx-journal           = { path = "crates/kx-journal",           version = "0.1.1" }
+kx-projection        = { path = "crates/kx-projection",        version = "0.1.1" }
+kx-llamacpp-sys      = { path = "crates/kx-llamacpp-sys",      version = "0.1.1" }
+kx-llamacpp          = { path = "crates/kx-llamacpp",          version = "0.1.1" }
+kx-model-validator   = { path = "crates/kx-model-validator",   version = "0.1.1" }
+kx-warrant           = { path = "crates/kx-warrant",           version = "0.1.1" }
 # The model-proposed tool-call AUTHORITY GATE (IMP-5, extracted PR-2d-1) — pure
 # leaf shared by the harness ReAct loop, the gateway pre-commit fence, and the
 # coordinator settle decode. Extracted (moved), never forked: a byte-mirror that
 # drifted would silently admit an ungranted tool (SN-8).
-kx-toolcall          = { path = "crates/kx-toolcall",          version = "0.1.0" }
-kx-tool-registry     = { path = "crates/kx-tool-registry",     version = "0.1.0" }
-kx-context-assembler = { path = "crates/kx-context-assembler", version = "0.1.0" }
-kx-memoizer          = { path = "crates/kx-memoizer",          version = "0.1.0" }
-kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.1.0" }
+kx-toolcall          = { path = "crates/kx-toolcall",          version = "0.1.1" }
+kx-tool-registry     = { path = "crates/kx-tool-registry",     version = "0.1.1" }
+kx-context-assembler = { path = "crates/kx-context-assembler", version = "0.1.1" }
+kx-memoizer          = { path = "crates/kx-memoizer",          version = "0.1.1" }
+kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.1.1" }
 # `default-features = false` (no llama.cpp FFI) is the WORKSPACE default for every
 # crate that depends on kx-inference, so the runtime's closure builds with no C++
 # toolchain (`cargo install kx-runtime`). It must live here, not on a member edge —
@@ -131,87 +131,87 @@ kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.1.0"
 # one crate that needs the in-process backend, kx-model-harness, opts back in with
 # `features = ["llamacpp"]`. kx-inference's own `default = ["llamacpp"]` keeps its
 # own build/test/doctests on the FFI when it is itself the target.
-kx-inference         = { path = "crates/kx-inference",         version = "0.1.0", default-features = false }
-kx-capability        = { path = "crates/kx-capability",        version = "0.1.0" }
-kx-executor          = { path = "crates/kx-executor",          version = "0.1.0" }
-kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.1.0" }
-kx-proto             = { path = "crates/kx-proto",             version = "0.1.0" }
-kx-coordinator       = { path = "crates/kx-coordinator",       version = "0.1.0" }
-kx-worker            = { path = "crates/kx-worker",            version = "0.1.0" }
+kx-inference         = { path = "crates/kx-inference",         version = "0.1.1", default-features = false }
+kx-capability        = { path = "crates/kx-capability",        version = "0.1.1" }
+kx-executor          = { path = "crates/kx-executor",          version = "0.1.1" }
+kx-scheduler         = { path = "crates/kx-scheduler",         version = "0.1.1" }
+kx-proto             = { path = "crates/kx-proto",             version = "0.1.1" }
+kx-coordinator       = { path = "crates/kx-coordinator",       version = "0.1.1" }
+kx-worker            = { path = "crates/kx-worker",            version = "0.1.1" }
 # The single-node engine — kx-chaos reuses its topology helpers (`derive_child_motes`,
 # `demo_topology_decision`) to check child-identity determinism under a shaper death.
-kx-runtime           = { path = "crates/kx-runtime",           version = "0.1.0" }
+kx-runtime           = { path = "crates/kx-runtime",           version = "0.1.1" }
 # The workflow engine (codename Morphic, P4.1) — compiles a WorkflowDef to a
 # Mote DAG. Sits above the scheduler; emits kx-mote + kx-warrant types only.
-kx-workflow          = { path = "crates/kx-workflow",          version = "0.1.0" }
+kx-workflow          = { path = "crates/kx-workflow",          version = "0.1.1" }
 # The data-management seam (P4.1c) — typed (tensor/vector/blob/multi-modal)
 # DataStore/Dataset/RetrievalIndex over committed content; journal-authoritative.
-kx-dataset           = { path = "crates/kx-dataset",           version = "0.1.0" }
+kx-dataset           = { path = "crates/kx-dataset",           version = "0.1.1" }
 # The opt-in SCALE retrieval backend (DP3, T2.3) — a file-backed in-process HNSW
 # index implementing kx-dataset::RetrievalIndex via the pure-Rust hnsw_rs crate.
 # Off the truth path (SN-8); the exact InMemory index stays the reproducible
 # default. Consumed only behind an opt-in feature (kx-gateway's `hnsw`, T3.7).
-kx-dataset-hnsw      = { path = "crates/kx-dataset-hnsw",      version = "0.1.0" }
+kx-dataset-hnsw      = { path = "crates/kx-dataset-hnsw",      version = "0.1.1" }
 # Deterministic-critic vocabulary (P4.2) — CriticVerdict / CriticReason / CheckSpec.
 # Parser-free + dataset-free so kx-mote can embed a CheckSpec in MoteDef without a
 # dependency cycle or inheriting regex/serde_json.
-kx-critic-types      = { path = "crates/kx-critic-types",      version = "0.1.0" }
+kx-critic-types      = { path = "crates/kx-critic-types",      version = "0.1.1" }
 # Deterministic-critic evaluator (P4.2) — the pure/total evaluate(spec, bytes) ->
 # CriticVerdict over the four checks (schema / dedup / stat-bounds / PII-leakage).
-kx-critic            = { path = "crates/kx-critic",            version = "0.1.0" }
+kx-critic            = { path = "crates/kx-critic",            version = "0.1.1" }
 # Step-capture projection (P4.2 pivot) — opt-in, off-truth-path per-Mote capture of
 # input/output/reasoning/thinking in blob storage; reuse the action, never the thinking.
-kx-capture           = { path = "crates/kx-capture",           version = "0.1.0" }
+kx-capture           = { path = "crates/kx-capture",           version = "0.1.1" }
 # Runtime audit sink (R4, D127 step 2.1) — append-only, off-truth-path, best-effort/
 # non-fatal lifecycle trail (AuditSink trait + AuditEvent + JsonlAuditSink/InMemory).
 # Join keys only (no payload/secrets); timestamps live only on the JSONL wire and
 # never feed the digest; SN-8 integer/crypto-equality. The guarantee-path crates
 # (frozen trio + journal/projection/memoizer) NEVER depend on it (a dep-wall test pins it).
-kx-audit             = { path = "crates/kx-audit",             version = "0.1.0" }
+kx-audit             = { path = "crates/kx-audit",             version = "0.1.1" }
 # Submission-time refusal vocabulary + predicates (M1.3) — a dependency-light LEAF
 # (kx-mote / kx-tool-registry / kx-warrant only) so the control-plane kx-coordinator
 # can enforce R-1..R-15 + D66 at SubmitMote WITHOUT linking kx-executor's inference
 # stack. kx-executor re-exports it for back-compat.
-kx-refusal           = { path = "crates/kx-refusal",           version = "0.1.0" }
+kx-refusal           = { path = "crates/kx-refusal",           version = "0.1.1" }
 # MCP adapter (M5.2, D80) — McpCapability, the first production Capability impl, the
 # concrete ToolKind::Mcp dispatch. A thin SYNC client (stdio now; ureq HTTP in M5.2b)
 # so the broker trait + kx-tool-registry stay dependency-clean (no tokio/rmcp).
-kx-mcp               = { path = "crates/kx-mcp",               version = "0.1.0" }
+kx-mcp               = { path = "crates/kx-mcp",               version = "0.1.1" }
 # The planner (M6, D73) — lowers an untrusted model PROPOSAL into a registered
 # Mote DAG (decode fail-closed; select ROLES not permissions; compile is the
 # structural gate). Sits above the scheduler; PURE lowering lib — depends only on
 # kx-workflow/kx-mote/kx-warrant/kx-critic-types (NEVER scheduler/projection/
 # executor/inference — the thesis dependency-ban, asserted in kx-model-harness).
-kx-planner           = { path = "crates/kx-planner",           version = "0.1.0" }
+kx-planner           = { path = "crates/kx-planner",           version = "0.1.1" }
 # The sharable catalog (M7, D82/D83) — the TaskSignature verdict-reuse foundation
 # + a content-addressed, idempotent, immutable signature registry. A SEPARATE
 # TRUTH (authoritative for WHAT recipes exist); off-journal + off the identity
 # path (composes kx-mote/kx-workflow identities, never bumps MoteDef). Depends
 # only on kx-mote/kx-workflow/kx-dataset — NEVER the journal or the frozen trio.
-kx-catalog           = { path = "crates/kx-catalog",           version = "0.1.0" }
+kx-catalog           = { path = "crates/kx-catalog",           version = "0.1.1" }
 # Teams / fleets (M7, D112) — journaled membership facts + a fail-closed fold +
 # composed warrant resolution. Membership is one-level-up delegation
 # (intersect(team_warrant, member_role)); nested fleet-of-teams = a bounded multi-hop
 # narrow. A SEPARATE TRUTH (off-journal, off the trust path, SN-8). Depends ONLY on
 # kx-catalog/kx-warrant; the journal + frozen trio NEVER depend on it (one-way edge).
-kx-fleet             = { path = "crates/kx-fleet",             version = "0.1.0" }
+kx-fleet             = { path = "crates/kx-fleet",             version = "0.1.1" }
 # M8 (D120) gateway backend: read-fold (journal -> ProjectionView / GetContent /
 # StreamEvents) + propose-proxy (SubmitRun -> coordinator). No journal write path;
 # never links the frozen-trio writers (a dep-wall test pins it).
-kx-gateway-core      = { path = "crates/kx-gateway-core",      version = "0.1.0" }
+kx-gateway-core      = { path = "crates/kx-gateway-core",      version = "0.1.1" }
 # R1 (D130) gateway dev BINARY: hosts the FROZEN KxGateway proto over kx-gateway-core
 # with an embedded single-system coordinator + local worker; the first network server
 # that binds a port outside tests. Deny-all auth stub (R2 fills it). FFI-free by default.
-kx-gateway           = { path = "crates/kx-gateway",           version = "0.1.0" }
+kx-gateway           = { path = "crates/kx-gateway",           version = "0.1.1" }
 # M8 (D121) inbound execution: resolve a published recipe by handle, validate +
 # bind args, compile, and submit under intersect(use, step) via the gateway
 # RunSubmitter. A composition over the catalog + gateway; adds no new write path.
-kx-invoke            = { path = "crates/kx-invoke",            version = "0.1.0" }
+kx-invoke            = { path = "crates/kx-invoke",            version = "0.1.1" }
 # M4 (D108.2) model lifecycle: backend-agnostic, FFI-FREE registry of model
 # identity + declared modalities + projector path + fail-closed GGUF validation.
 # An InferenceBackend resolves paths/capabilities through its ModelResolver seam;
 # the live loaded-model handle cache (kx-inference) keys on its identity_digest.
-kx-model-store       = { path = "crates/kx-model-store",       version = "0.1.0" }
+kx-model-store       = { path = "crates/kx-model-store",       version = "0.1.1" }
 bindgen            = "0.70"
 cmake              = "0.1"
 ureq               = { version = "2", default-features = false, features = ["tls"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kortecx"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python client SDK for the kortecx durable agentic-execution runtime (gRPC over the KxGateway contract)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kortecx/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript/JavaScript client SDK for the kortecx durable agentic-execution runtime (gRPC + gRPC-web over the frozen KxGateway contract).",
   "license": "Apache-2.0",
   "type": "module",

--- a/crates/kx-audit/Cargo.toml
+++ b/crates/kx-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-audit"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-capability/Cargo.toml
+++ b/crates/kx-capability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-capability"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-capture/Cargo.toml
+++ b/crates/kx-capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-capture"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-catalog/Cargo.toml
+++ b/crates/kx-catalog/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-catalog"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-chaos/Cargo.toml
+++ b/crates/kx-chaos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-chaos"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-cli/Cargo.toml
+++ b/crates/kx-cli/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-cli"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-content/Cargo.toml
+++ b/crates/kx-content/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-content"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-context-assembler/Cargo.toml
+++ b/crates/kx-context-assembler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-context-assembler"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-coordinator/Cargo.toml
+++ b/crates/kx-coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kx-coordinator"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/crates/kx-critic-types/Cargo.toml
+++ b/crates/kx-critic-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-critic-types"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-critic/Cargo.toml
+++ b/crates/kx-critic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-critic"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-dataset-hnsw/Cargo.toml
+++ b/crates/kx-dataset-hnsw/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-dataset-hnsw"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-dataset/Cargo.toml
+++ b/crates/kx-dataset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-dataset"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-executor/Cargo.toml
+++ b/crates/kx-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-executor"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-fleet/Cargo.toml
+++ b/crates/kx-fleet/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-fleet"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-gateway-core/Cargo.toml
+++ b/crates/kx-gateway-core/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-gateway-core"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-gateway"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-inference/Cargo.toml
+++ b/crates/kx-inference/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-inference"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-invoke/Cargo.toml
+++ b/crates/kx-invoke/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-invoke"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-journal/Cargo.toml
+++ b/crates/kx-journal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-journal"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-llamacpp-sys/Cargo.toml
+++ b/crates/kx-llamacpp-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-llamacpp-sys"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-llamacpp/Cargo.toml
+++ b/crates/kx-llamacpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-llamacpp"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-mcp/Cargo.toml
+++ b/crates/kx-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-mcp"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-memoizer/Cargo.toml
+++ b/crates/kx-memoizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-memoizer"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-model-harness/Cargo.toml
+++ b/crates/kx-model-harness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kx-model-harness"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kx-model-store/Cargo.toml
+++ b/crates/kx-model-store/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-model-store"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-model-validator/Cargo.toml
+++ b/crates/kx-model-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-model-validator"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-mote/Cargo.toml
+++ b/crates/kx-mote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-mote"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-normalizer/Cargo.toml
+++ b/crates/kx-normalizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-normalizer"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-planner/Cargo.toml
+++ b/crates/kx-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kx-planner"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kx-profile/Cargo.toml
+++ b/crates/kx-profile/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [package]
 name         = "kx-profile"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-projection/Cargo.toml
+++ b/crates/kx-projection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-projection"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-proto/Cargo.toml
+++ b/crates/kx-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kx-proto"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/crates/kx-refusal/Cargo.toml
+++ b/crates/kx-refusal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-refusal"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-runtime/Cargo.toml
+++ b/crates/kx-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-runtime"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-scheduler/Cargo.toml
+++ b/crates/kx-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-scheduler"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-tiering/Cargo.toml
+++ b/crates/kx-tiering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-tiering"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-tool-registry/Cargo.toml
+++ b/crates/kx-tool-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-tool-registry"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-toolcall/Cargo.toml
+++ b/crates/kx-toolcall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-toolcall"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-warrant/Cargo.toml
+++ b/crates/kx-warrant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-warrant"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }

--- a/crates/kx-worker/Cargo.toml
+++ b/crates/kx-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kx-worker"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/crates/kx-workflow/Cargo.toml
+++ b/crates/kx-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "kx-workflow"
-version      = "0.1.0"
+version      = "0.1.1"
 edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }


### PR DESCRIPTION
The clean-install verification campaign's patch release. Bumps workspace + all 42 crates + root [workspace.dependencies] + both bindings 0.1.0→0.1.1 (so `kx --version` reports `kx 0.1.1`), regenerates Cargo.lock, adds CHANGELOG [0.1.1].

Carries the two campaign fixes already on main:
- **F9** — Morphic capture instance-stamping (OSS #172).
- **F13** — SDK react invoke(wait) settles via ListReactTurns (OSS #173).

Manifests + lock + CHANGELOG only — no runtime-logic change ⇒ canonical digest `7d22d4bd…` invariant, frozen trio untouched. `kx --version` → `kx 0.1.1` (version_banner test green). After merge: tag v0.1.1 → release.yml builds the 3 FFI-free binaries + checksums.