### PR TITLE
feat(ui): Monaco editors + richer DAG + Monitoring dashboard + reference-parity (Track A)

### DIFF
--- a/ui/e2e/artifact-codeviewer.spec.ts
+++ b/ui/e2e/artifact-codeviewer.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("artifacts: a committed output renders in the offline Monaco code viewer", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  await runRecipe(page, { handle: "kx/recipes/fanout-demo" });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).count(), {
+      timeout: 30_000,
+    })
+    .toBe(5);
+
+  await page.getByTestId("nav-artifacts").click();
+  await expect(page.getByTestId("artifacts-section")).toBeVisible();
+  await expect(page.getByTestId("artifact-gallery")).toBeVisible({ timeout: 30_000 });
+  const rows = page.locator(".artifact-list__row");
+  await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+  await rows.first().click();
+  await expect(page.getByTestId("artifact-view")).toBeVisible({ timeout: 30_000 });
+  // The read-only viewer is real Monaco (loaded from the SAME-ORIGIN bundle — no CDN,
+  // proving the offline self-hosting), carrying the decoded payload.
+  const viewer = page.getByTestId("artifact-view-body");
+  await expect(viewer).toBeVisible({ timeout: 30_000 });
+  await expect(viewer.locator(".monaco-editor")).toBeVisible({ timeout: 30_000 });
+});

--- a/ui/e2e/dag-node-drawer.spec.ts
+++ b/ui/e2e/dag-node-drawer.spec.ts
@@ -22,11 +22,18 @@ test("dag: clicking a Mote opens the detail drawer with its committed result", a
     .toBe(5);
 
   const nodes = page.getByTestId("mote-node");
-  const first = nodes.first();
-  // Capture a node bounding box before opening the drawer (no-thrash assertion).
-  const before = await first.boundingBox();
+  const clickTarget = nodes.first();
+  // The clicked node's reactflow translate transform — its LAYOUT position within the
+  // pane. This is immune to the entrance fitView's viewport pan AND to reactflow's
+  // on-click DOM reorder (read by the node's own element); it changes ONLY on a relayout.
+  const nodeTransform = (loc: typeof clickTarget) =>
+    loc.evaluate((el) => {
+      const node = el.closest(".react-flow__node");
+      return node ? getComputedStyle(node).transform : "";
+    });
+  const layoutBefore = await nodeTransform(clickTarget);
 
-  await first.click();
+  await clickTarget.click();
   const drawer = page.getByTestId("node-detail-drawer");
   await expect(drawer).toBeVisible({ timeout: 15_000 });
   // It shows the Mote's state + its committed result in the read-only Monaco viewer.
@@ -36,10 +43,9 @@ test("dag: clicking a Mote opens the detail drawer with its committed result", a
     timeout: 30_000,
   });
 
-  // The graph did NOT relayout: the same node sits at the same position.
-  const after = await first.boundingBox();
-  expect(Math.abs((after?.x ?? 0) - (before?.x ?? 0))).toBeLessThan(2);
-  expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(2);
+  // The graph did NOT relayout: the node's layout transform is byte-identical (a relayout
+  // would change its translate; a benign viewport pan/scrollbar leaves it untouched).
+  expect(await nodeTransform(clickTarget)).toBe(layoutBefore);
 
   // Escape closes the drawer.
   await page.keyboard.press("Escape");

--- a/ui/e2e/dag-node-drawer.spec.ts
+++ b/ui/e2e/dag-node-drawer.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("dag: clicking a Mote opens the detail drawer with its committed result", async ({ page }) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  await runRecipe(page, { handle: "kx/recipes/fanout-demo" });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).count(), {
+      timeout: 30_000,
+    })
+    .toBe(5);
+
+  const nodes = page.getByTestId("mote-node");
+  const first = nodes.first();
+  // Capture a node bounding box before opening the drawer (no-thrash assertion).
+  const before = await first.boundingBox();
+
+  await first.click();
+  const drawer = page.getByTestId("node-detail-drawer");
+  await expect(drawer).toBeVisible({ timeout: 15_000 });
+  // It shows the Mote's state + its committed result in the read-only Monaco viewer.
+  await expect(drawer.getByTestId("state-pill")).toBeVisible();
+  await expect(page.getByTestId("node-detail-result")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("node-detail-result").locator(".monaco-editor")).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // The graph did NOT relayout: the same node sits at the same position.
+  const after = await first.boundingBox();
+  expect(Math.abs((after?.x ?? 0) - (before?.x ?? 0))).toBeLessThan(2);
+  expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(2);
+
+  // Escape closes the drawer.
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeHidden({ timeout: 15_000 });
+});

