### PR TITLE
feat(ui): PR-4.1b — Workflows + Blueprints card overhaul + workflows.md

### DIFF
--- a/docs/site/docs/workflows.md
+++ b/docs/site/docs/workflows.md
@@ -1,0 +1,80 @@
+---
+id: workflows
+title: Workflows
+sidebar_label: Workflows
+description: Your runs as bordered cards with clean names and a per-card action menu — open, re-run, clone, build-from, rename, and export (record or full results); plus the Blueprints catalog.
+---
+
+# Workflows
+
+The **Workflows** section is your run history. Every time you run a blueprint —
+from Chat, the Blueprints catalog, or the visual builder — the run is enumerated
+here: durable runs recovered from the journal (`ListRuns`) merged with this
+browser's session records. Each run is a **bordered card** with a clean display
+name and a per-card action menu.
+
+> A run is an immutable, committed fact. Workflows is presentation over that
+> truth: renames and session history are **client-local** (per gateway endpoint,
+> in your browser); the runs themselves live in the journal and never change.
+
+## The card
+
+- **Name.** The headline is a clean, humanized name (`kx/recipes/echo` →
+  *Echo*). A local **rename** wins over it; the raw handle stays as a secondary
+  mono chip so the exact recipe is never lost. A durable run recovered from the
+  journal carries a **journal** badge.
+- **Open.** Click the name to open the run's detail — the live **DAG**, the
+  **table**, **artifacts**, and the **activity / time-travel** tabs.
+- **Filter.** Filter the grid by name, id, or blueprint handle.
+- **Clear local history.** Clears only *this browser's* session records — the
+  durable journal runs (and your local renames) stay. The label is honest about
+  what it removes.
+
+## The action menu
+
+The **⋯** menu on each card carries the run's actions:
+
+- **Open in new tab** — the run detail in a new browser tab (`rel="noopener"`).
+- **Run again** — re-invoke the same blueprint + args. This is **idempotent**:
+  the same recipe + args resolves to the same already-committed result, so
+  "running again" honestly *joins* the committed run rather than duplicating it.
+- **Clone** — open the run's blueprint with its inputs **prefilled**; tweak and
+  run it as a new use case.
+- **Build from this** — reconstruct the run's graph in the [visual
+  builder](./blueprint-builder.md) to add agents, wire steps, and run a new
+  workflow.
+- **Rename** — set a client-local display name (this browser only).
+- **Export** — download the run **record** as JSON (id, name, blueprint handle,
+  args, timestamp).
+- **Export with results** — download a richer bundle that also fetches the
+  committed **DAG** and each step's **resolved output text** over
+  `GetProjection` / `GetContent`. Available once the run has a terminal step.
+- **Share** / **Schedule** — shown as disabled **Cloud** chips. Sharing across
+  parties and scheduling recurring runs are managed-cloud capabilities; the
+  console never fakes a control it cannot honor.
+
+## The Blueprints catalog
+
+The [**Blueprints**](./blueprint-builder.md) section is the companion catalog —
+the templates you run. It mirrors the same card language:
+
+- Each blueprint is a card with a clean name, its **description**, advisory
+  **tags**, and a **version** chip; the raw handle stays a secondary mono chip.
+- **Search** the catalog by intent (`SearchRecipes`, display-only ranking — a hit
+  *surfaces* a blueprint, never runs it).
+- Clicking a card opens its **input form** in a slide-over drawer; fill the
+  server-described fields and run it (the run lands back here in Workflows).
+- The card menu offers **Run**, **Open in new tab**, **View contract** (the
+  free-param contract in a read-only editor), **Edit in builder** (clone-to-edit
+  in the visual builder), **Rename**, **Export** (the blueprint definition), and
+  the same honest **Cloud** Share / Schedule chips.
+- **+ New blueprint** opens the visual builder.
+
+## See also
+
+- [Reading run outputs](./reading-run-outputs.md) — how a committed run resolves
+  to readable text across the console (and what an exported bundle contains).
+- [Blueprint builder](./blueprint-builder.md) — author and edit the blueprints
+  Workflows runs.
+- [Chat](./chat.md) — the conversational front door; each message is a run that
+  appears here.

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         "chat",
+        "workflows",
         "blueprint-builder",
         "agent-runner",
         "security",

--- a/ui/e2e/card-export.spec.ts
+++ b/ui/e2e/card-export.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * PR-4.1b: the Workflows + Blueprints card EXPORT affordances download real
+ * JSON over the live gateway (the lightweight record, the rich GetProjection/
+ * GetContent bundle, and the blueprint definition), and Open-in-new-tab carries
+ * `rel="noopener"`. This is the GR17 integration check for the new card menus.
+ */
+
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("workflows card: Export (lightweight + with-results) downloads run JSON; new-tab is rel=noopener", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  await runRecipe(page, { handle: "kx/recipes/echo", fields: { topic: "export-me" } });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId("nav-runs").click();
+  await expect(page.getByTestId("run-list")).toBeVisible({ timeout: 30_000 });
+
+  const card = page.getByTestId("run-card").first();
+
+  // Lightweight export → a run JSON file.
+  await card.getByTestId("run-menu").click();
+  const [light] = await Promise.all([
+    page.waitForEvent("download"),
+    card.getByTestId("run-export").click(),
+  ]);
+  expect(light.suggestedFilename()).toMatch(/^kortecx-run-.*\.json$/);
+
+  // Rich export → fetches the committed projection + resolved output, then downloads.
+  await card.getByTestId("run-menu").click();
+  const [rich] = await Promise.all([
+    page.waitForEvent("download"),
+    card.getByTestId("run-export-rich").click(),
+  ]);
+  expect(rich.suggestedFilename()).toMatch(/^kortecx-run-.*\.json$/);
+
+  // Open-in-new-tab is a safe external link.
+  await card.getByTestId("run-menu").click();
+  const newtab = card.getByTestId("run-open-newtab");
+  await expect(newtab).toHaveAttribute("target", "_blank");
+  await expect(newtab).toHaveAttribute("rel", "noopener noreferrer");
+});
+
+test("blueprint card: Export downloads the definition JSON", async ({ page }) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  await page.getByTestId("nav-recipes").click();
+  await expect(page.getByTestId("recipe-catalog")).toBeVisible({ timeout: 30_000 });
+
+  const bp = page
+    .getByTestId("blueprint-card")
+    .filter({ has: page.getByTestId("recipe-pick-kx/recipes/echo") });
+  await bp.getByTestId("blueprint-menu").click();
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    bp.getByTestId("blueprint-export").click(),
+  ]);
+  expect(download.suggestedFilename()).toMatch(/^kortecx-blueprint-.*\.json$/);
+});

