### PR TITLE
feat(ui,sdk,cli): W1 UI redesign core — light orange theme, login-gate shell, ⌘K palette, Blueprint display rename

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -157,11 +157,24 @@ The inbound execution path: bind a **published recipe** by handle (e.g.
 committed terminal Mote — exactly-once, no new write path. The runtime as a
 callable function. `kx-invoke`.
 
+### Blueprint / plan / recipe (terminology)
+Three words, three meanings — fixed so they never collide:
+**Blueprint** is the *user-facing* name for a reusable, shareable workflow
+template (what you pick, fill in, and run from the console/SDKs/CLI).
+**plan** is the *agentic topology step* — the planner/shaper's committed
+`TopologyDecision` in the live plan/re-plan loop (never a template).
+**recipe** is the *frozen wire-legacy* term for a Blueprint: `recipe_fingerprint`,
+`ListRecipes`/`GetRecipeForm`, and `kx/recipes/*` handles are durable,
+identity-load-bearing wire data and are **never renamed** (old clients +
+persisted runs keep working). Display layers say "Blueprint"; the wire says
+`recipe`; SDKs export additive `Blueprint*` aliases over the same types.
+
 ### Recipe / WorkflowDef
-A reusable, parameterized **workflow** that compiles to a Mote DAG. Authored as a
-`WorkflowDef` (steps + typed edges + free params), bound to args, then compiled.
-The shipped library (`map_reduce`, `fan_out_gather`, `retry_until_critic`,
-`react_tool_loop`, `image_batch_describe_reduce`) is composed from pure builders.
+A reusable, parameterized **workflow** that compiles to a Mote DAG (displayed as
+a **Blueprint**; `recipe` on the frozen wire). Authored as a `WorkflowDef`
+(steps + typed edges + free params), bound to args, then compiled. The shipped
+library (`map_reduce`, `fan_out_gather`, `retry_until_critic`, `react_tool_loop`,
+`image_batch_describe_reduce`) is composed from pure builders.
 `kx-workflow/src/recipes.rs`.
 
 ### Prompt template

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ kx run    --journal /tmp/kx.db --content /tmp/kx-content      # → 7d22d4bd… 
 - [Install & quick start](#install--quick-start) — prove exactly-once in 60 seconds
 - [Getting started](#getting-started) — run the runtime as a server, like a function
 - [Commands](#commands) — the full `kx` reference
-- [Recipes](#recipes) — reusable agentic workflows
+- [Blueprints](#blueprints) — reusable agentic workflows
 - [Local LLM inference](#local-llm-inference) — bring your own GGUF model
 - [How it works](#how-it-works) — the architecture in one read
 - [Extending](#extending) — bring your own journal, store, broker, backend
@@ -80,7 +80,7 @@ kortecx has a **two-tier** setup. Most of the runtime needs only Rust.
 
 | Tier | You get | You need |
 |---|---|---|
-| **Tier 0 — the runtime** *(required)* | `kx run` / `replay` / `serve`, the durability demo, recipes, the full CLI & gateway | **Rust 1.94.0+** only — **no C++ toolchain**. The `kx` binary is FFI-free. |
+| **Tier 0 — the runtime** *(required)* | `kx run` / `replay` / `serve`, the durability demo, blueprints, the full CLI & gateway | **Rust 1.94.0+** only — **no C++ toolchain**. The `kx` binary is FFI-free. |
 | **Tier 1 — local LLM inference** *(optional)* | real on-device model inference via llama.cpp | a **C++ toolchain** (CMake, clang/libclang, a C++ compiler) + the `llama.cpp` submodule + a **GGUF** model |
 
 [Rust](https://rustup.rs) honors the pinned toolchain in `rust-toolchain.toml`
@@ -147,7 +147,7 @@ In another terminal, **submit a run and wait for the committed result**:
 # A built-in pure demo run (the lowest-level entry point).
 kx submit --demo --wait
 
-# Invoke a PUBLISHED recipe by handle, bound to JSON args — run-to-result.
+# Invoke a PUBLISHED blueprint (wire-legacy: recipe) by handle, bound to JSON args — run-to-result.
 kx invoke kx/recipes/echo --args '{"topic":"durable agents"}' --wait
 
 # A multi-node DAG, model-free: root → 3 children → gather (5 Motes, all committed).
@@ -251,7 +251,7 @@ The `kx` CLI is one binary. `run`/`replay`/`digest` drive the engine locally;
 | `kx replay` | Recover an existing journal and finish the run | `--journal` `--content` · `--audit-log` · `--json` |
 | `kx digest` | Print the projection digest of a journal | `--journal` `--content` · `--json` |
 | `kx serve` | Host the embedded single-system gateway | `--journal` `--content` · `--listen` *(default `127.0.0.1:50151`)* · `--ws-listen` *(default `:50152`)* · `--dev-allow-local` · `--auth-token <t>=<party>` · `--auth-token-file` · `--tls-cert <path> --tls-key <path>` *(in-binary TLS)* · `--max-lease N` · `--catalog-dir` |
-| `kx invoke <handle>` | Bind a published recipe to JSON args and run it | `--args <json>` / `--args-file` · `--wait` · `--timeout-secs N` · `--out <file>` |
+| `kx invoke <handle>` | Bind a published blueprint to JSON args and run it | `--args <json>` / `--args-file` · `--wait` · `--timeout-secs N` · `--out <file>` |
 | `kx submit --demo` | Submit a built-in pure demo run | `--wait` · `--timeout-secs N` · `--out` |
 | `kx projection` | Render a run as a DAG of Mote states | `--instance <id>` · `--at-seq N` |
 | `kx content` | Fetch a committed result by ref (binary-safe) | `--ref <r>` · `--instance <id>` · `--out <file>` |
@@ -266,13 +266,14 @@ Client verbs share `--endpoint <url>` *(default `http://127.0.0.1:50151`)*,
 run is still in progress and resumable) · `1` everything else (RPC, IO, a failed
 Mote). `kx --help` and `kx help <command>` print usage.
 
-## Recipes
+## Blueprints
 
-A **recipe** is a reusable, parameterized workflow that compiles to a Mote DAG.
+A **Blueprint** (wire-legacy: *recipe* — the `kx/recipes/*` handles and RPC names
+never rename) is a reusable, parameterized workflow that compiles to a Mote DAG.
 Five are shipped (all deterministic, statically shaped), composable from pure
 building blocks plus a fail-closed prompt-template engine:
 
-| Recipe | Shape |
+| Blueprint | Shape |
 |---|---|
 | `map_reduce` | N mappers → one pure reduce |
 | `fan_out_gather` | N parallel non-deterministic workers → one pure gather |
@@ -323,7 +324,7 @@ to GPU`).
 ### Live model dispatch in `kx serve` (AL1, opt-in)
 
 By default `kx serve` runs the durable spine + the deterministic/sandboxed demo
-recipes (and is **FFI-free**). Built with the inference feature, the embedded worker
+blueprints (and is **FFI-free**). Built with the inference feature, the embedded worker
 can run **real model Motes**:
 
 ```bash
@@ -333,7 +334,7 @@ cargo build -p kx-cli --features inference   # a `kx` that links the llama.cpp b
 KX_SERVE_MODEL_GGUF="$(pwd)/target/models/qwen3-0.6b-q4_k_m.gguf" \
   kx serve --dev-allow-local --journal /tmp/kx.db --content /tmp/kx-content
 
-# in another shell — the model recipe runs greedy inference and commits the completion:
+# in another shell — the model blueprint runs greedy inference and commits the completion:
 kx invoke kx/recipes/chat --args '{"prompt":"What is the capital of France?"}' --wait --json
 ```
 
@@ -386,8 +387,8 @@ stack on top:
   `kx-executor` (lifecycle + commit protocols + recovery), `kx-inference`,
   `kx-critic`, `kx-runtime` (the single-node engine + `run`/`replay`/`digest`).
 - **Reach (v0.1.0):** `kx-gateway`/`kx-gateway-core` (the gRPC server),
-  `kx-cli` (the `kx` binary), `kx-invoke` (recipe → guaranteed run),
-  `kx-workflow` (recipes + prompt templating), `kx-catalog` (sharable signatures),
+  `kx-cli` (the `kx` binary), `kx-invoke` (blueprint → guaranteed run),
+  `kx-workflow` (the blueprint library + prompt templating), `kx-catalog` (sharable signatures),
   `kx-fleet` (teams), `kx-audit` (off-path audit trail).
 - **Distributed (optional):** `kx-coordinator` (sole journal writer) +
   `kx-worker` + `kx-proto` — same guarantees, wiring on the same seams, not a rewrite.
@@ -447,7 +448,7 @@ Interfaces will change before 1.0 — **pin a commit** if you build on it now.
 
 **Early development, built in the open.** Today (v0.1.0): a durable single-system
 runtime with exactly-once world effects and crash recovery, a gateway server, the
-unified `kx` CLI, a recipe library + prompt templating, an audit trail, a live
+unified `kx` CLI, a blueprint library + prompt templating, an audit trail, a live
 event stream, TypeScript & Python client SDKs over gRPC, and a React + Vite **web
 console** that renders the live execution DAG (gRPC-web). Next: event timeline /
 time-travel + multi-modal artifact review in the console, audio multi-modal

--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -34,7 +34,14 @@ from .errors import (
 )
 from .grants import AssetGrants, GrantView
 from .react import ReactTurn, ReactTurnPage
-from .recipes import RecipeForm, RecipeFormField, recipe_param_type_name
+from .recipes import (
+    BlueprintForm,
+    BlueprintFormField,
+    RecipeForm,
+    RecipeFormField,
+    blueprint_param_type_name,
+    recipe_param_type_name,
+)
 from .replan import ReplanRound, ReplanRoundPage
 from .run import AsyncRun, Result, Run
 from .runs import RunPage, RunSummary
@@ -73,6 +80,10 @@ __all__ = [
     "RecipeForm",
     "RecipeFormField",
     "recipe_param_type_name",
+    # Blueprint = the display name for the frozen `recipe` wire (D136; aliases)
+    "BlueprintForm",
+    "BlueprintFormField",
+    "blueprint_param_type_name",
     "TeamSummary",
     "TeamMember",
     "TeamMembers",

--- a/bindings/python/src/kortecx/recipes.py
+++ b/bindings/python/src/kortecx/recipes.py
@@ -62,3 +62,12 @@ class RecipeForm:
             handle=r.handle,
             fields=[RecipeFormField.from_proto(f) for f in r.fields],
         )
+
+
+# Display-layer aliases (D136): the user-facing name is **Blueprint** — a
+# reusable, shareable workflow template. The WIRE stays the frozen `recipe`
+# vocabulary (``ListRecipes``/``GetRecipeForm``, ``kx/recipes/*`` handles), so
+# these are pure additive aliases; nothing is renamed or deprecated.
+BlueprintForm = RecipeForm
+BlueprintFormField = RecipeFormField
+blueprint_param_type_name = recipe_param_type_name

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -53,6 +53,9 @@ export type { CaptureRecordPage } from "./capture.js";
 
 export { RecipeForm, RecipeFormField, recipeParamTypeName } from "./recipes.js";
 export type { RecipeParamTypeName } from "./recipes.js";
+// Blueprint = the display name for the frozen `recipe` wire (D136; additive aliases).
+export { BlueprintForm, BlueprintFormField, blueprintParamTypeName } from "./recipes.js";
+export type { BlueprintParamTypeName } from "./recipes.js";
 
 export { TeamSummary, TeamMember, TeamMembers, WarrantView, teamsFromProto } from "./teams.js";
 export { GrantView, AssetGrants } from "./grants.js";

--- a/bindings/typescript/src/recipes.ts
+++ b/bindings/typescript/src/recipes.ts
@@ -73,3 +73,22 @@ export class RecipeForm {
     );
   }
 }
+
+/*
+ * Display-layer aliases (D136): the user-facing name is **Blueprint** — a
+ * reusable, shareable workflow template. The WIRE stays the frozen `recipe`
+ * vocabulary (`ListRecipes`/`GetRecipeForm`, `kx/recipes/*` handles), so these
+ * are pure additive aliases; nothing is renamed or deprecated.
+ */
+
+/** Display alias for {@link RecipeForm} (wire: recipe). */
+export const BlueprintForm = RecipeForm;
+export type BlueprintForm = RecipeForm;
+
+/** Display alias for {@link RecipeFormField} (wire: recipe). */
+export const BlueprintFormField = RecipeFormField;
+export type BlueprintFormField = RecipeFormField;
+
+/** Display alias for {@link recipeParamTypeName} (wire: recipe). */
+export const blueprintParamTypeName = recipeParamTypeName;
+export type BlueprintParamTypeName = RecipeParamTypeName;

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -58,7 +58,7 @@ pub enum Cli {
     },
     /// Forward to the gateway server: the `serve` args (verb stripped).
     Serve(Vec<String>),
-    /// `invoke` a published recipe by handle.
+    /// `invoke` a published blueprint by handle (wire-legacy: recipe).
     Invoke(verbs::invoke::InvokeArgs),
     /// `submit` a built-in demo run.
     Submit(verbs::submit::SubmitArgs),
@@ -276,7 +276,7 @@ kx serve --journal <path> --content <dir> [--listen <addr:port>] [--ws-listen <a
             .into(),
         "invoke" => "\
 kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--timeout-secs N] [--out <file>] [client flags]
-  Bind a PUBLISHED recipe by handle (e.g. kx/recipes/echo) to JSON args and run it.
+  Bind a PUBLISHED blueprint (wire-legacy: recipe) by handle (e.g. kx/recipes/echo) to JSON args and run it.
   With --wait, poll to completion and print the committed result (run the runtime like
   a function). Without --wait, print the async handle (instance_id/terminal_mote_id)."
             .into(),

--- a/crates/kx-cli/src/verbs/invoke.rs
+++ b/crates/kx-cli/src/verbs/invoke.rs
@@ -1,6 +1,7 @@
-//! `kx invoke <handle> --args <json> [--wait] ...` — bind a PUBLISHED recipe by
-//! handle to JSON args and run it. The CLI sends only `handle` + raw args bytes;
-//! the server does resolve → validate → bind → intersect → submit (fail-closed).
+//! `kx invoke <handle> --args <json> [--wait] ...` — bind a PUBLISHED blueprint
+//! (wire-legacy: recipe) by handle to JSON args and run it. The CLI sends only
+//! `handle` + raw args bytes; the server does resolve → validate → bind →
+//! intersect → submit (fail-closed).
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -17,7 +18,7 @@ const DEFAULT_TIMEOUT_SECS: u64 = 120;
 /// Parsed `invoke` arguments.
 #[derive(Debug)]
 pub struct InvokeArgs {
-    /// The recipe handle (`namespace/collection/name`).
+    /// The blueprint handle (`namespace/collection/name`; wire-legacy: recipe).
     pub handle: String,
     /// Opaque JSON args bytes (validated server-side; sanity-checked client-side).
     pub args_json: Vec<u8>,
@@ -77,7 +78,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<InvokeArgs, CliEr
     }
 
     let handle = handle.ok_or_else(|| {
-        CliError::Usage("invoke requires a recipe handle (e.g. kx/recipes/echo)".into())
+        CliError::Usage("invoke requires a blueprint handle (e.g. kx/recipes/echo)".into())
     })?;
     let args_json = args_json.ok_or_else(|| {
         CliError::Usage("invoke requires --args <json> (or --args-file <path>)".into())

--- a/ui/README.md
+++ b/ui/README.md
@@ -5,7 +5,7 @@ contract, talking **gRPC-web** to a running `kx serve` via the existing
 [`@kortecx/sdk`](../bindings/typescript) browser client. No server tier: the
 journal is the source of truth and the client is stateless (D119).
 
-Connect to a gateway, submit a recipe, and **watch its Motes execute** — as a live
+Connect to a gateway, run a blueprint, and **watch its Motes execute** — as a live
 **XYFlow (reactflow) DAG** (nodes = Motes colored by state/`nd_class`, edges =
 `parents[]`) or a status table, both polled live from `GetProjection`. This is the
 T3.3 milestone on the OSS UI critical path (the live-DAG viewer over the T3.2 shell).
@@ -15,7 +15,7 @@ T3.3 milestone on the OSS UI critical path (the live-DAG viewer over the T3.2 sh
 - **Routing/state:** TanStack Router (typed routes + search params) + TanStack
   Query (server-state, polling, caching, retry).
 - **Live updates:** poll `GetProjection` over gRPC-web on an interval (TanStack
-  Query `refetchInterval`). Polling stops authoritatively when the recipe's
+  Query `refetchInterval`). Polling stops authoritatively when the blueprint's
   **terminal (sink) Mote** commits — its id is threaded from the `Invoke` response
   through the route (`?terminal=…`) — so a multi-node run keeps updating while its
   Mote set is still growing (a naïve "all visible Motes terminal" check stops too
@@ -70,7 +70,7 @@ npm run dev            # Vite dev server on http://localhost:5173
 ```
 
 **3. In the browser** open <http://localhost:5173>, connect to
-`http://127.0.0.1:50151`, then run a recipe and watch the DAG execute:
+`http://127.0.0.1:50151`, then run a blueprint and watch the DAG execute:
 
 - **`kx/recipes/echo`** (pre-filled, args `{"topic":"hello"}`) — a single COMMITTED node.
 - **`kx/recipes/fanout-demo`** (args `{}`) — a **5-node** fan-out → gather DAG

--- a/ui/e2e/connect-submit-poll.spec.ts
+++ b/ui/e2e/connect-submit-poll.spec.ts
@@ -22,8 +22,8 @@ test("connect → submit echo → watch a Mote reach COMMITTED (real gRPC-web + 
   await expect(endpoint).toHaveValue(gw.endpoint);
   await page.getByRole("button", { name: /^connect$/i }).click();
 
-  // Lands on the Activity dashboard; go to Recipes and run echo via its generated form.
-  await expect(page.getByTestId("activity-panel")).toBeVisible({ timeout: 30_000 });
+  // Lands on Chat (the connected default); go to Blueprints and run echo via its form.
+  await expect(page.getByTestId("chat-panel")).toBeVisible({ timeout: 30_000 });
   await runRecipe(page, { fields: { topic: "incidents" } });
 
   // Run-detail defaults to the live DAG: a Mote node appears and flips to COMMITTED

--- a/ui/e2e/fixtures/connect.ts
+++ b/ui/e2e/fixtures/connect.ts
@@ -3,7 +3,8 @@ import type { Gateway } from "./serve";
 
 /**
  * Drive the connect screen to a connected console. Optionally set the advanced WS
- * endpoint (for the Activity live tail). Resolves once the Activity dashboard shows.
+ * endpoint (for the Activity live tail). Resolves once the Chat default shows
+ * (chat is the connected landing — D137).
  */
 export async function connectConsole(
   page: Page,
@@ -17,14 +18,14 @@ export async function connectConsole(
     await page.getByLabel(/ws bridge endpoint/i).fill(opts.wsEndpoint);
   }
   await page.getByRole("button", { name: /^connect$/i }).click();
-  await expect(page.getByTestId("activity-panel")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("chat-panel")).toBeVisible({ timeout: 30_000 });
 }
 
 /**
- * Submit a recipe via the UI-2 recipe catalog: navigate to Recipes, select the
- * handle, fill any free-param fields, and click "Run recipe". Controlled inputs
+ * Submit a blueprint via the UI-2 catalog: navigate to Blueprints, select the
+ * handle, fill any free-param fields, and click "Run blueprint". Controlled inputs
  * are filled with click + pressSequentially (a bulk fill() can leave React state
- * stale — the recorded e2e gotcha). Defaults to the echo recipe with a topic.
+ * stale — the recorded e2e gotcha). Defaults to the echo blueprint with a topic.
  */
 export async function runRecipe(
   page: Page,
@@ -35,9 +36,9 @@ export async function runRecipe(
   await page.getByTestId("nav-recipes").click();
   await expect(page.getByTestId("recipe-catalog")).toBeVisible({ timeout: 30_000 });
   await page.getByTestId(`recipe-pick-${handle}`).click();
-  // Wait for the form to reflect the SELECTED recipe before interacting — switching
-  // handles re-fetches GetRecipeForm, and clicking too early would submit the old
-  // recipe's (still-visible) form.
+  // Wait for the form to reflect the SELECTED blueprint before interacting —
+  // switching handles re-fetches GetRecipeForm, and clicking too early would
+  // submit the old blueprint's (still-visible) form.
   await expect(page.locator(`[data-testid="recipe-form"][data-recipe="${handle}"]`)).toBeVisible({
     timeout: 30_000,
   });
@@ -46,5 +47,5 @@ export async function runRecipe(
     await input.click();
     await input.pressSequentially(value);
   }
-  await page.getByRole("button", { name: /run recipe/i }).click();
+  await page.getByRole("button", { name: /run blueprint/i }).click();
 }

--- a/ui/e2e/recipes-form.spec.ts
+++ b/ui/e2e/recipes-form.spec.ts
@@ -9,7 +9,7 @@ test.afterEach(() => {
   gw = undefined;
 });
 
-test("recipe catalog: pick echo, fill its generated form, run → COMMITTED", async ({ page }) => {
+test("blueprint catalog: pick echo, fill its generated form, run → COMMITTED", async ({ page }) => {
   gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
   await connectConsole(page, gw);
 
@@ -23,7 +23,7 @@ test("recipe catalog: pick echo, fill its generated form, run → COMMITTED", as
   const topic = page.getByTestId("field-topic");
   await topic.click();
   await topic.pressSequentially("incident review");
-  await page.getByRole("button", { name: /run recipe/i }).click();
+  await page.getByRole("button", { name: /run blueprint/i }).click();
 
   // Routes to the live run-detail DAG; the run commits over the real gRPC-web path.
   await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
@@ -32,7 +32,7 @@ test("recipe catalog: pick echo, fill its generated form, run → COMMITTED", as
   );
 });
 
-test("recipe form validation: a required field blocks submit until filled", async ({ page }) => {
+test("blueprint form validation: a required field blocks submit until filled", async ({ page }) => {
   gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
   await connectConsole(page, gw);
 
@@ -42,7 +42,7 @@ test("recipe form validation: a required field blocks submit until filled", asyn
   await expect(page.getByTestId("field-topic")).toBeVisible();
 
   // Submit with the required `topic` blank → an inline validation error, no run.
-  await page.getByRole("button", { name: /run recipe/i }).click();
+  await page.getByRole("button", { name: /run blueprint/i }).click();
   await expect(page.getByRole("alert")).toContainText(/required/i);
   await expect(page.getByTestId("mote-dag")).toHaveCount(0);
 
@@ -50,6 +50,6 @@ test("recipe form validation: a required field blocks submit until filled", asyn
   const topic = page.getByTestId("field-topic");
   await topic.click();
   await topic.pressSequentially("ok now");
-  await page.getByRole("button", { name: /run recipe/i }).click();
+  await page.getByRole("button", { name: /run blueprint/i }).click();
   await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
 });

--- a/ui/e2e/shell-nav.spec.ts
+++ b/ui/e2e/shell-nav.spec.ts
@@ -24,6 +24,7 @@ test("the app shell navigates to every section (brand + favicon present)", async
     ["nav-artifacts", "artifacts-section"],
     ["nav-datasets", "datasets-section"],
     ["nav-systems", "systems-section"],
+    ["nav-settings", "settings-section"],
     ["nav-activity", "activity-panel"],
   ];
   for (const [nav, panel] of sections) {

--- a/ui/e2e/sidebar-collapse.spec.ts
+++ b/ui/e2e/sidebar-collapse.spec.ts
@@ -19,13 +19,17 @@ test("the sidebar collapses to an icon rail and the choice persists across reloa
   // Assert on a nav item's text (avoids colliding with the page's <h1> headings).
   const item = page.getByTestId("nav-recipes");
   await expect(sidebar).toHaveAttribute("data-collapsed", "false");
-  await expect(item).toContainText("Recipes");
+  await expect(item).toContainText("Blueprints");
 
   await page.getByTestId("sidebar-toggle").click();
   await expect(sidebar).toHaveAttribute("data-collapsed", "true");
-  await expect(item).not.toContainText("Recipes"); // icon-only rail
+  await expect(item).not.toContainText("Blueprints"); // icon-only rail
 
-  // The shell renders even when disconnected, so the persisted collapse survives a reload.
+  // Connect is a login gate (D137): a reload drops the in-memory token, so the
+  // shell is GONE until we reconnect — and the persisted collapse then survives.
   await page.reload();
+  await expect(page.getByTestId("app-gate")).toBeVisible();
+  await expect(page.getByTestId("sidebar")).toHaveCount(0);
+  await connectConsole(page, gw);
   await expect(page.getByTestId("sidebar")).toHaveAttribute("data-collapsed", "true");
 });

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="dark light" />
+    <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>kortecx — runtime console</title>
   </head>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,11 +10,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.8",
+        "@fontsource/geist-mono": "5.2.8",
+        "@fontsource/geist-sans": "5.2.5",
         "@kortecx/sdk": "file:../bindings/typescript",
         "@tanstack/react-query": "^5.59.0",
         "@tanstack/react-router": "^1.58.0",
         "@xyflow/react": "^12.11.0",
         "framer-motion": "^11.5.0",
+        "lucide-react": "1.17.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -40,7 +43,7 @@
     },
     "../bindings/typescript": {
       "name": "@kortecx/sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
@@ -1101,6 +1104,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fontsource/geist-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-mono/-/geist-mono-5.2.8.tgz",
+      "integrity": "sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/geist-sans": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-sans/-/geist-sans-5.2.5.tgz",
+      "integrity": "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3317,6 +3338,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,11 +21,14 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.8",
+    "@fontsource/geist-mono": "5.2.8",
+    "@fontsource/geist-sans": "5.2.5",
     "@kortecx/sdk": "file:../bindings/typescript",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-router": "^1.58.0",
     "@xyflow/react": "^12.11.0",
     "framer-motion": "^11.5.0",
+    "lucide-react": "1.17.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/ui/src/app/motion.ts
+++ b/ui/src/app/motion.ts
@@ -19,3 +19,11 @@ export const statePulse = {
   animate: { scale: 1, opacity: 1 },
   transition: { duration: 0.25 } as Transition,
 };
+
+/** The ⌘K command palette entrance (subtle scale+fade; exits symmetrically). */
+export const paletteIn = {
+  initial: { opacity: 0, scale: 0.98, x: "-50%" },
+  animate: { opacity: 1, scale: 1, x: "-50%" },
+  exit: { opacity: 0, scale: 0.98, x: "-50%" },
+  transition: { duration: 0.12 } as Transition,
+};

--- a/ui/src/components/chat/ChatSettings.tsx
+++ b/ui/src/components/chat/ChatSettings.tsx
@@ -1,6 +1,6 @@
 import { ECHO_PRESET, type ChatSettings as Settings } from "../../lib/chat-settings";
 
-/** Chat settings: which recipe backs chat, its prompt param, + display toggles. */
+/** Chat settings: which blueprint backs chat, its prompt param, + display toggles. */
 export function ChatSettingsPanel({
   settings,
   onChange,
@@ -11,7 +11,7 @@ export function ChatSettingsPanel({
   return (
     <details className="chat-settings" data-testid="chat-settings">
       <summary>Settings</summary>
-      <label htmlFor="chat-handle">Recipe handle</label>
+      <label htmlFor="chat-handle">Blueprint handle</label>
       <input
         id="chat-handle"
         value={settings.handle}

--- a/ui/src/components/ds/Badge.tsx
+++ b/ui/src/components/ds/Badge.tsx
@@ -1,0 +1,35 @@
+export interface BadgeProps {
+  label: string;
+  /** Text/dot color (any CSS color; the pill background derives from it at ~9%). */
+  color?: string;
+  /** Show the leading status dot. */
+  dot?: boolean;
+  /** Pulse the dot (live/active states). */
+  pulse?: boolean;
+}
+
+/**
+ * The design-system status badge (reference `components/ui/Badge`): colored text
+ * on a same-hue tint, with an optional (pulsing) glow dot. Zero dependencies.
+ */
+export function Badge({
+  label,
+  color = "var(--primary-h)",
+  dot = false,
+  pulse = false,
+}: BadgeProps) {
+  return (
+    <span
+      className="ds-badge"
+      style={{ color, background: "color-mix(in srgb, currentColor 9%, transparent)" }}
+    >
+      {dot ? (
+        <span
+          className={pulse ? "ds-badge__dot ds-badge__dot--pulse" : "ds-badge__dot"}
+          aria-hidden="true"
+        />
+      ) : null}
+      {label}
+    </span>
+  );
+}

--- a/ui/src/components/ds/GlowCard.tsx
+++ b/ui/src/components/ds/GlowCard.tsx
@@ -1,0 +1,36 @@
+import { type HTMLMotionProps, motion } from "framer-motion";
+import type { CSSProperties } from "react";
+
+export interface GlowCardProps extends HTMLMotionProps<"div"> {
+  /** Border/glow accent on hover (any CSS color; defaults to the brand orange). */
+  glowColor?: string;
+  /** Disable the hover lift/glow for purely static cards. */
+  hover?: boolean;
+}
+
+/**
+ * The design-system card (reference `components/ui/GlowCard`): a white surface
+ * that lifts slightly and glows in the accent color on hover. Pure presentation —
+ * tokens drive every color, framer drives the micro-interaction.
+ */
+export function GlowCard({
+  glowColor = "var(--primary)",
+  hover = true,
+  className,
+  style,
+  children,
+  ...rest
+}: GlowCardProps) {
+  const classes = `glow-card${hover ? " glow-card--hover" : ""}${className ? ` ${className}` : ""}`;
+  const styles = { ...style, "--glow": glowColor } as CSSProperties;
+  return (
+    <motion.div
+      className={classes}
+      style={styles}
+      whileHover={hover ? { scale: 1.005, y: -1 } : undefined}
+      {...rest}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/ui/src/components/recipes/RecipeForm.tsx
+++ b/ui/src/components/recipes/RecipeForm.tsx
@@ -1,9 +1,9 @@
 /**
- * Render a recipe's free-param form (UI-2). Pure presentation over the
- * `lib/recipe-form` logic: each field is a typed input (text / number / checkbox /
- * enum select); on submit we validate + build the args object and hand it up. The
- * gateway re-validates server-side, so a stray value surfaces as an Invoke error,
- * not a silent bad run.
+ * Render a blueprint's free-param form (UI-2; `RecipeForm` on the frozen wire).
+ * Pure presentation over the `lib/recipe-form` logic: each field is a typed input
+ * (text / number / checkbox / enum select); on submit we validate + build the args
+ * object and hand it up. The gateway re-validates server-side, so a stray value
+ * surfaces as an Invoke error, not a silent bad run.
  */
 
 import type { RecipeForm as RecipeFormDef, RecipeFormField } from "@kortecx/sdk/web";
@@ -86,7 +86,7 @@ export function RecipeForm({
       onSubmit={submit}
     >
       {form.fields.length === 0 ? (
-        <p className="muted">This recipe takes no inputs — run it directly.</p>
+        <p className="muted">This blueprint takes no inputs — run it directly.</p>
       ) : (
         form.fields.map((field) => (
           <div className="form-field" key={field.name}>
@@ -109,7 +109,7 @@ export function RecipeForm({
         ))
       )}
       <button type="submit" disabled={pending}>
-        {pending ? "Submitting…" : "Run recipe"}
+        {pending ? "Submitting…" : "Run blueprint"}
       </button>
     </form>
   );

--- a/ui/src/components/sections/ArtifactsSection.tsx
+++ b/ui/src/components/sections/ArtifactsSection.tsx
@@ -44,7 +44,7 @@ function GalleryBrowser({ runId }: { runId?: string }) {
       {runs.length === 0 ? (
         <EmptyState
           title="No runs to browse"
-          detail="Submit a recipe from the Recipes section, then review its outputs here."
+          detail="Submit a blueprint from the Blueprints section, then review its outputs here."
         />
       ) : (
         <>

--- a/ui/src/components/sections/RecipesSection.tsx
+++ b/ui/src/components/sections/RecipesSection.tsx
@@ -12,11 +12,12 @@ const FALLBACK_HANDLE = "kx/recipes/echo";
 const FALLBACK_ARGS = '{\n  "topic": "hello"\n}';
 
 /**
- * The recipe catalog + submit. When the gateway wires the recipe catalog (UI-2),
- * we list the invocable handles and render each recipe's GENERATED free-param form
- * (`GetRecipeForm`). When it does not (an older gateway → UNIMPLEMENTED), we fall
- * back to the manual handle + JSON-args form. Either way, submitting records the
- * run in the session history and routes to the live run-detail DAG.
+ * The Blueprint catalog + submit (display name for the frozen `recipe` wire — the
+ * RPCs stay `ListRecipes`/`GetRecipeForm`, handles stay `kx/recipes/*`). When the
+ * gateway wires the catalog (UI-2), we list the invocable handles and render each
+ * blueprint's GENERATED free-param form. When it does not (an older gateway →
+ * UNIMPLEMENTED), we fall back to the manual handle + JSON-args form. Either way,
+ * submitting records the run in the session history and routes to the live DAG.
  */
 export function RecipesSection() {
   const navigate = useNavigate();
@@ -51,12 +52,12 @@ export function RecipesSection() {
 
   return (
     <section className="screen" data-testid="recipes-section">
-      <h1>Recipes</h1>
+      <h1>Blueprints</h1>
       <p className="muted">
-        Pick a recipe, fill its inputs, and run it — watch the run execute as a live DAG.
+        Pick a blueprint, fill its inputs, and run it — watch the run execute as a live DAG.
       </p>
 
-      {recipes.isLoading ? <EmptyState title="Loading recipes…" /> : null}
+      {recipes.isLoading ? <EmptyState title="Loading blueprints…" /> : null}
 
       {recipes.data ? (
         <RecipeCatalog handles={recipes.data} pending={invoke.isPending} onRun={start} />
@@ -71,7 +72,7 @@ export function RecipesSection() {
   );
 }
 
-/** The catalog-driven path: a recipe picker + the selected recipe's generated form. */
+/** The catalog-driven path: a blueprint picker + the selected blueprint's generated form. */
 function RecipeCatalog({
   handles,
   pending,
@@ -88,15 +89,15 @@ function RecipeCatalog({
   if (handles.length === 0) {
     return (
       <EmptyState
-        title="No recipes provisioned"
-        detail="This gateway exposes the recipe catalog but provisions no recipes."
+        title="No blueprints provisioned"
+        detail="This gateway exposes the blueprint catalog but provisions no blueprints."
       />
     );
   }
 
   return (
     <div data-testid="recipe-catalog">
-      <div className="recipe-picker" role="radiogroup" aria-label="Recipe">
+      <div className="recipe-picker" role="radiogroup" aria-label="Blueprint">
         {handles.map((h) => (
           <button
             key={h}
@@ -157,11 +158,11 @@ function ManualInvokeForm({
     <div data-testid="manual-invoke">
       {degraded ? (
         <p className="muted">
-          This gateway does not expose the recipe catalog — enter a handle + JSON args directly.
+          This gateway does not expose the blueprint catalog — enter a handle + JSON args directly.
         </p>
       ) : null}
       <form className="invoke-form" onSubmit={submit}>
-        <label htmlFor="handle">Recipe handle</label>
+        <label htmlFor="handle">Blueprint handle</label>
         <input
           id="handle"
           value={handle}

--- a/ui/src/components/sections/RunsSection.tsx
+++ b/ui/src/components/sections/RunsSection.tsx
@@ -48,7 +48,7 @@ export function RunsSection() {
         <input
           className="filter-input"
           data-testid="runs-filter"
-          placeholder="Filter by id or recipe…"
+          placeholder="Filter by id or blueprint…"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           spellCheck={false}
@@ -60,7 +60,7 @@ export function RunsSection() {
       {runs.length === 0 ? (
         <EmptyState
           title="No runs yet"
-          detail="Submit a recipe from the Recipes section to start one."
+          detail="Submit a blueprint from the Blueprints section to start one."
         />
       ) : shown.length === 0 ? (
         <EmptyState title="No matching runs" detail="Adjust the filter above." />

--- a/ui/src/components/sections/SettingsSection.tsx
+++ b/ui/src/components/sections/SettingsSection.tsx
@@ -1,0 +1,57 @@
+import { useConnection } from "../../kx/connection-context";
+import { Badge } from "../ds/Badge";
+import { GlowCard } from "../ds/GlowCard";
+
+/**
+ * Settings/Profile (W1 shell placeholder per the section taxonomy): the connection
+ * profile + console appearance facts. Read-only over existing client state — no new
+ * RPCs; preferences persist locally in this browser, never on the gateway.
+ */
+export function SettingsSection() {
+  const { status, endpoint, wsEndpoint } = useConnection();
+  const connected = status === "connected";
+  return (
+    <section className="screen" data-testid="settings-section">
+      <h1>Settings</h1>
+      <p className="muted">
+        Console preferences & the connection profile. Everything here lives in this browser —
+        nothing is stored on the gateway.
+      </p>
+      <div className="settings-grid">
+        <GlowCard>
+          <h2>Connection</h2>
+          <dl className="facts">
+            <dt>Status</dt>
+            <dd>
+              <Badge
+                label={status}
+                color={connected ? "var(--success)" : "var(--error)"}
+                dot
+                pulse={connected}
+              />
+            </dd>
+            <dt>Endpoint</dt>
+            <dd className="mono">{endpoint}</dd>
+            <dt>WS bridge</dt>
+            <dd className="mono">{wsEndpoint ?? "derived from the endpoint"}</dd>
+            <dt>Bearer token</dt>
+            <dd>kept in memory only — never persisted</dd>
+          </dl>
+        </GlowCard>
+        <GlowCard>
+          <h2>Appearance</h2>
+          <dl className="facts">
+            <dt>Theme</dt>
+            <dd>kortecx light (orange · black · white)</dd>
+            <dt>Type</dt>
+            <dd>Geist Sans · Geist Mono</dd>
+            <dt>Sidebar</dt>
+            <dd>collapse persists per browser (the sidebar hamburger)</dd>
+            <dt>Motion</dt>
+            <dd>honors your reduced-motion preference</dd>
+          </dl>
+        </GlowCard>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/shell/AppShell.tsx
+++ b/ui/src/components/shell/AppShell.tsx
@@ -1,7 +1,11 @@
 import { Outlet, useRouterState } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { pageFade } from "../../app/motion";
+import { useConnection } from "../../kx/connection-context";
+import { Brand } from "./Brand";
+import { CommandPalette } from "./CommandPalette";
+import { ConnectionStatus } from "./ConnectionStatus";
 import { Navbar } from "./Navbar";
 import { Sidebar } from "./Sidebar";
 
@@ -23,14 +27,36 @@ function persistCollapsed(collapsed: boolean): void {
   }
 }
 
+/** The animated route outlet (shared by the gate and the full shell). */
+function RouteOutlet() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={pageFade.initial}
+        animate={pageFade.animate}
+        exit={pageFade.exit}
+        transition={pageFade.transition}
+      >
+        <Outlet />
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
 /**
- * The application shell: a top navbar + a collapsible left sidebar + the animated
- * route outlet. The collapse state persists (localStorage). Route transitions keep
- * the established `pageFade` (honoring reduced-motion via the global MotionConfig).
+ * The application shell. Connect is a LOGIN GATE (D137): until the console is
+ * connected to a gateway there is no navbar/sidebar — just the centered route
+ * outlet (the connect screen, or a section's own ConnectGate for deep links).
+ * Once connected: top navbar + collapsible left sidebar (state persisted) +
+ * the ⌘K command palette + the animated outlet.
  */
 export function AppShell() {
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { status } = useConnection();
   const [collapsed, setCollapsed] = useState<boolean>(() => loadCollapsed());
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const connected = status === "connected";
 
   const toggle = useCallback(() => {
     setCollapsed((c) => {
@@ -40,26 +66,53 @@ export function AppShell() {
     });
   }, []);
 
+  const openPalette = useCallback(() => setPaletteOpen(true), []);
+  const closePalette = useCallback(() => setPaletteOpen(false), []);
+
+  // Global ⌘K / Ctrl+K — only meaningful once the nav exists (connected).
+  useEffect(() => {
+    if (!connected) {
+      return;
+    }
+    function onKeyDown(e: KeyboardEvent): void {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setPaletteOpen((open) => !open);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [connected]);
+
+  if (!connected) {
+    return (
+      <div className="gate" data-testid="app-gate">
+        <a href="#main" className="skip-link">
+          Skip to content
+        </a>
+        <header className="gate__head">
+          <Brand />
+          <div className="navbar__spacer" />
+          <ConnectionStatus />
+        </header>
+        <main className="gate__main" id="main">
+          <RouteOutlet />
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className={collapsed ? "shell shell--collapsed" : "shell"} data-testid="app-shell">
       <a href="#main" className="skip-link">
         Skip to content
       </a>
-      <Navbar onToggleSidebar={toggle} />
-      <Sidebar collapsed={collapsed} />
+      <Navbar onOpenPalette={openPalette} />
+      <Sidebar collapsed={collapsed} onToggle={toggle} />
       <main className="shell__main" id="main">
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={pathname}
-            initial={pageFade.initial}
-            animate={pageFade.animate}
-            exit={pageFade.exit}
-            transition={pageFade.transition}
-          >
-            <Outlet />
-          </motion.div>
-        </AnimatePresence>
+        <RouteOutlet />
       </main>
+      <CommandPalette open={paletteOpen} onClose={closePalette} />
     </div>
   );
 }

--- a/ui/src/components/shell/CommandPalette.tsx
+++ b/ui/src/components/shell/CommandPalette.tsx
@@ -1,0 +1,131 @@
+import { useNavigate } from "@tanstack/react-router";
+import { AnimatePresence, motion } from "framer-motion";
+import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { paletteIn } from "../../app/motion";
+import { Icon } from "./Icon";
+import { NAV_SECTIONS, type NavSection, SETTINGS_SECTION } from "./nav-model";
+
+const DESTINATIONS: readonly NavSection[] = [...NAV_SECTIONS, SETTINGS_SECTION];
+
+function matches(section: NavSection, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") {
+    return true;
+  }
+  return (
+    section.label.toLowerCase().includes(q) ||
+    section.hint.toLowerCase().includes(q) ||
+    section.id.includes(q)
+  );
+}
+
+/**
+ * The ⌘K command palette — jump to any console section. A custom modal (no cmdk
+ * dependency, mirroring the reference's hand-rolled dialog): substring filter,
+ * ↑/↓ + Enter keyboard navigation, Esc/backdrop to close. The global ⌘K listener
+ * lives in the AppShell (palette state is shell chrome).
+ */
+export function CommandPalette({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [cursor, setCursor] = useState(0);
+
+  const results = useMemo(() => DESTINATIONS.filter((s) => matches(s, query)), [query]);
+  const selected = results[Math.min(cursor, Math.max(results.length - 1, 0))];
+
+  // Reset the filter every time the palette opens (a fresh jump, not a session).
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setCursor(0);
+    }
+  }, [open]);
+
+  function go(section: NavSection): void {
+    onClose();
+    navigate({ to: section.path });
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setCursor((c) => Math.min(c + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setCursor((c) => Math.max(c - 1, 0));
+    } else if (e.key === "Enter" && selected) {
+      e.preventDefault();
+      go(selected);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {open ? (
+        <>
+          <motion.div
+            className="palette__backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.12 }}
+            onClick={onClose}
+            aria-hidden="true"
+          />
+          <motion.div
+            className="palette"
+            // biome-ignore lint/a11y/useSemanticElements: a native <dialog> can't ride AnimatePresence exit animations; dialog semantics are declared via role+aria-modal
+            role="dialog"
+            aria-modal="true"
+            aria-label="Command palette"
+            data-testid="command-palette"
+            initial={paletteIn.initial}
+            animate={paletteIn.animate}
+            exit={paletteIn.exit}
+            transition={paletteIn.transition}
+          >
+            <input
+              className="palette__input"
+              placeholder="Jump to a section…"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setCursor(0);
+              }}
+              onKeyDown={onKeyDown}
+              // biome-ignore lint/a11y/noAutofocus: a command palette focuses its input by design
+              autoFocus
+              spellCheck={false}
+              autoComplete="off"
+              aria-label="Search sections"
+            />
+            {results.length === 0 ? (
+              <p className="palette__empty">No matching section.</p>
+            ) : (
+              <nav className="palette__list" aria-label="Sections">
+                {results.map((section, i) => (
+                  <button
+                    type="button"
+                    key={section.id}
+                    className="palette__item"
+                    data-selected={section === selected}
+                    data-testid={`palette-item-${section.id}`}
+                    onClick={() => go(section)}
+                    onMouseEnter={() => setCursor(i)}
+                  >
+                    <Icon name={section.icon} size={16} />
+                    <span>{section.label}</span>
+                    <span className="palette__hint">{section.hint}</span>
+                  </button>
+                ))}
+              </nav>
+            )}
+          </motion.div>
+        </>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/ui/src/components/shell/Navbar.tsx
+++ b/ui/src/components/shell/Navbar.tsx
@@ -1,22 +1,18 @@
 import { Brand } from "./Brand";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { GlobalControls } from "./GlobalControls";
-import { Icon } from "./Icon";
+import { SearchTrigger } from "./SearchTrigger";
 
-/** The top bar: sidebar toggle · brand · global controls · connection status. */
-export function Navbar({ onToggleSidebar }: { onToggleSidebar: () => void }) {
+/**
+ * The top bar: brand · ⌘K search trigger · global controls · connection status.
+ * The sidebar hamburger lives in the Sidebar header (logo+hamburger, D137).
+ */
+export function Navbar({ onOpenPalette }: { onOpenPalette: () => void }) {
   return (
     <header className="navbar" data-testid="navbar">
-      <button
-        type="button"
-        className="iconbtn navbar__toggle"
-        onClick={onToggleSidebar}
-        aria-label="Toggle sidebar"
-        data-testid="sidebar-toggle"
-      >
-        <Icon name="menu" />
-      </button>
       <Brand />
+      <div className="navbar__spacer" />
+      <SearchTrigger onOpen={onOpenPalette} />
       <div className="navbar__spacer" />
       <GlobalControls />
       <ConnectionStatus />

--- a/ui/src/components/shell/SearchTrigger.tsx
+++ b/ui/src/components/shell/SearchTrigger.tsx
@@ -1,0 +1,18 @@
+import { Search } from "lucide-react";
+
+/** The TopNavbar ⌘K affordance — a pill button that opens the command palette. */
+export function SearchTrigger({ onOpen }: { onOpen: () => void }) {
+  return (
+    <button
+      type="button"
+      className="search-trigger"
+      onClick={onOpen}
+      aria-label="Open command palette"
+      data-testid="palette-trigger"
+    >
+      <Search size={15} aria-hidden="true" />
+      <span className="search-trigger__label">Search…</span>
+      <kbd>⌘K</kbd>
+    </button>
+  );
+}

--- a/ui/src/components/shell/Sidebar.tsx
+++ b/ui/src/components/shell/Sidebar.tsx
@@ -1,8 +1,13 @@
+import { Icon } from "./Icon";
 import { NavItem } from "./NavItem";
-import { NAV_SECTIONS } from "./nav-model";
+import { NAV_SECTIONS, SETTINGS_SECTION } from "./nav-model";
 
-/** The persistent section navigation (collapsible to an icon rail). */
-export function Sidebar({ collapsed }: { collapsed: boolean }) {
+/**
+ * The persistent section navigation. Header = logo + hamburger (collapse →
+ * logo-only rail); Settings is pinned bottom-left (D137); the seven sections
+ * scroll in between.
+ */
+export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
   return (
     <nav
       className={collapsed ? "sidebar sidebar--collapsed" : "sidebar"}
@@ -10,9 +15,27 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
       data-testid="sidebar"
       data-collapsed={collapsed}
     >
+      <div className="sidebar__head">
+        <span className="sidebar__logo">
+          <img src="/kortecx-icon.png" alt="" width={24} height={24} />
+          {collapsed ? null : <span className="sidebar__logoword">kortecx</span>}
+        </span>
+        <button
+          type="button"
+          className="iconbtn"
+          onClick={onToggle}
+          aria-label="Toggle sidebar"
+          data-testid="sidebar-toggle"
+        >
+          <Icon name="menu" />
+        </button>
+      </div>
       {NAV_SECTIONS.map((section) => (
         <NavItem key={section.id} section={section} collapsed={collapsed} />
       ))}
+      <div className="sidebar__settings">
+        <NavItem section={SETTINGS_SECTION} collapsed={collapsed} />
+      </div>
     </nav>
   );
 }

--- a/ui/src/components/shell/nav-model.ts
+++ b/ui/src/components/shell/nav-model.ts
@@ -14,7 +14,8 @@ export type IconName =
   | "recipes"
   | "artifacts"
   | "datasets"
-  | "systems";
+  | "systems"
+  | "settings";
 
 /**
  * The section route paths. This is a subset of the routes registered in
@@ -28,7 +29,8 @@ export type RoutePath =
   | "/recipes"
   | "/artifacts"
   | "/datasets"
-  | "/systems";
+  | "/systems"
+  | "/settings";
 
 export interface NavSection {
   /** Stable id (test/telemetry handle). */
@@ -59,11 +61,13 @@ export const NAV_SECTIONS: readonly NavSection[] = [
   { id: "chat", label: "Chat", path: "/chat", icon: "chat", hint: "Agentic chat over the runtime" },
   { id: "runs", label: "Runs", path: "/runs", icon: "runs", hint: "Run history (this session)" },
   {
+    // Display says "Blueprints" (D136); the id/path/icon stay on the frozen
+    // `recipes` wire-legacy handle (route, test-ids, RPC names never rename).
     id: "recipes",
-    label: "Recipes",
+    label: "Blueprints",
     path: "/recipes",
     icon: "recipes",
-    hint: "Catalog & submit a recipe",
+    hint: "Catalog & run a blueprint",
   },
   {
     id: "artifacts",
@@ -87,3 +91,16 @@ export const NAV_SECTIONS: readonly NavSection[] = [
     hint: "Gateway, health & teams",
   },
 ] as const;
+
+/**
+ * Settings is pinned shell chrome (bottom-left of the sidebar), NOT a scroll
+ * section — so it lives outside {@link NAV_SECTIONS} (whose seven ids are pinned
+ * by the nav-model unit test and iterated by the shell e2e).
+ */
+export const SETTINGS_SECTION: NavSection = {
+  id: "settings",
+  label: "Settings",
+  path: "/settings",
+  icon: "settings",
+  hint: "Profile & console preferences",
+} as const;

--- a/ui/src/components/systems/GrantInspector.tsx
+++ b/ui/src/components/systems/GrantInspector.tsx
@@ -43,7 +43,7 @@ export function GrantInspector({
       {catalogNotWired ? (
         <EmptyState
           title="Sharing not available here"
-          detail="This gateway does not expose the recipe catalog, so there are no assets to inspect."
+          detail="This gateway does not expose the blueprint catalog, so there are no assets to inspect."
         />
       ) : null}
 

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,6 +3,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AppProviders } from "./app/providers";
 import { router } from "./router/router";
+// Geist (self-hosted woff2 via @fontsource — no runtime CDN; weights the UI uses).
+import "@fontsource/geist-sans/400.css";
+import "@fontsource/geist-sans/500.css";
+import "@fontsource/geist-sans/600.css";
+import "@fontsource/geist-sans/700.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/500.css";
 import "@xyflow/react/dist/style.css";
 import "./styles/app.css";
 

--- a/ui/src/router/router.tsx
+++ b/ui/src/router/router.tsx
@@ -9,6 +9,7 @@ import { indexRoute } from "./routes/index";
 import { recipesRoute } from "./routes/recipes";
 import { runDetailRoute } from "./routes/run-detail";
 import { runsRoute } from "./routes/runs";
+import { settingsRoute } from "./routes/settings";
 import { systemsRoute } from "./routes/systems";
 
 const routeTree = rootRoute.addChildren([
@@ -22,6 +23,7 @@ const routeTree = rootRoute.addChildren([
   artifactsRoute,
   datasetsRoute,
   systemsRoute,
+  settingsRoute,
 ]);
 
 export const router = createRouter({

--- a/ui/src/router/routes/connect.tsx
+++ b/ui/src/router/routes/connect.tsx
@@ -23,7 +23,7 @@ function ConnectScreen() {
         onConnect={async (ep, token, ws) => {
           const ok = await connect(ep, token, ws);
           if (ok) {
-            navigate({ to: "/activity" });
+            navigate({ to: "/chat" });
           }
         }}
       />

--- a/ui/src/router/routes/index.tsx
+++ b/ui/src/router/routes/index.tsx
@@ -4,7 +4,8 @@ import { rootRoute } from "./__root";
 
 function IndexRedirect() {
   const { status } = useConnection();
-  return <Navigate to={status === "connected" ? "/activity" : "/connect"} />;
+  // Chat is the connected default (D137); disconnected lands on the login gate.
+  return <Navigate to={status === "connected" ? "/chat" : "/connect"} />;
 }
 
 export const indexRoute = createRoute({

--- a/ui/src/router/routes/settings.tsx
+++ b/ui/src/router/routes/settings.tsx
@@ -5,24 +5,26 @@ import { EmptyState } from "../../components/EmptyState";
 import { useConnection } from "../../kx/connection-context";
 import { rootRoute } from "./__root";
 
-const RecipesSection = lazy(() =>
-  import("../../components/sections/RecipesSection").then((m) => ({ default: m.RecipesSection })),
+const SettingsSection = lazy(() =>
+  import("../../components/sections/SettingsSection").then((m) => ({
+    default: m.SettingsSection,
+  })),
 );
 
-function RecipesScreen() {
+function SettingsScreen() {
   const { status } = useConnection();
   if (status !== "connected") {
     return <ConnectGate />;
   }
   return (
-    <Suspense fallback={<EmptyState title="Loading blueprints…" />}>
-      <RecipesSection />
+    <Suspense fallback={<EmptyState title="Loading settings…" />}>
+      <SettingsSection />
     </Suspense>
   );
 }
 
-export const recipesRoute = createRoute({
+export const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/recipes",
-  component: RecipesScreen,
+  path: "/settings",
+  component: SettingsScreen,
 });

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -5,38 +5,85 @@
  */
 
 :root {
-  color-scheme: dark;
-  --bg: #0b0e14;
-  --bg-elev: #131722;
-  --bg-input: #0e121b;
-  --border: #232a39;
-  --fg: #d8dee9;
-  --fg-muted: #8a93a6;
-  --accent: #5aa9ff;
-  --accent-fg: #04101f;
+  color-scheme: light;
 
-  /* Mote state tones */
-  --t-pending: #5b6573;
-  --t-scheduled: #d8a23a;
-  --t-committed: #3fb950;
-  --t-failed: #f0506e;
-  --t-repudiated: #e8833a;
-  --t-inconsistent: #b15be8;
-  --t-unknown: #4a5160;
+  /* Kortecx orange (W1 light theme — D137). #F04500 is the brand accent for
+   * borders/focus/glows; TEXT-BEARING orange surfaces use --primary-h (#D83C00,
+   * white-on-it = 4.60:1, WCAG-AA) per the locked contrast decision. */
+  --primary: #f04500;
+  --primary-h: #d83c00;
+  --primary-dim: rgba(240, 69, 0, 0.08);
+
+  --bg: #f0f0f0;
+  --surface: #ffffff;
+  --surface-elev: #ebebeb;
+  --text-1: #0d0d0d;
+  --text-2: rgba(13, 13, 13, 0.68);
+  --text-3: rgba(13, 13, 13, 0.46);
+  --border: rgba(13, 13, 13, 0.12);
+  --border-md: rgba(13, 13, 13, 0.18);
+  --border-strong: rgba(13, 13, 13, 0.26);
+  --focus: #f04500;
+
+  /* semantic + accent palette (reference globals.css, AA on light surfaces) */
+  --success: #059669;
+  --warning: #d97706;
+  --error: #dc2626;
+  --info: #2563eb;
+  --teal: #0d9488;
+  --violet: #7c3aed;
+  --rose: #e11d48;
+  --indigo: #4f46e5;
+  --teal-dim: rgba(13, 148, 136, 0.08);
+  --violet-dim: rgba(124, 58, 237, 0.08);
+  --rose-dim: rgba(225, 29, 72, 0.08);
+  --indigo-dim: rgba(79, 70, 229, 0.08);
+
+  /* layout + shape */
+  --radius: 6px;
+  --radius-sm: 4px;
+  --radius-lg: 10px;
+  --sidebar-w: 200px;
+  --sidebar-w-collapsed: 48px;
+  --topbar-h: 48px;
+
+  /* fonts (Geist via @fontsource; graceful system fallback) */
+  --font-sans: "Geist Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  --mono: var(--font-mono);
+
+  /* legacy aliases — the pre-W1 token names ~120 rules still consume. Values map
+   * onto the light palette; remove in a later sweep, never re-point to dark. */
+  --bg-elev: var(--surface);
+  --bg-input: #ffffff;
+  --fg: var(--text-1);
+  --fg-muted: var(--text-2);
+  --accent: var(--primary-h);
+  --accent-fg: #ffffff;
+
+  /* Mote state tones (re-mapped for light surfaces: each ≥4.5:1 as text on white
+   * AND under white pill text — the dark-theme hexes fail on light) */
+  --t-pending: #475569;
+  --t-scheduled: #b45309;
+  --t-committed: #047857;
+  --t-failed: #dc2626;
+  --t-repudiated: #c2410c;
+  --t-inconsistent: #7c3aed;
+  --t-unknown: #4b5563;
 
   /* nd_class tones */
-  --t-pure: #4f9dde;
-  --t-read-only-nondet: #36b3a8;
-  --t-world-mutating: #e85b9e;
+  --t-pure: #2563eb;
+  --t-read-only-nondet: #0f766e;
+  --t-world-mutating: #be123c;
 
   /* notice tones */
-  --n-retry: #d8a23a;
-  --n-reauth: #5aa9ff;
-  --n-forbidden: #f0506e;
-  --n-bad-input: #e8833a;
-  --n-not-wired: #8a93a6;
-  --n-not-found: #8a93a6;
-  --n-generic: #f0506e;
+  --n-retry: #b45309;
+  --n-reauth: #2563eb;
+  --n-forbidden: #dc2626;
+  --n-bad-input: #c2410c;
+  --n-not-wired: #4b5563;
+  --n-not-found: #4b5563;
+  --n-generic: #dc2626;
 }
 
 * {
@@ -47,19 +94,36 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--fg);
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font-sans);
   font-size: 14px;
   line-height: 1.5;
 }
 
 .mono {
-  font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.85em;
 }
 
 code {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.85em;
+}
+
+/* 4px scrollbars with the brand-tint thumb (reference design language) */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(240, 69, 0, 0.18) transparent;
+}
+*::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+*::-webkit-scrollbar-thumb {
+  background: rgba(240, 69, 0, 0.12);
+  border-radius: 999px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: rgba(240, 69, 0, 0.22);
 }
 
 /* ---- layout / nav ---- */
@@ -162,20 +226,23 @@ textarea {
   font: inherit;
 }
 textarea {
-  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   resize: vertical;
 }
 button {
-  background: var(--accent);
+  /* primary action: white on the darkened-orange gradient (AA ≥4.5:1; the locked
+   * contrast decision — #F04500 stays on borders/focus/glows, never under text) */
+  background: linear-gradient(135deg, #d83c00 0%, #c03500 100%);
   color: var(--accent-fg);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 0.5rem 0.9rem;
   font: inherit;
   font-weight: 600;
   cursor: pointer;
   margin-top: 0.75rem;
   align-self: flex-start;
+  box-shadow: 0 1px 4px rgba(240, 69, 0, 0.25);
 }
 button:disabled {
   opacity: 0.55;
@@ -213,12 +280,12 @@ button:disabled {
   border-radius: 999px;
   font-size: 0.78rem;
   font-weight: 600;
-  color: #04101f;
+  /* white text on every state tone — the light-palette tones are AA under white */
+  color: #fff;
   background: var(--t-unknown);
 }
 .pill--pending {
   background: var(--t-pending);
-  color: #fff;
 }
 .pill--scheduled {
   background: var(--t-scheduled);
@@ -234,11 +301,9 @@ button:disabled {
 }
 .pill--inconsistent {
   background: var(--t-inconsistent);
-  color: #fff;
 }
 .pill--unknown {
   background: var(--t-unknown);
-  color: #fff;
 }
 
 .badge {
@@ -478,9 +543,9 @@ button:disabled {
 
 /* ---- a11y: visible keyboard focus + skip link ---- */
 :focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus);
   outline-offset: 2px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 .skip-link {
   position: absolute;
@@ -501,12 +566,35 @@ button:disabled {
 .shell {
   min-height: 100vh;
   display: grid;
-  grid-template-columns: var(--sidebar-w, 220px) 1fr;
+  grid-template-columns: var(--sidebar-w, 200px) 1fr;
   grid-template-rows: auto 1fr;
   grid-template-areas: "nav nav" "sidebar main";
 }
 .shell--collapsed {
-  --sidebar-w: 60px;
+  --sidebar-w: var(--sidebar-w-collapsed);
+}
+
+/* the pre-connect login gate: no nav/sidebar — a slim brand header + the
+ * centered connect screen (login-page chrome only) */
+.gate {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.gate__head {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.gate__main {
+  flex: 1;
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem 1.5rem;
 }
 
 /* ---- navbar ---- */
@@ -943,7 +1031,7 @@ select {
 /* ---- responsive: collapse to an icon rail under tablet width ---- */
 @media (max-width: 760px) {
   .shell {
-    grid-template-columns: 60px 1fr;
+    grid-template-columns: var(--sidebar-w-collapsed) 1fr;
   }
   .sidebar .navitem__label {
     display: none;
@@ -1117,9 +1205,9 @@ select {
 .dataset-ingest-form textarea {
   flex: 1;
   padding: 0.45rem 0.6rem;
-  border: 1px solid var(--border, #2a2a35);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--bg-elev, #16161d);
+  background: var(--bg-input);
   color: inherit;
   font: inherit;
 }
@@ -1141,15 +1229,15 @@ select {
   gap: 0.6rem;
   align-items: baseline;
   padding: 0.45rem 0.6rem;
-  border: 1px solid var(--border, #2a2a35);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--bg-elev, #16161d);
+  background: var(--bg-elev);
 }
 .dataset-hit__score {
   flex: 0 0 auto;
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-mono);
   font-size: 0.8rem;
-  color: var(--accent, #6ea8fe);
+  color: var(--accent);
   cursor: help;
 }
 .dataset-hit__text {
@@ -1160,4 +1248,243 @@ select {
   margin: 0.5rem 0 0;
   color: var(--fg-muted);
   font-size: 0.9rem;
+}
+
+/* ===========================================================================
+ * W1 UI redesign — sidebar header, pinned Settings, ⌘K palette, design system.
+ * Light orange/black/white language (D137); token-driven like everything above.
+ * =========================================================================== */
+
+/* ---- sidebar: logo+hamburger header (top) + pinned Settings (bottom) ---- */
+.sidebar__head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.25rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0.4rem;
+}
+.sidebar--collapsed .sidebar__head {
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.sidebar__logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--fg);
+  min-width: 0;
+  flex: 1;
+}
+.sidebar--collapsed .sidebar__logo {
+  flex: initial;
+}
+.sidebar__logo img {
+  display: block;
+  border-radius: var(--radius);
+}
+.sidebar__logoword {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sidebar__settings {
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  padding-top: 0.4rem;
+}
+
+/* ---- top navbar: ⌘K search trigger ---- */
+.search-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 320px;
+  max-width: 38vw;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.6rem;
+  margin: 0;
+  font-weight: 500;
+  box-shadow: none;
+  cursor: pointer;
+}
+.search-trigger:hover {
+  border-color: var(--border-md);
+  color: var(--fg);
+}
+.search-trigger__label {
+  flex: 1;
+  text-align: left;
+}
+.search-trigger kbd {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 0.3rem;
+  background: var(--surface);
+  color: var(--fg-muted);
+}
+
+/* ---- ⌘K command palette ---- */
+.palette__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(13, 13, 13, 0.32);
+  backdrop-filter: blur(2px);
+}
+.palette {
+  position: fixed;
+  top: 12%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  width: 620px;
+  max-width: calc(100vw - 2rem);
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--border-md);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+.palette__input {
+  border: none;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  padding: 0.75rem 0.9rem;
+  background: var(--surface);
+}
+.palette__input:focus-visible {
+  outline: none;
+}
+.palette__list {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0.4rem;
+  overflow-y: auto;
+}
+.palette__item {
+  /* a native button, restyled flat (the global gradient button rule is for
+   * primary actions, not menu rows) */
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  margin: 0;
+  padding: 0.5rem 0.6rem;
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: var(--radius);
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  color: var(--fg);
+}
+.palette__item[data-selected="true"] {
+  background: var(--primary-dim);
+  color: var(--primary-h);
+}
+.palette__hint {
+  margin-left: auto;
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
+.palette__empty {
+  padding: 1rem 0.9rem;
+  color: var(--fg-muted);
+}
+
+/* ---- settings ---- */
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+  max-width: 980px;
+}
+@media (min-width: 1100px) {
+  .settings-grid {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+.settings-grid h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+/* ---- design system: GlowCard + Badge ---- */
+.glow-card {
+  background: var(--surface);
+  border: 1px solid var(--border-md);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.glow-card--hover:hover {
+  border-color: var(--glow, var(--primary));
+  box-shadow: 0 4px 20px rgba(240, 69, 0, 0.08);
+}
+.ds-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.ds-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 4px currentColor;
+}
+.ds-badge__dot--pulse {
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+/* ---- shared keyframes (reference motion language) ---- */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+@keyframes shimmer {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: 200px 0;
+  }
 }

--- a/ui/test/component/RecipeForm.test.tsx
+++ b/ui/test/component/RecipeForm.test.tsx
@@ -14,7 +14,7 @@ describe("RecipeForm", () => {
 
     fireEvent.change(screen.getByTestId("field-topic"), { target: { value: "hello" } });
     fireEvent.change(screen.getByTestId("field-count"), { target: { value: "3" } });
-    fireEvent.click(screen.getByRole("button", { name: /run recipe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /run blueprint/i }));
 
     expect(onSubmit).toHaveBeenCalledWith({ topic: "hello", count: 3 });
   });
@@ -26,7 +26,7 @@ describe("RecipeForm", () => {
     const onSubmit = vi.fn();
     render(<RecipeForm form={form} pending={false} onSubmit={onSubmit} />);
     fireEvent.change(screen.getByTestId("field-mode"), { target: { value: "slow" } });
-    fireEvent.click(screen.getByRole("button", { name: /run recipe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /run blueprint/i }));
     expect(onSubmit).toHaveBeenCalledWith({ mode: "slow" });
   });
 
@@ -36,7 +36,7 @@ describe("RecipeForm", () => {
     ]);
     const onSubmit = vi.fn();
     render(<RecipeForm form={form} pending={false} onSubmit={onSubmit} />);
-    fireEvent.click(screen.getByRole("button", { name: /run recipe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /run blueprint/i }));
     expect(screen.getByRole("alert")).toHaveTextContent("required");
     expect(onSubmit).not.toHaveBeenCalled();
   });
@@ -45,7 +45,7 @@ describe("RecipeForm", () => {
     const form = new RecipeFormDef("kx/recipes/fanout-demo", []);
     const onSubmit = vi.fn();
     render(<RecipeForm form={form} pending={false} onSubmit={onSubmit} />);
-    fireEvent.click(screen.getByRole("button", { name: /run recipe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /run blueprint/i }));
     expect(onSubmit).toHaveBeenCalledWith({});
   });
 });

--- a/ui/test/component/Sidebar.test.tsx
+++ b/ui/test/component/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -17,20 +17,30 @@ import { Sidebar } from "../../src/components/shell/Sidebar";
 
 describe("Sidebar", () => {
   it("renders an item with a label for every section when expanded", () => {
-    render(<Sidebar collapsed={false} />);
+    render(<Sidebar collapsed={false} onToggle={() => {}} />);
     for (const id of ["activity", "chat", "runs", "recipes", "artifacts", "datasets", "systems"]) {
       expect(screen.getByTestId(`nav-${id}`)).toBeInTheDocument();
     }
     expect(screen.getByText("Activity")).toBeInTheDocument();
     expect(screen.getByText("Chat")).toBeInTheDocument();
+    // The display rename (D136): the frozen `recipes` id shows "Blueprints".
+    expect(screen.getByTestId("nav-recipes")).toHaveTextContent("Blueprints");
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-collapsed", "false");
   });
 
   it("hides labels (icon rail) when collapsed", () => {
-    render(<Sidebar collapsed={true} />);
+    render(<Sidebar collapsed={true} onToggle={() => {}} />);
     // The items remain (icons), but the text labels are not rendered.
     expect(screen.getByTestId("nav-activity")).toBeInTheDocument();
     expect(screen.queryByText("Activity")).not.toBeInTheDocument();
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-collapsed", "true");
+  });
+
+  it("pins Settings at the bottom and hosts the collapse toggle", () => {
+    const onToggle = vi.fn();
+    render(<Sidebar collapsed={false} onToggle={onToggle} />);
+    expect(screen.getByTestId("nav-settings")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("sidebar-toggle"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/test/unit/nav-model.test.ts
+++ b/ui/test/unit/nav-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { NAV_SECTIONS } from "../../src/components/shell/nav-model";
+import { NAV_SECTIONS, SETTINGS_SECTION } from "../../src/components/shell/nav-model";
 
 describe("NAV_SECTIONS", () => {
   it("has the seven console sections", () => {
@@ -12,6 +12,14 @@ describe("NAV_SECTIONS", () => {
       "datasets",
       "systems",
     ]);
+  });
+
+  it("displays Blueprints over the frozen recipes wire (D136)", () => {
+    const recipes = NAV_SECTIONS.find((s) => s.id === "recipes");
+    expect(recipes?.label).toBe("Blueprints");
+    // The wire surface never renames: id, path, icon stay `recipes`.
+    expect(recipes?.path).toBe("/recipes");
+    expect(recipes?.icon).toBe("recipes");
   });
 
   it("ids and paths are unique", () => {
@@ -28,5 +36,14 @@ describe("NAV_SECTIONS", () => {
       expect(s.hint.length).toBeGreaterThan(0);
       expect(s.icon.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("SETTINGS_SECTION", () => {
+  it("is pinned shell chrome, not an eighth nav section", () => {
+    expect(SETTINGS_SECTION.id).toBe("settings");
+    expect(SETTINGS_SECTION.path).toBe("/settings");
+    expect(SETTINGS_SECTION.icon).toBe("settings");
+    expect(NAV_SECTIONS.some((s) => s.id === SETTINGS_SECTION.id)).toBe(false);
   });
 });


### PR DESCRIPTION
The Wave-1 UI foundation (D136/D137) — PR 1 of the user-approved 3-PR Wave-1 sequence (redesign core → bundle pass → MCP-intel foundation). **Wire-frozen throughout: zero proto/RPC/handle/route/test-id changes; frozen trio untouched; digest `7d22d4bd` invariant.**

## What

**Theme — the kortecx light palette (`ui/src/styles/app.css`)**
- Orange `#F04500` for borders/focus/glows/accents; **`#D83C00` under all white text** (4.60:1, WCAG-AA — the locked contrast decision; `#F04500` under white fails at 3.78:1).
- `#f0f0f0` base / white surfaces / near-black `#0d0d0d` text; every Mote state + notice tone re-mapped AA-safe for light surfaces (≥4.5:1 as text AND under white pill text).
- Geist Sans/Mono via `@fontsource` (self-hosted woff2 — no runtime CDN), gradient primary buttons, 4px brand-tint scrollbars, GlowCard hover glow, `fade-in-up`/`shimmer`/`pulse-dot` keyframes.
- Legacy token aliases (`--bg-elev`, `--fg`, `--accent`, …) keep every existing rule working — single-edit migration.

**Shell**
- **Connect is a login gate**: while disconnected the console renders a slim brand+status header + the route outlet only (no nav/sidebar). Deep links resolve through each section's ConnectGate.
- **Chat is the connected default** (`index → /chat`; post-connect lands on Chat).
- Sidebar: logo+hamburger header (collapse → logo-only 48px rail), **Settings pinned bottom-left** (new read-only section — connection profile + appearance facts, no new RPCs).
- TopNavbar: brand · **⌘K SearchTrigger** · controls · connection status; new custom `CommandPalette` (no cmdk dep) — substring filter, ↑/↓ + Enter nav, Esc/backdrop close.
- New design system: `ds/GlowCard` + `ds/Badge` + lucide-react.

**Blueprint display rename (D136 — display layer ONLY)**
- Nav label, section headings/copy, "Run blueprint", CLI help/doc strings, README/GLOSSARY prose (with a "wire-legacy: recipe" gloss + a new GLOSSARY terminology entry fixing Blueprint/plan/recipe).
- SDKs: **additive** `BlueprintForm`/`BlueprintFormField`/`blueprintParamTypeName` aliases (TS + Python). Nothing renamed or deprecated.
- Frozen and untouched: `ListRecipes`/`GetRecipeForm`/`Invoke`, `kx/recipes/*` handles, `/recipes` route, `recipes` nav id, all `data-testid`s, `recipe_fingerprint`.

## Rule 11 — interface impact
- UI section(s): **all** (theme) + **Blueprints** (rename) + **Settings** (new shell section)
- SDK module(s): `recipes` (additive Blueprint aliases, Py+TS)
- machine-experience: RPC surface unchanged; the aliases exercise the same `GetRecipeForm` path

## Golden Rule 8 — risks + mitigations
- *Login gate removes shell-while-disconnected*: `sidebar-collapse` e2e rewritten (reload → gate → reconnect → persisted collapse survives); `cors-denied`'s `conn-status` contract preserved via the gate header.
- *Default-route change (`/activity` → `/chat`)*: fixtures + `connect-submit-poll` updated; `/activity` itself unchanged (bookmarks fine).
- *Light-theme tone re-map*: all state/notice tones recomputed for white surfaces (table in the corpus mirror); visual pass done over live screenshots (gate/chat/blueprints/settings/palette/collapsed rail).
- *Wire freeze*: a 3-lens adversarial review workflow (wire-freeze / UI-correctness / theme-AA, 7 agents) confirmed zero wire drift; its one real finding (hardcoded textarea font) is fixed in this PR.

## Verification
- `just ci` green locally (fmt, clippy `-D warnings`, tests, deny, doc, ffi-link, **byte-determinism I1.c**, scale-smoke).
- UI: biome + tsc clean · **242** vitest (incl. real-`kx serve` contract tests) · **17/17** Playwright e2e (real gateway over gRPC-web, incl. the rewritten login-gate flow + Blueprint renames).
- SDKs: TS build + 75 tests green; Python `ruff check` + `ruff format --check` clean + alias identity asserted.
- GR10: no perf-relevant Rust change; the UI bundle baseline (569KB eager) is captured for the PR-UI-B bundle pass + ≤600KB gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)