--- a/ui/e2e/monitoring.spec.ts
+++ b/ui/e2e/monitoring.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("monitoring: the gateway-wide dashboard renders real telemetry", async ({ page }) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  // Run something first so there is at least one run to roll up.
+  await runRecipe(page, { handle: "kx/recipes/echo", fields: { topic: "monitor" } });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+
+  await page.getByTestId("nav-monitor").click();
+  await expect(page.getByTestId("monitoring-section")).toBeVisible({ timeout: 15_000 });
+
+  // Real numbers, not placeholders: the hero metric grid + a live gateway-health pill.
+  await expect(page.getByText("Runs", { exact: true }).first()).toBeVisible();
+  await expect(page.getByTestId("health-indicator")).toHaveText("LIVE");
+  // The Runs panel rolls up the just-run blueprint handle (real local+durable history).
+  await expect(page.getByText("kx/recipes/echo").first()).toBeVisible({ timeout: 15_000 });
+  // The self-correction / ReAct / capture panels render (data OR an honest empty/degrade
+  // note) — never a crash. At least one tally/empty note is present.
+  await expect(page.getByRole("heading", { name: "Self-correction" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "ReAct turns" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Action capture" })).toBeVisible();
+});

--- a/ui/e2e/shell-nav.spec.ts
+++ b/ui/e2e/shell-nav.spec.ts
@@ -31,6 +31,7 @@ test("the app shell navigates to every section (brand + favicon present)", async
     ["nav-systems", "systems-section", "Systems"],
     ["nav-settings", "settings-section", "Settings"],
     ["nav-activity", "activity-panel", "Activity"],
+    ["nav-monitor", "monitoring-section", "Monitoring"],
   ];
   for (const [nav, panel, crumb] of sections) {
     await page.getByTestId(nav).click();

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,11 +13,13 @@
         "@fontsource/geist-mono": "5.2.8",
         "@fontsource/geist-sans": "5.2.5",
         "@kortecx/sdk": "file:../bindings/typescript",
+        "@monaco-editor/react": "4.7.0",
         "@tanstack/react-query": "^5.59.0",
         "@tanstack/react-router": "^1.58.0",
         "@xyflow/react": "^12.11.0",
         "framer-motion": "^11.5.0",
         "lucide-react": "1.17.0",
+        "monaco-editor": "0.52.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1205,6 +1207,29 @@
     "node_modules/@kortecx/sdk": {
       "resolved": "../bindings/typescript",
       "link": true
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3479,6 +3504,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/motion-dom": {
       "version": "11.18.1",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
@@ -3930,6 +3962,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/std-env": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,11 +25,13 @@
     "@fontsource/geist-mono": "5.2.8",
     "@fontsource/geist-sans": "5.2.5",
     "@kortecx/sdk": "file:../bindings/typescript",
+    "@monaco-editor/react": "4.7.0",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-router": "^1.58.0",
     "@xyflow/react": "^12.11.0",
     "framer-motion": "^11.5.0",
     "lucide-react": "1.17.0",
+    "monaco-editor": "0.52.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/ui/src/components/activity/ActivityPanel.tsx
+++ b/ui/src/components/activity/ActivityPanel.tsx
@@ -3,6 +3,7 @@ import { useEventStream } from "../../kx/use-event-stream";
 import { useProjection } from "../../kx/use-projection";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
+import { HealthIndicator } from "../metrics/HealthIndicator";
 import { MetricsPanel } from "../metrics/MetricsPanel";
 import { ActivityFeed } from "./ActivityFeed";
 import { RunPicker } from "./RunPicker";
@@ -38,7 +39,19 @@ export function ActivityPanel({
 
   return (
     <section className="screen" data-testid="activity-panel">
-      <h1>Activity</h1>
+      <div className="dashboard-hero">
+        <div className="dashboard-hero__text">
+          <h1>Activity</h1>
+          <p className="muted">
+            Live run telemetry — pick a run to watch its Motes commit, scrub its history, and tail
+            its events.
+          </p>
+        </div>
+        <div className="dashboard-hero__aside">
+          <span className="dashboard-hero__label">Gateway</span>
+          <HealthIndicator />
+        </div>
+      </div>
       <RunPicker selected={instance} onSelect={onSelectInstance} />
       {instance == null ? (
         <EmptyState

--- a/ui/src/components/dag/MoteDag.tsx
+++ b/ui/src/components/dag/MoteDag.tsx
@@ -1,11 +1,20 @@
-import { Background, Controls, ReactFlow, ReactFlowProvider, useReactFlow } from "@xyflow/react";
-import { useEffect, useMemo } from "react";
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+} from "@xyflow/react";
+import { useEffect, useMemo, useState } from "react";
 import type { ProjectionVM } from "../../kx/use-projection";
 import { EmptyState } from "../EmptyState";
 import { MoteTable } from "../MoteTable";
 import { MoteNode } from "./MoteNode";
+import { NodeDetailDrawer } from "./NodeDetailDrawer";
 import { buildEdges, topologyHash } from "./dag-graph";
-import { buildFlowEdges, buildFlowNodes } from "./flow";
+import { buildFlowEdges, buildFlowNodes, miniMapColor } from "./flow";
+import type { MoteFlowNode } from "./flow";
 import { layoutGraph } from "./layout";
 
 /**
@@ -24,6 +33,10 @@ const nodeTypes = { mote: MoteNode };
 function DagFlow({ projection }: { projection: ProjectionVM }) {
   const motes = projection.motes;
   const topoHash = useMemo(() => topologyHash(motes), [motes]);
+  // The clicked Mote (drawer). Selection is for the DETAIL overlay only — reactflow's
+  // own `elementsSelectable` stays OFF, so this never perturbs nodes/edges/layout.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = selectedId ? (motes.find((mm) => mm.moteId === selectedId) ?? null) : null;
 
   // Relayout ONLY when the topology hash changes; a state-only poll reuses the
   // cached positions (the no-thrash invariant — see dag-graph.topologyHash).
@@ -58,21 +71,38 @@ function DagFlow({ projection }: { projection: ProjectionVM }) {
   }, [topoHash, fitView]);
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      nodeTypes={nodeTypes}
-      fitView
-      nodesDraggable={false}
-      nodesConnectable={false}
-      elementsSelectable={false}
-      proOptions={{ hideAttribution: true }}
-      minZoom={0.1}
-      maxZoom={1.5}
-    >
-      <Background gap={20} />
-      <Controls showInteractive={false} />
-    </ReactFlow>
+    <>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        onNodeClick={(_e, node: MoteFlowNode) => setSelectedId(node.id)}
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.1}
+        maxZoom={1.5}
+      >
+        <Background gap={20} />
+        <Controls showInteractive={false} />
+        <MiniMap
+          pannable
+          zoomable
+          nodeColor={(n) => miniMapColor((n.data as MoteFlowNode["data"]).mote.stateCode)}
+          nodeStrokeWidth={2}
+          className="dag-minimap"
+        />
+      </ReactFlow>
+      {selected ? (
+        <NodeDetailDrawer
+          mote={selected}
+          instanceId={projection.instanceId}
+          onClose={() => setSelectedId(null)}
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/ui/src/components/dag/MoteNode.tsx
+++ b/ui/src/components/dag/MoteNode.tsx
@@ -3,7 +3,7 @@ import type { NodeProps } from "@xyflow/react";
 import { m } from "framer-motion";
 import { memo } from "react";
 import { statePulse } from "../../app/motion";
-import { stateVisual } from "../../lib/colors";
+import { isTerminalState, stateVisual } from "../../lib/colors";
 import { shortHex } from "../../lib/format";
 import { AnomalyBadge } from "../AnomalyBadge";
 import { NdClassBadge } from "../NdClassBadge";
@@ -11,14 +11,17 @@ import { StatePill } from "../StatePill";
 import type { MoteFlowNode } from "./flow";
 
 /**
- * One Mote as a DAG node: id + state pill + nd_class badge (+ anomaly). Reuses
- * the table's visual vocabulary (`StatePill`/`NdClassBadge`/`stateVisual`) so the
- * two surfaces never diverge. A newly-mounted node (a dynamic shaper child) plays
- * the one-shot enter pulse; persistent nodes keep their instance (no re-pulse).
+ * One Mote as a DAG node, in the reference design language: a top accent bar + a
+ * status dot (pulsing while in-flight) + the short id, then the state/nd_class pills
+ * (+ anomaly). Reuses the table's visual vocabulary (`StatePill`/`NdClassBadge`/
+ * `stateVisual`) so the two surfaces never diverge. A newly-mounted node (a dynamic
+ * shaper child) plays the one-shot enter pulse; persistent nodes keep their instance.
+ * The whole card is clickable (reactflow `onNodeClick` opens the detail drawer).
  */
 function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
   const { mote } = data;
   const { tone } = stateVisual(mote.stateCode);
+  const inFlight = !isTerminalState(mote.stateCode);
   return (
     <m.div
       className={`dag-node dag-node--${tone}`}
@@ -30,9 +33,16 @@ function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
       transition={statePulse.transition}
       aria-label={`Mote ${shortHex(mote.moteId)}`}
     >
+      <span className="dag-node__accent" aria-hidden="true" />
       <Handle type="target" position={Position.Top} className="dag-handle" />
-      <div className="dag-node__id mono" title={mote.moteId}>
-        {shortHex(mote.moteId)}
+      <div className="dag-node__head">
+        <span
+          className={`dag-node__dot${inFlight ? " dag-node__dot--pulse" : ""}`}
+          aria-hidden="true"
+        />
+        <span className="dag-node__id mono" title={mote.moteId}>
+          {shortHex(mote.moteId)}
+        </span>
       </div>
       <div className="dag-node__row">
         <StatePill stateCode={mote.stateCode} />

--- a/ui/src/components/dag/NodeDetailDrawer.tsx
+++ b/ui/src/components/dag/NodeDetailDrawer.tsx
@@ -1,0 +1,145 @@
+/**
+ * The DAG node-detail drawer. Clicking a Mote in the live graph opens a right-side
+ * panel with that Mote's identity (id / state / nd_class / promotion / committed seq)
+ * and its committed result rendered READ-ONLY in the Monaco code viewer. Pure read
+ * surface — it reuses {@link useContent} (immutable, content-addressed) and the run's
+ * own `instanceId` (the ownership ticket), so it adds NO new RPC and NO new wire.
+ *
+ * It renders as a sibling OVERLAY of the ReactFlow canvas, so opening/closing never
+ * mutates the graph's nodes/edges/positions — the no-thrash layout invariant holds.
+ */
+
+import { m } from "framer-motion";
+import { useEffect } from "react";
+import { toUiError } from "../../kx/errors";
+import { useContent } from "../../kx/use-content";
+import type { MoteVM } from "../../kx/use-projection";
+import { promotionIsNotable, promotionLabel } from "../../lib/colors";
+import { formatSeq, shortHex } from "../../lib/format";
+import { AnomalyBadge } from "../AnomalyBadge";
+import { EmptyState } from "../EmptyState";
+import { ErrorNotice } from "../ErrorNotice";
+import { NdClassBadge } from "../NdClassBadge";
+import { StatePill } from "../StatePill";
+import { CodeViewer } from "../editor/CodeViewer";
+
+const slideIn = {
+  initial: { x: 24, opacity: 0 },
+  animate: { x: 0, opacity: 1 },
+  transition: { type: "spring", stiffness: 420, damping: 34 },
+} as const;
+
+export function NodeDetailDrawer({
+  mote,
+  instanceId,
+  onClose,
+}: {
+  mote: MoteVM;
+  instanceId: string;
+  onClose: () => void;
+}) {
+  // Close on Escape (a11y); re-bound per selected Mote.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="node-drawer__scrim"
+        aria-label="Close detail"
+        onClick={onClose}
+      />
+      <m.aside
+        className="node-drawer"
+        data-testid="node-detail-drawer"
+        data-mote={mote.moteId}
+        // biome-ignore lint/a11y/useSemanticElements: a native <dialog> can't ride framer-motion animations and would impose modal semantics; this is a non-modal side panel, dialog semantics declared via role+aria-label
+        role="dialog"
+        aria-label={`Mote ${shortHex(mote.moteId)} detail`}
+        initial={slideIn.initial}
+        animate={slideIn.animate}
+        transition={slideIn.transition}
+      >
+        <div className="node-drawer__head">
+          <code className="mono node-drawer__id" title={mote.moteId}>
+            {shortHex(mote.moteId)}
+          </code>
+          <button type="button" className="linkbtn" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <div className="node-drawer__badges">
+          <StatePill stateCode={mote.stateCode} />
+          <NdClassBadge ndClass={mote.ndClass} />
+          {promotionIsNotable(mote.promotion) ? (
+            <span className="badge" title="Promotion state">
+              {promotionLabel(mote.promotion)}
+            </span>
+          ) : null}
+        </div>
+        <AnomalyBadge anomaly={mote.anomaly} />
+
+        <dl className="node-drawer__meta">
+          <div>
+            <dt>Committed seq</dt>
+            <dd className="mono">{formatSeq(mote.committedSeq)}</dd>
+          </div>
+          <div>
+            <dt>Result ref</dt>
+            <dd className="mono" title={mote.resultRef ?? undefined}>
+              {mote.resultRef ? shortHex(mote.resultRef) : "—"}
+            </dd>
+          </div>
+          <div>
+            <dt>Parents</dt>
+            <dd className="mono">{mote.parents.length}</dd>
+          </div>
+        </dl>
+
+        <div className="node-drawer__result">
+          <span className="section-label">Committed result</span>
+          <NodeResult instanceId={instanceId} resultRef={mote.resultRef} />
+        </div>
+      </m.aside>
+    </>
+  );
+}
+
+/** The committed payload (via GetContent), or an honest "no result yet" for an
+ *  uncommitted Mote (the `useContent` query is disabled until a ref exists). */
+function NodeResult({ instanceId, resultRef }: { instanceId: string; resultRef: string | null }) {
+  const content = useContent(instanceId, resultRef ?? undefined);
+  if (!resultRef) {
+    return <EmptyState title="No committed result yet" detail="This Mote has not committed." />;
+  }
+  if (content.isLoading) {
+    return <EmptyState title="Loading result…" />;
+  }
+  if (content.error) {
+    return <ErrorNotice error={toUiError(content.error)} onRetry={() => void content.refetch()} />;
+  }
+  if (!content.data) {
+    return null;
+  }
+  if (content.data.kind === "empty") {
+    return <EmptyState title="Empty result" detail="This Mote committed no output." />;
+  }
+  return (
+    <CodeViewer
+      value={content.data.text}
+      language={content.data.kind === "json" ? "json" : "plaintext"}
+      testId="node-detail-result"
+      ariaLabel="Committed result"
+      height={Math.min(320, Math.max(96, content.data.text.split("\n").length * 19 + 24))}
+    />
+  );
+}

--- a/ui/src/components/dag/flow.ts
+++ b/ui/src/components/dag/flow.ts
@@ -6,9 +6,31 @@
 
 import type { Edge, Node } from "@xyflow/react";
 import type { MoteVM } from "../../kx/use-projection";
+import { stateVisual } from "../../lib/colors";
 import { buildEdges } from "./dag-graph";
 import { toRfEdge } from "./edges";
 import type { XY } from "./layout";
+
+/**
+ * Concrete hex per state tone for the MiniMap. The MiniMap paints SVG `fill`
+ * attributes, which (unlike CSS) do NOT resolve `var(--t-*)` — so this is the one
+ * place we mirror the `--t-*` light-theme values from `app.css`. Keep in sync.
+ */
+const TONE_UNKNOWN_HEX = "#4b5563";
+const TONE_HEX: Readonly<Record<string, string>> = {
+  pending: "#475569",
+  scheduled: "#b45309",
+  committed: "#047857",
+  failed: "#dc2626",
+  repudiated: "#c2410c",
+  inconsistent: "#7c3aed",
+  unknown: TONE_UNKNOWN_HEX,
+};
+
+/** MiniMap node fill for a Mote, keyed by its state tone (single source: `stateVisual`). */
+export function miniMapColor(stateCode: number): string {
+  return TONE_HEX[stateVisual(stateCode).tone] ?? TONE_UNKNOWN_HEX;
+}
 
 /** The data a `MoteNode` renders. The index signature satisfies reactflow's `Node<T>`. */
 export interface MoteNodeData {

--- a/ui/src/components/editor/CodeViewer.tsx
+++ b/ui/src/components/editor/CodeViewer.tsx
@@ -1,0 +1,39 @@
+/**
+ * A read-only, syntax-highlighted viewer backed by Monaco (offline, lazy). Used for
+ * committed artifact payloads, run results, and the DAG node-detail. Never executes
+ * or `innerHTML`s its input — Monaco renders the text as code. The language is
+ * inferred (json vs plaintext) unless the caller pins it. In jsdom it renders a
+ * `<pre data-testid>` so component tests assert the text content directly.
+ */
+
+import { type MonacoLanguage, inferLanguage } from "../../lib/monaco/infer-language";
+import { MonacoMount } from "./MonacoMount";
+
+export function CodeViewer({
+  value,
+  language,
+  height = 240,
+  testId,
+  ariaLabel = "Code viewer",
+}: {
+  value: string;
+  /** Pin the language; omit to infer json/plaintext from the value. */
+  language?: MonacoLanguage;
+  height?: number | string;
+  testId?: string;
+  ariaLabel?: string;
+}) {
+  const lang = language ?? inferLanguage(value);
+  return (
+    <div className="editor-surface editor-surface--view">
+      <MonacoMount
+        value={value}
+        language={lang}
+        readOnly
+        height={height}
+        testId={testId}
+        ariaLabel={ariaLabel}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/editor/JsonEditor.tsx
+++ b/ui/src/components/editor/JsonEditor.tsx
@@ -1,0 +1,39 @@
+/**
+ * An editable JSON control backed by Monaco (offline, lazy). A drop-in for the raw
+ * `<textarea>` JSON-args input — it owns ONLY the editing surface; validation stays
+ * in the parent's submit handler (the existing `JSON.parse` + `field-error` UX is
+ * unchanged). In jsdom it renders a `<textarea id data-testid>` so the manual-invoke
+ * tests keep driving it by the same handles.
+ */
+
+import { MonacoMount } from "./MonacoMount";
+
+export function JsonEditor({
+  id,
+  value,
+  onChange,
+  testId = "args",
+  ariaLabel = "Args (JSON object)",
+  height = 180,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  testId?: string;
+  ariaLabel?: string;
+  height?: number;
+}) {
+  return (
+    <div className="editor-surface editor-surface--edit">
+      <MonacoMount
+        id={id}
+        value={value}
+        language="json"
+        onChange={onChange}
+        testId={testId}
+        ariaLabel={ariaLabel}
+        height={height}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/editor/MonacoEditorImpl.tsx
+++ b/ui/src/components/editor/MonacoEditorImpl.tsx
@@ -1,0 +1,58 @@
+/**
+ * The REAL Monaco wrapper — the single module that imports the heavy editor graph
+ * (`@monaco-editor/react` + the offline `setup`). It is reached ONLY via
+ * `lazy(() => import("./MonacoEditorImpl"))` from {@link MonacoMount}, so Rollup
+ * emits it (and the worker chunks) as a LAZY chunk that never enters the eager
+ * bundle the size gate measures. Never import this module statically.
+ */
+
+import Editor from "@monaco-editor/react";
+import { KX_LIGHT, configureMonacoOnce } from "../../lib/monaco/setup";
+import type { EditorSurfaceProps } from "./editor-surface";
+
+// Point @monaco-editor/react at the bundled (offline) instance + theme before any
+// editor mounts. Module-top so it runs once when this lazy chunk first loads.
+configureMonacoOnce();
+
+const FIXED_OPTIONS = {
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  automaticLayout: true,
+  fontFamily: "var(--font-mono)",
+  fontSize: 13,
+  lineNumbersMinChars: 3,
+  folding: false,
+  renderLineHighlight: "line",
+  scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+  overviewRulerLanes: 0,
+  wordWrap: "on",
+  tabSize: 2,
+} as const;
+
+export default function MonacoEditorImpl({
+  value,
+  language,
+  readOnly = false,
+  onChange,
+  height = 220,
+  testId,
+  ariaLabel,
+}: EditorSurfaceProps) {
+  return (
+    <div className="monaco-host" data-testid={testId} aria-label={ariaLabel}>
+      <Editor
+        value={value}
+        language={language}
+        theme={KX_LIGHT}
+        height={height}
+        onChange={(v) => onChange?.(v ?? "")}
+        options={{
+          ...FIXED_OPTIONS,
+          readOnly,
+          domReadOnly: readOnly,
+          lineNumbers: readOnly ? "on" : "on",
+        }}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/editor/MonacoMount.tsx
+++ b/ui/src/components/editor/MonacoMount.tsx
@@ -1,0 +1,65 @@
+/**
+ * The lazy boundary for the Monaco editor + a headless fallback.
+ *
+ * Monaco needs Web Workers + a real layout, neither of which jsdom provides, and it
+ * is a multi-MB graph we must not pull into a test or the eager bundle. So:
+ *  - the real editor ({@link MonacoEditorImpl}) is imported only via `lazy()`, so it
+ *    is a lazy chunk;
+ *  - in a headless environment (jsdom — no `Worker`) we render a plain
+ *    `<textarea>`/`<pre>` directly and NEVER trigger the lazy import.
+ * The fallback keeps the same `value`/`onChange`/test-ids, so component tests drive a
+ * real, assertable control and the browser E2E exercises the real Monaco.
+ */
+
+import { Suspense, lazy } from "react";
+import type { EditorSurfaceProps } from "./editor-surface";
+
+const RealEditor = lazy(() => import("./MonacoEditorImpl"));
+
+/** No Web Worker ⇒ jsdom/SSR ⇒ render the plain fallback, never load Monaco. */
+function isHeadless(): boolean {
+  return typeof window === "undefined" || typeof Worker === "undefined";
+}
+
+function Fallback({
+  value,
+  readOnly,
+  onChange,
+  testId,
+  ariaLabel,
+  id,
+  height,
+}: EditorSurfaceProps) {
+  const style = { height: typeof height === "number" ? `${height}px` : height };
+  if (readOnly) {
+    return (
+      <pre className="editor-surface__fallback mono" data-testid={testId} aria-label={ariaLabel}>
+        {value}
+      </pre>
+    );
+  }
+  return (
+    <textarea
+      className="editor-surface__fallback mono"
+      id={id}
+      data-testid={testId}
+      aria-label={ariaLabel}
+      value={value}
+      style={style}
+      spellCheck={false}
+      autoComplete="off"
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  );
+}
+
+export function MonacoMount(props: EditorSurfaceProps) {
+  if (isHeadless()) {
+    return <Fallback {...props} />;
+  }
+  return (
+    <Suspense fallback={<Fallback {...props} />}>
+      <RealEditor {...props} />
+    </Suspense>
+  );
+}

--- a/ui/src/components/editor/editor-surface.ts
+++ b/ui/src/components/editor/editor-surface.ts
@@ -1,0 +1,25 @@
+/**
+ * The shared prop contract for every editor surface (the lazy {@link MonacoMount},
+ * the real {@link MonacoEditorImpl}, and the headless fallback). One concern: keep
+ * the boundary + the impl in lock-step without either importing the heavy graph.
+ */
+
+import type { MonacoLanguage } from "../../lib/monaco/infer-language";
+
+export interface EditorSurfaceProps {
+  /** The text shown (controlled — the parent owns the value). */
+  readonly value: string;
+  /** Monaco language id (we ship `json` + `plaintext` only). */
+  readonly language: MonacoLanguage;
+  /** Read-only viewer (no edits) vs an editable control. */
+  readonly readOnly?: boolean;
+  /** Edit callback (editable only). */
+  readonly onChange?: (value: string) => void;
+  /** CSS height (px number or any CSS length). */
+  readonly height?: number | string;
+  /** Stable test handle (preserved across the Monaco and fallback renders). */
+  readonly testId?: string;
+  readonly ariaLabel?: string;
+  /** DOM id forwarded to the editable fallback `<textarea>` (label association). */
+  readonly id?: string;
+}

--- a/ui/src/components/sections/ArtifactView.tsx
+++ b/ui/src/components/sections/ArtifactView.tsx
@@ -1,7 +1,10 @@
 import type { DecodedContent } from "../../lib/content-decode";
 import { EmptyState } from "../EmptyState";
+import { CodeViewer } from "../editor/CodeViewer";
 
-/** Render one decoded artifact blob (pretty JSON / text / bounded hex preview). */
+/** Render one decoded artifact blob (pretty JSON / text / bounded hex preview). A
+ *  syntax-highlighted, read-only Monaco viewer for non-empty payloads (offline +
+ *  lazy; jsdom degrades to a `<pre>` carrying the same test handle). */
 export function ArtifactView({ content }: { content: DecodedContent }) {
   return (
     <div className="artifact" data-testid="artifact-view" data-kind={content.kind}>
@@ -12,7 +15,13 @@ export function ArtifactView({ content }: { content: DecodedContent }) {
       {content.kind === "empty" ? (
         <EmptyState title="Empty artifact" detail="This committed Mote produced no output." />
       ) : (
-        <pre className="artifact__body">{content.text}</pre>
+        <CodeViewer
+          value={content.text}
+          language={content.kind === "json" ? "json" : "plaintext"}
+          testId="artifact-view-body"
+          ariaLabel="Artifact content"
+          height={Math.min(420, Math.max(120, content.text.split("\n").length * 19 + 24))}
+        />
       )}
     </div>
   );

--- a/ui/src/components/sections/MonitoringSection.tsx
+++ b/ui/src/components/sections/MonitoringSection.tsx
@@ -1,0 +1,214 @@
+/**
+ * Monitoring — the gateway-WIDE telemetry dashboard. Distinct from Activity (which is
+ * run-scoped): this folds cross-run signals the gateway already exposes — run counts,
+ * the self-correction trails (`ListReplanRounds` / `ListReactTurns`), the Morphic
+ * action-capture stream (`ListCaptureRecords`), and liveness. Pure renderer: every
+ * number comes from `lib/monitoring.ts` over the hooks; each panel degrades to an
+ * honest "not wired here" note when its RPC is unimplemented (never a hollow placeholder).
+ */
+
+import { m } from "framer-motion";
+import { fadeUp, stagger } from "../../app/motion";
+import { useCaptureRecords } from "../../kx/use-capture-records";
+import { useReactTurns } from "../../kx/use-react-turns";
+import { useReplanRounds } from "../../kx/use-replan-rounds";
+import { useRuns } from "../../kx/use-runs";
+import { shortHex } from "../../lib/format";
+import {
+  type Tally,
+  summarizeCaptures,
+  summarizeReact,
+  summarizeReplan,
+  summarizeRuns,
+  tallyRows,
+} from "../../lib/monitoring";
+import { GlowCard } from "../ds/GlowCard";
+import { HealthIndicator } from "../metrics/HealthIndicator";
+import { MetricCard } from "../metrics/MetricCard";
+
+function TallyList({ tally, empty }: { tally: Tally; empty: string }) {
+  const rows = tallyRows(tally);
+  if (rows.length === 0) {
+    return <p className="muted">{empty}</p>;
+  }
+  return (
+    <ul className="tally">
+      {rows.map(([label, count]) => (
+        <li className="tally__row" key={label}>
+          <span className="tally__label mono">{label}</span>
+          <span className="tally__count">{count}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** A panel header + body that shows a muted "not wired" note when its RPC is absent. */
+function Panel({
+  title,
+  hint,
+  notWired,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  notWired?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <GlowCard hover={false} className="monitor-panel" variants={fadeUp}>
+      <div className="monitor-panel__head">
+        <h2>{title}</h2>
+        {hint ? <span className="muted">{hint}</span> : null}
+      </div>
+      {notWired ? <p className="muted">Not wired on this gateway.</p> : children}
+    </GlowCard>
+  );
+}
+
+export function MonitoringSection() {
+  const runs = useRuns();
+  const replan = useReplanRounds();
+  const react = useReactTurns();
+  const capture = useCaptureRecords();
+
+  const runRollup = summarizeRuns(runs.runs);
+  const replanSummary = summarizeReplan(replan.rounds);
+  const reactSummary = summarizeReact(react.turns);
+  const captureSummary = summarizeCaptures(capture.records);
+
+  function refreshAll(): void {
+    runs.refresh();
+    void replan.refetch();
+    void react.refetch();
+    void capture.refetch();
+  }
+
+  return (
+    <section className="screen" data-testid="monitoring-section">
+      <div className="section-head">
+        <div>
+          <h1>Monitoring</h1>
+          <p className="muted">
+            Gateway-wide metrics, self-correction trails & the action-capture stream.
+          </p>
+        </div>
+        <button type="button" className="linkbtn" onClick={refreshAll}>
+          Refresh
+        </button>
+      </div>
+
+      <m.div className="metrics-grid" variants={stagger()} initial="hidden" animate="show">
+        <MetricCard label="Runs" value={runRollup.total} tone="committed" />
+        <MetricCard label="Re-plan rounds" value={replanSummary.total} tone="scheduled" />
+        <MetricCard label="ReAct turns" value={reactSummary.total} />
+        <MetricCard label="Tool calls" value={reactSummary.toolCalls} />
+        <MetricCard label="Captured actions" value={captureSummary.total} />
+      </m.div>
+
+      <m.div className="monitor-grid" variants={stagger()} initial="hidden" animate="show">
+        <Panel title="Runs" hint={`${runRollup.total} total`}>
+          <TallyList tally={runRollup.byHandle} empty="No runs recorded yet." />
+        </Panel>
+
+        <Panel
+          title="Self-correction"
+          hint={`${replanSummary.total} rounds · ${replanSummary.escalated} escalated`}
+          notWired={replan.notWired}
+        >
+          <p className="muted">
+            {replanSummary.failedStepCount} failed step
+            {replanSummary.failedStepCount === 1 ? "" : "s"} triggered re-plans.
+          </p>
+          <TallyList tally={replanSummary.byModel} empty="No re-plan rounds yet." />
+          {replan.rounds.length > 0 ? (
+            <table className="trail-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Shaper</th>
+                  <th>Model</th>
+                  <th>Escalated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {replan.rounds.slice(0, 8).map((r) => (
+                  <tr key={`${r.seq}-${r.round}`}>
+                    <td className="mono">{r.round}</td>
+                    <td className="mono">{shortHex(r.shaperMoteId)}</td>
+                    <td className="mono">{r.modelId || "—"}</td>
+                    <td>{r.escalated ? "⚠" : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </Panel>
+
+        <Panel
+          title="ReAct turns"
+          hint={`${reactSummary.toolCalls} tool calls`}
+          notWired={react.notWired}
+        >
+          <TallyList tally={reactSummary.byBranch} empty="No ReAct turns yet." />
+          {react.turns.length > 0 ? (
+            <table className="trail-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Branch</th>
+                  <th>Tool</th>
+                </tr>
+              </thead>
+              <tbody>
+                {react.turns.slice(0, 8).map((t) => (
+                  <tr key={`${t.seq}-${t.turn}`}>
+                    <td className="mono">{t.turn}</td>
+                    <td>{t.branch || "—"}</td>
+                    <td className="mono">{t.toolId ? `${t.toolId}@${t.toolVersion}` : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </Panel>
+
+        <Panel
+          title="Action capture"
+          hint={`${captureSummary.total} records`}
+          notWired={capture.notWired}
+        >
+          <TallyList tally={captureSummary.byNdClass} empty="No captured actions yet." />
+          {capture.records.length > 0 ? (
+            <table className="trail-table">
+              <thead>
+                <tr>
+                  <th>Mote</th>
+                  <th>Result</th>
+                  <th>nd_class</th>
+                  <th>seq</th>
+                </tr>
+              </thead>
+              <tbody>
+                {capture.records.slice(0, 10).map((r) => (
+                  <tr key={`${r.seq}-${r.moteId}`}>
+                    <td className="mono">{shortHex(r.moteId)}</td>
+                    <td className="mono">{shortHex(r.resultRef)}</td>
+                    <td className="mono">{r.ndClass || "—"}</td>
+                    <td className="mono">#{r.seq}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </Panel>
+
+        <Panel title="Gateway health">
+          <div className="monitor-health">
+            <HealthIndicator />
+          </div>
+        </Panel>
+      </m.div>
+    </section>
+  );
+}

--- a/ui/src/components/sections/RecipesSection.tsx
+++ b/ui/src/components/sections/RecipesSection.tsx
@@ -8,6 +8,7 @@ import { useRecipeForm, useRecipes } from "../../kx/use-recipes";
 import { useRuns } from "../../kx/use-runs";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
+import { JsonEditor } from "../editor/JsonEditor";
 import { RecipeForm } from "../recipes/RecipeForm";
 
 const FALLBACK_HANDLE = "kx/recipes/echo";
@@ -198,13 +199,7 @@ function ManualInvokeForm({
           autoComplete="off"
         />
         <label htmlFor="args">Args (JSON object)</label>
-        <textarea
-          id="args"
-          value={argsText}
-          onChange={(e) => setArgsText(e.target.value)}
-          rows={5}
-          spellCheck={false}
-        />
+        <JsonEditor id="args" value={argsText} onChange={setArgsText} />
         {argsError ? (
           <p className="field-error" role="alert">
             {argsError}

--- a/ui/src/components/shell/Icon.tsx
+++ b/ui/src/components/shell/Icon.tsx
@@ -9,6 +9,7 @@ import type { SVGProps } from "react";
 
 export type Glyph =
   | "activity"
+  | "monitor"
   | "chat"
   | "chevron-right"
   | "runs"
@@ -27,6 +28,7 @@ export type Glyph =
 // 24×24 viewBox, stroke = currentColor. Multi-subpath `d` is fine.
 const PATHS: Record<Glyph, string> = {
   activity: "M3 12h4l2 6 4-15 2 9h6",
+  monitor: "M3 3v18h18M8 16V9m4 7V5m4 11v-4",
   chat: "M4 5h16v11H9l-4 4v-4H4z",
   "chevron-right": "M9 6l6 6-6 6",
   runs: "M6 4v16l13-8z",

--- a/ui/src/components/shell/nav-model.ts
+++ b/ui/src/components/shell/nav-model.ts
@@ -9,6 +9,7 @@
 
 export type IconName =
   | "activity"
+  | "monitor"
   | "chat"
   | "runs"
   | "recipes"
@@ -25,6 +26,7 @@ export type IconName =
  */
 export type RoutePath =
   | "/activity"
+  | "/monitor"
   | "/chat"
   | "/runs"
   | "/recipes"
@@ -48,9 +50,9 @@ export interface NavSection {
 }
 
 /**
- * The seven operational sections plus the agentic Chat. Activity is the dashboard
- * landing (live feed + per-run metrics + time-travel). Datasets/Systems are present
- * as destinations now; their data viewers arrive in UI-2/UI-3 (forward-compatible).
+ * The operational sections plus the agentic Chat. Activity is the run-scoped landing
+ * (live feed + per-run metrics + time-travel); Monitoring is the gateway-wide
+ * dashboard (cross-run metrics + self-correction trails + the action-capture stream).
  */
 export const NAV_SECTIONS: readonly NavSection[] = [
   {
@@ -59,6 +61,13 @@ export const NAV_SECTIONS: readonly NavSection[] = [
     path: "/activity",
     icon: "activity",
     hint: "Live events, metrics & time-travel",
+  },
+  {
+    id: "monitor",
+    label: "Monitoring",
+    path: "/monitor",
+    icon: "monitor",
+    hint: "Gateway-wide metrics & self-correction trails",
   },
   { id: "chat", label: "Chat", path: "/chat", icon: "chat", hint: "Agentic chat over the runtime" },
   { id: "runs", label: "Runs", path: "/runs", icon: "runs", hint: "Run history (this session)" },
@@ -103,7 +112,7 @@ export const NAV_SECTIONS: readonly NavSection[] = [
 
 /**
  * Settings is pinned shell chrome (bottom-left of the sidebar), NOT a scroll
- * section — so it lives outside {@link NAV_SECTIONS} (whose eight ids are pinned
+ * section — so it lives outside {@link NAV_SECTIONS} (whose ids are pinned
  * by the nav-model unit test and iterated by the shell e2e).
  */
 export const SETTINGS_SECTION: NavSection = {

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -35,4 +35,13 @@ export const queryKeys = {
     ["kx", endpoint, "dataset-query", dataset, text, k] as const,
   /** Gateway liveness probe (endpoint-scoped). */
   health: (endpoint: string) => ["kx", endpoint, "health"] as const,
+  /** The re-plan-round trail (`ListReplanRounds`), scoped by page size. */
+  replanRounds: (endpoint: string, limit: number) =>
+    ["kx", endpoint, "replan-rounds", limit] as const,
+  /** The ReAct-turn trail (`ListReactTurns`); `instanceId` scopes to one run. */
+  reactTurns: (endpoint: string, instanceId: string | undefined, limit: number) =>
+    ["kx", endpoint, "react-turns", instanceId ?? "all", limit] as const,
+  /** The capture-record stream (`ListCaptureRecords`); `instanceId` scopes to one run. */
+  captureRecords: (endpoint: string, instanceId: string | undefined, limit: number) =>
+    ["kx", endpoint, "capture-records", instanceId ?? "all", limit] as const,
 };

--- a/ui/src/kx/use-capture-records.ts
+++ b/ui/src/kx/use-capture-records.ts
@@ -1,0 +1,33 @@
+/**
+ * The Morphic-capture stream hook (`ListCaptureRecords`) — the durable, join-key-only
+ * action exhaust of the serve path. Read-only, newest-first; optionally scoped to one
+ * run. Degrades to an empty list with `notWired` when the RPC is unwired.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { toUiError } from "./errors";
+import { queryKeys } from "./query-keys";
+
+export function useCaptureRecords(opts: { instanceId?: string; limit?: number } = {}) {
+  const { client, endpoint, status } = useConnection();
+  const limit = opts.limit ?? 100;
+  const instanceId = opts.instanceId;
+  const q = useQuery({
+    queryKey: queryKeys.captureRecords(endpoint, instanceId, limit),
+    enabled: status === "connected" && client !== null,
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.listCaptureRecords({ ...(instanceId ? { instanceId } : {}), limit });
+    },
+  });
+  return {
+    records: q.data?.records ?? [],
+    hasMore: q.data?.hasMore ?? false,
+    notWired: q.isError && toUiError(q.error).kind === "not-wired",
+    isLoading: q.isLoading,
+    refetch: q.refetch,
+  };
+}

--- a/ui/src/kx/use-react-turns.ts
+++ b/ui/src/kx/use-react-turns.ts
@@ -1,0 +1,33 @@
+/**
+ * The ReAct-turn history hook (`ListReactTurns`) — the durable Reason→Act→Observe
+ * trail of a gateway's live ReAct chains. Read-only, newest-first; optionally scoped
+ * to one run. Degrades to an empty list with `notWired` when the RPC is unwired.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { toUiError } from "./errors";
+import { queryKeys } from "./query-keys";
+
+export function useReactTurns(opts: { instanceId?: string; limit?: number } = {}) {
+  const { client, endpoint, status } = useConnection();
+  const limit = opts.limit ?? 100;
+  const instanceId = opts.instanceId;
+  const q = useQuery({
+    queryKey: queryKeys.reactTurns(endpoint, instanceId, limit),
+    enabled: status === "connected" && client !== null,
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.listReactTurns({ ...(instanceId ? { instanceId } : {}), limit });
+    },
+  });
+  return {
+    turns: q.data?.turns ?? [],
+    hasMore: q.data?.hasMore ?? false,
+    notWired: q.isError && toUiError(q.error).kind === "not-wired",
+    isLoading: q.isLoading,
+    refetch: q.refetch,
+  };
+}

--- a/ui/src/kx/use-replan-rounds.ts
+++ b/ui/src/kx/use-replan-rounds.ts
@@ -1,0 +1,31 @@
+/**
+ * The re-plan-round history hook (`ListReplanRounds`) — the durable trail of a
+ * gateway's model-driven re-plan loops. Read-only, newest-first. Degrades to an
+ * empty list with `notWired` when the gateway does not wire the RPC (older binary).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { toUiError } from "./errors";
+import { queryKeys } from "./query-keys";
+
+export function useReplanRounds(limit = 100) {
+  const { client, endpoint, status } = useConnection();
+  const q = useQuery({
+    queryKey: queryKeys.replanRounds(endpoint, limit),
+    enabled: status === "connected" && client !== null,
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.listReplanRounds({ limit });
+    },
+  });
+  return {
+    rounds: q.data?.rounds ?? [],
+    hasMore: q.data?.hasMore ?? false,
+    notWired: q.isError && toUiError(q.error).kind === "not-wired",
+    isLoading: q.isLoading,
+    refetch: q.refetch,
+  };
+}

--- a/ui/src/lib/monaco/infer-language.ts
+++ b/ui/src/lib/monaco/infer-language.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure language inference for the read-only code viewer. We only ever distinguish
+ * JSON from plaintext (the two languages the offline Monaco bundle ships — see
+ * `setup.ts`), so this stays a tiny, total, unit-testable function. An object/array
+ * that round-trips through `JSON.parse` is "json"; everything else is "plaintext".
+ * Mirrors `content-decode.ts`'s "only objects/arrays are JSON" rule.
+ */
+
+export type MonacoLanguage = "json" | "plaintext";
+
+export function inferLanguage(text: string): MonacoLanguage {
+  const trimmed = text.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+    return "plaintext";
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return parsed !== null && typeof parsed === "object" ? "json" : "plaintext";
+  } catch {
+    return "plaintext";
+  }
+}

--- a/ui/src/lib/monaco/setup.ts
+++ b/ui/src/lib/monaco/setup.ts
@@ -1,0 +1,70 @@
+/**
+ * Configure a SELF-HOSTED, OFFLINE Monaco singleton — the load-bearing switch for
+ * the embedded web console, which has no network at runtime.
+ *
+ * The default `@monaco-editor/react` loader fetches Monaco from the jsdelivr CDN.
+ * `loader.config({ monaco })` overrides that to use a LOCALLY-bundled instance, so
+ * `kx serve`'s zero-node console works with no egress. We import only the JSON
+ * language (+ its worker) and the base editor worker — plaintext needs no
+ * contribution — keeping the lazy chunk as small as Monaco allows.
+ *
+ * This module is imported ONLY from `MonacoEditorImpl.tsx`, which is itself reached
+ * only through `lazy(() => import("./MonacoEditorImpl"))`. So the whole Monaco graph
+ * (this file + the ESM editor + the `?worker` chunks) stays a LAZY chunk and never
+ * enters the eager modulepreload set the bundle-size gate measures.
+ */
+
+import { loader } from "@monaco-editor/react";
+// The tree-shakeable ESM API entry (NOT the `monaco-editor` barrel, which drags
+// every language). The JSON contribution adds the JSON language + diagnostics.
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import "monaco-editor/esm/vs/language/json/monaco.contribution";
+// `?worker` makes Vite emit each worker as its OWN hash-named chunk, loaded at
+// runtime by the editor — never a modulepreload, never in the eager set.
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+
+/** The console's light Monaco theme, mapped to the app's locked light tokens
+ *  (hard-coded hexes from `app.css` — reading CSS vars at define time is fragile). */
+const KX_LIGHT = "kx-light";
+
+let configured = false;
+
+/** Idempotent: wire the offline workers, point `@monaco-editor/react` at the bundled
+ *  instance, and register the `kx-light` theme. Safe to call from every editor mount. */
+export function configureMonacoOnce(): void {
+  if (configured) {
+    return;
+  }
+  configured = true;
+
+  // Monaco creates language services in Web Workers; without this it falls back to
+  // a (CDN) default. Same-origin `?worker` chunks keep it fully offline.
+  (self as unknown as { MonacoEnvironment: monaco.Environment }).MonacoEnvironment = {
+    getWorker(_workerId: string, label: string): Worker {
+      return label === "json" ? new JsonWorker() : new EditorWorker();
+    },
+  };
+
+  monaco.editor.defineTheme(KX_LIGHT, {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#ffffff",
+      "editor.foreground": "#0d0d0d",
+      "editorLineNumber.foreground": "#0d0d0d46",
+      "editorLineNumber.activeForeground": "#0d0d0dad",
+      "editor.selectionBackground": "#f0450022",
+      "editor.lineHighlightBackground": "#0d0d0d08",
+      "editorCursor.foreground": "#d83c00",
+      "editorIndentGuide.background1": "#0d0d0d14",
+      focusBorder: "#f04500",
+    },
+  });
+
+  // THE switch: use the bundled monaco, never the CDN.
+  loader.config({ monaco });
+}
+
+export { KX_LIGHT, monaco };

--- a/ui/src/lib/monitoring.ts
+++ b/ui/src/lib/monitoring.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure aggregations for the Monitoring view — gateway-WIDE telemetry derived only
+ * from data already on the wire (`ListRuns`, `ListReplanRounds`, `ListReactTurns`,
+ * `ListCaptureRecords`). No React, no I/O, no new RPC: every value is a deterministic
+ * function of the SDK view classes, so the whole module is unit-testable and the
+ * section stays a thin renderer (the `lib/metrics.ts` precedent).
+ */
+
+import type { CaptureRecord, ReactTurn, ReplanRound } from "@kortecx/sdk/web";
+import type { RunRecord } from "./recent-runs";
+
+/** A counter keyed by a string label (model id, branch, nd_class, handle). */
+export type Tally = Readonly<Record<string, number>>;
+
+function bump(into: Record<string, number>, key: string): void {
+  into[key] = (into[key] ?? 0) + 1;
+}
+
+export interface RunRollup {
+  readonly total: number;
+  /** Runs per invoked blueprint handle (unknown handle → "—"). */
+  readonly byHandle: Tally;
+}
+
+export function summarizeRuns(runs: readonly RunRecord[]): RunRollup {
+  const byHandle: Record<string, number> = {};
+  for (const r of runs) {
+    bump(byHandle, r.handle ?? "—");
+  }
+  return { total: runs.length, byHandle };
+}
+
+export interface ReplanSummary {
+  readonly total: number;
+  readonly escalated: number;
+  readonly failedStepCount: number;
+  readonly byModel: Tally;
+}
+
+export function summarizeReplan(rounds: readonly ReplanRound[]): ReplanSummary {
+  const byModel: Record<string, number> = {};
+  let escalated = 0;
+  let failedStepCount = 0;
+  for (const r of rounds) {
+    bump(byModel, r.modelId || "—");
+    if (r.escalated) {
+      escalated += 1;
+    }
+    failedStepCount += r.failedStepIds.length;
+  }
+  return { total: rounds.length, escalated, failedStepCount, byModel };
+}
+
+export interface ReactSummary {
+  readonly total: number;
+  /** Turns per settled branch (pending | answer | tool | dead_lettered). */
+  readonly byBranch: Tally;
+  readonly byModel: Tally;
+  /** Turns that fired a tool (branch === "tool"). */
+  readonly toolCalls: number;
+}
+
+export function summarizeReact(turns: readonly ReactTurn[]): ReactSummary {
+  const byBranch: Record<string, number> = {};
+  const byModel: Record<string, number> = {};
+  let toolCalls = 0;
+  for (const t of turns) {
+    bump(byBranch, t.branch || "—");
+    bump(byModel, t.modelId || "—");
+    if (t.branch === "tool") {
+      toolCalls += 1;
+    }
+  }
+  return { total: turns.length, byBranch, byModel, toolCalls };
+}
+
+export interface CaptureSummary {
+  readonly total: number;
+  readonly byNdClass: Tally;
+  readonly byBranch: Tally;
+}
+
+export function summarizeCaptures(records: readonly CaptureRecord[]): CaptureSummary {
+  const byNdClass: Record<string, number> = {};
+  const byBranch: Record<string, number> = {};
+  for (const r of records) {
+    bump(byNdClass, r.ndClass || "—");
+    bump(byBranch, r.reactBranch || "—");
+  }
+  return { total: records.length, byNdClass, byBranch };
+}
+
+/** Sort a tally into `[label, count]` rows, biggest first (stable for ties by label). */
+export function tallyRows(t: Tally): Array<readonly [string, number]> {
+  return Object.entries(t).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}

--- a/ui/src/router/router.tsx
+++ b/ui/src/router/router.tsx
@@ -6,6 +6,7 @@ import { chatRoute } from "./routes/chat";
 import { connectRoute } from "./routes/connect";
 import { datasetsRoute } from "./routes/datasets";
 import { indexRoute } from "./routes/index";
+import { monitorRoute } from "./routes/monitor";
 import { recipesRoute } from "./routes/recipes";
 import { runDetailRoute } from "./routes/run-detail";
 import { runsRoute } from "./routes/runs";
@@ -24,6 +25,7 @@ const routeTree = rootRoute.addChildren([
   artifactsRoute,
   datasetsRoute,
   toolsRoute,
+  monitorRoute,
   systemsRoute,
   settingsRoute,
 ]);

--- a/ui/src/router/routes/monitor.tsx
+++ b/ui/src/router/routes/monitor.tsx
@@ -1,0 +1,30 @@
+import { createRoute } from "@tanstack/react-router";
+import { Suspense, lazy } from "react";
+import { ConnectGate } from "../../components/ConnectGate";
+import { EmptyState } from "../../components/EmptyState";
+import { useConnection } from "../../kx/connection-context";
+import { rootRoute } from "./__root";
+
+const MonitoringSection = lazy(() =>
+  import("../../components/sections/MonitoringSection").then((m) => ({
+    default: m.MonitoringSection,
+  })),
+);
+
+function MonitorScreen() {
+  const { status } = useConnection();
+  if (status !== "connected") {
+    return <ConnectGate />;
+  }
+  return (
+    <Suspense fallback={<EmptyState title="Loading…" />}>
+      <MonitoringSection />
+    </Suspense>
+  );
+}
+
+export const monitorRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/monitor",
+  component: MonitorScreen,
+});

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1844,3 +1844,295 @@ select {
   margin: 0.3rem 0 0;
   font-size: 0.82rem;
 }
+
+/* ---- editor surfaces (Monaco + the headless fallback) ---- */
+.editor-surface {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--surface);
+}
+.editor-surface--edit {
+  margin: 0.25rem 0 0.6rem;
+}
+.editor-surface--view {
+  margin-top: 0.4rem;
+}
+.monaco-host {
+  width: 100%;
+}
+/* the jsdom/loading fallback shares the framed look so there's no layout jump */
+.editor-surface__fallback {
+  display: block;
+  width: 100%;
+  min-height: 120px;
+  margin: 0;
+  padding: 0.6rem 0.7rem;
+  border: 0;
+  resize: vertical;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--text-1);
+  background: var(--surface);
+  white-space: pre;
+  overflow: auto;
+}
+.editor-surface__fallback:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+/* ---- DAG node: reference accent bar + status dot ---- */
+.dag-node {
+  position: relative;
+}
+.dag-node--pending {
+  --node-tone: var(--t-pending);
+}
+.dag-node--scheduled {
+  --node-tone: var(--t-scheduled);
+}
+.dag-node--committed {
+  --node-tone: var(--t-committed);
+}
+.dag-node--failed {
+  --node-tone: var(--t-failed);
+}
+.dag-node--repudiated {
+  --node-tone: var(--t-repudiated);
+}
+.dag-node--inconsistent {
+  --node-tone: var(--t-inconsistent);
+}
+.dag-node--unknown {
+  --node-tone: var(--t-unknown);
+}
+.dag-node__accent {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  border-radius: 8px 8px 0 0;
+  background: var(--node-tone, var(--t-unknown));
+}
+.dag-node__head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.dag-node__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  flex: none;
+  background: var(--node-tone, var(--t-unknown));
+}
+.dag-node__dot--pulse {
+  animation: dag-dot-pulse 1.8s ease-in-out infinite;
+}
+@keyframes dag-dot-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.5);
+    opacity: 0.45;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dag-node__dot--pulse {
+    animation: none;
+  }
+}
+/* ---- DAG minimap (reference framing) ---- */
+.dag-minimap.react-flow__minimap {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+/* ---- DAG node-detail drawer (overlay; no layout thrash) ---- */
+.node-drawer__scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  padding: 0;
+  background: rgba(13, 13, 13, 0.04);
+  cursor: pointer;
+}
+.node-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(380px, 86%);
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  overflow: auto;
+  background: var(--surface);
+  border-left: 1px solid var(--border-md);
+  box-shadow: -8px 0 28px rgba(13, 13, 13, 0.1);
+}
+.node-drawer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+.node-drawer__id {
+  font-size: 0.95rem;
+}
+.node-drawer__badges {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.node-drawer__meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin: 0;
+}
+.node-drawer__meta dt {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+.node-drawer__meta dd {
+  margin: 0.1rem 0 0;
+  font-size: 0.85rem;
+}
+.node-drawer__result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+/* ---- section header (reference: title + subtitle + right-aligned actions) ---- */
+.section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+.section-head h1 {
+  margin-bottom: 0.15rem;
+}
+.section-head .muted {
+  margin: 0;
+}
+
+/* ---- dashboard hero band (Activity landing) ---- */
+.dashboard-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: radial-gradient(120% 140% at 0% 0%, var(--primary-dim), transparent 55%),
+    var(--surface);
+}
+.dashboard-hero__text h1 {
+  margin: 0 0 0.2rem;
+}
+.dashboard-hero__text .muted {
+  margin: 0;
+  max-width: 56ch;
+}
+.dashboard-hero__aside {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+}
+.dashboard-hero__label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+/* ---- Monitoring dashboard ---- */
+.monitor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+.monitor-panel {
+  padding: 0.85rem 1rem 0.95rem;
+}
+.monitor-panel__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.45rem;
+}
+.monitor-panel__head h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+.monitor-health {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.tally {
+  list-style: none;
+  margin: 0.2rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.tally__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.18rem 0;
+  border-bottom: 1px dashed var(--border);
+}
+.tally__label {
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+.tally__count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--text-2);
+}
+.trail-table {
+  width: 100%;
+  margin-top: 0.5rem;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+.trail-table th {
+  text-align: left;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  padding: 0.2rem 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+.trail-table td {
+  padding: 0.22rem 0.4rem;
+  border-bottom: 1px solid var(--border);
+  overflow-wrap: anywhere;
+}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -383,6 +383,7 @@ button:disabled {
 
 /* ---- live DAG ---- */
 .dag-canvas {
+  position: relative; /* containing block for the node-detail drawer + scrim overlay */
   height: 520px;
   margin-top: 0.75rem;
   border: 1px solid var(--border);

--- a/ui/test/component/CodeViewer.test.tsx
+++ b/ui/test/component/CodeViewer.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CodeViewer } from "../../src/components/editor/CodeViewer";
+
+// jsdom → the read-only `<pre>` fallback carrying the same test handle + content.
+describe("CodeViewer", () => {
+  it("renders a read-only <pre> with the content text", () => {
+    render(<CodeViewer value='{\n  "k": 1\n}' testId="cv" />);
+    const pre = screen.getByTestId("cv");
+    expect(pre.tagName).toBe("PRE");
+    expect(pre).toHaveTextContent('"k": 1');
+  });
+
+  it("renders plaintext values too", () => {
+    render(<CodeViewer value="hello world" testId="cv2" />);
+    expect(screen.getByTestId("cv2")).toHaveTextContent("hello world");
+  });
+});

--- a/ui/test/component/JsonEditor.test.tsx
+++ b/ui/test/component/JsonEditor.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { JsonEditor } from "../../src/components/editor/JsonEditor";
+
+// jsdom has no Worker → MonacoMount renders the textarea fallback (the real editor
+// is browser-only, exercised by the e2e). The fallback keeps the `args` id/testid.
+describe("JsonEditor", () => {
+  it("renders the fallback textarea with the `args` handles", () => {
+    render(<JsonEditor id="args" value='{"a":1}' onChange={() => {}} />);
+    const ta = screen.getByTestId("args");
+    expect(ta.tagName).toBe("TEXTAREA");
+    expect(ta).toHaveAttribute("id", "args");
+    expect(ta).toHaveValue('{"a":1}');
+  });
+
+  it("forwards edits via onChange (validation stays in the parent)", () => {
+    const onChange = vi.fn();
+    render(<JsonEditor id="args" value="" onChange={onChange} />);
+    fireEvent.change(screen.getByTestId("args"), { target: { value: "{}" } });
+    expect(onChange).toHaveBeenCalledWith("{}");
+  });
+});

--- a/ui/test/component/MonitoringSection.test.tsx
+++ b/ui/test/component/MonitoringSection.test.tsx
@@ -1,0 +1,37 @@
+import { ReplanRound } from "@kortecx/sdk/web";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MonitoringSection } from "../../src/components/sections/MonitoringSection";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+/** A typed-as-unimplemented throw (errors.ts duck-types `.code` → "not-wired"). */
+function unimplemented(): never {
+  throw Object.assign(new Error("not wired"), { code: "unimplemented" });
+}
+
+describe("MonitoringSection", () => {
+  it("renders real aggregated numbers from the gateway RPCs", async () => {
+    const mock = makeMockClient({
+      listRuns: async () => ({
+        runs: [{ instanceId: "i1", recipeFingerprint: "f", registeredUnixMs: 1 }],
+        hasMore: false,
+      }),
+      listReplanRounds: async () => ({
+        rounds: [new ReplanRound(0, "aabbcc", "qwen3", ["s1"], false, 9)],
+        hasMore: false,
+      }),
+    });
+    render(<MonitoringSection />, { wrapper: connectedWrapper(mock.client) });
+    expect(screen.getByTestId("monitoring-section")).toBeInTheDocument();
+    // The replan model rolls up into a real tally row + a trail-table row (not a
+    // placeholder) — both surface the resolved model id.
+    await waitFor(() => expect(screen.getAllByText("qwen3").length).toBeGreaterThan(0));
+  });
+
+  it("degrades an unimplemented RPC to a muted 'not wired' note", async () => {
+    const mock = makeMockClient({ listReplanRounds: async () => unimplemented() });
+    render(<MonitoringSection />, { wrapper: connectedWrapper(mock.client) });
+    await waitFor(() => expect(screen.getByText(/Not wired on this gateway/i)).toBeInTheDocument());
+  });
+});

--- a/ui/test/component/NodeDetailDrawer.test.tsx
+++ b/ui/test/component/NodeDetailDrawer.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NodeDetailDrawer } from "../../src/components/dag/NodeDetailDrawer";
+import type { MoteVM } from "../../src/kx/use-projection";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+const INSTANCE = "c".repeat(32);
+
+const committed: MoteVM = {
+  moteId: "a".repeat(64),
+  stateCode: 3, // COMMITTED
+  ndClass: 1, // PURE
+  promotion: 1,
+  resultRef: "b".repeat(64),
+  committedSeq: 12,
+  anomaly: null,
+  parents: [],
+};
+
+describe("NodeDetailDrawer", () => {
+  it("shows the Mote identity + the committed result via GetContent", async () => {
+    const payload = new TextEncoder().encode('{"ok":true}');
+    const mock = makeMockClient({ getContent: async () => payload });
+    render(<NodeDetailDrawer mote={committed} instanceId={INSTANCE} onClose={() => {}} />, {
+      wrapper: connectedWrapper(mock.client),
+    });
+    expect(screen.getByTestId("node-detail-drawer")).toBeInTheDocument();
+    expect(screen.getByTestId("state-pill")).toHaveTextContent("COMMITTED");
+    await waitFor(() =>
+      expect(screen.getByTestId("node-detail-result")).toHaveTextContent('"ok": true'),
+    );
+    expect(mock.getContent).toHaveBeenCalled();
+  });
+
+  it("an uncommitted Mote shows 'No committed result yet' (no GetContent call)", () => {
+    const mock = makeMockClient();
+    const pending: MoteVM = { ...committed, stateCode: 1, resultRef: null, committedSeq: null };
+    render(<NodeDetailDrawer mote={pending} instanceId={INSTANCE} onClose={() => {}} />, {
+      wrapper: connectedWrapper(mock.client),
+    });
+    expect(screen.getByText(/No committed result yet/i)).toBeInTheDocument();
+    expect(mock.getContent).not.toHaveBeenCalled();
+  });
+});

--- a/ui/test/component/dag/MoteDag.test.tsx
+++ b/ui/test/component/dag/MoteDag.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@xyflow/react", () => ({
   ReactFlowProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   Background: () => null,
   Controls: () => null,
+  MiniMap: () => null,
   useReactFlow: () => ({ fitView: () => {} }),
   Handle: () => null,
   Position: { Top: "top", Bottom: "bottom" },

--- a/ui/test/mocks/kx-client.ts
+++ b/ui/test/mocks/kx-client.ts
@@ -17,6 +17,9 @@ export interface MockClientImpl {
   listTeams?: (...args: unknown[]) => Promise<unknown>;
   listTeamMembers?: (...args: unknown[]) => Promise<unknown>;
   listAssetGrants?: (...args: unknown[]) => Promise<unknown>;
+  listReplanRounds?: (...args: unknown[]) => Promise<unknown>;
+  listReactTurns?: (...args: unknown[]) => Promise<unknown>;
+  listCaptureRecords?: (...args: unknown[]) => Promise<unknown>;
 }
 
 export function makeMockClient(impl: MockClientImpl = {}) {
@@ -53,6 +56,15 @@ export function makeMockClient(impl: MockClientImpl = {}) {
   const listTeams = vi.fn(impl.listTeams ?? (async () => []));
   const listTeamMembers = vi.fn(impl.listTeamMembers ?? (async () => ({ owner: "", members: [] })));
   const listAssetGrants = vi.fn(impl.listAssetGrants ?? (async () => ({ owner: "", grants: [] })));
+  const listReplanRounds = vi.fn(
+    impl.listReplanRounds ?? (async () => ({ rounds: [], hasMore: false })),
+  );
+  const listReactTurns = vi.fn(
+    impl.listReactTurns ?? (async () => ({ turns: [], hasMore: false })),
+  );
+  const listCaptureRecords = vi.fn(
+    impl.listCaptureRecords ?? (async () => ({ records: [], hasMore: false })),
+  );
   const close = vi.fn();
   const client = {
     listSignatures,
@@ -67,6 +79,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listTeams,
     listTeamMembers,
     listAssetGrants,
+    listReplanRounds,
+    listReactTurns,
+    listCaptureRecords,
     close,
     submitRun: vi.fn(),
     registerSignature: vi.fn(),
@@ -87,6 +102,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listTeams,
     listTeamMembers,
     listAssetGrants,
+    listReplanRounds,
+    listReactTurns,
+    listCaptureRecords,
     close,
   };
 }

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -56,6 +56,20 @@ vi.mock("framer-motion", () => {
   };
 });
 
+// Belt-and-suspenders: jsdom has no `Worker`, so `MonacoMount` renders its plain
+// `<textarea>`/`<pre>` fallback and NEVER lazy-loads the multi-MB Monaco graph. This
+// stub guarantees that even if a test env ever exposed `Worker`, importing
+// `@monaco-editor/react` resolves to a light textarea instead of the real editor.
+vi.mock("@monaco-editor/react", () => ({
+  default: (props: { value?: string; onChange?: (v: string) => void }) =>
+    React.createElement("textarea", {
+      "data-testid": "monaco-stub",
+      value: props.value ?? "",
+      onChange: (e: { target: { value: string } }) => props.onChange?.(e.target.value),
+    }),
+  loader: { config: () => {}, init: () => Promise.resolve({}) },
+}));
+
 // DOM-only setup (jsdom). Skipped in the node-environment contract test.
 if (typeof document !== "undefined") {
   await import("@testing-library/jest-dom/vitest");

--- a/ui/test/unit/infer-language.test.ts
+++ b/ui/test/unit/infer-language.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { inferLanguage } from "../../src/lib/monaco/infer-language";
+
+describe("inferLanguage", () => {
+  it("recognizes JSON objects and arrays", () => {
+    expect(inferLanguage('{"a":1}')).toBe("json");
+    expect(inferLanguage("  [1, 2, 3]  ")).toBe("json");
+    expect(inferLanguage('{\n  "topic": "hi"\n}')).toBe("json");
+  });
+
+  it("treats bare scalars + non-JSON as plaintext", () => {
+    expect(inferLanguage("42")).toBe("plaintext");
+    expect(inferLanguage('"just a string"')).toBe("plaintext");
+    expect(inferLanguage("hello world")).toBe("plaintext");
+    expect(inferLanguage("")).toBe("plaintext");
+  });
+
+  it("treats object-looking-but-invalid JSON as plaintext", () => {
+    expect(inferLanguage("{not valid")).toBe("plaintext");
+    expect(inferLanguage("[1, 2,")).toBe("plaintext");
+  });
+});

--- a/ui/test/unit/monitoring.test.ts
+++ b/ui/test/unit/monitoring.test.ts
@@ -1,0 +1,89 @@
+import { CaptureRecord, ReactTurn, ReplanRound } from "@kortecx/sdk/web";
+import { describe, expect, it } from "vitest";
+import {
+  summarizeCaptures,
+  summarizeReact,
+  summarizeReplan,
+  summarizeRuns,
+  tallyRows,
+} from "../../src/lib/monitoring";
+import type { RunRecord } from "../../src/lib/recent-runs";
+
+function run(handle: string | null): RunRecord {
+  return {
+    instanceId: handle ?? "x",
+    terminalMoteId: null,
+    recipeFingerprint: null,
+    handle,
+    startedAt: 0,
+  };
+}
+
+describe("summarizeRuns", () => {
+  it("counts runs by handle (null → '—')", () => {
+    const r = summarizeRuns([run("kx/recipes/echo"), run("kx/recipes/echo"), run(null)]);
+    expect(r.total).toBe(3);
+    expect(r.byHandle["kx/recipes/echo"]).toBe(2);
+    expect(r.byHandle["—"]).toBe(1);
+  });
+  it("empty → zeroed rollup", () => {
+    const r = summarizeRuns([]);
+    expect(r.total).toBe(0);
+    expect(tallyRows(r.byHandle)).toEqual([]);
+  });
+});
+
+describe("summarizeReplan", () => {
+  it("rolls up escalations, failed steps, and models", () => {
+    const rounds = [
+      new ReplanRound(0, "aa", "qwen3", ["s1", "s2"], false, 10),
+      new ReplanRound(1, "bb", "qwen3", ["s3"], true, 12),
+    ];
+    const s = summarizeReplan(rounds);
+    expect(s.total).toBe(2);
+    expect(s.escalated).toBe(1);
+    expect(s.failedStepCount).toBe(3);
+    expect(s.byModel.qwen3).toBe(2);
+  });
+});
+
+describe("summarizeReact", () => {
+  it("counts branches, models, and tool calls", () => {
+    const turns = [
+      new ReactTurn(0, "t0", "i0", "qwen3", "answer", "", "", 8, 6, 20),
+      new ReactTurn(1, "t1", "i0", "qwen3", "tool", "fs-read", "1", 8, 6, 22),
+      new ReactTurn(2, "t2", "i0", "qwen3", "tool", "fs-read", "1", 8, 6, 24),
+    ];
+    const s = summarizeReact(turns);
+    expect(s.total).toBe(3);
+    expect(s.toolCalls).toBe(2);
+    expect(s.byBranch.tool).toBe(2);
+    expect(s.byBranch.answer).toBe(1);
+    expect(s.byModel.qwen3).toBe(3);
+  });
+});
+
+describe("summarizeCaptures", () => {
+  it("counts by nd_class and react branch", () => {
+    const recs = [
+      new CaptureRecord("m0", "i0", "r0", "PURE", 30, null, ""),
+      new CaptureRecord("m1", "i0", "r1", "WORLD_MUTATING", 31, 1, "tool"),
+    ];
+    const s = summarizeCaptures(recs);
+    expect(s.total).toBe(2);
+    expect(s.byNdClass.PURE).toBe(1);
+    expect(s.byNdClass.WORLD_MUTATING).toBe(1);
+    expect(s.byBranch.tool).toBe(1);
+    expect(s.byBranch["—"]).toBe(1);
+  });
+});
+
+describe("tallyRows", () => {
+  it("sorts by count desc, then label asc", () => {
+    expect(tallyRows({ b: 1, a: 1, c: 3 })).toEqual([
+      ["c", 3],
+      ["a", 1],
+      ["b", 1],
+    ]);
+  });
+});

--- a/ui/test/unit/nav-model.test.ts
+++ b/ui/test/unit/nav-model.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from "vitest";
 import { NAV_SECTIONS, SETTINGS_SECTION } from "../../src/components/shell/nav-model";
 
 describe("NAV_SECTIONS", () => {
-  it("has the eight console sections", () => {
+  it("has the console sections in order", () => {
     expect(NAV_SECTIONS.map((s) => s.id)).toEqual([
       "activity",
+      "monitor",
       "chat",
       "runs",
       "recipes",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
   plugins: [react()],
   server: { port: 5173, strictPort: true },
   preview: { port: 4173, strictPort: true },
+  // Monaco's `?worker` chunks (editor.worker / json.worker — see lib/monaco/setup.ts)
+  // are ES modules; emit ES-format workers so they tree-shake + load same-origin in
+  // the offline embedded console (a default IIFE worker would inline the whole graph).
+  worker: { format: "es" },
   build: {
     rollupOptions: {
       output: { manualChunks: vendorChunk },


### PR DESCRIPTION
## What

A **UI-only enrichment** (Track A) over the already-functioning runtime — **zero
wire/proto/gateway/Rust change**, so the canonical projection digest `7d22d4bd` is invariant
by construction. Brings the console's section coverage + graphics closer to the visual
reference and makes the runtime more useful with **reactflow** + **monaco**.

### Monaco editors (offline + lazy)
- Self-hosted `monaco-editor` + `@monaco-editor/react` via `loader.config({ monaco })` — **no
  jsdelivr CDN** (the embedded `kx serve` console has no network at runtime). JSON + plaintext
  only, `?worker` ES-module workers.
- Reached **only** through `lazy(() => import("./MonacoEditorImpl"))`, so it stays a **lazy
  chunk** — the eager bundle gate is unchanged at **484,924 B (≤600 KiB)**. `MonacoMount`
  renders a `<textarea>`/`<pre>` fallback in jsdom (no `Worker`), so component tests never load
  the multi-MB graph.
- `JsonEditor` replaces the manual-args `<textarea>` (validation/`field-error`/test-ids
  preserved); a read-only `CodeViewer` powers the Artifacts viewer + the new DAG node detail.

### Richer run DAG (read-only, no-thrash preserved)
- Reference-style `MoteNode` (top accent bar + pulsing status dot), a `MiniMap`, and a
  click→drawer `NodeDetailDrawer` rendered as a **sibling overlay** (never relayouts — the
  `topologyHash`-keyed no-thrash invariant holds) showing the Mote's identity + its committed
  result via the existing `useContent` → `CodeViewer`.

### Monitoring dashboard (new gateway-wide section — real data only, no hollow UI)
- Pure `lib/monitoring.ts` aggregations over `ListRuns` / `ListReplanRounds` / `ListReactTurns`
  / `ListCaptureRecords`; each hook **degrades gracefully on UNIMPLEMENTED** (a muted "not
  wired" note, never a placeholder). New `/monitor` route + nav entry + icon.

### Reference-parity visuals
- Activity dashboard hero, consistent section headers, accent-barred metric cards, and the
  drawer/minimap/monitor styling in `app.css`. The locked AA button gradient is kept (the
  reference's `#F04500→#D83C00` is intentionally NOT ported — white text on it fails AA).

## Tests
- **267 vitest** pass — new `monitoring`/`infer-language` units + `JsonEditor`/`CodeViewer`/
  `NodeDetailDrawer`/`MonitoringSection` components (Monaco stubbed in jsdom).
- **4 new Playwright specs** — real Monaco loads **OFFLINE** in chromium from the vite-preview
  origin (`artifact-codeviewer`, `dag-node-drawer`) **and** from the **embedded console**
  (`console-serve`, `KX_CONSOLE_E2E=1`); the DAG does **not** thrash on drawer open/close
  (bbox assertion); Monitoring renders real telemetry. Full e2e suite green.

## Golden rules
- **Zero wire change** → frozen-trio untouched, digest `7d22d4bd` invariant (gate still runs).
- **GR10**: eager gate 484,924 B (unchanged, Monaco in the lazy remainder); embedded console
  binary 9.77 → **12.40 MB** (+2.63 MB — the accepted, measured offline self-host cost, still
  C++-free); numbers persisted privately. Monaco added **0** npm advisories.
- **GR3**: pure logic (`monitoring.ts`, `infer-language.ts`) split from thin components.

## Out of scope (follow-ups)
- The editable **arbitrary-DAG authoring builder** (new `SubmitWorkflow` server-compile RPC +
  SN-8 re-derivation + admission) — needs `dag-authoring-and-admission.md` first.
- Backend-less reference sections (Providers/Inference/Models/Logs/…) — added when their
  runtime backends land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)