### PR TITLE
fix(chat): clean model output — stop-token + fail-closed routing + P1.1 warrant route

### DIFF
--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -341,8 +341,8 @@ pub(crate) fn build_serve_backend(
 ///   FAIL-CLOSED, budget-cap the fan-out, lower it through VETTED recipes, and commit the
 ///   resulting [`TopologyDecision`] as the shaper's `result_ref` — so the coordinator's
 ///   materializer derives + dispatches the children. The model-driven agentic loop, live.
-/// - **leaf model** (`is_model_mote`, AL1): a greedy completion (recomputable) committed
-///   as content bytes — the shaper's children land here, running their per-child intent.
+/// - **leaf model** (a prompt-bearing Mote, AL1): a greedy completion (recomputable)
+///   committed as content bytes — the shaper's children land here, running their intent.
 ///
 /// A leased Mote's resolved Data context: the committed `(parent MoteId, result_ref)`
 /// pairs the worker delivers via [`kx_worker::ContextSink`] for F-7 assembly.
@@ -413,13 +413,15 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         }
     }
 
-    /// A model Mote: carries a `prompt` AND routes to a model this backend serves.
-    /// (The demo `echo`/`exec-demo` Motes carry no prompt, so they fall through.)
-    fn is_model_mote(&self, mote: &Mote) -> bool {
+    /// `true` iff the Mote carries a `prompt` — i.e. it is a MODEL step
+    /// (chat / shaper / ReAct turn / leaf completion), distinct from a PURE/demo
+    /// step (which carries no prompt and falls through to the inner echo/real-body
+    /// router). A prompt-bearing Mote whose `model_id` is NOT served must FAIL
+    /// CLOSED rather than fall through to the demo executor (see `run`).
+    fn has_prompt(mote: &Mote) -> bool {
         mote.def
             .config_subset
             .contains_key(&ConfigKey(PROMPT_KEY.to_string()))
-            && self.backend.supports(&mote.def.model_id)
     }
 
     /// Run a topology-SHAPER model Mote (PR-2b): the model proposes a fan-out, which is
@@ -723,28 +725,43 @@ impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
         env: Option<Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
         // Native deterministic CRITIC FIRST (PR-2c-3 critic-live): a critic carries no
-        // prompt (so `is_model_mote` is false) and would otherwise fall to the inner
+        // prompt (so `has_prompt` is false) and would otherwise fall to the inner
         // echo/real-body router, committing the wrong bytes instead of a verdict. Route
         // it to the in-process check (mirrors the FROZEN `run_native_critic_mote`).
         if mote.def.critic_check.is_some() {
             return self.run_critic(mote);
         }
-        // Shaper FIRST (a shaper is also a model Mote — has a prompt): the model proposes
-        // topology, lowered + committed as a TopologyDecision. Then the ReAct TURN arm
-        // (PR-2d-1: a turn is also a model Mote — raw-commit + the answer-only fence).
-        // Then leaf-model (greedy completion). Everything else → the inner real-body /
-        // PURE-echo router.
-        if self.is_model_mote(mote) {
-            if mote.def.is_topology_shaper {
+        // A prompt-bearing Mote is a MODEL step. If the backend does NOT serve its
+        // model_id, FAIL CLOSED — never delegate to the inner demo/echo executor.
+        // The old `is_model_mote = has_prompt && supports` collapsed "unserved model"
+        // into "not a model Mote", so a misrouted model step (e.g. a warrant whose
+        // `model_route` names a model that isn't served — the P1.1 class) silently
+        // committed the demo executor's `kx demo result for mote <hex>` placeholder,
+        // which then poisoned downstream F-7/ReAct context. A misroute must dead-letter
+        // VISIBLY (F4), not produce plausible-looking garbage (SN-8 / honest failure).
+        if Self::has_prompt(mote) {
+            if !self.backend.supports(&mote.def.model_id) {
+                return Err(internal(&format!(
+                    "model Mote {:?} routes to an unserved model {:?} — refusing to fall \
+                     back to the demo executor (fail-closed). Check the step warrant's \
+                     model_route and that `kx serve --features inference` serves it.",
+                    mote.id, mote.def.model_id
+                )));
+            }
+            // Shaper FIRST (a shaper is also a model Mote — has a prompt): the model
+            // proposes topology, lowered + committed as a TopologyDecision. Then the
+            // ReAct TURN arm (PR-2d-1: a turn is also a model Mote — raw-commit + the
+            // fence). Then leaf-model (greedy completion).
+            return if mote.def.is_topology_shaper {
                 self.run_shaper(mote, warrant)
             } else if Self::is_react_turn(mote) {
                 self.run_react_turn(mote, warrant)
             } else {
                 self.run_model(mote, warrant)
-            }
-        } else {
-            self.inner.run(mote, warrant, env)
+            };
         }
+        // No prompt ⇒ a PURE/demo/exec step → the inner real-body / PURE-echo router.
+        self.inner.run(mote, warrant, env)
     }
 
     fn supports(&self, executor_class: ExecutorClass) -> bool {
@@ -1073,6 +1090,57 @@ mod tests {
         // The result_ref IS the decision's content hash (so commit's D55 guard + the
         // materializer agree on the bytes).
         assert_eq!(out.result_ref, ContentRef::of(&td.encode()));
+    }
+
+    /// A prompt-bearing (MODEL) Mote whose model the backend does NOT serve must
+    /// FAIL CLOSED (dead-letter) — never fall through to the inner demo/echo
+    /// executor. Regression for the chat "kx demo result for mote …" context leak
+    /// and the P1.1 misroute class: the old `is_model_mote = has_prompt && supports`
+    /// collapsed "unserved" into "not a model Mote", silently committing a demo
+    /// placeholder that then poisoned downstream F-7/ReAct prompts.
+    #[test]
+    fn prompt_bearing_mote_with_unserved_model_fails_closed() {
+        struct UnservedBackend;
+        impl InferenceBackend for UnservedBackend {
+            fn dispatch(
+                &self,
+                _m: &ModelId,
+                _i: &InferenceInput,
+                _p: &kx_mote::InferenceParams,
+                _w: &WarrantSpec,
+            ) -> Result<InferenceOutput, InferenceError> {
+                panic!("dispatch must not run for an unserved model")
+            }
+            fn supports(&self, _model_id: &ModelId) -> bool {
+                false
+            }
+            fn name(&self) -> &'static str {
+                "unserved"
+            }
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        // NeverInner asserts the inner (demo/echo) executor is NEVER reached.
+        let exec = ModelRouterExecutor::new(
+            Arc::new(NeverInner),
+            Arc::new(UnservedBackend),
+            store.clone(),
+            None,
+        );
+        let err = exec
+            .run(
+                &shaper_mote(),
+                &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+                None,
+            )
+            .expect_err("an unserved-model MODEL Mote dead-letters (fail-closed)");
+        match err {
+            MoteExecutorError::Internal { reason, .. } => assert!(
+                reason.contains("unserved model"),
+                "fail-closed reason surfaced, not the inner-executor path: {reason}"
+            ),
+            other => panic!("expected a terminal Internal error, got {other:?}"),
+        }
     }
 
     // PR-2c-2: a re-plan round's shaper emits a `replan` envelope (its corrected prompt

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -528,7 +528,20 @@ impl DemoLibrary {
         // (blueprints/author) the Tier-1 DAG-authoring asset — granted Use to each
         // party so `SubmitWorkflow` resolves the party's authority from this same
         // ledger (no body/version; authoring submits one-off DAGs). Always seeded.
-        let blueprint_base = demo_warrant(exec_class);
+        //
+        // P1.1: when a model is served, the authoring grant's `model_route` MUST
+        // name the SERVED model — otherwise an authored MODEL step (whose warrant is
+        // this same `base`) routes to the demo PLACEHOLDER model and dead-letters at
+        // dispatch (served ≠ placeholder). The other axes stay `demo_warrant`'s (the
+        // PURE/EXEC authoring scope); only the model_route id is re-pointed. Warrants
+        // are off the MoteDef/journal/digest, so this is identity-invariant.
+        let blueprint_base = {
+            let mut w = demo_warrant(exec_class);
+            if let Some(model_id) = serve_model {
+                w.model_route.model_id = model_id.clone();
+            }
+            w
+        };
         seed_blueprint_asset(
             &grants,
             &owner,
@@ -930,6 +943,13 @@ impl HostWorkflowAuthor {
                         served.0
                     )));
                 }
+                // P1.1: the step warrant is `base` — and `blueprint_base` now carries
+                // the SERVED model in its `model_route` (see `seed`), so the dispatch
+                // id (served) == the warrant route id (served) and the dispatcher's
+                // strict check passes (it used to be the demo PLACEHOLDER route ≠
+                // served → the MODEL step dead-lettered). Using `base` verbatim keeps
+                // the step warrant == the authoring grant ⇒ a guaranteed no-op
+                // narrowing at admission (no `AttemptedWiden` on the model_route ceilings).
                 transform(
                     LogicRef::from_bytes(MODEL_LOGIC_REF),
                     served.clone(),
@@ -1871,6 +1891,66 @@ mod tests {
                 .await,
             Err(BinderError::NotAuthorized)
         ));
+    }
+
+    /// P1.1 regression: an authored MODEL step's bound warrant `model_route` names
+    /// the SERVED model (not the `blueprint_base` placeholder), so the dispatcher's
+    /// strict `mote.def.model_id == warrant.model_route.model_id` check passes and
+    /// the step RUNS instead of dead-lettering. Before the fix the step warrant was
+    /// the placeholder route ≠ served, so `SubmitWorkflow` MODEL steps dead-lettered
+    /// against any non-placeholder served model.
+    #[tokio::test]
+    async fn authored_model_step_warrant_routes_to_the_served_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let served = ModelId("kx-serve:test-model".into());
+        let lib = DemoLibrary::open_full(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            None,
+            Some(served.clone()),
+        )
+        .unwrap();
+        let author = HostWorkflowAuthor::from_shared(std::sync::Arc::new(lib));
+        let model_step = AuthorStep {
+            kind: AuthorStepKind::Model,
+            model_id: String::new(), // empty ⇒ bind to the served model
+            prompt: "summarize the discussion".into(),
+            body_signature_id: None,
+            tool_contract: std::collections::BTreeMap::new(),
+            params: std::collections::BTreeMap::new(),
+        };
+        let bound = author
+            .author(
+                "alice@acme",
+                3,
+                &[model_step],
+                &[],
+                AuthorExecutionMode::Frozen,
+            )
+            .await
+            .expect("a single MODEL step authors");
+        let (mote, warrant) = bound
+            .motes
+            .iter()
+            .find(|(m, _)| {
+                m.def
+                    .config_subset
+                    .contains_key(&ConfigKey(PROMPT_KEY.to_string()))
+            })
+            .expect("the authored DAG has a prompt-bearing MODEL Mote");
+        assert_eq!(
+            mote.def.model_id, served,
+            "the dispatch model id is the served model"
+        );
+        assert_eq!(
+            warrant.model_route.model_id, served,
+            "P1.1: the step warrant's model_route names the SERVED model (was the placeholder)"
+        );
+        assert_eq!(
+            mote.def.model_id, warrant.model_route.model_id,
+            "dispatch id == warrant route id (the dispatcher's strict equality holds)"
+        );
     }
 
     #[tokio::test]

