### PR TITLE
chore(llamacpp-sys): bump llama.cpp pin → gemma4uv (Gemma-4 omni) projector support

### DIFF
--- a/crates/kx-llamacpp-sys/PIN.md
+++ b/crates/kx-llamacpp-sys/PIN.md
@@ -14,11 +14,11 @@ against.
 | Submodule path | `crates/kx-llamacpp-sys/llama.cpp` |
 | Upstream URL | `https://github.com/ggerganov/llama.cpp` |
 | Tracking branch | `master` (advisory only — the SHA is what builds) |
-| **Pinned commit** | `1a03cf47f67be591699d1f0f7ca28e1ed6eb8c7e` |
-| **Version-tag-derived name** | `gguf-v0.18.0-826-g1a03cf47f` (826 commits past `gguf-v0.18.0`) |
-| Date of pin entry | 2026-05-25 |
+| **Pinned commit** | `d2462f8f7ac6d80070a587ffebf6cd73730f4280` |
+| **Version-tag-derived name** | `b9310-280-gd2462f8f7` (280 commits past build tag `b9310`) |
+| Date of pin entry | 2026-06-16 |
 
-The pinned commit subject is `hexagon: hmx flash attention (#22347)`.
+The pinned commit subject is `chat: fix LFM2/LFM2.5 ignoring json_schema (#24377)`.
 
 ## Why this matters
 
@@ -38,12 +38,14 @@ This is why the peer-review of P1.7-foundation flagged `kx-llamacpp-sys` as
 *ASSUMED-with-tail-risk* (the link compiles, smoke tests pass, but FFI bugs
 hide until specific call patterns hit them).
 
-> **Note (agent-model integration).** This pin already provides everything the
-> Qwen3-4B agent model + the GPU/decoding tuning need — **no bump required**:
-> `qwen3` arch (`src/llama-arch.cpp` `LLM_ARCH_QWEN3`), the `llama_flash_attn_type`
-> enum on `llama_context_params.flash_attn_type`, and `type_k`/`type_v` (`ggml_type`)
-> KV-cache element types. This SHA equals the `LLAMA_CPP_REF` the companion model
-> repo (`Kortecx/kortecx-model-base-0.0.1`) pins for GGUF format compatibility.
+> **Note (agent-model integration).** This pin supports both the Qwen3 agent
+> stand-in (`qwen3` arch, the `llama_flash_attn_type` enum on
+> `llama_context_params.flash_attn_type`, `type_k`/`type_v` KV-cache element
+> types) **and the Gemma-4-12B omni model** — the 2026-06-16 bump's motivation:
+> the `gemma4` text arch (`src/llama-arch.cpp`) plus the `gemma4uv` *unified
+> vision* projector (`tools/mtmd/models/gemma4uv.cpp`), which the prior
+> 2026-05-25 pin did not recognize (`clip_init: unknown projector type:
+> gemma4uv`). GGUF stays format V3, so existing Qwen3 fixtures load unchanged.
 
 The pin makes ABI drift **an explicit, audited event** rather than a
 shadow upgrade.
@@ -139,3 +141,4 @@ archive); Linux catches the CPU-only path. Both must pass.
 | Date | SHA | `git describe` | One-line audit note |
 |---|---|---|---|
 | 2026-05-25 | `1a03cf47f67b...` | `gguf-v0.18.0-826-g1a03cf47f` | Initial pin record (this commit). FFI surface clean against `kx-llamacpp/src/*.rs`; Drop coverage verified for Model/Context/Sampler/Batch/LlamaBackend. |
