### PR TITLE
feat(bundle,toolscout): W1.A5 MCP-intelligence foundation — TaskBundle + kx-toolscout (advisory-only by construction)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-bundle"
+version = "0.1.1"
+dependencies = [
+ "bincode 2.0.1",
+ "blake3",
+ "kx-mote",
+ "serde",
+]
+
+[[package]]
 name = "kx-capability"
 version = "0.1.1"
 dependencies = [
@@ -1979,6 +1989,23 @@ dependencies = [
  "kx-warrant",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "kx-toolscout"
+version = "0.1.1"
+dependencies = [
+ "bincode 2.0.1",
+ "blake3",
+ "kx-bundle",
+ "kx-content",
+ "kx-dataset",
+ "kx-mote",
+ "kx-warrant",
+ "kx-workflow",
+ "proptest",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ members = [
     "crates/kx-mcp",
     "crates/kx-planner",
     "crates/kx-catalog",
+    "crates/kx-bundle",
+    "crates/kx-toolscout",
     "crates/kx-fleet",
     "crates/kx-model-harness",
     "crates/kx-gateway-core",
@@ -189,6 +191,22 @@ kx-planner           = { path = "crates/kx-planner",           version = "0.1.1"
 # path (composes kx-mote/kx-workflow identities, never bumps MoteDef). Depends
 # only on kx-mote/kx-workflow/kx-dataset — NEVER the journal or the frozen trio.
 kx-catalog           = { path = "crates/kx-catalog",           version = "0.1.1" }
+# The W1.A5 MCP-intelligence AUTHORING SHAPE (the extension-library roadmap) —
+# TaskBundle, the content-addressed multi-tool task template that LOWERS to a
+# WorkflowDef. A thin TYPE crate (the TaskSignature precedent) so future
+# consumers (kx-mcp-gateway, wave 3) take the type without the toolscout
+# machinery. Pure leaf: kx-mote + serde/bincode/blake3 only; off-journal, off
+# the identity path until the lowered DAG passes the frozen compile.
+kx-bundle            = { path = "crates/kx-bundle",            version = "0.1.1" }
+# W1.A5 advisory tool discovery (the MCP-intelligence core) — multilingual
+# ToolFingerprints + the integer-bp tolerance ladder + a manifest index over
+# kx-dataset::RetrievalIndex + TaskBundle→WorkflowDef lowering behind the
+# planner-style EXACT (name, version) tool_grants gate. ADVISORY-ONLY BY
+# CONSTRUCTION (SN-8): scores order and retrieve, never authorize — lowering
+# takes no score input; the broker exact-equality gate stays the sole authority.
+# Depends only on kx-bundle/kx-mote/kx-warrant/kx-workflow/kx-dataset/kx-content
+# — NEVER the journal, the gateway, or the frozen trio.
+kx-toolscout         = { path = "crates/kx-toolscout",         version = "0.1.1" }
 # Teams / fleets (M7, D112) — journaled membership facts + a fail-closed fold +
 # composed warrant resolution. Membership is one-level-up delegation
 # (intersect(team_warrant, member_role)); nested fleet-of-teams = a bounded multi-hop

--- a/crates/kx-bundle/Cargo.toml
+++ b/crates/kx-bundle/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name         = "kx-bundle"
+version      = "0.1.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx TaskBundle (W1.A5 MCP-intelligence) — the content-addressed, multi-tool task template a user or model AUTHORS and kx-toolscout LOWERS to a WorkflowDef. A thin TYPE crate (the TaskSignature precedent): fingerprint = blake3(domain-tag ‖ canonical bincode), all-BTree canonical field order, integer-scaled tolerance (no floats, SN-8). Pure leaf — kx-mote + serde/bincode/blake3 only; never the journal, the gateway, or the frozen trio."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# ToolName / ToolVersion (the exact-equality tool identity) + the canonical
+# bincode config (the ONE encoding identity-bearing bytes use).
+kx-mote = { workspace = true }
+serde   = { workspace = true }
+bincode = { workspace = true }
+blake3  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-bundle/src/bundle.rs
+++ b/crates/kx-bundle/src/bundle.rs
@@ -1,0 +1,174 @@
+//! The [`TaskBundle`] type + its content-addressed fingerprint.
+//!
+//! Canonical-encoding discipline (the `MoteDef::hash` / `task_signature_hash`
+//! precedent): every collection is a `BTreeMap`/`BTreeSet` (deterministic
+//! order), every numeric field is an integer (no floats anywhere — SN-8
+//! forbids float confidence on anything that could be persisted), and the
+//! fingerprint is `blake3(domain-tag ‖ canonical bincode)` so two bundles
+//! built in different insertion orders hash identically.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_mote::{canonical_config, ToolName, ToolVersion};
+use serde::{Deserialize, Serialize};
+
+/// Bump on any change to the encoding bytes of [`TaskBundle`] (field add /
+/// remove / reorder / type change). Encoded in the body, so a bump re-derives
+/// every fingerprint.
+pub const TASK_BUNDLE_SCHEMA_VERSION: u16 = 1;
+
+/// The blake3 domain tag for [`TaskBundle::fingerprint`] — keeps bundle
+/// fingerprints disjoint from every other 32-byte hash in the system.
+const FINGERPRINT_DOMAIN: &[u8] = b"kx-bundle/task-bundle/v1";
+
+/// Advisory, per-tool authoring metadata: a human description plus normalized
+/// keywords grouped by BCP-47-ish language tag (e.g. `"en"`, `"hi"`, `"ja"`).
+/// Display/ordering material only — never an authority input.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolMeta {
+    /// A one-line human description of why this tool is in the sequence.
+    pub description: String,
+    /// Normalized intent keywords, per language tag (sorted, deduplicated).
+    pub keywords: BTreeMap<String, BTreeSet<String>>,
+}
+
+/// The 32-byte content-addressed identity of a [`TaskBundle`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TaskBundleFingerprint(pub [u8; 32]);
+
+impl TaskBundleFingerprint {
+    /// Lowercase-hex rendering (for logs / display; never parsed back).
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        let mut s = String::with_capacity(64);
+        for b in self.0 {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+        }
+        s
+    }
+}
+
+/// A reusable, content-addressed multi-tool task template.
+///
+/// `tool_sequence` is the ORDERED list of `(name, version)` pairs the lowered
+/// workflow will run as a chain; it MUST be a subset of the executing
+/// warrant's `tool_grants` — `kx-toolscout::lower_to_workflow_def` refuses
+/// otherwise (exact equality, the planner-IMP-5 gate). `tolerance_threshold_bp`
+/// is the advisory ranking cut in basis points (`0..=10_000`) — an integer by
+/// construction so no float confidence can ever be persisted (SN-8).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskBundle {
+    /// See [`TASK_BUNDLE_SCHEMA_VERSION`] (encoded → identity-bearing).
+    pub schema_version: u16,
+    /// The task's instruction (becomes each lowered step's prompt config).
+    pub intent: String,
+    /// Language tags the intent/keywords are expressed in (advisory).
+    pub language_tags: BTreeSet<String>,
+    /// The ordered tools the lowered workflow runs (exact identity pairs).
+    pub tool_sequence: Vec<(ToolName, ToolVersion)>,
+    /// Advisory per-tool metadata (keyed by name — one entry per tool name).
+    pub tool_metadata: BTreeMap<ToolName, ToolMeta>,
+    /// The advisory ranking cut, basis points `0..=10_000` (never a float).
+    pub tolerance_threshold_bp: u16,
+}
+
+impl TaskBundle {
+    /// The content-addressed identity: `blake3(domain-tag ‖ canonical bincode)`.
+    ///
+    /// A computed method, not a stored field (the [`kx_catalog`-style]
+    /// `task_signature_hash` shape): a stored self-hash would be
+    /// self-referential and could silently drift from the bytes.
+    ///
+    /// [`kx_catalog`-style]: https://docs.rs/kx-catalog
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the canonical bincode encode of this struct is
+    /// infallible (no floats, no non-encodable types — the `MoteDef::hash`
+    /// precedent); the `expect` documents that invariant.
+    #[must_use]
+    pub fn fingerprint(&self) -> TaskBundleFingerprint {
+        #[allow(clippy::expect_used)] // SAFETY: no floats, no maps with non-Ord
+        // keys, no non-encodable types — canonical bincode of this struct is
+        // infallible (the MoteDef::hash precedent).
+        let bytes = bincode::serde::encode_to_vec(self, canonical_config())
+            .expect("TaskBundle serialization is infallible (no floats, no non-encodable types)");
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(FINGERPRINT_DOMAIN);
+        hasher.update(&bytes);
+        TaskBundleFingerprint(*hasher.finalize().as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bundle() -> TaskBundle {
+        let mut keywords = BTreeMap::new();
+        keywords.insert(
+            "en".to_string(),
+            ["echo", "repeat"]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        );
+        TaskBundle {
+            schema_version: TASK_BUNDLE_SCHEMA_VERSION,
+            intent: "echo the topic back".to_string(),
+            language_tags: ["en".to_string()].into_iter().collect(),
+            tool_sequence: vec![(
+                ToolName("mcp-echo".to_string()),
+                ToolVersion("1".to_string()),
+            )],
+            tool_metadata: BTreeMap::from([(
+                ToolName("mcp-echo".to_string()),
+                ToolMeta {
+                    description: "deterministic echo".to_string(),
+                    keywords,
+                },
+            )]),
+            tolerance_threshold_bp: 6_000,
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic_and_field_sensitive() {
+        let a = bundle();
+        let b = bundle();
+        assert_eq!(a.fingerprint(), b.fingerprint(), "same bytes, same hash");
+
+        let mut c = bundle();
+        c.intent.push('!');
+        assert_ne!(
+            a.fingerprint(),
+            c.fingerprint(),
+            "intent is identity-bearing"
+        );
+
+        let mut d = bundle();
+        d.tolerance_threshold_bp = 6_001;
+        assert_ne!(
+            a.fingerprint(),
+            d.fingerprint(),
+            "threshold is identity-bearing"
+        );
+    }
+
+    #[test]
+    fn insertion_order_cannot_move_the_fingerprint() {
+        // BTree collections canonicalize: build the metadata map in the
+        // opposite insertion order and the encoding must be byte-identical.
+        let mut x = bundle();
+        x.tool_metadata
+            .insert(ToolName("a-first".to_string()), ToolMeta::default());
+        let mut y = bundle();
+        let prior = y.tool_metadata.clone();
+        y.tool_metadata = BTreeMap::new();
+        y.tool_metadata
+            .insert(ToolName("a-first".to_string()), ToolMeta::default());
+        y.tool_metadata.extend(prior);
+        assert_eq!(x.fingerprint(), y.fingerprint());
+    }
+}

--- a/crates/kx-bundle/src/lib.rs
+++ b/crates/kx-bundle/src/lib.rs
@@ -1,0 +1,20 @@
+//! W1.A5 — the [`TaskBundle`] authoring shape (the MCP-intelligence foundation).
+//!
+//! A **`TaskBundle`** is the content-addressed template for a multi-tool task: an
+//! intent, an ordered tool sequence, per-tool advisory metadata, and an
+//! integer-scaled tolerance threshold. It is what a user (or, later, a model
+//! through the kx-mcp-gateway composer) authors; `kx-toolscout` LOWERS it to a
+//! [`WorkflowDef`](https://docs.rs/kx-workflow) behind the exact-equality
+//! `tool_grants` gate, and the **frozen** `kx_workflow::compile` derives the
+//! Mote DAG. The bundle itself is off-journal and off the identity path — Mote
+//! identity enters only through the lowered, compiled DAG.
+//!
+//! Kept as a thin TYPE crate (the `TaskSignature` precedent) so wave-3
+//! consumers (kx-mcp-gateway) can take the type without the toolscout
+//! machinery.
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod bundle;
+
+pub use bundle::{TaskBundle, TaskBundleFingerprint, ToolMeta, TASK_BUNDLE_SCHEMA_VERSION};

--- a/crates/kx-bundle/tests/fingerprint_golden.rs
+++ b/crates/kx-bundle/tests/fingerprint_golden.rs
@@ -1,0 +1,58 @@
+//! The pinned-hex fingerprint golden — the cross-machine byte-determinism
+//! oracle for [`TaskBundle`]'s canonical encoding (the I1.c discipline applied
+//! to the new type). If this hex moves, the encoding bytes moved: that is a
+//! `TASK_BUNDLE_SCHEMA_VERSION` bump + a deliberate, documented re-derive,
+//! never an accident.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::BTreeMap;
+
+use kx_bundle::{TaskBundle, ToolMeta, TASK_BUNDLE_SCHEMA_VERSION};
+use kx_mote::{ToolName, ToolVersion};
+
+fn golden_bundle() -> TaskBundle {
+    let mut keywords = BTreeMap::new();
+    keywords.insert(
+        "en".to_string(),
+        ["search", "web"].iter().map(|s| (*s).to_string()).collect(),
+    );
+    keywords.insert(
+        "hi".to_string(),
+        ["khoj"].iter().map(|s| (*s).to_string()).collect(),
+    );
+    TaskBundle {
+        schema_version: TASK_BUNDLE_SCHEMA_VERSION,
+        intent: "find and summarize the topic".to_string(),
+        language_tags: ["en".to_string(), "hi".to_string()].into_iter().collect(),
+        tool_sequence: vec![
+            (
+                ToolName("web-search".to_string()),
+                ToolVersion("2".to_string()),
+            ),
+            (
+                ToolName("summarize".to_string()),
+                ToolVersion("1".to_string()),
+            ),
+        ],
+        tool_metadata: BTreeMap::from([(
+            ToolName("web-search".to_string()),
+            ToolMeta {
+                description: "search the public web".to_string(),
+                keywords,
+            },
+        )]),
+        tolerance_threshold_bp: 7_500,
+    }
+}
+
+#[test]
+fn the_v1_fingerprint_is_pinned() {
+    let hex = golden_bundle().fingerprint().to_hex();
+    // Pinned at first derivation (schema v1). A change here is a deliberate
+    // schema bump, never drift.
+    assert_eq!(
+        hex, "5843eb09131d67033e705d59bd0bd8398ee29ffea69fd68580ce39ff1c73878c",
+        "TaskBundle v1 canonical encoding moved"
+    );
+}

--- a/crates/kx-toolscout/Cargo.toml
+++ b/crates/kx-toolscout/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name         = "kx-toolscout"
+version      = "0.1.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx ADVISORY tool discovery (W1.A5, the MCP-intelligence core) — multilingual ToolFingerprints, the exact-kw → Jaro-Winkler → embedding-cosine tolerance ladder (integer basis points, no floats persisted), a tool-manifest index over kx-dataset::RetrievalIndex, and TaskBundle → WorkflowDef lowering behind the planner-style EXACT (name, version) tool_grants gate. SN-8 by construction: scores ORDER and RETRIEVE, never AUTHORIZE — lowering takes no score input and the broker's exact-equality gate stays the sole authority. Pure leaf: never the journal, the gateway, or the frozen trio."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The TaskBundle authoring shape this crate ranks + lowers.
+kx-bundle   = { workspace = true }
+# ToolName/ToolVersion/LogicRef/ConfigKey/ConfigVal/EdgeMeta/PROMPT_KEY + the
+# canonical bincode config (fingerprint bytes).
+kx-mote     = { workspace = true }
+# WarrantSpec/ToolGrant — the authority set lowering is gated against.
+kx-warrant  = { workspace = true }
+# WorkflowDef/StepDef builders + the FROZEN compile (the structural gate).
+kx-workflow = { workspace = true }
+# RetrievalIndex/Hit — the SN-8-confined similarity seam the manifest index
+# composes (embedding rung 3).
+kx-dataset  = { workspace = true }
+# ContentRef — the fingerprint-hash key type shared with the retrieval index.
+kx-content  = { workspace = true }
+serde       = { workspace = true }
+bincode     = { workspace = true }
+blake3      = { workspace = true }
+thiserror   = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-toolscout/src/error.rs
+++ b/crates/kx-toolscout/src/error.rs
@@ -1,0 +1,28 @@
+//! The crate error — every refusal is loud and names what was refused.
+
+use kx_mote::{ToolName, ToolVersion};
+use kx_workflow::CompileError;
+
+/// Lowering / compilation failures. Fail-closed: an empty bundle or an
+/// ungranted tool refuses BEFORE any step is built.
+#[derive(Debug, thiserror::Error)]
+pub enum ToolScoutError {
+    /// The bundle's `tool_sequence` is empty — nothing to lower.
+    #[error("the task bundle names no tools (empty tool_sequence)")]
+    EmptyBundle,
+
+    /// A sequenced tool is not in the warrant's grant set. EXACT
+    /// `(name, version)` membership (SN-8) — a matching name with a different
+    /// version is just as refused as an unknown tool.
+    #[error("tool {name}@{version} is not granted by the warrant (exact-match refusal)", name = .name.0, version = .version.0)]
+    UngrantedTool {
+        /// The refused tool's name.
+        name: ToolName,
+        /// The refused tool's version.
+        version: ToolVersion,
+    },
+
+    /// The frozen structural gate rejected the lowered definition.
+    #[error("the lowered workflow failed to compile")]
+    Compile(#[from] CompileError),
+}

--- a/crates/kx-toolscout/src/fingerprint.rs
+++ b/crates/kx-toolscout/src/fingerprint.rs
@@ -1,0 +1,115 @@
+//! [`ToolFingerprint`] — the multilingual, content-addressed tool manifest the
+//! advisory index ranks against.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_content::ContentRef;
+use kx_mote::{canonical_config, ToolName, ToolVersion};
+use serde::{Deserialize, Serialize};
+
+/// Bump on any change to the encoding bytes of [`ToolFingerprint`].
+pub const TOOL_FINGERPRINT_SCHEMA_VERSION: u16 = 1;
+
+/// The blake3 domain tag for [`ToolFingerprint::fingerprint_hash`].
+const FINGERPRINT_DOMAIN: &[u8] = b"kx-toolscout/tool-fingerprint/v1";
+
+/// Normalize a keyword for matching: trim, ASCII-lowercase, collapse internal
+/// whitespace runs to one space.
+///
+/// Deliberately dependency-free: NO Unicode case folding / NFC normalization
+/// (that would be a new dependency for marginal gain at this tier) — so
+/// non-ASCII keywords (e.g. Hindi, Japanese) match by exact codepoints after
+/// whitespace collapse. Registrars store keywords pre-normalized in whatever
+/// form their language needs; this function is the single normal form both
+/// sides (registration + query) pass through, so they cannot drift.
+#[must_use]
+pub fn normalize_keyword(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut pending_space = false;
+    for c in s.trim().chars() {
+        if c.is_whitespace() {
+            pending_space = true;
+            continue;
+        }
+        if pending_space {
+            out.push(' ');
+            pending_space = false;
+        }
+        out.push(c.to_ascii_lowercase());
+    }
+    out
+}
+
+/// A tool's advisory manifest: identity + description + normalized intent
+/// keywords per language tag. Ranking material ONLY — the broker never reads
+/// this type (advisory-never-authorizes is structural: `kx-capability` has no
+/// dependency on this crate).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolFingerprint {
+    /// See [`TOOL_FINGERPRINT_SCHEMA_VERSION`] (encoded → identity-bearing).
+    pub schema_version: u16,
+    /// The tool's exact name (the grant-set identity half).
+    pub tool_id: ToolName,
+    /// The tool's exact version (the other identity half).
+    pub tool_version: ToolVersion,
+    /// A one-line human description (rung-2 fuzzy material).
+    pub description: String,
+    /// Normalized keywords per language tag (sorted, deduplicated). Store
+    /// values pre-passed through [`normalize_keyword`].
+    pub keywords: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl ToolFingerprint {
+    /// The content-addressed key this manifest indexes under —
+    /// `blake3(domain-tag ‖ canonical bincode)` as a [`ContentRef`], so it
+    /// slots straight into [`kx_dataset::RetrievalIndex`] (whose deterministic
+    /// tiebreak orders by ascending `ContentRef`).
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the canonical bincode encode of this struct is
+    /// infallible (no floats, no non-encodable types — the `MoteDef::hash`
+    /// precedent); the `expect` documents that invariant.
+    #[must_use]
+    pub fn fingerprint_hash(&self) -> ContentRef {
+        #[allow(clippy::expect_used)] // SAFETY: no floats, no non-encodable
+        // types — canonical bincode of this struct is infallible (the
+        // MoteDef::hash precedent).
+        let bytes = bincode::serde::encode_to_vec(self, canonical_config()).expect(
+            "ToolFingerprint serialization is infallible (no floats, no non-encodable types)",
+        );
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(FINGERPRINT_DOMAIN);
+        hasher.update(&bytes);
+        ContentRef::from_bytes(*hasher.finalize().as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_trims_lowercases_and_collapses() {
+        assert_eq!(normalize_keyword("  Web   Search "), "web search");
+        assert_eq!(normalize_keyword("ECHO"), "echo");
+        // Non-ASCII passes through by codepoint (documented limitation).
+        assert_eq!(normalize_keyword(" खोज "), "खोज");
+    }
+
+    #[test]
+    fn hash_is_deterministic_and_version_sensitive() {
+        let fp = ToolFingerprint {
+            schema_version: TOOL_FINGERPRINT_SCHEMA_VERSION,
+            tool_id: ToolName("mcp-echo".to_string()),
+            tool_version: ToolVersion("1".to_string()),
+            description: "echo".to_string(),
+            keywords: BTreeMap::new(),
+        };
+        assert_eq!(fp.fingerprint_hash(), fp.fingerprint_hash());
+
+        let mut v2 = fp.clone();
+        v2.tool_version = ToolVersion("2".to_string());
+        assert_ne!(fp.fingerprint_hash(), v2.fingerprint_hash());
+    }
+}

--- a/crates/kx-toolscout/src/index.rs
+++ b/crates/kx-toolscout/src/index.rs
@@ -1,0 +1,114 @@
+//! [`ToolManifestIndex`] — manifests + (optional) embedding vectors behind the
+//! SN-8-confined [`RetrievalIndex`] seam.
+//!
+//! The index RANKS; it never grants. Its output is `(ContentRef, score-bp)`
+//! pairs for a picker/preview surface — the score type never crosses into
+//! [`crate::lower_to_workflow_def`] (whose signature admits no score), and the
+//! committed world only ever sees exact identities.
+
+use std::collections::BTreeMap;
+
+use kx_bundle::TaskBundle;
+use kx_content::ContentRef;
+use kx_dataset::RetrievalIndex;
+
+use crate::fingerprint::ToolFingerprint;
+use crate::score::fingerprint_tolerance_score;
+
+/// A caller-supplied text-embedding function (the `FuzzyDiscovery` stance:
+/// embeddings are OPAQUE, caller-supplied vectors — this crate never computes
+/// or ships a model). Absent ⇒ the string rungs alone rank (neutral fallback).
+pub trait Embedder {
+    /// Embed `text` into the SAME vector space the index's vectors use.
+    fn embed(&self, text: &str) -> Vec<f32>;
+}
+
+/// The advisory tool-manifest index: fingerprints keyed by their content hash,
+/// with optional embedding vectors living in any [`RetrievalIndex`] backend
+/// (exact `InMemoryRetrievalIndex` for reproducible sets; the `hnsw` backend at
+/// scale — both already behind the seam).
+pub struct ToolManifestIndex<I: RetrievalIndex> {
+    vectors: I,
+    manifests: BTreeMap<ContentRef, ToolFingerprint>,
+}
+
+impl<I: RetrievalIndex> ToolManifestIndex<I> {
+    /// Wrap a vector backend (usually freshly constructed).
+    pub fn new(vectors: I) -> Self {
+        Self {
+            vectors,
+            manifests: BTreeMap::new(),
+        }
+    }
+
+    /// Register a manifest, optionally with a description-embedding vector.
+    /// Vectorless manifests still rank via the string rungs.
+    pub fn insert(&mut self, fp: ToolFingerprint, vector: Option<Vec<f32>>) {
+        let key = fp.fingerprint_hash();
+        if let Some(v) = vector {
+            self.vectors.insert(key, v);
+        }
+        self.manifests.insert(key, fp);
+    }
+
+    /// Number of registered manifests.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.manifests.len()
+    }
+
+    /// `true` when no manifest is registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.manifests.is_empty()
+    }
+
+    /// Look a manifest up by its content hash (e.g. to render a ranked hit).
+    #[must_use]
+    pub fn manifest(&self, key: &ContentRef) -> Option<&ToolFingerprint> {
+        self.manifests.get(key)
+    }
+
+    /// Rank every registered manifest against the bundle's intent, best
+    /// first, deterministically: score descending, then ascending
+    /// `ContentRef` (the same tiebreak as `InMemoryRetrievalIndex`). With an
+    /// embedder, rung 3 consults the vector backend for each manifest's
+    /// cosine; without one the string rungs alone decide.
+    ///
+    /// ADVISORY output: `(manifest key, score-bp)` for display/ordering only.
+    #[must_use]
+    pub fn rank(
+        &self,
+        bundle: &TaskBundle,
+        embedder: Option<&dyn Embedder>,
+        k: usize,
+    ) -> Vec<(ContentRef, u16)> {
+        // Resolve rung-3 cosines in ONE backend query (score desc by contract).
+        let cosines: BTreeMap<ContentRef, f32> = match embedder {
+            Some(e) => {
+                let query = e.embed(&bundle.intent);
+                self.vectors
+                    .query(&query, self.vectors.len())
+                    .into_iter()
+                    .map(|hit| (hit.id, hit.score))
+                    .collect()
+            }
+            None => BTreeMap::new(),
+        };
+
+        let mut scored: Vec<(ContentRef, u16)> = self
+            .manifests
+            .iter()
+            .map(|(key, fp)| {
+                let cos = cosines.get(key).copied();
+                (*key, fingerprint_tolerance_score(bundle, fp, cos))
+            })
+            .collect();
+        scored.sort_by(|a, b| {
+            b.1.cmp(&a.1)
+                .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
+        });
+        scored.truncate(k);
+        scored
+    }
+}

--- a/crates/kx-toolscout/src/jw.rs
+++ b/crates/kx-toolscout/src/jw.rs
@@ -1,0 +1,107 @@
+//! In-crate Jaro-Winkler similarity (the score ladder's rung 2).
+//!
+//! ~60 lines of pure, total code instead of a new external dependency
+//! (`strsim` is not in the tree; Golden Rule 6 weighs a dep against the
+//! surface it saves — here it saves none worth a deny/lockfile pass). The
+//! float exists only TRANSIENTLY inside the scorer: `score.rs` projects it to
+//! integer basis points with `floor` before anything compares or returns it.
+
+/// Jaro similarity over codepoint slices, in `[0, 1]`.
+#[allow(clippy::cast_precision_loss)] // string lengths ≪ 2^52 — exact in f64
+fn jaro(a: &[char], b: &[char]) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let window = (a.len().max(b.len()) / 2).saturating_sub(1);
+    let mut b_taken = vec![false; b.len()];
+    let mut matches: Vec<char> = Vec::new();
+
+    for (i, ca) in a.iter().enumerate() {
+        let lo = i.saturating_sub(window);
+        let hi = (i + window + 1).min(b.len());
+        for j in lo..hi {
+            if !b_taken[j] && b[j] == *ca {
+                b_taken[j] = true;
+                matches.push(*ca);
+                break;
+            }
+        }
+    }
+    if matches.is_empty() {
+        return 0.0;
+    }
+
+    // Transpositions: compare the match sequences from both sides.
+    let mut b_matches: Vec<char> = Vec::with_capacity(matches.len());
+    for (j, taken) in b_taken.iter().enumerate() {
+        if *taken {
+            b_matches.push(b[j]);
+        }
+    }
+    let transpositions = matches
+        .iter()
+        .zip(b_matches.iter())
+        .filter(|(x, y)| x != y)
+        .count();
+
+    let m = matches.len() as f64;
+    let t = (transpositions / 2) as f64;
+    (m / a.len() as f64 + m / b.len() as f64 + (m - t) / m) / 3.0
+}
+
+/// Jaro-Winkler similarity in `[0, 1]`: Jaro boosted by up to 4 chars of
+/// common prefix (the standard `p = 0.1` scaling).
+///
+/// **ADVISORY ONLY (SN-8).** A similarity score orders discovery candidates;
+/// it must NEVER be an authorization input — the exact-equality
+/// `tool_grants` gate in [`lower_to_workflow_def`](crate::lower_to_workflow_def)
+/// is the sole authority path.
+#[must_use]
+#[allow(clippy::cast_precision_loss)] // prefix ≤ 4 — exact in f64
+pub fn jaro_winkler(a: &str, b: &str) -> f64 {
+    let ac: Vec<char> = a.chars().collect();
+    let bc: Vec<char> = b.chars().collect();
+    let j = jaro(&ac, &bc);
+    let prefix = ac
+        .iter()
+        .zip(bc.iter())
+        .take(4)
+        .take_while(|(x, y)| x == y)
+        .count() as f64;
+    j + prefix * 0.1 * (1.0 - j)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The published reference vectors (Winkler 1990 / the strsim test set).
+    #[test]
+    fn published_vectors() {
+        let close = |x: f64, y: f64| (x - y).abs() < 1e-4;
+        assert!(close(jaro_winkler("MARTHA", "MARHTA"), 0.9611));
+        assert!(close(jaro_winkler("DIXON", "DICKSONX"), 0.8133));
+        assert!(close(jaro_winkler("identical", "identical"), 1.0));
+        assert!(close(jaro_winkler("abc", "xyz"), 0.0));
+        assert!(close(jaro_winkler("", ""), 1.0));
+        assert!(close(jaro_winkler("a", ""), 0.0));
+    }
+
+    #[test]
+    fn symmetric_and_bounded() {
+        let pairs = [
+            ("kortecx", "kortex"),
+            ("search", "résearch"),
+            ("खोज", "खोजना"),
+        ];
+        for (a, b) in pairs {
+            let ab = jaro_winkler(a, b);
+            let ba = jaro_winkler(b, a);
+            assert!((ab - ba).abs() < 1e-12, "symmetry for {a}/{b}");
+            assert!((0.0..=1.0).contains(&ab), "bounds for {a}/{b}");
+        }
+    }
+}

--- a/crates/kx-toolscout/src/lib.rs
+++ b/crates/kx-toolscout/src/lib.rs
@@ -1,0 +1,38 @@
+//! W1.A5 — advisory tool discovery + [`TaskBundle`](kx_bundle::TaskBundle)
+//! lowering (the MCP-intelligence core).
+//!
+//! **SN-8 boundary (load-bearing — the [`kx_dataset::RetrievalIndex`] note
+//! restated).** Everything in this crate that scores, ranks, or fuzzily
+//! matches is ADVISORY: it orders candidates for a picker/preview surface and
+//! nothing else. No score is ever an input to authority — [`lower_to_workflow_def`]
+//! takes a bundle and a warrant, refuses any tool outside `warrant.tool_grants`
+//! by EXACT `(name, version)` equality (the same gate as
+//! `kx-capability`'s broker precheck and `kx-toolcall`'s decode), and the
+//! lowered `WorkflowDef` goes through the **frozen** `kx_workflow::compile` +
+//! the normal admission/broker path. Similarity can surface a tool; it can
+//! never grant one.
+//!
+//! Module map (one concern per file): [`fingerprint`](ToolFingerprint) — the
+//! multilingual manifest shape; `jw` — the in-crate Jaro-Winkler (pure, no new
+//! dependency); [`score`](fingerprint_tolerance_score) — the exact-kw →
+//! Jaro-Winkler → embedding-cosine ladder in integer basis points;
+//! [`index`](ToolManifestIndex) — manifests + vectors behind
+//! `RetrievalIndex`; [`lower`](lower_to_workflow_def) — bundle → `WorkflowDef`
+//! → (convenience) the frozen compile.
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod error;
+mod fingerprint;
+mod jw;
+mod lower;
+mod score;
+
+mod index;
+
+pub use error::ToolScoutError;
+pub use fingerprint::{normalize_keyword, ToolFingerprint, TOOL_FINGERPRINT_SCHEMA_VERSION};
+pub use index::{Embedder, ToolManifestIndex};
+pub use jw::jaro_winkler;
+pub use lower::{compile_bundle, lower_to_workflow_def};
+pub use score::{fingerprint_tolerance_score, SCORE_MAX_BP};

--- a/crates/kx-toolscout/src/lower.rs
+++ b/crates/kx-toolscout/src/lower.rs
@@ -1,0 +1,138 @@
+//! [`lower_to_workflow_def`] — a [`TaskBundle`] becomes a [`WorkflowDef`],
+//! fail-closed, behind the exact-equality grant gate.
+//!
+//! Mirrors the two proven shapes: the per-tool step is the `react_tool_loop`
+//! act step (`kx_workflow::generator` + a singleton `tool_contract` —
+//! READ-ONLY-NONDET, `StageThenCommit`), and the refusal + seed discipline is
+//! `kx-planner`'s (IMP-5 exact `(name, version)` membership BEFORE any step is
+//! built; the seed derives from the committed bundle bytes, never a clock).
+//! Scores are structurally absent here — the function signature admits none
+//! (advisory-never-authorizes, SN-8).
+
+use std::collections::BTreeMap;
+
+use kx_bundle::TaskBundle;
+use kx_mote::{ConfigKey, ConfigVal, EdgeMeta, LogicRef, ModelId, PROMPT_KEY};
+use kx_warrant::{ToolGrant, WarrantSpec};
+use kx_workflow::{compile, generator, CompiledWorkflow, WorkflowDef};
+
+use crate::error::ToolScoutError;
+
+/// The blake3 domain tag for the per-step sentinel [`LogicRef`]s — disjoint
+/// from every gateway sentinel and every real logic hash by construction.
+const STEP_LOGIC_DOMAIN: &[u8] = b"kx-toolscout/step/v1";
+
+/// Derive step `i`'s sentinel logic ref: `blake3(domain ‖ fingerprint ‖ i)`.
+/// Distinct per (bundle, position) so two steps running the same tool at
+/// different positions keep distinct Mote identities.
+fn step_logic(fingerprint: &[u8; 32], i: u32) -> LogicRef {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(STEP_LOGIC_DOMAIN);
+    hasher.update(fingerprint);
+    hasher.update(&i.to_le_bytes());
+    LogicRef::from_bytes(*hasher.finalize().as_bytes())
+}
+
+/// Lower a bundle into a [`WorkflowDef`]: one generator step per sequenced
+/// tool (singleton `tool_contract`, the bundle's intent as the identity-bearing
+/// prompt config), chained by Data edges in sequence order.
+///
+/// **Why every step carries the FULL caller warrant** (a deliberate contrast
+/// with `kx-planner`'s per-role `intersect(parent, role)` narrowing, D75):
+/// this tier has no roles — a bundle is a flat tool chain under ONE intent,
+/// so there is no per-step role template to intersect against. The warrant
+/// passed in IS the executing authority the caller already holds: every
+/// sequenced tool is pre-checked against it here (below), each step's
+/// `tool_contract` is the SINGLETON for its own tool (so a step cannot
+/// propose a sibling's tool), and the broker re-verifies the grant at
+/// dispatch. Authority never widens; per-step narrowing arrives with the
+/// role-bearing composer tier (kx-mcp-gateway, wave 3).
+///
+/// # Errors
+///
+/// - [`ToolScoutError::EmptyBundle`] — nothing to lower.
+/// - [`ToolScoutError::UngrantedTool`] — a sequenced tool is not in
+///   `warrant.tool_grants` by EXACT `(name, version)` equality. Checked for
+///   the WHOLE sequence before any step is built (fail-closed; the
+///   `kx-capability` precheck and `kx-toolcall` decode apply the same gate at
+///   dispatch and decode — defense in depth, one semantics).
+/// - [`ToolScoutError::Compile`] — an edge declaration failed (the fixed
+///   chain shape never produces one; kept honest by propagation).
+pub fn lower_to_workflow_def(
+    bundle: &TaskBundle,
+    warrant: &WarrantSpec,
+    model_id: &ModelId,
+    capability: &kx_mote::ToolName,
+) -> Result<WorkflowDef, ToolScoutError> {
+    if bundle.tool_sequence.is_empty() {
+        return Err(ToolScoutError::EmptyBundle);
+    }
+
+    // The authority gate — before ANY step exists.
+    for (name, version) in &bundle.tool_sequence {
+        let grant = ToolGrant {
+            tool_id: name.clone(),
+            tool_version: version.clone(),
+        };
+        if !warrant.tool_grants.contains(&grant) {
+            return Err(ToolScoutError::UngrantedTool {
+                name: name.clone(),
+                version: version.clone(),
+            });
+        }
+    }
+
+    let fingerprint = bundle.fingerprint();
+    // Replay-stable seed from the bundle's content-addressed identity (the
+    // planner's `seed_from_plan_bytes` shape) — never a clock.
+    let seed = u32::from_le_bytes([
+        fingerprint.0[0],
+        fingerprint.0[1],
+        fingerprint.0[2],
+        fingerprint.0[3],
+    ]);
+
+    let mut wf = WorkflowDef::new(seed);
+    let mut prev = None;
+    for (i, (name, version)) in bundle.tool_sequence.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        // SAFETY: a tool sequence longer than u32::MAX is unrepresentable in
+        // practice (the bundle would not encode); positions stay exact.
+        let mut step = generator(
+            step_logic(&fingerprint.0, i as u32),
+            model_id.clone(),
+            warrant.clone(),
+            capability.clone(),
+        );
+        step.tool_contract = BTreeMap::from([(name.clone(), version.clone())]);
+        step.config_subset.insert(
+            ConfigKey(PROMPT_KEY.to_string()),
+            ConfigVal(bundle.intent.as_bytes().to_vec()),
+        );
+        let step_ref = wf.add_step(step);
+        if let Some(parent) = prev {
+            wf.add_edge(parent, step_ref, EdgeMeta::data())?;
+        }
+        prev = Some(step_ref);
+    }
+    Ok(wf)
+}
+
+/// [`lower_to_workflow_def`] then the **frozen** [`compile`] — the one-call
+/// path from a bundle to a registered Mote DAG (the planner `compile_plan`
+/// shape). `compile` derives every `MoteId`; nothing here hand-assigns
+/// identity.
+///
+/// # Errors
+///
+/// Everything [`lower_to_workflow_def`] refuses, plus [`ToolScoutError::Compile`]
+/// from the structural gate.
+pub fn compile_bundle(
+    bundle: &TaskBundle,
+    warrant: &WarrantSpec,
+    model_id: &ModelId,
+    capability: &kx_mote::ToolName,
+) -> Result<CompiledWorkflow, ToolScoutError> {
+    let wf = lower_to_workflow_def(bundle, warrant, model_id, capability)?;
+    Ok(compile(&wf)?)
+}

--- a/crates/kx-toolscout/src/score.rs
+++ b/crates/kx-toolscout/src/score.rs
@@ -1,0 +1,258 @@
+//! [`fingerprint_tolerance_score`] — the advisory ranking ladder.
+//!
+//! Three rungs, strictly ordered so a stronger signal always outranks a
+//! weaker one: exact normalized-keyword equality (10 000 bp, short-circuit) >
+//! Jaro-Winkler fuzz (capped 9 000 bp) > embedding cosine (capped 8 000 bp,
+//! only when the caller supplies an [`Embedder`](crate::Embedder) AND the
+//! manifest was indexed with a vector — the NEUTRAL fallback: no embedder, no
+//! rung, the string rungs alone decide). The result is `max(rungs)` in bp —
+//! floats exist only transiently inside this function (`floor` projection),
+//! so the value is deterministic across runs and SAFE to persist if a caller
+//! ever needs to (integer-scaled, the `kx-catalog` advisory-metadata
+//! discipline). SN-8: this number ORDERS a picker; it never authorizes.
+
+use kx_bundle::TaskBundle;
+
+use crate::fingerprint::{normalize_keyword, ToolFingerprint};
+use crate::jw::jaro_winkler;
+
+/// The ladder's ceiling: an exact keyword hit, in basis points.
+pub const SCORE_MAX_BP: u16 = 10_000;
+
+/// Rung 2's ceiling — strictly below rung 1 so fuzz never ties exactness.
+const JW_CAP_BP: f64 = 9_000.0;
+
+/// Rung 3's ceiling — strictly below rung 2 so opaque-vector similarity never
+/// outranks a string match the user can see and audit.
+const COSINE_CAP_BP: f64 = 8_000.0;
+
+/// The query keywords: the bundle's intent tokens plus every keyword AND
+/// per-tool description word from its own tool metadata, normalized,
+/// restricted to languages in `bundle.language_tags` (every language when the
+/// set is empty — the neutral multilingual fallback). Single tokens feed the
+/// pairwise rungs; MULTI-WORD manifest keywords are handled by the
+/// phrase-containment check in [`fingerprint_tolerance_score`] (a token list
+/// alone could never exact-match `"web search"`).
+fn query_keywords(bundle: &TaskBundle) -> Vec<String> {
+    let mut out: Vec<String> = bundle
+        .intent
+        .split_whitespace()
+        .map(normalize_keyword)
+        .collect();
+    for meta in bundle.tool_metadata.values() {
+        out.extend(meta.description.split_whitespace().map(normalize_keyword));
+        for (lang, words) in &meta.keywords {
+            if bundle.language_tags.is_empty() || bundle.language_tags.contains(lang) {
+                out.extend(words.iter().map(|w| normalize_keyword(w)));
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Word-boundary phrase containment: `true` iff the normalized `keyword`
+/// appears in `haystack_padded` (a normalized text pre-padded with one space
+/// on each side) as a whole word/phrase — `"web search"` hits inside
+/// `"run a web search now"`, while `"search"` can NOT hit inside
+/// `"researching"`.
+fn phrase_hit(haystack_padded: &str, keyword: &str) -> bool {
+    !keyword.is_empty() && haystack_padded.contains(&format!(" {keyword} "))
+}
+
+/// The fingerprint's candidate keywords, language-filtered the same way.
+fn manifest_keywords<'a>(bundle: &TaskBundle, fp: &'a ToolFingerprint) -> Vec<&'a str> {
+    let langs_intersect = fp
+        .keywords
+        .keys()
+        .any(|lang| bundle.language_tags.contains(lang));
+    fp.keywords
+        .iter()
+        .filter(|(lang, _)| !langs_intersect || bundle.language_tags.contains(*lang))
+        .flat_map(|(_, words)| words.iter().map(String::as_str))
+        .collect()
+}
+
+/// Score `fp` against the bundle's intent. See the module note for the ladder
+/// and the SN-8 contract. `embedding_cosine` is the rung-3 input the caller
+/// resolves — typically [`ToolManifestIndex::rank`](crate::ToolManifestIndex)
+/// querying the retrieval index; `None` is the neutral fallback.
+///
+/// **ADVISORY ONLY (SN-8).** This number orders a discovery/picker surface and
+/// nothing else — it must NEVER gate what runs or what is granted. The sole
+/// authorization gate is [`lower_to_workflow_def`](crate::lower_to_workflow_def)'s
+/// exact `(name, version)` `tool_grants` check (re-enforced by the broker at
+/// dispatch); that path takes no score input by construction.
+#[must_use]
+pub fn fingerprint_tolerance_score(
+    bundle: &TaskBundle,
+    fp: &ToolFingerprint,
+    embedding_cosine: Option<f32>,
+) -> u16 {
+    let query = query_keywords(bundle);
+    let candidates = manifest_keywords(bundle, fp);
+    // Word-boundary-padded normalized intent, so MULTI-WORD manifest keywords
+    // ("web search") can exact-hit rung 1 — token-vs-token alone never could.
+    let intent_padded = format!(" {} ", normalize_keyword(&bundle.intent));
+
+    // Rung 1 — exact normalized equality (token-vs-keyword OR the keyword as
+    // a whole phrase inside the intent): the ceiling, short-circuit.
+    for c in &candidates {
+        if phrase_hit(&intent_padded, c) || query.iter().any(|q| q == c) {
+            return SCORE_MAX_BP;
+        }
+    }
+
+    // Rung 2 — best pairwise Jaro-Winkler over keywords + the description.
+    let mut best_jw = 0.0f64;
+    for q in &query {
+        for c in &candidates {
+            let s = jaro_winkler(q, c);
+            if s > best_jw {
+                best_jw = s;
+            }
+        }
+        let s = jaro_winkler(q, &normalize_keyword(&fp.description));
+        if s > best_jw {
+            best_jw = s;
+        }
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    // SAFETY: best_jw ∈ [0,1] ⇒ the product ∈ [0, 9000] — in u16 range.
+    let jw_bp = (best_jw * JW_CAP_BP).floor() as u16;
+
+    // Rung 3 — embedding cosine, only when a vector similarity was resolved.
+    let cos_bp = match embedding_cosine {
+        Some(cos) => {
+            let unit = f64::midpoint(f64::from(cos.clamp(-1.0, 1.0)), 1.0);
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            // SAFETY: unit ∈ [0,1] ⇒ the product ∈ [0, 8000] — in u16 range.
+            let bp = (unit * COSINE_CAP_BP).floor() as u16;
+            bp
+        }
+        None => 0,
+    };
+
+    jw_bp.max(cos_bp)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use kx_bundle::{TaskBundle, ToolMeta, TASK_BUNDLE_SCHEMA_VERSION};
+    use kx_mote::{ToolName, ToolVersion};
+
+    use super::*;
+    use crate::fingerprint::TOOL_FINGERPRINT_SCHEMA_VERSION;
+
+    fn fp(keywords: &[(&str, &[&str])], description: &str) -> ToolFingerprint {
+        ToolFingerprint {
+            schema_version: TOOL_FINGERPRINT_SCHEMA_VERSION,
+            tool_id: ToolName("t".to_string()),
+            tool_version: ToolVersion("1".to_string()),
+            description: description.to_string(),
+            keywords: keywords
+                .iter()
+                .map(|(lang, words)| {
+                    (
+                        (*lang).to_string(),
+                        words
+                            .iter()
+                            .map(|w| (*w).to_string())
+                            .collect::<BTreeSet<_>>(),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn bundle(intent: &str, langs: &[&str]) -> TaskBundle {
+        TaskBundle {
+            schema_version: TASK_BUNDLE_SCHEMA_VERSION,
+            intent: intent.to_string(),
+            language_tags: langs.iter().map(|s| (*s).to_string()).collect(),
+            tool_sequence: vec![(ToolName("t".to_string()), ToolVersion("1".to_string()))],
+            tool_metadata: BTreeMap::from([(ToolName("t".to_string()), ToolMeta::default())]),
+            tolerance_threshold_bp: 5_000,
+        }
+    }
+
+    #[test]
+    fn a_multi_word_manifest_keyword_exact_hits_inside_the_intent() {
+        // The review-confirmed gap: token-vs-token alone could never match
+        // "web search" — the phrase-containment rung must.
+        let b = bundle("run a web search now", &["en"]);
+        let phrase = fp(&[("en", &["web search"])], "");
+        assert_eq!(fingerprint_tolerance_score(&b, &phrase, None), SCORE_MAX_BP);
+
+        // Word boundaries hold: "search" must NOT exact-hit inside
+        // "researching" (it may still fuzz on rung 2, strictly below).
+        let b2 = bundle("researching the topic", &["en"]);
+        let single = fp(&[("en", &["search"])], "");
+        assert!(fingerprint_tolerance_score(&b2, &single, None) < SCORE_MAX_BP);
+    }
+
+    #[test]
+    fn bundle_tool_meta_descriptions_feed_the_query() {
+        // The bundle's own per-tool description words are rung material too.
+        let mut b = bundle("zzz", &["en"]);
+        b.tool_metadata.insert(
+            ToolName("t".to_string()),
+            ToolMeta {
+                description: "deterministic echo helper".to_string(),
+                keywords: BTreeMap::new(),
+            },
+        );
+        let manifest = fp(&[("en", &["echo"])], "");
+        assert_eq!(
+            fingerprint_tolerance_score(&b, &manifest, None),
+            SCORE_MAX_BP
+        );
+    }
+
+    #[test]
+    fn the_rungs_are_strictly_ordered() {
+        let b = bundle("search the web", &["en"]);
+        let exact = fingerprint_tolerance_score(&b, &fp(&[("en", &["search"])], ""), None);
+        let fuzzy = fingerprint_tolerance_score(&b, &fp(&[("en", &["searches"])], ""), None);
+        let cosine_only =
+            fingerprint_tolerance_score(&b, &fp(&[("en", &["zzz"])], "zzz"), Some(0.95));
+        assert_eq!(exact, SCORE_MAX_BP);
+        assert!(fuzzy < exact, "jw ({fuzzy}) must stay below exact");
+        assert!(
+            cosine_only < fuzzy,
+            "cosine ({cosine_only}) must stay below a strong jw"
+        );
+        assert!(cosine_only > 0);
+    }
+
+    #[test]
+    fn no_embedder_is_a_neutral_fallback() {
+        let b = bundle("translate the document", &["en"]);
+        let manifest = fp(&[("en", &["zzz"])], "qqq");
+        let without = fingerprint_tolerance_score(&b, &manifest, None);
+        let with = fingerprint_tolerance_score(&b, &manifest, Some(0.9));
+        assert!(without < with, "the cosine rung only adds when resolved");
+    }
+
+    #[test]
+    fn language_intersection_filters_and_falls_back() {
+        // The bundle speaks hi; the manifest has en+hi → only hi keywords match.
+        let b = bundle("खोज", &["hi"]);
+        let manifest = fp(&[("en", &["search"]), ("hi", &["खोज"])], "");
+        assert_eq!(
+            fingerprint_tolerance_score(&b, &manifest, None),
+            SCORE_MAX_BP
+        );
+
+        // No language overlap at all → every manifest language is considered.
+        let b2 = bundle("search", &["fr"]);
+        let manifest2 = fp(&[("en", &["search"])], "");
+        assert_eq!(
+            fingerprint_tolerance_score(&b2, &manifest2, None),
+            SCORE_MAX_BP
+        );
+    }
+}

--- a/crates/kx-toolscout/tests/conformance.rs
+++ b/crates/kx-toolscout/tests/conformance.rs
@@ -1,0 +1,199 @@
+//! The W1.A5 conformance suite — the advisory-never-authorizes contract,
+//! pinned as tests:
+//!
+//! 1. An ungranted tool (unknown name OR right-name-wrong-version) refuses
+//!    LOWERING, before any step exists.
+//! 2. A fully-granted bundle lowers and passes the FROZEN compile, in
+//!    sequence order, each Mote carrying its singleton tool contract.
+//! 3. Lowering is deterministic — byte-identical `MoteId`s across runs (plus
+//!    a proptest sweep over arbitrary small bundles).
+//! 4. Scores STRUCTURALLY cannot reach lowering: two index states that rank
+//!    the same tools in OPPOSITE orders lower to byte-identical DAGs.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_bundle::{TaskBundle, TASK_BUNDLE_SCHEMA_VERSION};
+use kx_dataset::InMemoryRetrievalIndex;
+use kx_mote::{ModelId, ToolName, ToolVersion};
+use kx_toolscout::{
+    compile_bundle, lower_to_workflow_def, ToolFingerprint, ToolManifestIndex, ToolScoutError,
+    TOOL_FINGERPRINT_SCHEMA_VERSION,
+};
+use kx_warrant::ToolGrant;
+use kx_workflow::{compile, permissive_warrant};
+use proptest::prelude::*;
+
+fn model() -> ModelId {
+    ModelId("test-model".to_string())
+}
+
+fn capability() -> ToolName {
+    ToolName("model.generate".to_string())
+}
+
+fn tool(name: &str, version: &str) -> (ToolName, ToolVersion) {
+    (ToolName(name.to_string()), ToolVersion(version.to_string()))
+}
+
+/// A permissive warrant granting exactly `tools`.
+fn warrant_granting(tools: &[(ToolName, ToolVersion)]) -> kx_warrant::WarrantSpec {
+    let mut w = permissive_warrant(model());
+    w.tool_grants = tools
+        .iter()
+        .map(|(n, v)| ToolGrant {
+            tool_id: n.clone(),
+            tool_version: v.clone(),
+        })
+        .collect::<BTreeSet<_>>();
+    w
+}
+
+fn bundle_of(tools: Vec<(ToolName, ToolVersion)>, intent: &str) -> TaskBundle {
+    TaskBundle {
+        schema_version: TASK_BUNDLE_SCHEMA_VERSION,
+        intent: intent.to_string(),
+        language_tags: ["en".to_string()].into_iter().collect(),
+        tool_sequence: tools,
+        tool_metadata: BTreeMap::new(),
+        tolerance_threshold_bp: 5_000,
+    }
+}
+
+#[test]
+fn ungranted_tool_refuses_lowering() {
+    let granted = tool("web-search", "2");
+    let bundle = bundle_of(vec![granted.clone(), tool("exfiltrate", "1")], "find it");
+    let warrant = warrant_granting(&[granted]);
+
+    let err = lower_to_workflow_def(&bundle, &warrant, &model(), &capability()).unwrap_err();
+    assert!(
+        matches!(err, ToolScoutError::UngrantedTool { ref name, .. } if name.0 == "exfiltrate"),
+        "unknown tool must refuse: {err}"
+    );
+}
+
+#[test]
+fn right_name_wrong_version_is_just_as_refused() {
+    // SN-8: the grant is the exact (name, version) PAIR — a version drift is
+    // an ungranted tool, never a fuzzy match (the kx-toolcall pin, restated).
+    let bundle = bundle_of(vec![tool("web-search", "3")], "find it");
+    let warrant = warrant_granting(&[tool("web-search", "2")]);
+
+    let err = lower_to_workflow_def(&bundle, &warrant, &model(), &capability()).unwrap_err();
+    assert!(matches!(err, ToolScoutError::UngrantedTool { .. }), "{err}");
+}
+
+#[test]
+fn empty_bundle_refuses() {
+    let bundle = bundle_of(vec![], "do nothing");
+    let warrant = warrant_granting(&[]);
+    let err = lower_to_workflow_def(&bundle, &warrant, &model(), &capability()).unwrap_err();
+    assert!(matches!(err, ToolScoutError::EmptyBundle));
+}
+
+#[test]
+fn granted_bundle_lowers_and_compiles_in_sequence_order() {
+    let seq = vec![tool("web-search", "2"), tool("summarize", "1")];
+    let bundle = bundle_of(seq.clone(), "find and summarize");
+    let warrant = warrant_granting(&seq);
+
+    let compiled = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+    assert_eq!(compiled.motes.len(), 2);
+    // Topological (submission) order is the sequence order — and each Mote
+    // carries exactly its own singleton tool contract.
+    for (mote, (name, version)) in compiled.motes.iter().zip(seq.iter()) {
+        assert_eq!(
+            mote.mote.def.tool_contract,
+            BTreeMap::from([(name.clone(), version.clone())]),
+            "singleton contract per step"
+        );
+    }
+}
+
+#[test]
+fn lowering_is_deterministic() {
+    let seq = vec![tool("a", "1"), tool("b", "1"), tool("c", "2")];
+    let bundle = bundle_of(seq.clone(), "chain them");
+    let warrant = warrant_granting(&seq);
+
+    let one = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+    let two = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+    let ids =
+        |c: &kx_workflow::CompiledWorkflow| c.motes.iter().map(|m| m.mote.id).collect::<Vec<_>>();
+    assert_eq!(ids(&one), ids(&two), "byte-identical MoteIds across runs");
+}
+
+#[test]
+fn scores_never_reach_lowering() {
+    // Two manifest indexes ranking the SAME tools in OPPOSITE orders (one has
+    // an exact keyword hit, the other only fuzz) — the lowered DAG bytes must
+    // be IDENTICAL, because lowering's signature admits no score at all.
+    let seq = vec![tool("web-search", "2"), tool("summarize", "1")];
+    let bundle = bundle_of(seq.clone(), "search the web");
+    let warrant = warrant_granting(&seq);
+
+    let manifest = |name: &str, kw: &str| ToolFingerprint {
+        schema_version: TOOL_FINGERPRINT_SCHEMA_VERSION,
+        tool_id: ToolName(name.to_string()),
+        tool_version: ToolVersion("2".to_string()),
+        description: String::new(),
+        keywords: BTreeMap::from([(
+            "en".to_string(),
+            [kw.to_string()].into_iter().collect::<BTreeSet<_>>(),
+        )]),
+    };
+
+    let mut index_a = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    index_a.insert(manifest("web-search", "search"), None); // exact hit
+    index_a.insert(manifest("summarize", "zzz"), None);
+    let mut index_b = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    index_b.insert(manifest("web-search", "zzz"), None);
+    index_b.insert(manifest("summarize", "search"), None); // opposite winner
+
+    let rank_a = index_a.rank(&bundle, None, 2);
+    let rank_b = index_b.rank(&bundle, None, 2);
+    assert_ne!(
+        rank_a.first().map(|(_, s)| *s),
+        rank_b.iter().map(|(_, s)| *s).min(),
+        "the two indexes really do rank differently"
+    );
+
+    let one = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+    let two = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+    let ids =
+        |c: &kx_workflow::CompiledWorkflow| c.motes.iter().map(|m| m.mote.id).collect::<Vec<_>>();
+    assert_eq!(ids(&one), ids(&two), "ranking state cannot move identity");
+}
+
+proptest! {
+    /// Determinism sweep: ANY granted bundle (1..=6 distinct tools, arbitrary
+    /// short intents) lowers + compiles to the same MoteIds twice.
+    #[test]
+    fn any_granted_bundle_is_deterministic(
+        n in 1usize..=6,
+        intent in "[a-z ]{1,32}",
+    ) {
+        let seq: Vec<_> = (0..n).map(|i| tool(&format!("tool-{i}"), "1")).collect();
+        let bundle = bundle_of(seq.clone(), &intent);
+        let warrant = warrant_granting(&seq);
+
+        let one = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+        let two = compile_bundle(&bundle, &warrant, &model(), &capability()).unwrap();
+        let a: Vec<_> = one.motes.iter().map(|m| m.mote.id).collect();
+        let b: Vec<_> = two.motes.iter().map(|m| m.mote.id).collect();
+        prop_assert_eq!(a, b);
+    }
+}
+
+/// The frozen compile stays the structural gate: the lowered def passes the
+/// SAME `compile` everything else uses (no parallel compile path).
+#[test]
+fn the_lowered_def_passes_the_frozen_compile_directly() {
+    let seq = vec![tool("a", "1")];
+    let bundle = bundle_of(seq.clone(), "one step");
+    let warrant = warrant_granting(&seq);
+    let wf = lower_to_workflow_def(&bundle, &warrant, &model(), &capability()).unwrap();
+    compile(&wf).expect("the frozen structural gate admits the lowered def");
+}

--- a/crates/kx-toolscout/tests/gr10_spike.rs
+++ b/crates/kx-toolscout/tests/gr10_spike.rs
@@ -1,0 +1,129 @@
+//! GR10 — the measure-and-persist spike (run on demand, numbers → the PRIVATE
+//! `docs/benchmarks/` corpus):
+//!
+//! ```sh
+//! cargo test -p kx-toolscout --release --test gr10_spike -- --ignored --nocapture
+//! ```
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+use kx_bundle::{TaskBundle, TASK_BUNDLE_SCHEMA_VERSION};
+use kx_dataset::InMemoryRetrievalIndex;
+use kx_mote::{ModelId, ToolName, ToolVersion};
+use kx_toolscout::{
+    compile_bundle, Embedder, ToolFingerprint, ToolManifestIndex, TOOL_FINGERPRINT_SCHEMA_VERSION,
+};
+use kx_warrant::ToolGrant;
+use kx_workflow::permissive_warrant;
+
+struct HashEmbedder;
+impl Embedder for HashEmbedder {
+    fn embed(&self, text: &str) -> Vec<f32> {
+        // 32-dim deterministic direction from the blake3 bytes.
+        blake3::hash(text.as_bytes())
+            .as_bytes()
+            .iter()
+            .map(|b| f32::from(*b) / 255.0)
+            .collect()
+    }
+}
+
+#[test]
+#[ignore = "GR10 spike — run with --ignored --nocapture and persist the numbers"]
+fn rank_1k_fingerprints_and_lower_a_10_step_bundle() {
+    let embed = HashEmbedder;
+
+    // --- corpus: 1,000 manifests, 3 languages × 8 keywords each ---
+    let mut index = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    for i in 0..1_000u32 {
+        let mut keywords = BTreeMap::new();
+        for lang in ["en", "hi", "ja"] {
+            keywords.insert(
+                lang.to_string(),
+                (0..8)
+                    .map(|k| format!("{lang}-kw-{i}-{k}"))
+                    .collect::<BTreeSet<_>>(),
+            );
+        }
+        let fp = ToolFingerprint {
+            schema_version: TOOL_FINGERPRINT_SCHEMA_VERSION,
+            tool_id: ToolName(format!("tool-{i}")),
+            tool_version: ToolVersion("1".to_string()),
+            description: format!("synthetic tool number {i}"),
+            keywords,
+        };
+        let vector = embed.embed(&fp.description);
+        index.insert(fp, Some(vector));
+    }
+
+    let bundle = TaskBundle {
+        schema_version: TASK_BUNDLE_SCHEMA_VERSION,
+        intent: "find the synthetic tool that searches the web".to_string(),
+        language_tags: ["en".to_string()].into_iter().collect(),
+        tool_sequence: (0..10)
+            .map(|i| (ToolName(format!("tool-{i}")), ToolVersion("1".to_string())))
+            .collect(),
+        tool_metadata: BTreeMap::new(),
+        tolerance_threshold_bp: 5_000,
+    };
+
+    let t = Instant::now();
+    let without = index.rank(&bundle, None, 10);
+    let rank_string_only = t.elapsed();
+
+    let t = Instant::now();
+    let with = index.rank(&bundle, Some(&embed), 10);
+    let rank_with_embedding = t.elapsed();
+
+    // --- lower + compile a 10-step bundle ---
+    let mut warrant = permissive_warrant(ModelId("m".to_string()));
+    warrant.tool_grants = bundle
+        .tool_sequence
+        .iter()
+        .map(|(n, v)| ToolGrant {
+            tool_id: n.clone(),
+            tool_version: v.clone(),
+        })
+        .collect();
+
+    let t = Instant::now();
+    let one = compile_bundle(
+        &bundle,
+        &warrant,
+        &ModelId("m".to_string()),
+        &ToolName("model.generate".to_string()),
+    )
+    .unwrap();
+    let lower_compile = t.elapsed();
+    let two = compile_bundle(
+        &bundle,
+        &warrant,
+        &ModelId("m".to_string()),
+        &ToolName("model.generate".to_string()),
+    )
+    .unwrap();
+    let a: Vec<_> = one.motes.iter().map(|m| m.mote.id).collect();
+    let b: Vec<_> = two.motes.iter().map(|m| m.mote.id).collect();
+    assert_eq!(a, b, "spike doubles as a determinism oracle");
+
+    println!("GR10 kx-toolscout spike (1k manifests, 3 langs × 8 kw):");
+    println!(
+        "  rank k=10, string rungs only : {rank_string_only:?} (top {})",
+        without.len()
+    );
+    println!(
+        "  rank k=10, with 32-dim embed : {rank_with_embedding:?} (top {})",
+        with.len()
+    );
+    println!(
+        "  lower+compile 10-step bundle : {lower_compile:?} ({} motes)",
+        one.motes.len()
+    );
+}

--- a/crates/kx-toolscout/tests/multilingual.rs
+++ b/crates/kx-toolscout/tests/multilingual.rs
@@ -1,0 +1,162 @@
+//! Multilingual ranking — the ladder orders across languages and the
+//! threshold cut + deterministic tiebreak hold.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kx_bundle::{TaskBundle, ToolMeta, TASK_BUNDLE_SCHEMA_VERSION};
+use kx_dataset::InMemoryRetrievalIndex;
+use kx_mote::{ToolName, ToolVersion};
+use kx_toolscout::{
+    Embedder, ToolFingerprint, ToolManifestIndex, SCORE_MAX_BP, TOOL_FINGERPRINT_SCHEMA_VERSION,
+};
+
+fn manifest(name: &str, lang_keywords: &[(&str, &[&str])], description: &str) -> ToolFingerprint {
+    ToolFingerprint {
+        schema_version: TOOL_FINGERPRINT_SCHEMA_VERSION,
+        tool_id: ToolName(name.to_string()),
+        tool_version: ToolVersion("1".to_string()),
+        description: description.to_string(),
+        keywords: lang_keywords
+            .iter()
+            .map(|(lang, words)| {
+                (
+                    (*lang).to_string(),
+                    words
+                        .iter()
+                        .map(|w| (*w).to_string())
+                        .collect::<BTreeSet<_>>(),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn bundle(intent: &str, langs: &[&str], keywords: &[(&str, &[&str])]) -> TaskBundle {
+    TaskBundle {
+        schema_version: TASK_BUNDLE_SCHEMA_VERSION,
+        intent: intent.to_string(),
+        language_tags: langs.iter().map(|s| (*s).to_string()).collect(),
+        tool_sequence: vec![(ToolName("t".to_string()), ToolVersion("1".to_string()))],
+        tool_metadata: BTreeMap::from([(
+            ToolName("t".to_string()),
+            ToolMeta {
+                description: String::new(),
+                keywords: keywords
+                    .iter()
+                    .map(|(lang, words)| {
+                        (
+                            (*lang).to_string(),
+                            words
+                                .iter()
+                                .map(|w| (*w).to_string())
+                                .collect::<BTreeSet<_>>(),
+                        )
+                    })
+                    .collect(),
+            },
+        )]),
+        tolerance_threshold_bp: 6_000,
+    }
+}
+
+/// A toy deterministic embedder: a 4-dim bag-of-bytes direction. Enough to
+/// exercise the rung-3 path end-to-end without any model.
+struct ToyEmbedder;
+impl Embedder for ToyEmbedder {
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let mut v = [0.0f32; 4];
+        for (i, b) in text.bytes().enumerate() {
+            v[i % 4] += f32::from(b) / 255.0;
+        }
+        v.to_vec()
+    }
+}
+
+#[test]
+fn an_exact_hindi_hit_outranks_english_fuzz_and_cosine() {
+    // The bundle speaks Hindi; one manifest matches खोज exactly, one only
+    // fuzzes in English, one matches only by embedding.
+    let b = bundle("खोज", &["hi"], &[("hi", &[] as &[&str])]);
+
+    let exact_hi = manifest("exact-hi", &[("hi", &["खोज"])], "");
+    let fuzz_en = manifest("fuzz-en", &[("en", &["खोजना"])], "");
+    let cosine_only = manifest("cos-only", &[("en", &["zzz"])], "zzz");
+
+    let mut index = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    let embed = ToyEmbedder;
+    index.insert(exact_hi.clone(), Some(embed.embed("खोज")));
+    index.insert(fuzz_en.clone(), Some(embed.embed("totally different")));
+    index.insert(cosine_only.clone(), Some(embed.embed("खोज")));
+
+    let ranked = index.rank(&b, Some(&embed), 3);
+    assert_eq!(ranked.len(), 3);
+    assert_eq!(ranked[0].0, exact_hi.fingerprint_hash(), "exact wins");
+    assert_eq!(ranked[0].1, SCORE_MAX_BP);
+    // The खोज/खोजना fuzz beats the no-string cosine-only hit (rung order).
+    assert_eq!(ranked[1].0, fuzz_en.fingerprint_hash());
+    assert!(ranked[1].1 > ranked[2].1);
+}
+
+#[test]
+fn the_threshold_cut_is_callers_advisory_filter() {
+    let b = bundle("search the web", &["en"], &[]);
+    let strong = manifest("strong", &[("en", &["search"])], "");
+    let weak = manifest("weak", &[("en", &["zzz"])], "qqq");
+
+    let mut index = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    index.insert(strong, None);
+    index.insert(weak, None);
+
+    let ranked = index.rank(&b, None, 10);
+    let above: Vec<_> = ranked
+        .iter()
+        .filter(|(_, score)| *score >= b.tolerance_threshold_bp)
+        .collect();
+    assert_eq!(above.len(), 1, "only the strong hit passes the 6000bp cut");
+}
+
+#[test]
+fn equal_scores_tiebreak_by_ascending_content_ref() {
+    // Two manifests with the identical keyword set score identically — the
+    // order must still be deterministic (ascending ContentRef, the
+    // InMemoryRetrievalIndex tiebreak mirrored).
+    let b = bundle("echo", &["en"], &[]);
+    let one = manifest("one", &[("en", &["echo"])], "");
+    let two = manifest("two", &[("en", &["echo"])], "");
+
+    let mut index = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    index.insert(one.clone(), None);
+    index.insert(two.clone(), None);
+
+    let ranked = index.rank(&b, None, 2);
+    assert_eq!(ranked[0].1, ranked[1].1, "identical scores");
+    let mut expected = [one.fingerprint_hash(), two.fingerprint_hash()];
+    expected.sort_by(|a, c| a.as_bytes().cmp(c.as_bytes()));
+    assert_eq!(ranked[0].0, expected[0]);
+    assert_eq!(ranked[1].0, expected[1]);
+}
+
+#[test]
+fn embedderless_rank_equals_string_rungs_only() {
+    let b = bundle("summarize this", &["en"], &[]);
+    let m1 = manifest("m1", &[("en", &["summarize"])], "");
+    let m2 = manifest("m2", &[("en", &["summary"])], "");
+
+    let mut with_vectors = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    let embed = ToyEmbedder;
+    with_vectors.insert(m1.clone(), Some(embed.embed("noise one")));
+    with_vectors.insert(m2.clone(), Some(embed.embed("noise two")));
+
+    let mut without_vectors = ToolManifestIndex::new(InMemoryRetrievalIndex::new());
+    without_vectors.insert(m1, None);
+    without_vectors.insert(m2, None);
+
+    // No embedder passed ⇒ vectors are inert; the two indexes agree exactly.
+    assert_eq!(
+        with_vectors.rank(&b, None, 2),
+        without_vectors.rank(&b, None, 2),
+        "the neutral fallback ignores stored vectors"
+    );
+}


### PR DESCRIPTION
PR 3 of the Wave-1 sequence (#175 redesign core ✅ → #176 bundle pass ✅ → **this**) — the W1.A5 MCP-intelligence foundation. **Two new PURE Track-A crates: zero gateway/proto/server changes, frozen trio untouched, digest `7d22d4bd` invariant, zero new external dependencies** (Cargo.lock delta = exactly the two new workspace nodes; deny.toml unchanged; no dep_wall entry needed — pure leaf crates, no FFI/gateway edge).

## What

**`crates/kx-bundle`** — `TaskBundle`, the content-addressed multi-tool task template (intent · ordered `tool_sequence` · per-tool multilingual `ToolMeta` · integer-bp tolerance threshold). `fingerprint()` = `blake3("kx-bundle/task-bundle/v1" ‖ canonical bincode)` as a computed method (the `TaskSignature` shape), reusing `kx_mote::canonical_config` — ONE encoding discipline, all-BTree canonical order, **no floats anywhere**. A thin type crate so the wave-3 composer (kx-mcp-gateway) takes the type without the machinery. The v1 fingerprint hex is golden-pinned (cross-machine byte determinism).

**`crates/kx-toolscout`** — the advisory discovery core:
- `ToolFingerprint` — multilingual keyword manifests, content-addressed to a `ContentRef` (slots into `RetrievalIndex`'s deterministic ascending-ref tiebreak).
- In-crate **Jaro-Winkler** (~60 pure lines, golden-tested against the published MARTHA/MARHTA + DIXON/DICKSONX vectors) — no `strsim` dep.
- `fingerprint_tolerance_score` — the strictly-ordered ladder in **integer basis points**: exact normalized keyword (10 000, short-circuit; **word-boundary phrase containment** so `"web search"` exact-hits inside `"run a web search now"` while `"search"` cannot hit inside `"researching"`) > JW fuzz (cap 9 000) > embedding cosine (cap 8 000, only with a caller-supplied `Embedder` + an indexed vector; absent = the neutral fallback). Floats exist only transiently — SN-8's no-persisted-float-confidence by construction.
- `ToolManifestIndex<I: RetrievalIndex>` — manifests + optional vectors; `rank()` → `(ContentRef, bp)` sorted score-desc, ascending-ref tiebreak.
- `lower_to_workflow_def` — bundle → `WorkflowDef` behind the **fail-closed EXACT `(name, version)` `tool_grants` gate** (the planner-IMP-5 / kx-toolcall semantics, checked for the whole sequence BEFORE any step is built). Steps mirror the `react_tool_loop` act step (generator + singleton `tool_contract` + intent under `PROMPT_KEY`); seed = LE u32 of the bundle fingerprint; `compile_bundle` = lower + the **frozen** `kx_workflow::compile`. The full-caller-warrant-per-step choice is documented (no roles at this tier; deliberate contrast with the planner's `intersect(parent, role)`; broker re-verifies at dispatch).

## SN-8 — advisory-never-authorizes, structurally

`lower_to_workflow_def`'s signature admits no score; `rank()` output is display material; the broker exact-equality gate stays the sole authority (and `kx-capability` has no dependency on this crate). Pinned by the conformance suite: *scores-never-reach-lowering* proves two indexes ranking the same tools in OPPOSITE orders lower to byte-identical DAGs.

## Verification

- 24 tests: conformance (ungranted refuses incl. right-name-wrong-version · granted lowers+compiles in sequence order · deterministic MoteIds + proptest sweep · scores-never-reach-lowering · the frozen compile is the gate) + multilingual (exact-hi > fuzz-en > cosine-only · threshold cut · ascending-ref tiebreak · embedderless neutrality · multi-word phrase hits) + goldens (TaskBundle v1 hex · JW published vectors).
- A 7-agent 3-lens adversarial review (SN-8 authority / encoding-determinism / algorithm correctness, refutation-verified) — 4 confirmed findings, ALL fixed in this PR (the multi-word rung-1 gap + three doc/scoring-completeness items).
- Full `just ci` green locally (fmt, clippy `-D warnings`, tests, deny, doc, ffi-link, byte-determinism I1.c, scale-smoke).
- GR10 spike (release, Apple M3): rank 1k manifests (3 langs × 8 kw) k=10 ≈ **17–24 ms**; lower+compile a 10-step bundle ≈ **80 µs** (the spike doubles as a determinism oracle). Numbers persisted in the private benchmarks mirror.

## Rule 11 — interface impact

- UI section(s): none yet (declared) — the Tools/MCP + Blueprints picker surfaces arrive with the W2 toolscout RPCs per the taxonomy
- SDK module(s): none yet (no RPC exists for this layer)
- machine-experience: none (pure crates, consumed in-process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)