--- a/crates/kx-inference/src/cache.rs
+++ b/crates/kx-inference/src/cache.rs
@@ -485,8 +485,18 @@ fn generate(
     let mut ctx = Context::new_with_params(model, &ctx_params).map_err(map_llama_err)?;
     let vocab = model.vocab();
 
+    // `parse_special: true` — the prompt carries ChatML control markers
+    // (`<|im_start|>`/`<|im_end|>`, rendered by the gateway's `chatml()` wrap).
+    // They MUST tokenize as the real special/control tokens, not literal text:
+    // the model was trained on the special-token turn structure, so with literal
+    // text it never emits the special EOG token (`<|im_end|>`, 151645) and runs
+    // to `max_output_tokens` re-emitting the scaffolding it was primed with. With
+    // `true` the markers become control tokens, the model emits the special EOG,
+    // and the `is_eog` check below stops generation cleanly (the EOG token renders
+    // empty under `token_to_piece_into(.., special=false)`, so it never leaks into
+    // the output). Mirrors the proven `kx-llamacpp/examples/chat.rs` + the mtmd path.
     let prompt_tokens = vocab
-        .tokenize(&job.prompt, true, false)
+        .tokenize(&job.prompt, true, true)
         .map_err(map_llama_err)?;
     check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
 


### PR DESCRIPTION
## What

The chat path produced garbage (the user's pasted "request/response observer" output): the model rambled past `<|im_end|>` re-emitting the ChatML scaffolding (`<|im_start|>system…<|im_end|>` repeated), and a prior `kx demo result for mote <hex>` leaked into the prompt. Three **independent, root-caused** fixes.

This is a dedicated **inference + gateway-routing correctness** change in the **D108.2 sanctioned-capability lane**: `kx-inference/src/dispatcher.rs`, `kx-executor`, `kx-scheduler` are **untouched** (frozen-trio guard passes), and the canonical projection digest **`7d22d4bd` is verified invariant** (a0_guard).

### A — stop-token (`kx-inference/src/cache.rs`)
Tokenize the prompt with `parse_special: true` (was `false`). The prompt carries ChatML control markers (the gateway's `chatml()` wrap); with `false` they tokenized as **literal text**, so the model — trained on the special-token turn structure — never emitted the special EOG (`<|im_end|>`, id 151645) and ran to `max_output_tokens` re-emitting the scaffolding. With `true` the markers become control tokens, the model emits the EOG, and the existing `is_eog` check stops cleanly (the EOG renders empty under `token_to_piece_into(.., special=false)`). Mirrors the proven `examples/chat.rs` + mtmd paths.

### B — fail-closed routing (`kx-gateway/src/model_exec.rs`)
A prompt-bearing (MODEL) Mote whose model the backend does **not** serve now **dead-letters** instead of falling through to the demo/echo executor. The old `is_model_mote = has_prompt && supports` collapsed *"unserved model"* into *"not a model Mote"*, so a misrouted model step silently committed `kx demo result for mote <hex>` — which then poisoned downstream F-7/ReAct prompt context. A misroute must fail **visibly** (F4 dead-letter), never produce plausible garbage (SN-8 / honest failure).

### C — P1.1 warrant route (`kx-gateway/src/provision.rs`)
The `SubmitWorkflow` authoring grant (`blueprint_base`) now names the **served** model in its `model_route` when a model is served (was the demo placeholder `llama-3.1-8b-instruct-q4_k_m`). An authored MODEL step's warrant is this same `base`, so the dispatcher's strict `mote.def.model_id == warrant.model_route.model_id` check passes and the step **runs** instead of dead-lettering. Only the model_route id is re-pointed (other axes stay `demo_warrant`'s, for PURE/EXEC); warrants are off MoteDef/journal/digest ⇒ identity-invariant. **Unblocks SubmitWorkflow MODEL steps + chat→Blueprint summarize.**

## Pre-flight (GR8)
- **Breaks?** No schema/wire/journal/digest change — `7d22d4bd` invariant (verified); warrants aren't in `MoteDef`, so identity-invariant. `parse_special: true` makes user content containing literal `<|im_end|>` parse as a control token — a minor prompt-injection surface bounded to the **single-node operator** (D129; not a multi-tenant trust boundary). The proper hardening (render via the model's own `apply_chat_template`) is a noted follow-up.
- **Performance?** A one-flag tokenize + a cheap routing predicate — no hot-path allocation, no regression.
- **Security?** B **closes** a hole (demo output masquerading as model output / poisoning context).

## Tests
- `prompt_bearing_mote_with_unserved_model_fails_closed` — a MODEL Mote on an unserved model dead-letters, never reaches the demo inner executor (B regression).
- `authored_model_step_warrant_routes_to_the_served_model` — the authored MODEL step's warrant route == served, dispatcher strict-equality holds (C/P1.1 regression).
- **Live-verified on Qwen3-4B:** `kx invoke kx/recipes/chat --args '{"prompt":"talk about python programming"}'` now returns a clean, coherent, structured answer — no scaffolding, no demo leak — stopping at the token budget.
- Gate: fmt · clippy `-D warnings` · doc `-D warnings` · `kx-gateway` (116 inference / 87 FFI-free) + `kx-inference` suites · a0_guard `7d22d4bd` invariant · frozen-trio diff empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)