### PR TITLE
feat(ui): chat UX feedback — Monaco markdown composer, attach below send, chat history, visible model control (PR-1.1)

### DIFF
--- a/ui/e2e/chat-attach.spec.ts
+++ b/ui/e2e/chat-attach.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { typeMessage } from "./fixtures/chat";
 import { connectConsole } from "./fixtures/connect";
 import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
 
@@ -51,7 +52,7 @@ test("attach uploads a PNG (PutContent), previews it, dedups a re-pick, and send
 
   // Send: the user bubble carries the attachment (preview + DigestChip) and the
   // echo turn still commits (display-only path — no undeclared arg was sent).
-  await page.getByLabel(/^message$/i).fill("what is attached?");
+  await typeMessage(page, "what is attached?");
   await page.getByTestId("send").click();
   await expect(page.getByTestId("bubble-attachments")).toBeVisible();
   await expect(page.getByTestId("bubble-user").getByTestId("digest-chip")).toBeVisible();
@@ -72,7 +73,7 @@ test("a failed turn offers retry with identical args and recovers when the gatew
 
   // Fail the first turn by pointing chat at a recipe the gateway cannot run.
   await page.getByLabel(/blueprint handle/i).fill("kx/recipes/does-not-exist");
-  await page.getByLabel(/^message$/i).fill("retry me");
+  await typeMessage(page, "retry me");
   await page.getByTestId("send").click();
   await expect(page.getByTestId("bubble-assistant")).toHaveAttribute("data-status", "failed", {
     timeout: 30_000,

--- a/ui/e2e/chat-echo.spec.ts
+++ b/ui/e2e/chat-echo.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { typeMessage } from "./fixtures/chat";
 import { connectConsole } from "./fixtures/connect";
 import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
 
@@ -22,7 +23,7 @@ test("chat round-trips against the model-free echo recipe (Invoke→poll→GetCo
   await page.getByTestId("chat-settings").locator("summary").click();
   await page.getByTestId("echo-preset").click();
 
-  await page.getByLabel(/^message$/i).fill("hello there");
+  await typeMessage(page, "hello there");
   await page.getByTestId("send").click();
 
   // The user's message + an assistant turn that reaches a committed result.
@@ -44,12 +45,13 @@ test("a chat turn fails gracefully when the gateway is unreachable", async ({ pa
   gw.stop();
   gw = undefined;
 
-  await page.getByLabel(/^message$/i).fill("are you there?");
+  await typeMessage(page, "are you there?");
   await page.getByTestId("send").click();
 
   await expect(page.getByTestId("bubble-assistant")).toHaveAttribute("data-status", "failed", {
     timeout: 30_000,
   });
-  // The composer is still interactive (the app did not crash).
-  await expect(page.getByLabel(/^message$/i)).toBeEnabled();
+  // The composer is still interactive (the app did not crash): typing re-arms send.
+  await typeMessage(page, "still alive");
+  await expect(page.getByTestId("send")).toBeEnabled();
 });

--- a/ui/e2e/chat-history.spec.ts
+++ b/ui/e2e/chat-history.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { typeMessage } from "./fixtures/chat";
+import { connectConsole } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("a chat autosaves, survives a reload, and restores from History", async ({ page }) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  await page.getByTestId("nav-chat").click();
+  await page.getByTestId("chat-settings").locator("summary").click();
+  await page.getByTestId("echo-preset").click();
+
+  await typeMessage(page, "remember this chat");
+  await page.getByTestId("send").click();
+  await expect(page.getByTestId("bubble-assistant")).toHaveAttribute("data-status", "done", {
+    timeout: 30_000,
+  });
+
+  // Reload: the live thread is gone (presentation state), the history is not.
+  await page.reload();
+  await connectConsole(page, gw);
+  await page.getByTestId("nav-chat").click();
+  await expect(page.getByTestId("bubble-user")).toHaveCount(0);
+
+  await page.getByTestId("chat-history-toggle").click();
+  await expect(page.getByTestId("chat-history")).toBeVisible();
+  const item = page.getByTestId("chat-history-item");
+  await expect(item).toHaveCount(1);
+  await expect(item).toContainText("remember this chat");
+
+  // Restore: the saved messages come back into the live thread.
+  await page.getByTestId("chat-history-load").click();
+  await expect(page.getByTestId("chat-history")).toHaveCount(0);
+  await expect(page.getByTestId("bubble-user")).toContainText("remember this chat");
+  await expect(page.getByTestId("bubble-assistant")).toHaveAttribute("data-status", "done");
+
+  // Forget it: the list empties.
+  await page.getByTestId("chat-history-toggle").click();
+  await page.getByTestId("chat-history-delete").click();
+  await expect(page.getByTestId("chat-history-item")).toHaveCount(0);
+});

--- a/ui/e2e/fixtures/chat.ts
+++ b/ui/e2e/fixtures/chat.ts
@@ -1,0 +1,13 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Type into the chat composer. The composer is a Monaco surface in the real
+ * browser (PR-1.1), so label-based `fill()` no longer applies — click the
+ * editor (or its Suspense textarea fallback; same testid) and type through the
+ * keyboard, which both surfaces accept.
+ */
+export async function typeMessage(page: Page, text: string): Promise<void> {
+  const input = page.getByTestId("composer-input");
+  await input.click();
+  await page.keyboard.type(text);
+}

--- a/ui/e2e/models-picker.spec.ts
+++ b/ui/e2e/models-picker.spec.ts
@@ -9,7 +9,7 @@ test.afterEach(() => {
   gw = undefined;
 });
 
-test("the model picker hides on a model-less serve (honest empty — no fake knob)", async ({
+test("the model control is VISIBLE with an honest empty state on a model-less serve", async ({
   page,
 }) => {
   gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
@@ -18,10 +18,12 @@ test("the model picker hides on a model-less serve (honest empty — no fake kno
   await page.getByTestId("nav-chat").click();
   await expect(page.getByTestId("chat-panel")).toBeVisible();
 
-  // The FFI-free test serve answers ListModels with an EMPTY list — the picker
-  // must not render (and nothing crashes).
-  await expect(page.getByTestId("model-picker")).toHaveCount(0);
+  // The FFI-free test serve answers ListModels with an EMPTY list — the control
+  // stays VISIBLE (PR-1.1 review feedback) as an honest, disabled empty state;
+  // the SELECT (a knob with nothing to pick) does not render.
+  await expect(page.getByTestId("model-picker-empty")).toBeVisible();
+  await expect(page.getByTestId("model-picker-empty")).toContainText("none on this serve");
+  await expect(page.getByTestId("model-picker-select")).toHaveCount(0);
   // The chat surface stays fully usable.
-  await expect(page.getByLabel(/^message$/i)).toBeEnabled();
   await expect(page.getByTestId("attach-btn")).toBeVisible();
 });

--- a/ui/e2e/recipes-form.spec.ts
+++ b/ui/e2e/recipes-form.spec.ts
@@ -43,7 +43,10 @@ test("blueprint form validation: a required field blocks submit until filled", a
 
   // Submit with the required `topic` blank → an inline validation error, no run.
   await page.getByRole("button", { name: /run blueprint/i }).click();
-  await expect(page.getByRole("alert")).toContainText(/required/i);
+  // Filtered: Monaco (the chat composer, PR-1.1) appends EMPTY global
+  // role="alert" aria containers to document.body that persist across SPA
+  // navigation — match the actual validation message, not "any alert".
+  await expect(page.getByRole("alert").filter({ hasText: /required/i })).toBeVisible();
   await expect(page.getByTestId("mote-dag")).toHaveCount(0);
 
   // Fill it and the run proceeds.

--- a/ui/src/components/chat/ChatHistory.tsx
+++ b/ui/src/components/chat/ChatHistory.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { CHATS_CHANGED_EVENT, type SavedChat, deleteChat, loadChats } from "../../lib/chat-history";
+import { EmptyState } from "../EmptyState";
+
+/**
+ * The chat-history slide-over: every saved chat on THIS endpoint (client-local
+ * localStorage — the open-question-5 decision; server-side sessions are a
+ * future sidecar), newest-updated first. Click restores a thread; the × forgets
+ * it. Follows the activity-drawer slide-over interaction (backdrop + Escape).
+ */
+export function ChatHistory({
+  endpoint,
+  open,
+  onClose,
+  onLoad,
+}: {
+  endpoint: string;
+  open: boolean;
+  onClose: () => void;
+  onLoad: (chat: SavedChat) => void;
+}) {
+  const [chats, setChats] = useState<SavedChat[]>([]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const refresh = (): void => setChats(loadChats(endpoint));
+    refresh();
+    window.addEventListener(CHATS_CHANGED_EVENT, refresh);
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener(CHATS_CHANGED_EVENT, refresh);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open, endpoint, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: scrim click-to-close, with Escape as the keyboard path */}
+      <div className="chat-history__backdrop" onClick={onClose} data-testid="chat-history-close" />
+      <aside className="chat-history" data-testid="chat-history" aria-label="Chat history">
+        <div className="chat-history__head">
+          <h2>Chat history</h2>
+          <button type="button" className="linkbtn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <p className="muted chat-history__note">
+          Saved in this browser for <code>{endpoint}</code>.
+        </p>
+        {chats.length === 0 ? (
+          <EmptyState title="No saved chats" detail="Finished chats appear here automatically." />
+        ) : (
+          <ul className="chat-history__list">
+            {chats.map((c) => (
+              <li key={c.id} className="chat-history__item" data-testid="chat-history-item">
+                <button
+                  type="button"
+                  className="chat-history__load"
+                  onClick={() => onLoad(c)}
+                  data-testid="chat-history-load"
+                >
+                  <span className="chat-history__title">{c.title}</span>
+                  <span className="muted">
+                    {new Date(c.updatedAt).toLocaleString()} · {c.messages.length} message
+                    {c.messages.length === 1 ? "" : "s"}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="iconbtn chat-history__delete"
+                  onClick={() => setChats(deleteChat(endpoint, c.id))}
+                  aria-label={`Delete chat: ${c.title}`}
+                  data-testid="chat-history-delete"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+    </>
+  );
+}

--- a/ui/src/components/chat/ChatHistory.tsx
+++ b/ui/src/components/chat/ChatHistory.tsx
@@ -46,8 +46,13 @@ export function ChatHistory({
 
   return (
     <>
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: scrim click-to-close, with Escape as the keyboard path */}
-      <div className="chat-history__backdrop" onClick={onClose} data-testid="chat-history-close" />
+      <button
+        type="button"
+        className="chat-history__backdrop"
+        aria-label="Close chat history"
+        onClick={onClose}
+        data-testid="chat-history-close"
+      />
       <aside className="chat-history" data-testid="chat-history" aria-label="Chat history">
         <div className="chat-history__head">
           <h2>Chat history</h2>

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -1,11 +1,15 @@
 import { m } from "framer-motion";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { fadeUp } from "../../app/motion";
+import { useConnection } from "../../kx/connection-context";
 import { useAttachments } from "../../kx/use-attachments";
 import { useChat } from "../../kx/use-chat";
+import { type SavedChat, saveChat } from "../../lib/chat-history";
 import { type ChatSettings, loadChatSettings, saveChatSettings } from "../../lib/chat-settings";
 import type { MessageAttachment } from "../../lib/chat-thread";
+import { Icon } from "../shell/Icon";
 import { AttachmentStrip } from "./AttachmentStrip";
+import { ChatHistory } from "./ChatHistory";
 import { ChatSettingsPanel } from "./ChatSettings";
 import { Composer } from "./Composer";
 import { DegradeNotice } from "./DegradeNotice";
@@ -18,10 +22,13 @@ import { ThinkingTrace } from "./ThinkingTrace";
  * committed result; the DAG-of-thought shows the run executing. Batch A: attach
  * images (uploaded via PutContent; they ride the vision recipe when the serve
  * is image-capable, display-only otherwise) and pick the model (a server-
- * validated free-param). Degrades to a guidance notice when no chat recipe /
- * model is provisioned.
+ * validated free-param). PR-1.1: every thread autosaves to the client-local
+ * per-endpoint history (restorable from the History slide-over) and the
+ * composer is a Monaco markdown surface. Degrades to a guidance notice when no
+ * chat recipe/model is provisioned.
  */
 export function ChatPanel() {
+  const { endpoint } = useConnection();
   const [settings, setSettings] = useState<ChatSettings>(() => loadChatSettings());
   const chat = useChat({
     handle: settings.handle,
@@ -29,10 +36,29 @@ export function ChatPanel() {
     modelId: settings.modelId,
   });
   const attach = useAttachments();
+  const [historyOpen, setHistoryOpen] = useState(false);
+  // The identity the autosave upserts under; a new id per fresh/restored thread.
+  const chatIdRef = useRef<string>(crypto.randomUUID());
+
+  // Autosave: every thread change upserts this chat (empty threads are a no-op).
+  useEffect(() => {
+    saveChat(endpoint, chatIdRef.current, chat.thread.messages);
+  }, [endpoint, chat.thread]);
 
   function updateSettings(next: ChatSettings): void {
     setSettings(next);
     saveChatSettings(next);
+  }
+
+  function newChat(): void {
+    chatIdRef.current = crypto.randomUUID();
+    chat.reset();
+  }
+
+  function loadSaved(saved: SavedChat): void {
+    chatIdRef.current = saved.id;
+    chat.loadThread(saved.messages);
+    setHistoryOpen(false);
   }
 
   function sendWithAttachments(text: string): void {
@@ -60,11 +86,23 @@ export function ChatPanel() {
     >
       <div className="screen__head">
         <h1>New Chat</h1>
-        {chat.thread.messages.length > 0 ? (
-          <button type="button" className="linkbtn" onClick={chat.reset}>
-            New chat
+        <div className="screen__head-actions">
+          <button
+            type="button"
+            className="iconbtn"
+            onClick={() => setHistoryOpen(true)}
+            aria-label="Chat history"
+            title="Chat history"
+            data-testid="chat-history-toggle"
+          >
+            <Icon name="history" />
           </button>
-        ) : null}
+          {chat.thread.messages.length > 0 ? (
+            <button type="button" className="linkbtn" onClick={newChat}>
+              New chat
+            </button>
+          ) : null}
+        </div>
       </div>
       <p className="muted">
         Each message runs <code>{settings.handle}</code>; the reply is the run's committed result.
@@ -99,6 +137,13 @@ export function ChatPanel() {
         sendBlocked={attach.uploading}
         onSend={sendWithAttachments}
         onPickFiles={attach.addFiles}
+      />
+
+      <ChatHistory
+        endpoint={endpoint}
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        onLoad={loadSaved}
       />
     </m.section>
   );

--- a/ui/src/components/chat/Composer.tsx
+++ b/ui/src/components/chat/Composer.tsx
@@ -1,9 +1,15 @@
-import { type FormEvent, type KeyboardEvent, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { IMAGE_ACCEPT } from "../../lib/content-resolver";
+import { MonacoMount } from "../editor/MonacoMount";
 import { Icon } from "../shell/Icon";
 
-/** The message input. Enter sends; Shift+Enter inserts a newline. The attach
- *  button (Batch A) picks image files; the parent owns the upload + strip. */
+/**
+ * The message input — a Monaco surface with MARKDOWN highlighting (D141.2's
+ * last exception closed; jsdom renders the textarea fallback with the same
+ * test handles). Plain Enter sends; Shift+Enter inserts a newline. The action
+ * column sits on the right: send on top, attach BELOW it (user-directed
+ * 2026-06-12 review feedback); the parent owns uploads + the pending strip.
+ */
 export function Composer({
   disabled,
   sendBlocked,
@@ -27,68 +33,62 @@ export function Composer({
     }
   }
 
-  function submit(e: FormEvent<HTMLFormElement>): void {
-    e.preventDefault();
-    doSend();
-  }
-
-  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      doSend();
-    }
-  }
-
   return (
-    <form className="composer" onSubmit={submit} data-testid="composer">
-      {onPickFiles ? (
-        <>
-          <input
-            ref={fileRef}
-            type="file"
-            accept={IMAGE_ACCEPT}
-            multiple
-            hidden
-            data-testid="attach-input"
-            onChange={(e) => {
-              if (e.target.files && e.target.files.length > 0) {
-                onPickFiles(e.target.files);
-                e.target.value = ""; // re-picking the same file must re-fire
-              }
-            }}
-          />
-          <button
-            type="button"
-            className="iconbtn composer__attach"
-            disabled={disabled}
-            onClick={() => fileRef.current?.click()}
-            aria-label="Attach an image"
-            title="Attach an image"
-            data-testid="attach-btn"
-          >
-            <Icon name="attach" />
-          </button>
-        </>
-      ) : null}
-      <textarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        onKeyDown={onKeyDown}
-        rows={2}
-        placeholder="Message the runtime…"
-        aria-label="Message"
-        spellCheck={false}
-        disabled={disabled}
-      />
-      <button
-        type="submit"
-        className="iconbtn composer__send"
-        disabled={disabled || sendBlocked || text.trim() === ""}
-        aria-label="Send message"
-        data-testid="send"
-      >
-        <Icon name="send" />
-      </button>
-    </form>
+    <div className="composer" data-testid="composer">
+      <div className="composer__editor">
+        <MonacoMount
+          value={text}
+          language="markdown"
+          onChange={setText}
+          onSubmit={doSend}
+          readOnly={disabled}
+          height={96}
+          testId="composer-input"
+          ariaLabel="Message"
+          placeholder="Message the runtime… (markdown; Shift+Enter for a newline)"
+        />
+      </div>
+      <div className="composer__actions">
+        <button
+          type="button"
+          className="iconbtn composer__send"
+          disabled={disabled || sendBlocked || text.trim() === ""}
+          onClick={doSend}
+          aria-label="Send message"
+          data-testid="send"
+        >
+          <Icon name="send" />
+        </button>
+        {onPickFiles ? (
+          <>
+            <input
+              ref={fileRef}
+              type="file"
+              accept={IMAGE_ACCEPT}
+              multiple
+              hidden
+              data-testid="attach-input"
+              onChange={(e) => {
+                if (e.target.files && e.target.files.length > 0) {
+                  onPickFiles(e.target.files);
+                  e.target.value = ""; // re-picking the same file must re-fire
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="iconbtn composer__attach"
+              disabled={disabled}
+              onClick={() => fileRef.current?.click()}
+              aria-label="Attach an image"
+              title="Attach an image"
+              data-testid="attach-btn"
+            >
+              <Icon name="attach" />
+            </button>
+          </>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/ui/src/components/chat/MessageBubble.tsx
+++ b/ui/src/components/chat/MessageBubble.tsx
@@ -1,7 +1,31 @@
 import type { ReactNode } from "react";
-import type { ChatMessage } from "../../lib/chat-thread";
+import { useUploadPreview } from "../../kx/use-upload-preview";
+import type { ChatMessage, MessageAttachment } from "../../lib/chat-thread";
 import { DigestChip } from "../DigestChip";
 import { ErrorNotice } from "../ErrorNotice";
+
+/** One attachment figure. A LIVE thread previews from the session-local `blob:`
+ *  URL of the user's own file; a RESTORED thread re-resolves the bytes through
+ *  the uploads scope (same server-derived ref). No URL resolves ⇒ chip only. */
+function AttachmentFigure({ attachment }: { attachment: MessageAttachment }) {
+  const restored = useUploadPreview(
+    attachment.ref,
+    attachment.mediaType,
+    attachment.objectUrl === undefined,
+  );
+  const src = attachment.objectUrl ?? restored;
+  return (
+    <figure className="bubble__attachment">
+      {src !== null && attachment.mediaType.startsWith("image/") ? (
+        <img src={src} alt={attachment.filename} />
+      ) : null}
+      <figcaption>
+        <span title={attachment.filename}>{attachment.filename}</span>
+        <DigestChip hex={attachment.ref} label={attachment.filename} />
+      </figcaption>
+    </figure>
+  );
+}
 
 /** One chat bubble (user/assistant). `trace` slots the assistant's DAG-of-thought;
  *  `onRetry` arms the failed-turn retry (identical args — the server dedups). */
@@ -30,17 +54,7 @@ export function MessageBubble({
       {message.attachments && message.attachments.length > 0 ? (
         <div className="bubble__attachments" data-testid="bubble-attachments">
           {message.attachments.map((a) => (
-            <figure key={a.ref} className="bubble__attachment">
-              {a.objectUrl && a.mediaType.startsWith("image/") ? (
-                // The session-local blob: preview of the user's OWN file —
-                // untrusted server bytes never render as media here.
-                <img src={a.objectUrl} alt={a.filename} />
-              ) : null}
-              <figcaption>
-                <span title={a.filename}>{a.filename}</span>
-                <DigestChip hex={a.ref} label={a.filename} />
-              </figcaption>
-            </figure>
+            <AttachmentFigure key={a.ref} attachment={a} />
           ))}
         </div>
       ) : null}

--- a/ui/src/components/chat/ModelPicker.tsx
+++ b/ui/src/components/chat/ModelPicker.tsx
@@ -1,10 +1,13 @@
 import { useModels } from "../../kx/use-models";
 
 /**
- * The composer model picker (Batch A): a dropdown over `ListModels`. Hidden
- * when the gateway predates the RPC or serves no model (no fake knob). The
- * selection only ever rides as a recipe ENUM free-param the SERVER validates
- * at binding (SN-8) — picking a model here grants nothing.
+ * The composer model control (Batch A): a dropdown over `ListModels`, ALWAYS
+ * visible on a ListModels-capable gateway (user-directed 2026-06-12 review
+ * feedback — an unmounted control reads as missing). A model-less serve shows
+ * an honest, disabled empty state instead of a fake knob; only a gateway that
+ * predates the RPC (or one still loading) renders nothing. The selection only
+ * ever rides as a recipe ENUM free-param the SERVER validates at binding
+ * (SN-8) — picking a model here grants nothing.
  */
 export function ModelPicker({
   value,
@@ -13,9 +16,19 @@ export function ModelPicker({
   value: string | undefined;
   onChange: (modelId: string) => void;
 }) {
-  const { models, unsupported } = useModels();
-  if (unsupported || !models || models.length === 0) {
+  const { models, unsupported, loading } = useModels();
+  if (unsupported || loading || models === undefined) {
     return null;
+  }
+  if (models.length === 0) {
+    return (
+      <span className="modelpicker modelpicker--empty" data-testid="model-picker-empty">
+        <span className="modelpicker__label">Model</span>
+        <span className="muted" title="Start kx serve with KX_SERVE_MODEL_GGUF to serve a model.">
+          none on this serve
+        </span>
+      </span>
+    );
   }
   const selected = models.find((m) => m.modelId === value) ?? models[0];
   return (

--- a/ui/src/components/editor/MonacoEditorImpl.tsx
+++ b/ui/src/components/editor/MonacoEditorImpl.tsx
@@ -6,7 +6,8 @@
  * bundle the size gate measures. Never import this module statically.
  */
 
-import Editor from "@monaco-editor/react";
+import Editor, { type OnMount } from "@monaco-editor/react";
+import { useRef } from "react";
 import { useTheme } from "../../app/use-theme";
 import { KX_DARK, KX_LIGHT, configureMonacoOnce } from "../../lib/monaco/setup";
 import type { EditorSurfaceProps } from "./editor-surface";
@@ -38,8 +39,23 @@ export default function MonacoEditorImpl({
   height = 220,
   testId,
   ariaLabel,
+  onSubmit,
+  placeholder,
 }: EditorSurfaceProps) {
   const { resolved } = useTheme();
+  // The Enter command is registered ONCE on mount; route it through a ref so
+  // the latest submit callback fires without re-registering per render.
+  const submitRef = useRef(onSubmit);
+  submitRef.current = onSubmit;
+
+  const handleMount: OnMount = (editor, monaco) => {
+    if (onSubmit !== undefined) {
+      // Plain Enter submits (the chat-composer contract); Shift+Enter keeps the
+      // DEFAULT newline binding (a distinct keybinding, untouched).
+      editor.addCommand(monaco.KeyCode.Enter, () => submitRef.current?.());
+    }
+  };
+
   return (
     <div className="monaco-host" data-testid={testId} aria-label={ariaLabel}>
       <Editor
@@ -48,11 +64,13 @@ export default function MonacoEditorImpl({
         theme={resolved === "dark" ? KX_DARK : KX_LIGHT}
         height={height}
         onChange={(v) => onChange?.(v ?? "")}
+        onMount={handleMount}
         options={{
           ...FIXED_OPTIONS,
           readOnly,
           domReadOnly: readOnly,
           lineNumbers: readOnly ? "on" : "on",
+          placeholder,
         }}
       />
     </div>

--- a/ui/src/components/editor/MonacoMount.tsx
+++ b/ui/src/components/editor/MonacoMount.tsx
@@ -29,6 +29,8 @@ function Fallback({
   ariaLabel,
   id,
   height,
+  onSubmit,
+  placeholder,
 }: EditorSurfaceProps) {
   const style = { height: typeof height === "number" ? `${height}px` : height };
   if (readOnly) {
@@ -48,7 +50,20 @@ function Fallback({
       style={style}
       spellCheck={false}
       autoComplete="off"
+      placeholder={placeholder}
       onChange={(e) => onChange?.(e.target.value)}
+      onKeyDown={
+        onSubmit === undefined
+          ? undefined
+          : (e) => {
+              // The same contract as the real editor's Enter command: plain
+              // Enter submits, Shift+Enter inserts the newline.
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                onSubmit();
+              }
+            }
+      }
     />
   );
 }

--- a/ui/src/components/editor/editor-surface.ts
+++ b/ui/src/components/editor/editor-surface.ts
@@ -22,4 +22,9 @@ export interface EditorSurfaceProps {
   readonly ariaLabel?: string;
   /** DOM id forwarded to the editable fallback `<textarea>` (label association). */
   readonly id?: string;
+  /** Plain-Enter submit (the chat composer). Shift+Enter keeps inserting a
+   *  newline in BOTH the real editor and the fallback textarea. */
+  readonly onSubmit?: () => void;
+  /** Ghost text shown while empty (Monaco `placeholder` option / textarea attr). */
+  readonly placeholder?: string;
 }

--- a/ui/src/components/shell/Icon.tsx
+++ b/ui/src/components/shell/Icon.tsx
@@ -10,6 +10,7 @@ import type { SVGProps } from "react";
 export type Glyph =
   | "activity"
   | "attach"
+  | "history"
   | "monitor"
   | "chat"
   | "chevron-right"
@@ -35,6 +36,7 @@ const PATHS: Record<Glyph, string> = {
   activity: "M3 12h4l2 6 4-15 2 9h6",
   attach:
     "M21 12.5l-8.5 8.5a6 6 0 01-8.5-8.5L12.5 4a4 4 0 015.7 5.7L9.7 18.2a2 2 0 01-2.9-2.9L15 7",
+  history: "M3 12a9 9 0 109-9 9.7 9.7 0 00-7 3.2M3 4v4h4M12 7v5l3.5 2",
   monitor: "M3 3v18h18M8 16V9m4 7V5m4 11v-4",
   chat: "M4 5h16v11H9l-4 4v-4H4z",
   "chevron-right": "M9 6l6 6-6 6",

--- a/ui/src/kx/use-chat.ts
+++ b/ui/src/kx/use-chat.ts
@@ -18,6 +18,7 @@
 import type { RecipeForm } from "@kortecx/sdk/web";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import {
+  type ChatMessage,
   type ChatThread,
   EMPTY_THREAD,
   type MessageAttachment,
@@ -64,6 +65,8 @@ export interface UseChat {
   send(text: string, attachments?: readonly MessageAttachment[]): Promise<void>;
   /** Re-dispatch a FAILED turn with its identical args. */
   retry(assistantId: string): Promise<void>;
+  /** Restore a saved thread (chat history) — replaces the live one. */
+  loadThread(messages: readonly ChatMessage[]): void;
   reset(): void;
 }
 
@@ -268,6 +271,13 @@ export function useChat({ handle, promptKey, modelId }: UseChatOptions): UseChat
     [thread, startTurn],
   );
 
+  const loadThread = useCallback((messages: readonly ChatMessage[]): void => {
+    setActive(null);
+    setDegraded(null);
+    finalizedRef.current = null;
+    dispatch({ type: "load_thread", messages });
+  }, []);
+
   const reset = useCallback((): void => {
     setActive(null);
     setDegraded(null);
@@ -283,6 +293,7 @@ export function useChat({ handle, promptKey, modelId }: UseChatOptions): UseChat
     activeAssistantId: active?.assistantId,
     send,
     retry,
+    loadThread,
     reset,
   };
 }

--- a/ui/src/kx/use-upload-preview.ts
+++ b/ui/src/kx/use-upload-preview.ts
@@ -1,0 +1,53 @@
+/**
+ * Re-resolve a RESTORED attachment's image preview through the uploads scope
+ * (Batch A `GetContentBatch`). A live chat previews from the session-local
+ * `blob:` URL of the user's own file; a thread restored from history has no
+ * such URL, so the bytes come back from the gateway's content store (the SAME
+ * server-derived ref) and become a fresh object URL. Content-addressed ⇒ the
+ * query caches forever; a uniform-empty item (other endpoint / pruned store)
+ * resolves to `null` and the bubble shows the chip only.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { classifyItem } from "../lib/content-resolver";
+import { useConnection } from "./connection-context";
+import { queryKeys } from "./query-keys";
+
+export function useUploadPreview(ref: string, mediaType: string, enabled: boolean): string | null {
+  const { client, endpoint, status } = useConnection();
+  const query = useQuery({
+    queryKey: queryKeys.contentBatch(endpoint, "uploads", ref),
+    enabled: enabled && status === "connected" && client !== null && mediaType.startsWith("image/"),
+    staleTime: Number.POSITIVE_INFINITY, // content-addressed ⇒ immutable
+    retry: false,
+    queryFn: async (): Promise<string | null> => {
+      if (!client) {
+        return null;
+      }
+      const items = await client.getContentBatch([ref]);
+      const item = items[0];
+      if (!item || item.missing) {
+        return null;
+      }
+      const resolved = classifyItem(item);
+      if (resolved.kind !== "image") {
+        return null;
+      }
+      return URL.createObjectURL(new Blob([resolved.bytes as BlobPart], { type: mediaType }));
+    },
+  });
+
+  const url = query.data ?? null;
+  // Revoke the object URL when it falls out of use (component unmount or a
+  // re-resolve) — mirrors use-attachments' lifecycle discipline.
+  useEffect(() => {
+    return () => {
+      if (url !== null) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, [url]);
+
+  return url;
+}

--- a/ui/src/lib/chat-history.ts
+++ b/ui/src/lib/chat-history.ts
@@ -1,0 +1,143 @@
+/**
+ * Client-local chat history backed by localStorage (the `recent-runs.ts`
+ * pattern): keyed PER ENDPOINT so switching gateways never mixes histories,
+ * bounded, fail-closed (a corrupt/unavailable store yields an empty list).
+ *
+ * Per the build-out plan's open-question-5 decision this is PRESENTATION state
+ * — client-local now; durable server-side sessions are a future sidecar batch.
+ * Attachment `objectUrl`s are STRIPPED on save (`blob:` URLs die with the
+ * document); a restored image preview re-resolves through the uploads scope
+ * (`use-upload-preview`). In-flight turns are downgraded to `failed` on save so
+ * a restored thread re-arms through the existing retry affordance instead of
+ * spinning forever.
+ */
+
+import type { ChatMessage } from "./chat-thread";
+
+export interface SavedChat {
+  readonly id: string;
+  /** Display title — the first user message, truncated. */
+  readonly title: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly messages: readonly ChatMessage[];
+}
+
+/** Keep the history bounded (newest-updated first). */
+const MAX_CHATS = 30;
+const TITLE_MAX = 64;
+
+/** Fired on `window` whenever the persisted history changes (same-tab refresh —
+ *  the browser `storage` event only fires in OTHER tabs). */
+export const CHATS_CHANGED_EVENT = "kortecx:chats-changed";
+
+function notifyChatsChanged(): void {
+  try {
+    window.dispatchEvent(new Event(CHATS_CHANGED_EVENT));
+  } catch {
+    /* non-browser env */
+  }
+}
+
+function keyFor(endpoint: string): string {
+  return `kortecx.ui.chats:${endpoint}`;
+}
+
+/** The display title for a thread: its first user message, truncated. */
+export function chatTitle(messages: readonly ChatMessage[]): string {
+  const first = messages.find((m) => m.role === "user")?.text ?? "(empty chat)";
+  const oneLine = first.replace(/\s+/g, " ").trim();
+  return oneLine.length > TITLE_MAX ? `${oneLine.slice(0, TITLE_MAX)}…` : oneLine;
+}
+
+/** A message as persisted: no `blob:` object URLs, no in-flight statuses. */
+function sanitizeMessage(m: ChatMessage): ChatMessage {
+  const attachments = m.attachments?.map(({ objectUrl: _drop, ...rest }) => rest);
+  const inFlight = m.status === "pending" || m.status === "thinking";
+  return {
+    ...m,
+    attachments,
+    // An interrupted turn restores as FAILED (re-armable via retry) — never as
+    // a forever-spinner.
+    status: inFlight ? "failed" : m.status,
+    error: inFlight
+      ? {
+          code: "interrupted",
+          kind: "retry",
+          title: "Interrupted",
+          message: "This turn was in flight when the chat was saved — retry to re-run it.",
+          retryable: true,
+        }
+      : m.error,
+  };
+}
+
+export function loadChats(endpoint: string): SavedChat[] {
+  try {
+    const raw = localStorage.getItem(keyFor(endpoint));
+    if (raw === null) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isSavedChat).slice(0, MAX_CHATS);
+  } catch {
+    return [];
+  }
+}
+
+/** Upsert a chat by id (newest-updated first, bounded), return the list.
+ *  An EMPTY thread is a no-op (nothing worth listing). */
+export function saveChat(
+  endpoint: string,
+  id: string,
+  messages: readonly ChatMessage[],
+  now: number = Date.now(),
+): SavedChat[] {
+  if (messages.length === 0) {
+    return loadChats(endpoint);
+  }
+  const existing = loadChats(endpoint);
+  const prior = existing.find((c) => c.id === id);
+  const next: SavedChat = {
+    id,
+    title: chatTitle(messages),
+    createdAt: prior?.createdAt ?? now,
+    updatedAt: now,
+    messages: messages.map(sanitizeMessage),
+  };
+  const list = [next, ...existing.filter((c) => c.id !== id)].slice(0, MAX_CHATS);
+  try {
+    localStorage.setItem(keyFor(endpoint), JSON.stringify(list));
+  } catch {
+    /* best-effort (quota/private mode) */
+  }
+  notifyChatsChanged();
+  return list;
+}
+
+export function deleteChat(endpoint: string, id: string): SavedChat[] {
+  const list = loadChats(endpoint).filter((c) => c.id !== id);
+  try {
+    localStorage.setItem(keyFor(endpoint), JSON.stringify(list));
+  } catch {
+    /* best-effort */
+  }
+  notifyChatsChanged();
+  return list;
+}
+
+function isSavedChat(v: unknown): v is SavedChat {
+  if (v === null || typeof v !== "object") {
+    return false;
+  }
+  const c = v as Record<string, unknown>;
+  return (
+    typeof c.id === "string" &&
+    typeof c.title === "string" &&
+    typeof c.updatedAt === "number" &&
+    Array.isArray(c.messages)
+  );
+}

--- a/ui/src/lib/chat-thread.ts
+++ b/ui/src/lib/chat-thread.ts
@@ -61,6 +61,8 @@ export type ChatAction =
   /** Re-dispatch a FAILED turn with its identical args (Batch A idempotent-run
    *  UX: content-addressed refs + server dedup make the re-run safe). */
   | { type: "turn_retry"; assistantId: string }
+  /** Restore a saved thread (chat history) — replaces the whole message list. */
+  | { type: "load_thread"; messages: readonly ChatMessage[] }
   | { type: "reset" };
 
 /** Replace the message with `id` via `fn` (identity if not found). */
@@ -115,6 +117,8 @@ export function chatReducer(state: ChatThread, action: ChatAction): ChatThread {
       return patch(state, action.assistantId, (m) =>
         m.status === "failed" ? { ...m, status: "pending", error: undefined, text: "" } : m,
       );
+    case "load_thread":
+      return { messages: [...action.messages] };
     case "reset":
       return EMPTY_THREAD;
     default:

--- a/ui/src/lib/monaco/infer-language.ts
+++ b/ui/src/lib/monaco/infer-language.ts
@@ -1,12 +1,14 @@
 /**
- * Pure language inference for the read-only code viewer. We only ever distinguish
- * JSON from plaintext (the two languages the offline Monaco bundle ships — see
- * `setup.ts`), so this stays a tiny, total, unit-testable function. An object/array
- * that round-trips through `JSON.parse` is "json"; everything else is "plaintext".
- * Mirrors `content-decode.ts`'s "only objects/arrays are JSON" rule.
+ * Pure language inference for the read-only code viewer. The offline Monaco
+ * bundle ships JSON + plaintext + markdown (markdown is a tokenizer-only basic
+ * language for the chat composer — see `setup.ts`); inference itself only ever
+ * distinguishes JSON from plaintext, so this stays a tiny, total, unit-testable
+ * function. An object/array that round-trips through `JSON.parse` is "json";
+ * everything else is "plaintext". Mirrors `content-decode.ts`'s
+ * "only objects/arrays are JSON" rule.
  */
 
-export type MonacoLanguage = "json" | "plaintext";
+export type MonacoLanguage = "json" | "plaintext" | "markdown";
 
 export function inferLanguage(text: string): MonacoLanguage {
   const trimmed = text.trim();

--- a/ui/src/lib/monaco/setup.ts
+++ b/ui/src/lib/monaco/setup.ts
@@ -18,6 +18,9 @@ import { loader } from "@monaco-editor/react";
 // The tree-shakeable ESM API entry (NOT the `monaco-editor` barrel, which drags
 // every language). The JSON contribution adds the JSON language + diagnostics.
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+// The markdown BASIC language (tokenizer only, no worker/diagnostics) — the chat
+// composer's syntax highlighting. Tiny; rides this same lazy chunk.
+import "monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution";
 import "monaco-editor/esm/vs/language/json/monaco.contribution";
 // `?worker` makes Vite emit each worker as its OWN hash-named chunk, loaded at
 // runtime by the editor — never a modulepreload, never in the eager set.

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1116,18 +1116,6 @@ select {
 .thinking-trace {
   margin-top: 0.5rem;
 }
-.composer {
-  display: flex;
-  gap: 0.5rem;
-  align-items: flex-end;
-  border-top: 1px solid var(--border);
-  padding-top: 0.6rem;
-}
-.composer textarea {
-  flex: 1;
-  margin: 0;
-  resize: vertical;
-}
 .chat-settings {
   margin: 0.5rem 0;
 }
@@ -1152,6 +1140,120 @@ select {
   display: flex;
   justify-content: flex-end;
   padding-top: 0.4rem;
+}
+.composer {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+  border-top: 1px solid var(--border);
+  padding-top: 0.6rem;
+}
+.composer__editor {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.composer__editor .editor-surface__fallback {
+  width: 100%;
+  margin: 0;
+  border: 0;
+  resize: vertical;
+}
+/* The action column: send on top, attach BELOW it (user-directed 2026-06-12). */
+.composer__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  justify-content: flex-start;
+}
+.chat-history__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  border: 0;
+  padding: 0;
+  background: var(--backdrop-color);
+  cursor: pointer;
+}
+.chat-history {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 80;
+  width: min(420px, 94vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  border-left: 1px solid var(--border-md);
+  box-shadow: -16px 0 48px rgba(0, 0, 0, 0.25);
+  overflow-y: auto;
+  padding: 1rem;
+}
+.chat-history__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.chat-history__head h2 {
+  margin: 0;
+}
+.chat-history__note {
+  margin-top: 0.2rem;
+}
+.chat-history__list {
+  list-style: none;
+  margin: 0.6rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.chat-history__item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.chat-history__load {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  text-align: left;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem 0.65rem;
+  cursor: pointer;
+  color: var(--fg);
+  font-size: 0.88rem;
+}
+.chat-history__load:hover {
+  border-color: var(--fg-muted);
+}
+.chat-history__title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+.chat-history__delete {
+  padding: 0 0.35rem;
+}
+.modelpicker--empty {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.screen__head-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 .modelpicker {
   display: inline-flex;

--- a/ui/test/unit/chat-attachments.test.ts
+++ b/ui/test/unit/chat-attachments.test.ts
@@ -111,3 +111,18 @@ describe("planVisionArgs (form-gated — never send an undeclared arg)", () => {
     });
   });
 });
+
+describe("chatReducer load_thread (chat history restore)", () => {
+  it("replaces the whole message list", () => {
+    const live = sendWithAttachment(EMPTY_THREAD);
+    const restored = chatReducer(live, {
+      type: "load_thread",
+      messages: [
+        { id: "x1", role: "user", text: "from history", status: "done" },
+        { id: "x2", role: "assistant", text: "the saved reply", status: "done", forUserId: "x1" },
+      ],
+    });
+    expect(restored.messages.map((m) => m.id)).toEqual(["x1", "x2"]);
+    expect(restored.messages[1]?.text).toBe("the saved reply");
+  });
+});

--- a/ui/test/unit/chat-history.test.ts
+++ b/ui/test/unit/chat-history.test.ts
@@ -1,0 +1,92 @@
+/** PR-1.1 chat history — pure localStorage store (per-endpoint, bounded,
+ *  fail-closed; objectUrls stripped; in-flight turns downgraded on save). */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { chatTitle, deleteChat, loadChats, saveChat } from "../../src/lib/chat-history";
+import type { ChatMessage } from "../../src/lib/chat-thread";
+
+const EP = "http://127.0.0.1:50151";
+
+function msg(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: over.id ?? "u1",
+    role: "user",
+    text: "hello runtime",
+    status: "done",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("saveChat / loadChats", () => {
+  it("upserts by id, newest-updated first, per endpoint", () => {
+    saveChat(EP, "a", [msg({ text: "first chat" })], 100);
+    saveChat(EP, "b", [msg({ text: "second chat" })], 200);
+    saveChat(EP, "a", [msg({ text: "first chat" }), msg({ id: "u2", text: "more" })], 300);
+    const chats = loadChats(EP);
+    expect(chats.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(chats[0]?.messages).toHaveLength(2);
+    expect(chats[0]?.createdAt).toBe(100); // upsert keeps the original createdAt
+    expect(loadChats("http://other:1")).toEqual([]);
+  });
+
+  it("an empty thread is a no-op (nothing worth listing)", () => {
+    saveChat(EP, "a", []);
+    expect(loadChats(EP)).toEqual([]);
+  });
+
+  it("strips blob: objectUrls and downgrades in-flight turns on save", () => {
+    const messages: ChatMessage[] = [
+      msg({
+        attachments: [
+          { ref: "cd".repeat(32), filename: "x.png", mediaType: "image/png", objectUrl: "blob:x" },
+        ],
+      }),
+      msg({ id: "a1", role: "assistant", text: "", status: "thinking", forUserId: "u1" }),
+    ];
+    saveChat(EP, "a", messages, 100);
+    const [chat] = loadChats(EP);
+    expect(chat?.messages[0]?.attachments?.[0]?.objectUrl).toBeUndefined();
+    expect(chat?.messages[0]?.attachments?.[0]?.ref).toBe("cd".repeat(32));
+    // The interrupted turn restores re-armable, never a forever-spinner.
+    expect(chat?.messages[1]?.status).toBe("failed");
+    expect(chat?.messages[1]?.error?.retryable).toBe(true);
+  });
+
+  it("caps the history at 30 (newest kept)", () => {
+    for (let i = 0; i < 35; i++) {
+      saveChat(EP, `c${i}`, [msg({ text: `chat ${i}` })], i);
+    }
+    const chats = loadChats(EP);
+    expect(chats).toHaveLength(30);
+    expect(chats[0]?.id).toBe("c34");
+  });
+
+  it("is fail-closed on a corrupt store", () => {
+    localStorage.setItem(`kortecx.ui.chats:${EP}`, "{not json");
+    expect(loadChats(EP)).toEqual([]);
+    localStorage.setItem(`kortecx.ui.chats:${EP}`, JSON.stringify({ nope: 1 }));
+    expect(loadChats(EP)).toEqual([]);
+  });
+});
+
+describe("deleteChat", () => {
+  it("forgets one chat and keeps the rest", () => {
+    saveChat(EP, "a", [msg()], 1);
+    saveChat(EP, "b", [msg({ text: "other" })], 2);
+    const left = deleteChat(EP, "a");
+    expect(left.map((c) => c.id)).toEqual(["b"]);
+    expect(loadChats(EP).map((c) => c.id)).toEqual(["b"]);
+  });
+});
+
+describe("chatTitle", () => {
+  it("is the first user message, whitespace-collapsed and truncated", () => {
+    expect(chatTitle([msg({ text: "  what\n is \tthis? " })])).toBe("what is this?");
+    expect(chatTitle([msg({ text: "x".repeat(100) })])).toBe(`${"x".repeat(64)}…`);
+    expect(chatTitle([])).toBe("(empty chat)");
+  });
+});


### PR DESCRIPTION
User review feedback on PR-1 New Chat (#187), four items, UI-only:

1. **Attach below send** — the composer's action column (right side): send on top, attach beneath it.
2. **Chat history** — client-local, per-endpoint localStorage (the plan archive's open-question-5 decision: presentation state now, server-side sessions later). Threads autosave on every change; a History slide-over lists them (title · time · count) with restore + delete; `objectUrl`s are stripped on save and in-flight turns downgrade to re-armable `failed`; restored image previews re-resolve through the uploads scope (`GetContentBatch`, same server-derived ref).
3. **Monaco markdown composer** — D141.2's last exception closed: the input is a Monaco surface (markdown tokenizer added to the offline bundle — rides the existing lazy chunk, eager budget untouched at 490 KB/600 KB); plain Enter sends via `editor.addCommand`, Shift+Enter keeps the newline; the jsdom textarea fallback carries the identical contract (additive `onSubmit`/`placeholder` on the shared editor surface).
4. **Visible model control** — a model-less serve now shows an honest disabled empty state ("none on this serve") instead of unmounting; only a gateway predating `ListModels` renders nothing.

**Also fixes a real regression the Monaco composer exposed** (root-caused, not retried, per GR12): Monaco appends empty global `role="alert"` aria containers to `document.body` that survive SPA navigation — `recipes-form.spec`'s bare `getByRole("alert")` strict locator now collides; filtered to the actual validation message.

**Gates**: 391 vitest · biome · tsc · `npm run size` (eager unchanged — markdown is lazy) · full Playwright **28 passed, 0 flaky** (new `chat-history.spec` reload-restore round trip; the Monaco-aware `typeMessage` fixture replaces label-fill). Live both-theme embedded-console review delivered (Monaco highlighting, Enter-sends, attach-below-send, history restore across reload, visible model state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)