### PR TITLE
feat(ui): W1 bundle pass — vendor manualChunks, LazyMotion strict, eager-JS ≤600KB CI gate, DevTools dock phase 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev clang cmake build-essential
 
+      # The full-workspace debug target (incl. the llama.cpp FFI build) plus
+      # the restored cargo-test cache (~4 GiB compressed, 3-5x extracted) no
+      # longer fit in a standard runner's ~14 GB free disk — the job died with
+      # "No space left on device" at cache restore. Drop the preinstalled
+      # bundles this job never uses (~25-30 GB reclaimed in under a minute).
+      - name: Free runner disk space (the test target + cache need the headroom)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force > /dev/null 2>&1 || true
+          df -h /
+
       - name: Cache Cargo registry + target
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,10 @@ jobs:
         working-directory: ui
         run: npm run build
 
+      - name: Eager-JS bundle gate (entry + modulepreload ≤ 600 KiB)
+        working-directory: ui
+        run: npm run size
+
       - name: Install the Playwright browser (chromium only)
         working-directory: ui
         run: npx playwright install --with-deps chromium

--- a/ui/e2e/devtools.spec.ts
+++ b/ui/e2e/devtools.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("the DevTools dock opens lazily, shows gateway health, and tails run events", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw, { wsEndpoint: gw.wsEndpoint });
+
+  // Closed by default; the navbar toggle lazy-loads + opens the dock.
+  await expect(page.getByTestId("devtools-dock")).toHaveCount(0);
+  await page.getByTestId("devtools-toggle").click();
+  await expect(page.getByTestId("devtools-dock")).toBeVisible({ timeout: 15_000 });
+
+  // Health tab: the gateway probe + the connection profile.
+  await page.getByTestId("devtools-tab-health").click();
+  await expect(page.getByTestId("devtools-health")).toContainText("live", { timeout: 15_000 });
+  await expect(page.getByTestId("devtools-health")).toContainText(gw.endpoint);
+
+  // Events tab: empty until a run exists, then tails the latest run's deltas.
+  await page.getByTestId("devtools-tab-events").click();
+  await expect(page.getByTestId("devtools-no-run")).toBeVisible();
+
+  await runRecipe(page);
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("devtools-events")).toBeVisible();
+  await expect(page.getByTestId("devtools-dock").getByTestId("event-row").first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Close restores the chrome.
+  await page.getByTestId("devtools-close").click();
+  await expect(page.getByTestId("devtools-dock")).toHaveCount(0);
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,8 @@
     "format": "biome format --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "size": "node scripts/check-bundle-size.mjs"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.8",

--- a/ui/scripts/check-bundle-size.mjs
+++ b/ui/scripts/check-bundle-size.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * The eager-JS bundle gate (W1, zero-dep). The EAGER set is exactly what the
+ * browser loads before any user interaction: the `<script type="module">` entry
+ * plus every `<link rel="modulepreload">` chunk Vite emits into `dist/index.html`
+ * (statically-imported vendor chunks). Lazy chunks (MoteDag, sections, the
+ * motion-features pack, the DevTools dock) are reported but NOT counted.
+ *
+ * Budget: 600 KiB raw (override with KX_UI_EAGER_BUDGET_BYTES for emergencies —
+ * a deliberate, reviewed override, never a silent default bump).
+ *
+ * Exit 1 over budget. The printed table doubles as the GR10 evidence blob.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const UI_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = join(UI_ROOT, "dist");
+const BUDGET = Number(process.env.KX_UI_EAGER_BUDGET_BYTES ?? 614_400);
+
+/** Pull the eager JS URLs out of dist/index.html (entry scripts + modulepreloads). */
+export function eagerJsUrls(html) {
+  const urls = new Set();
+  for (const m of html.matchAll(/<script[^>]+type="module"[^>]*\ssrc="([^"]+\.js)"/g)) {
+    urls.add(m[1]);
+  }
+  for (const m of html.matchAll(/<link[^>]+rel="modulepreload"[^>]*\shref="([^"]+\.js)"/g)) {
+    urls.add(m[1]);
+  }
+  return [...urls];
+}
+
+function main() {
+  const html = readFileSync(join(DIST, "index.html"), "utf8");
+  const eager = eagerJsUrls(html);
+  if (eager.length === 0) {
+    console.error("check-bundle-size: no eager JS found in dist/index.html — did the build run?");
+    process.exit(1);
+  }
+
+  let total = 0;
+  const rows = [];
+  for (const url of eager) {
+    const path = join(DIST, url.replace(/^\//, ""));
+    const bytes = statSync(path).size;
+    total += bytes;
+    rows.push([url, bytes]);
+  }
+  rows.sort((a, b) => b[1] - a[1]);
+
+  console.log("eager JS (entry + modulepreload):");
+  for (const [url, bytes] of rows) {
+    console.log(`  ${String(bytes).padStart(9)} B  ${url}`);
+  }
+  console.log(`  ${String(total).padStart(9)} B  TOTAL (budget ${BUDGET} B)`);
+
+  // Informational: the lazy remainder (everything else under dist/assets).
+  const eagerNames = new Set(rows.map(([u]) => u.split("/").pop()));
+  let lazyTotal = 0;
+  for (const f of readdirSync(join(DIST, "assets"))) {
+    if (f.endsWith(".js") && !eagerNames.has(f)) {
+      lazyTotal += statSync(join(DIST, "assets", f)).size;
+    }
+  }
+  console.log(`  ${String(lazyTotal).padStart(9)} B  lazy remainder (not gated)`);
+
+  if (total > BUDGET) {
+    console.error(`\nFAIL: eager JS ${total} B exceeds the ${BUDGET} B budget.`);
+    process.exit(1);
+  }
+  console.log("\nOK: eager JS within budget.");
+}
+
+// Import-safe for the parser unit test; executes when run directly.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/ui/src/app/motion-features.ts
+++ b/ui/src/app/motion-features.ts
@@ -1,0 +1,8 @@
+/**
+ * The framer-motion feature pack, loaded LAZILY by `<LazyMotion>` (providers.tsx).
+ * Keeping this in its own module means the animation engine rides a dynamic chunk —
+ * the eager bundle carries only the tiny `m`/`LazyMotion` core. `domAnimation`
+ * covers everything we use (tweens, variants, exit animations); nothing needs
+ * `domMax` (no drag/layout animations).
+ */
+export { domAnimation } from "framer-motion";

--- a/ui/src/app/providers.tsx
+++ b/ui/src/app/providers.tsx
@@ -1,8 +1,11 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { MotionConfig } from "framer-motion";
+import { LazyMotion, MotionConfig } from "framer-motion";
 import { type ReactNode, useState } from "react";
 import { type ClientFactory, KxConnectionProvider } from "../kx/connection-context";
 import { makeQueryClient } from "./query-client";
+
+/** Load the animation engine as a dynamic chunk (see `motion-features.ts`). */
+const loadMotionFeatures = () => import("./motion-features").then((m) => m.domAnimation);
 
 export interface AppProvidersProps {
   children: ReactNode;
@@ -10,13 +13,21 @@ export interface AppProvidersProps {
   createClient?: ClientFactory;
 }
 
-/** Composes the server-state, connection, and motion providers. */
+/**
+ * Composes the server-state, connection, and motion providers. `LazyMotion strict`
+ * is the bundle-regression guard: any `motion.*` usage (which would drag the full
+ * eager animation engine back in) THROWS — components must use `m.*`.
+ */
 export function AppProviders({ children, createClient }: AppProvidersProps) {
   const [queryClient] = useState(() => makeQueryClient());
   return (
     <QueryClientProvider client={queryClient}>
       <KxConnectionProvider createClient={createClient}>
-        <MotionConfig reducedMotion="user">{children}</MotionConfig>
+        <MotionConfig reducedMotion="user">
+          <LazyMotion strict features={loadMotionFeatures}>
+            {children}
+          </LazyMotion>
+        </MotionConfig>
       </KxConnectionProvider>
     </QueryClientProvider>
   );

--- a/ui/src/components/StatePill.tsx
+++ b/ui/src/components/StatePill.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { statePulse } from "../app/motion";
 import { stateVisual } from "../lib/colors";
 
@@ -6,7 +6,7 @@ import { stateVisual } from "../lib/colors";
 export function StatePill({ stateCode }: { stateCode: number }) {
   const { label, tone } = stateVisual(stateCode);
   return (
-    <motion.span
+    <m.span
       key={stateCode}
       className={`pill pill--${tone}`}
       data-testid="state-pill"
@@ -16,6 +16,6 @@ export function StatePill({ stateCode }: { stateCode: number }) {
       transition={statePulse.transition}
     >
       {label}
-    </motion.span>
+    </m.span>
   );
 }

--- a/ui/src/components/dag/MoteNode.tsx
+++ b/ui/src/components/dag/MoteNode.tsx
@@ -1,6 +1,6 @@
 import { Handle, Position } from "@xyflow/react";
 import type { NodeProps } from "@xyflow/react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { memo } from "react";
 import { statePulse } from "../../app/motion";
 import { stateVisual } from "../../lib/colors";
@@ -20,7 +20,7 @@ function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
   const { mote } = data;
   const { tone } = stateVisual(mote.stateCode);
   return (
-    <motion.div
+    <m.div
       className={`dag-node dag-node--${tone}`}
       data-testid="mote-node"
       data-mote={mote.moteId}
@@ -40,7 +40,7 @@ function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
       </div>
       <AnomalyBadge anomaly={mote.anomaly} />
       <Handle type="source" position={Position.Bottom} className="dag-handle" />
-    </motion.div>
+    </m.div>
   );
 }
 

--- a/ui/src/components/devtools/DevToolsDock.tsx
+++ b/ui/src/components/devtools/DevToolsDock.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { useConnection } from "../../kx/connection-context";
+import { useEventStream } from "../../kx/use-event-stream";
+import { useHealth } from "../../kx/use-health";
+import { useRuns } from "../../kx/use-runs";
+import { ActivityFeed } from "../activity/ActivityFeed";
+
+const TAIL_MAX = 200;
+
+/**
+ * DevTools dock phase 1 (Monitoring/DevTools): a bottom dock with a live event
+ * tail (the most recent run, over the WS bridge) and a gateway-health panel.
+ * Pure UI over EXISTING surfaces (`wsEvents`, the health probe, the run history)
+ * — zero new RPCs. The dock is lazy-loaded and mounted only while open, so its
+ * chunk never enters the eager set and the WS tail never duplicates a closed
+ * dock's connection.
+ */
+export function DevToolsDock({ onClose }: { onClose: () => void }) {
+  const [tab, setTab] = useState<"events" | "health">("events");
+  return (
+    <section className="devtools" data-testid="devtools-dock" aria-label="DevTools">
+      <header className="devtools__bar">
+        <div className="devtools__tabs" role="tablist" aria-label="DevTools panels">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "events"}
+            className="devtools__tab"
+            data-testid="devtools-tab-events"
+            onClick={() => setTab("events")}
+          >
+            Events
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "health"}
+            className="devtools__tab"
+            data-testid="devtools-tab-health"
+            onClick={() => setTab("health")}
+          >
+            Health
+          </button>
+        </div>
+        <button
+          type="button"
+          className="iconbtn devtools__close"
+          onClick={onClose}
+          aria-label="Close DevTools"
+          data-testid="devtools-close"
+        >
+          ×
+        </button>
+      </header>
+      <div className="devtools__body">{tab === "events" ? <EventsTab /> : <HealthTab />}</div>
+    </section>
+  );
+}
+
+/** Tail the MOST RECENT run's deltas (newest-first, bounded ring). */
+function EventsTab() {
+  const { runs } = useRuns();
+  const latest = runs[0];
+  const stream = useEventStream(latest?.instanceId, { max: TAIL_MAX });
+  if (!latest) {
+    return (
+      <p className="muted" data-testid="devtools-no-run">
+        No runs this session — run a blueprint and its events tail here.
+      </p>
+    );
+  }
+  return (
+    <div data-testid="devtools-events">
+      <p className="muted devtools__context mono">run {latest.instanceId}</p>
+      <ActivityFeed events={stream.events} active={stream.active} dropped={stream.dropped} />
+    </div>
+  );
+}
+
+/** Gateway liveness + the connection profile (the conn-status pill, expanded). */
+function HealthTab() {
+  const { endpoint, wsEndpoint } = useConnection();
+  const health = useHealth();
+  const h = health.data ?? "down";
+  return (
+    <dl className="facts" data-testid="devtools-health">
+      <dt>Gateway</dt>
+      <dd>
+        <span
+          className={`dot ${h === "live" ? "dot--ok" : h === "degraded" ? "dot--degraded" : "dot--off"}`}
+        />{" "}
+        {h}
+      </dd>
+      <dt>Endpoint</dt>
+      <dd className="mono">{endpoint}</dd>
+      <dt>WS bridge</dt>
+      <dd className="mono">{wsEndpoint ?? "derived from the endpoint"}</dd>
+    </dl>
+  );
+}

--- a/ui/src/components/devtools/index.ts
+++ b/ui/src/components/devtools/index.ts
@@ -1,0 +1,6 @@
+import { lazy } from "react";
+
+/** Lazy entry — the dock's chunk loads only when first opened (never eager). */
+export const DevToolsDock = lazy(() =>
+  import("./DevToolsDock").then((m) => ({ default: m.DevToolsDock })),
+);

--- a/ui/src/components/ds/GlowCard.tsx
+++ b/ui/src/components/ds/GlowCard.tsx
@@ -1,4 +1,4 @@
-import { type HTMLMotionProps, motion } from "framer-motion";
+import { type HTMLMotionProps, m } from "framer-motion";
 import type { CSSProperties } from "react";
 
 export interface GlowCardProps extends HTMLMotionProps<"div"> {
@@ -24,13 +24,13 @@ export function GlowCard({
   const classes = `glow-card${hover ? " glow-card--hover" : ""}${className ? ` ${className}` : ""}`;
   const styles = { ...style, "--glow": glowColor } as CSSProperties;
   return (
-    <motion.div
+    <m.div
       className={classes}
       style={styles}
       whileHover={hover ? { scale: 1.005, y: -1 } : undefined}
       {...rest}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }

--- a/ui/src/components/shell/AppShell.tsx
+++ b/ui/src/components/shell/AppShell.tsx
@@ -1,8 +1,9 @@
 import { Outlet, useRouterState } from "@tanstack/react-router";
-import { AnimatePresence, motion } from "framer-motion";
-import { useCallback, useEffect, useState } from "react";
+import { AnimatePresence, m } from "framer-motion";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { pageFade } from "../../app/motion";
 import { useConnection } from "../../kx/connection-context";
+import { DevToolsDock } from "../devtools";
 import { Brand } from "./Brand";
 import { CommandPalette } from "./CommandPalette";
 import { ConnectionStatus } from "./ConnectionStatus";
@@ -10,18 +11,19 @@ import { Navbar } from "./Navbar";
 import { Sidebar } from "./Sidebar";
 
 const SIDEBAR_KEY = "kortecx.ui.sidebar";
+const DEVTOOLS_KEY = "kortecx.ui.devtools";
 
-function loadCollapsed(): boolean {
+function loadFlag(key: string): boolean {
   try {
-    return localStorage.getItem(SIDEBAR_KEY) === "1";
+    return localStorage.getItem(key) === "1";
   } catch {
     return false;
   }
 }
 
-function persistCollapsed(collapsed: boolean): void {
+function persistFlag(key: string, value: boolean): void {
   try {
-    localStorage.setItem(SIDEBAR_KEY, collapsed ? "1" : "0");
+    localStorage.setItem(key, value ? "1" : "0");
   } catch {
     /* best-effort */
   }
@@ -32,7 +34,7 @@ function RouteOutlet() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   return (
     <AnimatePresence mode="wait">
-      <motion.div
+      <m.div
         key={pathname}
         initial={pageFade.initial}
         animate={pageFade.animate}
@@ -40,7 +42,7 @@ function RouteOutlet() {
         transition={pageFade.transition}
       >
         <Outlet />
-      </motion.div>
+      </m.div>
     </AnimatePresence>
   );
 }
@@ -54,14 +56,23 @@ function RouteOutlet() {
  */
 export function AppShell() {
   const { status } = useConnection();
-  const [collapsed, setCollapsed] = useState<boolean>(() => loadCollapsed());
+  const [collapsed, setCollapsed] = useState<boolean>(() => loadFlag(SIDEBAR_KEY));
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [devtoolsOpen, setDevtoolsOpen] = useState<boolean>(() => loadFlag(DEVTOOLS_KEY));
   const connected = status === "connected";
 
   const toggle = useCallback(() => {
     setCollapsed((c) => {
       const next = !c;
-      persistCollapsed(next);
+      persistFlag(SIDEBAR_KEY, next);
+      return next;
+    });
+  }, []);
+
+  const toggleDevtools = useCallback(() => {
+    setDevtoolsOpen((open) => {
+      const next = !open;
+      persistFlag(DEVTOOLS_KEY, next);
       return next;
     });
   }, []);
@@ -107,12 +118,17 @@ export function AppShell() {
       <a href="#main" className="skip-link">
         Skip to content
       </a>
-      <Navbar onOpenPalette={openPalette} />
+      <Navbar onOpenPalette={openPalette} onToggleDevtools={toggleDevtools} />
       <Sidebar collapsed={collapsed} onToggle={toggle} />
       <main className="shell__main" id="main">
         <RouteOutlet />
       </main>
       <CommandPalette open={paletteOpen} onClose={closePalette} />
+      {devtoolsOpen ? (
+        <Suspense fallback={null}>
+          <DevToolsDock onClose={toggleDevtools} />
+        </Suspense>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/shell/CommandPalette.tsx
+++ b/ui/src/components/shell/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
 import { paletteIn } from "../../app/motion";
 import { Icon } from "./Icon";
@@ -66,7 +66,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
     <AnimatePresence>
       {open ? (
         <>
-          <motion.div
+          <m.div
             className="palette__backdrop"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -75,7 +75,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
             onClick={onClose}
             aria-hidden="true"
           />
-          <motion.div
+          <m.div
             className="palette"
             // biome-ignore lint/a11y/useSemanticElements: a native <dialog> can't ride AnimatePresence exit animations; dialog semantics are declared via role+aria-modal
             role="dialog"
@@ -123,7 +123,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
                 ))}
               </nav>
             )}
-          </motion.div>
+          </m.div>
         </>
       ) : null}
     </AnimatePresence>

--- a/ui/src/components/shell/Icon.tsx
+++ b/ui/src/components/shell/Icon.tsx
@@ -19,7 +19,8 @@ export type Glyph =
   | "refresh"
   | "search"
   | "send"
-  | "settings";
+  | "settings"
+  | "terminal";
 
 // 24×24 viewBox, stroke = currentColor. Multi-subpath `d` is fine.
 const PATHS: Record<Glyph, string> = {
@@ -38,6 +39,7 @@ const PATHS: Record<Glyph, string> = {
   send: "M4 12l16-7-7 16-2-7z",
   settings:
     "M12 9a3 3 0 100 6 3 3 0 000-6zM19 12a7 7 0 00-.1-1l2-1.5-2-3.4-2.3 1a7 7 0 00-1.7-1l-.3-2.6h-4l-.3 2.6a7 7 0 00-1.7 1l-2.3-1-2 3.4 2 1.5a7 7 0 000 2l-2 1.5 2 3.4 2.3-1a7 7 0 001.7 1l.3 2.6h4l.3-2.6a7 7 0 001.7-1l2.3 1 2-3.4-2-1.5a7 7 0 00.1-1z",
+  terminal: "M4 17l6-5-6-5M12 19h8",
 };
 
 const FALLBACK = "M12 12h.01";

--- a/ui/src/components/shell/Navbar.tsx
+++ b/ui/src/components/shell/Navbar.tsx
@@ -1,19 +1,35 @@
 import { Brand } from "./Brand";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { GlobalControls } from "./GlobalControls";
+import { Icon } from "./Icon";
 import { SearchTrigger } from "./SearchTrigger";
 
 /**
- * The top bar: brand · ⌘K search trigger · global controls · connection status.
- * The sidebar hamburger lives in the Sidebar header (logo+hamburger, D137).
+ * The top bar: brand · ⌘K search trigger · devtools toggle · global controls ·
+ * connection status. The sidebar hamburger lives in the Sidebar header (D137).
  */
-export function Navbar({ onOpenPalette }: { onOpenPalette: () => void }) {
+export function Navbar({
+  onOpenPalette,
+  onToggleDevtools,
+}: {
+  onOpenPalette: () => void;
+  onToggleDevtools: () => void;
+}) {
   return (
     <header className="navbar" data-testid="navbar">
       <Brand />
       <div className="navbar__spacer" />
       <SearchTrigger onOpen={onOpenPalette} />
       <div className="navbar__spacer" />
+      <button
+        type="button"
+        className="iconbtn"
+        onClick={onToggleDevtools}
+        aria-label="Toggle DevTools"
+        data-testid="devtools-toggle"
+      >
+        <Icon name="terminal" />
+      </button>
       <GlobalControls />
       <ConnectionStatus />
     </header>

--- a/ui/src/kx/use-runs.ts
+++ b/ui/src/kx/use-runs.ts
@@ -17,6 +17,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  RUNS_CHANGED_EVENT,
   type RunRecord,
   clearRuns,
   loadRuns,
@@ -54,6 +55,17 @@ export function useRuns(): UseRuns {
   useEffect(() => {
     setLocal(loadRuns(endpoint));
     setLimit(PAGE);
+  }, [endpoint]);
+
+  // Stay fresh across hook INSTANCES in the same tab: another component's
+  // `add`/`clear` (e.g. a Blueprints submit while the DevTools dock tails)
+  // dispatches RUNS_CHANGED_EVENT — re-read the persisted history.
+  useEffect(() => {
+    function onRunsChanged(): void {
+      setLocal(loadRuns(endpoint));
+    }
+    window.addEventListener(RUNS_CHANGED_EVENT, onRunsChanged);
+    return () => window.removeEventListener(RUNS_CHANGED_EVENT, onRunsChanged);
   }, [endpoint]);
 
   const server = useQuery({

--- a/ui/src/lib/recent-runs.ts
+++ b/ui/src/lib/recent-runs.ts
@@ -48,6 +48,22 @@ export function mergeServerRuns(local: RunRecord[], server: ServerRun[]): RunRec
 /** Keep the session history bounded (newest-first). */
 const MAX_RUNS = 50;
 
+/**
+ * Fired on `window` whenever the persisted history changes. The browser's
+ * `storage` event only fires in OTHER tabs, so two `useRuns` instances in the
+ * SAME tab (e.g. the Blueprints submit + the DevTools dock tail) would go stale
+ * without it.
+ */
+export const RUNS_CHANGED_EVENT = "kortecx:runs-changed";
+
+function notifyRunsChanged(): void {
+  try {
+    window.dispatchEvent(new Event(RUNS_CHANGED_EVENT));
+  } catch {
+    /* non-browser env (unit tests without a window) */
+  }
+}
+
 function keyFor(endpoint: string): string {
   return `kortecx.ui.runs:${endpoint}`;
 }
@@ -77,6 +93,7 @@ export function recordRun(endpoint: string, run: RunRecord): RunRecord[] {
   } catch {
     /* best-effort */
   }
+  notifyRunsChanged();
   return next;
 }
 
@@ -86,6 +103,7 @@ export function clearRuns(endpoint: string): void {
   } catch {
     /* best-effort */
   }
+  notifyRunsChanged();
 }
 
 function isRunRecord(v: unknown): v is RunRecord {

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1488,3 +1488,60 @@ select {
     background-position: 200px 0;
   }
 }
+
+/* ---- DevTools dock (phase 1; lazy, mounted only while open) ---- */
+.devtools {
+  position: fixed;
+  left: var(--sidebar-w, 200px);
+  right: 0;
+  bottom: 0;
+  z-index: 40;
+  height: 280px;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-top: 2px solid var(--primary);
+  box-shadow: 0 -8px 24px rgba(13, 13, 13, 0.08);
+}
+.shell--collapsed .devtools {
+  left: var(--sidebar-w-collapsed);
+}
+.devtools__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+.devtools__tabs {
+  display: flex;
+  gap: 0.25rem;
+}
+.devtools__tab {
+  background: none;
+  box-shadow: none;
+  border: none;
+  margin: 0;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius);
+  color: var(--fg-muted);
+  font-weight: 500;
+  cursor: pointer;
+}
+.devtools__tab[aria-selected="true"] {
+  background: var(--primary-dim);
+  color: var(--primary-h);
+}
+.devtools__close {
+  margin-left: auto;
+  font-size: 1rem;
+}
+.devtools__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0.75rem;
+}
+.devtools__context {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+}

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -47,8 +47,12 @@ vi.mock("framer-motion", () => {
   );
   return {
     motion,
+    // The LazyMotion `m.*` components share the same plain-element stub.
+    m: motion,
     AnimatePresence: ({ children }: { children: unknown }) => children,
     MotionConfig: ({ children }: { children: unknown }) => children,
+    LazyMotion: ({ children }: { children: unknown }) => children,
+    domAnimation: {},
   };
 });
 

--- a/ui/test/unit/bundle-size-script.test.ts
+++ b/ui/test/unit/bundle-size-script.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — a plain .mjs script (no d.ts); the parser export is unit-tested here.
+import { eagerJsUrls } from "../../scripts/check-bundle-size.mjs";
+
+const HTML = `<!doctype html>
+<html><head>
+  <link rel="modulepreload" crossorigin href="/assets/vendor-react-Ab12Cd34.js">
+  <link rel="modulepreload" crossorigin href="/assets/vendor-router-Ef56Gh78.js">
+  <link rel="stylesheet" crossorigin href="/assets/index-XyZ.css">
+  <script type="module" crossorigin src="/assets/index-Qr90St12.js"></script>
+</head><body><div id="root"></div></body></html>`;
+
+describe("check-bundle-size eager-set parser", () => {
+  it("collects the module entry + every modulepreload JS, nothing else", () => {
+    const urls = eagerJsUrls(HTML).sort();
+    expect(urls).toEqual([
+      "/assets/index-Qr90St12.js",
+      "/assets/vendor-react-Ab12Cd34.js",
+      "/assets/vendor-router-Ef56Gh78.js",
+    ]);
+  });
+
+  it("ignores CSS preloads and dedupes repeats", () => {
+    const twice = HTML + HTML;
+    expect(eagerJsUrls(twice).length).toBe(3);
+    expect(eagerJsUrls(HTML).some((u: string) => u.endsWith(".css"))).toBe(false);
+  });
+
+  it("returns empty on a build-less page (the script fails loud)", () => {
+    expect(eagerJsUrls("<html><body>no scripts</body></html>")).toEqual([]);
+  });
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,10 +5,37 @@ import { defineConfig } from "vitest/config";
 // One config drives the dev server, the production build, AND vitest. The dev
 // (5173) / preview (4173) ports are pinned + strict so the gateway's deny-by-default
 // `--cors-origin` allowlist can name them exactly (a flaky CORS mismatch otherwise).
+// The EAGER vendor split (cache-stable, machine-checkable via modulepreload links
+// in dist/index.html — the eager set `scripts/check-bundle-size.mjs` gates ≤600KB).
+// An explicit ALLOWLIST, never a catch-all `node_modules → vendor`: a catch-all
+// would hoist @xyflow/dagre (which must stay inside the lazy MoteDag chunk) and
+// framer-motion (whose animation engine must stay in the dynamic motion-features
+// chunk — the LazyMotion split) into the eager set.
+function vendorChunk(id: string): string | undefined {
+  if (!id.includes("node_modules")) {
+    return undefined;
+  }
+  if (/node_modules\/(react|react-dom|scheduler)\//.test(id)) {
+    return "vendor-react";
+  }
+  if (/node_modules\/@tanstack\/(react-router|router-core|history|react-store|store)\//.test(id)) {
+    return "vendor-router";
+  }
+  if (/node_modules\/@tanstack\/(react-query|query-core)\//.test(id)) {
+    return "vendor-query";
+  }
+  return undefined;
+}
+
 export default defineConfig({
   plugins: [react()],
   server: { port: 5173, strictPort: true },
   preview: { port: 4173, strictPort: true },
+  build: {
+    rollupOptions: {
+      output: { manualChunks: vendorChunk },
+    },
+  },
   test: {
     // Component/unit tests run in jsdom; the contract test opts into the node
     // environment per-file (`// @vitest-environment node`) so it gets real


### PR DESCRIPTION
PR 2 of the Wave-1 sequence (redesign core #175 ✅ → **this** → PR-MCP W1.A5). UI/build-layer only: **zero wire/proto/SDK-surface change; frozen trio untouched; digest `7d22d4bd` invariant.**

## What

- **Vendor `manualChunks` (allowlist function)** — `vendor-react` / `vendor-router` / `vendor-query`. Deliberately NOT a catch-all: `@xyflow`+dagre stay inside the lazy `MoteDag` chunk and framer-motion stays splittable so its engine rides the dynamic chunk below.
- **LazyMotion `strict`** + `motion.*` → `m.*` (AppShell, CommandPalette, StatePill, MoteNode, GlowCard). The 53KB `domAnimation` engine now loads as a **lazy** `motion-features` chunk; `strict` throws on any stray `motion.*` import — the permanent bundle-regression guard.
- **Eager-JS CI gate** — zero-dep `ui/scripts/check-bundle-size.mjs`: the eager set = the module entry + every `modulepreload` link in `dist/index.html`; prints the per-chunk table (the GR10 evidence), fails > 600 KiB (`KX_UI_EAGER_BUDGET_BYTES` override for deliberate, reviewed bumps). Wired as `npm run size` + a ci.yml ui-job step; the HTML parser is unit-tested.
- **DevTools dock phase 1** (Monitoring/DevTools per the Rule-11 taxonomy): a lazy bottom dock, mounted only while open — **Events** tails the latest run over the WS bridge (reuses `ActivityFeed`/`useEventStream`, bounded 200) · **Health** shows the gateway probe + connection profile. Navbar toggle, persisted per browser. Pure UI over existing surfaces — zero new RPCs.
- **Run-history freshness fix** — `recordRun`/`clearRuns` dispatch a same-tab `RUNS_CHANGED_EVENT`; `useRuns` subscribes. Two hook instances in one tab (a Blueprints submit + the dock tail) no longer go stale (the browser `storage` event only fires in *other* tabs; this staleness predates the dock).

## Result (GR10 — full table in the private benchmarks mirror)

| | eager JS | budget |
|---|---|---|
| pre-redesign (v0.1.1) | 557,851 B (one chunk) | — |
| post-#175 | 569,420 B | — |
| **this PR** | **477,572 B** (index 207,065 + react 141,812 + router 87,372 + query 41,323) | 614,400 B ✅ |

Lazy remainder 325,973 B (MoteDag 223.6KB · motion-features 53.3KB · sections · dock). Gzip eager ≈150KB.

## Rule 11 — interface impact
- UI section(s): **Monitoring/DevTools** (dock phase 1); every section benefits from the smaller eager load
- SDK module(s): none
- machine-experience: none (no RPC change)

## Verification

biome + tsc clean · **245** vitest (incl. the new bundle-script parser unit) · **18/18** Playwright e2e (incl. the new `devtools.spec.ts`: lazy open → health → live event tail after a run → close) · `npm run size` green (table above) · no Rust diff beyond none (ci.yml only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)