### PR TITLE
feat(ui): resolve & display response TEXT everywhere (D142.2 content-resolution completion)

### DIFF
--- a/docs/site/docs/reading-run-outputs.md
+++ b/docs/site/docs/reading-run-outputs.md
@@ -1,0 +1,115 @@
+---
+id: reading-run-outputs
+title: Reading run outputs
+sidebar_label: Reading run outputs
+description: How committed results are stored content-addressed and resolved back to text in the console, the SDKs, and the CLI.
+---
+
+# Reading run outputs
+
+Every Mote that commits produces a **result** — the bytes it computed. Kortecx
+stores those bytes **content-addressed** and hands you back a small pointer. This
+page explains how the output is stored, how to read it back, and how the console
+turns a pointer into the text you actually see.
+
+## How a result is stored
+
+When a Mote commits, its output bytes are written **once** to the gateway's
+content store, keyed by their own hash:
+
+```
+result_ref = blake3(result_bytes)      // a 32-byte content address
+```
+
+The durable journal records only that 32-byte `result_ref` — never the payload.
+The commit protocol verifies the bytes are present in the content store
+**before** it writes the `Committed` fact (so a ref always resolves), and because
+the ref *is* the hash of the content, the lookup can never go stale: identical
+output always lands at the same address, and the same address always returns the
+same bytes.
+
+This is why a run's graph stays small and fast to query no matter how large its
+outputs are — the topology holds pointers, the content store holds bytes.
+
+## Reading it back
+
+Resolve a ref with **`GetContent`** (one ref) or **`GetContentBatch`** (up to 64
+refs in a single round trip — the N+1 collapse for tables and feeds). Both are
+**run-scoped**: a ref is readable only by the run that produced it (pass the
+run's `instance_id`), and an unauthorized, missing, or malformed ref comes back
+as a **uniform empty item** — there is no existence oracle.
+
+### TypeScript
+
+```ts
+import { KxClient } from "@kortecx/sdk";
+
+const kx = new KxClient("http://127.0.0.1:50151");
+const run = await kx.invoke("kx/recipes/echo", { topic: "hello" }, { wait: true });
+
+// One result:
+const bytes = await kx.getContent(run.resultRef, run.instanceId);
+console.log(new TextDecoder().decode(bytes));
+
+// Many at once (preview-sized), e.g. every committed Mote in a run:
+const items = await kx.getContentBatch(refs, {
+  instanceId: run.instanceId,
+  maxBytesPerItem: 4096n,
+});
+for (const it of items) {
+  if (it.missing) continue; // uniform denial — not an error
+  console.log(it.contentRef, new TextDecoder().decode(it.payload), it.truncated);
+}
+```
+
+### Python
+
+```python
+from kortecx import KxClient
+
+kx = KxClient("http://127.0.0.1:50151")
+run = kx.invoke("kx/recipes/echo", {"topic": "hello"}, wait=True)
+
+# One result:
+data = kx.get_content(run.result_ref, run.instance_id)
+print(data.decode())
+
+# Many at once (preview-sized):
+items = kx.get_content_batch(refs, instance_id=run.instance_id, max_bytes_per_item=4096)
+for it in items:
+    if it.missing:        # uniform denial — not an error
+        continue
+    print(it.content_ref, it.payload.decode(errors="replace"), it.truncated)
+```
+
+### CLI
+
+```sh
+# kx invoke --wait inlines a printable result as result_utf8 (text) + result_hex.
+kx invoke kx/recipes/echo --args '{"topic":"hello"}' --wait --json
+
+# Or fetch any committed ref directly (run-scoped with --instance):
+kx content get --ref <result_ref_hex> --instance <instance_id_hex>
+kx content get --ref <result_ref_hex> --out result.bin   # large/binary → a file
+```
+
+## How the console shows it
+
+The web console never makes you read a hash. Wherever a result appears — the run
+**table**, the **DAG** node, the **Artifacts** list, the **Activity** feed, the
+node **inspector**, and **chat** answers — the **resolved text is the headline**
+and the content address rides alongside as a small **digest chip** you can click
+to copy. The console batches all the refs visible on a surface into a single
+`GetContentBatch`, so a wide table or a long feed resolves in one round trip, and
+each row repaints from `resolving…` to its text as the batch lands.
+
+Honest states are kept honest: an uncommitted Mote shows a dash (no result yet),
+an empty result reads `(empty)`, non-UTF-8 output reads `binary · N B` (never a
+fake text headline), and a preview truncated at the per-item clamp links to the
+full artifact. None of these are ever shown as a bare hash.
+
+:::note Display only
+Resolved content is for reading. Identity and authority always come from the
+runtime: the ref is a content address (it changes when the bytes change), never a
+capability — reading it still goes through the run-scoped, uniform-denial check.
+:::

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         "tools",
         "scripts",
         "agent-runner",
+        "reading-run-outputs",
         "observability",
       ],
     },

--- a/ui/e2e/result-text-fidelity.spec.ts
+++ b/ui/e2e/result-text-fidelity.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+/**
+ * D142.2 content-resolution: every run-output surface shows the RESOLVED result
+ * TEXT as the headline (with the digest demoted to a copy chip), never a bare
+ * hash. The model-free echo recipe commits a fully-printable demo result
+ * ("kx demo result for mote <hex>\n"), so the resolved text is a stable,
+ * assertable string across the table, DAG node, artifact list, and event feed —
+ * in BOTH themes.
+ */
+
+const DEMO_TEXT = "kx demo result for mote";
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("run outputs resolve to TEXT across table, DAG, artifacts + feed (both themes)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  // WS bridge so the run-scoped Activity feed tails real committed deltas.
+  await connectConsole(page, gw, { wsEndpoint: gw.wsEndpoint });
+
+  await runRecipe(page, { handle: "kx/recipes/echo", fields: { topic: "fidelity" } });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).count(), {
+      timeout: 30_000,
+    })
+    .toBeGreaterThan(0);
+
+  // --- DAG node: the resolved text is on the node (a glimpse of the output). ---
+  await expect(page.locator(".dag-node__result").first()).toContainText(DEMO_TEXT, {
+    timeout: 30_000,
+  });
+
+  // --- Table: the Result column is the resolved text headline + a digest chip. ---
+  await page.getByTestId("run-tab-table").click();
+  const preview = page.getByTestId("result-preview").first();
+  await expect(preview).toHaveAttribute("data-state", "text", { timeout: 30_000 });
+  await expect(preview).toContainText(DEMO_TEXT);
+  // the digest rides as the SECONDARY affordance (present, not the headline)
+  await expect(preview.getByTestId("digest-chip")).toBeVisible();
+
+  // --- Artifacts: each list row leads with the resolved text. ---
+  await page.getByTestId("run-tab-artifacts").click();
+  await expect(page.getByTestId("artifact-gallery")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator(".artifact-list__row .result-preview").first()).toContainText(
+    DEMO_TEXT,
+    { timeout: 30_000 },
+  );
+
+  // --- Activity feed: the committed event row shows the resolved text. ---
+  await page.getByTestId("run-tab-activity").click();
+  await expect(page.getByTestId("run-activity-tab")).toBeVisible();
+  const feedRow = page.getByTestId("event-row").filter({ hasText: DEMO_TEXT }).first();
+  await expect(feedRow).toBeVisible({ timeout: 30_000 });
+
+  // --- Both themes: the resolution is theme-agnostic (tokens only). Flip to dark
+  //     and re-confirm the table headline still resolves to text (not a hash). ---
+  await page.getByTestId("nav-settings").click();
+  await expect(page.getByTestId("settings-section")).toBeVisible();
+  await page.getByTestId("theme-chip-dark").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+  await page.getByTestId("nav-runs").click();
+  await page.getByTestId("run-open").first().click();
+  await page.getByTestId("run-tab-table").click();
+  const darkPreview = page.getByTestId("result-preview").first();
+  await expect(darkPreview).toHaveAttribute("data-state", "text", { timeout: 30_000 });
+  await expect(darkPreview).toContainText(DEMO_TEXT);
+});

--- a/ui/src/components/MoteRow.tsx
+++ b/ui/src/components/MoteRow.tsx
@@ -1,12 +1,25 @@
 import { memo } from "react";
 import type { MoteVM } from "../kx/use-projection";
 import { promotionIsNotable, promotionLabel } from "../lib/colors";
+import type { DecodedContent } from "../lib/content-decode";
 import { formatSeq, shortHex } from "../lib/format";
 import { AnomalyBadge } from "./AnomalyBadge";
 import { NdClassBadge } from "./NdClassBadge";
+import { ResultPreview } from "./ResultPreview";
 import { StatePill } from "./StatePill";
 
