### PR TITLE
feat(ui): PR-B — grouped+colored sidebar + New-flyout + token footer + status box (D150)

### DIFF
--- a/docs/site/docs/chat.md
+++ b/docs/site/docs/chat.md
@@ -29,6 +29,12 @@ Pick the model with the **model picker** below the thread. The model list is
 discovered from the connected gateway (`ListModels`); an FFI-free serve shows an
 honest empty state rather than a fake menu.
 
+When the gateway has **no chat model provisioned**, chat shows an honest
+"no model — connect one" notice (start a model with
+`kx serve --features inference`) instead of silently echoing your prompt. You can
+still choose the model-free `kx/recipes/echo` recipe in chat settings for a
+deterministic round-trip — a deliberate choice the console honors as-is.
+
 ## Attach
 
 The **attach** button (next to send) opens a menu:

--- a/ui/e2e/chat-echo.spec.ts
+++ b/ui/e2e/chat-echo.spec.ts
@@ -19,9 +19,17 @@ test("chat round-trips against the model-free echo recipe (Invoke→poll→GetCo
   await page.getByTestId("nav-chat").click();
   await expect(page.getByTestId("chat-panel")).toBeVisible();
 
+  // PR-B (GR15): on this model-free serve chat proactively shows the honest
+  // "no model — connect one" notice (instead of silently echoing).
+  await expect(page.getByTestId("degrade-notice")).toBeVisible();
+
   // Point chat at the deterministic, model-free echo recipe.
   await page.getByTestId("chat-settings").locator("summary").click();
   await page.getByTestId("echo-preset").click();
+
+  // Picking echo is a DELIBERATE model-free choice — the notice is dismissed
+  // (resolveChatBacking honors echo verbatim; it no longer masks a gap).
+  await expect(page.getByTestId("degrade-notice")).toHaveCount(0);
 
   await typeMessage(page, "hello there");
   await page.getByTestId("send").click();

--- a/ui/e2e/shell-nav.spec.ts
+++ b/ui/e2e/shell-nav.spec.ts
@@ -54,3 +54,33 @@ test("the app shell navigates to every section (brand + favicon present)", async
   await page.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 });
+
+test("the sidebar groups sections + a New flyout; Cloud is honest-disabled (PR-B)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  // The five coloured groups + the honest Cloud group render their labels.
+  for (const g of ["workspace", "data", "tools", "monitoring", "security", "cloud"]) {
+    await expect(page.getByTestId(`nav-group-${g}`)).toBeVisible();
+  }
+  await expect(page.getByTestId("nav-group-workspace")).toContainText("Workspace");
+
+  // The topbar system-status box reports REAL health (live on a reachable serve).
+  await expect(page.getByTestId("system-status")).toBeVisible();
+  await expect(page.getByTestId("system-status")).toHaveAttribute("data-health", "live");
+
+  // The New flyout opens (below the trigger) and routes to a real target.
+  await page.getByTestId("sidebar-new").click();
+  await expect(page.getByTestId("sidebar-new-menu")).toBeVisible();
+  await expect(page.getByTestId("new-blueprint")).toBeVisible();
+  await page.getByTestId("new-chat").click();
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+
+  // Cloud placeholders render but are NEVER navigable (greyed, aria-disabled, no link).
+  const cloud = page.getByTestId("cloud-sharing");
+  await expect(cloud).toBeVisible();
+  await expect(cloud).toHaveAttribute("aria-disabled", "true");
+  expect(await cloud.evaluate((el) => el.tagName)).toBe("DIV");
+});

