### PR TITLE
feat(ui): dual-theme console — dark #09090b palette + switcher (UI build-out PR-0)

### DIFF
--- a/ui/e2e/theme.spec.ts
+++ b/ui/e2e/theme.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("the theme toggle switches palettes and persists across reload (pre-paint)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  const html = page.locator("html");
+  // Playwright's chromium defaults to a light OS preference → system resolves light.
+  await expect(html).toHaveAttribute("data-theme", "light");
+
+  await page.getByTestId("nav-settings").click();
+  await expect(page.getByTestId("settings-section")).toBeVisible();
+  await page.getByTestId("theme-chip-dark").click();
+  await expect(html).toHaveAttribute("data-theme", "dark");
+  await expect(page.getByTestId("theme-resolved")).toContainText("kortecx dark");
+  // the body actually paints the terminal-dark page bg (#09090b)
+  const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+  expect(bg).toBe("rgb(9, 9, 11)");
+
+  // Reload drops the in-memory token (login gate) but NOT the theme: the
+  // index.html pre-paint script stamps dark before first paint.
+  await page.reload();
+  await expect(page.getByTestId("app-gate")).toBeVisible();
+  await expect(html).toHaveAttribute("data-theme", "dark");
+
+  // Reconnect and smoke a data section in dark (DAG/catalog tokens re-resolve).
+  await connectConsole(page, gw);
+  await expect(html).toHaveAttribute("data-theme", "dark");
+  await page.getByTestId("nav-recipes").click();
+  await expect(page.getByTestId("recipe-catalog")).toBeVisible({ timeout: 30_000 });
+
+  // Back to system → light again (and the chip state follows).
+  await page.getByTestId("nav-settings").click();
+  await page.getByTestId("theme-chip-system").click();
+  await expect(html).toHaveAttribute("data-theme", "light");
+  await expect(page.getByTestId("theme-chip-system")).toHaveAttribute("aria-pressed", "true");
+});
+
+test.describe("OS dark preference", () => {
+  test.use({ colorScheme: "dark" });
+
+  test("'system' follows prefers-color-scheme: dark from the very first paint", async ({
+    page,
+  }) => {
+    gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+    await page.goto("/connect");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+    // An explicit light choice overrides the OS signal.
+    await connectConsole(page, gw);
+    await page.getByTestId("nav-settings").click();
+    await page.getByTestId("theme-chip-light").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -6,6 +6,28 @@
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>kortecx — runtime console</title>
+    <!-- Pre-paint theme stamp (PR-0 dual theme): resolve the stored preference
+         before first paint so a dark-mode reload never flashes light. Keep the
+         key + semantics in sync with src/lib/theme.ts (raw string, not JSON). -->
+    <script>
+      (function () {
+        var theme = "light";
+        try {
+          var pref = localStorage.getItem("kortecx.ui.theme");
+          if (
+            pref === "dark" ||
+            (pref !== "light" &&
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches)
+          ) {
+            theme = "dark";
+          }
+        } catch (e) {
+          /* storage unavailable — light default */
+        }
+        document.documentElement.dataset.theme = theme;
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/app/use-theme.ts
+++ b/ui/src/app/use-theme.ts
@@ -1,0 +1,37 @@
+/**
+ * React binding for the theme store (lib/theme.ts) — `useSyncExternalStore` over
+ * the module store, so every consumer (Settings chips, Monaco) re-renders on a
+ * preference change OR an OS prefers-color-scheme flip.
+ */
+
+import { useSyncExternalStore } from "react";
+import {
+  type ResolvedTheme,
+  type ThemePreference,
+  getResolvedTheme,
+  getThemePreference,
+  setThemePreference,
+  subscribeTheme,
+} from "../lib/theme";
+
+export interface ThemeControls {
+  /** The stored choice ("system" | "light" | "dark"). */
+  readonly preference: ThemePreference;
+  /** The palette actually rendering ("light" | "dark"). */
+  readonly resolved: ResolvedTheme;
+  readonly setPreference: (pref: ThemePreference) => void;
+}
+
+export function useTheme(): ThemeControls {
+  const preference = useSyncExternalStore(
+    subscribeTheme,
+    getThemePreference,
+    (): ThemePreference => "system",
+  );
+  const resolved = useSyncExternalStore(
+    subscribeTheme,
+    getResolvedTheme,
+    (): ResolvedTheme => "light",
+  );
+  return { preference, resolved, setPreference: setThemePreference };
+}

--- a/ui/src/components/editor/MonacoEditorImpl.tsx
+++ b/ui/src/components/editor/MonacoEditorImpl.tsx
@@ -7,7 +7,8 @@
  */
 
 import Editor from "@monaco-editor/react";
-import { KX_LIGHT, configureMonacoOnce } from "../../lib/monaco/setup";
+import { useTheme } from "../../app/use-theme";
+import { KX_DARK, KX_LIGHT, configureMonacoOnce } from "../../lib/monaco/setup";
 import type { EditorSurfaceProps } from "./editor-surface";
 
 // Point @monaco-editor/react at the bundled (offline) instance + theme before any
@@ -38,12 +39,13 @@ export default function MonacoEditorImpl({
   testId,
   ariaLabel,
 }: EditorSurfaceProps) {
+  const { resolved } = useTheme();
   return (
     <div className="monaco-host" data-testid={testId} aria-label={ariaLabel}>
       <Editor
         value={value}
         language={language}
-        theme={KX_LIGHT}
+        theme={resolved === "dark" ? KX_DARK : KX_LIGHT}
         height={height}
         onChange={(v) => onChange?.(v ?? "")}
         options={{

--- a/ui/src/components/sections/SettingsSection.tsx
+++ b/ui/src/components/sections/SettingsSection.tsx
@@ -1,16 +1,19 @@
 import { m } from "framer-motion";
 import { fadeUp, stagger } from "../../app/motion";
+import { useTheme } from "../../app/use-theme";
 import { useConnection } from "../../kx/connection-context";
+import { THEME_PREFERENCES } from "../../lib/theme";
 import { Badge } from "../ds/Badge";
 import { GlowCard } from "../ds/GlowCard";
 
 /**
  * Settings/Profile (W1 shell placeholder per the section taxonomy): the connection
- * profile + console appearance facts. Read-only over existing client state — no new
- * RPCs; preferences persist locally in this browser, never on the gateway.
+ * profile + console appearance controls. No new RPCs; preferences persist locally
+ * in this browser (theme via lib/theme.ts), never on the gateway.
  */
 export function SettingsSection() {
   const { status, endpoint, wsEndpoint } = useConnection();
+  const { preference, resolved, setPreference } = useTheme();
   const connected = status === "connected";
   return (
     <section className="screen" data-testid="settings-section">
@@ -44,7 +47,26 @@ export function SettingsSection() {
           <h2>Appearance</h2>
           <dl className="facts">
             <dt>Theme</dt>
-            <dd>kortecx light (orange · black · white)</dd>
+            <dd>
+              {/* chip buttons, not a <select> — the recorded controlled-select e2e gotcha */}
+              <div className="chip-row">
+                {THEME_PREFERENCES.map((pref) => (
+                  <button
+                    key={pref}
+                    type="button"
+                    className={`chip${preference === pref ? " chip--active" : ""}`}
+                    aria-pressed={preference === pref}
+                    data-testid={`theme-chip-${pref}`}
+                    onClick={() => setPreference(pref)}
+                  >
+                    <span className="chip__label">{pref}</span>
+                  </button>
+                ))}
+              </div>
+              <span className="muted" data-testid="theme-resolved">
+                rendering: kortecx {resolved}
+              </span>
+            </dd>
             <dt>Type</dt>
             <dd>Geist Sans · Geist Mono</dd>
             <dt>Sidebar</dt>

--- a/ui/src/lib/monaco/setup.ts
+++ b/ui/src/lib/monaco/setup.ts
@@ -24,14 +24,17 @@ import "monaco-editor/esm/vs/language/json/monaco.contribution";
 import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 
-/** The console's light Monaco theme, mapped to the app's locked light tokens
- *  (hard-coded hexes from `app.css` — reading CSS vars at define time is fragile). */
+/** The console's Monaco themes, mapped to the app's locked palettes (hard-coded
+ *  hexes from `app.css` — reading CSS vars at define time is fragile). One per
+ *  data-theme; MonacoEditorImpl picks by the resolved theme. */
 const KX_LIGHT = "kx-light";
+const KX_DARK = "kx-dark";
 
 let configured = false;
 
 /** Idempotent: wire the offline workers, point `@monaco-editor/react` at the bundled
- *  instance, and register the `kx-light` theme. Safe to call from every editor mount. */
+ *  instance, and register the `kx-light`/`kx-dark` themes. Safe to call from every
+ *  editor mount. */
 export function configureMonacoOnce(): void {
   if (configured) {
     return;
@@ -63,8 +66,27 @@ export function configureMonacoOnce(): void {
     },
   });
 
+  // The dark twin, on the app.css dark surface (#111113) with the brightened
+  // text-bearing orange (#ff7033) for the cursor.
+  monaco.editor.defineTheme(KX_DARK, {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#111113",
+      "editor.foreground": "#f4f4f5",
+      "editorLineNumber.foreground": "#f4f4f546",
+      "editorLineNumber.activeForeground": "#f4f4f5ad",
+      "editor.selectionBackground": "#f0450033",
+      "editor.lineHighlightBackground": "#f4f4f50a",
+      "editorCursor.foreground": "#ff7033",
+      "editorIndentGuide.background1": "#f4f4f514",
+      focusBorder: "#f04500",
+    },
+  });
+
   // THE switch: use the bundled monaco, never the CDN.
   loader.config({ monaco });
 }
 
-export { KX_LIGHT, monaco };
+export { KX_DARK, KX_LIGHT, monaco };

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,0 +1,131 @@
+/**
+ * Theme preference store (PR-0 dual theme) — pure logic + a tiny module store; no
+ * React here (the `useTheme` hook in app/use-theme.ts subscribes via
+ * `useSyncExternalStore`). Persistence mirrors the chat-settings pattern
+ * (localStorage with try/catch fallbacks; corruption-safe).
+ *
+ * The stored value is the RAW string ("system" | "light" | "dark") — NOT JSON —
+ * because the pre-paint inline script in index.html reads the same key with
+ * `localStorage.getItem` only. Keep STORAGE_KEY + the resolve semantics in sync
+ * with that script: dark ⇔ stored "dark", or anything-but-"light" while the OS
+ * prefers dark.
+ */
+
+export type ThemePreference = "system" | "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "kortecx.ui.theme";
+
+export const THEME_PREFERENCES: readonly ThemePreference[] = ["system", "light", "dark"];
+
+function isThemePreference(v: unknown): v is ThemePreference {
+  return v === "system" || v === "light" || v === "dark";
+}
+
+/** Pure: preference + the OS signal → the palette to render. */
+export function resolveTheme(pref: ThemePreference, systemDark: boolean): ResolvedTheme {
+  if (pref === "system") {
+    return systemDark ? "dark" : "light";
+  }
+  return pref;
+}
+
+/** Load the stored preference; anything missing/foreign degrades to "system". */
+export function loadThemePreference(): ThemePreference {
+  try {
+    const raw = localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemePreference(raw) ? raw : "system";
+  } catch {
+    return "system";
+  }
+}
+
+/** Persist (best-effort; storage may be unavailable in private mode). */
+export function saveThemePreference(pref: ThemePreference): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, pref);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Does the OS prefer dark right now? jsdom has no matchMedia — degrade to false. */
+export function systemPrefersDark(): boolean {
+  try {
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module store: one preference, one OS listener, N subscribers.
+// ---------------------------------------------------------------------------
+
+let preference: ThemePreference | null = null;
+let osListenerAttached = false;
+const listeners = new Set<() => void>();
+
+function currentPreference(): ThemePreference {
+  if (preference === null) {
+    preference = loadThemePreference();
+  }
+  return preference;
+}
+
+function notify(): void {
+  for (const cb of listeners) {
+    cb();
+  }
+}
+
+/** Attach the prefers-color-scheme listener once (first subscriber). */
+function attachOsListener(): void {
+  if (osListenerAttached) {
+    return;
+  }
+  osListenerAttached = true;
+  try {
+    window.matchMedia?.("(prefers-color-scheme: dark)").addEventListener("change", () => {
+      applyResolvedTheme();
+      notify();
+    });
+  } catch {
+    /* no matchMedia (jsdom) — "system" just stays light */
+  }
+}
+
+export function getThemePreference(): ThemePreference {
+  return currentPreference();
+}
+
+export function getResolvedTheme(): ResolvedTheme {
+  return resolveTheme(currentPreference(), systemPrefersDark());
+}
+
+/** Stamp the resolved palette onto <html> (the selector app.css keys on). */
+export function applyResolvedTheme(): void {
+  document.documentElement.dataset.theme = getResolvedTheme();
+}
+
+/** Set + persist + re-stamp + notify subscribers. */
+export function setThemePreference(pref: ThemePreference): void {
+  preference = pref;
+  saveThemePreference(pref);
+  applyResolvedTheme();
+  notify();
+}
+
+/** Subscribe to preference/OS changes (useSyncExternalStore-shaped). */
+export function subscribeTheme(cb: () => void): () => void {
+  attachOsListener();
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** Test-only: drop the cached preference so the next read hits localStorage. */
+export function resetThemeStoreForTests(): void {
+  preference = null;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AppProviders } from "./app/providers";
+import { applyResolvedTheme } from "./lib/theme";
 import { router } from "./router/router";
 // Geist (self-hosted woff2 via @fontsource — no runtime CDN; weights the UI uses).
 import "@fontsource/geist-sans/400.css";
@@ -12,6 +13,10 @@ import "@fontsource/geist-mono/400.css";
 import "@fontsource/geist-mono/500.css";
 import "@xyflow/react/dist/style.css";
 import "./styles/app.css";
+
+// Re-stamp the theme the index.html pre-paint script chose (belt + braces: tests
+// and any host page without the inline script still get the right palette).
+applyResolvedTheme();
 
 const rootEl = document.getElementById("root");
 if (rootEl === null) {

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -53,13 +53,20 @@
   --mono: var(--font-mono);
 
   /* legacy aliases — the pre-W1 token names ~120 rules still consume. Values map
-   * onto the light palette; remove in a later sweep, never re-point to dark. */
+   * onto the active palette via var() so the dark theme re-points them wholesale. */
   --bg-elev: var(--surface);
   --bg-input: #ffffff;
   --fg: var(--text-1);
   --fg-muted: var(--text-2);
   --accent: var(--primary-h);
   --accent-fg: #ffffff;
+
+  /* theme-flipping companions (PR-0 dual theme): text over state-tone pills, the
+   * dot-grid texture ink, and the overlay backdrops/scrims. */
+  --pill-fg: #ffffff;
+  --dot-grid-color: rgba(13, 13, 13, 0.1);
+  --backdrop-color: rgba(13, 13, 13, 0.32);
+  --scrim-color: rgba(13, 13, 13, 0.04);
 
   /* Mote state tones (re-mapped for light surfaces: each ≥4.5:1 as text on white
    * AND under white pill text — the dark-theme hexes fail on light) */
@@ -84,6 +91,80 @@
   --n-not-wired: #4b5563;
   --n-not-found: #4b5563;
   --n-generic: #dc2626;
+}
+
+/* ===========================================================================
+ * PR-0 dual theme (2026-06-12 user decision): the dark, terminal-flavored
+ * #09090b palette from the product brief, behind `data-theme="dark"` on <html>
+ * (set pre-paint by the index.html inline script; driven by lib/theme.ts).
+ *
+ * The D136/D137 AA contrast lock applies to BOTH palettes — every text-bearing
+ * pair here holds ≥4.5:1, audited by test/unit/theme-contrast.test.ts. #F04500
+ * stays a non-text accent in dark too; the TEXT-BEARING orange brightens to
+ * #FF7033 and carries near-black text (--accent-fg), never white. State tones
+ * brighten for dark surfaces, so pill text flips dark via --pill-fg.
+ * =========================================================================== */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --primary: #f04500;
+  --primary-h: #ff7033;
+  --primary-dim: rgba(240, 69, 0, 0.14);
+
+  --bg: #09090b;
+  --surface: #111113;
+  --surface-elev: #1a1a1e;
+  --text-1: #f4f4f5;
+  --text-2: rgba(244, 244, 245, 0.72);
+  --text-3: rgba(244, 244, 245, 0.55);
+  --border: rgba(244, 244, 245, 0.14);
+  --border-md: rgba(244, 244, 245, 0.2);
+  --border-strong: rgba(244, 244, 245, 0.3);
+  --focus: #f04500;
+
+  --success: #34d399;
+  --warning: #fbbf24;
+  --error: #f87171;
+  --info: #60a5fa;
+  --teal: #2dd4bf;
+  --violet: #a78bfa;
+  --rose: #fb7185;
+  --indigo: #818cf8;
+  --teal-dim: rgba(45, 212, 191, 0.12);
+  --violet-dim: rgba(167, 139, 250, 0.12);
+  --rose-dim: rgba(251, 113, 133, 0.12);
+  --indigo-dim: rgba(129, 140, 248, 0.12);
+
+  --bg-input: #141417;
+  --accent-fg: #1a0a00;
+  --pill-fg: #0d0d0d;
+  --dot-grid-color: rgba(244, 244, 245, 0.08);
+  --backdrop-color: rgba(0, 0, 0, 0.55);
+  --scrim-color: rgba(0, 0, 0, 0.3);
+
+  /* Mote state tones, brightened for dark surfaces: each ≥4.5:1 as text on
+   * --bg/--surface AND under the dark --pill-fg pill text. */
+  --t-pending: #94a3b8;
+  --t-scheduled: #fbbf24;
+  --t-committed: #34d399;
+  --t-failed: #f87171;
+  --t-repudiated: #fb923c;
+  --t-inconsistent: #a78bfa;
+  --t-unknown: #9ca3af;
+
+  /* nd_class tones */
+  --t-pure: #60a5fa;
+  --t-read-only-nondet: #2dd4bf;
+  --t-world-mutating: #fb7185;
+
+  /* notice tones */
+  --n-retry: #fbbf24;
+  --n-reauth: #60a5fa;
+  --n-forbidden: #f87171;
+  --n-bad-input: #fb923c;
+  --n-not-wired: #9ca3af;
+  --n-not-found: #9ca3af;
+  --n-generic: #f87171;
 }
 
 * {
@@ -231,9 +312,11 @@ textarea {
 }
 button {
   /* primary action: white on the darkened-orange gradient (AA ≥4.5:1; the locked
-   * contrast decision — #F04500 stays on borders/focus/glows, never under text) */
+   * contrast decision — #F04500 stays on borders/focus/glows, never under text).
+   * The gradient is theme-independent, so its text stays literal white — it must
+   * NOT follow --accent-fg, which flips dark with the brightened dark-theme orange. */
   background: linear-gradient(135deg, #d83c00 0%, #c03500 100%);
-  color: var(--accent-fg);
+  color: #ffffff;
   border: none;
   border-radius: var(--radius);
   padding: 0.5rem 0.9rem;
@@ -280,8 +363,9 @@ button:disabled {
   border-radius: 999px;
   font-size: 0.78rem;
   font-weight: 600;
-  /* white text on every state tone — the light-palette tones are AA under white */
-  color: #fff;
+  /* pill text flips per theme: white over the deep light-palette tones, near-black
+   * over the brightened dark-palette tones — AA in both (the contrast audit test) */
+  color: var(--pill-fg);
   background: var(--t-unknown);
 }
 .pill--pending {
@@ -331,7 +415,7 @@ button:disabled {
   border-color: var(--border);
 }
 .badge--anomaly {
-  color: #fff;
+  color: var(--pill-fg);
   background: var(--t-failed);
 }
 
@@ -1395,7 +1479,7 @@ select {
   position: fixed;
   inset: 0;
   z-index: 90;
-  background: rgba(13, 13, 13, 0.32);
+  background: var(--backdrop-color);
   backdrop-filter: blur(2px);
 }
 .palette {
@@ -1574,7 +1658,7 @@ select {
   animation: pulse-dot 2s ease-in-out infinite;
 }
 .dot-grid {
-  background-image: radial-gradient(circle, rgba(13, 13, 13, 0.1) 1px, transparent 1px);
+  background-image: radial-gradient(circle, var(--dot-grid-color) 1px, transparent 1px);
   background-size: 24px 24px;
 }
 .skeleton {
@@ -1810,7 +1894,7 @@ select {
   height: 1.1rem;
   border-radius: 999px;
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-fg);
   font-size: 0.7rem;
   font-weight: 700;
 }
@@ -1959,7 +2043,7 @@ select {
   inset: 0;
   border: 0;
   padding: 0;
-  background: rgba(13, 13, 13, 0.04);
+  background: var(--scrim-color);
   cursor: pointer;
 }
 .node-drawer {

--- a/ui/test/component/SystemsSection.test.tsx
+++ b/ui/test/component/SystemsSection.test.tsx
@@ -47,11 +47,16 @@ describe("SystemsSection", () => {
 
     expect(screen.getByTestId("teams-panel")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByTestId("team-pick-kx/teams/demo")).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByTestId("member-table")).toBeInTheDocument());
-    expect(screen.getByTestId("member-row-alice@acme")).toBeInTheDocument();
-    // alice is a delegate → the delegate badge.
-    const delegates = document.querySelectorAll(".role-badge--delegate");
-    expect(delegates).toHaveLength(1);
+    // The row assertions must be EVENTUAL, not just gated on the table: the grant
+    // inspector's asset auto-select RE-KEYS useTeamMembers(team, assetRef), which
+    // briefly swaps the already-rendered table back to "Loading members…" — a bare
+    // getByTestId after the table waitFor races that window (a CI-reproduced flake).
+    await waitFor(() => {
+      expect(screen.getByTestId("member-table")).toBeInTheDocument();
+      expect(screen.getByTestId("member-row-alice@acme")).toBeInTheDocument();
+      // alice is a delegate → the delegate badge.
+      expect(document.querySelectorAll(".role-badge--delegate")).toHaveLength(1);
+    });
   });
 
   it("shows the grants inspector with the team grant on echo", async () => {

--- a/ui/test/unit/theme-contrast.test.ts
+++ b/ui/test/unit/theme-contrast.test.ts
@@ -1,0 +1,230 @@
+/**
+ * The AA contrast audit (PR-0 dual theme) — the D136/D137 contrast lock, executable.
+ *
+ * Parses BOTH palettes straight out of `src/styles/app.css` (the single styling
+ * source) and asserts WCAG 2.x contrast on every text-bearing token pair. The NEW
+ * dark palette is held to the full ≥4.5:1 everywhere. A handful of LIGHT pairs
+ * shipped below 4.5 under the locked D137 palette (tertiary labels, semantic badge
+ * text, accents on the tinted page bg); PR-0 does not retune the locked light set —
+ * those pairs are pinned at their shipped floors so they can only improve.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CSS_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "../../src/styles/app.css");
+
+// ---------------------------------------------------------------------------
+// Tiny color math (sRGB → WCAG relative luminance → contrast ratio).
+// ---------------------------------------------------------------------------
+
+interface Rgba {
+  readonly r: number; // 0..255
+  readonly g: number;
+  readonly b: number;
+  readonly a: number; // 0..1
+}
+
+function parseColor(value: string): Rgba | null {
+  const v = value.trim();
+  const hex = /^#([0-9a-f]{6})$/i.exec(v);
+  if (hex?.[1] !== undefined) {
+    const n = Number.parseInt(hex[1], 16);
+    return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff, a: 1 };
+  }
+  const rgba = /^rgba\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)$/i.exec(v);
+  if (rgba) {
+    const [, r, g, b, a] = rgba;
+    if (r !== undefined && g !== undefined && b !== undefined && a !== undefined) {
+      return { r: Number(r), g: Number(g), b: Number(b), a: Number(a) };
+    }
+  }
+  return null;
+}
+
+/** Alpha-composite `fg` over an OPAQUE `bg`. */
+function composite(fg: Rgba, bg: Rgba): Rgba {
+  const a = fg.a;
+  return {
+    r: fg.r * a + bg.r * (1 - a),
+    g: fg.g * a + bg.g * (1 - a),
+    b: fg.b * a + bg.b * (1 - a),
+    a: 1,
+  };
+}
+
+function channel(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(c: Rgba): number {
+  return 0.2126 * channel(c.r) + 0.7152 * channel(c.g) + 0.0722 * channel(c.b);
+}
+
+/** WCAG contrast of `fg` text over an opaque `bg` (compositing translucent fg). */
+function contrast(fg: Rgba, bg: Rgba): number {
+  const f = luminance(composite(fg, bg));
+  const b = luminance(bg);
+  const [hi, lo] = f > b ? [f, b] : [b, f];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// Palette extraction from app.css.
+// ---------------------------------------------------------------------------
+
+type Palette = ReadonlyMap<string, Rgba>;
+
+function parseBlock(css: string, selectorRe: RegExp): Palette {
+  const block = selectorRe.exec(css)?.[1];
+  expect(block, `selector ${selectorRe} present in app.css`).toBeDefined();
+  const tokens = new Map<string, Rgba>();
+  for (const m of (block as string).matchAll(/--([\w-]+)\s*:\s*([^;]+);/g)) {
+    const [, name, raw] = m;
+    if (name === undefined || raw === undefined) {
+      continue;
+    }
+    const color = parseColor(raw);
+    if (color) {
+      tokens.set(`--${name}`, color);
+    }
+  }
+  return tokens;
+}
+
+const css = readFileSync(CSS_PATH, "utf8");
+const light = parseBlock(css, /:root\s*\{([^}]*)\}/);
+const dark = parseBlock(css, /:root\[data-theme="dark"\]\s*\{([^}]*)\}/);
+
+function tokenOf(palette: Palette, theme: string, name: string): Rgba {
+  const c = palette.get(name);
+  expect(c, `${theme} palette defines ${name} as a literal color`).toBeDefined();
+  return c as Rgba;
+}
+
+// ---------------------------------------------------------------------------
+// The audited pairs. min.light pins shipped D137 floors; min.dark is the full
+// AA bar for the NEW palette (the PR-0 gate: no dark token below 4.5 on text).
+// ---------------------------------------------------------------------------
+
+const MOTE_TONES = [
+  "--t-pending",
+  "--t-scheduled",
+  "--t-committed",
+  "--t-failed",
+  "--t-repudiated",
+  "--t-inconsistent",
+  "--t-unknown",
+] as const;
+const ND_TONES = ["--t-pure", "--t-read-only-nondet", "--t-world-mutating"] as const;
+const SEMANTIC = ["--success", "--warning", "--error", "--info"] as const;
+
+interface Pair {
+  readonly fg: string;
+  readonly bg: string;
+  readonly min: { readonly light: number; readonly dark: number };
+  readonly why: string;
+}
+
+const PAIRS: Pair[] = [
+  // body / card / elevated / input text
+  ...["--bg", "--surface", "--surface-elev", "--bg-input"].map((bg) => ({
+    fg: "--text-1",
+    bg,
+    min: { light: 4.5, dark: 4.5 },
+    why: "primary text",
+  })),
+  ...["--bg", "--surface", "--surface-elev", "--bg-input"].map((bg) => ({
+    fg: "--text-2",
+    bg,
+    min: { light: 4.5, dark: 4.5 },
+    why: "secondary text",
+  })),
+  // tertiary uppercase micro-labels: shipped at ~3.1 in light (grandfathered)
+  ...["--bg", "--surface"].map((bg) => ({
+    fg: "--text-3",
+    bg,
+    min: { light: 3.0, dark: 4.5 },
+    why: "tertiary labels",
+  })),
+  // the text-bearing orange (links, active chips) on cards and the page bg
+  {
+    fg: "--primary-h",
+    bg: "--surface",
+    min: { light: 4.5, dark: 4.5 },
+    why: "accent text on cards",
+  },
+  // shipped light value washes to ~4.06 on the tinted #f0f0f0 page bg (grandfathered)
+  { fg: "--primary-h", bg: "--bg", min: { light: 4.0, dark: 4.5 }, why: "accent text on page bg" },
+  // text over accent surfaces (.bubble--user, .skip-link, pressed view-toggle)
+  { fg: "--accent-fg", bg: "--primary-h", min: { light: 4.5, dark: 4.5 }, why: "text on accent" },
+  // pills: --pill-fg text over every mote-state tone
+  ...MOTE_TONES.map((bg) => ({
+    fg: "--pill-fg",
+    bg,
+    min: { light: 4.5, dark: 4.5 },
+    why: "pill text on state tone",
+  })),
+  // tones as text on cards
+  ...[...MOTE_TONES, ...ND_TONES].map((fg) => ({
+    fg,
+    bg: "--surface",
+    min: { light: 4.5, dark: 4.5 },
+    why: "tone as text on cards",
+  })),
+  // tones as text on the page bg: light #f0f0f0 washes the weakest shipped tone
+  // (--t-failed #dc2626) to a measured 4.24 — grandfathered, pinned so it can
+  // only improve
+  ...[...MOTE_TONES, ...ND_TONES].map((fg) => ({
+    fg,
+    bg: "--bg",
+    min: { light: 4.2, dark: 4.5 },
+    why: "tone as text on page bg",
+  })),
+  // semantic badge text: shipped light values bottom out ~3.2 (grandfathered)
+  ...SEMANTIC.map((fg) => ({
+    fg,
+    bg: "--surface",
+    min: { light: 3.0, dark: 4.5 },
+    why: "semantic badge text",
+  })),
+];
+
+describe("theme contrast (the executable AA lock)", () => {
+  for (const [theme, palette] of [
+    ["light", light],
+    ["dark", dark],
+  ] as const) {
+    describe(`${theme} palette`, () => {
+      for (const pair of PAIRS) {
+        it(`${pair.fg} on ${pair.bg} ≥ ${pair.min[theme]} (${pair.why})`, () => {
+          const fg = tokenOf(palette, theme, pair.fg);
+          const bg = tokenOf(palette, theme, pair.bg);
+          expect(bg.a, `${pair.bg} must be opaque to sit under text`).toBe(1);
+          expect(contrast(fg, bg)).toBeGreaterThanOrEqual(pair.min[theme]);
+        });
+      }
+    });
+  }
+
+  it("the theme-independent button gradient keeps white text AA at both stops", () => {
+    const white = parseColor("#ffffff") as Rgba;
+    for (const stop of ["#d83c00", "#c03500"]) {
+      expect(contrast(white, parseColor(stop) as Rgba)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("the dark block overrides every audited token (no silent light fallthrough)", () => {
+    const audited = new Set<string>();
+    for (const p of PAIRS) {
+      audited.add(p.fg);
+      audited.add(p.bg);
+    }
+    for (const name of audited) {
+      expect(dark.has(name), `dark palette defines ${name}`).toBe(true);
+    }
+  });
+});

--- a/ui/test/unit/theme.test.ts
+++ b/ui/test/unit/theme.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  THEME_STORAGE_KEY,
+  applyResolvedTheme,
+  getResolvedTheme,
+  getThemePreference,
+  loadThemePreference,
+  resetThemeStoreForTests,
+  resolveTheme,
+  saveThemePreference,
+  setThemePreference,
+  subscribeTheme,
+} from "../../src/lib/theme";
+
+beforeEach(() => {
+  localStorage.clear();
+  resetThemeStoreForTests();
+  delete document.documentElement.dataset.theme;
+});
+
+afterEach(() => {
+  localStorage.clear();
+  resetThemeStoreForTests();
+});
+
+describe("resolveTheme", () => {
+  it("passes explicit preferences through untouched", () => {
+    expect(resolveTheme("light", true)).toBe("light");
+    expect(resolveTheme("dark", false)).toBe("dark");
+  });
+
+  it("follows the OS signal for 'system'", () => {
+    expect(resolveTheme("system", false)).toBe("light");
+    expect(resolveTheme("system", true)).toBe("dark");
+  });
+});
+
+describe("persistence", () => {
+  it("defaults to 'system' when nothing is stored", () => {
+    expect(loadThemePreference()).toBe("system");
+  });
+
+  it("round-trips a stored preference as a RAW string (the inline-script contract)", () => {
+    saveThemePreference("dark");
+    // raw, not JSON — index.html's pre-paint script compares with ===
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(loadThemePreference()).toBe("dark");
+  });
+
+  it("degrades a foreign stored value to 'system' (corruption-safe)", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, '"dark"'); // a JSON-stringified relic
+    expect(loadThemePreference()).toBe("system");
+    localStorage.setItem(THEME_STORAGE_KEY, "neon");
+    expect(loadThemePreference()).toBe("system");
+  });
+});
+
+describe("the store", () => {
+  it("setThemePreference persists, stamps <html data-theme>, and notifies", () => {
+    const seen = vi.fn();
+    const unsubscribe = subscribeTheme(seen);
+
+    setThemePreference("dark");
+    expect(getThemePreference()).toBe("dark");
+    expect(getResolvedTheme()).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    setThemePreference("light");
+    expect(seen).toHaveBeenCalledTimes(1); // unsubscribed — no further calls
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("'system' resolves light when matchMedia is unavailable (jsdom)", () => {
+    // jsdom ships no matchMedia; the store must degrade, never throw.
+    setThemePreference("system");
+    expect(getResolvedTheme()).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("applyResolvedTheme stamps the stored preference on a fresh load", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    resetThemeStoreForTests();
+    applyResolvedTheme();
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+});


### PR DESCRIPTION
## What

The first PR of the approved UI build-out sequence (PR-0): the console gains the dark, terminal-flavored `#09090b` palette from the product brief **alongside** the locked light theme, behind a `system / light / dark` switcher in Settings (★ 2026-06-12 user decision: both themes, toggle).

- **`app.css`** — a `[data-theme="dark"]` token block over the existing custom-property architecture. State/nd/notice tones brighten for dark surfaces, so pill text flips dark via the new `--pill-fg`; the text-bearing orange brightens to `#FF7033` carrying near-black `--accent-fg` (`#F04500` stays a non-text accent in dark too); backdrop/scrim/dot-grid inks tokenized. The theme-independent button gradient keeps literal white text.
- **`index.html`** — a pre-paint inline stamp so a dark-mode reload never flashes light; **`lib/theme.ts`** store (raw-string localStorage, `prefers-color-scheme`, corruption-safe, degrades without `matchMedia`); **`app/use-theme.ts`** React binding.
- **Settings → Appearance** — chip switcher (chips, not a `<select>` — the recorded controlled-select e2e gotcha) + a live "rendering: kortecx dark" readout.
- **Monaco** — a `kx-dark` twin theme; editors follow the resolved theme live.

## The AA lock is now executable

`test/unit/theme-contrast.test.ts` parses **both** palettes straight out of `app.css` and audits every text-bearing token pair (90 assertions): the new dark set holds **≥4.5:1 everywhere**; the shipped light floors are pinned exactly (the handful of pre-existing sub-4.5 light pairs — tertiary micro-labels, semantic badge text, accents on the tinted page bg — are grandfathered at measured values so they can only improve).

## GR8 pre-flight

- (a) breaks-live: none — pure additive token block; light render is byte-identical (verified by the unchanged e2e suite). The one behavioral fix: 3 hardcoded `#fff` text usages re-pointed to theme tokens, identical in light.
- (b) perf: +~1 KiB eager JS (theme store) — eager budget 487.9 KiB / 600 KiB; the inline stamp is ~300 B.
- (c) security: none — no new I/O surface; theme preference is non-secret localStorage.

## Gates

`biome ci` ✓ · `tsc` ✓ · 365 unit/contract tests (98 new) ✓ · build + eager-JS budget ✓ · full Playwright e2e **24 passed** (2 new: pre-paint persistence across reload; OS dark preference honored from first paint, explicit choice overrides) ✓ · live visual review in both themes (screenshots verified) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)