### PR TITLE
feat: W1a-1 — Prometheus /metrics export + serve-path audit log (T-OBS2/T-OBS1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ version = "0.1.1"
 dependencies = [
  "criterion",
  "getrandom 0.3.4",
+ "kx-audit",
  "kx-content",
  "kx-journal",
  "kx-mote",
@@ -1538,6 +1539,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "kx-audit",
  "kx-bundle",
  "kx-capability",
  "kx-capture",
@@ -1557,6 +1559,7 @@ dependencies = [
  "kx-model-store",
  "kx-model-validator",
  "kx-mote",
+ "kx-otel",
  "kx-planner",
  "kx-proto",
  "kx-refusal",
@@ -1820,6 +1823,18 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "kx-otel"
+version = "0.1.1"
+dependencies = [
+ "kx-content",
+ "kx-gateway-core",
+ "kx-journal",
+ "kx-mote",
+ "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "crates/kx-model-store",
     "crates/kx-cli",
     "crates/kx-profile",
+    "crates/kx-otel",
 ]
 exclude = [
     "kx-cloud",
@@ -217,6 +218,10 @@ kx-fleet             = { path = "crates/kx-fleet",             version = "0.1.1"
 # StreamEvents) + propose-proxy (SubmitRun -> coordinator). No journal write path;
 # never links the frozen-trio writers (a dep-wall test pins it).
 kx-gateway-core      = { path = "crates/kx-gateway-core",      version = "0.1.1" }
+# W1a (T-OBS2) observability metrics: folds the read-only journal into RED counters
+# + renders the Prometheus text format. FFI-free, no build.rs; off the truth path
+# (a dep-wall test keeps it out of the frozen-trio + journal-writer closure).
+kx-otel              = { path = "crates/kx-otel",              version = "0.1.1" }
 # R1 (D130) gateway dev BINARY: hosts the FROZEN KxGateway proto over kx-gateway-core
 # with an embedded single-system coordinator + local worker; the first network server
 # that binds a port outside tests. Deny-all auth stub (R2 fills it). FFI-free by default.

--- a/crates/kx-cli/tests/common/mod.rs
+++ b/crates/kx-cli/tests/common/mod.rs
@@ -40,6 +40,8 @@ pub fn gateway_config(
         cors_origins: Vec::new(),
         console_listen: ConsoleMode::Disabled,
         content_max_bytes: kx_gateway::DEFAULT_CONTENT_MAX_BYTES,
+        metrics_listen: None,
+        audit_log: None,
     }
 }
 

--- a/crates/kx-coordinator/Cargo.toml
+++ b/crates/kx-coordinator/Cargo.toml
@@ -25,6 +25,12 @@ kx-projection = { workspace = true }
 kx-mote = { workspace = true }
 kx-content = { workspace = true }
 kx-warrant = { workspace = true }
+# W1a (T-OBS1): the OFF-TRUTH-PATH audit sink. The serve coordinator emits the
+# operator lifecycle (admitted / committed / failed) to an optional sink so the
+# long-running `kx serve` has the durable operator audit trail the CLI already
+# has. NOT the frozen trio + the dep-wall test (kx-audit/tests/boundary.rs) keeps
+# the guarantee-path crates off this edge; record() is infallible (digest-inert).
+kx-audit = { workspace = true }
 # Resolve-at-submit (M1.2, D79): the coordinator resolves the warrant's
 # tool_grants and captures the resolved versions as off-DAG run metadata. This
 # is a NEW dep edge but does NOT touch the frozen trio

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -7,9 +7,10 @@
 
 use std::sync::Arc;
 
+use kx_audit::{AuditEvent, AuditSink, DispatchKind};
 use kx_content::LocalFsContentStore;
 use kx_journal::{FailureReason, Journal, JournalEntry};
-use kx_mote::{Mote, MoteId};
+use kx_mote::{Mote, MoteId, NdClass};
 use kx_projection::MoteState;
 use kx_proto::proto;
 use kx_proto::proto::coordinator_server::Coordinator;
@@ -31,6 +32,11 @@ use crate::state::CoreHandle;
 pub struct CoordinatorService {
     core: CoreHandle,
     registry: Arc<dyn WorkerRegistry>,
+    /// W1a (T-OBS1): the OPTIONAL off-truth-path operator audit sink. `None`
+    /// (every constructor's default) ⇒ no audit emit, byte-identical to today.
+    /// Set by the gateway via [`CoordinatorService::with_audit_sink`] for the
+    /// long-running serve. Best-effort: `record` is infallible + never gates a run.
+    audit: Option<Arc<dyn AuditSink>>,
 }
 
 impl CoordinatorService {
@@ -128,6 +134,7 @@ impl CoordinatorService {
                 None,
             ),
             registry,
+            audit: None,
         }
     }
 
@@ -160,6 +167,7 @@ impl CoordinatorService {
                 Some(shaper_roles),
             ),
             registry,
+            audit: None,
         }
     }
 
@@ -219,6 +227,26 @@ impl CoordinatorService {
             Arc::new(SystemClock),
             Arc::new(OsRandomNonce),
         )
+    }
+
+    /// W1a (T-OBS1): attach an OFF-TRUTH-PATH operator audit sink (builder style,
+    /// like the runtime's `RuntimeAuditSink`). The serve coordinator then emits the
+    /// admitted / committed / failed lifecycle as best-effort [`AuditEvent`]s. The
+    /// gateway supplies a `JsonlAuditSink` from `--audit-log`; every other caller
+    /// leaves it `None` (no emit). NEVER gates a run — `record` is infallible.
+    #[must_use]
+    pub fn with_audit_sink(mut self, sink: Arc<dyn AuditSink>) -> Self {
+        self.audit = Some(sink);
+        self
+    }
+
+    /// Emit one lifecycle event to the audit sink, if one is attached. A no-op when
+    /// `None`, so the off-truth-path guarantee holds (no time/identity recomputation;
+    /// the sink only echoes already-derived join keys).
+    fn audit(&self, event: AuditEvent) {
+        if let Some(sink) = &self.audit {
+            sink.record(event);
+        }
     }
 
     /// Read-side accessor: the current [`MoteState`] of `mote_id` in the
