### PR TITLE
feat(ui): PR-C1 — Dashboard landing + per-model telemetry + failure-reason labels (D150/D152)

### DIFF
--- a/docs/site/docs/observability.md
+++ b/docs/site/docs/observability.md
@@ -2,19 +2,77 @@
 id: observability
 title: Observability
 sidebar_label: Observability
-description: Live events, time-travel, run capture, the audit log, and health.
+description: The Dashboard, gateway-wide Monitoring, per-model telemetry, failure triage, and health.
 ---
 
 # Observability
 
-Kortecx streams every state change as it commits, lets you scrub any run back to
-any point in its history, captures each serve-path run's actions to a durable
-sidecar, and exposes gateway health and an off-the-truth-path audit log.
+Kortecx records every state change as a durable journal fact and exposes a
+read-only view of that truth through the console and the SDK. Nothing here is
+fabricated: each number traces to a committed fact or an honest empty state.
 
-:::note Coming soon
-The observability guide — `kx events --follow`, `kx projection --at-seq`, the
-console Activity / DevTools surfaces, run capture (`ListCaptureRecords`), and
-`kx health` — lands with a later docs PR. For now, see the
+## The Dashboard
+
+The **Dashboard** (a Workspace nav item) is the operator's at-a-glance landing. It
+folds data already on the wire into a small, honest KPI grid plus a live activity
+tail:
+
+- **Runs** — the durable run count (`ListRuns` merged with the per-endpoint session
+  history).
+- **Output tokens** and **p50 wall ms** — summed / percentiled over the **loaded
+  telemetry window** (`ListMoteTelemetry`). The sublabel ("over last N motes") is
+  literal: telemetry is cursor-paged, so these cover the page you have loaded, not
+  all of history.
+- **Serving models** — the number of models backing the live serve loop
+  (`ListModels`). On an FFI-free serve this is honestly `0` / `—`.
+- **Recent runs** + **Live activity** — the newest runs (click through to a run's
+  detail) and the cross-run event tail.
+
+The default landing is still **Chat** — the Dashboard is an additional entry point,
+not a redirect.
+
+## Monitoring
+
+The **Monitoring** section is the deeper, gateway-wide view, with three
+URL-addressable tabs:
+
+- **Overview** — cross-run rollups: run counts by blueprint, the self-correction
+  trails (`ListReplanRounds` / `ListReactTurns`), the action-capture stream
+  (`ListCaptureRecords`), and gateway health. Each panel degrades to an honest
+  "not wired on this gateway" note rather than a hollow placeholder.
+- **Live feed** — the continuous cross-run event tail (`StreamAllEvents`), newest
+  first, each row attributed to its run.
+- **Telemetry** — the host-measured execution exhaust (`ListMoteTelemetry`):
+  wall-clock, model/tool usage, and the committed `seq`, cursor-paged.
+
+### Per-model telemetry rollup
+
+The Telemetry tab derives a **per-model rollup** client-side over the loaded
+window — `count`, `p50` / `p95` wall-clock ms (nearest-rank), and total
+`output_tokens` per model — beside a KPI strip of the window aggregates. The table
+is captioned **"over the last N motes (this page, not all-time)"** and is honestly
+**absent when no model mote ran** (e.g. an FFI-free serve, where motes carry no
+model id). Cost and per-expert billing are shown as a disabled **Cloud** tile: OSS
+serves locally and has no price, input-token, or expert entity to bill.
+
+## Failure triage
+
+A failed event row surfaces the journal's `FailureReason` as a short label
+(e.g. `TIMED OUT`, `VALIDATOR REJECTED`, `WORKER CRASHED`, `DEAD-LETTERED`) next to
+the `FAILED` pill, mirroring the closed enum in the runtime. A row that carried no
+reason shows no label — the reason is never invented.
+
+## Health
+
+Gateway liveness is inferred from a cheap unary round-trip on an interval (the same
+probe the connect flow uses) and rendered as a `LIVE` / `DEGRADED` / `DOWN` pill on
+the Dashboard and in Monitoring. From the CLI, `kx health` reports the same
+liveness.
+
+:::note More on the way
+Structured log filtering, failure-reason humanization across the live feed, an
+alerts inbox, and JSONL export land with a later observability batch. Time-travel
+(`kx projection --at-seq`) and run capture (`ListCaptureRecords`) are covered in the
 [Quickstart](./quickstart.md#run-your-first-blueprint) and the
 [production notes in the README](https://github.com/Kortecx/kortecx/blob/main/README.md#production-notes).
 :::

--- a/ui/e2e/dashboard.spec.ts
+++ b/ui/e2e/dashboard.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("dashboard: honest-empty before any run, real KPIs + recent runs after (both themes)", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw, { wsEndpoint: gw.wsEndpoint });
+
+  // The Dashboard is a NEW Workspace nav item; chat is STILL the default (D137).
+  await page.getByTestId("nav-dashboard").click();
+  await expect(page.getByTestId("dashboard-section")).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("dashboard-kpis")).toBeVisible();
+  // Honest-empty recent runs before anything has executed.
+  await expect(page.getByText(/No runs yet/i)).toBeVisible();
+  // GR15: none of the reference app's FABRICATED cards leak in.
+  await expect(page.getByText(/active agents/i)).toHaveCount(0);
+  await expect(page.getByText(/success rate/i)).toHaveCount(0);
+  await expect(page.getByText(/tasks today/i)).toHaveCount(0);
+
+  // Seed a real run, then the dashboard reflects it (local + durable history).
+  await runRecipe(page, { handle: "kx/recipes/echo", fields: { topic: "dash" } });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId("nav-dashboard").click();
+  await expect(page.getByTestId("dashboard-run").first()).toBeVisible({ timeout: 15_000 });
+
+  // BOTH THEMES (D142.1 / GR13): the landing renders under the dark palette.
+  await page.getByTestId("theme-toggle").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect(page.getByTestId("dashboard-kpis")).toBeVisible();
+  await expect(page.getByTestId("dashboard-run").first()).toBeVisible();
+});