-function MoteRowImpl({ mote }: { mote: MoteVM }) {
+function MoteRowImpl({
+  mote,
+  content,
+  missing = false,
+  resolving = false,
+}: {
+  mote: MoteVM;
+  /** The resolved result (from the table's batch fetch); undefined while resolving. */
+  content?: DecodedContent;
+  missing?: boolean;
+  resolving?: boolean;
+}) {
   return (
     <tr data-testid="mote-row" data-mote={mote.moteId} data-state={mote.stateCode}>
       <td className="mono" title={mote.moteId}>
@@ -20,7 +33,18 @@ function MoteRowImpl({ mote }: { mote: MoteVM }) {
       </td>
       <td>{promotionIsNotable(mote.promotion) ? promotionLabel(mote.promotion) : ""}</td>
       <td className="num">{formatSeq(mote.committedSeq)}</td>
-      <td className="mono">{mote.resultRef ? shortHex(mote.resultRef) : ""}</td>
+      <td className="mote-table__result">
+        {/* max=4096 (the preview-byte cap) means JS does NOT pre-clip — the text
+            grows to fill the cell and CSS ellipsis-clips at the chip, so the chip
+            sits flush against the text with no gap. The full text is in `title`. */}
+        <ResultPreview
+          resultRef={mote.resultRef}
+          content={content}
+          missing={missing}
+          loading={resolving}
+          max={4096}
+        />
+      </td>
       <td>
         <AnomalyBadge anomaly={mote.anomaly} />
       </td>
@@ -31,6 +55,8 @@ function MoteRowImpl({ mote }: { mote: MoteVM }) {
 // Re-render a row only when a field that affects its display changes. With the
 // data layer's structural sharing the prop reference is usually already stable;
 // this comparator is the belt-and-braces guarantee the perf budget relies on.
+// `content`/`missing`/`resolving` ride the batch fetch — compare them too so a
+// row repaints from "resolving…" to its resolved text.
 export const MoteRow = memo(MoteRowImpl, (prev, next) => {
   const a = prev.mote;
   const b = next.mote;
@@ -41,6 +67,9 @@ export const MoteRow = memo(MoteRowImpl, (prev, next) => {
     a.promotion === b.promotion &&
     a.resultRef === b.resultRef &&
     a.committedSeq === b.committedSeq &&
-    a.anomaly === b.anomaly
+    a.anomaly === b.anomaly &&
+    prev.content === next.content &&
+    prev.missing === next.missing &&
+    prev.resolving === next.resolving
   );
 });

--- a/ui/src/components/MoteTable.tsx
+++ b/ui/src/components/MoteTable.tsx
@@ -1,14 +1,26 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
+import { useResultMap } from "../kx/use-content-batch";
 import type { ProjectionVM } from "../kx/use-projection";
 import { EmptyState } from "./EmptyState";
 import { MoteRow } from "./MoteRow";
 
 /**
- * The run's Motes as a status table. This is the T3.3 forward seam: the live DAG
- * viewer will replace this view (keeping the same `ProjectionVM` input). Memoized so
- * an unchanged poll (stable `projection` reference via structural sharing) is a no-op.
+ * The run's Motes as a status table. The Result column shows the RESOLVED text
+ * (the headline) with a digest chip (D142.2) — every committed result is fetched
+ * in ONE `getContentBatch` via `useResultMap` (the N+1 collapse), so the whole
+ * table resolves with a single round trip. Memoized so an unchanged poll (stable
+ * `projection` reference via structural sharing) is a no-op.
  */
 function MoteTableImpl({ projection }: { projection: ProjectionVM }) {
+  // Batch-resolve every committed result in the visible projection (one RPC).
+  // The run scope rides the projection (no separate prop to thread, so the DAG's
+  // >MAX table fallback resolves text too).
+  const refs = useMemo(
+    () => projection.motes.flatMap((m) => (m.resultRef ? [m.resultRef] : [])),
+    [projection.motes],
+  );
+  const { byRef, isLoading } = useResultMap(projection.instanceId, refs);
+
   if (projection.motes.length === 0) {
     return (
       <EmptyState
@@ -19,6 +31,18 @@ function MoteTableImpl({ projection }: { projection: ProjectionVM }) {
   }
   return (
     <table className="mote-table" data-testid="mote-table">
+      {/* Fixed column widths so the Result column is BOUNDED — its resolved text
+          ellipsis-clips inside the cell and the trailing digest chip stays on
+          screen (an unbounded Result column pushes the chip past the viewport). */}
+      <colgroup>
+        <col style={{ width: "13%" }} />
+        <col style={{ width: "11%" }} />
+        <col style={{ width: "9%" }} />
+        <col style={{ width: "11%" }} />
+        <col style={{ width: "9%" }} />
+        <col style={{ width: "37%" }} />
+        <col style={{ width: "10%" }} />
+      </colgroup>
       <thead>
         <tr>
           <th scope="col">Mote</th>
@@ -31,9 +55,18 @@ function MoteTableImpl({ projection }: { projection: ProjectionVM }) {
         </tr>
       </thead>
       <tbody>
-        {projection.motes.map((m) => (
-          <MoteRow key={m.moteId} mote={m} />
-        ))}
+        {projection.motes.map((m) => {
+          const vm = m.resultRef ? byRef.get(m.resultRef) : undefined;
+          return (
+            <MoteRow
+              key={m.moteId}
+              mote={m}
+              content={vm?.content}
+              missing={vm?.missing ?? false}
+              resolving={isLoading}
+            />
+          );
+        })}
       </tbody>
     </table>
   );

--- a/ui/src/components/ResultPreview.tsx
+++ b/ui/src/components/ResultPreview.tsx
@@ -1,0 +1,88 @@
+import type { DecodedContent } from "../lib/content-decode";
+import { DigestChip } from "./DigestChip";
+
+/**
+ * The D142.2 "resolved text is the HEADLINE, the digest a secondary pointer"
+ * treatment for a committed result, in an inline/dense context (mote tables,
+ * the artifact list, event feeds, the DAG node). PRESENTATIONAL: the container
+ * batch-fetches all visible refs in ONE `getContentBatch` (the N+1 collapse —
+ * see `use-content-batch`) and feeds each row its decoded `content`, so a wide
+ * table/feed never fans out per row. The full payload is one click away (the
+ * node-detail Result pane / artifact view render the complete text).
+ *
+ * States (all honest): uncommitted (no ref) · resolving · unavailable (the
+ * uniform-empty item) · empty result · binary · truncated preview · text.
+ */
+
+/** Collapse whitespace + clip to a one-line preview (the dense-context headline). */
+export function oneLine(text: string, max = 140): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+export function ResultPreview({
+  resultRef,
+  content,
+  loading = false,
+  missing = false,
+  max = 140,
+  chip = true,
+}: {
+  /** The committed result's content ref (hex), or null when uncommitted. */
+  resultRef: string | null;
+  /** The decoded payload (from the container's batch fetch); undefined while loading. */
+  content?: DecodedContent;
+  loading?: boolean;
+  /** True iff the batch returned the uniform-empty item for this ref. */
+  missing?: boolean;
+  /** One-line preview character cap. */
+  max?: number;
+  /** Render the trailing `DigestChip`. Set false when the container sits inside a
+   *  `<button>` (nested buttons are invalid) and renders its own chip as a sibling. */
+  chip?: boolean;
+}) {
+  // Uncommitted Mote — no result yet (honest, not a hash).
+  if (!resultRef) {
+    return <span className="muted">—</span>;
+  }
+
+  const chipEl = chip ? <DigestChip hex={resultRef} label="result" /> : null;
+
+  if (loading && !content) {
+    return (
+      <span className="result-preview" data-testid="result-preview" data-state="loading">
+        <span className="muted">resolving…</span> {chipEl}
+      </span>
+    );
+  }
+  if (missing) {
+    return (
+      <span className="result-preview" data-testid="result-preview" data-state="missing">
+        <span className="muted">unavailable</span> {chipEl}
+      </span>
+    );
+  }
+  if (!content || content.kind === "empty") {
+    return (
+      <span className="result-preview" data-testid="result-preview" data-state="empty">
+        <span className="muted">(empty)</span> {chipEl}
+      </span>
+    );
+  }
+  if (content.kind === "binary") {
+    return (
+      <span className="result-preview" data-testid="result-preview" data-state="binary">
+        <span className="muted">binary · {content.byteLength} B</span> {chipEl}
+      </span>
+    );
+  }
+  // text | json: the resolved text IS the headline; the digest is the pointer.
+  return (
+    <span className="result-preview" data-testid="result-preview" data-state="text">
+      <span className="result-preview__text" title={content.text}>
+        {oneLine(content.text, max)}
+      </span>{" "}
+      {chipEl}
+    </span>
+  );
+}

--- a/ui/src/components/activity/ActivityFeed.tsx
+++ b/ui/src/components/activity/ActivityFeed.tsx
@@ -1,17 +1,37 @@
 import type { Delta } from "@kortecx/sdk/web";
+import { useMemo } from "react";
+import { useResultMap } from "../../kx/use-content-batch";
 import { EmptyState } from "../EmptyState";
 import { EventRow } from "./EventRow";
 
-/** The live event list (newest-first). Handles empty, listening, and dropped tails. */
+/**
+ * The live event list (newest-first). Handles empty, listening, and dropped tails.
+ * Committed rows resolve their result TEXT in one batch round trip (the N+1
+ * collapse, run-scoped) so the feed shows outputs, not hashes (D142.2). When
+ * `instanceId` is absent the rows degrade to the summary (no resolution).
+ */
 export function ActivityFeed({
   events,
   dropped,
   active,
+  instanceId,
 }: {
   events: Delta[];
   dropped: boolean;
   active: boolean;
+  instanceId?: string;
 }) {
+  // Resolve the visible committed deltas' results (bounded to what's on screen).
+  // No instance scope ⇒ no fetch (the query stays disabled on an empty ref set).
+  const refs = useMemo(
+    () =>
+      instanceId
+        ? events.flatMap((d) => (d.kind === "committed" && d.resultRef ? [d.resultRef] : []))
+        : [],
+    [events, instanceId],
+  );
+  const { byRef, isLoading } = useResultMap(instanceId ?? "", refs);
+
   if (events.length === 0) {
     return (
       <EmptyState
@@ -28,13 +48,19 @@ export function ActivityFeed({
         </p>
       ) : null}
       <ul className="feed__list">
-        {events.map((d, i) => (
-          <EventRow
-            key={`${d.seq}:${d.kind}:${d.moteId ?? d.targetMoteId ?? ""}`}
-            delta={d}
-            index={i}
-          />
-        ))}
+        {events.map((d, i) => {
+          const vm = d.resultRef ? byRef.get(d.resultRef) : undefined;
+          return (
+            <EventRow
+              key={`${d.seq}:${d.kind}:${d.moteId ?? d.targetMoteId ?? ""}`}
+              delta={d}
+              content={vm?.content}
+              missing={vm?.missing ?? false}
+              resolving={isLoading}
+              index={i}
+            />
+          );
+        })}
       </ul>
     </div>
   );

--- a/ui/src/components/activity/ActivityPanel.tsx
+++ b/ui/src/components/activity/ActivityPanel.tsx
@@ -87,7 +87,12 @@ export function ActivityPanel({
             <TimeTravelScrubber currentSeq={headSeq} atSeq={atSeq} onChange={onAtSeq} />
           ) : null}
           <h2>Live events</h2>
-          <ActivityFeed events={stream.events} dropped={stream.dropped} active={stream.active} />
+          <ActivityFeed
+            events={stream.events}
+            dropped={stream.dropped}
+            active={stream.active}
+            instanceId={instance}
+          />
         </>
       )}
     </section>

--- a/ui/src/components/activity/EventRow.tsx
+++ b/ui/src/components/activity/EventRow.tsx
@@ -1,11 +1,32 @@
 import type { Delta } from "@kortecx/sdk/web";
 import { m } from "framer-motion";
 import { rowEntrance } from "../../app/motion";
+import type { DecodedContent } from "../../lib/content-decode";
 import { eventSummary, eventVisual } from "../../lib/event-format";
+import { ResultPreview } from "../ResultPreview";
 
-/** One event delta as a feed row (kind pill · summary · seq). Pure presentational. */
-export function EventRow({ delta, index = 0 }: { delta: Delta; index?: number }) {
+/**
+ * One event delta as a feed row (kind pill · summary · resolved result · seq).
+ * A `committed` row shows the RESOLVED result text as the headline (D142.2) when
+ * its content is supplied by the feed's batch resolve, with the digest as a
+ * trailing chip — so the feed reads as outputs, not hashes. Pure presentational.
+ */
+export function EventRow({
+  delta,
+  content,
+  missing = false,
+  resolving = false,
+  index = 0,
+}: {
+  delta: Delta;
+  /** The resolved committed result (from the feed's batch fetch); undefined while resolving. */
+  content?: DecodedContent;
+  missing?: boolean;
+  resolving?: boolean;
+  index?: number;
+}) {
   const v = eventVisual(delta.kind);
+  const showResult = delta.kind === "committed" && Boolean(delta.resultRef);
   return (
     <m.li
       className="event-row"
@@ -14,7 +35,16 @@ export function EventRow({ delta, index = 0 }: { delta: Delta; index?: number })
       {...rowEntrance(index)}
     >
       <span className={`pill pill--${v.tone}`}>{v.label}</span>
-      <span className="event-row__summary">{eventSummary(delta)}</span>
+      <span className="event-row__summary">{eventSummary(delta, undefined, showResult)}</span>
+      {showResult ? (
+        <ResultPreview
+          resultRef={delta.resultRef ?? null}
+          content={content}
+          missing={missing}
+          loading={resolving}
+          max={80}
+        />
+      ) : null}
       <span className="mono event-row__seq">#{delta.seq}</span>
     </m.li>
   );

--- a/ui/src/components/activity/GlobalFeed.tsx
+++ b/ui/src/components/activity/GlobalFeed.tsx
@@ -1,12 +1,16 @@
 import type { GlobalDelta } from "@kortecx/sdk/web";
 import { Link } from "@tanstack/react-router";
 import { m } from "framer-motion";
+import { useMemo } from "react";
 import { rowEntrance } from "../../app/motion";
+import { type RunScopedRef, useResultMapMulti } from "../../kx/use-content-batch";
 import { useGlobalEvents } from "../../kx/use-global-events";
 import { useRecipeNames } from "../../kx/use-recipes";
+import type { DecodedContent } from "../../lib/content-decode";
 import { eventSummary, eventVisual } from "../../lib/event-format";
 import { shortHex } from "../../lib/format";
 import { EmptyState } from "../EmptyState";
+import { ResultPreview } from "../ResultPreview";
 
 /**
  * The GLOBAL cross-run live feed (Batch C) — every journal delta on the node,
@@ -18,6 +22,18 @@ import { EmptyState } from "../EmptyState";
 export function GlobalFeed({ onSelectRun }: { onSelectRun?: (instanceId: string) => void }) {
   const stream = useGlobalEvents();
   const recipeNames = useRecipeNames();
+  // Resolve the visible committed deltas' results, grouped by their owning run
+  // (GetContentBatch is run-scoped — one batch per distinct run in the window).
+  const pairs = useMemo<RunScopedRef[]>(
+    () =>
+      stream.events.flatMap((d) =>
+        d.kind === "committed" && d.resultRef && d.instanceId
+          ? [{ instanceId: d.instanceId, ref: d.resultRef }]
+          : [],
+      ),
+    [stream.events],
+  );
+  const { byRef, isLoading } = useResultMapMulti(pairs);
 
   if (stream.notWired) {
     return (
@@ -57,33 +73,48 @@ export function GlobalFeed({ onSelectRun }: { onSelectRun?: (instanceId: string)
         </p>
       ) : null}
       <ul className="feed__list">
-        {stream.events.map((d, i) => (
-          <GlobalEventRow
-            key={`${d.seq}:${d.kind}:${d.moteId ?? d.instanceId}`}
-            delta={d}
-            index={i}
-            recipeName={d.recipeFingerprint ? recipeNames.data?.[d.recipeFingerprint] : undefined}
-            onSelectRun={onSelectRun}
-          />
-        ))}
+        {stream.events.map((d, i) => {
+          const vm = d.resultRef ? byRef.get(d.resultRef) : undefined;
+          return (
+            <GlobalEventRow
+              key={`${d.seq}:${d.kind}:${d.moteId ?? d.instanceId}`}
+              delta={d}
+              index={i}
+              recipeName={d.recipeFingerprint ? recipeNames.data?.[d.recipeFingerprint] : undefined}
+              onSelectRun={onSelectRun}
+              content={vm?.content}
+              missing={vm?.missing ?? false}
+              resolving={isLoading}
+            />
+          );
+        })}
       </ul>
     </div>
   );
 }
 
-/** One global delta as a feed row: kind pill · summary · run link · seq. */
+/** One global delta as a feed row: kind pill · summary · resolved result · run
+ *  link · seq. A committed row shows the result TEXT (D142.2); the run link is a
+ *  sibling of the chip (both inside the row, never nested). */
 function GlobalEventRow({
   delta,
   index,
   recipeName,
   onSelectRun,
+  content,
+  missing = false,
+  resolving = false,
 }: {
   delta: GlobalDelta;
   index: number;
   recipeName?: string;
   onSelectRun?: (instanceId: string) => void;
+  content?: DecodedContent;
+  missing?: boolean;
+  resolving?: boolean;
 }) {
   const v = eventVisual(delta.kind);
+  const showResult = delta.kind === "committed" && Boolean(delta.resultRef);
   return (
     <m.li
       className="event-row"
@@ -92,7 +123,16 @@ function GlobalEventRow({
       {...rowEntrance(index)}
     >
       <span className={`pill pill--${v.tone}`}>{v.label}</span>
-      <span className="event-row__summary">{eventSummary(delta, recipeName)}</span>
+      <span className="event-row__summary">{eventSummary(delta, recipeName, showResult)}</span>
+      {showResult ? (
+        <ResultPreview
+          resultRef={delta.resultRef ?? null}
+          content={content}
+          missing={missing}
+          loading={resolving}
+          max={80}
+        />
+      ) : null}
       {delta.instanceId ? (
         onSelectRun ? (
           <button

--- a/ui/src/components/dag/MoteDag.tsx
+++ b/ui/src/components/dag/MoteDag.tsx
@@ -7,6 +7,7 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import { useEffect, useMemo, useState } from "react";
+import { useResultMap } from "../../kx/use-content-batch";
 import type { ProjectionVM } from "../../kx/use-projection";
 import { EmptyState } from "../EmptyState";
 import { MoteTable } from "../MoteTable";
@@ -52,8 +53,16 @@ function DagFlow({ projection }: { projection: ProjectionVM }) {
   // Edges are topology — recompute only on a topology change.
   // biome-ignore lint/correctness/useExhaustiveDependencies: edges depend on topology only (same justification as positions).
   const edges = useMemo(() => buildFlowEdges(motes), [topoHash]);
-  // Node DATA (state/anomaly) re-merges every poll WITHOUT relayout.
-  const nodes = useMemo(() => buildFlowNodes(motes, positions), [motes, positions]);
+  // Batch-resolve every committed result (one RPC, shared with the table). `byRef`
+  // is reference-stable across an unchanged poll (memoized in useResultMap), so it
+  // doesn't re-create nodes — node DATA only re-merges when results actually land.
+  const refs = useMemo(() => motes.flatMap((m) => (m.resultRef ? [m.resultRef] : [])), [motes]);
+  const { byRef, isLoading } = useResultMap(projection.instanceId, refs);
+  // Node DATA (state/anomaly + resolved result) re-merges every poll WITHOUT relayout.
+  const nodes = useMemo(
+    () => buildFlowNodes(motes, positions, { byRef, loading: isLoading }),
+    [motes, positions, byRef, isLoading],
+  );
 
   // Refit the viewport when the topology grows (dynamic children appear). Guarded
   // so a headless/jsdom flow (no measured viewport) is a harmless no-op.

--- a/ui/src/components/dag/MoteNode.tsx
+++ b/ui/src/components/dag/MoteNode.tsx
@@ -7,6 +7,7 @@ import { isTerminalState, stateVisual } from "../../lib/colors";
 import { shortHex } from "../../lib/format";
 import { AnomalyBadge } from "../AnomalyBadge";
 import { NdClassBadge } from "../NdClassBadge";
+import { ResultPreview } from "../ResultPreview";
 import { StatePill } from "../StatePill";
 import type { MoteFlowNode } from "./flow";
 
@@ -19,7 +20,7 @@ import type { MoteFlowNode } from "./flow";
  * The whole card is clickable (reactflow `onNodeClick` opens the detail drawer).
  */
 function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
-  const { mote } = data;
+  const { mote, resultContent, resultMissing, resultLoading } = data;
   const { tone } = stateVisual(mote.stateCode);
   const inFlight = !isTerminalState(mote.stateCode);
   return (
@@ -48,6 +49,20 @@ function MoteNodeImpl({ data }: NodeProps<MoteFlowNode>) {
         <StatePill stateCode={mote.stateCode} />
         <NdClassBadge ndClass={mote.ndClass} />
       </div>
+      {mote.resultRef ? (
+        <div className="dag-node__result">
+          {/* The resolved text glimpse; the chip + full result live in the
+              click→drawer (a chip button here would bubble to the node click). */}
+          <ResultPreview
+            resultRef={mote.resultRef}
+            content={resultContent}
+            missing={resultMissing}
+            loading={resultLoading}
+            max={64}
+            chip={false}
+          />
+        </div>
+      ) : null}
       <AnomalyBadge anomaly={mote.anomaly} />
       <Handle type="source" position={Position.Bottom} className="dag-handle" />
     </m.div>

--- a/ui/src/components/dag/NodeDetailDrawer.tsx
+++ b/ui/src/components/dag/NodeDetailDrawer.tsx
@@ -21,6 +21,7 @@ import type { MoteVM } from "../../kx/use-projection";
 import { promotionIsNotable, promotionLabel } from "../../lib/colors";
 import { formatSeq, shortHex } from "../../lib/format";
 import { AnomalyBadge } from "../AnomalyBadge";
+import { DigestChip } from "../DigestChip";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
 import { NdClassBadge } from "../NdClassBadge";
@@ -125,8 +126,12 @@ export function NodeDetailDrawer({
           </div>
           <div>
             <dt>Result ref</dt>
-            <dd className="mono" title={mote.resultRef ?? undefined}>
-              {mote.resultRef ? shortHex(mote.resultRef) : "—"}
+            <dd>
+              {mote.resultRef ? (
+                <DigestChip hex={mote.resultRef} label="result" />
+              ) : (
+                <span className="mono">—</span>
+              )}
             </dd>
           </div>
           <div>

--- a/ui/src/components/dag/flow.ts
+++ b/ui/src/components/dag/flow.ts
@@ -5,8 +5,10 @@
  */
 
 import type { Edge, Node } from "@xyflow/react";
+import type { BatchedContentVM } from "../../kx/use-content-batch";
 import type { MoteVM } from "../../kx/use-projection";
 import { stateVisual } from "../../lib/colors";
+import type { DecodedContent } from "../../lib/content-decode";
 import { buildEdges } from "./dag-graph";
 import { toRfEdge } from "./edges";
 import type { XY } from "./layout";
@@ -35,23 +37,49 @@ export function miniMapColor(stateCode: number): string {
 /** The data a `MoteNode` renders. The index signature satisfies reactflow's `Node<T>`. */
 export interface MoteNodeData {
   readonly mote: MoteVM;
+  /** The resolved committed result (D142.2: text headline on the node). */
+  readonly resultContent?: DecodedContent;
+  /** The batch returned the uniform-empty item for this result ref. */
+  readonly resultMissing?: boolean;
+  /** The batch is still resolving (show `resolving…`). */
+  readonly resultLoading?: boolean;
   readonly [key: string]: unknown;
 }
 
 export type MoteFlowNode = Node<MoteNodeData, "mote">;
 
-/** Positioned reactflow nodes (positions come from the memoized dagre layout). */
+/** A run's resolved results, indexed by content ref (the `useResultMap` shape). */
+export interface ResultLookup {
+  readonly byRef: ReadonlyMap<string, BatchedContentVM>;
+  readonly loading: boolean;
+}
+
+/**
+ * Positioned reactflow nodes (positions come from the memoized dagre layout).
+ * When `results` is provided, each node carries its RESOLVED result so the DAG
+ * node shows the text headline (D142.2) — the same `byRef` map the table uses,
+ * so the two surfaces resolve identically from one batch round trip.
+ */
 export function buildFlowNodes(
   motes: readonly MoteVM[],
   positions: ReadonlyMap<string, XY>,
+  results?: ResultLookup,
 ): MoteFlowNode[] {
-  return motes.map((m) => ({
-    id: m.moteId,
-    type: "mote",
-    position: positions.get(m.moteId) ?? { x: 0, y: 0 },
-    data: { mote: m },
-    draggable: false,
-  }));
+  return motes.map((m) => {
+    const vm = m.resultRef ? results?.byRef.get(m.resultRef) : undefined;
+    return {
+      id: m.moteId,
+      type: "mote",
+      position: positions.get(m.moteId) ?? { x: 0, y: 0 },
+      data: {
+        mote: m,
+        resultContent: vm?.content,
+        resultMissing: vm?.missing ?? false,
+        resultLoading: m.resultRef ? (results?.loading ?? false) : false,
+      },
+      draggable: false,
+    };
+  });
 }
 
 /** Styled reactflow edges from the Motes' parent links (dangling dropped). */

--- a/ui/src/components/devtools/DevToolsDock.tsx
+++ b/ui/src/components/devtools/DevToolsDock.tsx
@@ -72,7 +72,12 @@ function EventsTab() {
   return (
     <div data-testid="devtools-events">
       <p className="muted devtools__context mono">run {latest.instanceId}</p>
-      <ActivityFeed events={stream.events} active={stream.active} dropped={stream.dropped} />
+      <ActivityFeed
+        events={stream.events}
+        active={stream.active}
+        dropped={stream.dropped}
+        instanceId={latest.instanceId}
+      />
     </div>
   );
 }

--- a/ui/src/components/sections/ArtifactGallery.tsx
+++ b/ui/src/components/sections/ArtifactGallery.tsx
@@ -7,16 +7,19 @@
  */
 
 import { m } from "framer-motion";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { fadeUp, hoverLift, stagger } from "../../app/motion";
 import { toUiError } from "../../kx/errors";
 import { useContent } from "../../kx/use-content";
+import { useResultMap } from "../../kx/use-content-batch";
 import { useRunArtifacts } from "../../kx/use-run-artifacts";
 import { artifactKindVisual } from "../../lib/artifact-kind";
 import type { DecodedContent } from "../../lib/content-decode";
 import { shortHex } from "../../lib/format";
+import { DigestChip } from "../DigestChip";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
+import { ResultPreview } from "../ResultPreview";
 import { ArtifactView } from "./ArtifactView";
 
 function download(name: string, text: string): void {
@@ -31,6 +34,10 @@ function download(name: string, text: string): void {
 export function ArtifactGallery({ instanceId }: { instanceId: string }) {
   const { artifacts, isLoading, error, refetch } = useRunArtifacts(instanceId);
   const [openRef, setOpenRef] = useState<string | null>(null);
+  // Batch-resolve every artifact's text for the list headline (one RPC, the N+1
+  // collapse) — the full payload still opens lazily on click below.
+  const refs = useMemo(() => artifacts.map((a) => a.resultRef), [artifacts]);
+  const { byRef, isLoading: previewsLoading } = useResultMap(instanceId, refs);
 
   if (isLoading) {
     return <EmptyState title="Loading run…" />;
@@ -56,6 +63,7 @@ export function ArtifactGallery({ instanceId }: { instanceId: string }) {
       <m.ul className="artifact-list" variants={stagger()} initial="hidden" animate="show">
         {artifacts.map((a) => {
           const open = openRef === a.resultRef;
+          const vm = byRef.get(a.resultRef);
           return (
             <m.li
               className="artifact-list__item card-hover"
@@ -63,17 +71,31 @@ export function ArtifactGallery({ instanceId }: { instanceId: string }) {
               variants={fadeUp}
               {...hoverLift}
             >
-              <button
-                type="button"
-                className="artifact-list__row mono"
-                data-testid={`artifact-${a.resultRef}`}
-                aria-expanded={open}
-                onClick={() => setOpenRef(open ? null : a.resultRef)}
-              >
-                <span className="artifact-list__mote">{shortHex(a.moteId)}</span>
-                <span className="muted">→</span>
-                <span className="artifact-list__ref">{shortHex(a.resultRef)}</span>
-              </button>
+              <div className="artifact-list__row">
+                <button
+                  type="button"
+                  className="artifact-list__toggle"
+                  data-testid={`artifact-${a.resultRef}`}
+                  aria-expanded={open}
+                  onClick={() => setOpenRef(open ? null : a.resultRef)}
+                >
+                  <span className="artifact-list__mote mono">{shortHex(a.moteId)}</span>
+                  <span className="muted" aria-hidden="true">
+                    →
+                  </span>
+                  {/* Resolved text is the headline; the chip rides as a sibling
+                      (a DigestChip button can't nest in this toggle button). */}
+                  <ResultPreview
+                    resultRef={a.resultRef}
+                    content={vm?.content}
+                    missing={vm?.missing ?? false}
+                    loading={previewsLoading}
+                    max={120}
+                    chip={false}
+                  />
+                </button>
+                <DigestChip hex={a.resultRef} label="result" />
+              </div>
               {open ? <ArtifactCard instanceId={instanceId} contentRef={a.resultRef} /> : null}
             </m.li>
           );

--- a/ui/src/components/sections/MonitoringSection.tsx
+++ b/ui/src/components/sections/MonitoringSection.tsx
@@ -14,8 +14,10 @@
 
 import { Link } from "@tanstack/react-router";
 import { m } from "framer-motion";
+import { useMemo } from "react";
 import { fadeUp, stagger } from "../../app/motion";
 import { useCaptureRecords } from "../../kx/use-capture-records";
+import { type RunScopedRef, useResultMapMulti } from "../../kx/use-content-batch";
 import { useReactTurns } from "../../kx/use-react-turns";
 import { useReplanRounds } from "../../kx/use-replan-rounds";
 import { useRuns } from "../../kx/use-runs";
@@ -32,6 +34,7 @@ import {
 import type { MonitorTab } from "../../router/routes/monitor";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
+import { ResultPreview } from "../ResultPreview";
 import { GlobalFeed } from "../activity/GlobalFeed";
 import { GlowCard } from "../ds/GlowCard";
 import { HealthIndicator } from "../metrics/HealthIndicator";
@@ -236,6 +239,19 @@ function OverviewView() {
   const replanSummary = summarizeReplan(replan.rounds);
   const reactSummary = summarizeReact(react.turns);
   const captureSummary = summarizeCaptures(capture.records);
+  // Resolve the (bounded, 10-row) capture table's results to TEXT, grouped by
+  // run (the records span runs; GetContentBatch is run-scoped). Telemetry stays
+  // exhaust — but the Result is the headline here, not a bare hash (D142.2).
+  const capturePairs = useMemo<RunScopedRef[]>(
+    () =>
+      capture.records
+        .slice(0, 10)
+        .flatMap((r) =>
+          r.resultRef && r.instanceId ? [{ instanceId: r.instanceId, ref: r.resultRef }] : [],
+        ),
+    [capture.records],
+  );
+  const captureResults = useResultMapMulti(capturePairs);
 
   function refreshAll(): void {
     runs.refresh();
@@ -349,14 +365,25 @@ function OverviewView() {
                 </tr>
               </thead>
               <tbody>
-                {capture.records.slice(0, 10).map((r) => (
-                  <tr key={`${r.seq}-${r.moteId}`}>
-                    <td className="mono">{shortHex(r.moteId)}</td>
-                    <td className="mono">{shortHex(r.resultRef)}</td>
-                    <td className="mono">{r.ndClass || "—"}</td>
-                    <td className="mono">#{r.seq}</td>
-                  </tr>
-                ))}
+                {capture.records.slice(0, 10).map((r) => {
+                  const vm = r.resultRef ? captureResults.byRef.get(r.resultRef) : undefined;
+                  return (
+                    <tr key={`${r.seq}-${r.moteId}`}>
+                      <td className="mono">{shortHex(r.moteId)}</td>
+                      <td className="trail-table__result">
+                        <ResultPreview
+                          resultRef={r.resultRef || null}
+                          content={vm?.content}
+                          missing={vm?.missing ?? false}
+                          loading={captureResults.isLoading}
+                          max={60}
+                        />
+                      </td>
+                      <td className="mono">{r.ndClass || "—"}</td>
+                      <td className="mono">#{r.seq}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           ) : null}

--- a/ui/src/kx/use-content-batch.ts
+++ b/ui/src/kx/use-content-batch.ts
@@ -7,7 +7,9 @@
  * Content-addressed ⇒ the query never goes stale.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import type { KxClientBase } from "@kortecx/sdk/web";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { type DecodedContent, decodeContent } from "../lib/content-decode";
 import { chunkRefs } from "../lib/content-resolver";
 import { useConnection } from "./connection-context";
@@ -28,6 +30,32 @@ export interface BatchedContentVM {
 
 const PREVIEW_BYTES = 4096n;
 
+/** Resolve one run's refs (chunked at the 64-ref server cap). Run-scoped: the
+ *  gateway denies a ref that is not a committed result of `instanceId`. */
+async function fetchContentBatch(
+  client: KxClientBase,
+  instanceId: string,
+  refs: readonly string[],
+): Promise<BatchedContentVM[]> {
+  const out: BatchedContentVM[] = [];
+  for (const chunk of chunkRefs(refs)) {
+    const items = await client.getContentBatch(chunk, {
+      instanceId,
+      maxBytesPerItem: PREVIEW_BYTES,
+    });
+    for (const i of items) {
+      out.push({
+        contentRef: i.contentRef,
+        missing: i.missing,
+        truncated: i.truncated,
+        fullSize: Number(i.fullSize),
+        content: decodeContent(i.payload),
+      });
+    }
+  }
+  return out;
+}
+
 export function useContentBatch(instanceId: string, refs: readonly string[]) {
   const { client, endpoint, status } = useConnection();
   // Refs are content-addressed and arrive in a stable (parent) order, so the
@@ -41,24 +69,89 @@ export function useContentBatch(instanceId: string, refs: readonly string[]) {
       if (!client) {
         throw new Error("not connected");
       }
-      // Chunk at the server's 64-ref cap (a >64 fan-in stays correct).
-      const out: BatchedContentVM[] = [];
-      for (const chunk of chunkRefs(refs)) {
-        const items = await client.getContentBatch(chunk, {
-          instanceId,
-          maxBytesPerItem: PREVIEW_BYTES,
-        });
-        for (const i of items) {
-          out.push({
-            contentRef: i.contentRef,
-            missing: i.missing,
-            truncated: i.truncated,
-            fullSize: Number(i.fullSize),
-            content: decodeContent(i.payload),
-          });
+      return fetchContentBatch(client, instanceId, refs);
+    },
+  });
+}
+
+/**
+ * Resolve a run's committed result refs and index them BY REF, for the
+ * dense-context "resolved text headline + digest" surfaces (the mote table, the
+ * DAG nodes, the artifact list, the event feeds). ONE batch round trip for all
+ * visible refs (the N+1 collapse); content-addressed ⇒ cached forever. Returns
+ * a lookup + `isLoading` so a row renders `resolving…` then its text.
+ */
+export function useResultMap(instanceId: string, refs: readonly string[]) {
+  const q = useContentBatch(instanceId, refs);
+  // Memoize on the query data so the map reference is STABLE across an unchanged
+  // poll — feeding it into reactflow node data (the DAG) then never re-creates
+  // nodes, preserving the no-thrash invariant.
+  const byRef = useMemo(() => {
+    const m = new Map<string, BatchedContentVM>();
+    for (const vm of q.data ?? []) {
+      m.set(vm.contentRef, vm);
+    }
+    return m;
+  }, [q.data]);
+  return { byRef, isLoading: q.isLoading };
+}
+
+/** One run's result ref, for the cross-run feed resolver. */
+export interface RunScopedRef {
+  readonly instanceId: string;
+  readonly ref: string;
+}
+
+/**
+ * Resolve result refs that span MULTIPLE runs (the global event feed). Because
+ * `GetContentBatch` is run-scoped (a ref is fetchable only by its owning run),
+ * the refs are grouped by `instanceId` and resolved with one batch query PER
+ * RUN (`useQueries`). Returns a flat `byRef` lookup (content-addressed refs are
+ * globally unique) + an aggregate `isLoading`. Content-addressed ⇒ cached
+ * forever, so re-renders of the live tail never refetch a resolved row.
+ */
+export function useResultMapMulti(pairs: readonly RunScopedRef[]) {
+  const { client, endpoint, status } = useConnection();
+  // Group refs by run; dedupe within a run (a stable, sorted key per run).
+  const groups = useMemo(() => {
+    const m = new Map<string, Set<string>>();
+    for (const { instanceId, ref } of pairs) {
+      const set = m.get(instanceId);
+      if (set) {
+        set.add(ref);
+      } else {
+        m.set(instanceId, new Set([ref]));
+      }
+    }
+    return [...m.entries()].map(([instanceId, set]) => ({
+      instanceId,
+      refs: [...set].sort(),
+    }));
+  }, [pairs]);
+
+  // `combine` is memoized by React Query on the per-run results, so the merged
+  // `byRef` reference is stable across renders until a batch actually settles
+  // (a flat map — content-addressed refs are globally unique across runs).
+  return useQueries({
+    queries: groups.map(({ instanceId, refs }) => ({
+      queryKey: queryKeys.contentBatch(endpoint, instanceId, refs.join(",")),
+      enabled: status === "connected" && client !== null && refs.length > 0,
+      staleTime: Number.POSITIVE_INFINITY,
+      queryFn: async (): Promise<BatchedContentVM[]> => {
+        if (!client) {
+          throw new Error("not connected");
+        }
+        return fetchContentBatch(client, instanceId, refs);
+      },
+    })),
+    combine: (results) => {
+      const byRef = new Map<string, BatchedContentVM>();
+      for (const r of results) {
+        for (const vm of r.data ?? []) {
+          byRef.set(vm.contentRef, vm);
         }
       }
-      return out;
+      return { byRef, isLoading: results.some((r) => r.isLoading) };
     },
   });
 }

--- a/ui/src/lib/event-format.ts
+++ b/ui/src/lib/event-format.ts
@@ -42,12 +42,14 @@ export function eventVisual(kind: string): EventVisual {
 
 /** A one-line human summary of a delta (the Mote it concerns + its effect).
  *  `recipeName` labels a `run_registered` row when the fingerprint→handle join
- *  resolved one (else the row degrades to the fingerprint hex). */
-export function eventSummary(d: EventLike, recipeName?: string): string {
+ *  resolved one (else the row degrades to the fingerprint hex). `omitResultRef`
+ *  drops the trailing `→ <hash>` on a committed row when the caller renders the
+ *  RESOLVED result text alongside (so the hash never doubles as the headline). */
+export function eventSummary(d: EventLike, recipeName?: string, omitResultRef = false): string {
   switch (d.kind) {
     case "committed":
       return `Mote ${shortHex(d.moteId ?? "")} committed${
-        d.resultRef ? ` → ${shortHex(d.resultRef)}` : ""
+        d.resultRef && !omitResultRef ? ` → ${shortHex(d.resultRef)}` : ""
       }`;
     case "failed":
       return `Mote ${shortHex(d.moteId ?? "")} failed`;

--- a/ui/src/router/routes/workflow-detail.tsx
+++ b/ui/src/router/routes/workflow-detail.tsx
@@ -220,7 +220,12 @@ function ActivityTab({
         <TimeTravelScrubber currentSeq={headSeq} atSeq={atSeq} onChange={onAtSeq} />
       ) : null}
       <h2>Live events</h2>
-      <ActivityFeed events={stream.events} dropped={stream.dropped} active={stream.active} />
+      <ActivityFeed
+        events={stream.events}
+        dropped={stream.dropped}
+        active={stream.active}
+        instanceId={instanceId}
+      />
     </div>
   );
 }

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -424,6 +424,10 @@ button:disabled {
   width: 100%;
   border-collapse: collapse;
   margin-top: 0.75rem;
+  table-layout: fixed; /* honour the colgroup widths so Result stays bounded */
+}
+.mote-table td {
+  overflow: hidden; /* fixed layout: clip rather than overflow the bounded cell */
 }
 .mote-table th,
 .mote-table td {
@@ -438,6 +442,17 @@ button:disabled {
 }
 .mote-table .num {
   text-align: right;
+}
+/* The Result column leads with the resolved text + a trailing digest chip. The
+   preview fills the (fixed-width) cell as a flex row; the text grows and
+   ellipsis-clips at the chip, so the chip sits flush against the text and stays
+   on screen (the cell is bounded by the colgroup). */
+.mote-table__result .result-preview {
+  display: flex;
+  width: 100%;
+}
+.mote-table__result .result-preview__text {
+  flex: 1 1 auto;
 }
 
 /* ---- view toggle (DAG / table) ---- */
@@ -513,6 +528,16 @@ button:disabled {
   gap: 0.4rem;
   align-items: center;
   flex-wrap: wrap;
+}
+/* The resolved result on the node: one clamped line + the trailing digest chip
+   (the full text is one click away in the detail drawer). */
+.dag-node__result {
+  font-size: 0.78rem;
+  color: var(--fg);
+  max-width: 100%;
+}
+.dag-node__result .result-preview {
+  max-width: 100%;
 }
 .dag-handle {
   width: 6px;
@@ -917,10 +942,19 @@ select {
   background: var(--bg-elev);
 }
 .event-row__summary {
-  flex: 1;
+  flex: 0 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+}
+/* The resolved result takes the remaining row width and clamps to one line
+   (the committed-row headline); the seq stays pinned right in every row. */
+.event-row .result-preview {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .event-row__seq {
   color: var(--fg-muted);
+  margin-left: auto;
 }
 
 /* ---- scrubber / run picker / run list ---- */
@@ -1098,20 +1132,32 @@ select {
   border-bottom: 1px solid var(--border);
   padding: 0.3rem 0;
 }
+/* The row is now a flex container: a text-headline toggle button + a sibling
+   DigestChip (nested buttons are invalid HTML). */
 .artifact-list__row {
   display: flex;
   gap: 0.6rem;
   align-items: center;
+  padding: 0.2rem 0;
+  width: 100%;
+  min-width: 0;
+}
+.artifact-list__toggle {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
   background: none;
   border: none;
   color: var(--accent);
   cursor: pointer;
-  padding: 0.2rem 0;
-  width: 100%;
+  padding: 0;
   text-align: left;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .artifact-list__mote {
   color: var(--fg);
+  flex: 0 0 auto;
 }
 .artifact-card {
   margin: 0.4rem 0 0.6rem;
@@ -1384,10 +1430,33 @@ select {
   font-size: 0.75rem;
   padding: 0.05rem 0.5rem;
   cursor: pointer;
+  /* A chip is a single hex token — never wrap it, and never let a flex parent
+     shrink it (it trails resolved text in dense rows; the text clips, not the chip). */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 .digestchip:hover {
   color: var(--fg);
   border-color: var(--fg-muted);
+}
+
+/* ---- resolved-result preview (D142.2: text headline + digest chip) ---- */
+/* The dense-context "resolved text is the headline, the hash a secondary chip"
+   treatment — shared by the mote table, the DAG node, the artifact list and the
+   event feeds. The text gets the space; the chip trails it, the muted states
+   ((empty)/binary/unavailable/resolving) read as honest, not as a hash. */
+.result-preview {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  min-width: 0;
+  max-width: 100%;
+}
+.result-preview__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 .bubble__attachments {
   display: flex;
@@ -2566,6 +2635,10 @@ select {
   padding: 0.22rem 0.4rem;
   border-bottom: 1px solid var(--border);
   overflow-wrap: anywhere;
+}
+/* The capture table's Result cell holds a clamped one-line preview + chip. */
+.trail-table__result {
+  max-width: 22rem;
 }
 
 /* the navbar power/disconnect button (the endpoint text + link left the bar);

--- a/ui/test/component/MoteTable.test.tsx
+++ b/ui/test/component/MoteTable.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MoteTable } from "../../src/components/MoteTable";
 import { toProjectionVM } from "../../src/kx/use-projection";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
 import {
   allStatesProjection,
   largeProjection,
@@ -9,26 +11,34 @@ import {
   projection,
 } from "../mocks/projection-fixtures";
 
+// MoteTable batch-resolves its committed results (run-scoped GetContentBatch),
+// so it needs a connected connection + query client. The fixtures' Motes carry
+// no result refs by default ⇒ the batch query stays disabled (no fetch); these
+// tests assert structure/state/anomaly, not the resolved Result column.
+const wrapper = connectedWrapper(makeMockClient().client);
+
 describe("MoteTable", () => {
   it("renders one row per Mote across all states", () => {
-    render(<MoteTable projection={toProjectionVM(allStatesProjection())} />);
+    render(<MoteTable projection={toProjectionVM(allStatesProjection())} />, { wrapper });
     expect(screen.getAllByTestId("mote-row")).toHaveLength(7);
   });
 
   it("empty projection shows an empty state, not a table", () => {
-    render(<MoteTable projection={toProjectionVM(projection([]))} />);
+    render(<MoteTable projection={toProjectionVM(projection([]))} />, { wrapper });
     expect(screen.getByTestId("empty-state")).toBeInTheDocument();
     expect(screen.queryByTestId("mote-table")).not.toBeInTheDocument();
   });
 
   it("a single Mote renders one row", () => {
-    render(<MoteTable projection={toProjectionVM(projection([mote({ stateCode: 3 })]))} />);
+    render(<MoteTable projection={toProjectionVM(projection([mote({ stateCode: 3 })]))} />, {
+      wrapper,
+    });
     expect(screen.getAllByTestId("mote-row")).toHaveLength(1);
   });
 
   it("maps each state code to its pill tone (incl. UNKNOWN for out-of-range)", () => {
     const vm = toProjectionVM(projection([mote({ stateCode: 3 }), mote({ stateCode: 99 })]));
-    render(<MoteTable projection={vm} />);
+    render(<MoteTable projection={vm} />, { wrapper });
     const pills = screen.getAllByTestId("state-pill");
     expect(pills[0]).toHaveAttribute("data-tone", "committed");
     expect(pills[1]).toHaveAttribute("data-tone", "unknown");
@@ -38,14 +48,14 @@ describe("MoteTable", () => {
     const vm = toProjectionVM(
       projection([mote({ stateCode: 6, anomaly: 2 }), mote({ stateCode: 3, anomaly: null })]),
     );
-    render(<MoteTable projection={vm} />);
+    render(<MoteTable projection={vm} />, { wrapper });
     expect(screen.getAllByTestId("anomaly-badge")).toHaveLength(1);
   });
 
   it("renders 5000 Motes within the perf budget", () => {
     const vm = toProjectionVM(largeProjection(5000));
     const t0 = performance.now();
-    render(<MoteTable projection={vm} />);
+    render(<MoteTable projection={vm} />, { wrapper });
     const elapsed = performance.now() - t0;
     expect(screen.getAllByTestId("mote-row")).toHaveLength(5000);
     // Generous jsdom budget — guards against accidental O(n^2) work in the table.

--- a/ui/test/component/activity.test.tsx
+++ b/ui/test/component/activity.test.tsx
@@ -3,10 +3,17 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ActivityFeed } from "../../src/components/activity/ActivityFeed";
 import { TimeTravelScrubber } from "../../src/components/activity/TimeTravelScrubber";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+// ActivityFeed batch-resolves its committed results (D142.2), so it needs a
+// connected context. These tests pass no `instanceId` ⇒ no fetch; they assert
+// the feed's structure (rows/order/dropped), not the resolved Result column.
+const wrapper = connectedWrapper(makeMockClient().client);
 
 describe("ActivityFeed", () => {
   it("empty state when there are no events", () => {
-    render(<ActivityFeed events={[]} dropped={false} active={false} />);
+    render(<ActivityFeed events={[]} dropped={false} active={false} />, { wrapper });
     expect(screen.getByText(/no events yet/i)).toBeInTheDocument();
   });
 
@@ -15,7 +22,7 @@ describe("ActivityFeed", () => {
       new Delta(2, "failed", "aa".repeat(32)),
       new Delta(1, "committed", "bb".repeat(32), "cc".repeat(32)),
     ];
-    render(<ActivityFeed events={events} dropped={false} active={true} />);
+    render(<ActivityFeed events={events} dropped={false} active={true} />, { wrapper });
     const rows = screen.getAllByTestId("event-row");
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveAttribute("data-kind", "failed");
@@ -25,6 +32,7 @@ describe("ActivityFeed", () => {
   it("shows a dropped-stream notice", () => {
     render(
       <ActivityFeed events={[new Delta(1, "committed", "aa".repeat(32))]} dropped active={false} />,
+      { wrapper },
     );
     expect(screen.getByTestId("feed-dropped")).toBeInTheDocument();
   });

--- a/ui/test/component/dag/MoteDag.test.tsx
+++ b/ui/test/component/dag/MoteDag.test.tsx
@@ -27,6 +27,8 @@ vi.mock("@xyflow/react", () => ({
 import { MAX_DAG_NODES, MoteDag } from "../../../src/components/dag/MoteDag";
 import * as layout from "../../../src/components/dag/layout";
 import { toProjectionVM } from "../../../src/kx/use-projection";
+import { connectedWrapper } from "../../mocks/harness";
+import { makeMockClient } from "../../mocks/kx-client";
 import {
   diamondProjection,
   growsBetweenPolls,
@@ -36,9 +38,14 @@ import {
 
 const vm = (p: ReturnType<typeof projection>) => toProjectionVM(p);
 
+// DagFlow batch-resolves committed results (run-scoped GetContentBatch), so the
+// canvas needs a connected context + query client. Fixtures carry no result refs
+// ⇒ the batch stays disabled; these tests assert nodes/edges/layout, not content.
+const wrapper = connectedWrapper(makeMockClient().client);
+
 describe("MoteDag", () => {
   it("renders the canvas with one node per Mote + one edge per parent (diamond)", () => {
-    render(<MoteDag projection={vm(diamondProjection())} />);
+    render(<MoteDag projection={vm(diamondProjection())} />, { wrapper });
     expect(screen.getByTestId("mote-dag")).toHaveAttribute("role", "img");
     const rf = screen.getByTestId("rf");
     expect(rf).toHaveAttribute("data-nodes", "4");
@@ -46,19 +53,19 @@ describe("MoteDag", () => {
   });
 
   it("empty projection → empty state, no canvas", () => {
-    render(<MoteDag projection={vm(projection([]))} />);
+    render(<MoteDag projection={vm(projection([]))} />, { wrapper });
     expect(screen.getByTestId("empty-state")).toBeInTheDocument();
     expect(screen.queryByTestId("mote-dag")).not.toBeInTheDocument();
   });
 
   it("renders the DAG at the node-count boundary (MAX)", () => {
-    render(<MoteDag projection={vm(largeProjection(MAX_DAG_NODES))} />);
+    render(<MoteDag projection={vm(largeProjection(MAX_DAG_NODES))} />, { wrapper });
     expect(screen.getByTestId("mote-dag")).toBeInTheDocument();
     expect(screen.getByTestId("rf")).toHaveAttribute("data-nodes", String(MAX_DAG_NODES));
   });
 
   it("falls back to the table beyond MAX nodes", () => {
-    render(<MoteDag projection={vm(largeProjection(MAX_DAG_NODES + 1))} />);
+    render(<MoteDag projection={vm(largeProjection(MAX_DAG_NODES + 1))} />, { wrapper });
     expect(screen.getByTestId("dag-fallback")).toBeInTheDocument();
     expect(screen.getByTestId("mote-table")).toBeInTheDocument();
     expect(screen.queryByTestId("mote-dag")).not.toBeInTheDocument();
@@ -67,7 +74,7 @@ describe("MoteDag", () => {
   it("does NOT relayout on a state-only poll (no dagre thrash)", () => {
     const spy = vi.spyOn(layout, "layoutGraph");
     const [, grown, stateOnly] = growsBetweenPolls();
-    const { rerender } = render(<MoteDag projection={vm(grown)} />);
+    const { rerender } = render(<MoteDag projection={vm(grown)} />, { wrapper });
     const afterFirst = spy.mock.calls.length;
     expect(afterFirst).toBeGreaterThan(0);
     rerender(<MoteDag projection={vm(stateOnly)} />); // children flip COMMITTED — same topology
@@ -78,7 +85,7 @@ describe("MoteDag", () => {
   it("relayouts when the topology grows (a dynamic child appears)", () => {
     const spy = vi.spyOn(layout, "layoutGraph");
     const [rootOnly, grown] = growsBetweenPolls();
-    const { rerender } = render(<MoteDag projection={vm(rootOnly)} />);
+    const { rerender } = render(<MoteDag projection={vm(rootOnly)} />, { wrapper });
     const afterFirst = spy.mock.calls.length;
     rerender(<MoteDag projection={vm(grown)} />); // two children appear
     expect(spy.mock.calls.length).toBeGreaterThan(afterFirst);

--- a/ui/test/unit/dag-flow.test.ts
+++ b/ui/test/unit/dag-flow.test.ts
@@ -2,8 +2,21 @@
 
 import { describe, expect, it } from "vitest";
 import { buildFlowEdges, buildFlowNodes } from "../../src/components/dag/flow";
+import type { BatchedContentVM } from "../../src/kx/use-content-batch";
 import { toProjectionVM } from "../../src/kx/use-projection";
-import { diamondProjection, nid } from "../mocks/projection-fixtures";
+import { decodeContent } from "../../src/lib/content-decode";
+import { diamondProjection, mote, nid, projection } from "../mocks/projection-fixtures";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+function vm(ref: string, text: string, missing = false): BatchedContentVM {
+  return {
+    contentRef: ref,
+    missing,
+    truncated: false,
+    fullSize: text.length,
+    content: decodeContent(enc(text)),
+  };
+}
 
 describe("buildFlowNodes", () => {
   const motes = toProjectionVM(diamondProjection()).motes;
@@ -24,6 +37,51 @@ describe("buildFlowNodes", () => {
   it("a node with no layout position falls back to the origin", () => {
     const fallback = buildFlowNodes(motes, new Map());
     expect(fallback[0]?.position).toEqual({ x: 0, y: 0 });
+  });
+
+  it("without a results lookup, nodes carry no resolved content", () => {
+    expect(nodes[0]?.data.resultContent).toBeUndefined();
+    expect(nodes[0]?.data.resultMissing).toBe(false);
+    expect(nodes[0]?.data.resultLoading).toBe(false);
+  });
+});
+
+describe("buildFlowNodes — resolved results (D142.2)", () => {
+  const refA = "11".repeat(32);
+  const committed = toProjectionVM(
+    projection([
+      mote({ moteId: nid(100), resultRef: refA }),
+      mote({ moteId: nid(101), resultRef: null }), // uncommitted
+    ]),
+  ).motes;
+  const positions = new Map<string, { x: number; y: number }>();
+
+  it("threads the resolved text onto a committed node", () => {
+    const out = buildFlowNodes(committed, positions, {
+      byRef: new Map([[refA, vm(refA, "resolved output")]]),
+      loading: false,
+    });
+    expect(out[0]?.data.resultContent?.text).toBe("resolved output");
+    expect(out[0]?.data.resultMissing).toBe(false);
+    expect(out[0]?.data.resultLoading).toBe(false);
+  });
+
+  it("an uncommitted node never carries content or a loading flag", () => {
+    const out = buildFlowNodes(committed, positions, { byRef: new Map(), loading: true });
+    // node[1] has no resultRef → no content, and loading stays false for it
+    expect(out[1]?.data.resultContent).toBeUndefined();
+    expect(out[1]?.data.resultLoading).toBe(false);
+    // node[0] HAS a ref but it isn't resolved yet → loading propagates
+    expect(out[0]?.data.resultLoading).toBe(true);
+    expect(out[0]?.data.resultContent).toBeUndefined();
+  });
+
+  it("propagates the uniform-empty (missing) verdict", () => {
+    const out = buildFlowNodes(committed, positions, {
+      byRef: new Map([[refA, vm(refA, "", true)]]),
+      loading: false,
+    });
+    expect(out[0]?.data.resultMissing).toBe(true);
   });
 });
 

--- a/ui/test/unit/event-format.test.ts
+++ b/ui/test/unit/event-format.test.ts
@@ -30,6 +30,16 @@ describe("eventSummary", () => {
     expect(s).not.toContain("→");
   });
 
+  it("omitResultRef drops the trailing hash (the row renders resolved text instead)", () => {
+    const s = eventSummary(
+      { seq: 3, kind: "committed", moteId: id, resultRef: ref },
+      undefined,
+      true,
+    );
+    expect(s).toContain("committed");
+    expect(s).not.toContain("→");
+  });
+
   it("failed / repudiated / effect_staged read naturally", () => {
     expect(eventSummary({ seq: 1, kind: "failed", moteId: id })).toContain("failed");
     expect(eventSummary({ seq: 1, kind: "repudiated", targetMoteId: id })).toContain("repudiated");

--- a/ui/test/unit/result-preview.test.tsx
+++ b/ui/test/unit/result-preview.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ResultPreview, oneLine } from "../../src/components/ResultPreview";
+import { decodeContent } from "../../src/lib/content-decode";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const REF = "ab".repeat(32);
+
+describe("oneLine", () => {
+  it("collapses whitespace and trims", () => {
+    expect(oneLine("a\n  b\t c  ")).toBe("a b c");
+  });
+  it("clips to the cap with an ellipsis", () => {
+    expect(oneLine("abcdefghij", 4)).toBe("abcd…");
+  });
+  it("leaves a short string untouched (no ellipsis)", () => {
+    expect(oneLine("short", 80)).toBe("short");
+  });
+});
+
+describe("ResultPreview", () => {
+  it("uncommitted (no ref) renders an em dash, never a hash", () => {
+    const { container } = render(<ResultPreview resultRef={null} />);
+    expect(container.textContent).toBe("—");
+    expect(screen.queryByTestId("result-preview")).toBeNull();
+    expect(screen.queryByTestId("digest-chip")).toBeNull();
+  });
+
+  it("loading shows resolving… + the digest chip", () => {
+    render(<ResultPreview resultRef={REF} loading />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "loading");
+    expect(el).toHaveTextContent("resolving…");
+    expect(screen.getByTestId("digest-chip")).toBeInTheDocument();
+  });
+
+  it("missing (uniform-empty item) reads 'unavailable', honestly", () => {
+    render(<ResultPreview resultRef={REF} missing />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "missing");
+    expect(el).toHaveTextContent("unavailable");
+  });
+
+  it("empty result reads '(empty)'", () => {
+    render(<ResultPreview resultRef={REF} content={decodeContent(enc(""))} />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "empty");
+    expect(el).toHaveTextContent("(empty)");
+  });
+
+  it("text result shows the resolved TEXT as the headline (not the hash)", () => {
+    render(<ResultPreview resultRef={REF} content={decodeContent(enc("the model said hello"))} />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "text");
+    expect(el).toHaveTextContent("the model said hello");
+    // the digest is present but SECONDARY (a chip), not the headline
+    expect(screen.getByTestId("digest-chip")).toBeInTheDocument();
+  });
+
+  it("json result pretty-prints as text (collapsed to one line)", () => {
+    render(<ResultPreview resultRef={REF} content={decodeContent(enc('{"a":1}'))} />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "text");
+    expect(el).toHaveTextContent('"a": 1');
+  });
+
+  it("non-UTF-8 is shown as 'binary · N B' (never a fake hash headline)", () => {
+    const bytes = new Uint8Array([0xff, 0xfe, 0xfd]);
+    render(<ResultPreview resultRef={REF} content={decodeContent(bytes)} />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "binary");
+    expect(el).toHaveTextContent("binary · 3 B");
+  });
+
+  it("clips a long text result to the max headline length", () => {
+    const long = "x".repeat(500);
+    render(<ResultPreview resultRef={REF} content={decodeContent(enc(long))} max={40} />);
+    const text = screen.getByTestId("result-preview").querySelector(".result-preview__text");
+    expect(text?.textContent?.endsWith("…")).toBe(true);
+    // 40 chars + the ellipsis
+    expect((text?.textContent ?? "").length).toBe(41);
+    // the FULL text stays available in the title (hover / a11y)
+    expect(text).toHaveAttribute("title", long);
+  });
+
+  it("chip=false omits the digest chip (for inside-a-button containers)", () => {
+    render(<ResultPreview resultRef={REF} content={decodeContent(enc("hi"))} chip={false} />);
+    expect(screen.getByTestId("result-preview")).toHaveTextContent("hi");
+    expect(screen.queryByTestId("digest-chip")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The console was showing **mote-ids / content-ref hashes** where the actual model/mote **response text** belongs (run table, DAG nodes, artifacts list, activity/monitoring feeds, inspector header). Storage was already sound — every committed result is content-addressed, the journal holds only the 32-byte `result_ref`, and R-11 verifies the bytes exist before journaling `Committed`. The gap was **UI resolution + consistency**: the dense surfaces never fetched the bytes.

This lands ONE shared **"resolved text is the headline, the digest is a secondary chip"** treatment (D142.2) across every run-output surface. Each surface resolves via a single batched `GetContentBatch` (the N+1 collapse); content-addressed ⇒ cached forever.

## Surfaces (every state honest: uncommitted · resolving · empty · binary · missing)

- **Run table** (`MoteTable`/`MoteRow`) — Result column → resolved text + `DigestChip`; a `colgroup` bounds the column so the text ellipsis-clips and the chip stays on screen.
- **Live DAG** (`MoteNode` via `flow.buildFlowNodes`) — a resolved-text glimpse on each node; the full result + chip are one click away in the drawer.
- **Node inspector** (`NodeDetailDrawer`) — the bare "Result ref" hash → a `DigestChip` (the Result pane already resolves the full text).
- **Artifacts list** (`ArtifactGallery`) — each row leads with the resolved text + chip.
- **Activity feed** + **global feed** — committed rows show resolved text; cross-run resolution via a new run-grouped `useResultMapMulti` (`GetContentBatch` is run-scoped, so refs are grouped by owning run).
- **Monitoring capture table** — the Result cell resolves to text (bounded to the visible 10 rows).
- **Chat / inspector Inputs** — confirmed already resolving (no change).

Shared building blocks: `ResultPreview` (presentational, optional trailing chip), `useResultMap` (reference-stable map so the DAG's no-thrash invariant holds) + `useResultMapMulti` (combine-memoized cross-run), `eventSummary(omitResultRef)`. `DigestChip` is now nowrap + non-shrinking.

## Rules

- **GR13 / D142.2** — completes the resolved-text-headline + DigestChip contract across run/response surfaces; reuses the established DigestChip + content-resolver pattern (no new interaction pattern).
- **GR8** — perf: one batched fetch per surface + `staleTime: Infinity`; the 512 KiB per-item clamp surfaces truncation honestly. Security: `GetContent`/`GetContentBatch` scoping unchanged (run-scoped, uniform denial, no existence oracle). Compat: **additive UI only — no proto/journal/digest change**; canonical projection digest `7d22d4bd` invariant, frozen trio empty.
- **GR14** — new docs page **"Reading run outputs"** (content-addressed storage + `GetContent`/`GetContentBatch` in TS/Py/CLI + how the console resolves text).

## Tests

- **Unit/component (vitest):** `ResultPreview` across all states; `buildFlowNodes` resolved-result cases; `eventSummary(omitResultRef)`. Existing DAG/table/feed component tests wrapped in the connected harness. **425 pass.**
- **e2e (Playwright, both themes):** a real run resolves to TEXT across the table, DAG node, artifact list, and activity feed against a live gateway; flips to dark theme and re-asserts.
- Full gate green: `biome ci` · `tsc` · vitest · e2e · eager size within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)