@@ -340,6 +368,9 @@ impl Coordinator for CoordinatorService {
         // The coordinator-derived identity (D53) — captured before the move so
         // it can ride a REJECTED response when the submit is refused (M1.3).
         let mote_id = mote.id.as_bytes().to_vec();
+        // W1a (T-OBS1): the nd_class for the admitted-Mote audit line (captured
+        // before the move into `submit`). Off the truth path — echoed, never recomputed.
+        let nd_class = mote.nd_class();
 
         match self
             .core
@@ -352,6 +383,29 @@ impl Coordinator for CoordinatorService {
                 } else {
                     proto::SubmitStatus::Accepted
                 };
+                // W1a (T-OBS1): a genuinely-new admission is an operator-relevant
+                // lifecycle event (a duplicate re-submit is not — the journal already
+                // has it). Mapped to MoteDispatched (the Mote entered the runtime for
+                // execution); the kind is derived from nd_class (no recovery context
+                // at submit). Best-effort + off the digest. NOTE: this is the
+                // CLIENT-submission admission line; coordinator-MATERIALIZED agentic
+                // children (shaper children, ReAct/re-plan turns) are spliced onto the
+                // sole-writer thread (state.rs materialize_*) and so are audited via
+                // their report_commit/report_failure (MoteCommitted/MoteFailed) only —
+                // every durable outcome is captured; a per-child dispatch line for the
+                // agentic loop is an additive follow-on (threads the sink into core).
+                if !outcome.duplicate {
+                    let kind = if matches!(nd_class, NdClass::Pure) {
+                        DispatchKind::Pure
+                    } else {
+                        DispatchKind::WmFresh
+                    };
+                    self.audit(AuditEvent::MoteDispatched {
+                        mote_id: outcome.mote_id,
+                        nd_class,
+                        kind,
+                    });
+                }
                 Ok(Response::new(proto::SubmitMoteResponse {
                     mote_id: outcome.mote_id.as_bytes().to_vec(),
                     status: status as i32,
@@ -401,12 +455,25 @@ impl Coordinator for CoordinatorService {
             return Err(CoordinatorError::UnknownWorker(worker).into());
         }
         let proposal = commit::assemble(req)?;
+        // W1a (T-OBS1): capture the commit's join keys before the proposal moves
+        // into the sole-writer core, so a NEWLY-committed Mote can be audited below.
+        let (audit_mote_id, audit_result_ref, audit_nd) =
+            (proposal.mote_id, proposal.result_ref, proposal.nd_class);
         let applied = self.core.commit(proposal).await?;
         let outcome = if applied.already_committed {
             proto::CommitOutcome::AlreadyCommitted
         } else {
             proto::CommitOutcome::Committed
         };
+        // W1a (T-OBS1): emit the durable-effect audit line only for a genuinely new
+        // commit (an already-committed re-report is not a new fact). Off the digest.
+        if !applied.already_committed {
+            self.audit(AuditEvent::MoteCommitted {
+                mote_id: audit_mote_id,
+                result_ref: audit_result_ref,
+                nd_class: audit_nd,
+            });
+        }
         tracing::info!(
             seq = applied.committed_seq,
             already_committed = applied.already_committed,
@@ -486,6 +553,11 @@ impl Coordinator for CoordinatorService {
             .core
             .report_failure(mote_id, idempotency_key, reason_class, worker)
             .await?;
+        // W1a (T-OBS1): a freshly-appended terminal failure is an operator-relevant
+        // event (a deduped re-report is not). Off the truth path; never gates the run.
+        if appended {
+            self.audit(AuditEvent::MoteFailed { mote_id });
+        }
         tracing::info!(
             seq = failed_seq,
             appended,

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -150,16 +150,25 @@ tonic-web          = { workspace = true }
 # allowlist; never a wildcard). `cors` feature only; tower/http already locked via
 # tonic. Outermost layer so OPTIONS preflight is answered before the auth interceptor.
 tower-http         = { workspace = true }
-# D139 (the embedded web console, `console` feature): hyper serves the
-# compile-time-embedded SPA (build.rs `include_bytes!` codegen of `ui/dist`) on a
-# THIRD loopback listener — GET/HEAD only, no runtime filesystem (path traversal
-# structurally impossible). All four are tonic transitives already in the lock:
-# zero new entries, deny.toml untouched, the dep wall holds (no FFI).
-hyper              = { workspace = true, optional = true }
-hyper-util         = { workspace = true, optional = true }
-http-body-util     = { workspace = true, optional = true }
-http               = { workspace = true, optional = true }
-bytes              = { workspace = true, optional = true }
+# The hyper http1 stack backs TWO loopback listeners: the embedded web console
+# (D139, `console` feature — serves the compile-time-embedded SPA, GET/HEAD only,
+# no runtime filesystem) AND the W1a (T-OBS2) Prometheus `/metrics` endpoint
+# (always available, opt-in via `--metrics-listen`). NON-optional since W1a so the
+# metrics surface works on EVERY build (default/inference/hnsw) without requiring
+# the console feature. All are tonic/tower-http transitives already in the lock:
+# zero new crate entries, deny.toml untouched, the dep wall holds (no FFI).
+hyper              = { workspace = true }
+hyper-util         = { workspace = true }
+http-body-util     = { workspace = true }
+http               = { workspace = true }
+bytes              = { workspace = true }
+# W1a (T-OBS2): RED metrics folded from the read-only journal + Prometheus text
+# render. FFI-free, no build.rs (the dep-wall + check-reproducible stay green).
+kx-otel            = { workspace = true }
+# W1a (T-OBS1): the JSONL operator audit sink for the serve path (the gateway
+# constructs it from `--audit-log` and injects it into the embedded coordinator).
+# Off the truth path; FFI-free (the dep-wall keeps it off the guarantee crates).
+kx-audit           = { workspace = true }
 # Additive feature bump over the workspace tokio (rt-multi-thread/macros/net):
 # `signal` for graceful Ctrl-C shutdown, `time` for the worker poll/backoff +
 # connect-retry + the R5 live-tail poll interval, `sync` for the R5 per-subscriber
@@ -228,8 +237,10 @@ hnsw = ["dep:kx-dataset-hnsw"]
 # at COMPILE time by build.rs, so a console build needs `ui/dist` (a repo checkout
 # with node, or the prebuilt release which ships it) — plain `cargo build/install`
 # stays node-free and byte-identical. FFI-free (hyper stack only); composes with
-# `hnsw`/`inference`. Release binaries ship `--features console,hnsw` (D139.4).
-console = ["dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:http", "dep:bytes"]
+# `hnsw`/`inference`. Release binaries ship `--features console,hnsw` (D139.4). The
+# hyper stack is now NON-optional (shared with the always-on `/metrics` endpoint),
+# so this feature only gates the console module + build.rs SPA embedding.
+console = []
 
 [lints]
 workspace = true

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -106,6 +106,18 @@ pub struct GatewayConfig {
     /// The fail-closed `PutContent` payload cap in bytes (Batch A). Default
     /// [`DEFAULT_CONTENT_MAX_BYTES`]; `--content-max-bytes <BYTES>` overrides.
     pub content_max_bytes: u64,
+    /// W1a (T-OBS2): the address:port the Prometheus `/metrics` endpoint binds, or
+    /// `None` (the default) to NOT serve metrics. Opt-in via `--metrics-listen
+    /// <addr:port>` (deny-by-default posture). The endpoint is unauthenticated (the
+    /// scraper convention, like `grpc.health.v1`) — bind loopback or a trusted
+    /// network; a non-loopback bind is allowed but warns at startup (Cloud adds the
+    /// auth/party-scope). A `0` port is ephemeral (used by tests).
+    pub metrics_listen: Option<SocketAddr>,
+    /// W1a (T-OBS1): a JSONL operator audit log path for the long-running serve, or
+    /// `None` (the default) to NOT write one. Opt-in via `--audit-log <path>`; opened
+    /// in APPEND mode so the trail accumulates across restarts. Off the truth path
+    /// (best-effort, never gates a run); the operator owns retention/rotation.
+    pub audit_log: Option<PathBuf>,
 }
 
 /// PEM paths for the gRPC listener's server TLS (A1). The embedded loopback
@@ -142,7 +154,7 @@ pub const USAGE: &str =
 [--max-lease <N>] [--dev-allow-local | --allow-local-dev] \
 [--auth-token <token>=<party>]... [--auth-token-file <path>] [--catalog-dir <dir>] \
 [--tls-cert <path> --tls-key <path>] [--cors-origin <scheme://host[:port]>]... \
-[--content-max-bytes <BYTES>]\n       \
+[--content-max-bytes <BYTES>] [--metrics-listen <addr:port>] [--audit-log <path>]\n       \
 kx-gateway --help | --version";
 
 impl Cli {
@@ -168,6 +180,9 @@ impl Cli {
     }
 }
 
+// A flat `--flag value` parsing loop: one arm per flag keeps the grammar in one
+// readable place; splitting it into sub-parsers would scatter the contract.
+#[allow(clippy::too_many_lines)]
 fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, GatewayError> {
     let mut listen: Option<SocketAddr> = None;
     let mut ws_listen: SocketAddr = DEFAULT_WS_LISTEN;
@@ -183,6 +198,8 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
     let mut console_listen = ConsoleMode::Default;
     let mut console_flag_seen = false;
     let mut content_max_bytes: u64 = DEFAULT_CONTENT_MAX_BYTES;
+    let mut metrics_listen: Option<SocketAddr> = None;
+    let mut audit_log: Option<PathBuf> = None;
 
     while let Some(flag) = args.next() {
         let mut take_value = |name: &str| -> Result<String, GatewayError> {
@@ -238,6 +255,15 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
                     ))
                 })?;
             }
+            // W1a (T-OBS2): opt-in Prometheus metrics endpoint (default OFF).
+            "--metrics-listen" => {
+                metrics_listen = Some(parse_addr(
+                    "--metrics-listen",
+                    &take_value("--metrics-listen")?,
+                )?);
+            }
+            // W1a (T-OBS1): opt-in serve-path JSONL audit log (default OFF).
+            "--audit-log" => audit_log = Some(PathBuf::from(take_value("--audit-log")?)),
             other => return Err(GatewayError::Config(format!("unknown flag {other:?}"))),
         }
     }
@@ -273,6 +299,8 @@ fn parse_serve(mut args: impl Iterator<Item = String>) -> Result<GatewayConfig, 
         cors_origins,
         console_listen,
         content_max_bytes,
+        metrics_listen,
+        audit_log,
     })
 }
 
@@ -614,6 +642,46 @@ mod tests {
         assert!(base(&["--content-max-bytes", "0"]).is_err());
         assert!(base(&["--content-max-bytes", "lots"]).is_err());
         assert!(base(&["--content-max-bytes"]).is_err());
+    }
+
+    #[test]
+    fn metrics_listen_and_audit_log_default_off_and_parse() {
+        let base = |extra: &[&str]| {
+            let mut a = vec![
+                "serve",
+                "--listen",
+                "127.0.0.1:0",
+                "--journal",
+                "/tmp/j",
+                "--content",
+                "/tmp/c",
+            ];
+            a.extend_from_slice(extra);
+            Cli::from_args(a)
+        };
+        // Default: both OFF (deny-by-default observability posture).
+        let c = serve(base(&[]).unwrap());
+        assert_eq!(c.metrics_listen, None);
+        assert_eq!(c.audit_log, None);
+        // Opt-in: both parse.
+        let c = serve(
+            base(&[
+                "--metrics-listen",
+                "127.0.0.1:9090",
+                "--audit-log",
+                "/tmp/audit.jsonl",
+            ])
+            .unwrap(),
+        );
+        assert_eq!(
+            c.metrics_listen,
+            Some("127.0.0.1:9090".parse::<SocketAddr>().unwrap())
+        );
+        assert_eq!(c.audit_log, Some(PathBuf::from("/tmp/audit.jsonl")));
+        // A malformed metrics addr is a config error; a missing value too.
+        assert!(base(&["--metrics-listen", "not-an-addr"]).is_err());
+        assert!(base(&["--metrics-listen"]).is_err());
+        assert!(base(&["--audit-log"]).is_err());
     }
 
     #[test]

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -79,6 +79,9 @@ mod error;
 // executor wrapper — always-on, FFI-free (rusqlite already in the closure).
 mod feedback;
 mod live_tail;
+// W1a (T-OBS2): the always-available Prometheus `/metrics` listener (opt-in via
+// `--metrics-listen`). FFI-free (hyper http1 only); not feature-gated.
+mod metrics;
 // PR-2d-2: the bundled deterministic stdio MCP tool's wiring (locate the bin,
 // register the capability + the typed ToolDef). Behind `inference` (the react
 // decode arm lives in the inference-gated executor; the MCP adapter is FFI-free).

--- a/crates/kx-gateway/src/metrics.rs
+++ b/crates/kx-gateway/src/metrics.rs
@@ -1,0 +1,174 @@
+//! W1a (T-OBS2): the Prometheus `/metrics` HTTP listener — a loopback/trusted
+//! observability endpoint mirroring the embedded console listener (hyper http1,
+//! GET/HEAD only, no runtime filesystem).
+//!
+//! Serving rules (small on purpose):
+//! - `GET|HEAD /metrics` → `200` `text/plain` (the rendered RED metrics body).
+//! - `GET|HEAD /` or `/health` → `200 ok` (a cheap liveness ping for a probe).
+//! - any other path → `404`; a non-GET/HEAD method → `405` with an `Allow` header.
+//!
+//! **Unauthenticated by design** (the Prometheus scraper convention, like the
+//! `grpc.health.v1` service): bind loopback or a trusted network. A non-loopback
+//! bind is allowed but warns at startup (Cloud adds auth/party-scope). The body is
+//! a snapshot of durable-fact RED counters ([`kx_otel::MetricsHandle`]) plus an
+//! optional recent-window latency block from the telemetry exhaust — never an
+//! identity or digest input, so metrics on/off/scraped leaves the digest unchanged.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http::{header, Method, Request, Response, StatusCode};
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
+use kx_gateway_core::TelemetryView;
+use kx_otel::{LatencySummary, MetricsHandle};
+use tokio::net::TcpListener;
+
+/// Prometheus text exposition content type (format version 0.0.4).
+const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// How many recent telemetry rows the latency window covers.
+const LATENCY_WINDOW: usize = 256;
+
+/// Compute the recent-window latency summary from the telemetry seam, or `None`
+/// when no model Mote has run (an honest omission — never fabricated zeros). Uses
+/// the SAME exhaust the Monitoring UI reads (`ListMoteTelemetry`).
+fn latency_summary(telemetry: &dyn TelemetryView) -> Option<LatencySummary> {
+    let (rows, _has_more) = telemetry.list(LATENCY_WINDOW, None, None, None).ok()?;
+    let mut walls: Vec<u64> = Vec::with_capacity(rows.len());
+    let mut output_tokens: u64 = 0;
+    for r in &rows {
+        // Only model Motes carry a latency/token signal; echo/passthrough rows
+        // (empty model_id) would skew the window with non-inference timings.
+        if r.model_id.is_empty() {
+            continue;
+        }
+        walls.push(r.wall_clock_ms);
+        output_tokens = output_tokens.saturating_add(r.output_tokens.unwrap_or(0));
+    }
+    if walls.is_empty() {
+        return None;
+    }
+    walls.sort_unstable();
+    Some(LatencySummary {
+        window: walls.len() as u64,
+        p50_ms: nearest_rank(&walls, 50),
+        p95_ms: nearest_rank(&walls, 95),
+        output_tokens,
+    })
+}
+
+/// Nearest-rank percentile over an ASCENDING, non-empty slice. Integer math only
+/// (no float on any path), all-`usize` indexing (no truncating casts).
+fn nearest_rank(sorted: &[u64], percentile: usize) -> u64 {
+    let n = sorted.len();
+    // rank = ceil(percentile/100 * n), clamped to 1..=n; index = rank - 1.
+    let rank = (percentile * n).div_ceil(100).max(1);
+    let idx = (rank - 1).min(n - 1);
+    sorted[idx]
+}
+
+/// A small `text/plain` response with `nosniff`.
+// SAFETY: every builder uses only static status codes + header names/values, so
+// `.body()` is infallible by construction (the documented-infallible pattern the
+// workspace lints sanction; mirrors `console::respond`).
+#[allow(clippy::expect_used)]
+fn text(status: StatusCode, body: &'static str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .body(Full::new(Bytes::from_static(body.as_bytes())))
+        .expect("static text response builds")
+}
+
+/// Build the response for one request (the rendered body is dynamic; everything
+/// else is a static status).
+// SAFETY: the `/metrics` builder uses only static header names/values + a freshly
+// rendered owned body, so `.body()` is infallible (same sanctioned pattern).
+#[allow(clippy::expect_used)]
+fn respond(
+    req: &Request<Incoming>,
+    handle: &MetricsHandle,
+    telemetry: Option<&Arc<dyn TelemetryView>>,
+) -> Response<Full<Bytes>> {
+    if req.method() != Method::GET && req.method() != Method::HEAD {
+        return Response::builder()
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .header(header::ALLOW, "GET, HEAD")
+            .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+            .body(Full::new(Bytes::new()))
+            .expect("static 405 response builds");
+    }
+    match req.uri().path() {
+        "/metrics" => {
+            let latency = telemetry.and_then(|t| latency_summary(t.as_ref()));
+            let body = handle.render(latency.as_ref());
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, PROM_CONTENT_TYPE)
+                .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+                .header(header::CACHE_CONTROL, "no-cache")
+                .body(Full::new(Bytes::from(body)))
+                .expect("rendered metrics response builds")
+        }
+        "/" | "/health" => text(StatusCode::OK, "ok\n"),
+        _ => text(StatusCode::NOT_FOUND, "not found\n"),
+    }
+}
+
+/// Accept loop: serve `/metrics` on `listener` until aborted (the task is aborted
+/// on gateway shutdown, like the console + WS bridge). Accept errors are logged
+/// and the loop continues — one bad connection never takes the endpoint down.
+pub(crate) async fn serve_metrics(
+    listener: TcpListener,
+    handle: MetricsHandle,
+    telemetry: Option<Arc<dyn TelemetryView>>,
+) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _peer)) => {
+                let handle = handle.clone();
+                let telemetry = telemetry.clone();
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let svc = service_fn(move |req: Request<Incoming>| {
+                        let handle = handle.clone();
+                        let telemetry = telemetry.clone();
+                        async move { Ok::<_, Infallible>(respond(&req, &handle, telemetry.as_ref())) }
+                    });
+                    if let Err(error) = http1::Builder::new().serve_connection(io, svc).await {
+                        tracing::debug!(%error, "metrics connection ended with an error");
+                    }
+                });
+            }
+            Err(error) => {
+                tracing::warn!(%error, "metrics accept failed; continuing");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearest_rank_matches_known_percentiles() {
+        let v = vec![10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        // p50 nearest-rank: ceil(0.5*10)=5 → index 4 → 50.
+        assert_eq!(nearest_rank(&v, 50), 50);
+        // p95 nearest-rank: ceil(0.95*10)=10 → index 9 → 100.
+        assert_eq!(nearest_rank(&v, 95), 100);
+        // p100 → last.
+        assert_eq!(nearest_rank(&v, 100), 100);
+        // single element.
+        assert_eq!(nearest_rank(&[42], 50), 42);
+        assert_eq!(nearest_rank(&[42], 95), 42);
+    }
+}

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -16,15 +16,18 @@
 //! [`ReadOnly`] handle with no `append`.
 
 use std::net::SocketAddr;
+// `Arc` + the `AuditSink` trait are used by the (feature-independent)
+// `RunningGateway` struct field + `shutdown()` flush, so they MUST be imported
+// unconditionally — the rest of the audit/worker wiring is `embedded-worker`-gated.
+use std::sync::Arc;
 
+use kx_audit::AuditSink;
 use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 
 use crate::config::GatewayConfig;
 use crate::error::GatewayError;
 
-#[cfg(feature = "embedded-worker")]
-use std::sync::Arc;
 #[cfg(feature = "embedded-worker")]
 use std::time::Duration;
 #[cfg(feature = "embedded-worker")]
@@ -33,6 +36,7 @@ use {
         DemoLibrary, HostRecipeBinder, HostRecipeCatalog, HostSignatureCatalog, HostWorkflowAuthor,
     },
     crate::teams::{seed_workspace_team, HostGrantView, HostMembershipView},
+    kx_audit::JsonlAuditSink,
     kx_capability::{CapabilityBroker, LocalCapabilityBroker},
     kx_catalog::SqliteCatalog,
     kx_content::{ContentRef, ContentStore, LocalFsContentStore},
@@ -41,8 +45,8 @@ use {
     kx_fleet::SqliteMembershipLedger,
     kx_gateway_core::{
         EventTailer, GatewayService, GlobalEventTailer, GrantView, JournalReader, MembershipView,
-        ReadOnly, RecipeBinder, RecipeCatalog, SignatureCatalog, TonicCoordinatorSubmitter,
-        WorkflowAuthor,
+        ReadOnly, RecipeBinder, RecipeCatalog, SignatureCatalog, TelemetryView,
+        TonicCoordinatorSubmitter, WorkflowAuthor,
     },
     kx_journal::SqliteJournal,
     kx_proto::proto::coordinator_server::CoordinatorServer,
@@ -203,6 +207,13 @@ pub struct RunningGateway {
     /// Where the embedded web console (D139) is bound, when this binary carries
     /// the `console` feature and the config did not disable it.
     console_local_addr: Option<SocketAddr>,
+    /// W1a (T-OBS2): where the Prometheus `/metrics` endpoint is bound, or `None`
+    /// when `--metrics-listen` was not given (default OFF).
+    metrics_local_addr: Option<SocketAddr>,
+    /// W1a (T-OBS1): the serve-path audit sink, retained so a graceful
+    /// [`RunningGateway::shutdown`] can flush its buffered trail to disk (the
+    /// JSONL sink also flushes on Drop, the crash safety net). `None` ⇒ no audit.
+    audit_sink: Option<Arc<dyn AuditSink>>,
     shutdown: oneshot::Sender<()>,
     /// Flips the live-tail poll loops off so their (otherwise endless) streams end
     /// and the gateway's graceful drain can complete (R5). Signalled BEFORE the
@@ -236,6 +247,14 @@ impl RunningGateway {
         self.console_local_addr
     }
 
+    /// W1a (T-OBS2): the address the Prometheus `/metrics` endpoint is bound to
+    /// (resolved from a `:0` request), or `None` when `--metrics-listen` was not
+    /// given. Scrape `http://<addr>/metrics`.
+    #[must_use]
+    pub fn metrics_local_addr(&self) -> Option<SocketAddr> {
+        self.metrics_local_addr
+    }
+
     /// Stop accepting new gateway RPCs, drain in-flight ones, then abort the
     /// embedded coordinator + worker. The journal is always left at a safe
     /// boundary: commits are durable before they are acked, and any
@@ -246,6 +265,7 @@ impl RunningGateway {
             live_shutdown,
             gateway,
             aux,
+            audit_sink,
             ..
         } = self;
         // Stop the live-tail poll loops FIRST so their endless streams end —
@@ -261,6 +281,13 @@ impl RunningGateway {
         };
         for handle in &aux {
             handle.abort();
+        }
+        // W1a (T-OBS1): the in-flight commits have drained (their audit lines are
+        // buffered in the sink); flush the trail to disk so a graceful shutdown
+        // leaves a COMPLETE audit log (the Drop-flush only fires when the last Arc
+        // drops — non-deterministic relative to this return). Best-effort.
+        if let Some(sink) = &audit_sink {
+            sink.flush();
         }
         result
     }
@@ -423,6 +450,26 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     };
     #[cfg(not(feature = "inference"))]
     let coordinator = CoordinatorService::with_store(writer, content.clone());
+    // W1a (T-OBS1): build the optional serve-path operator audit sink ONCE. Opened
+    // in APPEND mode so the JSONL trail accumulates across restarts; a bad/unwritable
+    // path fails `start` LOUDLY (never a silently-dropped audit). Kept as a shared
+    // Arc so the gateway can FLUSH it on graceful shutdown (the Drop-flush is the
+    // crash safety net; an explicit flush makes a clean shutdown's trail complete).
+    // OFF the truth path (record is infallible, never gates a run, never a digest
+    // input) — `None` ⇒ no sink, byte-identical to today (deny-by-default).
+    let audit_sink: Option<Arc<dyn AuditSink>> = match cfg.audit_log.as_ref() {
+        Some(path) => {
+            let sink = JsonlAuditSink::append(path).map_err(|e| {
+                GatewayError::Config(format!("--audit-log {}: {e}", path.display()))
+            })?;
+            Some(Arc::new(sink))
+        }
+        None => None,
+    };
+    let coordinator = match &audit_sink {
+        Some(sink) => coordinator.with_audit_sink(sink.clone()),
+        None => coordinator,
+    };
     let coord_addr = resolve_listen(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
     let coord_task = tokio::spawn(async move {
         if let Err(error) = Server::builder()
@@ -565,6 +612,19 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     // Typed as `Arc<dyn JournalReader>` so the SAME read-only handle backs both the
     // gateway read-fold and the R5 WebSocket bridge (cheap clone, one fold source).
     let reader: Arc<dyn JournalReader> = Arc::new(ReadOnly::new(read_journal));
+    // W1a (T-OBS2): the metrics handle folds the SAME read-only journal handle into
+    // RED counters (off the truth path — never journaled, never a digest input).
+    // Built only when `--metrics-listen` is set (default OFF, deny-by-default). A
+    // background tick refreshes the cached snapshot; the `/metrics` scrape serves it
+    // without scanning the journal, so scrape latency is independent of journal size.
+    let metrics_handle = cfg.metrics_listen.map(|_| {
+        kx_otel::MetricsHandle::new(
+            reader.clone(),
+            kx_otel::BuildInfo {
+                version: env!("CARGO_PKG_VERSION"),
+            },
+        )
+    });
     let submitter = Arc::new(connect_submitter_with_retry(&coord_endpoint).await?);
 
     // (3b) Durable catalog directory (R2a/R2b): `--catalog-dir` (default:
@@ -720,6 +780,32 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
             }
         })
     };