--- a/ui/e2e/sidebar-collapse.spec.ts
+++ b/ui/e2e/sidebar-collapse.spec.ts
@@ -18,12 +18,16 @@ test("the sidebar collapses to an icon rail and the choice persists across reloa
   const sidebar = page.getByTestId("sidebar");
   // Assert on a nav item's text (avoids colliding with the page's <h1> headings).
   const item = page.getByTestId("nav-recipes");
+  // The PR-B group label is visible when expanded, gone on the rail.
+  const group = page.getByTestId("nav-group-data");
   await expect(sidebar).toHaveAttribute("data-collapsed", "false");
   await expect(item).toContainText("Blueprints");
+  await expect(group).toContainText("Data");
 
   await page.getByTestId("sidebar-toggle").click();
   await expect(sidebar).toHaveAttribute("data-collapsed", "true");
   await expect(item).not.toContainText("Blueprints"); // icon-only rail
+  await expect(group).not.toContainText("Data"); // group labels drop on the rail
 
   // Connect is a login gate (D137): a reload drops the in-memory token, so the
   // shell is GONE until we reconnect — and the persisted collapse then survives.

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { fadeUp } from "../../app/motion";
 import { useConnection } from "../../kx/connection-context";
 import { useAttachments } from "../../kx/use-attachments";
 import { REACT_RECIPE_HANDLE, useChat } from "../../kx/use-chat";
+import { useModels } from "../../kx/use-models";
 import { useRecipes } from "../../kx/use-recipes";
 import {
   type SavedChat,
@@ -17,6 +18,7 @@ import {
   loadChatSettings,
   resolveChatBacking,
   saveChatSettings,
+  shouldPromptNoModel,
 } from "../../lib/chat-settings";
 import type { MessageAttachment } from "../../lib/chat-thread";
 import { download } from "../../lib/download";
@@ -55,6 +57,17 @@ export function ChatPanel() {
   // stale model-free `echo` handle can't silently echo the prompt when a model is
   // provisioned (GR15). The model chat recipe backs chat whenever served.
   const backing = resolveChatBacking(settings, available);
+  // Proactively surface the honest "no model — connect one" state on a no-model
+  // serve (GR15 §2.208 backlog), BEFORE a send silently echoes. Gated on the
+  // backing NOT being a deliberate `echo` choice — that path is honored verbatim
+  // (resolveChatBacking's contract; the echo e2e + Settings preset stay green).
+  const models = useModels();
+  const promptNoModel = shouldPromptNoModel({
+    modelCount: models.models?.length,
+    loading: models.loading,
+    unsupported: models.unsupported,
+    backingHandle: backing.handle,
+  });
   const chat = useChat({
     handle: backing.handle,
     promptKey: backing.promptKey,
@@ -246,7 +259,11 @@ export function ChatPanel() {
       ) : null}
 
       <ChatSettingsPanel settings={settings} onChange={updateSettings} />
-      {chat.degraded ? <DegradeNotice error={chat.degraded} /> : null}
+      {chat.degraded ? (
+        <DegradeNotice error={chat.degraded} />
+      ) : promptNoModel ? (
+        <DegradeNotice />
+      ) : null}
 
       <MessageList
         thread={chat.thread}

--- a/ui/src/components/chat/DegradeNotice.tsx
+++ b/ui/src/components/chat/DegradeNotice.tsx
@@ -1,11 +1,15 @@
 import type { UiError } from "../../kx/errors";
 import { ErrorNotice } from "../ErrorNotice";
 
-/** Shown when the configured chat recipe/model isn't provisioned on this gateway. */
-export function DegradeNotice({ error }: { error: UiError }) {
+/**
+ * Shown when the configured chat recipe/model isn't provisioned on this gateway.
+ * `error` is optional: a turn failure passes the real `UiError`; the PROACTIVE
+ * no-model state (a no-model serve, before any send) renders the guidance alone.
+ */
+export function DegradeNotice({ error }: { error?: UiError }) {
   return (
     <div data-testid="degrade-notice">
-      <ErrorNotice error={error} />
+      {error ? <ErrorNotice error={error} /> : null}
       <p className="muted">
         No chat model is provisioned on this gateway. Start one with{" "}
         <code>kx serve --features inference</code>, or switch chat to the model-free{" "}

--- a/ui/src/components/shell/NavItem.tsx
+++ b/ui/src/components/shell/NavItem.tsx
@@ -1,14 +1,34 @@
 import { Link } from "@tanstack/react-router";
+import type { CSSProperties } from "react";
 import { Icon } from "./Icon";
-import type { NavSection } from "./nav-model";
+import type { NavSection, SectionColor } from "./nav-model";
 
-/** One sidebar entry. Collapsed → icon only (label becomes the tooltip). */
-export function NavItem({ section, collapsed }: { section: NavSection; collapsed: boolean }) {
+/**
+ * One sidebar entry. Collapsed → icon only (label becomes the tooltip). When a
+ * group `color` is set (PR-B / D150), the item carries the section accent as a
+ * `--nav-color` custom property: the colour reads on the ICON + hover/active TINT +
+ * an active accent bar, while the LABEL text stays high-contrast (the WCAG-AA lock
+ * — the accent palette is below 4.5:1 as small light-theme text). `neutral` (and
+ * the no-colour Settings item) keep the default muted styling.
+ */
+export function NavItem({
+  section,
+  collapsed,
+  color,
+}: {
+  section: NavSection;
+  collapsed: boolean;
+  color?: SectionColor;
+}) {
+  const colored = color !== undefined && color !== "neutral";
+  const base = colored ? "navitem navitem--colored" : "navitem";
+  const style = colored ? ({ "--nav-color": `var(--${color})` } as CSSProperties) : undefined;
   return (
     <Link
       to={section.path}
-      className="navitem"
-      activeProps={{ className: "navitem navitem--active" }}
+      className={base}
+      activeProps={{ className: `${base} navitem--active` }}
+      style={style}
       title={collapsed ? section.label : section.hint}
       data-testid={`nav-${section.id}`}
     >

--- a/ui/src/components/shell/Navbar.tsx
+++ b/ui/src/components/shell/Navbar.tsx
@@ -4,6 +4,7 @@ import { ConnectionStatus } from "./ConnectionStatus";
 import { GlobalControls } from "./GlobalControls";
 import { Icon } from "./Icon";
 import { SearchTrigger } from "./SearchTrigger";
+import { SystemStatus } from "./SystemStatus";
 
 /**
  * The top bar (the inverted-L's horizontal arm — starts where the sidebar ends):
@@ -59,6 +60,7 @@ export function Navbar({
       >
         <Icon name={resolved === "dark" ? "sun" : "moon"} />
       </button>
+      <SystemStatus />
       <ConnectionStatus />
     </header>
   );

--- a/ui/src/components/shell/Sidebar.tsx
+++ b/ui/src/components/shell/Sidebar.tsx
@@ -1,14 +1,27 @@
+import { Link } from "@tanstack/react-router";
 import { Brand } from "./Brand";
 import { Icon } from "./Icon";
 import { NavItem } from "./NavItem";
-import { NAV_SECTIONS, SETTINGS_SECTION } from "./nav-model";
+import { Popover } from "./Popover";
+import { TokenUsageFooter } from "./TokenUsageFooter";
+import {
+  CLOUD_GROUP_LABEL,
+  CLOUD_PLACEHOLDERS,
+  NAV_GROUPS,
+  NAV_SECTIONS,
+  SETTINGS_SECTION,
+} from "./nav-model";
 
 /**
- * The persistent section navigation. Header = the brand (the console's SINGLE
- * logo anchor — the navbar shows a breadcrumb instead) + hamburger (collapse →
- * icon-only rail); Settings is pinned bottom-left (D137); the eight sections
- * scroll in between.
+ * The persistent section navigation (PR-B / D150 reference-app adoption). Header =
+ * the brand (the console's single logo anchor) + collapse hamburger; a primary
+ * "New" flyout (real targets only); the eight sections in COLOURED GROUPS
+ * (Workspace · Data · Tools · Monitoring · Security) plus an HONEST disabled
+ * "Cloud" group (GR15 / D129); a real-or-honest-empty token footer; Settings pinned
+ * bottom-left. Collapsed → an icon rail (group labels + footer drop away).
  */
+const SECTION_BY_ID = new Map(NAV_SECTIONS.map((s) => [s.id, s]));
+
 export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
   return (
     <nav
@@ -29,9 +42,110 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
           <Icon name="menu" />
         </button>
       </div>
-      {NAV_SECTIONS.map((section) => (
-        <NavItem key={section.id} section={section} collapsed={collapsed} />
-      ))}
+
+      <div className="sidebar__new">
+        <Popover
+          trigger={
+            collapsed ? (
+              <Icon name="plus" />
+            ) : (
+              <>
+                <Icon name="plus" size={15} />
+                <span>New</span>
+              </>
+            )
+          }
+          triggerClassName="sidebar__new-btn"
+          triggerLabel="Create new"
+          triggerTestId="sidebar-new"
+          align="left"
+          direction="down"
+          menuTestId="sidebar-new-menu"
+        >
+          {(close) => (
+            <>
+              <Link
+                to="/chat"
+                role="menuitem"
+                className="popover__item"
+                data-testid="new-chat"
+                onClick={close}
+              >
+                <Icon name="chat" size={15} />
+                <span>New chat</span>
+              </Link>
+              <Link
+                to="/blueprints/new"
+                role="menuitem"
+                className="popover__item"
+                data-testid="new-blueprint"
+                onClick={close}
+              >
+                <Icon name="recipes" size={15} />
+                <span>New blueprint</span>
+              </Link>
+              <Link
+                to="/blueprints/new"
+                role="menuitem"
+                className="popover__item"
+                data-testid="new-workflow"
+                onClick={close}
+              >
+                <Icon name="runs" size={15} />
+                <span>New workflow</span>
+              </Link>
+            </>
+          )}
+        </Popover>
+      </div>
+
+      <div className="sidebar__groups">
+        {NAV_GROUPS.map((group) => (
+          <div
+            key={group.id}
+            className="sidebar__group"
+            data-color={group.color}
+            data-testid={`nav-group-${group.id}`}
+          >
+            {collapsed ? null : <p className="sidebar__group-label">{group.label}</p>}
+            {group.sectionIds.map((id) => {
+              const section = SECTION_BY_ID.get(id);
+              return section ? (
+                <NavItem key={id} section={section} collapsed={collapsed} color={group.color} />
+              ) : null;
+            })}
+          </div>
+        ))}
+        <div
+          className="sidebar__group"
+          data-color="neutral"
+          data-testid="nav-group-cloud"
+          aria-label="Cloud (coming soon)"
+        >
+          {collapsed ? null : <p className="sidebar__group-label">{CLOUD_GROUP_LABEL}</p>}
+          {CLOUD_PLACEHOLDERS.map((p) => (
+            <div
+              key={p.id}
+              className="navitem navitem--disabled"
+              aria-disabled="true"
+              data-testid={`cloud-${p.id}`}
+              title={`${p.label} — a managed Cloud capability`}
+            >
+              <span className="navitem__icon">
+                <Icon name={p.icon} />
+              </span>
+              {collapsed ? null : (
+                <>
+                  <span className="navitem__label">{p.label}</span>
+                  <span className="chip chip--soon">Cloud</span>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {collapsed ? null : <TokenUsageFooter />}
       <div className="sidebar__settings">
         <NavItem section={SETTINGS_SECTION} collapsed={collapsed} />
       </div>

--- a/ui/src/components/shell/SystemStatus.tsx
+++ b/ui/src/components/shell/SystemStatus.tsx
@@ -1,0 +1,30 @@
+import { type Health, useHealth } from "../../kx/use-health";
+
+/**
+ * The topbar system-status box (PR-B / D150). Adopts the reference app's status
+ * pill HONESTLY: gateway liveness is REAL (`useHealth` polls `listSignatures`), so
+ * we show the live/degraded/down tone + a pulse dot + the word. The reference's
+ * "active agents" + "uptime" have NO backing RPC, so they are OMITTED rather than
+ * fabricated (GR15 / D142.4 telemetry-first). Liveness mirrors `ConnectionStatus`
+ * (live default; an unreachable gateway resolves to `down`).
+ */
+const TONE: Record<Health, string> = {
+  live: "status-dot--online",
+  degraded: "status-dot--busy",
+  down: "status-dot--error",
+};
+const WORD: Record<Health, string> = { live: "Live", degraded: "Degraded", down: "Down" };
+
+export function SystemStatus() {
+  const health = useHealth();
+  const h: Health = health.data ?? "live";
+  return (
+    <span className="status-box" data-testid="system-status" data-health={h} title={`Gateway ${h}`}>
+      <span
+        className={`status-dot ${TONE[h]}${h === "live" ? " status-dot--pulse" : ""}`}
+        aria-hidden="true"
+      />
+      <span className="status-box__label">{WORD[h]}</span>
+    </span>
+  );
+}

--- a/ui/src/components/shell/TokenUsageFooter.tsx
+++ b/ui/src/components/shell/TokenUsageFooter.tsx
@@ -1,0 +1,41 @@
+import { useTelemetry } from "../../kx/use-telemetry";
+
+/**
+ * The sidebar footer token readout (PR-B / D150). Adopts the reference app's
+ * "Daily Token Usage" affordance HONESTLY (GR15 / D142.4): the runtime exposes
+ * per-mote `outputTokens` via `ListMoteTelemetry` (set only on inference builds;
+ * `inputTokens` is never populated in OSS and there is NO quota/limit RPC). So we
+ * show a REAL output-token readout for today — output-only, with NO fabricated
+ * limit/bar — and an honest-empty caption when there is no model telemetry.
+ *
+ * Rendered only when the sidebar is expanded (the caller gates on `collapsed`), so
+ * the telemetry poll never runs on the icon rail.
+ */
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+export function TokenUsageFooter() {
+  const tel = useTelemetry();
+  const since = startOfTodayMs();
+  const total = tel.rows.reduce(
+    (sum, r) => (r.startedUnixMs >= since ? sum + (r.outputTokens ?? 0) : sum),
+    0,
+  );
+  const hasReal = !tel.notWired && total > 0;
+
+  return (
+    <div className="sidebar__footer" data-testid="token-usage">
+      <p className="sidebar__footer-label">Output tokens · today</p>
+      {hasReal ? (
+        <p className="sidebar__footer-value mono">{total.toLocaleString()}</p>
+      ) : (
+        <p className="sidebar__footer-empty" data-testid="token-usage-empty">
+          {tel.notWired ? "— no usage telemetry" : "— no model telemetry"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/shell/nav-model.ts
+++ b/ui/src/components/shell/nav-model.ts
@@ -17,6 +17,8 @@
  * a run's detail page — one capability, one home.
  */
 
+import type { Glyph } from "./Icon";
+
 export type IconName =
   | "activity"
   | "monitor"
@@ -146,3 +148,66 @@ export const SETTINGS_SECTION: NavSection = {
   icon: "settings",
   hint: "Profile & console preferences",
 } as const;
+
+/**
+ * Section-grouping colour (PR-B reference-app adoption, D150). A TOKEN NAME, never
+ * a raw hex — `app.css` owns the per-theme flip, so the AA-lock stays the single
+ * source of truth. Maps 1:1 to a `--{color}` palette token (`neutral` → `--text-3`).
+ */
+export type SectionColor = "warning" | "teal" | "violet" | "error" | "success" | "neutral";
+
+/**
+ * A sidebar GROUP — a presentation layer OVER {@link NAV_SECTIONS} (which stays the
+ * single source of section identity). `sectionIds` reference NAV_SECTIONS ids in
+ * render order; the nav-model test asserts every section is grouped exactly once,
+ * so a new section can never silently fall out of the sidebar.
+ */
+export interface NavGroup {
+  /** Stable group id (test handle). */
+  readonly id: string;
+  /** Uppercase display label (renames freely). */
+  readonly label: string;
+  /** The group's accent colour (a palette token name). */
+  readonly color: SectionColor;
+  /** Section ids INTO {@link NAV_SECTIONS}, in render order. */
+  readonly sectionIds: readonly string[];
+}
+
+/**
+ * The sidebar groups (D150 — user-decided mapping of the eight REAL sections). The
+ * flat {@link NAV_SECTIONS} order is UNCHANGED (its unit-test assertion + flat
+ * consumers stay green); this drives the sidebar's grouped render order only.
+ */
+export const NAV_GROUPS: readonly NavGroup[] = [
+  {
+    id: "workspace",
+    label: "Workspace",
+    color: "warning",
+    sectionIds: ["chat", "runs", "recipes"],
+  },
+  { id: "data", label: "Data", color: "teal", sectionIds: ["datasets", "context"] },
+  { id: "tools", label: "Tools", color: "violet", sectionIds: ["tools"] },
+  { id: "monitoring", label: "Monitoring", color: "error", sectionIds: ["monitor"] },
+  { id: "security", label: "Security", color: "success", sectionIds: ["systems"] },
+] as const;
+
+/**
+ * An HONEST disabled "Cloud" placeholder (GR15 don't-fake-gaps + D129 cloud line).
+ * Has NO `path` — it is NEVER navigable, rendered greyed with a "Cloud" chip. These
+ * map to our ACTUAL planned managed-cloud capabilities (D118 permissioned
+ * federation · D129 managed multi-party), so the group is honest about what arrives
+ * in Cloud rather than fabricating a local feature.
+ */
+export interface CloudPlaceholder {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: Glyph;
+}
+
+export const CLOUD_GROUP_LABEL = "Cloud";
+
+export const CLOUD_PLACEHOLDERS: readonly CloudPlaceholder[] = [
+  { id: "sharing", label: "Sharing", icon: "share" },
+  { id: "federation", label: "Federation", icon: "systems" },
+  { id: "experts", label: "Experts", icon: "activity" },
+] as const;

--- a/ui/src/lib/chat-settings.ts
+++ b/ui/src/lib/chat-settings.ts
@@ -65,6 +65,31 @@ export function resolveChatBacking(
   return { handle: settings.handle, promptKey: settings.promptKey };
 }
 
+/**
+ * Whether to PROACTIVELY surface the "no model — connect one" guidance (GR15
+ * §2.208): true only on a no-model serve (`ListModels` resolved to an empty list,
+ * not loading, the RPC supported) AND when the backing is NOT a deliberate `echo`
+ * choice. A chosen `echo` is honored verbatim (resolveChatBacking's contract) — it
+ * is an explicit model-free round-trip, not a gap to flag. Pure (no React) so the
+ * decision is unit-tested without rendering the whole panel.
+ */
+export function shouldPromptNoModel(opts: {
+  /** `ListModels` count (`undefined` while loading / before the first response). */
+  readonly modelCount: number | undefined;
+  readonly loading: boolean;
+  /** The gateway predates `ListModels` (don't prompt — we can't know). */
+  readonly unsupported: boolean;
+  /** The reconciled chat backing handle (from {@link resolveChatBacking}). */
+  readonly backingHandle: string;
+}): boolean {
+  return (
+    opts.modelCount === 0 &&
+    !opts.loading &&
+    !opts.unsupported &&
+    opts.backingHandle !== ECHO_PRESET.handle
+  );
+}
+
 const KEY = "kortecx.ui.chat";
 
 function isString(v: unknown): v is string {

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -20,6 +20,8 @@
   --text-1: #0d0d0d;
   --text-2: rgba(13, 13, 13, 0.68);
   --text-3: rgba(13, 13, 13, 0.46);
+  /* faintest tier — decoration only (separators/faint dots); never text (AA) */
+  --text-4: rgba(13, 13, 13, 0.26);
   --border: rgba(13, 13, 13, 0.12);
   --border-md: rgba(13, 13, 13, 0.18);
   --border-strong: rgba(13, 13, 13, 0.26);
@@ -117,6 +119,8 @@
   --text-1: #f4f4f5;
   --text-2: rgba(244, 244, 245, 0.72);
   --text-3: rgba(244, 244, 245, 0.55);
+  /* faintest tier — decoration only (separators/faint dots); never text (AA) */
+  --text-4: rgba(244, 244, 245, 0.32);
   --border: rgba(244, 244, 245, 0.14);
   --border-md: rgba(244, 244, 245, 0.2);
   --border-strong: rgba(244, 244, 245, 0.3);
@@ -826,6 +830,149 @@ button:disabled {
 .sidebar--collapsed .navitem {
   justify-content: center;
   padding: 0.5rem;
+}
+
+/* PR-B (D150): per-group section colour. The accent reads on the ICON + hover/
+ * active TINT + the active accent bar; the LABEL text stays high-contrast (the
+ * accent palette is < 4.5:1 as small light-theme text — the AA lock). */
+.navitem--colored:hover {
+  background: color-mix(in srgb, var(--nav-color) 8%, transparent);
+  color: var(--fg);
+}
+.navitem--colored:hover .navitem__icon,
+.navitem--colored.navitem--active .navitem__icon {
+  color: var(--nav-color);
+}
+.navitem--colored.navitem--active {
+  background: color-mix(in srgb, var(--nav-color) 12%, transparent);
+  color: var(--fg);
+  font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--nav-color);
+}
+/* honest-disabled Cloud placeholders (never navigable) */
+.navitem--disabled {
+  color: var(--fg-muted);
+  cursor: default;
+  opacity: 0.72;
+}
+.navitem--disabled .chip--soon {
+  margin-left: auto;
+}
+
+/* ---- sidebar: New flyout · coloured groups · token footer (PR-B / D150) ---- */
+.sidebar__new {
+  padding: 0.1rem 0.1rem 0.35rem;
+}
+.sidebar__new .popover {
+  width: 100%;
+}
+.sidebar__new-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 100%;
+  margin: 0;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  /* inherits the theme-independent primary gradient from the base button{} rule */
+}
+.sidebar--collapsed .sidebar__new-btn {
+  padding: 0.4rem;
+}
+/* the groups flow naturally at the top (the sidebar scrolls when tall); the footer
+ * + Settings pin to the bottom via their auto top margins — NEVER flex-grow the
+ * groups (a tight viewport would shrink the box below its content and overlap the
+ * footer/Settings, intercepting their clicks). */
+.sidebar__groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.sidebar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.sidebar__group + .sidebar__group {
+  margin-top: 0.35rem;
+}
+.sidebar__group-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--section-color, var(--text-3));
+  margin: 0;
+  padding: 0.35rem 0.6rem 0.15rem;
+}
+.sidebar__group[data-color="warning"] {
+  --section-color: var(--warning);
+}
+.sidebar__group[data-color="teal"] {
+  --section-color: var(--teal);
+}
+.sidebar__group[data-color="violet"] {
+  --section-color: var(--violet);
+}
+.sidebar__group[data-color="error"] {
+  --section-color: var(--error);
+}
+.sidebar__group[data-color="success"] {
+  --section-color: var(--success);
+}
+.sidebar__group[data-color="neutral"] {
+  --section-color: var(--text-3);
+}
+/* collapsed rail: drop labels, keep a faint separator between groups */
+.sidebar--collapsed .sidebar__group + .sidebar__group {
+  margin-top: 0.3rem;
+  padding-top: 0.3rem;
+  border-top: 1px solid var(--text-4);
+}
+.sidebar__footer {
+  margin-top: auto;
+  padding: 0.4rem 0.6rem 0.2rem;
+}
+.sidebar__footer-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin: 0;
+}
+.sidebar__footer-value {
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-1);
+  margin: 0.1rem 0 0;
+}
+.sidebar__footer-empty {
+  font-size: 0.72rem;
+  color: var(--text-3);
+  margin: 0.1rem 0 0;
+}
+
+/* ---- topbar system-status box (PR-B / D150) ---- */
+.status-box {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-elev, var(--bg-input));
+  font-size: 0.72rem;
+  color: var(--text-2);
+}
+.status-box__label {
+  font-weight: 600;
+}
+/* navbar icon buttons pick up a gentle accent on hover (PR-B polish) */
+.navbar .iconbtn:hover {
+  color: var(--accent);
 }
 
 /* ---- main content ---- */

--- a/ui/test/component/Sidebar.test.tsx
+++ b/ui/test/component/Sidebar.test.tsx
@@ -13,6 +13,12 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   };
 });
 
+// The token footer reads live telemetry (react-query + connection); stub the hook
+// so the sidebar renders without a provider tree (the footer's own test covers it).
+vi.mock("../../src/kx/use-telemetry", () => ({
+  useTelemetry: () => ({ rows: [], notWired: false, isLoading: false }),
+}));
+
 import { Sidebar } from "../../src/components/shell/Sidebar";
 
 describe("Sidebar", () => {
@@ -36,11 +42,45 @@ describe("Sidebar", () => {
     expect(screen.getByTestId("brand")).toHaveTextContent("kortecx");
   });
 
-  it("hides labels (icon rail) when collapsed", () => {
+  it("groups the sections with coloured labels (PR-B / D150)", () => {
+    render(<Sidebar collapsed={false} onToggle={() => {}} />);
+    for (const g of ["workspace", "data", "tools", "monitoring", "security", "cloud"]) {
+      expect(screen.getByTestId(`nav-group-${g}`)).toBeInTheDocument();
+    }
+    // Group labels render when expanded (scoped to the group container — single-
+    // section groups share a name with their item, so the testid disambiguates).
+    expect(screen.getByTestId("nav-group-workspace")).toHaveTextContent("Workspace");
+    expect(screen.getByTestId("nav-group-data")).toHaveTextContent("Data");
+    expect(screen.getByTestId("nav-group-cloud")).toHaveTextContent("Cloud");
+  });
+
+  it("hosts the New flyout trigger and the token footer", () => {
+    render(<Sidebar collapsed={false} onToggle={() => {}} />);
+    expect(screen.getByTestId("sidebar-new")).toBeInTheDocument();
+    expect(screen.getByTestId("token-usage")).toBeInTheDocument();
+    // No telemetry rows in the stub → honest-empty readout (never a fabricated 0).
+    expect(screen.getByTestId("token-usage-empty")).toBeInTheDocument();
+  });
+
+  it("renders Cloud placeholders as honest-disabled (never navigable)", () => {
+    render(<Sidebar collapsed={false} onToggle={() => {}} />);
+    for (const id of ["sharing", "federation", "experts"]) {
+      const el = screen.getByTestId(`cloud-${id}`);
+      expect(el).toBeInTheDocument();
+      expect(el).toHaveAttribute("aria-disabled", "true");
+      // Not a link / button — a plain greyed entry.
+      expect(el.tagName).toBe("DIV");
+    }
+  });
+
+  it("hides labels, group labels and the footer (icon rail) when collapsed", () => {
     render(<Sidebar collapsed={true} onToggle={() => {}} />);
     // The items remain (icons), but the text labels are not rendered.
     expect(screen.getByTestId("nav-chat")).toBeInTheDocument();
     expect(screen.queryByText("New Chat")).not.toBeInTheDocument();
+    // Group labels and the token footer drop away on the rail.
+    expect(screen.getByTestId("nav-group-workspace")).not.toHaveTextContent("Workspace");
+    expect(screen.queryByTestId("token-usage")).not.toBeInTheDocument();
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-collapsed", "true");
     // Collapsed rail keeps the brand icon, drops the wordmark.
     expect(screen.getByTestId("brand")).toBeInTheDocument();

--- a/ui/test/component/SystemStatus.test.tsx
+++ b/ui/test/component/SystemStatus.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mutable health return, swapped per test.
+const hp = vi.hoisted(() => ({ data: "live" as "live" | "degraded" | "down" | undefined }));
+vi.mock("../../src/kx/use-health", () => ({ useHealth: () => ({ data: hp.data }) }));
+
+import { SystemStatus } from "../../src/components/shell/SystemStatus";
+
+afterEach(() => {
+  hp.data = "live";
+});
+
+describe("SystemStatus (PR-B real-only health box)", () => {
+  it("shows the live tone + pulse when the gateway is live", () => {
+    render(<SystemStatus />);
+    const box = screen.getByTestId("system-status");
+    expect(box).toHaveAttribute("data-health", "live");
+    expect(box).toHaveTextContent("Live");
+    expect(box.querySelector(".status-dot--online")).not.toBeNull();
+    expect(box.querySelector(".status-dot--pulse")).not.toBeNull();
+  });
+
+  it("shows degraded (no pulse) without fabricating agent/uptime fields", () => {
+    hp.data = "degraded";
+    render(<SystemStatus />);
+    const box = screen.getByTestId("system-status");
+    expect(box).toHaveAttribute("data-health", "degraded");
+    expect(box).toHaveTextContent("Degraded");
+    expect(box.querySelector(".status-dot--busy")).not.toBeNull();
+    expect(box.querySelector(".status-dot--pulse")).toBeNull();
+    // honest: only the health word — no active-agents / uptime (no RPC).
+    expect(box.textContent).toBe("Degraded");
+  });
+
+  it("shows down when the gateway is unreachable", () => {
+    hp.data = "down";
+    render(<SystemStatus />);
+    const box = screen.getByTestId("system-status");
+    expect(box).toHaveAttribute("data-health", "down");
+    expect(box.querySelector(".status-dot--error")).not.toBeNull();
+  });
+
+  it("defaults to live when health is undefined (mirrors ConnectionStatus)", () => {
+    hp.data = undefined;
+    render(<SystemStatus />);
+    expect(screen.getByTestId("system-status")).toHaveAttribute("data-health", "live");
+  });
+});

--- a/ui/test/component/TokenUsageFooter.test.tsx
+++ b/ui/test/component/TokenUsageFooter.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mutable telemetry return, swapped per test (hoisted above the vi.mock factory).
+const tel = vi.hoisted(() => ({
+  ret: {
+    rows: [] as Array<{ outputTokens: number | null; startedUnixMs: number }>,
+    notWired: false,
+  },
+}));
+vi.mock("../../src/kx/use-telemetry", () => ({ useTelemetry: () => tel.ret }));
+
+import { TokenUsageFooter } from "../../src/components/shell/TokenUsageFooter";
+
+function startOfToday(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+afterEach(() => {
+  tel.ret = { rows: [], notWired: false };
+});
+
+describe("TokenUsageFooter (PR-B real-or-honest-empty)", () => {
+  it("honest-empty when there is no model telemetry (no fabricated 0)", () => {
+    render(<TokenUsageFooter />);
+    expect(screen.getByTestId("token-usage")).toBeInTheDocument();
+    expect(screen.getByTestId("token-usage-empty")).toHaveTextContent("no model telemetry");
+  });
+
+  it("honest-empty (distinct caption) when the telemetry RPC is not wired", () => {
+    tel.ret = { rows: [], notWired: true };
+    render(<TokenUsageFooter />);
+    expect(screen.getByTestId("token-usage-empty")).toHaveTextContent("no usage telemetry");
+  });
+
+  it("sums today's REAL output tokens (output-only, no fabricated limit)", () => {
+    const today = startOfToday() + 1000;
+    tel.ret = {
+      notWired: false,
+      rows: [
+        { outputTokens: 1200, startedUnixMs: today },
+        { outputTokens: 280, startedUnixMs: today },
+        { outputTokens: null, startedUnixMs: today }, // a PURE mote — contributes 0
+      ],
+    };
+    render(<TokenUsageFooter />);
+    expect(screen.queryByTestId("token-usage-empty")).not.toBeInTheDocument();
+    expect(screen.getByTestId("token-usage")).toHaveTextContent("1,480");
+  });
+
+  it("excludes rows from before today (the 'today' window)", () => {
+    const yesterday = startOfToday() - 60_000;
+    tel.ret = { notWired: false, rows: [{ outputTokens: 9999, startedUnixMs: yesterday }] };
+    render(<TokenUsageFooter />);
+    // Nothing today → honest-empty, never yesterday's count.
+    expect(screen.getByTestId("token-usage-empty")).toBeInTheDocument();
+  });
+});

--- a/ui/test/unit/chat-settings.test.ts
+++ b/ui/test/unit/chat-settings.test.ts
@@ -7,6 +7,7 @@ import {
   loadChatSettings,
   resolveChatBacking,
   saveChatSettings,
+  shouldPromptNoModel,
 } from "../../src/lib/chat-settings";
 
 const echoSettings: ChatSettings = {
@@ -127,5 +128,34 @@ describe("resolveChatBacking — the live-recipe reconciliation (GR15)", () => {
       handle: ECHO_PRESET.handle,
       promptKey: ECHO_PRESET.promptKey,
     });
+  });
+});
+
+describe("shouldPromptNoModel — the proactive no-model honest-empty (GR15 §2.208)", () => {
+  const base = {
+    modelCount: 0,
+    loading: false,
+    unsupported: false,
+    backingHandle: MODEL_CHAT_HANDLE,
+  };
+
+  it("prompts on a no-model serve with the default (non-echo) backing", () => {
+    expect(shouldPromptNoModel(base)).toBe(true);
+  });
+
+  it("does NOT prompt when echo is the deliberate backing (honored verbatim)", () => {
+    expect(shouldPromptNoModel({ ...base, backingHandle: ECHO_PRESET.handle })).toBe(false);
+  });
+
+  it("does NOT prompt while ListModels is still loading", () => {
+    expect(shouldPromptNoModel({ ...base, modelCount: undefined, loading: true })).toBe(false);
+  });
+
+  it("does NOT prompt when a model IS provisioned", () => {
+    expect(shouldPromptNoModel({ ...base, modelCount: 2 })).toBe(false);
+  });
+
+  it("does NOT prompt on a gateway that predates ListModels (unsupported)", () => {
+    expect(shouldPromptNoModel({ ...base, modelCount: undefined, unsupported: true })).toBe(false);
   });
 });

--- a/ui/test/unit/nav-model.test.ts
+++ b/ui/test/unit/nav-model.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  CLOUD_PLACEHOLDERS,
   HIDDEN_SECTIONS,
+  NAV_GROUPS,
   NAV_SECTIONS,
   SETTINGS_SECTION,
+  type SectionColor,
 } from "../../src/components/shell/nav-model";
 
 describe("NAV_SECTIONS", () => {
@@ -69,5 +72,65 @@ describe("SETTINGS_SECTION", () => {
     expect(SETTINGS_SECTION.path).toBe("/settings");
     expect(SETTINGS_SECTION.icon).toBe("settings");
     expect(NAV_SECTIONS.some((s) => s.id === SETTINGS_SECTION.id)).toBe(false);
+  });
+});
+
+describe("NAV_GROUPS (PR-B / D150 sidebar grouping)", () => {
+  const COLORS: readonly SectionColor[] = [
+    "warning",
+    "teal",
+    "violet",
+    "error",
+    "success",
+    "neutral",
+  ];
+
+  it("groups in the user-decided order", () => {
+    expect(NAV_GROUPS.map((g) => g.id)).toEqual([
+      "workspace",
+      "data",
+      "tools",
+      "monitoring",
+      "security",
+    ]);
+  });
+
+  it("every grouped section id references a real NAV_SECTIONS section", () => {
+    const ids = new Set(NAV_SECTIONS.map((s) => s.id));
+    for (const g of NAV_GROUPS) {
+      for (const id of g.sectionIds) {
+        expect(ids.has(id), `group ${g.id} references unknown section ${id}`).toBe(true);
+      }
+    }
+  });
+
+  it("partitions NAV_SECTIONS exactly once (none dropped, none duplicated)", () => {
+    const grouped = NAV_GROUPS.flatMap((g) => g.sectionIds);
+    expect(grouped.length).toBe(NAV_SECTIONS.length);
+    expect(new Set(grouped).size).toBe(grouped.length);
+    expect(new Set(grouped)).toEqual(new Set(NAV_SECTIONS.map((s) => s.id)));
+  });
+
+  it("uses only allowed section colours", () => {
+    for (const g of NAV_GROUPS) {
+      expect(COLORS).toContain(g.color);
+    }
+  });
+});
+
+describe("CLOUD_PLACEHOLDERS (honest-disabled — GR15/D129)", () => {
+  it("are never navigable: NO path field on any placeholder", () => {
+    for (const p of CLOUD_PLACEHOLDERS) {
+      expect(p).not.toHaveProperty("path");
+      expect(p.label.length).toBeGreaterThan(0);
+      expect(p.icon.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("do not collide with real section ids", () => {
+    const sectionIds = new Set(NAV_SECTIONS.map((s) => s.id));
+    for (const p of CLOUD_PLACEHOLDERS) {
+      expect(sectionIds.has(p.id)).toBe(false);
+    }
   });
 });

--- a/ui/test/unit/theme-contrast.test.ts
+++ b/ui/test/unit/theme-contrast.test.ts
@@ -191,6 +191,15 @@ const PAIRS: Pair[] = [
     min: { light: 3.0, dark: 4.5 },
     why: "semantic badge text",
   })),
+  // PR-B (D150): the sidebar group-label section accents (warning/error/success
+  // are already covered by SEMANTIC). teal/violet join at the same grandfathered
+  // light floor; dark holds the full AA bar. Pinned so they can only improve.
+  ...["--teal", "--violet"].map((fg) => ({
+    fg,
+    bg: "--surface",
+    min: { light: 3.0, dark: 4.5 },
+    why: "group-label section accent",
+  })),
 ];
 
 describe("theme contrast (the executable AA lock)", () => {


### PR DESCRIPTION
## PR-B — reference-app interface adoption #2 (D150)

Second of the 3-PR reference-app (`kortecx_`) interface adoption. **UI-ONLY** — the diff is confined to `ui/` + `docs/`, so the canonical projection digest `7d22d4bd` + the frozen trio (kx-executor/kx-scheduler/kx-inference dispatcher) are **invariant by construction**; `Cargo.lock` unchanged; no proto/RPC/journal/runtime change.

### What changed
- **Grouped + coloured sidebar** — `NAV_GROUPS` (Workspace · Data · Tools · Monitoring · Security) layered over the **unchanged flat `NAV_SECTIONS`** (its order + every frozen `nav-${id}` testid preserved), plus an honest disabled **Cloud** group (Sharing · Federation · Experts — GR15/D129, never navigable, greyed with a "Cloud" chip). The section accent reads on **icons + hover/active tints + an active accent bar**; **label text stays high-contrast** — the executable WCAG-AA lock holds (the accent palette is < 4.5:1 as small light-theme text, so it is never used as nav body text). Group-label accents (`teal`/`violet`) are pinned in `theme-contrast.test.ts` at the grandfathered-semantic floor.
- **New-button flyout** (reuses `Popover` `direction="down"`) — real targets only: New chat → `/chat`, New blueprint/workflow → `/blueprints/new` (the PR-4 builder).
- **Token footer** — a **real** "output tokens · today" readout aggregated from `ListMoteTelemetry`, honest-empty otherwise (output-only; **no fabricated limit/quota** — GR15/D142.4; OSS has no quota RPC).
- **Topbar system-status box** — real health + pulse (`useHealth`); the reference's active-agents/uptime have no backing RPC, so they are **omitted rather than fabricated**.
- **No-model chat honest-empty** (the §2.208 GR15 backlog) — a proactive `DegradeNotice` via a pure `shouldPromptNoModel` predicate, gated to honor the deliberate `kx/recipes/echo` choice.

### GR8 pre-flight
- **Breaks:** none — frozen handles preserved (grouping is additive over the flat list); the nav-order test stays green; the AA lock is extended (not relaxed) for the two new accents; the proactive notice is gated on `!echoChosen` (the `chat-echo` regression guard proves the deliberate-echo path is untouched).
- **Perf:** eager bundle **538,867 / 614,400 B** (+5.5 KiB; Monaco/reactflow/framer-motion stay lazy). New chrome reuses the existing `useTelemetry`/`useModels`/`useHealth` queries (react-query dedupes).
- **Security/honesty:** no fabricated metrics — status box = real health only; footer = real output tokens or honest-empty; Cloud placeholders honest-disabled; the proactive notice surfaces a real gap. Display-only reads; SN-8 unaffected.

### Tests
- **vitest 515** (+26): nav groups partition + Cloud-no-path guards, Sidebar group labels/flyout/Cloud/footer, `TokenUsageFooter` real-vs-empty, `SystemStatus` tones, `shouldPromptNoModel`, AA `teal`/`violet`.
- **Playwright 48 passed** (1 skipped): new `shell-nav` PR-B (groups + flyout routes + Cloud not-navigable + status box), `sidebar-collapse` group-label visible/hidden, `chat-echo` no-model proactive-notice regression guard, `theme` both palettes; `datasets` confirmed against an `hnsw` build.
- `biome ci` · `tsc` · `theme-contrast` AA lock · `check-bundle-size`.

> Merge gated on a live both-theme console review (on an inference serve, `KX_SERVE_MODEL_GGUF`) + `toolexi` approval, per the standing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)