+| 2026-06-16 | `d2462f8f7ac6...` | `b9310-280-gd2462f8f7` | +671 commits. Motivation: the `gemma4uv` unified-vision projector (Gemma-4-12B omni), absent from the prior pin. **`llama.h` C API stable for all bound symbols** (only additive `llama_n_rs_seq` + a `llama_set_warmup` deprecation we don't use). **Two changes required:** (1) `mtmd_helper_bitmap_init_from_buf` gained a `placeholder` bool and now returns `mtmd_helper_bitmap_wrapper { bitmap, video_ctx }` — `kx-llamacpp/src/mtmd.rs` updated to pass `false` + take `.bitmap`; (2) upstream added a default-ON unified `llama` app (`app/`) that links `llama-server-impl` (we build `LLAMA_BUILD_SERVER=OFF`) → added `LLAMA_BUILD_APP=OFF` in `build.rs` (`tools/mtmd`/`libmtmd.a` stays built under `LLAMA_BUILD_TOOLS`). Drop coverage re-verified; no enum-discriminant or struct-layout drift in used types. |

--- a/crates/kx-llamacpp-sys/build.rs
+++ b/crates/kx-llamacpp-sys/build.rs
@@ -112,6 +112,13 @@ fn main() {
         .define("LLAMA_BUILD_TESTS", "OFF")
         .define("LLAMA_BUILD_EXAMPLES", "OFF")
         .define("LLAMA_BUILD_SERVER", "OFF")
+        // The unified `llama` app binary (added upstream 2026-06) links
+        // `llama-server-impl`, which `LLAMA_BUILD_SERVER=OFF` does not build —
+        // so the default-ON app target fails to link. We only need the static
+        // libs (ggml/llama/mtmd), so disable it. NOTE: `LLAMA_BUILD_TOOLS` MUST
+        // stay ON — `tools/mtmd` (libmtmd.a, the multi-modal projector) lives
+        // under `tools/`.
+        .define("LLAMA_BUILD_APP", "OFF")
         // CUDA is cloud-side per D28. Disable for OSS portability.
         .define("GGML_CUDA", "OFF")
         // BLAS optional; disable to keep the build dep-light.

--- a/crates/kx-llamacpp/src/mtmd.rs
+++ b/crates/kx-llamacpp/src/mtmd.rs
@@ -373,9 +373,18 @@ impl Bitmap {
     /// - [`LlamaError::AudioNotSupported`] if the bytes are audio.
     pub fn from_image_buf(mtmd: &Mtmd<'_, '_>, bytes: &[u8]) -> Result<Self, LlamaError> {
         // SAFETY: `mtmd.ptr` valid; `bytes` is a valid `len`-byte buffer that
-        // outlives the (synchronous) call. Returns null on decode failure.
+        // outlives the (synchronous) call. Returns a wrapper whose `.bitmap` is
+        // null on decode failure (the `placeholder=false` path eagerly decodes;
+        // `.video_ctx` is only set for video input, which this image-only path
+        // never requests, so it is null here and needs no free).
         let raw = unsafe {
-            sys::mtmd_helper_bitmap_init_from_buf(mtmd.ptr.as_ptr(), bytes.as_ptr(), bytes.len())
+            sys::mtmd_helper_bitmap_init_from_buf(
+                mtmd.ptr.as_ptr(),
+                bytes.as_ptr(),
+                bytes.len(),
+                false,
+            )
+            .bitmap
         };
         let ptr = NonNull::new(raw).ok_or(LlamaError::BitmapDecodeFailed {
             n_bytes: bytes.len(),


### PR DESCRIPTION
**PR-0 of the Gemma-4-12B migration** (the pin bump is split out as its own audited PR per the FFI-surface discipline in `PIN.md` / Golden Rule 1/6). PR-1 (the model migration: serve default, prompt-format, JSON-fence extraction, profiling) builds on top.

## What
Advance the vendored llama.cpp submodule **`1a03cf47` → `d2462f8f7`** (`b9310-280-gd2462f8f7`, 2026-06-10, +671 commits) to gain the **`gemma4uv` unified-vision projector** for the Gemma-4-12B omni model. The prior 2026-05-25 pin loaded Gemma-4 *text* but rejected its mmproj: `clip_init: unknown projector type: gemma4uv`.

## FFI re-audit (the PIN.md ritual)
The `llama.h` C API is **stable** for every bound symbol (only additive `llama_n_rs_seq` + an unused `llama_set_warmup` deprecation). Two changes required:

- **`kx-llamacpp/src/mtmd.rs`** — `mtmd_helper_bitmap_init_from_buf` gained a `placeholder` bool and now returns `mtmd_helper_bitmap_wrapper { bitmap, video_ctx }`. Pass `false`, take `.bitmap`. The public `Bitmap::from_image_buf` signature is unchanged, so all callers (`kx-inference`, smoke tests, `describe_image`) are untouched.
- **`kx-llamacpp-sys/build.rs`** — `LLAMA_BUILD_APP=OFF`. Upstream added a default-ON unified `llama` app (`app/`) linking `llama-server-impl`, which we don't build (`LLAMA_BUILD_SERVER=OFF`) → link failure. We only need the static libs; `tools/mtmd`/`libmtmd.a` stays built under `LLAMA_BUILD_TOOLS`.

## Verification (Apple-M3, Metal)
- ✅ `gemma4uv` mmproj loads (vision + audio encoders present)
- ✅ `smoke-test-with-model` (stories260K FFI pipeline) green
- ✅ `real-model-e2e` (Qwen3-0.6B) — clean completion, no scaffolding leak, greedy-deterministic across gateways
- ✅ canonical projection digest **`7d22d4bd` unchanged** (FFI-free, by construction)
- ✅ `clippy --workspace --all-targets -D warnings` clean; `rustfmt` clean
- ✅ frozen trio (`dispatcher.rs`) untouched
- `PIN.md` updated with the audit note + pin-history row

🤖 Generated with [Claude Code](https://claude.com/claude-code)