+    // (3f-quater) W1a (T-OBS2): the metrics fold tick — incrementally folds the
+    //      journal tail into the cached RED snapshot, mirroring the telemetry tick's
+    //      cadence + shutdown catch-up. Off the sole-writer thread; read-only handle;
+    //      fail-open (a fold error keeps the last good snapshot). Spawned only when
+    //      `--metrics-listen` is set; `None` ⇒ no task, byte-identical to today.
+    let metrics_task = metrics_handle.clone().map(|handle| {
+        let mut shutdown = live_shutdown_rx.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_millis(250));
+            loop {
+                tokio::select! {
+                    _ = tick.tick() => {
+                        if let Err(error) = handle.refresh() {
+                            tracing::debug!(%error, "metrics fold tick failed; serving last snapshot");
+                        }
+                    }
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() {
+                            let _ = handle.refresh(); // final catch-up
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+    });
 
     // (3g) W1.A5: the always-on advisory toolscout view — manifests from the
     //      SAME registry surface the serve path resolves against (built-ins
@@ -905,6 +991,34 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     #[cfg(not(feature = "console"))]
     let (console_local_addr, console_tcp): (Option<SocketAddr>, Option<()>) = (None, None);
 
+    // (5c) W1a (T-OBS2): bind the Prometheus `/metrics` listener (when enabled)
+    //      EARLY so a port conflict fails `start` loudly, but SERVE it LATE (aux)
+    //      like the console + ws accept loops (bind early, serve late — no orphan on
+    //      a later fallible step). Unauthenticated by design (the scraper convention);
+    //      a non-loopback bind is allowed but warns (Cloud adds auth/party-scope).
+    let (metrics_local_addr, metrics_tcp) = match cfg.metrics_listen {
+        Some(addr) => {
+            let tcp = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+                GatewayError::Bind(format!(
+                    "metrics listener {addr}: {e} (another process on this port? \
+                     pick one with --metrics-listen <addr:port>)"
+                ))
+            })?;
+            let local = tcp
+                .local_addr()
+                .map_err(|e| GatewayError::Bind(e.to_string()))?;
+            if !local.ip().is_loopback() {
+                tracing::warn!(
+                    metrics = %local,
+                    "the /metrics endpoint is UNAUTHENTICATED and bound to a non-loopback \
+                     address — restrict it to a trusted network (Cloud adds auth/party-scope)"
+                );
+            }
+            (Some(local), Some(tcp))
+        }
+        None => (None, None),
+    };
+
     // Cloned for the ws accept loop, which spawns LAST (after every fallible
     // start step) so a failed start never orphans it.
     let ws_resolver = resolver.clone();