--- a/ui/e2e/runs-list.spec.ts
+++ b/ui/e2e/runs-list.spec.ts
@@ -28,8 +28,8 @@ test("runs: a submitted run appears in the run list and re-opens", async ({ page
   await page.getByTestId("runs-filter").fill("zzz-no-match");
   await expect(page.getByTestId("run-list")).toHaveCount(0);
 
-  // Re-open the run from the list (clear the filter first).
+  // Re-open the run from its card (clear the filter first).
   await page.getByTestId("runs-filter").fill("");
-  await page.getByTestId("run-list").locator("a").first().click();
+  await page.getByTestId("run-open").first().click();
   await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
 });

--- a/ui/e2e/workflows-controls.spec.ts
+++ b/ui/e2e/workflows-controls.spec.ts
@@ -1,8 +1,8 @@
 /**
- * PR-2.1 review-feedback round: the Workflows page controls (New workflow ·
- * Clone-prefill · Rename · the honest "Clear local history"), the Blueprints
- * catalog TABLE + the Monaco contract popup, the printable demo result, and
- * the agent toggle's honest ABSENCE on an FFI-free serve.
+ * PR-4.1b card overhaul: the Workflows page CARDS + per-card action menu (New
+ * workflow · Clone-prefill · Rename · the honest "Clear local history"), the
+ * Blueprints catalog CARD GRID + the Monaco contract popup, the readable
+ * passthrough result, and the agent toggle's honest ABSENCE on an FFI-free serve.
  */
 
 import { expect, test } from "@playwright/test";
@@ -16,7 +16,7 @@ test.afterEach(() => {
   gw = undefined;
 });
 
-test("workflows: clone prefills the blueprint form; rename + clear-local-history stay honest", async ({
+test("workflows: a run card menu clones (prefilled), renames, and clear-local-history stays honest", async ({
   page,
 }) => {
   gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
@@ -28,19 +28,21 @@ test("workflows: clone prefills the blueprint form; rename + clear-local-history
   await page.getByTestId("nav-runs").click();
   await expect(page.getByTestId("run-list")).toBeVisible();
 
-  // The row is LABELED by its recipe handle (session record).
-  const row = page.locator(".run-list__item").first();
-  await expect(row).toContainText("kx/recipes/echo");
+  // The card carries its recipe handle as a secondary chip (clean name = "Echo").
+  const card = page.getByTestId("run-card").first();
+  await expect(card).toContainText("kx/recipes/echo");
 
-  // Rename (client-local) → the row shows the custom name.
-  await row.getByTestId("run-rename").click();
-  await row.getByTestId("run-rename-input").fill("incident triage");
-  await row.getByTestId("run-rename-input").press("Enter");
-  await expect(row).toContainText("incident triage");
+  // Rename (client-local) via the per-card menu → the card shows the custom name.
+  await card.getByTestId("run-menu").click();
+  await card.getByTestId("run-rename").click();
+  await card.getByTestId("run-rename-input").fill("incident triage");
+  await card.getByTestId("run-rename-input").press("Enter");
+  await expect(card).toContainText("incident triage");
 
-  // Clone → the Blueprints form opens PRE-FILLED with the prior args.
-  await row.getByTestId("run-clone").click();
-  await expect(page.getByTestId("recipe-table")).toBeVisible({ timeout: 30_000 });
+  // Clone (menu) → the Blueprints run form opens PRE-FILLED with the prior args.
+  await card.getByTestId("run-menu").click();
+  await card.getByTestId("run-clone").click();
+  await expect(page.getByTestId("recipe-catalog")).toBeVisible({ timeout: 30_000 });
   await expect(
     page.locator('[data-testid="recipe-form"][data-recipe="kx/recipes/echo"]'),
   ).toBeVisible({ timeout: 30_000 });
@@ -51,12 +53,13 @@ test("workflows: clone prefills the blueprint form; rename + clear-local-history
   await page.getByTestId("nav-runs").click();
   await page.getByTestId("clear-local-history").click();
   await expect(page.getByTestId("run-list")).toBeVisible({ timeout: 30_000 });
-  const durable = page.locator(".run-list__item").first();
+  const durable = page.getByTestId("run-card").first();
   await expect(durable).toContainText("journal"); // the recovered-from-journal badge
   await expect(durable).toContainText("incident triage"); // renames outlive the clear
 
-  // Dropping the rename falls back to the fingerprint→handle JOIN (PR-2.1):
-  // the durable row is still NAMED by its recipe, not a bare hex id.
+  // Dropping the rename falls back to the humanized handle + its raw-handle chip:
+  // the durable card is still NAMED by its recipe, not a bare hex id.
+  await durable.getByTestId("run-menu").click();
   await durable.getByTestId("run-rename").click();
   await durable.getByTestId("run-rename-input").fill("");
   await durable.getByTestId("run-rename-input").press("Enter");
@@ -67,14 +70,21 @@ test("workflows: clone prefills the blueprint form; rename + clear-local-history
   await expect(page).toHaveURL(/\/recipes$/);
 });
 
-test("blueprints: the catalog is a table; View opens the contract in Monaco", async ({ page }) => {
+test("blueprints: the catalog is a card grid; the menu's View opens the contract in Monaco", async ({
+  page,
+}) => {
   gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
   await connectConsole(page, gw);
 
   await page.getByTestId("nav-recipes").click();
-  await expect(page.getByTestId("recipe-table")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("recipe-catalog")).toBeVisible({ timeout: 30_000 });
 
-  await page.getByTestId("recipe-view-kx/recipes/echo").click();
+  // Open the echo card's action menu → View contract.
+  const bp = page
+    .getByTestId("blueprint-card")
+    .filter({ has: page.getByTestId("recipe-pick-kx/recipes/echo") });
+  await bp.getByTestId("blueprint-menu").click();
+  await bp.getByTestId("recipe-view-kx/recipes/echo").click();
   const viewer = page.getByTestId("blueprint-viewer");
   await expect(viewer).toBeVisible();
   await expect(viewer.getByTestId("blueprint-contract")).toContainText("kx/recipes/echo", {

--- a/ui/src/components/sections/BlueprintCard.tsx
+++ b/ui/src/components/sections/BlueprintCard.tsx
@@ -1,0 +1,241 @@
+import type { RecipeInfo } from "@kortecx/sdk/web";
+import { Link } from "@tanstack/react-router";
+import { m } from "framer-motion";
+import { useState } from "react";
+import { fadeUp, hoverLift } from "../../app/motion";
+import { useConnection } from "../../kx/connection-context";
+import { toUiError } from "../../kx/errors";
+import { useBlueprintExport } from "../../kx/use-blueprint-export";
+import { setBlueprintName } from "../../lib/blueprint-names";
+import { ErrorNotice } from "../ErrorNotice";
+import { Icon } from "../shell/Icon";
+import { Popover } from "../shell/Popover";
+
+/**
+ * One blueprint as a bordered card (PR-4.1b): a clean display name headline +
+ * description subtitle + advisory tag/version chips (the raw handle stays a
+ * secondary mono chip) + a per-card action menu (the reused `Popover`/D148).
+ * "Edit in builder" is the blueprint's honest settings (the builder IS the
+ * editor); Share + Schedule are cross-party / cloud (D129) → honest-disabled
+ * "Cloud" chips (D142 don't-fake-gaps). The card title opens the run form.
+ */
+export function BlueprintCard({
+  handle,
+  headline,
+  customName,
+  summary,
+  onRun,
+  onView,
+}: {
+  handle: string;
+  /** Display headline (local rename > humanized handle). */
+  headline: string;
+  /** The current client-local custom name (seeds the rename draft), or null. */
+  customName: string | null;
+  /** Advisory catalog metadata (description/tags/version), if the gateway has it. */
+  summary: RecipeInfo | undefined;
+  /** Open this blueprint's input form (the run-form drawer). */
+  onRun: (handle: string) => void;
+  /** Open this blueprint's contract viewer. */
+  onView: (handle: string) => void;
+}) {
+  const { endpoint } = useConnection();
+  const exporter = useBlueprintExport();
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState(customName ?? "");
+
+  const description = summary?.description ?? "";
+  const tags = summary?.tags ?? [];
+  const version = summary?.version ?? "";
+  const exporting = exporter.pendingHandle === handle;
+
+  function saveRename(): void {
+    setBlueprintName(endpoint, handle, draft);
+    setRenaming(false);
+  }
+
+  return (
+    <m.article
+      className="glow-card glow-card--hover card-grid__card"
+      data-testid="blueprint-card"
+      variants={fadeUp}
+      {...hoverLift}
+    >
+      <div className="card-grid__head">
+        <button
+          type="button"
+          className="card-grid__title"
+          data-testid={`recipe-pick-${handle}`}
+          title="Open this blueprint's input form"
+          onClick={() => onRun(handle)}
+        >
+          {headline}
+        </button>
+        <Popover
+          trigger={<Icon name="menu" size={16} />}
+          triggerClassName="iconbtn"
+          triggerLabel="Blueprint actions"
+          triggerTestId="blueprint-menu"
+          align="right"
+          direction="down"
+          menuTestId="blueprint-menu-panel"
+        >
+          {(close) => (
+            <>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item"
+                data-testid={`recipe-run-${handle}`}
+                onClick={() => {
+                  close();
+                  onRun(handle);
+                }}
+              >
+                <Icon name="runs" size={15} />
+                <span>Run</span>
+              </button>
+              <Link
+                to="/recipes"
+                search={{ handle }}
+                target="_blank"
+                rel="noopener noreferrer"
+                role="menuitem"
+                className="popover__item"
+                data-testid="blueprint-open-newtab"
+                onClick={close}
+              >
+                <Icon name="external-link" size={15} />
+                <span>Open in new tab</span>
+              </Link>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item"
+                data-testid={`recipe-view-${handle}`}
+                title="View the blueprint's contract (inputs + types)"
+                onClick={() => {
+                  close();
+                  onView(handle);
+                }}
+              >
+                <Icon name="recipes" size={15} />
+                <span>View contract</span>
+              </button>
+              <Link
+                to="/blueprints/new"
+                role="menuitem"
+                className="popover__item"
+                data-testid="blueprint-edit"
+                title="Open the visual builder to edit a copy of this blueprint"
+                onClick={close}
+              >
+                <Icon name="settings" size={15} />
+                <span>Edit in builder</span>
+              </Link>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item"
+                data-testid="blueprint-rename"
+                onClick={() => {
+                  setDraft(customName ?? "");
+                  setRenaming(true);
+                  close();
+                }}
+              >
+                <Icon name="settings" size={15} />
+                <span>Rename</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item"
+                data-testid="blueprint-export"
+                disabled={exporting}
+                title="Export this blueprint's definition (contract + metadata) as JSON"
+                onClick={() => {
+                  void exporter.exportBlueprint({ handle, description, tags, version }).then(close);
+                }}
+              >
+                <Icon name="download" size={15} />
+                <span>{exporting ? "Exporting…" : "Export"}</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item popover__item--disabled"
+                data-testid="blueprint-share"
+                disabled
+                aria-disabled="true"
+                title="Share across parties — a managed cloud capability"
+              >
+                <Icon name="share" size={15} />
+                <span>Share</span>
+                <span className="chip chip--soon">Cloud</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item popover__item--disabled"
+                data-testid="blueprint-schedule"
+                disabled
+                aria-disabled="true"
+                title="Schedule recurring runs — a managed cloud capability"
+              >
+                <Icon name="calendar" size={15} />
+                <span>Schedule</span>
+                <span className="chip chip--soon">Cloud</span>
+              </button>
+            </>
+          )}
+        </Popover>
+      </div>
+
+      {description ? <p className="card-grid__sub">{description}</p> : null}
+
+      {renaming ? (
+        <span className="card-grid__rename">
+          <input
+            value={draft}
+            data-testid="blueprint-rename-input"
+            aria-label="Blueprint name"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                saveRename();
+              }
+              if (e.key === "Escape") {
+                setRenaming(false);
+              }
+            }}
+            spellCheck={false}
+            autoComplete="off"
+          />
+          <button type="button" className="linkbtn" onClick={saveRename}>
+            Save
+          </button>
+        </span>
+      ) : null}
+
+      {tags.length > 0 ? (
+        <div className="card-grid__tags">
+          {tags.map((t) => (
+            <span key={t} className="chip chip--tag">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="card-grid__meta">
+        <code className="mono card-grid__handle" title={handle}>
+          {handle}
+        </code>
+        {version ? <span className="card-grid__time">v{version}</span> : null}
+      </div>
+
+      {exporter.error ? <ErrorNotice error={toUiError(exporter.error)} /> : null}
+    </m.article>
+  );
+}

--- a/ui/src/components/sections/BlueprintFormDrawer.tsx
+++ b/ui/src/components/sections/BlueprintFormDrawer.tsx
@@ -1,0 +1,88 @@
+import { m } from "framer-motion";
+import { useEffect } from "react";
+import { toUiError } from "../../kx/errors";
+import { useRecipeForm } from "../../kx/use-recipes";
+import { humanizeHandle } from "../../lib/humanize-handle";
+import { EmptyState } from "../EmptyState";
+import { ErrorNotice } from "../ErrorNotice";
+import { RecipeForm } from "../recipes/RecipeForm";
+
+/**
+ * The blueprint run-form in a slide-over drawer (PR-4.1b): clicking a Blueprint
+ * card (or its "Run" menu item) opens this; the clone-lite landing
+ * (`/recipes?handle=&args=`) auto-opens it PREFILLED. Reuses the `.node-drawer`
+ * skeleton + Escape convention (BlueprintViewer / NodeDetailDrawer). The form
+ * itself (`RecipeForm`, testid `recipe-form` + `data-recipe`) is unchanged —
+ * the gateway re-validates every arg server-side (SN-8).
+ */
+export function BlueprintFormDrawer({
+  handle,
+  prefill,
+  pending,
+  onRun,
+  onClose,
+}: {
+  handle: string;
+  /** Prefill values (the clone-lite landing: a run's prior args). */
+  prefill?: Record<string, unknown>;
+  pending: boolean;
+  onRun: (handle: string, args: Record<string, unknown>) => void;
+  onClose: () => void;
+}) {
+  const form = useRecipeForm(handle);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="node-drawer__scrim"
+        aria-label="Close blueprint form"
+        onClick={onClose}
+      />
+      <m.aside
+        className="node-drawer"
+        data-testid="blueprint-form-drawer"
+        // biome-ignore lint/a11y/useSemanticElements: a native <dialog> can't ride framer-motion animations; non-modal side-panel semantics declared via role+aria-label (the NodeDetailDrawer precedent)
+        role="dialog"
+        aria-label={`Run blueprint ${handle}`}
+        initial={{ x: 24, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        transition={{ type: "spring", stiffness: 420, damping: 34 }}
+      >
+        <div className="node-drawer__head">
+          <strong>{humanizeHandle(handle)}</strong>
+          <button type="button" className="linkbtn" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+        <code className="mono muted" title={handle}>
+          {handle}
+        </code>
+        {form.isLoading ? <EmptyState title="Loading form…" /> : null}
+        {form.error ? (
+          <ErrorNotice error={toUiError(form.error)} onRetry={() => void form.refetch()} />
+        ) : null}
+        {form.data ? (
+          <RecipeForm
+            // Re-key per handle+prefill so a clone-landing remount prefills.
+            key={`${handle}:${prefill ? "prefilled" : "blank"}`}
+            form={form.data}
+            pending={pending}
+            onSubmit={(args) => onRun(handle, args)}
+            initial={prefill}
+          />
+        ) : null}
+      </m.aside>
+    </>
+  );
+}

--- a/ui/src/components/sections/RecipesSection.tsx
+++ b/ui/src/components/sections/RecipesSection.tsx
@@ -1,28 +1,42 @@
+import type { RecipeInfo } from "@kortecx/sdk/web";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { m } from "framer-motion";
-import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
-import { rowEntrance } from "../../app/motion";
+import { type FormEvent, useEffect, useState } from "react";
+import { stagger } from "../../app/motion";
+import { useConnection } from "../../kx/connection-context";
 import { toUiError } from "../../kx/errors";
 import { useInvoke } from "../../kx/use-invoke";
 import { useRecipeSearch } from "../../kx/use-recipe-search";
-import { useRecipeForm, useRecipes } from "../../kx/use-recipes";
+import { useRecipeForm, useRecipeSummaries, useRecipes } from "../../kx/use-recipes";
 import { useRuns } from "../../kx/use-runs";
+import { BLUEPRINT_NAMES_CHANGED_EVENT, loadBlueprintNames } from "../../lib/blueprint-names";
+import { blueprintInputs } from "../../lib/export-blueprint";
+import { humanizeHandle } from "../../lib/humanize-handle";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
 import { CodeViewer } from "../editor/CodeViewer";
 import { JsonEditor } from "../editor/JsonEditor";
-import { RecipeForm } from "../recipes/RecipeForm";
+import { BlueprintCard } from "./BlueprintCard";
+import { BlueprintFormDrawer } from "./BlueprintFormDrawer";
 
 const FALLBACK_HANDLE = "kx/recipes/echo";
 const FALLBACK_ARGS = '{\n  "topic": "hello"\n}';
 
+/** The display shape a Blueprint card renders. */
+interface BlueprintDisplay {
+  readonly headline: string;
+  readonly customName: string | null;
+}
+
 /**
  * The Blueprint catalog + submit (display name for the frozen `recipe` wire).
- * PR-2.1: the catalog is a TABLE — one blueprint per row with per-row controls
- * (Run → the form below; View → the contract in a read-only Monaco popup) —
- * and the route accepts `?handle=&args=` to land with a prior run's inputs
- * PREFILLED (the clone-lite flow from Workflows). Sharing across parties is a
- * cloud capability (D129) — no fake control here.
+ * PR-4.1b: the catalog is a CARD GRID — one blueprint per card with a clean
+ * display name, a description subtitle + advisory tag/version chips, and a
+ * per-card action menu (Run · Open-in-new-tab · View contract · Edit in builder
+ * · Rename · Export · Share[Cloud] · Schedule[Cloud]). Clicking a card opens
+ * the run form in a slide-over drawer; `?handle=&args=` auto-opens it PREFILLED
+ * (the clone-lite flow from Workflows). Sharing across parties + scheduling are
+ * cloud capabilities (D129) — honest-disabled chips, never fake controls.
  */
 export function RecipesSection({
   initialHandle,
@@ -34,9 +48,36 @@ export function RecipesSection({
   initialArgs?: string;
 }) {
   const navigate = useNavigate();
+  const { endpoint } = useConnection();
   const { add } = useRuns();
   const invoke = useInvoke();
   const recipes = useRecipes();
+  const summaries = useRecipeSummaries();
+  const [names, setNames] = useState<Record<string, string>>(() => loadBlueprintNames(endpoint));
+  const [openForm, setOpenForm] = useState<{
+    handle: string;
+    prefill?: Record<string, unknown>;
+  } | null>(null);
+  const [viewing, setViewing] = useState<string | null>(null);
+
+  // Stay fresh across blueprint-rename events + endpoint switches.
+  useEffect(() => {
+    setNames(loadBlueprintNames(endpoint));
+    function onNamesChanged(): void {
+      setNames(loadBlueprintNames(endpoint));
+    }
+    window.addEventListener(BLUEPRINT_NAMES_CHANGED_EVENT, onNamesChanged);
+    return () => window.removeEventListener(BLUEPRINT_NAMES_CHANGED_EVENT, onNamesChanged);
+  }, [endpoint]);
+
+  // Clone-lite landing: when `?handle=` targets a provisioned blueprint, open
+  // its run form PREFILLED (fires once the catalog has loaded).
+  const catalog = recipes.data;
+  useEffect(() => {
+    if (initialHandle && catalog && catalog.includes(initialHandle)) {
+      setOpenForm({ handle: initialHandle, prefill: parsePrefill(initialArgs) });
+    }
+  }, [initialHandle, initialArgs, catalog]);
 
   function start(handle: string, args: Record<string, unknown>): void {
     invoke.mutate(
@@ -49,7 +90,7 @@ export function RecipesSection({
             recipeFingerprint,
             handle,
             startedAt: Date.now(),
-            // PR-2.1: keep the args so the Workflows row can Run-again/Clone.
+            // Keep the args so the Workflows card can Run-again/Clone.
             args: JSON.stringify(args),
           });
           navigate({
@@ -60,6 +101,13 @@ export function RecipesSection({
         },
       },
     );
+  }
+
+  /** Display name precedence: local rename > humanized handle. */
+  function nameFor(handle: string): BlueprintDisplay {
+    const local = names[handle];
+    const customName = local && local.trim() !== "" ? local : null;
+    return { headline: customName ?? humanizeHandle(handle), customName };
   }
 
   const invokeError = invoke.error ? toUiError(invoke.error) : null;
@@ -83,13 +131,13 @@ export function RecipesSection({
 
       {recipes.isLoading ? <EmptyState title="Loading blueprints…" /> : null}
 
-      {recipes.data ? (
-        <RecipeTable
-          handles={recipes.data}
-          pending={invoke.isPending}
-          onRun={start}
-          initialHandle={initialHandle}
-          initialArgs={initialArgs}
+      {catalog ? (
+        <BlueprintCatalog
+          handles={catalog}
+          summaries={summaries.data ?? {}}
+          nameFor={nameFor}
+          onRun={(handle) => setOpenForm({ handle })}
+          onView={setViewing}
         />
       ) : null}
 
@@ -98,7 +146,67 @@ export function RecipesSection({
       ) : null}
 
       {invokeError ? <ErrorNotice error={invokeError} onRetry={() => invoke.reset()} /> : null}
+
+      {openForm ? (
+        <BlueprintFormDrawer
+          handle={openForm.handle}
+          prefill={openForm.prefill}
+          pending={invoke.isPending}
+          onRun={start}
+          onClose={() => setOpenForm(null)}
+        />
+      ) : null}
+
+      {viewing ? <BlueprintViewer handle={viewing} onClose={() => setViewing(null)} /> : null}
     </section>
+  );
+}
+
+/** The catalog as a card grid — one {@link BlueprintCard} per provisioned handle. */
+function BlueprintCatalog({
+  handles,
+  summaries,
+  nameFor,
+  onRun,
+  onView,
+}: {
+  handles: string[];
+  summaries: Record<string, RecipeInfo>;
+  nameFor: (handle: string) => BlueprintDisplay;
+  onRun: (handle: string) => void;
+  onView: (handle: string) => void;
+}) {
+  if (handles.length === 0) {
+    return (
+      <EmptyState
+        title="No blueprints provisioned"
+        detail="This gateway exposes the blueprint catalog but provisions no blueprints."
+      />
+    );
+  }
+  return (
+    <m.div
+      className="card-grid"
+      data-testid="recipe-catalog"
+      variants={stagger()}
+      initial="hidden"
+      animate="show"
+    >
+      {handles.map((h) => {
+        const d = nameFor(h);
+        return (
+          <BlueprintCard
+            key={h}
+            handle={h}
+            headline={d.headline}
+            customName={d.customName}
+            summary={summaries[h]}
+            onRun={onRun}
+            onView={onView}
+          />
+        );
+      })}
+    </m.div>
   );
 }
 
@@ -176,128 +284,11 @@ function parsePrefill(argsText: string | undefined): Record<string, unknown> | u
   return undefined;
 }
 
-/** The catalog table: one blueprint per row + per-row Run/View controls. */
-function RecipeTable({
-  handles,
-  pending,
-  onRun,
-  initialHandle,
-  initialArgs,
-}: {
-  handles: string[];
-  pending: boolean;
-  onRun: (handle: string, args: Record<string, unknown>) => void;
-  initialHandle?: string;
-  initialArgs?: string;
-}) {
-  const [selected, setSelected] = useState(() =>
-    initialHandle && handles.includes(initialHandle)
-      ? initialHandle
-      : (handles[0] ?? FALLBACK_HANDLE),
-  );
-  const handle = handles.includes(selected) ? selected : (handles[0] ?? FALLBACK_HANDLE);
-  const form = useRecipeForm(handle);
-  const [viewing, setViewing] = useState<string | null>(null);
-  const formRef = useRef<HTMLDivElement | null>(null);
-  // Only the clone-lite landing's TARGET blueprint gets the prefill.
-  const prefill = useMemo(
-    () => (handle === initialHandle ? parsePrefill(initialArgs) : undefined),
-    [handle, initialHandle, initialArgs],
-  );
-
-  if (handles.length === 0) {
-    return (
-      <EmptyState
-        title="No blueprints provisioned"
-        detail="This gateway exposes the blueprint catalog but provisions no blueprints."
-      />
-    );
-  }
-
-  return (
-    <div data-testid="recipe-catalog">
-      <table className="recipe-table" data-testid="recipe-table">
-        <thead>
-          <tr>
-            <th scope="col">Blueprint</th>
-            <th scope="col" className="recipe-table__actions">
-              Actions
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {handles.map((h, i) => (
-            <m.tr
-              key={h}
-              className={h === handle ? "recipe-row recipe-row--active" : "recipe-row"}
-              data-testid={`recipe-row-${h}`}
-              {...rowEntrance(i)}
-            >
-              <td>
-                <button
-                  type="button"
-                  data-testid={`recipe-pick-${h}`}
-                  className={`recipe-chip${h === handle ? " recipe-chip--active" : ""}`}
-                  aria-pressed={h === handle}
-                  onClick={() => setSelected(h)}
-                >
-                  {h}
-                </button>
-              </td>
-              <td className="recipe-table__actions">
-                <button
-                  type="button"
-                  className="linkbtn"
-                  data-testid={`recipe-run-${h}`}
-                  title="Open this blueprint's input form below"
-                  onClick={() => {
-                    setSelected(h);
-                    formRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-                  }}
-                >
-                  Run
-                </button>
-                <button
-                  type="button"
-                  className="linkbtn"
-                  data-testid={`recipe-view-${h}`}
-                  title="View the blueprint's contract (inputs + types)"
-                  onClick={() => setViewing(h)}
-                >
-                  View
-                </button>
-              </td>
-            </m.tr>
-          ))}
-        </tbody>
-      </table>
-
-      <div ref={formRef}>
-        {form.isLoading ? <EmptyState title="Loading form…" /> : null}
-        {form.error ? (
-          <ErrorNotice error={toUiError(form.error)} onRetry={() => void form.refetch()} />
-        ) : null}
-        {form.data ? (
-          <RecipeForm
-            // Re-key per handle+prefill so a clone-landing remount prefills.
-            key={`${handle}:${prefill ? "prefilled" : "blank"}`}
-            form={form.data}
-            pending={pending}
-            onSubmit={(args) => onRun(handle, args)}
-            initial={prefill}
-          />
-        ) : null}
-      </div>
-
-      {viewing ? <BlueprintViewer handle={viewing} onClose={() => setViewing(null)} /> : null}
-    </div>
-  );
-}
-
 /**
  * The blueprint-contract popup (PR-2.1): the handle + its full free-param
  * contract rendered as JSON in the read-only Monaco viewer (D141.2). Pure
- * display — the contract is exactly what `GetRecipeForm` declares.
+ * display — the contract is exactly what `GetRecipeForm` declares (shaped by the
+ * shared `blueprintInputs`, so the viewer + the Export file never drift).
  */
 function BlueprintViewer({ handle, onClose }: { handle: string; onClose: () => void }) {
   const form = useRecipeForm(handle);
@@ -314,20 +305,7 @@ function BlueprintViewer({ handle, onClose }: { handle: string; onClose: () => v
   }, [onClose]);
 
   const contract = form.data
-    ? JSON.stringify(
-        {
-          handle: form.data.handle,
-          inputs: form.data.fields.map((f) => ({
-            name: f.name,
-            type: f.type,
-            required: f.required,
-            ...(f.maxLen ? { max_len: f.maxLen } : {}),
-            ...(f.allowed.length > 0 ? { allowed: f.allowed } : {}),
-          })),
-        },
-        null,
-        2,
-      )
+    ? JSON.stringify({ handle: form.data.handle, inputs: blueprintInputs(form.data) }, null, 2)
     : null;
 
   return (

--- a/ui/src/components/sections/RunCard.tsx
+++ b/ui/src/components/sections/RunCard.tsx
@@ -1,0 +1,287 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import { m } from "framer-motion";
+import { useState } from "react";
+import { fadeUp, hoverLift } from "../../app/motion";
+import { useConnection } from "../../kx/connection-context";
+import { toUiError } from "../../kx/errors";
+import { useInvoke } from "../../kx/use-invoke";
+import { useRunExport } from "../../kx/use-run-export";
+import { shortHex } from "../../lib/format";
+import type { RunRecord } from "../../lib/recent-runs";
+import { setRunName } from "../../lib/run-names";
+import { ErrorNotice } from "../ErrorNotice";
+import { Icon } from "../shell/Icon";
+import { Popover } from "../shell/Popover";
+
+/**
+ * One run as a bordered card (PR-4.1b): a clean display name headline (the raw
+ * handle stays a secondary mono chip) + a per-card action menu (the reused
+ * `Popover`/D148). Sharing + scheduling are cross-party / cloud (D129) — shown
+ * as honest-disabled "Cloud" chips (D142 don't-fake-gaps); a committed run is
+ * immutable, so there is deliberately NO "settings" item (Clone / Build-from
+ * are the real re-config paths). Open-in-new-tab uses `rel="noopener"`.
+ */
+export function RunCard({
+  run,
+  headline,
+  rawHandle,
+  customName,
+}: {
+  run: RunRecord;
+  /** The display headline (local rename > humanized handle > short id). */
+  headline: string;
+  /** The raw handle for the secondary mono chip + the e2e/disambiguation. */
+  rawHandle: string | null;
+  /** The current client-local custom name (seeds the rename draft), or null. */
+  customName: string | null;
+}) {
+  const { endpoint } = useConnection();
+  const navigate = useNavigate();
+  const invoke = useInvoke();
+  const exporter = useRunExport();
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState(customName ?? "");
+
+  // A durable-only card (recovered from the journal, not started in this browser).
+  const journalOnly = run.handle === null && (run.args ?? null) === null;
+  const canRunAgain = Boolean(run.handle && run.args);
+  const richPending = exporter.pendingId === run.instanceId;
+
+  function runAgain(): void {
+    if (!run.handle || !run.args) {
+      return;
+    }
+    let args: Record<string, unknown>;
+    try {
+      args = JSON.parse(run.args) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    // Idempotent by construction: the same recipe+args resolves to the same
+    // already-committed Mote (the memoizer) — "running again" honestly JOINS it.
+    invoke.mutate(
+      { handle: run.handle, args },
+      {
+        onSuccess: ({ instanceId, terminalMoteId }) => {
+          void navigate({
+            to: "/workflows/$instanceId",
+            params: { instanceId },
+            search: { terminal: terminalMoteId },
+          });
+        },
+      },
+    );
+  }
+
+  function saveRename(): void {
+    setRunName(endpoint, run.instanceId, draft);
+    setRenaming(false);
+  }
+
+  return (
+    <m.article
+      className="glow-card glow-card--hover card-grid__card"
+      data-testid="run-card"
+      variants={fadeUp}
+      {...hoverLift}
+    >
+      <div className="card-grid__head">
+        <Link
+          to="/workflows/$instanceId"
+          params={{ instanceId: run.instanceId }}
+          search={run.terminalMoteId ? { terminal: run.terminalMoteId } : {}}
+          className="card-grid__title"
+          data-testid="run-open"
+        >
+          {headline}
+        </Link>
+        <Popover
+          trigger={<Icon name="menu" size={16} />}
+          triggerClassName="iconbtn"
+          triggerLabel="Run actions"
+          triggerTestId="run-menu"
+          align="right"
+          direction="down"
+          menuTestId="run-menu-panel"
+        >
+          {(close) => (
+            <>
+              <Link
+                to="/workflows/$instanceId"
+                params={{ instanceId: run.instanceId }}
+                search={run.terminalMoteId ? { terminal: run.terminalMoteId } : {}}
+                target="_blank"
+                rel="noopener noreferrer"
+                role="menuitem"
+                className="popover__item"
+                data-testid="run-open-newtab"
+                onClick={close}
+              >
+                <Icon name="external-link" size={15} />
+                <span>Open in new tab</span>
+              </Link>
+              {canRunAgain ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="popover__item"
+                  data-testid="run-again"
+                  disabled={invoke.isPending}
+                  title="Re-invoke the same blueprint + args (idempotent: joins the committed result)"
+                  onClick={() => {
+                    close();
+                    runAgain();
+                  }}
+                >
+                  <Icon name="refresh" size={15} />
+                  <span>{invoke.isPending ? "Running…" : "Run again"}</span>
+                </button>
+              ) : null}
+              {run.handle ? (
+                <Link
+                  to="/recipes"
+                  search={{ handle: run.handle, ...(run.args ? { args: run.args } : {}) }}
+                  role="menuitem"
+                  className="popover__item"
+                  data-testid="run-clone"
+                  title="Open this run's blueprint with its inputs prefilled — tweak and run as a new use case"
+                  onClick={close}
+                >
+                  <Icon name="copy" size={15} />
+                  <span>Clone</span>
+                </Link>
+              ) : null}
+              <Link
+                to="/blueprints/new"
+                search={{ clone: run.instanceId }}
+                role="menuitem"
+                className="popover__item"
+                data-testid="run-remix"
+                title="Reconstruct this run's graph in the visual builder"
+                onClick={close}
+              >
+                <Icon name="recipes" size={15} />
+                <span>Build from this</span>
+              </Link>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item"
+                data-testid="run-rename"
+                onClick={() => {
+                  setDraft(customName ?? "");
+                  setRenaming(true);
+                  close();
+                }}
+              >
+                <Icon name="settings" size={15} />
+                <span>Rename</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item"
+                data-testid="run-export"
+                title="Export this run's record as JSON (this browser)"
+                onClick={() => {
+                  close();
+                  exporter.exportLight(run, headline);
+                }}
+              >
+                <Icon name="download" size={15} />
+                <span>Export</span>
+              </button>
+              {run.terminalMoteId ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="popover__item"
+                  data-testid="run-export-rich"
+                  disabled={richPending}
+                  title="Export the committed DAG + each step's resolved output (fetches from the gateway)"
+                  onClick={() => {
+                    void exporter.exportRich(run, headline).then(close);
+                  }}
+                >
+                  <Icon name="download" size={15} />
+                  <span>{richPending ? "Exporting…" : "Export with results"}</span>
+                </button>
+              ) : null}
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item popover__item--disabled"
+                data-testid="run-share"
+                disabled
+                aria-disabled="true"
+                title="Share across parties — a managed cloud capability"
+              >
+                <Icon name="share" size={15} />
+                <span>Share</span>
+                <span className="chip chip--soon">Cloud</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="popover__item popover__item--disabled"
+                data-testid="run-schedule"
+                disabled
+                aria-disabled="true"
+                title="Schedule recurring runs — a managed cloud capability"
+              >
+                <Icon name="calendar" size={15} />
+                <span>Schedule</span>
+                <span className="chip chip--soon">Cloud</span>
+              </button>
+            </>
+          )}
+        </Popover>
+      </div>
+
+      {renaming ? (
+        <span className="card-grid__rename">
+          <input
+            value={draft}
+            data-testid="run-rename-input"
+            aria-label="Run name"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                saveRename();
+              }
+              if (e.key === "Escape") {
+                setRenaming(false);
+              }
+            }}
+            spellCheck={false}
+            autoComplete="off"
+          />
+          <button type="button" className="linkbtn" onClick={saveRename}>
+            Save
+          </button>
+        </span>
+      ) : null}
+
+      <div className="card-grid__meta">
+        {rawHandle ? (
+          <code className="mono card-grid__handle" title={rawHandle}>
+            {rawHandle}
+          </code>
+        ) : (
+          <code className="mono card-grid__handle" title={run.instanceId}>
+            {shortHex(run.instanceId)}
+          </code>
+        )}
+        {journalOnly ? (
+          <span className="badge" title="Recovered from the journal (not started in this browser)">
+            journal
+          </span>
+        ) : null}
+        <span className="card-grid__time">{new Date(run.startedAt).toLocaleTimeString()}</span>
+      </div>
+
+      {invoke.error ? <ErrorNotice error={toUiError(invoke.error)} /> : null}
+      {exporter.error ? <ErrorNotice error={toUiError(exporter.error)} /> : null}
+    </m.article>
+  );
+}

--- a/ui/src/components/sections/RunsSection.tsx
+++ b/ui/src/components/sections/RunsSection.tsx
@@ -1,25 +1,33 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { m } from "framer-motion";
 import { useEffect, useMemo, useState } from "react";
-import { rowEntrance } from "../../app/motion";
+import { stagger } from "../../app/motion";
 import { useConnection } from "../../kx/connection-context";
-import { toUiError } from "../../kx/errors";
-import { useInvoke } from "../../kx/use-invoke";
 import { useRecipeNames } from "../../kx/use-recipes";
 import { useRuns } from "../../kx/use-runs";
 import { shortHex } from "../../lib/format";
+import { humanizeHandle } from "../../lib/humanize-handle";
 import type { RunRecord } from "../../lib/recent-runs";
-import { RUN_NAMES_CHANGED_EVENT, loadRunNames, setRunName } from "../../lib/run-names";
+import { RUN_NAMES_CHANGED_EVENT, loadRunNames } from "../../lib/run-names";
 import { EmptyState } from "../EmptyState";
-import { ErrorNotice } from "../ErrorNotice";
+import { RunCard } from "./RunCard";
+
+/** The display shape a Workflows card renders. */
+interface RunDisplay {
+  /** Headline: local rename > humanized handle > short id. */
+  readonly headline: string;
+  /** The raw handle (or fingerprint-joined handle), for the secondary chip. */
+  readonly rawHandle: string | null;
+  /** The client-local custom name (seeds the rename draft), or null. */
+  readonly customName: string | null;
+}
 
 /**
- * The Workflows home (PR-2.1): durable runs enumerated from the journal
- * (`ListRuns`) merged with this session's per-invocation records — labeled by
- * recipe handle (the fingerprint→handle join) or a client-local rename, with
- * per-row controls: Open · Run again (idempotent re-invoke) · Clone (prefill
- * the Blueprints form). Authoring stays in Blueprints (D141.1) — the "New
- * workflow" button LINKS there, never duplicates it.
+ * The Workflows home (PR-4.1b): durable runs enumerated from the journal
+ * (`ListRuns`) merged with this session's per-invocation records, rendered as
+ * bordered CARDS with clean display names (the raw handle stays a secondary
+ * chip) + a per-card action menu. Authoring stays in Blueprints (D141.1) — the
+ * "New workflow" button LINKS there, never duplicates it.
  */
 export function RunsSection() {
   const { endpoint } = useConnection();
@@ -40,13 +48,25 @@ export function RunsSection() {
 
   const fingerprintNames = recipeNames.data ?? {};
 
-  /** Display name precedence: local rename > session handle > fingerprint join. */
-  function nameFor(r: RunRecord): string | null {
+  /** The handle that labels a run (session handle > fingerprint join). */
+  function handleFor(r: RunRecord): string | null {
     return (
-      names[r.instanceId] ??
-      r.handle ??
-      (r.recipeFingerprint ? (fingerprintNames[r.recipeFingerprint] ?? null) : null)
+      r.handle ?? (r.recipeFingerprint ? (fingerprintNames[r.recipeFingerprint] ?? null) : null)
     );
+  }
+
+  /** Display name precedence: local rename > humanized handle > short id. */
+  function displayFor(r: RunRecord): RunDisplay {
+    const local = names[r.instanceId];
+    const handleName = handleFor(r);
+    const customName = local && local.trim() !== "" ? local : null;
+    if (customName) {
+      return { headline: customName, rawHandle: handleName, customName };
+    }
+    if (handleName) {
+      return { headline: humanizeHandle(handleName), rawHandle: handleName, customName: null };
+    }
+    return { headline: shortHex(r.instanceId), rawHandle: null, customName: null };
   }
 
   const shown = useMemo(() => {
@@ -120,16 +140,26 @@ export function RunsSection() {
       ) : shown.length === 0 ? (
         <EmptyState title="No matching runs" detail="Adjust the filter above." />
       ) : (
-        <ul className="run-list" data-testid="run-list">
-          {shown.map((r, i) => (
-            <RunRow
-              key={`${r.instanceId}:${r.terminalMoteId ?? ""}`}
-              run={r}
-              index={i}
-              name={nameFor(r)}
-            />
-          ))}
-        </ul>
+        <m.div
+          className="card-grid"
+          data-testid="run-list"
+          variants={stagger()}
+          initial="hidden"
+          animate="show"
+        >
+          {shown.map((r) => {
+            const d = displayFor(r);
+            return (
+              <RunCard
+                key={`${r.instanceId}:${r.terminalMoteId ?? ""}`}
+                run={r}
+                headline={d.headline}
+                rawHandle={d.rawHandle}
+                customName={d.customName}
+              />
+            );
+          })}
+        </m.div>
       )}
 
       {hasMore ? (
@@ -138,146 +168,5 @@ export function RunsSection() {
         </button>
       ) : null}
     </section>
-  );
-}
-
-/** One run row: name + id + time, with Open/Run-again/Clone/Rename controls. */
-function RunRow({ run, index, name }: { run: RunRecord; index: number; name: string | null }) {
-  const { endpoint } = useConnection();
-  const navigate = useNavigate();
-  const invoke = useInvoke();
-  const [renaming, setRenaming] = useState(false);
-  const [draft, setDraft] = useState(name ?? "");
-
-  // A durable-only row (recovered from the journal, not started in this browser).
-  const journalOnly = run.handle === null && (run.args ?? null) === null;
-  const canRunAgain = Boolean(run.handle && run.args);
-
-  function runAgain(): void {
-    if (!run.handle || !run.args) {
-      return;
-    }
-    let args: Record<string, unknown>;
-    try {
-      args = JSON.parse(run.args) as Record<string, unknown>;
-    } catch {
-      return;
-    }
-    // Idempotent by construction: the same recipe+args resolves to the same
-    // already-committed Mote (the memoizer) — "running again" honestly JOINS it.
-    invoke.mutate(
-      { handle: run.handle, args },
-      {
-        onSuccess: ({ instanceId, terminalMoteId }) => {
-          void navigate({
-            to: "/workflows/$instanceId",
-            params: { instanceId },
-            search: { terminal: terminalMoteId },
-          });
-        },
-      },
-    );
-  }
-
-  function saveRename(): void {
-    setRunName(endpoint, run.instanceId, draft);
-    setRenaming(false);
-  }
-
-  return (
-    <m.li className="run-list__item card-hover" {...rowEntrance(index)}>
-      <div className="run-list__main">
-        <Link
-          to="/workflows/$instanceId"
-          params={{ instanceId: run.instanceId }}
-          search={run.terminalMoteId ? { terminal: run.terminalMoteId } : {}}
-          className="run-list__link"
-          data-testid="run-open"
-        >
-          {renaming ? null : (
-            <span className="run-list__name">{name ?? shortHex(run.instanceId)}</span>
-          )}
-        </Link>
-        {renaming ? (
-          <span className="run-list__rename">
-            <input
-              value={draft}
-              data-testid="run-rename-input"
-              aria-label="Run name"
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  saveRename();
-                }
-                if (e.key === "Escape") {
-                  setRenaming(false);
-                }
-              }}
-              spellCheck={false}
-              autoComplete="off"
-            />
-            <button type="button" className="linkbtn" onClick={saveRename}>
-              Save
-            </button>
-          </span>
-        ) : null}
-        <code className="mono muted" title={run.instanceId}>
-          {shortHex(run.instanceId)}
-        </code>
-        {journalOnly ? (
-          <span className="badge" title="Recovered from the journal (not started in this browser)">
-            journal
-          </span>
-        ) : null}
-      </div>
-      <span className="muted">{new Date(run.startedAt).toLocaleTimeString()}</span>
-      <span className="run-list__actions">
-        {canRunAgain ? (
-          <button
-            type="button"
-            className="linkbtn"
-            data-testid="run-again"
-            disabled={invoke.isPending}
-            title="Re-invoke the same blueprint + args (idempotent: joins the committed result)"
-            onClick={runAgain}
-          >
-            {invoke.isPending ? "Running…" : "Run again"}
-          </button>
-        ) : null}
-        {run.handle ? (
-          <Link
-            to="/recipes"
-            search={{ handle: run.handle, ...(run.args ? { args: run.args } : {}) }}
-            className="linkbtn"
-            data-testid="run-clone"
-            title="Open this run's blueprint with its inputs prefilled — tweak and run as a new use case"
-          >
-            Clone
-          </Link>
-        ) : null}
-        <Link
-          to="/blueprints/new"
-          search={{ clone: run.instanceId }}
-          className="linkbtn"
-          data-testid="run-remix"
-          title="Reconstruct this run's graph in the visual builder — add agents, wire steps, run as a new workflow"
-        >
-          Build from this
-        </Link>
-        <button
-          type="button"
-          className="linkbtn"
-          data-testid="run-rename"
-          onClick={() => {
-            setDraft(name ?? "");
-            setRenaming((v) => !v);
-          }}
-          title="Rename (this browser only)"
-        >
-          Rename
-        </button>
-      </span>
-      {invoke.error ? <ErrorNotice error={toUiError(invoke.error)} /> : null}
-    </m.li>
   );
 }

--- a/ui/src/components/shell/Icon.tsx
+++ b/ui/src/components/shell/Icon.tsx
@@ -33,6 +33,9 @@ export type Glyph =
   | "terminal"
   | "copy"
   | "download"
+  | "share"
+  | "external-link"
+  | "calendar"
   | "thumb-up"
   | "thumb-down";
 
@@ -68,6 +71,10 @@ const PATHS: Record<Glyph, string> = {
   terminal: "M4 17l6-5-6-5M12 19h8",
   copy: "M9 9h11a2 2 0 012 2v9a2 2 0 01-2 2h-9a2 2 0 01-2-2v-9a2 2 0 012-2zM5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1",
   download: "M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3",
+  share:
+    "M18 8a3 3 0 100-6 3 3 0 000 6zm0 14a3 3 0 100-6 3 3 0 000 6zM6 15a3 3 0 100-6 3 3 0 000 6zm2.6-1.3l6.8 4m0-11.4l-6.8 4",
+  "external-link": "M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3",
+  calendar: "M3 6a2 2 0 012-2h14a2 2 0 012 2v13a2 2 0 01-2 2H5a2 2 0 01-2-2zm0 4h18M8 2v4m8-4v4",
   "thumb-up":
     "M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3zM7 22H4a2 2 0 01-2-2v-7a2 2 0 012-2h3",
   "thumb-down":

--- a/ui/src/components/shell/Popover.tsx
+++ b/ui/src/components/shell/Popover.tsx
@@ -17,6 +17,7 @@ export function Popover({
   triggerTestId,
   triggerDisabled,
   align = "left",
+  direction = "up",
   menuTestId,
   children,
 }: {
@@ -29,6 +30,10 @@ export function Popover({
   triggerDisabled?: boolean;
   /** Which edge the panel aligns to the trigger. */
   align?: "left" | "right";
+  /** Whether the panel opens above (`up`, default — the bottom-anchored composer)
+   *  or below (`down`) the trigger. Top-anchored callers (list/grid cards) MUST
+   *  use `down` so the panel does not land off the top of the viewport. */
+  direction?: "up" | "down";
   menuTestId?: string;
   children: (close: () => void) => ReactNode;
 }) {
@@ -80,7 +85,7 @@ export function Popover({
       {open ? (
         <div
           id={menuId}
-          className={`popover__panel popover__panel--${align}`}
+          className={`popover__panel popover__panel--${align} popover__panel--${direction}`}
           role="menu"
           data-testid={menuTestId}
         >

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -17,6 +17,8 @@ export const queryKeys = {
   recipes: (endpoint: string) => ["kx", endpoint, "recipes"] as const,
   /** The fingerprint→handle naming map (`ListRecipes` summaries, PR-2.1). */
   recipeNames: (endpoint: string) => ["kx", endpoint, "recipe-names"] as const,
+  /** The handle→summary metadata map (`ListRecipes` summaries, PR-4.1b cards). */
+  recipeSummaries: (endpoint: string) => ["kx", endpoint, "recipe-summaries"] as const,
   /** One recipe's free-param form (`GetRecipeForm`), scoped by handle. */
   recipeForm: (endpoint: string, handle: string) =>
     ["kx", endpoint, "recipe-form", handle] as const,

--- a/ui/src/kx/use-blueprint-export.ts
+++ b/ui/src/kx/use-blueprint-export.ts
@@ -1,0 +1,50 @@
+/**
+ * Export a Blueprint's definition as JSON (the Blueprints card affordance).
+ * Fetches the `GetRecipeForm` contract on demand and serializes it (with the
+ * advisory catalog metadata) via the pure `lib/export-blueprint`. The fetch is
+ * on-demand — NOT a per-card query — so the catalog grid stays light.
+ */
+
+import { useState } from "react";
+import { download } from "../lib/download";
+import {
+  type BlueprintMeta,
+  exportBlueprintFilename,
+  exportBlueprintJson,
+} from "../lib/export-blueprint";
+import { useConnection } from "./connection-context";
+
+export interface UseBlueprintExport {
+  exportBlueprint(meta: BlueprintMeta): Promise<void>;
+  /** The handle currently fetching its contract, or `null`. */
+  readonly pendingHandle: string | null;
+  readonly error: unknown;
+}
+
+export function useBlueprintExport(): UseBlueprintExport {
+  const { client } = useConnection();
+  const [pendingHandle, setPendingHandle] = useState<string | null>(null);
+  const [error, setError] = useState<unknown>(null);
+
+  async function exportBlueprint(meta: BlueprintMeta): Promise<void> {
+    if (!client) {
+      return;
+    }
+    setPendingHandle(meta.handle);
+    setError(null);
+    try {
+      const form = await client.getRecipeForm(meta.handle);
+      download(
+        exportBlueprintFilename(meta.handle),
+        exportBlueprintJson(meta, form),
+        "application/json",
+      );
+    } catch (e) {
+      setError(e);
+    } finally {
+      setPendingHandle(null);
+    }
+  }
+
+  return { exportBlueprint, pendingHandle, error };
+}

--- a/ui/src/kx/use-recipes.ts
+++ b/ui/src/kx/use-recipes.ts
@@ -6,7 +6,7 @@
  * so it caches indefinitely.
  */
 
-import type { RecipeForm } from "@kortecx/sdk/web";
+import type { RecipeForm, RecipeInfo } from "@kortecx/sdk/web";
 import { useQuery } from "@tanstack/react-query";
 import { useConnection } from "./connection-context";
 import { queryKeys } from "./query-keys";
@@ -51,6 +51,36 @@ export function useRecipeNames() {
         return map;
       } catch {
         return {}; // not wired / old gateway — unlabeled rows are honest
+      }
+    },
+  });
+}
+
+/**
+ * The handle→summary metadata map (PR-4.1b Blueprint cards): the SAME
+ * `ListRecipes` summaries `useRecipeNames` reads, but keyed by handle and
+ * keeping the advisory `description`/`tags`/`version` the cards render as a
+ * subtitle + chips. Tolerant: an old gateway (or no catalog) yields an EMPTY
+ * map — cards degrade to the handle headline, never an error.
+ */
+export function useRecipeSummaries() {
+  const { client, endpoint, status } = useConnection();
+  return useQuery({
+    queryKey: queryKeys.recipeSummaries(endpoint),
+    enabled: status === "connected" && client !== null,
+    queryFn: async (): Promise<Record<string, RecipeInfo>> => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      try {
+        const summaries = await client.listRecipeSummaries();
+        const map: Record<string, RecipeInfo> = {};
+        for (const s of summaries) {
+          map[s.handle] = s;
+        }
+        return map;
+      } catch {
+        return {}; // not wired / old gateway — handle-only cards are honest
       }
     },
   });

--- a/ui/src/kx/use-run-export.ts
+++ b/ui/src/kx/use-run-export.ts
@@ -1,0 +1,91 @@
+/**
+ * Export a run as JSON (the Workflows card affordance). Two paths over ONE pure
+ * envelope (`lib/export-run`):
+ *   - `exportLight` — synchronous, the client-known {@link RunRecord} only.
+ *   - `exportRich`  — fetches the committed projection (`GetProjection`) + each
+ *     Mote's resolved output (`GetContent`), proving the UI↔gateway dataflow.
+ * The impure fetch/decode lives here; the serialization stays pure + tested in
+ * `lib/export-run`. `pendingId` is the instance currently fetching (one card at
+ * a time per hook instance); `error` is the last rich-export failure.
+ */
+
+import { useState } from "react";
+import { decodeContent } from "../lib/content-decode";
+import { download } from "../lib/download";
+import {
+  type RunArtifactExport,
+  type RunBundle,
+  exportRunFilename,
+  exportRunJson,
+} from "../lib/export-run";
+import type { RunRecord } from "../lib/recent-runs";
+import { useConnection } from "./connection-context";
+import { toProjectionVM } from "./use-projection";
+
+const MIME = "application/json";
+
+export interface UseRunExport {
+  exportLight(record: RunRecord, name: string): void;
+  exportRich(record: RunRecord, name: string): Promise<void>;
+  /** The instanceId currently fetching a rich export, or `null`. */
+  readonly pendingId: string | null;
+  readonly error: unknown;
+}
+
+export function useRunExport(): UseRunExport {
+  const { client } = useConnection();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<unknown>(null);
+
+  function exportLight(record: RunRecord, name: string): void {
+    download(exportRunFilename(name), exportRunJson(record, name), MIME);
+  }
+
+  async function exportRich(record: RunRecord, name: string): Promise<void> {
+    if (!client) {
+      return;
+    }
+    setPendingId(record.instanceId);
+    setError(null);
+    try {
+      const projection = toProjectionVM(await client.getProjection(record.instanceId));
+      const artifacts: RunArtifactExport[] = [];
+      for (const motes of projection.motes) {
+        if (motes.resultRef === null) {
+          continue;
+        }
+        const decoded = decodeContent(await client.getContent(motes.resultRef, record.instanceId));
+        artifacts.push({
+          moteId: motes.moteId,
+          resultRef: motes.resultRef,
+          kind: decoded.kind,
+          text: decoded.text,
+          byteLength: decoded.byteLength,
+        });
+      }
+      const bundle: RunBundle = {
+        currentSeq: projection.currentSeq,
+        motes: projection.motes.map((m) => ({
+          moteId: m.moteId,
+          state: m.stateCode,
+          ndClass: m.ndClass,
+          committedSeq: m.committedSeq,
+          resultRef: m.resultRef,
+          parents: m.parents.map((e) => ({
+            parentId: e.parentId,
+            edgeKind: e.edgeKind,
+            nonCascade: e.nonCascade,
+          })),
+        })),
+        artifacts,
+      };
+      download(exportRunFilename(name), exportRunJson(record, name, bundle), MIME);
+    } catch (e) {
+      setError(e);
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return { exportLight, exportRich, pendingId, error };
+}

--- a/ui/src/lib/blueprint-names.ts
+++ b/ui/src/lib/blueprint-names.ts
@@ -1,0 +1,67 @@
+/**
+ * Client-local Blueprint display names (PR-4.1b), keyed per endpoint by the
+ * stable wire HANDLE — the `run-names.ts` pattern. PRESENTATION state only: the
+ * wire has no blueprint-name field, so a rename lives in THIS browser and never
+ * leaves it. Fail-closed: a corrupt/unavailable store reads as "no names",
+ * never throws.
+ */
+
+const MAX_NAMES = 200;
+
+/** Fired on `window` whenever the persisted names change (same-tab freshness —
+ *  the `RUN_NAMES_CHANGED_EVENT` rationale). */
+export const BLUEPRINT_NAMES_CHANGED_EVENT = "kortecx:blueprint-names-changed";
+
+function notifyChanged(): void {
+  try {
+    window.dispatchEvent(new Event(BLUEPRINT_NAMES_CHANGED_EVENT));
+  } catch {
+    /* non-browser env */
+  }
+}
+
+function keyFor(endpoint: string): string {
+  return `kortecx.ui.blueprint-names:${endpoint}`;
+}
+
+export function loadBlueprintNames(endpoint: string): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(keyFor(endpoint));
+    if (raw === null) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string" && v.trim() !== "") {
+        out[k] = v;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Set (or clear, with an empty string) the local name for a blueprint `handle`. */
+export function setBlueprintName(endpoint: string, handle: string, name: string): void {
+  const names = loadBlueprintNames(endpoint);
+  const trimmed = name.trim();
+  if (trimmed === "") {
+    delete names[handle];
+  } else {
+    names[handle] = trimmed.slice(0, 120);
+  }
+  // Bounded: drop arbitrary overflow entries (insertion order is good enough
+  // for a presentation map).
+  const entries = Object.entries(names).slice(-MAX_NAMES);
+  try {
+    localStorage.setItem(keyFor(endpoint), JSON.stringify(Object.fromEntries(entries)));
+  } catch {
+    /* best-effort */
+  }
+  notifyChanged();
+}

--- a/ui/src/lib/export-blueprint.ts
+++ b/ui/src/lib/export-blueprint.ts
@@ -1,0 +1,67 @@
+/**
+ * Serialize a Blueprint to a stable, self-describing JSON document (the
+ * Blueprints card "Export" affordance). A pure transform over the
+ * `GetRecipeForm` contract + the advisory catalog metadata
+ * (description/tags/version). {@link blueprintInputs} is the single source of
+ * the contract's input shape — reused by the read-only contract viewer so the
+ * exported file and the on-screen contract never drift.
+ */
+
+import type { RecipeForm } from "@kortecx/sdk/web";
+
+/** The on-disk export version (bump on a shape change). */
+const EXPORT_VERSION = 1;
+
+/** Advisory catalog metadata for a blueprint (display/discovery only, SN-8). */
+export interface BlueprintMeta {
+  readonly handle: string;
+  readonly description?: string;
+  readonly tags?: readonly string[];
+  readonly version?: string;
+}
+
+/** One declared input of a blueprint's contract (plain, serializable). */
+export interface BlueprintInput {
+  readonly name: string;
+  readonly type: string;
+  readonly required: boolean;
+  readonly max_len?: number;
+  readonly allowed?: readonly string[];
+}
+
+/** Map a `RecipeForm` contract to its serializable input list (single source). */
+export function blueprintInputs(form: RecipeForm): BlueprintInput[] {
+  return form.fields.map((f) => ({
+    name: f.name,
+    type: f.type,
+    required: f.required,
+    ...(f.maxLen ? { max_len: f.maxLen } : {}),
+    ...(f.allowed.length > 0 ? { allowed: f.allowed } : {}),
+  }));
+}
+
+/** A safe, slugged filename for an exported blueprint (never empty, no path chars). */
+export function exportBlueprintFilename(handle: string, now: number = Date.now()): string {
+  const slug =
+    handle
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 48) || "blueprint";
+  return `kortecx-blueprint-${slug}-${now}.json`;
+}
+
+/** Serialize a blueprint (metadata + contract inputs) to a stable JSON string. */
+export function exportBlueprintJson(meta: BlueprintMeta, form: RecipeForm): string {
+  const out = {
+    kind: "kortecx.blueprint",
+    version: EXPORT_VERSION,
+    handle: meta.handle,
+    description: meta.description ?? "",
+    tags: meta.tags ?? [],
+    blueprint_version: meta.version ?? "",
+    inputs: blueprintInputs(form),
+  };
+  return JSON.stringify(out, null, 2);
+}

--- a/ui/src/lib/export-run.ts
+++ b/ui/src/lib/export-run.ts
@@ -1,0 +1,75 @@
+/**
+ * Serialize a run to a stable, self-describing JSON document (the Workflows
+ * card "Export" affordance). A pure transform: the lightweight envelope is the
+ * client-known {@link RunRecord}; the OPTIONAL {@link RunBundle} (the committed
+ * DAG + each Mote's resolved output text) is assembled by the impure
+ * `use-run-export` hook from a fetched `GetProjection`/`GetContent` pair, so
+ * this module stays free of any network/React dependency (SN-8: the bundle is
+ * exactly what the gateway returned, never recomputed here).
+ */
+
+import type { RunRecord } from "./recent-runs";
+
+/** The on-disk export version (bump on a shape change). */
+const EXPORT_VERSION = 1;
+
+/** One committed output of a run: its producing Mote + the resolved content. */
+export interface RunArtifactExport {
+  readonly moteId: string;
+  readonly resultRef: string;
+  /** The decode kind (`text`/`json`/`binary`/`empty`) — see `content-decode`. */
+  readonly kind: string;
+  /** The displayable text (pretty JSON / raw text / bounded hex preview). */
+  readonly text: string;
+  readonly byteLength: number;
+}
+
+/** One committed Mote in the exported DAG (plain, serializable). */
+export interface RunBundleMote {
+  readonly moteId: string;
+  readonly state: number;
+  readonly ndClass: number;
+  readonly committedSeq: number | null;
+  readonly resultRef: string | null;
+  readonly parents: ReadonlyArray<{
+    readonly parentId: string;
+    readonly edgeKind: string;
+    readonly nonCascade: boolean;
+  }>;
+}
+
+/** The committed projection + resolved artifacts for a rich run export. */
+export interface RunBundle {
+  readonly currentSeq: number;
+  readonly motes: readonly RunBundleMote[];
+  readonly artifacts: readonly RunArtifactExport[];
+}
+
+/** A safe, slugged filename for an exported run (never empty, no path chars). */
+export function exportRunFilename(name: string, now: number = Date.now()): string {
+  const slug =
+    name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 48) || "run";
+  return `kortecx-run-${slug}-${now}.json`;
+}
+
+/** Serialize a run (record + optional committed results) to a stable JSON string. */
+export function exportRunJson(record: RunRecord, name: string, bundle?: RunBundle): string {
+  const out = {
+    kind: "kortecx.run",
+    version: EXPORT_VERSION,
+    name,
+    instance_id: record.instanceId,
+    terminal_mote_id: record.terminalMoteId,
+    recipe_fingerprint: record.recipeFingerprint,
+    handle: record.handle,
+    args: record.args ?? null,
+    started_at: record.startedAt,
+    ...(bundle ? { results: bundle } : {}),
+  };
+  return JSON.stringify(out, null, 2);
+}

--- a/ui/src/lib/humanize-handle.ts
+++ b/ui/src/lib/humanize-handle.ts
@@ -1,0 +1,33 @@
+/**
+ * The "clean name" rule for the Workflows + Blueprints cards (PR-4.1b): turn a
+ * wire handle like `"kx/recipes/echo"` into a readable display headline
+ * (`"Echo"`) while the raw handle stays available as a secondary mono chip.
+ * PURE + total — no React, no SDK. DISPLAY ONLY: identity never derives from
+ * this (SN-8); the handle on the wire is unchanged.
+ */
+
+/** The bare leaf of a slash-separated handle (`"kx/recipes/echo"` → `"echo"`). */
+export function handleLeaf(handle: string): string {
+  const trimmed = handle.trim().replace(/\/+$/, "");
+  const slash = trimmed.lastIndexOf("/");
+  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+}
+
+/**
+ * A humanized display name: the leaf with `-`/`_` separators turned to spaces
+ * and each word Title-Cased (`"kx/recipes/agent_loop"` → `"Agent Loop"`). An
+ * empty/whitespace handle returns the trimmed input unchanged so the caller can
+ * fall back to a hex id.
+ */
+export function humanizeHandle(handle: string): string {
+  const leaf = handleLeaf(handle);
+  if (leaf === "") {
+    return handle.trim();
+  }
+  return leaf
+    .replace(/[-_]+/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1701,7 +1701,6 @@ select {
 }
 .popover__panel {
   position: absolute;
-  bottom: calc(100% + 6px);
   min-width: 184px;
   z-index: 40;
   display: flex;
@@ -1712,6 +1711,14 @@ select {
   border: 1px solid var(--border-md);
   border-radius: var(--radius);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+}
+/* Vertical anchor: `--up` opens above the trigger (the bottom-anchored composer);
+ * `--down` opens below (top-anchored list/grid cards, so it stays on-screen). */
+.popover__panel--up {
+  bottom: calc(100% + 6px);
+}
+.popover__panel--down {
+  top: calc(100% + 6px);
 }
 .popover__panel--left {
   left: 0;
@@ -2284,6 +2291,90 @@ select {
     var(--stripe, var(--primary)),
     color-mix(in srgb, var(--stripe, var(--primary)) 35%, transparent)
   );
+}
+/* ---- PR-4.1b: Workflows + Blueprints catalog cards (reference card grid;
+ * tokens-only, both themes — every fg/bg pair is already AA-audited) ---- */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin: 0.85rem 0 1rem;
+  list-style: none;
+  padding: 0;
+}
+.card-grid__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.9rem 1rem;
+}
+.card-grid__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.card-grid__title {
+  font-weight: 600;
+  font-size: 0.98rem;
+  color: var(--fg);
+  text-decoration: none;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+a.card-grid__title:hover {
+  color: var(--primary-h);
+  text-decoration: underline;
+}
+/* the Blueprint card title is a button (opens the form drawer) — strip the
+ * global gradient button chrome so it reads as a heading link. */
+button.card-grid__title {
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+}
+button.card-grid__title:hover {
+  color: var(--primary-h);
+}
+.card-grid__sub {
+  color: var(--text-2);
+  font-size: 0.85rem;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.card-grid__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.card-grid__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: auto;
+}
+.card-grid__handle {
+  font-size: 0.72rem;
+  color: var(--text-3);
+}
+.card-grid__time {
+  color: var(--text-3);
+  font-size: 0.75rem;
+  margin-left: auto;
+}
+.card-grid__rename {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+.card-grid__rename input {
+  flex: 1;
+  min-width: 0;
 }
 .status-dot {
   display: inline-block;

--- a/ui/test/component/BlueprintCard.test.tsx
+++ b/ui/test/component/BlueprintCard.test.tsx
@@ -1,0 +1,107 @@
+/** PR-4.1b BlueprintCard — headline/subtitle/tags, the per-card action menu
+ *  (Cloud-disabled Share/Schedule, Edit-in-builder), and export wiring. */
+
+import { RecipeInfo } from "@kortecx/sdk/web";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ to, search, params, activeProps, children, ...rest }: any) =>
+    React.createElement("a", { href: typeof to === "string" ? to : "#", ...rest }, children),
+}));
+vi.mock("../../src/kx/connection-context", () => ({
+  useConnection: () => ({ endpoint: "http://ep" }),
+}));
+
+const exportBlueprint = vi.fn(() => Promise.resolve());
+vi.mock("../../src/kx/use-blueprint-export", () => ({
+  useBlueprintExport: () => ({ exportBlueprint, pendingHandle: null, error: null }),
+}));
+
+import { BlueprintCard } from "../../src/components/sections/BlueprintCard";
+
+const summary = new RecipeInfo(
+  "kx/recipes/echo",
+  "ef".repeat(16),
+  "Echoes the topic",
+  ["util"],
+  "1",
+);
+
+afterEach(() => {
+  exportBlueprint.mockClear();
+  localStorage.clear();
+});
+
+function renderCard(props: Partial<Parameters<typeof BlueprintCard>[0]> = {}) {
+  const onRun = vi.fn();
+  const onView = vi.fn();
+  render(
+    <BlueprintCard
+      handle="kx/recipes/echo"
+      headline="Echo"
+      customName={null}
+      summary={summary}
+      onRun={onRun}
+      onView={onView}
+      {...props}
+    />,
+  );
+  return { onRun, onView };
+}
+
+describe("BlueprintCard", () => {
+  it("renders the headline, description subtitle, tags and raw handle chip", () => {
+    renderCard();
+    expect(screen.getByTestId("recipe-pick-kx/recipes/echo")).toHaveTextContent("Echo");
+    expect(screen.getByText("Echoes the topic")).toBeInTheDocument();
+    expect(screen.getByText("util")).toBeInTheDocument();
+    expect(screen.getAllByText("kx/recipes/echo").length).toBeGreaterThan(0);
+  });
+
+  it("opens the form via the title and the Run menu item", () => {
+    const { onRun } = renderCard();
+    fireEvent.click(screen.getByTestId("recipe-pick-kx/recipes/echo"));
+    expect(onRun).toHaveBeenCalledWith("kx/recipes/echo");
+    fireEvent.click(screen.getByTestId("blueprint-menu"));
+    fireEvent.click(screen.getByTestId("recipe-run-kx/recipes/echo"));
+    expect(onRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("View contract calls onView; Edit-in-builder links to the builder", () => {
+    const { onView } = renderCard();
+    fireEvent.click(screen.getByTestId("blueprint-menu"));
+    // Edit-in-builder targets the visual builder (assert before View closes the menu).
+    expect(screen.getByTestId("blueprint-edit")).toHaveAttribute("href", "/blueprints/new");
+    fireEvent.click(screen.getByTestId("recipe-view-kx/recipes/echo"));
+    expect(onView).toHaveBeenCalledWith("kx/recipes/echo");
+  });
+
+  it("Share + Schedule are honest-disabled Cloud chips", () => {
+    renderCard();
+    fireEvent.click(screen.getByTestId("blueprint-menu"));
+    for (const id of ["blueprint-share", "blueprint-schedule"]) {
+      const item = screen.getByTestId(id);
+      expect(item).toBeDisabled();
+      expect(item).toHaveTextContent("Cloud");
+    }
+  });
+
+  it("Export sends the blueprint's metadata to the exporter", () => {
+    renderCard();
+    fireEvent.click(screen.getByTestId("blueprint-menu"));
+    fireEvent.click(screen.getByTestId("blueprint-export"));
+    expect(exportBlueprint).toHaveBeenCalledWith({
+      handle: "kx/recipes/echo",
+      description: "Echoes the topic",
+      tags: ["util"],
+      version: "1",
+    });
+  });
+
+  it("a local rename wins over the humanized handle", () => {
+    renderCard({ headline: "My Blueprint", customName: "My Blueprint" });
+    expect(screen.getByTestId("recipe-pick-kx/recipes/echo")).toHaveTextContent("My Blueprint");
+  });
+});

--- a/ui/test/component/RunCard.test.tsx
+++ b/ui/test/component/RunCard.test.tsx
@@ -1,0 +1,107 @@
+/** PR-4.1b RunCard — clean headline, the per-card action menu (Cloud-disabled
+ *  Share/Schedule, NO settings on an immutable run), export wiring + rename. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RunRecord } from "../../src/lib/recent-runs";
+
+// TanStack Links → plain anchors (router integration is covered by the e2e).
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ to, search, params, activeProps, children, ...rest }: any) =>
+    React.createElement("a", { href: typeof to === "string" ? to : "#", ...rest }, children),
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("../../src/kx/connection-context", () => ({
+  useConnection: () => ({ endpoint: "http://ep" }),
+}));
+vi.mock("../../src/kx/use-invoke", () => ({
+  useInvoke: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+}));
+
+const exportLight = vi.fn();
+const exportRich = vi.fn(() => Promise.resolve());
+vi.mock("../../src/kx/use-run-export", () => ({
+  useRunExport: () => ({ exportLight, exportRich, pendingId: null, error: null }),
+}));
+
+import { RunCard } from "../../src/components/sections/RunCard";
+
+const base: RunRecord = {
+  instanceId: "ab".repeat(16),
+  terminalMoteId: "cd".repeat(16),
+  recipeFingerprint: "ef".repeat(16),
+  handle: "kx/recipes/echo",
+  startedAt: 1_700_000_000_000,
+  args: '{"topic":"hi"}',
+};
+
+afterEach(() => {
+  exportLight.mockClear();
+  exportRich.mockClear();
+  localStorage.clear();
+});
+
+describe("RunCard", () => {
+  it("shows the clean headline + the raw handle as a secondary chip", () => {
+    render(<RunCard run={base} headline="Echo" rawHandle="kx/recipes/echo" customName={null} />);
+    expect(screen.getByTestId("run-open")).toHaveTextContent("Echo");
+    expect(screen.getByText("kx/recipes/echo")).toBeInTheDocument();
+  });
+
+  it("opens the action menu; Share/Schedule are Cloud-disabled and there is NO settings item", () => {
+    render(<RunCard run={base} headline="Echo" rawHandle="kx/recipes/echo" customName={null} />);
+    fireEvent.click(screen.getByTestId("run-menu"));
+    // The real, enabled actions.
+    expect(screen.getByTestId("run-open-newtab")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTestId("run-open-newtab")).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByTestId("run-clone")).toBeInTheDocument();
+    expect(screen.getByTestId("run-remix")).toBeInTheDocument();
+    expect(screen.getByTestId("run-export-rich")).toBeInTheDocument(); // has a terminal Mote
+    // Honest-disabled cloud capabilities.
+    for (const id of ["run-share", "run-schedule"]) {
+      const item = screen.getByTestId(id);
+      expect(item).toBeDisabled();
+      expect(item).toHaveTextContent("Cloud");
+    }
+    // An immutable run has no "settings" affordance (don't-fake-gaps).
+    expect(screen.queryByTestId("run-settings")).toBeNull();
+  });
+
+  it("exports the run record (lightweight) and the rich bundle", () => {
+    render(<RunCard run={base} headline="Echo" rawHandle="kx/recipes/echo" customName={null} />);
+    fireEvent.click(screen.getByTestId("run-menu"));
+    fireEvent.click(screen.getByTestId("run-export"));
+    expect(exportLight).toHaveBeenCalledWith(base, "Echo");
+    fireEvent.click(screen.getByTestId("run-menu"));
+    fireEvent.click(screen.getByTestId("run-export-rich"));
+    expect(exportRich).toHaveBeenCalledWith(base, "Echo");
+  });
+
+  it("rename reveals the inline input and persists to the client-local store", () => {
+    render(<RunCard run={base} headline="Echo" rawHandle="kx/recipes/echo" customName={null} />);
+    fireEvent.click(screen.getByTestId("run-menu"));
+    fireEvent.click(screen.getByTestId("run-rename"));
+    const input = screen.getByTestId("run-rename-input");
+    fireEvent.change(input, { target: { value: "incident triage" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(localStorage.getItem("kortecx.ui.run-names:http://ep")).toContain("incident triage");
+  });
+
+  it("hides handle-only actions for a durable journal-only run", () => {
+    const journalOnly: RunRecord = {
+      instanceId: "11".repeat(16),
+      terminalMoteId: null,
+      recipeFingerprint: "ef".repeat(16),
+      handle: null,
+      startedAt: 1_700_000_000_000,
+      args: null,
+    };
+    render(<RunCard run={journalOnly} headline="Echo" rawHandle={null} customName={null} />);
+    fireEvent.click(screen.getByTestId("run-menu"));
+    expect(screen.queryByTestId("run-again")).toBeNull();
+    expect(screen.queryByTestId("run-clone")).toBeNull();
+    expect(screen.queryByTestId("run-export-rich")).toBeNull(); // no terminal Mote
+    expect(screen.getByText("journal")).toBeInTheDocument();
+  });
+});

--- a/ui/test/unit/blueprint-names.test.ts
+++ b/ui/test/unit/blueprint-names.test.ts
@@ -1,0 +1,30 @@
+/** PR-4.1b client-local Blueprint names: per-endpoint, bounded, fail-closed. */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { loadBlueprintNames, setBlueprintName } from "../../src/lib/blueprint-names";
+
+const EP = "http://127.0.0.1:50151";
+const HANDLE = "kx/recipes/echo";
+
+describe("blueprint-names store", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("sets, trims, and clears names per endpoint, keyed by handle", () => {
+    setBlueprintName(EP, HANDLE, "  Triage agent  ");
+    expect(loadBlueprintNames(EP)).toEqual({ [HANDLE]: "Triage agent" });
+    // Another endpoint never sees it.
+    expect(loadBlueprintNames("http://other:1")).toEqual({});
+    // An empty rename clears.
+    setBlueprintName(EP, HANDLE, "   ");
+    expect(loadBlueprintNames(EP)).toEqual({});
+  });
+
+  it("caps a name's length and survives corrupt storage", () => {
+    setBlueprintName(EP, HANDLE, "x".repeat(500));
+    expect(loadBlueprintNames(EP)[HANDLE]).toHaveLength(120);
+    localStorage.setItem(`kortecx.ui.blueprint-names:${EP}`, "{not json");
+    expect(loadBlueprintNames(EP)).toEqual({});
+    localStorage.setItem(`kortecx.ui.blueprint-names:${EP}`, JSON.stringify([1, 2]));
+    expect(loadBlueprintNames(EP)).toEqual({});
+  });
+});

--- a/ui/test/unit/export-blueprint.test.ts
+++ b/ui/test/unit/export-blueprint.test.ts
@@ -1,0 +1,65 @@
+/** PR-4.1b blueprint export: definition (contract + advisory metadata) JSON. */
+
+import { RecipeForm, RecipeFormField } from "@kortecx/sdk/web";
+import { describe, expect, it } from "vitest";
+import {
+  blueprintInputs,
+  exportBlueprintFilename,
+  exportBlueprintJson,
+} from "../../src/lib/export-blueprint";
+
+const form = new RecipeForm("kx/recipes/echo", [
+  new RecipeFormField("topic", "str", true, 256, []),
+  new RecipeFormField("mode", "enum", false, null, ["fast", "slow"]),
+]);
+
+describe("exportBlueprintFilename", () => {
+  it("slugs safely and never empties", () => {
+    expect(exportBlueprintFilename("kx/recipes/echo", 42)).toBe(
+      "kortecx-blueprint-kx-recipes-echo-42.json",
+    );
+    expect(exportBlueprintFilename("", 7)).toBe("kortecx-blueprint-blueprint-7.json");
+  });
+});
+
+describe("blueprintInputs", () => {
+  it("maps the contract, omitting absent max_len/allowed", () => {
+    expect(blueprintInputs(form)).toEqual([
+      { name: "topic", type: "str", required: true, max_len: 256 },
+      { name: "mode", type: "enum", required: false, allowed: ["fast", "slow"] },
+    ]);
+  });
+});
+
+describe("exportBlueprintJson", () => {
+  it("emits a self-describing envelope with metadata + inputs", () => {
+    const doc = JSON.parse(
+      exportBlueprintJson(
+        {
+          handle: "kx/recipes/echo",
+          description: "Echoes the topic",
+          tags: ["util"],
+          version: "1",
+        },
+        form,
+      ),
+    );
+    expect(doc).toMatchObject({
+      kind: "kortecx.blueprint",
+      version: 1,
+      handle: "kx/recipes/echo",
+      description: "Echoes the topic",
+      tags: ["util"],
+      blueprint_version: "1",
+    });
+    expect(doc.inputs).toHaveLength(2);
+    expect(doc.inputs[0]).toEqual({ name: "topic", type: "str", required: true, max_len: 256 });
+  });
+
+  it("defaults missing metadata to empty (advisory only)", () => {
+    const doc = JSON.parse(exportBlueprintJson({ handle: "kx/recipes/echo" }, form));
+    expect(doc.description).toBe("");
+    expect(doc.tags).toEqual([]);
+    expect(doc.blueprint_version).toBe("");
+  });
+});

--- a/ui/test/unit/export-run.test.ts
+++ b/ui/test/unit/export-run.test.ts
@@ -1,0 +1,67 @@
+/** PR-4.1b run export: stable, self-describing JSON (lightweight + rich). */
+
+import { describe, expect, it } from "vitest";
+import { type RunBundle, exportRunFilename, exportRunJson } from "../../src/lib/export-run";
+import type { RunRecord } from "../../src/lib/recent-runs";
+
+const record: RunRecord = {
+  instanceId: "ab".repeat(16),
+  terminalMoteId: "cd".repeat(16),
+  recipeFingerprint: "ef".repeat(16),
+  handle: "kx/recipes/echo",
+  startedAt: 1_700_000_000_000,
+  args: '{"topic":"hi"}',
+};
+
+describe("exportRunFilename", () => {
+  it("slugs safely (no path chars) and never empties", () => {
+    expect(exportRunFilename("Incident / triage!", 42)).toBe("kortecx-run-incident-triage-42.json");
+    expect(exportRunFilename("   ", 7)).toBe("kortecx-run-run-7.json");
+  });
+});
+
+describe("exportRunJson", () => {
+  it("emits the lightweight envelope from the record alone", () => {
+    const doc = JSON.parse(exportRunJson(record, "My run"));
+    expect(doc).toMatchObject({
+      kind: "kortecx.run",
+      version: 1,
+      name: "My run",
+      instance_id: "ab".repeat(16),
+      terminal_mote_id: "cd".repeat(16),
+      handle: "kx/recipes/echo",
+      args: '{"topic":"hi"}',
+      started_at: 1_700_000_000_000,
+    });
+    expect(doc.results).toBeUndefined();
+  });
+
+  it("includes the committed bundle when given one (rich export)", () => {
+    const bundle: RunBundle = {
+      currentSeq: 9,
+      motes: [
+        {
+          moteId: "11".repeat(16),
+          state: 5,
+          ndClass: 0,
+          committedSeq: 9,
+          resultRef: "22".repeat(16),
+          parents: [{ parentId: "33".repeat(16), edgeKind: "data", nonCascade: false }],
+        },
+      ],
+      artifacts: [
+        {
+          moteId: "11".repeat(16),
+          resultRef: "22".repeat(16),
+          kind: "text",
+          text: "hi",
+          byteLength: 2,
+        },
+      ],
+    };
+    const doc = JSON.parse(exportRunJson(record, "My run", bundle));
+    expect(doc.results.currentSeq).toBe(9);
+    expect(doc.results.artifacts[0].text).toBe("hi");
+    expect(doc.results.motes[0].parents[0].edgeKind).toBe("data");
+  });
+});

--- a/ui/test/unit/humanize-handle.test.ts
+++ b/ui/test/unit/humanize-handle.test.ts
@@ -1,0 +1,31 @@
+/** PR-4.1b clean-name rule: humanize a wire handle for the card headline. */
+
+import { describe, expect, it } from "vitest";
+import { handleLeaf, humanizeHandle } from "../../src/lib/humanize-handle";
+
+describe("humanizeHandle", () => {
+  it("strips the namespace and Title-Cases the leaf", () => {
+    expect(humanizeHandle("kx/recipes/echo")).toBe("Echo");
+    expect(humanizeHandle("kx/recipes/agent_loop")).toBe("Agent Loop");
+    expect(humanizeHandle("kx/recipes/passthrough-dag")).toBe("Passthrough Dag");
+  });
+
+  it("handles single-segment, already-clean, and trailing-slash handles", () => {
+    expect(humanizeHandle("my-recipe")).toBe("My Recipe");
+    expect(humanizeHandle("Echo")).toBe("Echo");
+    expect(humanizeHandle("kx/recipes/")).toBe("Recipes");
+  });
+
+  it("falls back to the trimmed input on an empty leaf", () => {
+    expect(humanizeHandle("")).toBe("");
+    expect(humanizeHandle("   ")).toBe("");
+  });
+});
+
+describe("handleLeaf", () => {
+  it("returns the bare leaf for the secondary chip", () => {
+    expect(handleLeaf("kx/recipes/echo")).toBe("echo");
+    expect(handleLeaf("solo")).toBe("solo");
+    expect(handleLeaf("kx/recipes/")).toBe("recipes");
+  });
+});


### PR DESCRIPTION
## PR-4.1b — Workflows + Blueprints card overhaul (+ `workflows.md`)

The second split of PR-4.1 (per the D143/§2.200 RC sequence). Turns the two
first-generation list surfaces into reference-app-quality **bordered cards** with
clean display names and a **per-card action menu**, reusing the PR-4.1a primitives
(`shell/Popover` = D148, `lib/download`, the `.chip--soon` "Cloud" chip, the
per-endpoint client-local stores).

**UI + docs ONLY** — additive, no proto/RPC/journal/backend change. The full change
set is confined to `ui/` + `docs/` ⇒ canonical digest `7d22d4bd` invariant **by
construction**, frozen trio untouched, `Cargo.lock` unchanged (verified locally:
`I1.c byte-determinism: PASS`).

### Workflows (run history) cards
Clean humanized name headline (`kx/recipes/echo` → *Echo*; the raw handle stays a
secondary mono chip) + a `⋯` menu: **Open · Open-in-new-tab** (`rel=noopener`) **·
Run again · Clone · Build from this · Rename · Export** (run record) **· Export with
results** (committed DAG + each step's resolved output via the already-wired
`GetProjection`/`GetContent`) **· Share / Schedule** as honest-disabled **"Cloud"**
chips (D129/D142.3). No "settings" on an immutable run (don't-fake-gaps).

### Blueprints (catalog) cards
Headline + description subtitle + advisory tag/version chips; menu: **Run ·
Open-in-new-tab · View contract · Edit in builder · Rename** (client-local) **·
Export** (definition) **· Share / Schedule** Cloud chips. The run form moves into a
`.node-drawer` slide-over; the clone-landing (`/recipes?handle=&args=`) auto-opens it
prefilled.

### New modules (GR3)
Pure: `humanize-handle`, `blueprint-names`, `export-run`, `export-blueprint`
(+ `use-run-export` / `use-blueprint-export` hooks). The `Popover` gains an opt-in
`direction="down"` so top-anchored card menus stay on-screen (the bottom-anchored chat
composer keeps the default `up`) — this fixed a BUG-12-class off-viewport menu caught
by the e2e.

### Docs (GR14)
New `docs/site/docs/workflows.md` + sidebar entry.

### Tested (GR12 five-layer · GR17 verbatim gate)
- vitest **494** (+13 unit, +11 component) · full Playwright **46** (new
  `card-export`; migrated `runs-list` + `workflows-controls` to the card+menu model)
- `biome ci .` ✓ · `tsc --noEmit` ✓ · eager bundle **533,209 / 614,400 B** (sections
  stay lazy) · docusaurus build ✓ · `check-reproducible` I1.c **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)