--- a/ui/e2e/monitoring-feed.spec.ts
+++ b/ui/e2e/monitoring-feed.spec.ts
@@ -51,6 +51,13 @@ test("monitoring: URL-addressable tabs, the live cross-run feed, telemetry rows 
   await expect(page).toHaveURL(/\/monitor\?tab=telemetry$/);
   await expect(page.getByTestId("telemetry-row").first()).toBeVisible({ timeout: 20_000 });
 
+  // PR-C1 density: a real KPI strip derived from the loaded telemetry window +
+  // the honest-disabled cost tile (Cloud-only — never a fabricated number). The
+  // per-model rollup table is honestly ABSENT on an FFI-free serve (no model mote).
+  await expect(page.getByTestId("telemetry-kpis")).toBeVisible();
+  await expect(page.getByTestId("cost-tile-disabled")).toBeVisible();
+  await expect(page.getByTestId("telemetry-by-model")).toHaveCount(0);
+
   // Tab clicks rewrite the URL (overview drops the param).
   await page.getByTestId("monitor-tab-overview").click();
   await expect(page).toHaveURL(/\/monitor$/);

--- a/ui/e2e/theme.spec.ts
+++ b/ui/e2e/theme.spec.ts
@@ -40,6 +40,11 @@ test("the theme toggle switches palettes and persists across reload (pre-paint)"
   await page.getByTestId("nav-recipes").click();
   await expect(page.getByTestId("recipe-catalog")).toBeVisible({ timeout: 30_000 });
 
+  // The PR-C1 Dashboard landing renders under the dark palette (KPI accent bars +
+  // metric tones re-resolve; the contrast lock covers the text tiers).
+  await page.getByTestId("nav-dashboard").click();
+  await expect(page.getByTestId("dashboard-kpis")).toBeVisible({ timeout: 15_000 });
+
   // Back to system → light again (and the chip state follows).
   await page.getByTestId("nav-settings").click();
   await page.getByTestId("theme-chip-system").click();

--- a/ui/src/components/metrics/MetricCard.tsx
+++ b/ui/src/components/metrics/MetricCard.tsx
@@ -2,15 +2,22 @@ import { m } from "framer-motion";
 import type { ReactNode } from "react";
 import { fadeUp } from "../../app/motion";
 
-/** One labelled stat. `tone` tints the value (reuses the `--t-*` palette). */
+/**
+ * One labelled stat. `tone` tints the value + accent bar (reuses the `--t-*` /
+ * semantic palette); `sub` is an optional honest qualifier (e.g. "over the last N
+ * motes") rendered under the label in a muted tier — never the headline. The accent
+ * bar is decorative, so a tone never puts text on an accent colour (the AA lock).
+ */
 export function MetricCard({
   label,
   value,
   tone,
+  sub,
 }: {
   label: string;
   value: ReactNode;
   tone?: string;
+  sub?: ReactNode;
 }) {
   return (
     <m.div
@@ -20,6 +27,7 @@ export function MetricCard({
     >
       <span className="metric-card__value">{value}</span>
       <span className="metric-card__label">{label}</span>
+      {sub ? <span className="metric-card__sub">{sub}</span> : null}
     </m.div>
   );
 }

--- a/ui/src/components/sections/DashboardSection.tsx
+++ b/ui/src/components/sections/DashboardSection.tsx
@@ -1,0 +1,142 @@
+/**
+ * The Dashboard — an at-a-glance landing over data the gateway ALREADY exposes.
+ * Distinct from Monitoring (the deep telemetry view) and Activity (the run-scoped
+ * drawer): this is the operator's home, an honest overview with NO fabricated
+ * numbers (GR15). Every KPI traces to a real RPC — runs (`ListRuns`), output
+ * tokens + p50 latency (`ListMoteTelemetry`, over the loaded window), and the
+ * count of models backing the live loop (`ListModels`). The reference app's
+ * fabricated cards (active-agents, tasks-today, sparklines, cost, success-rate,
+ * per-provider latency) are deliberately OMITTED rather than faked.
+ *
+ * Pure renderer: composes existing hooks + the shared `MetricCard`, `GlobalFeed`
+ * and `HealthIndicator`. Added as a Workspace nav item; `/` still lands on Chat
+ * (D137) — the default route is unchanged.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { m } from "framer-motion";
+import { stagger } from "../../app/motion";
+import { useModels } from "../../kx/use-models";
+import { useRuns } from "../../kx/use-runs";
+import { useTelemetry } from "../../kx/use-telemetry";
+import { shortHex } from "../../lib/format";
+import { summarizeRuns, wallClockPercentiles } from "../../lib/monitoring";
+import { EmptyState } from "../EmptyState";
+import { GlobalFeed } from "../activity/GlobalFeed";
+import { GlowCard } from "../ds/GlowCard";
+import { HealthIndicator } from "../metrics/HealthIndicator";
+import { MetricCard } from "../metrics/MetricCard";
+
+/** The quick-start targets — pure navigation, no data (never implies a capability
+ *  we lack). Each lands on a REAL section. */
+const QUICK_START = [
+  { to: "/chat", title: "Start a chat", hint: "Agentic conversation over the runtime" },
+  { to: "/recipes", title: "Run a blueprint", hint: "Catalog & invoke a workflow" },
+  { to: "/datasets", title: "Ground with datasets", hint: "Ingest & search RAG corpora" },
+  { to: "/monitor", title: "Open Monitoring", hint: "Telemetry & self-correction trails" },
+] as const;
+
+export function DashboardSection() {
+  const runs = useRuns();
+  const telemetry = useTelemetry();
+  const models = useModels();
+
+  const runRollup = summarizeRuns(runs.runs);
+  const wall = wallClockPercentiles(telemetry.rows);
+  const servingCount = models.models?.filter((mdl) => mdl.serving).length;
+  const recent = runs.runs.slice(0, 6);
+
+  return (
+    <section className="screen" data-testid="dashboard-section">
+      <div className="section-head">
+        <div>
+          <h1>Dashboard</h1>
+          <p className="muted">
+            A live at-a-glance overview of this gateway — runs, throughput &amp; health.
+          </p>
+        </div>
+        <HealthIndicator />
+      </div>
+
+      <m.div
+        className="metrics-grid"
+        variants={stagger()}
+        initial="hidden"
+        animate="show"
+        data-testid="dashboard-kpis"
+      >
+        <MetricCard label="Runs" value={runRollup.total} tone="committed" />
+        <MetricCard
+          label="Output tokens"
+          value={wall.totalOutputTokens}
+          tone="info"
+          sub={`over last ${wall.count} motes`}
+        />
+        <MetricCard
+          label="p50 wall ms"
+          value={wall.p50WallMs}
+          tone="neutral"
+          sub={`over last ${wall.count} motes`}
+        />
+        <MetricCard
+          label="Serving models"
+          value={servingCount ?? "—"}
+          tone="scheduled"
+          sub={models.unsupported ? "not wired here" : "back the live loop"}
+        />
+      </m.div>
+
+      <div className="dashboard-cols">
+        <GlowCard hover={false} className="monitor-panel" data-testid="dashboard-recent">
+          <div className="monitor-panel__head">
+            <h2>Recent runs</h2>
+            <Link to="/workflows" className="linkbtn">
+              All workflows
+            </Link>
+          </div>
+          {recent.length === 0 ? (
+            <EmptyState
+              title="No runs yet"
+              detail="Invoke a blueprint or start a chat — runs show up here as they register."
+            />
+          ) : (
+            <ul className="dashboard-runs">
+              {recent.map((r) => (
+                <li className="dashboard-runs__row" key={r.instanceId} data-testid="dashboard-run">
+                  <Link
+                    to="/workflows/$instanceId"
+                    params={{ instanceId: r.instanceId }}
+                    className="dashboard-runs__handle linkbtn"
+                    title="Open this run"
+                  >
+                    {r.handle ?? shortHex(r.instanceId)}
+                  </Link>
+                  <span className="dashboard-runs__time">
+                    {r.startedAt > 0 ? new Date(r.startedAt).toLocaleTimeString() : "—"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </GlowCard>
+
+        <GlowCard hover={false} className="monitor-panel" data-testid="dashboard-feed">
+          <div className="monitor-panel__head">
+            <h2>Live activity</h2>
+            <span className="muted">newest first</span>
+          </div>
+          <GlobalFeed />
+        </GlowCard>
+      </div>
+
+      <div className="quickstart-grid" data-testid="dashboard-quickstart">
+        {QUICK_START.map((q) => (
+          <Link key={q.to} to={q.to} className="quickstart-card">
+            <span className="quickstart-card__title">{q.title}</span>
+            <span className="quickstart-card__hint">{q.hint}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/sections/MonitoringSection.tsx
+++ b/ui/src/components/sections/MonitoringSection.tsx
@@ -29,7 +29,9 @@ import {
   summarizeReact,
   summarizeReplan,
   summarizeRuns,
+  summarizeTelemetryByModel,
   tallyRows,
+  wallClockPercentiles,
 } from "../../lib/monitoring";
 import type { MonitorTab } from "../../router/routes/monitor";
 import { EmptyState } from "../EmptyState";
@@ -145,6 +147,10 @@ function FeedView() {
  *  usage + the fired tool per committed mote, cursor-paged newest-first. */
 function TelemetryView() {
   const t = useTelemetry();
+  // Client-side rollups over the LOADED telemetry window (cursor-paged, so this is
+  // "the last N motes on this page", NOT all-time — labeled honestly below).
+  const byModel = useMemo(() => summarizeTelemetryByModel(t.rows), [t.rows]);
+  const wall = useMemo(() => wallClockPercentiles(t.rows), [t.rows]);
   return (
     <GlowCard hover={false} className="monitor-panel" data-testid="monitor-telemetry">
       <div className="monitor-panel__head">
@@ -167,6 +173,76 @@ function TelemetryView() {
         />
       ) : (
         <>
+          <m.div
+            className="metrics-grid"
+            variants={stagger()}
+            initial="hidden"
+            animate="show"
+            data-testid="telemetry-kpis"
+          >
+            <MetricCard label="Motes" value={byModel.windowSize} tone="neutral" sub="this page" />
+            <MetricCard
+              label="p50 wall ms"
+              value={wall.p50WallMs}
+              tone="info"
+              sub={`over last ${wall.count}`}
+            />
+            <MetricCard
+              label="p95 wall ms"
+              value={wall.p95WallMs}
+              tone="info"
+              sub={`over last ${wall.count}`}
+            />
+            <MetricCard
+              label="Output tokens"
+              value={wall.totalOutputTokens}
+              tone="committed"
+              sub="this page"
+            />
+            {/* Honest-disabled: OSS serves locally — no price / input_tokens / expert
+                entity to bill. Per-expert cost arrives with managed Cloud (D129). */}
+            <div className="metric-card metric-card--disabled" data-testid="cost-tile-disabled">
+              <span className="metric-card__value">
+                <span className="chip--soon">Cloud</span>
+              </span>
+              <span className="metric-card__label">Cost &amp; per-expert billing</span>
+              <span className="metric-card__sub">No cost/input-token data in OSS (D129).</span>
+            </div>
+          </m.div>
+
+          {byModel.rows.length > 0 ? (
+            <>
+              <div className="monitor-panel__head">
+                <h3>Per-model rollup</h3>
+                <span className="muted">
+                  over the last {byModel.windowSize} motes (this page, not all-time)
+                </span>
+              </div>
+              <table className="trail-table" data-testid="telemetry-by-model">
+                <thead>
+                  <tr>
+                    <th>Model</th>
+                    <th>Count</th>
+                    <th>p50&nbsp;ms</th>
+                    <th>p95&nbsp;ms</th>
+                    <th>Out&nbsp;tokens</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {byModel.rows.map((r) => (
+                    <tr key={r.modelId} data-testid="telemetry-by-model-row">
+                      <td className="mono">{r.modelId}</td>
+                      <td className="mono">{r.count}</td>
+                      <td className="mono">{r.p50WallMs}</td>
+                      <td className="mono">{r.p95WallMs}</td>
+                      <td className="mono">{r.totalOutputTokens}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          ) : null}
+
           <table className="trail-table" data-testid="telemetry-table">
             <thead>
               <tr>

--- a/ui/src/components/shell/nav-model.ts
+++ b/ui/src/components/shell/nav-model.ts
@@ -38,6 +38,7 @@ export type IconName =
  * `<Link to>` (no cast) — and a typo here is a compile error, not a dead link.
  */
 export type RoutePath =
+  | "/dashboard"
   | "/monitor"
   | "/chat"
   | "/workflows"
@@ -61,8 +62,16 @@ export interface NavSection {
   readonly hint: string;
 }
 
-/** The eight spec-IA sections, in the spec's order. */
+/** The spec-IA sections, in the spec's order. The Dashboard landing (PR-C1, D150)
+ *  leads the Workspace group; `/` still redirects to Chat (D137 — unchanged). */
 export const NAV_SECTIONS: readonly NavSection[] = [
+  {
+    id: "dashboard",
+    label: "Dashboard",
+    path: "/dashboard",
+    icon: "activity",
+    hint: "A live at-a-glance overview of this gateway",
+  },
   {
     id: "chat",
     label: "New Chat",
@@ -183,7 +192,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
     id: "workspace",
     label: "Workspace",
     color: "warning",
-    sectionIds: ["chat", "runs", "recipes"],
+    sectionIds: ["dashboard", "chat", "runs", "recipes"],
   },
   { id: "data", label: "Data", color: "teal", sectionIds: ["datasets", "context"] },
   { id: "tools", label: "Tools", color: "violet", sectionIds: ["tools"] },

--- a/ui/src/lib/event-format.ts
+++ b/ui/src/lib/event-format.ts
@@ -40,6 +40,32 @@ export function eventVisual(kind: string): EventVisual {
   return KIND_VISUAL[kind] ?? UNKNOWN_VISUAL;
 }
 
+/**
+ * The journal's `FailureReason` discriminant → a short triage label. Mirrors the
+ * closed enum in `kx-journal/src/entry.rs` (variants 0-8, in declaration order).
+ * An unknown discriminant maps to "UNKNOWN REASON" rather than crashing (the proto
+ * is additive-only); a `null`/absent reason returns `null` so a failed row that
+ * carried no reason shows NO fabricated label (GR15 — never invent a cause).
+ */
+const FAILURE_REASON: Readonly<Record<number, string>> = {
+  0: "TIMED OUT",
+  1: "EXECUTOR REFUSED",
+  2: "VALIDATOR REJECTED",
+  3: "WORKER CRASHED",
+  4: "UPSTREAM REPUDIATED",
+  5: "UNSAFE WORLD-MUTATING",
+  6: "COMPENSATED",
+  7: "QUARANTINED",
+  8: "DEAD-LETTERED",
+};
+
+export function failureReasonLabel(code: number | null | undefined): string | null {
+  if (code === null || code === undefined) {
+    return null;
+  }
+  return FAILURE_REASON[code] ?? "UNKNOWN REASON";
+}
+
 /** A one-line human summary of a delta (the Mote it concerns + its effect).
  *  `recipeName` labels a `run_registered` row when the fingerprint→handle join
  *  resolved one (else the row degrades to the fingerprint hex). `omitResultRef`
@@ -51,8 +77,10 @@ export function eventSummary(d: EventLike, recipeName?: string, omitResultRef = 
       return `Mote ${shortHex(d.moteId ?? "")} committed${
         d.resultRef && !omitResultRef ? ` → ${shortHex(d.resultRef)}` : ""
       }`;
-    case "failed":
-      return `Mote ${shortHex(d.moteId ?? "")} failed`;
+    case "failed": {
+      const reason = failureReasonLabel(d.reasonClass);
+      return `Mote ${shortHex(d.moteId ?? "")} failed${reason ? ` — ${reason}` : ""}`;
+    }
     case "repudiated":
       return `Mote ${shortHex(d.targetMoteId ?? "")} repudiated`;
     case "effect_staged":

--- a/ui/src/lib/monitoring.ts
+++ b/ui/src/lib/monitoring.ts
@@ -6,7 +6,7 @@
  * section stays a thin renderer (the `lib/metrics.ts` precedent).
  */
 
-import type { CaptureRecord, ReactTurn, ReplanRound } from "@kortecx/sdk/web";
+import type { CaptureRecord, MoteTelemetryRow, ReactTurn, ReplanRound } from "@kortecx/sdk/web";
 import type { RunRecord } from "./recent-runs";
 
 /** A counter keyed by a string label (model id, branch, nd_class, handle). */
@@ -93,4 +93,98 @@ export function summarizeCaptures(records: readonly CaptureRecord[]): CaptureSum
 /** Sort a tally into `[label, count]` rows, biggest first (stable for ties by label). */
 export function tallyRows(t: Tally): Array<readonly [string, number]> {
   return Object.entries(t).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+/** A per-model execution-telemetry rollup row. Wall-clock percentiles are
+ *  host-measured (`MoteTelemetryRow.wallClockMs`); `totalOutputTokens` sums only
+ *  the real `outputTokens` (model motes on an inference build) — a `null` count
+ *  contributes 0, never a fabricated number (GR15). `inputTokens` is NEVER summed
+ *  (the OSS backend reports no input count). */
+export interface ModelRollupRow {
+  readonly modelId: string;
+  readonly count: number;
+  readonly p50WallMs: number;
+  readonly p95WallMs: number;
+  readonly totalOutputTokens: number;
+}
+
+export interface TelemetryByModel {
+  /** Rows the rollup was computed over — the honest "N" in "over the last N motes".
+   *  `useTelemetry` is cursor-paged, so this is the LOADED window, not all-time. */
+  readonly windowSize: number;
+  /** Per-model rows, biggest first (stable for ties by model id). */
+  readonly rows: readonly ModelRollupRow[];
+}
+
+/** The nearest-rank percentile of an ASCENDING-sorted, non-empty array. `q` in
+ *  [0,1]; clamps so q≤0 → first and a length-1 array → its sole element. Chosen
+ *  over interpolation as the simplest defensible percentile for small windows. */
+function nearestRank(sortedAsc: readonly number[], q: number): number {
+  const n = sortedAsc.length;
+  if (n === 0) {
+    return 0;
+  }
+  const rank = Math.ceil(q * n) - 1;
+  const idx = Math.min(n - 1, Math.max(0, rank));
+  return sortedAsc[idx] ?? 0;
+}
+
+/**
+ * Roll up execution-telemetry rows by the model that ran. Rows with no model
+ * (`modelId === ""` — tool/non-model motes) are EXCLUDED so the per-model table
+ * stays honest (they would otherwise pollute a synthetic bucket). `windowSize`
+ * is the RAW input length (so a caller can truthfully say "over the last N motes",
+ * even when every row was a non-model mote). Pure: a deterministic function of the
+ * rows, unit-testable, no React/IO — the `summarizeRuns` precedent.
+ */
+export function summarizeTelemetryByModel(rows: readonly MoteTelemetryRow[]): TelemetryByModel {
+  const groups = new Map<string, { walls: number[]; outTokens: number }>();
+  for (const r of rows) {
+    if (r.modelId === "") {
+      continue;
+    }
+    const g = groups.get(r.modelId) ?? { walls: [], outTokens: 0 };
+    g.walls.push(r.wallClockMs);
+    g.outTokens += r.outputTokens ?? 0;
+    groups.set(r.modelId, g);
+  }
+  const out: ModelRollupRow[] = [];
+  for (const [modelId, g] of groups) {
+    const sorted = [...g.walls].sort((a, b) => a - b);
+    out.push({
+      modelId,
+      count: sorted.length,
+      p50WallMs: nearestRank(sorted, 0.5),
+      p95WallMs: nearestRank(sorted, 0.95),
+      totalOutputTokens: g.outTokens,
+    });
+  }
+  out.sort((a, b) => b.count - a.count || a.modelId.localeCompare(b.modelId));
+  return { windowSize: rows.length, rows: out };
+}
+
+export interface WallStats {
+  /** Rows the stats cover (the loaded telemetry window). */
+  readonly count: number;
+  readonly p50WallMs: number;
+  readonly p95WallMs: number;
+  /** Σ of the real `outputTokens` in the window (null → 0; never fabricated). */
+  readonly totalOutputTokens: number;
+}
+
+/** Window-wide wall-clock percentiles + output-token total over ALL telemetry rows
+ *  (model and non-model motes — wall time is host-measured for every commit). The
+ *  honest aggregate for a "latency / tokens, last N motes" KPI. Pure. */
+export function wallClockPercentiles(rows: readonly MoteTelemetryRow[]): WallStats {
+  const sorted = rows.map((r) => r.wallClockMs).sort((a, b) => a - b);
+  let totalOutputTokens = 0;
+  for (const r of rows) {
+    totalOutputTokens += r.outputTokens ?? 0;
+  }
+  return {
+    count: sorted.length,
+    p50WallMs: nearestRank(sorted, 0.5),
+    p95WallMs: nearestRank(sorted, 0.95),
+    totalOutputTokens,
+  };
 }

--- a/ui/src/router/router.tsx
+++ b/ui/src/router/router.tsx
@@ -6,6 +6,7 @@ import { blueprintsNewRoute } from "./routes/blueprints-new";
 import { chatRoute } from "./routes/chat";
 import { connectRoute } from "./routes/connect";
 import { contextRoute } from "./routes/context";
+import { dashboardRoute } from "./routes/dashboard";
 import { datasetsRoute } from "./routes/datasets";
 import { indexRoute } from "./routes/index";
 import { monitorRoute } from "./routes/monitor";
@@ -25,6 +26,7 @@ const routeTree = rootRoute.addChildren([
   workflowsRoute,
   workflowDetailRoute,
   activityRoute,
+  dashboardRoute,
   chatRoute,
   runsRoute,
   runDetailRedirectRoute,

--- a/ui/src/router/routes/dashboard.tsx
+++ b/ui/src/router/routes/dashboard.tsx
@@ -1,0 +1,31 @@
+import { createRoute } from "@tanstack/react-router";
+import { Suspense, lazy } from "react";
+import { ConnectGate } from "../../components/ConnectGate";
+import { EmptyState } from "../../components/EmptyState";
+import { useConnection } from "../../kx/connection-context";
+import { rootRoute } from "./__root";
+
+// Lazy-loaded so the landing stays OFF the eager bundle (the ~600KiB budget).
+const DashboardSection = lazy(() =>
+  import("../../components/sections/DashboardSection").then((m) => ({
+    default: m.DashboardSection,
+  })),
+);
+
+function DashboardScreen() {
+  const { status } = useConnection();
+  if (status !== "connected") {
+    return <ConnectGate />;
+  }
+  return (
+    <Suspense fallback={<EmptyState title="Loading dashboard…" />}>
+      <DashboardSection />
+    </Suspense>
+  );
+}
+
+export const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/dashboard",
+  component: DashboardScreen,
+});

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -1055,6 +1055,32 @@ select {
 .metric-card--scheduled .metric-card__value {
   color: var(--t-scheduled);
 }
+/* PR-C1 KPI tones: accent-bar-only (value stays --text-1) so no NEW audited
+ * text-on-accent pair enters the contrast lock — the accent bar is decorative. */
+.metric-card--pending {
+  --metric-accent: var(--t-pending);
+}
+.metric-card--info {
+  --metric-accent: var(--info);
+}
+.metric-card--neutral {
+  --metric-accent: var(--text-3);
+}
+/* An honest-disabled tile (e.g. a Cloud-only metric we don't fabricate). */
+.metric-card--disabled {
+  --metric-accent: var(--border);
+  background: var(--surface-elev, var(--bg-input));
+}
+.metric-card--disabled .metric-card__value,
+.metric-card--disabled .metric-card__label {
+  color: var(--text-3);
+}
+/* A muted honest qualifier under the label (e.g. "over the last N motes"). */
+.metric-card__sub {
+  font-size: 0.62rem;
+  color: var(--text-3);
+  margin-top: 0.1rem;
+}
 .state-bar {
   display: flex;
   height: 10px;
@@ -3140,6 +3166,71 @@ button.card-grid__title:hover {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-3);
+}
+
+/* ---- Dashboard landing (PR-C1) ---- */
+.dashboard-cols {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+@media (min-width: 1000px) {
+  .dashboard-cols {
+    grid-template-columns: 1.6fr 1fr;
+    align-items: start;
+  }
+}
+.quickstart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.6rem;
+  margin-top: 0.85rem;
+}
+.quickstart-card {
+  display: block;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: inherit;
+  text-decoration: none;
+}
+.quickstart-card:hover {
+  border-color: color-mix(in srgb, var(--primary) 50%, var(--border));
+  box-shadow: 0 4px 20px rgba(240, 69, 0, 0.1);
+}
+.quickstart-card__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+.quickstart-card__hint {
+  color: var(--text-3);
+  font-size: 0.72rem;
+  margin-top: 0.15rem;
+}
+.dashboard-runs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.dashboard-runs__row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.dashboard-runs__handle {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dashboard-runs__time {
+  color: var(--text-3);
+  font-size: 0.72rem;
 }
 
 /* ---- Monitoring dashboard ---- */

--- a/ui/test/component/DashboardSection.test.tsx
+++ b/ui/test/component/DashboardSection.test.tsx
@@ -1,0 +1,61 @@
+import { MoteTelemetryRow } from "@kortecx/sdk/web";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// The dashboard renders TanStack <Link>s; stub them to plain <a> so the section
+// tests in isolation (real router navigation is covered by e2e/dashboard.spec.ts).
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    Link: ({ to, params, activeProps, children, ...rest }: any) =>
+      React.createElement("a", { href: typeof to === "string" ? to : "#", ...rest }, children),
+  };
+});
+
+import { DashboardSection } from "../../src/components/sections/DashboardSection";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+describe("DashboardSection", () => {
+  it("renders honest KPIs derived from real RPCs (no fabricated cards)", async () => {
+    const mock = makeMockClient({
+      listMoteTelemetry: async () => ({
+        rows: [
+          new MoteTelemetryRow("m1", "", 10, null, 5, "qwen3", "", 0, 2),
+          new MoteTelemetryRow("m2", "", 30, null, 7, "qwen3", "", 0, 1),
+        ],
+        hasMore: false,
+      }),
+      listModels: async () => [
+        {
+          modelId: "qwen3",
+          modalities: ["text"],
+          description: "",
+          serving: true,
+          contextLen: 4096,
+        },
+        { modelId: "x", modalities: ["text"], description: "", serving: false, contextLen: 4096 },
+      ],
+    });
+    render(<DashboardSection />, { wrapper: connectedWrapper(mock.client) });
+    expect(screen.getByTestId("dashboard-section")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("dashboard-kpis")).toBeInTheDocument());
+    // Output tokens KPI = 5 + 7 = 12 (real, summed from telemetry — never fabricated).
+    await waitFor(() => expect(screen.getByText("12")).toBeInTheDocument());
+    // The honest window qualifier appears (not implied all-time).
+    expect(screen.getAllByText(/over last 2 motes/i).length).toBeGreaterThan(0);
+    // GR15: none of the reference app's fabricated cards leak in.
+    expect(screen.queryByText(/active agents/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/success rate/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tasks today/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
+  });
+
+  it("shows an honest-empty recent-runs state when there are no runs", async () => {
+    const mock = makeMockClient({});
+    render(<DashboardSection />, { wrapper: connectedWrapper(mock.client) });
+    await waitFor(() => expect(screen.getByText(/No runs yet/i)).toBeInTheDocument());
+  });
+});

--- a/ui/test/component/MonitoringSection.test.tsx
+++ b/ui/test/component/MonitoringSection.test.tsx
@@ -1,4 +1,4 @@
-import { ReplanRound } from "@kortecx/sdk/web";
+import { MoteTelemetryRow, ReplanRound } from "@kortecx/sdk/web";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MonitoringSection } from "../../src/components/sections/MonitoringSection";
@@ -33,5 +33,27 @@ describe("MonitoringSection", () => {
     const mock = makeMockClient({ listReplanRounds: async () => unimplemented() });
     render(<MonitoringSection />, { wrapper: connectedWrapper(mock.client) });
     await waitFor(() => expect(screen.getByText(/Not wired on this gateway/i)).toBeInTheDocument());
+  });
+
+  it("Telemetry tab shows a per-model rollup + honest-disabled cost tile (no faked cost)", async () => {
+    const mock = makeMockClient({
+      listMoteTelemetry: async () => ({
+        // Unattributed rows ("" instanceId) so the raw table renders "—" rather
+        // than a <Link> (the harness has no RouterProvider); the rollup groups by
+        // model regardless.
+        rows: [
+          new MoteTelemetryRow("m1", "", 10, null, 5, "qwen3", "", 0, 2),
+          new MoteTelemetryRow("m2", "", 30, null, 7, "qwen3", "", 0, 1),
+        ],
+        hasMore: false,
+      }),
+    });
+    render(<MonitoringSection tab="telemetry" />, { wrapper: connectedWrapper(mock.client) });
+    // The per-model rollup renders the resolved model id, honestly windowed.
+    await waitFor(() => expect(screen.getByTestId("telemetry-by-model")).toBeInTheDocument());
+    expect(screen.getByText(/not all-time/i)).toBeInTheDocument();
+    expect(screen.getAllByText("qwen3").length).toBeGreaterThan(0);
+    // Cost is honest-disabled (Cloud), never a fabricated number.
+    expect(screen.getByTestId("cost-tile-disabled")).toBeInTheDocument();
   });
 });

--- a/ui/test/mocks/kx-client.ts
+++ b/ui/test/mocks/kx-client.ts
@@ -25,6 +25,7 @@ export interface MockClientImpl {
   listCaptureRecords?: (...args: unknown[]) => Promise<unknown>;
   getMoteDetail?: (...args: unknown[]) => Promise<unknown>;
   getContentBatch?: (...args: unknown[]) => Promise<unknown>;
+  listModels?: (...args: unknown[]) => Promise<unknown>;
 }
 
 export function makeMockClient(impl: MockClientImpl = {}) {
@@ -87,6 +88,7 @@ export function makeMockClient(impl: MockClientImpl = {}) {
       }),
   );
   const getContentBatch = vi.fn(impl.getContentBatch ?? (async () => []));
+  const listModels = vi.fn(impl.listModels ?? (async () => []));
   const close = vi.fn();
   const client = {
     listSignatures,
@@ -108,6 +110,7 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listCaptureRecords,
     getMoteDetail,
     getContentBatch,
+    listModels,
     close,
     submitRun: vi.fn(),
     registerSignature: vi.fn(),
@@ -133,6 +136,7 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listCaptureRecords,
     getMoteDetail,
     getContentBatch,
+    listModels,
     close,
   };
 }

--- a/ui/test/unit/event-format.test.ts
+++ b/ui/test/unit/event-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { eventSummary, eventVisual } from "../../src/lib/event-format";
+import { eventSummary, eventVisual, failureReasonLabel } from "../../src/lib/event-format";
 
 describe("eventVisual", () => {
   it("maps known kinds to reused state tones", () => {
@@ -46,7 +46,40 @@ describe("eventSummary", () => {
     expect(eventSummary({ seq: 1, kind: "effect_staged", moteId: id })).toContain("effect");
   });
 
+  it("a failed row appends the FailureReason label when the wire carried one", () => {
+    const s = eventSummary({ seq: 1, kind: "failed", moteId: id, reasonClass: 0 });
+    expect(s).toContain("failed");
+    expect(s).toContain("TIMED OUT");
+  });
+
+  it("a failed row with no reason class shows NO fabricated reason", () => {
+    expect(eventSummary({ seq: 1, kind: "failed", moteId: id })).not.toContain("—");
+    expect(eventSummary({ seq: 1, kind: "failed", moteId: id, reasonClass: null })).not.toContain(
+      "—",
+    );
+  });
+
   it("unknown kind falls back to a generic summary", () => {
     expect(eventSummary({ seq: 1, kind: "weird" })).toContain("weird");
+  });
+});
+
+describe("failureReasonLabel", () => {
+  it("maps every journal FailureReason discriminant (0-8)", () => {
+    expect(failureReasonLabel(0)).toBe("TIMED OUT");
+    expect(failureReasonLabel(1)).toBe("EXECUTOR REFUSED");
+    expect(failureReasonLabel(2)).toBe("VALIDATOR REJECTED");
+    expect(failureReasonLabel(3)).toBe("WORKER CRASHED");
+    expect(failureReasonLabel(4)).toBe("UPSTREAM REPUDIATED");
+    expect(failureReasonLabel(5)).toBe("UNSAFE WORLD-MUTATING");
+    expect(failureReasonLabel(6)).toBe("COMPENSATED");
+    expect(failureReasonLabel(7)).toBe("QUARANTINED");
+    expect(failureReasonLabel(8)).toBe("DEAD-LETTERED");
+  });
+
+  it("null/undefined → null (no fabricated cause); unknown discriminant → UNKNOWN", () => {
+    expect(failureReasonLabel(null)).toBeNull();
+    expect(failureReasonLabel(undefined)).toBeNull();
+    expect(failureReasonLabel(99)).toBe("UNKNOWN REASON");
   });
 });

--- a/ui/test/unit/monitoring.test.ts
+++ b/ui/test/unit/monitoring.test.ts
@@ -1,13 +1,25 @@
-import { CaptureRecord, ReactTurn, ReplanRound } from "@kortecx/sdk/web";
+import { CaptureRecord, MoteTelemetryRow, ReactTurn, ReplanRound } from "@kortecx/sdk/web";
 import { describe, expect, it } from "vitest";
 import {
   summarizeCaptures,
   summarizeReact,
   summarizeReplan,
   summarizeRuns,
+  summarizeTelemetryByModel,
   tallyRows,
+  wallClockPercentiles,
 } from "../../src/lib/monitoring";
 import type { RunRecord } from "../../src/lib/recent-runs";
+
+/** Build a telemetry row with only the fields the rollup reads. */
+function tel(
+  modelId: string,
+  wallClockMs: number,
+  outputTokens: number | null = null,
+  seq = 0,
+): MoteTelemetryRow {
+  return new MoteTelemetryRow("m", "", wallClockMs, null, outputTokens, modelId, "", 0, seq);
+}
 
 function run(handle: string | null): RunRecord {
   return {
@@ -85,5 +97,80 @@ describe("tallyRows", () => {
       ["a", 1],
       ["b", 1],
     ]);
+  });
+});
+
+describe("summarizeTelemetryByModel", () => {
+  it("empty window → zeroed rollup", () => {
+    expect(summarizeTelemetryByModel([])).toEqual({ windowSize: 0, rows: [] });
+  });
+
+  it("groups by model with nearest-rank p50/p95 and summed output tokens", () => {
+    // qwen3 walls [10,20,30,40,100]: p50 = rank ceil(.5*5)-1=2 → 30; p95 = ceil(.95*5)-1=4 → 100.
+    const s = summarizeTelemetryByModel([
+      tel("qwen3", 10, 5),
+      tel("qwen3", 20, null),
+      tel("qwen3", 30, 7),
+      tel("qwen3", 40, 0),
+      tel("qwen3", 100, 8),
+    ]);
+    expect(s.windowSize).toBe(5);
+    expect(s.rows).toHaveLength(1);
+    expect(s.rows[0]?.modelId).toBe("qwen3");
+    expect(s.rows[0]?.count).toBe(5);
+    expect(s.rows[0]?.p50WallMs).toBe(30);
+    expect(s.rows[0]?.p95WallMs).toBe(100);
+    // null contributes 0, never a fabricated count.
+    expect(s.rows[0]?.totalOutputTokens).toBe(5 + 7 + 0 + 8);
+  });
+
+  it("a single-row window clamps both percentiles to the sole value", () => {
+    const s = summarizeTelemetryByModel([tel("m", 42, 3)]);
+    expect(s.rows[0]?.p50WallMs).toBe(42);
+    expect(s.rows[0]?.p95WallMs).toBe(42);
+  });
+
+  it("a two-row window picks defensible nearest-rank values", () => {
+    // walls [5,9]: p50 ceil(.5*2)-1=0 → 5; p95 ceil(.95*2)-1=1 → 9.
+    const s = summarizeTelemetryByModel([tel("m", 9), tel("m", 5)]);
+    expect(s.rows[0]?.p50WallMs).toBe(5);
+    expect(s.rows[0]?.p95WallMs).toBe(9);
+  });
+
+  it("excludes non-model motes (empty modelId) but counts them in windowSize", () => {
+    const s = summarizeTelemetryByModel([tel("", 50), tel("qwen3", 12, 4), tel("", 70)]);
+    expect(s.windowSize).toBe(3); // honest: "over the last 3 motes"
+    expect(s.rows.map((r) => r.modelId)).toEqual(["qwen3"]);
+    expect(s.rows[0]?.count).toBe(1);
+  });
+
+  it("sorts rows by count desc, then model id asc", () => {
+    const s = summarizeTelemetryByModel([
+      tel("bbb", 1),
+      tel("aaa", 1),
+      tel("ccc", 1),
+      tel("ccc", 2),
+    ]);
+    expect(s.rows.map((r) => r.modelId)).toEqual(["ccc", "aaa", "bbb"]);
+  });
+});
+
+describe("wallClockPercentiles", () => {
+  it("empty → zeroed", () => {
+    expect(wallClockPercentiles([])).toEqual({
+      count: 0,
+      p50WallMs: 0,
+      p95WallMs: 0,
+      totalOutputTokens: 0,
+    });
+  });
+
+  it("covers ALL rows (incl. non-model motes) and sums real output tokens only", () => {
+    const w = wallClockPercentiles([tel("", 100, null), tel("qwen3", 10, 4), tel("qwen3", 30, 6)]);
+    expect(w.count).toBe(3);
+    // walls [10,30,100]: p50 → 30, p95 → 100.
+    expect(w.p50WallMs).toBe(30);
+    expect(w.p95WallMs).toBe(100);
+    expect(w.totalOutputTokens).toBe(10);
   });
 });

--- a/ui/test/unit/nav-model.test.ts
+++ b/ui/test/unit/nav-model.test.ts
@@ -9,8 +9,9 @@ import {
 } from "../../src/components/shell/nav-model";
 
 describe("NAV_SECTIONS", () => {
-  it("has the eight spec-IA sections in the spec's order", () => {
+  it("has the spec-IA sections in the spec's order (Dashboard leads — PR-C1/D150)", () => {
     expect(NAV_SECTIONS.map((s) => s.id)).toEqual([
+      "dashboard",
       "chat",
       "runs",
       "recipes",
@@ -20,6 +21,13 @@ describe("NAV_SECTIONS", () => {
       "monitor",
       "systems",
     ]);
+  });
+
+  it("the Dashboard landing keeps Chat as the default route (D137 unchanged)", () => {
+    const byId = new Map(NAV_SECTIONS.map((s) => [s.id, s]));
+    expect(byId.get("dashboard")?.label).toBe("Dashboard");
+    expect(byId.get("dashboard")?.path).toBe("/dashboard");
+    expect(byId.get("dashboard")?.icon).toBe("activity");
   });
 
   it("display labels rename; ids/icons stay on the frozen wire-legacy handles", () => {


### PR DESCRIPTION
## PR-C1 — "Density + honest landing" (first of the PR-C split)

UI-only re-skin batch continuing **D150** reference-app adoption + the **D152**
data-engine exposure items mapped to PR-C. Backend intact: diff confined to `ui/` +
`docs/site/`, `Cargo.lock` unchanged, canonical projection digest `7d22d4bd` + the
frozen trio invariant **by construction** (no Rust/proto/journal touched).

PR-C was split (user-approved) along a data-derivation seam: **PR-C1 (this)** = the
landing + density + failure labels; **PR-C2 (next)** = the Models section + the
Blueprints/Datasets re-skin with the no-faked-delete guard.

### What's in it
- **Dashboard landing** — new `lazy()` `/dashboard` route + Workspace nav item. `/`
  still lands on **Chat (D137 unchanged)** — surfaced here to revisit later, not
  silently overturned. Honest KPI grid (Runs · output tokens · p50 wall ms ·
  serving models — all real, windowed "over last N motes") + recent runs + live
  feed + quick-start links. Every fabricated reference card (active-agents /
  tasks-today / queue / sparklines / cost / success-rate / provider-latency) is
  **OMITTED, not faked** (GR15).
- **Performance density** (Monitoring → Telemetry) — pure `summarizeTelemetryByModel`
  (count / p50 / p95 wall-ms / output-tokens, nearest-rank) + `wallClockPercentiles`
  + a per-model rollup table captioned "**over the last N motes (this page, not
  all-time)**" (honestly **absent** when no model mote ran) + a KPI strip + an
  honest-disabled **"Cost & per-expert billing" Cloud tile** (no OSS price/
  input-token/expert entity — D129).
- **Failure triage** — `failureReasonLabel` maps the journal's **9-variant**
  `FailureReason` (`kx-journal/src/entry.rs:545-590`) into the failed event summary
  everywhere the feed renders (`FAILED` → `FAILED — TIMED OUT` …); a null reason
  shows **no fabricated cause**.
- **metric-card** — accent-only `info`/`neutral`/`pending`/`disabled` tones + a
  muted `__sub`. Value text stays `--text-1` ⇒ **no new audited text-on-accent
  pair**; the AA contrast lock is unaffected.

### GR8 pre-flight
- **Correctness/honesty:** the honest-mapping omissions + "last N" labeling + the
  null-token guard keep every number real; new test-ids/sections are all NET-NEW
  (D142.1 frozen handles untouched); telemetry/model rows are display-only (SN-8).
- **Performance:** eager bundle **539,804 B / 614,400** (+~1 KiB; both new sections
  stay `lazy()` — no Monaco/reactflow touched). Rollups are O(n log n) over ≤200-row
  pages in `useMemo`.
- **Security/egress:** none — every byte from existing RPCs over the established
  connection; no new fetch/origin/key-store.
- **Fwd/back-compat:** additive; old gateways degrade via existing
  `unsupported`/`notWired`/empty paths.

### Test evidence (local gate)
- `vitest` 531 passed · `tsc --noEmit` clean · `biome ci .` clean.
- `vite build` clean; bundle within budget (table above).
- e2e vs a real `kx serve`: `dashboard.spec` (honest-empty → real KPIs → both
  themes), `monitoring-feed` (telemetry KPIs + cost tile + rollup-absent on
  FFI-free), `theme` (dashboard in dark), `shell-nav` + `sidebar-collapse` (new nav
  item) — all green.

### Docs (GR14)
`docs/site/docs/observability.md` — fleshed the stub with the Dashboard, the
per-model rollup (+ the "not all-time" caveat), and the FailureReason labels.

### Review
Pending: live both-theme console review on a **fresh inference serve**
(`just review-serve`) + `toolexi` approval. Merge only after explicit user OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)