@@ -1028,6 +1142,25 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     #[cfg(not(feature = "console"))]
     let _ = console_tcp;
 
+    // W1a (T-OBS2): the metrics fold tick + the /metrics accept loop join the aux
+    // set (spawned only when `--metrics-listen` is set; served LATE, after every
+    // fallible start step). The accept loop reuses the telemetry seam for the
+    // recent-window latency block (None when no model Mote has run — honest omit).
+    if let Some(task) = metrics_task {
+        aux.push(task);
+    }
+    if let (Some(tcp), Some(handle)) = (metrics_tcp, metrics_handle) {
+        let telemetry_view: Option<Arc<dyn TelemetryView>> = Some(telemetry_ledger.clone());
+        aux.push(tokio::spawn(crate::metrics::serve_metrics(
+            tcp,
+            handle,
+            telemetry_view,
+        )));
+        if let Some(local) = metrics_local_addr {
+            tracing::info!(url = %format!("http://{local}/metrics"), "metrics endpoint ready");
+        }
+    }
+
     // The operator-facing startup banner: every RESOLVED durable path + endpoint
     // in one place, so a zero-config `kx serve` (auto paths under ~/.kortecx) is
     // transparent — the operator can find the journal, inspect the sidecar DBs,
@@ -1038,12 +1171,15 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         local_addr,
         ws_local_addr,
         console_local_addr,
+        metrics_local_addr,
     );
 
     Ok(RunningGateway {
         local_addr,
         ws_local_addr,
         console_local_addr,
+        metrics_local_addr,
+        audit_sink,
         shutdown,
         live_shutdown,
         gateway,
@@ -1066,6 +1202,7 @@ fn log_startup_banner(
     local_addr: SocketAddr,
     ws_local_addr: SocketAddr,
     console_local_addr: Option<SocketAddr>,
+    metrics_local_addr: Option<SocketAddr>,
 ) {
     let auth_mode = if cfg.dev_allow_local {
         "dev-allow-local (loopback only, no token)"
@@ -1083,6 +1220,15 @@ fn log_startup_banner(
         .unwrap_or_else(|| Path::new("."));
     let console_url =
         console_local_addr.map_or_else(|| "(disabled)".to_string(), |a| format!("http://{a}/"));
+    // W1a (T-OBS2/T-OBS1): the opt-in observability surfaces, "(disabled)" when off.
+    let metrics_url = metrics_local_addr.map_or_else(
+        || "(disabled)".to_string(),
+        |a| format!("http://{a}/metrics"),
+    );
+    let audit_log = cfg
+        .audit_log
+        .as_ref()
+        .map_or_else(|| "(disabled)".to_string(), |p| p.display().to_string());
     let connect_hint = if cfg.dev_allow_local {
         format!("kx runs list --endpoint http://{local_addr}")
     } else {
@@ -1106,6 +1252,8 @@ fn log_startup_banner(
         grpc_endpoint = %format!("http://{local_addr}"),
         ws_endpoint   = %format!("ws://{ws_local_addr}"),
         console_url   = %console_url,
+        metrics_url   = %metrics_url,
+        audit_log     = %audit_log,
         auth_mode,
         connect_hint  = %connect_hint,
         "kx-gateway STARTUP — resolved durable layout + endpoints",

--- a/crates/kx-gateway/tests/common/mod.rs
+++ b/crates/kx-gateway/tests/common/mod.rs
@@ -117,6 +117,8 @@ pub fn gateway_config(
         cors_origins: Vec::new(),
         console_listen: ConsoleMode::Disabled,
         content_max_bytes: kx_gateway::DEFAULT_CONTENT_MAX_BYTES,
+        metrics_listen: None,
+        audit_log: None,
     }
 }
 

--- a/crates/kx-gateway/tests/observability_e2e.rs
+++ b/crates/kx-gateway/tests/observability_e2e.rs
@@ -1,0 +1,220 @@
+//! W1a (T-OBS1 + T-OBS2) end-to-end: a REAL bound `kx serve` with both the
+//! Prometheus `/metrics` endpoint AND the JSONL operator audit log enabled.
+//!
+//! - `metrics_endpoint_reflects_a_real_run`: scrape `/metrics` before a run
+//!   (counters at zero), drive a PURE run to Committed, scrape again — the RED
+//!   counters (`runs_registered_total`, `motes_committed_total`) advance, derived
+//!   from the durable journal. `/health` answers, a bad method is 405.
+//! - `serve_audit_log_captures_the_lifecycle`: the run writes
+//!   `mote_dispatched` + `mote_committed` JSONL lines (the committed Mote's hex id),
+//!   flushed deterministically on graceful shutdown.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_gateway::{start, GatewayConfig};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tonic::transport::Channel;
+
+/// A dev config with the observability surfaces enabled: an ephemeral `/metrics`
+/// listener + a JSONL audit log at `audit_path`.
+fn obs_config(dir: &TempDir, audit_path: PathBuf) -> GatewayConfig {
+    let mut cfg = common::gateway_config(dir, true, HashMap::new());
+    cfg.metrics_listen = Some("127.0.0.1:0".parse().unwrap());
+    cfg.audit_log = Some(audit_path);
+    cfg
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+/// One raw HTTP/1.1 GET (status line, lowercased headers, body) — no new dev-deps
+/// (mirrors `console_e2e::raw_http`); proves the endpoint answers plain HTTP, which
+/// is exactly what a Prometheus scraper sends.
+async fn raw_get(addr: SocketAddr, method: &str, path: &str) -> (String, String, String) {
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let req = format!("{method} {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).await.unwrap();
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.unwrap();
+    let split = buf
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("a complete HTTP response head");
+    let head = String::from_utf8_lossy(&buf[..split]).to_string();
+    let body = String::from_utf8_lossy(&buf[split + 4..]).to_string();
+    let (status, headers) = head.split_once("\r\n").unwrap_or((head.as_str(), ""));
+    (status.to_string(), headers.to_ascii_lowercase(), body)
+}
+
+/// Extract the integer value of a single-sample Prometheus counter line.
+fn metric_value(body: &str, name: &str) -> u64 {
+    for line in body.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(name) {
+            // The sample is `name <value>` (no labels on these single-sample counters).
+            if let Some(v) = rest.split_whitespace().next() {
+                if let Ok(n) = v.parse::<u64>() {
+                    return n;
+                }
+            }
+        }
+    }
+    panic!("metric {name} not found in /metrics body:\n{body}");
+}
+
+async fn drive_pure_run(c: &mut KxGatewayClient<Channel>, seed: u8) -> ([u8; 32], Vec<u8>) {
+    let mote = common::pure_mote(seed, &[]);
+    let warrant = common::pure_warrant();
+    let handle = c
+        .submit_run(proto::SubmitRunRequest {
+            recipe_fingerprint: vec![0x5a; 32],
+            motes: vec![proto::SubmitMoteSpec {
+                mote: Some(mote.into()),
+                warrant: Some(warrant.into()),
+                accept_at_least_once: false,
+                react_seed: false,
+            }],
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let instance_id = handle.instance_id.clone();
+    for _ in 0..100 {
+        let view = c
+            .get_projection(proto::GetProjectionRequest {
+                instance_id: instance_id.clone(),
+                at_seq: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(m) = view
+            .motes
+            .iter()
+            .find(|m| m.state == proto::MoteSnapshotState::Committed as i32)
+        {
+            return (m.mote_id.clone().try_into().unwrap(), instance_id);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("the submitted Mote never reached Committed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn metrics_endpoint_reflects_a_real_run() {
+    let dir = TempDir::new().unwrap();
+    let audit = dir.path().join("audit.jsonl");
+    let running = start(obs_config(&dir, audit)).await.unwrap();
+    let metrics = running
+        .metrics_local_addr()
+        .expect("--metrics-listen binds the /metrics endpoint");
+    let mut c = client(running.local_addr()).await;
+
+    // (1) Before any run: the endpoint answers 200 text/plain with zeroed counters.
+    let (status, headers, body) = raw_get(metrics, "GET", "/metrics").await;
+    assert!(status.contains("200"), "{status}");
+    assert!(headers.contains("text/plain"), "{headers}");
+    assert!(body.contains("kortecx_up 1"));
+    assert_eq!(metric_value(&body, "kortecx_motes_committed_total"), 0);
+
+    // (2) Drive a PURE run to Committed.
+    drive_pure_run(&mut c, 1).await;
+
+    // (3) The RED counters advance (derived from the durable journal; the fold tick
+    //     runs every 250ms, so poll briefly for the post-commit snapshot).
+    let mut committed = 0;
+    for _ in 0..40 {
+        let (_, _, body) = raw_get(metrics, "GET", "/metrics").await;
+        committed = metric_value(&body, "kortecx_motes_committed_total");
+        if committed >= 1 {
+            assert!(
+                metric_value(&body, "kortecx_runs_registered_total") >= 1,
+                "a committed run also registered"
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        committed >= 1,
+        "kortecx_motes_committed_total never advanced"
+    );
+
+    // (4) Honest serving rules: /health pings, a non-GET is 405.
+    let (status, _, body) = raw_get(metrics, "GET", "/health").await;
+    assert!(status.contains("200"), "{status}");
+    assert!(body.contains("ok"));
+    let (status, _, _) = raw_get(metrics, "POST", "/metrics").await;
+    assert!(status.contains("405"), "{status}");
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serve_audit_log_captures_the_lifecycle() {
+    let dir = TempDir::new().unwrap();
+    let audit_path = dir.path().join("audit.jsonl");
+    let running = start(obs_config(&dir, audit_path.clone())).await.unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let (mote_id, _instance) = drive_pure_run(&mut c, 3).await;
+
+    // Graceful shutdown flushes the buffered audit trail to disk (deterministic —
+    // not the Drop-flush race).
+    running.shutdown().await.unwrap();
+
+    let log = std::fs::read_to_string(&audit_path).expect("the audit log was written");
+    let mote_hex: String = mote_id.iter().map(|b| format!("{b:02x}")).collect();
+    // The committed Mote appears as BOTH an admission (dispatched) and a durable
+    // commit, each carrying its server-derived hex id (SN-8 — echoed, not recomputed).
+    assert!(
+        log.contains("\"type\":\"mote_dispatched\""),
+        "audit log has the admission line:\n{log}"
+    );
+    assert!(
+        log.contains("\"type\":\"mote_committed\""),
+        "audit log has the commit line:\n{log}"
+    );
+    assert!(
+        log.contains(&mote_hex),
+        "audit log references the committed Mote {mote_hex}:\n{log}"
+    );
+    // Every non-empty line is a JSONL object carrying a wall-clock stamp (off the
+    // digest — the kx-audit unit tests pin the full JSON shape; here we confirm the
+    // serve trail's lines are well-formed objects with the audit envelope).
+    for line in log.lines().filter(|l| !l.is_empty()) {
+        assert!(
+            line.starts_with('{') && line.ends_with('}'),
+            "JSONL object: {line}"
+        );
+        assert!(
+            line.contains("\"ts_ms\":"),
+            "audit line carries a ts_ms: {line}"
+        );
+        assert!(
+            line.contains("\"seq\":"),
+            "audit line carries a seq: {line}"
+        );
+    }
+}

--- a/crates/kx-otel/Cargo.toml
+++ b/crates/kx-otel/Cargo.toml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-otel"
+version      = "0.1.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx observability metrics (W1a / T-OBS2): an FFI-free, build.rs-free crate that folds the read-only journal into RED (rate/errors/duration) counters and renders the Prometheus text exposition format. Derived from durable committed facts only — never an identity or digest input."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# The read-only journal seam (JournalReader / ReadOnly<J>) + the journal entry
+# kinds the RED counters fold over. FFI-free edges only (the dep_wall pins it):
+# kx-otel reads committed facts, it never dispatches inference.
+kx-gateway-core = { workspace = true }
+kx-journal      = { workspace = true }
+thiserror       = { workspace = true }
+tracing         = { workspace = true }
+
+[dev-dependencies]
+# In-memory journal to drive the fold deterministically in unit tests.
+kx-mote    = { workspace = true }
+kx-content = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-otel/src/error.rs
+++ b/crates/kx-otel/src/error.rs
@@ -1,0 +1,17 @@
+//! [`OtelError`] — the (rare) failure surface of a metrics fold.
+//!
+//! The only thing that can fail is *reading* the journal (a backend I/O error).
+//! Rendering is infallible (a pure string build). Callers treat a fold error as
+//! "serve the last good snapshot" — metrics are best-effort observability and must
+//! never block or fail the run they observe.
+
+use kx_journal::JournalError;
+
+/// A failure while folding the read-only journal into metrics.
+#[derive(Debug, thiserror::Error)]
+pub enum OtelError {
+    /// The underlying journal read failed. The caller keeps the last good
+    /// snapshot rather than surfacing the error to a scraper.
+    #[error("journal read failed during metrics fold: {0}")]
+    Journal(#[from] JournalError),
+}

--- a/crates/kx-otel/src/fold.rs
+++ b/crates/kx-otel/src/fold.rs
@@ -1,0 +1,301 @@
+//! [`MetricsState`] — RED counters folded from durable, committed journal facts.
+//!
+//! The fold is **incremental + idempotent**: it advances a high-water `last_seq`
+//! and only reads entries above it, so a periodic refresh is O(new entries), and
+//! re-running it over an empty tail is a no-op. Every counter is a monotone sum
+//! over journal entry KINDS — never a recomputed identity, never a digest input
+//! (off the truth path, like [`crate`]'s sibling `kx-audit`). A scrape renders a
+//! snapshot of this state; it never scans the journal itself.
+
+use kx_gateway_core::JournalReader;
+use kx_journal::{FailureReason, JournalEntry};
+
+use crate::error::OtelError;
+
+/// The number of [`FailureReason`] discriminants (0..=8). Kept as a constant so a
+/// future journal-schema variant addition is a single-line, compiler-checked bump
+/// (the `from_u8` round-trip in `reason_index` guards the mapping).
+pub const FAILURE_REASON_COUNT: usize = 9;
+
+/// Stable lowercase snake labels for each [`FailureReason`], indexed by `as_u8`.
+/// These ride the Prometheus `reason="…"` label, so they are part of the metric
+/// contract — append-only, never reordered (mirrors the UI `failureReasonLabel`).
+pub const FAILURE_REASON_LABELS: [&str; FAILURE_REASON_COUNT] = [
+    "timed_out",                 // 0 TimedOut
+    "executor_refused",          // 1 ExecutorRefused
+    "validator_rejected",        // 2 ValidatorRejected
+    "worker_crashed",            // 3 WorkerCrashed
+    "upstream_repudiated",       // 4 UpstreamRepudiated
+    "unsafe_world_mutating",     // 5 UnsafeWorldMutatingConstruction
+    "compensated_at_least_once", // 6 CompensatedAtLeastOnce
+    "quarantined_at_least_once", // 7 QuarantinedAtLeastOnce
+    "dead_lettered",             // 8 DeadLettered
+];
+
+/// RED metrics accumulated from the journal. All counters are cumulative since
+/// `seq 0`; Prometheus derives rates from the counter deltas across scrapes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MetricsState {
+    /// `RunRegistered` facts — runs admitted (the rate numerator).
+    pub runs_registered: u64,
+    /// `Proposed` facts — scheduler placements.
+    pub proposed: u64,
+    /// `Committed` facts — durable Mote effects (success).
+    pub committed: u64,
+    /// `Failed` facts — terminal Mote failures (the error count).
+    pub failed: u64,
+    /// `Failed` facts bucketed by [`FailureReason`] (indexed by `as_u8`).
+    pub failed_by_reason: [u64; FAILURE_REASON_COUNT],
+    /// `Repudiated` facts — committed Motes later invalidated.
+    pub repudiated: u64,
+    /// `EffectStaged` facts — WORLD-MUTATING intents durably staged.
+    pub effect_staged: u64,
+    /// The highest journal `seq` folded so far (the incremental high-water mark).
+    pub last_seq: u64,
+}
+
+impl MetricsState {
+    /// A fresh, all-zero state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The success ratio `committed / (committed + failed)` scaled to basis points
+    /// (0..=10000), or `None` when no terminal outcome has been observed. Integer
+    /// math only (no float on any path) — a Prometheus consumer divides by 10000.
+    #[must_use]
+    pub fn success_ratio_bp(&self) -> Option<u64> {
+        let terminal = self.committed + self.failed;
+        (terminal > 0).then(|| (self.committed * 10_000) / terminal)
+    }
+
+    /// Fold all journal entries with `seq > last_seq` into the counters and advance
+    /// `last_seq` to the journal head. Idempotent: a refresh with no new entries is
+    /// a no-op. Reads through the [`JournalReader`] read-only seam — there is no
+    /// `append` it could name (illegal-states-unrepresentable).
+    ///
+    /// # Errors
+    /// Returns [`OtelError::Journal`] if reading the journal head or tail fails;
+    /// the counters are left unchanged so the caller can serve the last snapshot.
+    pub fn fold_from(&mut self, reader: &dyn JournalReader) -> Result<(), OtelError> {
+        let head = reader.current_seq()?;
+        if head <= self.last_seq {
+            return Ok(());
+        }
+        // `seq` is 1-based (RunRegistered is seq 1); read the open tail (last, head].
+        for entry in reader.read_entries_by_seq((self.last_seq + 1)..(head + 1))? {
+            self.apply(&entry);
+        }
+        // Advance to the head we read through — robust even if a kind we don't
+        // bucket (off-DAG metadata facts) is the highest seq in the tail.
+        self.last_seq = head;
+        Ok(())
+    }
+
+    /// Apply one entry to the counters (the per-kind bucketing).
+    fn apply(&mut self, entry: &JournalEntry) {
+        match entry {
+            JournalEntry::RunRegistered { .. } => self.runs_registered += 1,
+            JournalEntry::Proposed { .. } => self.proposed += 1,
+            JournalEntry::Committed { .. } => self.committed += 1,
+            JournalEntry::Failed { reason_class, .. } => {
+                self.failed += 1;
+                self.failed_by_reason[reason_index(*reason_class)] += 1;
+            }
+            JournalEntry::Repudiated { .. } => self.repudiated += 1,
+            JournalEntry::EffectStaged { .. } => self.effect_staged += 1,
+            // Off-DAG metadata facts (RunVersionsResolved, DigestSealed,
+            // ReplanRound, ReactRound, …) are not RED signals — counted only by
+            // the `last_seq` high-water advance in `fold_from`.
+            _ => {}
+        }
+    }
+}
+
+/// Map a [`FailureReason`] to its `failed_by_reason` array index. Uses the
+/// canonical `as_u8`, clamped defensively to the array bounds (a forward-compat
+/// journal could in principle carry a discriminant this build does not know — it
+/// is bucketed into the last slot rather than panicking, fail-open).
+fn reason_index(reason: FailureReason) -> usize {
+    let idx = reason.as_u8() as usize;
+    idx.min(FAILURE_REASON_COUNT - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use kx_content::ContentRef;
+    use kx_journal::{FailureReason, JournalEntry, JournalError};
+    use kx_mote::{MoteDefHash, MoteId, NdClass};
+
+    use super::*;
+
+    /// A hand-built reader over a fixed entry list — tests the fold in isolation
+    /// from journal append/dedup/ordering rules.
+    struct MockReader {
+        entries: Vec<(u64, JournalEntry)>,
+    }
+
+    impl JournalReader for MockReader {
+        fn read_entries_by_seq(
+            &self,
+            range: Range<u64>,
+        ) -> Result<Box<dyn Iterator<Item = JournalEntry> + '_>, JournalError> {
+            let v: Vec<JournalEntry> = self
+                .entries
+                .iter()
+                .filter(|(seq, _)| range.contains(seq))
+                .map(|(_, e)| e.clone())
+                .collect();
+            Ok(Box::new(v.into_iter()))
+        }
+
+        fn current_seq(&self) -> Result<u64, JournalError> {
+            Ok(self.entries.iter().map(|(s, _)| *s).max().unwrap_or(0))
+        }
+    }
+
+    fn run_registered(seq: u64) -> JournalEntry {
+        JournalEntry::RunRegistered {
+            instance_id: [seq as u8; 16],
+            recipe_fingerprint: [0; 32],
+            ts: 0,
+            seq,
+        }
+    }
+
+    fn committed(seq: u64) -> JournalEntry {
+        JournalEntry::Committed {
+            mote_id: MoteId::from_bytes([seq as u8; 32]),
+            idempotency_key: [seq as u8; 32],
+            seq,
+            nondeterminism: NdClass::Pure,
+            result_ref: ContentRef::from_bytes([seq as u8; 32]),
+            parents: Default::default(),
+            warrant_ref: ContentRef::from_bytes([0; 32]),
+            mote_def_hash: MoteDefHash::from_bytes([0; 32]),
+        }
+    }
+
+    fn failed(seq: u64, reason: FailureReason) -> JournalEntry {
+        JournalEntry::Failed {
+            mote_id: MoteId::from_bytes([seq as u8; 32]),
+            idempotency_key: [seq as u8; 32],
+            seq,
+            reason_class: reason,
+            reporter_id: 0,
+        }
+    }
+
+    #[test]
+    fn folds_red_counters_from_a_fixed_journal() {
+        let reader = MockReader {
+            entries: vec![
+                (1, run_registered(1)),
+                (2, committed(2)),
+                (3, committed(3)),
+                (4, failed(4, FailureReason::TimedOut)),
+                (5, failed(5, FailureReason::DeadLettered)),
+            ],
+        };
+        let mut state = MetricsState::new();
+        state.fold_from(&reader).unwrap();
+
+        assert_eq!(state.runs_registered, 1);
+        assert_eq!(state.committed, 2);
+        assert_eq!(state.failed, 2);
+        assert_eq!(
+            state.failed_by_reason[FailureReason::TimedOut.as_u8() as usize],
+            1
+        );
+        assert_eq!(
+            state.failed_by_reason[FailureReason::DeadLettered.as_u8() as usize],
+            1
+        );
+        assert_eq!(state.last_seq, 5);
+        // 2 committed / 4 terminal = 5000 bp.
+        assert_eq!(state.success_ratio_bp(), Some(5_000));
+    }
+
+    #[test]
+    fn fold_is_incremental_and_idempotent() {
+        let mut entries = vec![(1, run_registered(1)), (2, committed(2))];
+        let mut state = MetricsState::new();
+        state
+            .fold_from(&MockReader {
+                entries: entries.clone(),
+            })
+            .unwrap();
+        assert_eq!(state.committed, 1);
+        assert_eq!(state.last_seq, 2);
+
+        // Re-folding the SAME journal adds nothing (idempotent).
+        state
+            .fold_from(&MockReader {
+                entries: entries.clone(),
+            })
+            .unwrap();
+        assert_eq!(state.committed, 1, "re-fold must not double-count");
+
+        // Append a new commit; only the new tail is folded.
+        entries.push((3, committed(3)));
+        state.fold_from(&MockReader { entries }).unwrap();
+        assert_eq!(state.committed, 2);
+        assert_eq!(state.last_seq, 3);
+    }
+
+    #[test]
+    fn empty_journal_is_all_zero() {
+        let state = {
+            let mut s = MetricsState::new();
+            s.fold_from(&MockReader { entries: vec![] }).unwrap();
+            s
+        };
+        assert_eq!(state, MetricsState::default());
+        assert_eq!(state.success_ratio_bp(), None);
+    }
+
+    /// GR10 spike (run `cargo test -p kx-otel --release -- --ignored fold_spike
+    /// --nocapture`): the cost of a full cold fold over an N-entry journal + a
+    /// render. The fold is incremental in production (a tick reads only the new
+    /// tail), so this cold pass is the conservative ceiling. Off the hot path; the
+    /// scrape never folds (it serves the cached snapshot). Numbers persist to the
+    /// PRIVATE `docs/benchmarks/` (SN-2), never asserted (a ratio gate would belong
+    /// in `scale-smoke`).
+    #[test]
+    #[ignore = "perf spike — run explicitly with --release --ignored --nocapture"]
+    fn fold_spike() {
+        use std::time::Instant;
+        const N: u64 = 50_000;
+        let mut entries = Vec::with_capacity(N as usize);
+        for seq in 1..=N {
+            // A representative mix: one run, mostly commits, ~10% failures.
+            let e = match seq % 10 {
+                0 => failed(seq, FailureReason::TimedOut),
+                1 => run_registered(seq),
+                _ => committed(seq),
+            };
+            entries.push((seq, e));
+        }
+        let reader = MockReader { entries };
+
+        let t0 = Instant::now();
+        let mut state = MetricsState::new();
+        state.fold_from(&reader).unwrap();
+        let fold = t0.elapsed();
+
+        let t1 = Instant::now();
+        let body =
+            crate::render::render(&state, &crate::render::BuildInfo { version: "spike" }, None);
+        let render = t1.elapsed();
+
+        let per_entry_ns = fold.as_nanos() / u128::from(N);
+        println!(
+            "kx-otel fold_spike: N={N} fold={fold:?} ({per_entry_ns} ns/entry) \
+             render={render:?} body_bytes={}",
+            body.len()
+        );
+    }
+}

--- a/crates/kx-otel/src/lib.rs
+++ b/crates/kx-otel/src/lib.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-otel` — OFF-TRUTH-PATH observability metrics (W1a / T-OBS2).
+//!
+//! Folds the **read-only journal** into RED metrics — **R**ate (runs/commits),
+//! **E**rrors (failures by reason), and (host-supplied) **D**uration — and renders
+//! the Prometheus text exposition format. Everything here is derived from durable
+//! committed facts; nothing is an identity or digest input, so turning metrics on
+//! changes only what is *observed* (the canonical product digest `7d22d4bd…` is
+//! byte-unchanged with metrics on, off, or scraped — the `kx-audit` posture).
+//!
+//! ## Design constraints (the workspace invariants)
+//! - **FFI-free** — kx-otel reads journal facts; it never dispatches inference, so
+//!   the dep-wall keeps it off the llama.cpp closure (any contributor can build it).
+//! - **No `build.rs`** — no compile-time environment capture, so the artifact is
+//!   byte-deterministic and the `check-reproducible` (I1.c) gate is unaffected.
+//! - **Off the hot path / fail-open** — the fold is incremental
+//!   ([`MetricsState::fold_from`]) and runs on a background tick; a scrape renders a
+//!   cached [`MetricsState`] snapshot ([`MetricsHandle::render`]) and never scans
+//!   the journal, so scrape latency is independent of journal size.
+//! - **Read-only by type** — the handle holds an [`kx_gateway_core::JournalReader`]
+//!   (no `append`); a write cannot type-check.
+
+#![forbid(unsafe_code)]
+// Tests assert on rendered/folded values via unwrap and build fixture entries
+// from small seqs (`seq as u8` byte patterns); the safety/pedantic lints (deny in
+// library code) are relaxed for tests per the workspace Rule-3 convention.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::cast_possible_truncation,
+        clippy::default_trait_access,
+        clippy::similar_names
+    )
+)]
+
+mod error;
+mod fold;
+mod render;
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use kx_gateway_core::JournalReader;
+
+pub use error::OtelError;
+pub use fold::{MetricsState, FAILURE_REASON_COUNT, FAILURE_REASON_LABELS};
+pub use render::{render, BuildInfo, LatencySummary};
+
+/// A shareable metrics handle: the read-only journal seam + a cached
+/// [`MetricsState`] snapshot.
+///
+/// Lifecycle (mirrors the gateway's telemetry ledger): a background task calls
+/// [`Self::refresh`] on a tick to fold the journal tail into the cached snapshot;
+/// the `/metrics` scrape calls [`Self::render`] which serves the cached snapshot
+/// (plus optional host-supplied latency) **without** folding — so a scrape is
+/// fast regardless of journal size. Cloneable: the inner state + reader are
+/// `Arc`-shared, so the tick and the scrape see the same cache.
+#[derive(Clone)]
+pub struct MetricsHandle {
+    state: Arc<Mutex<MetricsState>>,
+    reader: Arc<dyn JournalReader>,
+    build: BuildInfo,
+}
+
+impl MetricsHandle {
+    /// Build a handle over a read-only journal seam, labelling renders with `build`.
+    #[must_use]
+    pub fn new(reader: Arc<dyn JournalReader>, build: BuildInfo) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(MetricsState::new())),
+            reader,
+            build,
+        }
+    }
+
+    /// Fold the journal tail into the cached snapshot (incremental + idempotent).
+    /// Call this on a background tick. A poisoned cache lock is recovered (the
+    /// inner state is plain counters — a panicked holder leaves it usable).
+    ///
+    /// # Errors
+    /// Returns [`OtelError::Journal`] if the underlying journal read fails; the
+    /// cached snapshot is left intact so a scrape still serves the last good data.
+    pub fn refresh(&self) -> Result<(), OtelError> {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        state.fold_from(self.reader.as_ref())
+    }
+
+    /// A clone of the current cached snapshot (no journal read).
+    #[must_use]
+    pub fn snapshot(&self) -> MetricsState {
+        self.state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Render the `/metrics` body from the cached snapshot plus optional
+    /// host-supplied recent-window latency. Does **not** fold — serve the cache.
+    #[must_use]
+    pub fn render(&self, latency: Option<&LatencySummary>) -> String {
+        let snapshot = self.snapshot();
+        render(&snapshot, &self.build, latency)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use kx_journal::{JournalEntry, JournalError};
+
+    use super::*;
+
+    struct EmptyReader;
+    impl JournalReader for EmptyReader {
+        fn read_entries_by_seq(
+            &self,
+            _range: Range<u64>,
+        ) -> Result<Box<dyn Iterator<Item = JournalEntry> + '_>, JournalError> {
+            Ok(Box::new(std::iter::empty()))
+        }
+        fn current_seq(&self) -> Result<u64, JournalError> {
+            Ok(0)
+        }
+    }
+
+    #[test]
+    fn handle_renders_empty_state() {
+        let handle = MetricsHandle::new(Arc::new(EmptyReader), BuildInfo { version: "0.0.0" });
+        handle.refresh().unwrap();
+        let body = handle.render(None);
+        assert!(body.contains("kortecx_up 1"));
+        assert!(body.contains("kortecx_motes_committed_total 0"));
+        assert_eq!(handle.snapshot(), MetricsState::new());
+    }
+}

--- a/crates/kx-otel/src/render.rs
+++ b/crates/kx-otel/src/render.rs
@@ -1,0 +1,288 @@
+//! Prometheus text exposition rendering — deterministic, allocation-cheap, and
+//! dependency-free (the format is line-based; pulling a metrics crate would only
+//! add a tonic/version surface for what is a few `writeln!`s).
+//!
+//! Contract: every family emits exactly one `# HELP` + one `# TYPE` line followed
+//! by its sample line(s). A scrape renders a snapshot of [`MetricsState`] plus an
+//! optional [`LatencySummary`] the host supplies from its telemetry exhaust — so
+//! the durable-fact COUNTERS and the operational-window LATENCY gauges share one
+//! formatter (a single source of format truth across the metrics surface).
+
+use std::fmt::Write as _;
+
+use crate::fold::{MetricsState, FAILURE_REASON_LABELS};
+
+/// Build metadata surfaced as `kortecx_build_info{version="…"} 1`.
+#[derive(Debug, Clone, Copy)]
+pub struct BuildInfo {
+    /// The gateway crate version (e.g. `CARGO_PKG_VERSION`).
+    pub version: &'static str,
+}
+
+/// Recent-window latency + token totals, supplied by the host from its telemetry
+/// exhaust (off the durable-fact path — the same numbers the Monitoring UI shows).
+/// `None` when no telemetry seam is wired (an FFI-free serve), in which case the
+/// duration block is honestly omitted rather than rendered as zero.
+#[derive(Debug, Clone, Copy)]
+pub struct LatencySummary {
+    /// How many recent model Motes the percentiles cover.
+    pub window: u64,
+    /// Nearest-rank p50 of per-Mote wall-clock milliseconds over the window.
+    pub p50_ms: u64,
+    /// Nearest-rank p95 of per-Mote wall-clock milliseconds over the window.
+    pub p95_ms: u64,
+    /// Summed `output_tokens` over the window.
+    pub output_tokens: u64,
+}
+
+/// A minimal Prometheus text-format writer.
+struct PromWriter {
+    buf: String,
+}
+
+impl PromWriter {
+    fn new() -> Self {
+        Self {
+            // Pre-size for the ~25 lines a typical render emits.
+            buf: String::with_capacity(2048),
+        }
+    }
+
+    /// Emit the `# HELP` + `# TYPE` header for a metric family (once per family).
+    fn family(&mut self, name: &str, kind: &str, help: &str) {
+        // Infallible: writing to a String never errors.
+        let _ = writeln!(self.buf, "# HELP {name} {help}");
+        let _ = writeln!(self.buf, "# TYPE {name} {kind}");
+    }
+
+    /// Emit one sample line `name{labels} value`.
+    fn sample(&mut self, name: &str, labels: &[(&str, &str)], value: u64) {
+        self.buf.push_str(name);
+        if !labels.is_empty() {
+            self.buf.push('{');
+            for (i, (k, v)) in labels.iter().enumerate() {
+                if i > 0 {
+                    self.buf.push(',');
+                }
+                let _ = write!(self.buf, "{k}=\"");
+                escape_label_value(&mut self.buf, v);
+                self.buf.push('"');
+            }
+            self.buf.push('}');
+        }
+        let _ = writeln!(self.buf, " {value}");
+    }
+
+    /// A single-sample counter family.
+    fn counter(&mut self, name: &str, help: &str, value: u64) {
+        self.family(name, "counter", help);
+        self.sample(name, &[], value);
+    }
+
+    /// A single-sample gauge family.
+    fn gauge(&mut self, name: &str, help: &str, value: u64) {
+        self.family(name, "gauge", help);
+        self.sample(name, &[], value);
+    }
+
+    fn finish(self) -> String {
+        self.buf
+    }
+}
+
+/// Escape a Prometheus label value (`\` → `\\`, `"` → `\"`, newline → `\n`).
+fn escape_label_value(buf: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            '\\' => buf.push_str(r"\\"),
+            '"' => buf.push_str("\\\""),
+            '\n' => buf.push_str(r"\n"),
+            c => buf.push(c),
+        }
+    }
+}
+
+/// Render the full `/metrics` body for a `MetricsState` snapshot plus optional
+/// recent-window latency. Pure + deterministic: the same inputs always yield the
+/// same bytes (unit-tested as a golden string).
+#[must_use]
+pub fn render(state: &MetricsState, build: &BuildInfo, latency: Option<&LatencySummary>) -> String {
+    let mut w = PromWriter::new();
+
+    w.gauge(
+        "kortecx_up",
+        "1 when the gateway metrics endpoint is serving.",
+        1,
+    );
+
+    w.family(
+        "kortecx_build_info",
+        "gauge",
+        "Build metadata; always 1, the version rides the label.",
+    );
+    w.sample("kortecx_build_info", &[("version", build.version)], 1);
+
+    // --- Rate (cumulative counters; Prometheus derives the per-second rate) ---
+    w.counter(
+        "kortecx_runs_registered_total",
+        "Runs admitted (RunRegistered journal facts).",
+        state.runs_registered,
+    );
+    w.counter(
+        "kortecx_motes_proposed_total",
+        "Mote placements proposed (Proposed journal facts).",
+        state.proposed,
+    );
+    w.counter(
+        "kortecx_motes_committed_total",
+        "Mote effects committed durably (Committed journal facts).",
+        state.committed,
+    );
+
+    // --- Errors ---
+    w.counter(
+        "kortecx_motes_failed_total",
+        "Terminal Mote failures (Failed journal facts).",
+        state.failed,
+    );
+    w.family(
+        "kortecx_motes_failed_by_reason_total",
+        "counter",
+        "Terminal Mote failures bucketed by failure reason.",
+    );
+    for (i, label) in FAILURE_REASON_LABELS.iter().enumerate() {
+        w.sample(
+            "kortecx_motes_failed_by_reason_total",
+            &[("reason", label)],
+            state.failed_by_reason[i],
+        );
+    }
+    w.counter(
+        "kortecx_motes_repudiated_total",
+        "Committed Motes later invalidated (Repudiated journal facts).",
+        state.repudiated,
+    );
+    w.counter(
+        "kortecx_effects_staged_total",
+        "WORLD-MUTATING effects staged (EffectStaged journal facts).",
+        state.effect_staged,
+    );
+    if let Some(bp) = state.success_ratio_bp() {
+        w.gauge(
+            "kortecx_success_ratio_basis_points",
+            "Committed / (committed + failed), in basis points (0..=10000).",
+            bp,
+        );
+    }
+
+    // --- Duration (operational recent-window latency from the telemetry exhaust) ---
+    // Distinct p50/p95 GAUGE families (not a `quantile`-labelled series): these are
+    // a point-in-time recent-window snapshot, not a cumulative `summary`, and the
+    // `quantile` label is reserved for summary-typed metrics in the OpenMetrics model
+    // (a strict parser rejects it on a gauge). Honest types > clever labels.
+    if let Some(l) = latency {
+        w.gauge(
+            "kortecx_mote_wall_p50_ms",
+            "Recent-window p50 per-Mote wall-clock latency (ms; model motes).",
+            l.p50_ms,
+        );
+        w.gauge(
+            "kortecx_mote_wall_p95_ms",
+            "Recent-window p95 per-Mote wall-clock latency (ms; model motes).",
+            l.p95_ms,
+        );
+        w.gauge(
+            "kortecx_telemetry_window_motes",
+            "Number of recent model Motes the latency window covers.",
+            l.window,
+        );
+        w.gauge(
+            "kortecx_output_tokens_window",
+            "Summed output_tokens over the recent telemetry window.",
+            l.output_tokens,
+        );
+    }
+
+    // --- The journal high-water mark (a liveness/progress gauge) ---
+    w.gauge(
+        "kortecx_journal_seq",
+        "Highest journal sequence folded into these metrics.",
+        state.last_seq,
+    );
+
+    w.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BUILD: BuildInfo = BuildInfo { version: "9.9.9" };
+
+    fn sample_state() -> MetricsState {
+        let mut s = MetricsState::new();
+        s.runs_registered = 3;
+        s.proposed = 7;
+        s.committed = 5;
+        s.failed = 2;
+        s.failed_by_reason[0] = 1; // timed_out
+        s.failed_by_reason[8] = 1; // dead_lettered
+        s.repudiated = 0;
+        s.effect_staged = 4;
+        s.last_seq = 21;
+        s
+    }
+
+    #[test]
+    fn renders_counters_without_latency() {
+        let out = render(&sample_state(), &BUILD, None);
+        assert!(out.contains("# TYPE kortecx_motes_committed_total counter"));
+        assert!(out.contains("kortecx_motes_committed_total 5"));
+        assert!(out.contains("kortecx_motes_failed_by_reason_total{reason=\"timed_out\"} 1"));
+        assert!(out.contains("kortecx_motes_failed_by_reason_total{reason=\"dead_lettered\"} 1"));
+        assert!(out.contains("kortecx_build_info{version=\"9.9.9\"} 1"));
+        assert!(out.contains("kortecx_success_ratio_basis_points 7142")); // 5/7 * 10000
+        assert!(out.contains("kortecx_journal_seq 21"));
+        // No latency block when latency is absent (honest omit, not zeros).
+        assert!(!out.contains("kortecx_mote_wall_p50_ms"));
+        assert!(!out.contains("kortecx_mote_wall_p95_ms"));
+        assert!(out.contains("kortecx_up 1"));
+    }
+
+    #[test]
+    fn renders_latency_block_when_supplied() {
+        let latency = LatencySummary {
+            window: 100,
+            p50_ms: 42,
+            p95_ms: 130,
+            output_tokens: 9001,
+        };
+        let out = render(&sample_state(), &BUILD, Some(&latency));
+        assert!(out.contains("# TYPE kortecx_mote_wall_p50_ms gauge"));
+        assert!(out.contains("kortecx_mote_wall_p50_ms 42"));
+        assert!(out.contains("kortecx_mote_wall_p95_ms 130"));
+        assert!(out.contains("kortecx_telemetry_window_motes 100"));
+        assert!(out.contains("kortecx_output_tokens_window 9001"));
+    }
+
+    #[test]
+    fn render_is_deterministic() {
+        let s = sample_state();
+        assert_eq!(render(&s, &BUILD, None), render(&s, &BUILD, None));
+    }
+
+    #[test]
+    fn label_values_are_escaped() {
+        let mut buf = String::new();
+        escape_label_value(&mut buf, "a\"b\\c");
+        assert_eq!(buf, "a\\\"b\\\\c");
+    }
+
+    #[test]
+    fn empty_state_renders_zero_counters_and_no_ratio() {
+        let out = render(&MetricsState::new(), &BUILD, None);
+        assert!(out.contains("kortecx_motes_committed_total 0"));
+        // No terminal outcomes ⇒ no success-ratio gauge (honest absence).
+        assert!(!out.contains("kortecx_success_ratio_basis_points"));
+    }
+}

--- a/crates/kx-profile/src/spikes.rs
+++ b/crates/kx-profile/src/spikes.rs
@@ -100,6 +100,8 @@ pub(crate) fn config(dir: &Path) -> Result<GatewayConfig, ProfileError> {
         cors_origins: Vec::new(),
         console_listen: ConsoleMode::Disabled,
         content_max_bytes: kx_gateway::DEFAULT_CONTENT_MAX_BYTES,
+        metrics_listen: None,
+        audit_log: None,
     })
 }
 

--- a/docs/site/docs/observability.md
+++ b/docs/site/docs/observability.md
@@ -2,7 +2,7 @@
 id: observability
 title: Observability
 sidebar_label: Observability
-description: The Dashboard, gateway-wide Monitoring, per-model telemetry, failure triage, and health.
+description: The Dashboard, gateway-wide Monitoring, per-model telemetry, failure triage, health, Prometheus metrics export, and the operator audit log.
 ---
 
 # Observability
@@ -67,12 +67,90 @@ reason shows no label — the reason is never invented.
 Gateway liveness is inferred from a cheap unary round-trip on an interval (the same
 probe the connect flow uses) and rendered as a `LIVE` / `DEGRADED` / `DOWN` pill on
 the Dashboard and in Monitoring. From the CLI, `kx health` reports the same
-liveness.
+liveness. The gateway also serves the standard `grpc.health.v1.Health` service for
+`grpc_health_probe` / Kubernetes gRPC probes.
+
+## Metrics export (Prometheus)
+
+For scraping into Prometheus / Grafana / an OTLP pipeline, `kx serve` exposes a
+**Prometheus text `/metrics` endpoint**, off by default and enabled with one flag:
+
+```bash
+kx serve --dev-allow-local --metrics-listen 127.0.0.1:9090
+# scrape it:
+curl -s http://127.0.0.1:9090/metrics
+```
+
+The metrics are **RED signals derived from the durable journal** — counters that an
+operator turns into rate, error-ratio, and saturation dashboards. They are computed
+on a background fold of committed facts and served from a cached snapshot, so a
+scrape is fast regardless of journal size:
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `kortecx_runs_registered_total` | counter | runs admitted (`RunRegistered` facts) |
+| `kortecx_motes_committed_total` | counter | durable Mote effects (`Committed` facts) |
+| `kortecx_motes_failed_total` | counter | terminal Mote failures (`Failed` facts) |
+| `kortecx_motes_failed_by_reason_total{reason}` | counter | failures bucketed by reason (`timed_out`, `dead_lettered`, …) |
+| `kortecx_motes_repudiated_total` | counter | committed Motes later invalidated |
+| `kortecx_effects_staged_total` | counter | WORLD-MUTATING effects staged |
+| `kortecx_success_ratio_basis_points` | gauge | `committed / (committed + failed)` × 10000 |
+| `kortecx_journal_seq` | gauge | the highest journal sequence folded |
+| `kortecx_mote_wall_p50_ms` / `kortecx_mote_wall_p95_ms` | gauge | recent-window p50/p95 execution latency (model motes) |
+| `kortecx_output_tokens_window` | gauge | summed `output_tokens` over the recent window |
+| `kortecx_up` / `kortecx_build_info{version}` | gauge | endpoint liveness + build |
+
+The latency block is **honestly omitted** when no model Mote has run (e.g. an
+FFI-free serve). The endpoint is **unauthenticated by design** (the scraper
+convention, like the health service): bind it to loopback or a trusted network. The
+canonical-projection digest is unchanged whether metrics are on, off, or scraped —
+metrics only read committed facts; they are never an identity or digest input.
+
+> OTLP push to a collector is a hardening follow-on; the Prometheus pull endpoint is
+> the single-node path. Cross-party scoping + auth on the metrics surface is Cloud.
+
+## Audit log
+
+The long-running serve can write a **JSONL operator audit trail** — a structured,
+append-only record of the run lifecycle for SIEM ingestion / accountability:
+
+```bash
+kx serve --dev-allow-local --audit-log /var/log/kortecx/audit.jsonl
+```
+
+One JSON object per line, opened in **append** mode (the trail accumulates across
+restarts) and flushed on graceful shutdown:
+
+```json
+{"seq":0,"ts_ms":1718524800123,"type":"mote_dispatched","mote_id":"ab…","nd_class":"pure","kind":"pure"}
+{"seq":1,"ts_ms":1718524800456,"type":"mote_committed","mote_id":"ab…","result_ref":"cd…","nd_class":"pure"}
+{"seq":2,"ts_ms":1718524805000,"type":"mote_failed","mote_id":"ef…"}
+```
+
+Each line carries a monotonic `seq`, a wall-clock `ts_ms`, and **server-derived hex
+ids only** — join keys back to the journal, never payload bytes, model output, or
+warrant secrets. The audit log is **off the truth path**: it is best-effort, never
+gates a run, and is never a digest input — the journal remains the durable truth and
+the digest is recomputable from it. The operator owns retention/rotation (e.g.
+`logrotate`).
+
+**Coverage.** Every durable outcome is audited: `mote_committed` and `mote_failed`
+cover **all** Motes, whether client-submitted or materialized by the live agentic
+loop (shaper children, ReAct/re-plan turns). `mote_dispatched` marks **client
+submissions** at admission; internally-materialized agentic children are spliced
+onto the sole-writer thread and so appear as `mote_committed` / `mote_failed` without
+a separate admission line (a per-child dispatch line for the agentic loop is an
+additive follow-on). Filter the trail with `jq`:
+
+```bash
+jq -c 'select(.type=="mote_failed")' /var/log/kortecx/audit.jsonl
+```
 
 :::note More on the way
-Structured log filtering, failure-reason humanization across the live feed, an
-alerts inbox, and JSONL export land with a later observability batch. Time-travel
-(`kx projection --at-seq`) and run capture (`ListCaptureRecords`) are covered in the
+A failures/refusals **alerts inbox** (acknowledge / resolve), live-feed **filter
+chips + JSONL export**, and a **token-economy** breakdown land with the next
+observability batches. Time-travel (`kx projection --at-seq`) and run capture
+(`ListCaptureRecords`) are covered in the
 [Quickstart](./quickstart.md#run-your-first-blueprint) and the
 [production notes in the README](https://github.com/Kortecx/kortecx/blob/main/README.md#production-notes).
 :::

--- a/justfile
+++ b/justfile
@@ -415,6 +415,12 @@ features-guard:
     cargo check -p kx-cli --features hnsw
     cargo check -p kx-cli --features inference,hnsw
     echo " ✓ features-guard: hnsw + inference,hnsw both build"
+    # W1a (SN-6): the gateway-only / external-coordinator config (default feature
+    # `embedded-worker` OFF) reserved by the `start_impl` stub must stay BUILDABLE,
+    # so a feature-independent struct field never references a feature-gated import
+    # (the W1a-1 audit-sink cfg-leak class). CI builds only the default features.
+    cargo check -p kx-gateway --no-default-features
+    echo " ✓ features-guard: kx-gateway --no-default-features builds"
 
 # Byte-determinism check (I1.c). Two consecutive release builds must produce
 # bit-identical artifacts. Failure indicates the build is nondeterministic and


### PR DESCRIPTION
## W1a-1 — RC observability/ops hardening (batch 1 of 3)

First of the three **W1a** RC observability batches. Closes the *observable + auditable at scale* gap with two **opt-in, off-truth-path** surfaces. No proto / SDK / UI change (those land in W1a-2 Alerts inbox and W1a-3 Logs triage + token-economy).

### T-OBS2 — Prometheus `/metrics`
- NEW **FFI-free, build.rs-free** `kx-otel` crate folds the **read-only journal** into **RED metrics** (rate / errors / duration) from durable committed facts only.
- `kx serve --metrics-listen <addr:port>` (**default OFF**) mounts a `/metrics` endpoint — a 4th hyper listener mirroring the embedded console. Cumulative counters (`runs_registered_total`, `motes_committed_total`, `motes_failed_total{reason}`, …) + `success_ratio_basis_points` + `journal_seq` + an optional recent-window latency block (p50/p95 gauges + output-token sum) from the telemetry exhaust.
- A **background tick** folds into a cached snapshot; a scrape serves the cache and **never scans the journal** (scrape latency independent of journal size). Unauthenticated by design (scraper convention) — bind loopback/trusted; a non-loopback bind warns.

### T-OBS1 — serve-path audit log
- The coordinator emits the operator lifecycle (`mote_dispatched` / `mote_committed` / `mote_failed`) to an optional `kx-audit` sink; `kx serve --audit-log <path>` writes a JSONL trail (**append** mode), **flushed deterministically on graceful shutdown**. Server-derived hex ids only — no payloads/secrets (SN-8).

### Invariants (verified)
- Canonical projection digest **`7d22d4bd` INVARIANT** (`just verify-quickstart`); **frozen trio untouched**; **I1.c byte-determinism PASS**; dep-wall clean (`kx-otel` FFI-free; no `kx-llamacpp` in kx-runtime/kx-cli); `cargo-deny` clean; **Cargo.lock edge-only** (no new external crates); both surfaces **default-OFF ⇒ byte-identical** when unused.

### Tests (five-layer)
- `kx-otel` unit (fold / render / determinism / handle) + **GR10** fold spike (127 ns/entry, render 36 µs).
- gateway config unit + `observability_e2e` against a **live serve**: `/metrics` counters advance on a real run; the audit JSONL captures the lifecycle.
- **Live smoke**: `kx invoke kx/recipes/echo` → `/metrics` shows runs=1, committed=1, success=100%; the audit trail shows `mote_dispatched`+`mote_committed` with the mote_id matching the invoke's `terminal_mote_id`.
- **Adversarial multi-agent review** (8 agents): 3 medium findings fixed — `--no-default-features` build (cfg-gated import leak; + a `features-guard` guard added), OpenMetrics `quantile`-on-gauge (renamed to distinct p50/p95 gauges), audit coverage honest-scope (materialized agentic children are committed-audited).

### Docs
- `observability.md` Metrics + Audit log sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)