### PR TITLE
feat(inference,gateway): model-agnostic chat templating + Gemma-4 omni serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ development; interfaces may change before 1.0 — pin a commit if you build on i
 
 ### Added
 
+- **Gemma-4-12B omni support + model-agnostic prompt templating.** A model-serving
+  gateway now formats every model with its OWN chat template — applying the GGUF's
+  embedded template through llama.cpp where it renders, with a built-in
+  per-architecture fallback (`ChatML` / Gemma) for models llama.cpp cannot render
+  (such as Gemma-4) — so a model is never fed another model's format. A recipe's
+  structured reply is normalized symmetrically: a leading reasoning block
+  (`<think>` or Gemma's reasoning channel) or a Markdown JSON code fence around a
+  plan / tool-call envelope is stripped before the fail-closed parse. Pull and serve
+  the recommended local model (Apache-2.0, text + image) with `just
+  fetch-gemma-model` and `just review-serve-gemma`. (serve/inference/docs)
 - **Data Lab — a multi-modal asset viewer + the datasets keystone.** Committed run
   artifacts and retrieval hits now render **inline in the browser** by kind: images,
   video, and audio (from a `blob:` object URL — never a remote `src`, so no

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -175,14 +175,22 @@ const MAX_SERVE_N_CTX: u32 = 8192;
 /// `kx_model_harness::registration::AGENT_MIN_CTX_TOKENS`).
 const AGENT_MIN_CTX_TOKENS: u32 = 2048;
 
+/// The fixed system instruction for the served chat / agentic model (the
+/// precise-assistant "training contract"). Shared by the model-agnostic
+/// `render_chat` path (passed as the system message, then wrapped in the model's
+/// OWN template) and the hand-rolled [`chatml`] fallback (embedded into the
+/// ChatML system turn) — so the system prompt is identical on both paths.
+const SERVE_SYSTEM: &str = "You are a precise assistant. Follow the instruction exactly.";
+
 /// Qwen ChatML wrapping of a user prompt — the **training contract** the
 /// companion model repo mirrors (kept byte-identical to
 /// `kx_model_harness::prompt::chatml`; duplicated here so the production gateway
-/// need not depend on the eval harness).
+/// need not depend on the eval harness). The FALLBACK used when the backend
+/// cannot render the model's own chat template (PR-1 model-agnostic templating).
 #[must_use]
 fn chatml(prompt: &str) -> String {
     format!(
-        "<|im_start|>system\nYou are a precise assistant. Follow the instruction exactly.<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\n{SERVE_SYSTEM}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
     )
 }
 
@@ -549,12 +557,26 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         // text; they ride as a content_ref the backend fetches through its
         // bound store. A present-but-malformed ref fails CLOSED (silently
         // answering without the attached image would be a lie).
+        // Model-agnostic prompt formatting (PR-1): render the system + instruction
+        // through the served model's OWN chat template (the backend applies the
+        // GGUF's embedded template via llama.cpp, with a built-in per-arch
+        // fallback — e.g. Gemma-4, whose template llama.cpp cannot render). A
+        // backend that can't render (the deterministic test stub) returns `None`,
+        // so we fall back to the long-standing hand-rolled ChatML — byte-identical
+        // to pre-PR-1 for those paths. The wrapping is presentation only, never an
+        // identity/authority input (SN-8); the raw `instruction` already fixed the
+        // Mote identity via `config_subset[PROMPT_KEY]`.
+        let format = |user: &str| -> String {
+            self.backend
+                .render_chat(&mote.def.model_id, SERVE_SYSTEM, user)
+                .unwrap_or_else(|| chatml(user))
+        };
         let input = match image_ref_from_config(mote).map_err(|e| internal(&e))? {
             Some(image) => InferenceInput::Multimodal {
-                text: chatml(&format!("{MEDIA_MARKER}{instruction}")),
+                text: format(&format!("{MEDIA_MARKER}{instruction}")),
                 content_refs: std::iter::once(image).collect(),
             },
-            None => InferenceInput::text(chatml(&instruction)),
+            None => InferenceInput::text(format(&instruction)),
         };
         let params = inference_params_from_mote(mote, warrant)
             .map_err(|e| internal(&format!("inference params: {e}")))?;

--- a/crates/kx-inference/src/backend.rs
+++ b/crates/kx-inference/src/backend.rs
@@ -113,6 +113,25 @@ pub trait InferenceBackend: Send + Sync {
         self.dispatch(model_id, input, params, warrant)
     }
 
+    /// Render a chat prompt (`system` + `user`) into the model's expected input
+    /// string, using the model's OWN chat template where the backend can.
+    ///
+    /// Model-agnostic prompt formatting: the OSS llama backend OVERRIDES this to
+    /// apply the GGUF's embedded `chat_template` via llama.cpp (`apply_chat_template`
+    /// — what `llama-server` does), with a built-in per-architecture fallback for
+    /// models whose template llama.cpp cannot render (e.g. Gemma-4). The DEFAULT
+    /// returns `None`, so a caller falls back to its own formatting and the trait
+    /// stays dyn-compatible. Cloud backends (`vLLM` / `SGLang`) that apply the
+    /// template server-side may also leave this `None`.
+    ///
+    /// `None` ⇒ the caller should format the prompt itself (e.g. hand-rolled
+    /// `ChatML`). This is purely presentation: the rendered string is NOT an
+    /// identity or authority input (SN-8) — it is tokenized and fed to the model.
+    fn render_chat(&self, model_id: &ModelId, system: &str, user: &str) -> Option<String> {
+        let (_, _, _) = (model_id, system, user);
+        None
+    }
+
     /// Whether this backend can serve the named model.
     ///
     /// The dispatcher uses this to choose which backend to route a

--- a/crates/kx-inference/src/cache.rs
+++ b/crates/kx-inference/src/cache.rs
@@ -39,8 +39,8 @@ use std::time::{Duration, Instant};
 
 use kx_content::ContentRef;
 use kx_llamacpp::{
-    Bitmap, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model, ModelWithProjector,
-    Mtmd, PoolingType, Sampler, Vocab,
+    Bitmap, ChatMessage, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model,
+    ModelWithProjector, Mtmd, PoolingType, Sampler, Vocab,
 };
 use kx_mote::{InferenceParams, ModelId};
 use smallvec::SmallVec;
@@ -125,15 +125,35 @@ struct EmbedJob {
     reply: Sender<Result<EmbeddingOutput, InferenceError>>,
 }
 
-/// The owner thread serves both completion and embedding jobs over one channel
-/// so a single loaded-model LRU backs both (an embedding reuses the cached
-/// generation model). Boxed variants keep the enum small (the completion `Job`
-/// is heavyweight).
+/// One chat-template render request handed to the owner thread (model-agnostic
+/// templating). Shares the owner thread + loaded-model LRU with [`Job`]/[`EmbedJob`]
+/// so a render reuses an already-cached model. Produces the model's expected
+/// prompt STRING — via the GGUF's embedded `chat_template` (llama.cpp's `minja`,
+/// model-agnostic), falling back to a built-in arch template when `minja` cannot
+/// render the embedded one (e.g. Gemma-4's complex tool-calling template). No
+/// sampler, no generation loop.
+struct RenderJob {
+    /// Loaded-model cache key (the same identity used by [`Job`]).
+    identity: ContentRef,
+    /// Where to load the model from on a cache miss.
+    path: PathBuf,
+    /// `(role, content)` messages, in order (typically system then user).
+    messages: Vec<(String, String)>,
+    /// Where the owner thread sends the rendered prompt.
+    reply: Sender<Result<String, InferenceError>>,
+}
+
+/// The owner thread serves completion, embedding, and chat-template-render jobs
+/// over one channel so a single loaded-model LRU backs all three (each reuses the
+/// cached model). Boxed variants keep the enum small (the completion `Job` is
+/// heavyweight).
 enum OwnerJob {
     /// A completion / generation request (text or multimodal).
     Generate(Box<Job>),
     /// An embedding request (DP1).
     Embed(Box<EmbedJob>),
+    /// A chat-template render request (model-agnostic prompt formatting).
+    RenderChat(Box<RenderJob>),
 }
 
 /// Map the FFI-free [`EmbeddingPooling`] seam type to `kx-llamacpp`'s
@@ -273,6 +293,37 @@ impl ModelCache {
                 message: "model-cache owner thread died mid-job (recv failed)".to_string(),
             })?
     }
+
+    /// Render `messages` into the model's expected prompt STRING on the owner
+    /// thread (where the model is resident), and block until the reply. Shares the
+    /// loaded-model LRU, so a render reuses a model a prior dispatch cached (and a
+    /// subsequent generation of the rendered prompt then hits that warm model).
+    pub(crate) fn render_chat(
+        &self,
+        identity: ContentRef,
+        path: PathBuf,
+        messages: Vec<(String, String)>,
+    ) -> Result<String, InferenceError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let job = RenderJob {
+            identity,
+            path,
+            messages,
+            reply: reply_tx,
+        };
+        self.tx
+            .send(OwnerJob::RenderChat(Box::new(job)))
+            .map_err(|_| InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: "model-cache owner thread is gone (send failed)".to_string(),
+            })?;
+        reply_rx
+            .recv()
+            .map_err(|_| InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: "model-cache owner thread died mid-job (recv failed)".to_string(),
+            })?
+    }
 }
 
 /// The owner thread's loop. Owns the (`!Send`) backend and the loaded-model LRU
@@ -295,6 +346,9 @@ fn owner_loop(
                         let _ = job.reply.send(Err(err.clone()));
                     }
                     OwnerJob::Embed(job) => {
+                        let _ = job.reply.send(Err(err.clone()));
+                    }
+                    OwnerJob::RenderChat(job) => {
                         let _ = job.reply.send(Err(err.clone()));
                     }
                 }
@@ -320,6 +374,10 @@ fn owner_loop(
             }
             OwnerJob::Embed(job) => {
                 let result = run_embed_job(&backend, &mut lru, capacity, loads, &job);
+                let _ = job.reply.send(result);
+            }
+            OwnerJob::RenderChat(job) => {
+                let result = run_render_job(&backend, &mut lru, capacity, loads, &job);
                 let _ = job.reply.send(result);
             }
         }
@@ -391,6 +449,37 @@ fn run_embed_job<'b>(
         model_id: job.model_id.clone(),
         elapsed: start.elapsed(),
     })
+}
+
+/// Resolve-or-load the model (reusing the SHARED LRU), then render `job.messages`
+/// into the model's expected prompt string. The PRIMARY path is the model's own
+/// embedded `chat_template` via llama.cpp's `minja` (model-agnostic — what
+/// `llama-server` does); on a `minja` render failure (e.g. Gemma-4's complex
+/// tool-calling template, `rc = -1`) it falls back to a built-in template keyed on
+/// the GGUF architecture. No sampler, no generation loop — a single template
+/// apply, so it is cheap once the model is warm.
+fn run_render_job<'b>(
+    backend: &'b LlamaBackend,
+    lru: &mut Vec<(ContentRef, ModelWithProjector<'b>)>,
+    capacity: usize,
+    loads: &AtomicU64,
+    job: &RenderJob,
+) -> Result<String, InferenceError> {
+    let entry = get_or_load(backend, lru, capacity, loads, job.identity, &job.path)
+        .map_err(map_llama_err)?;
+    let model = entry.model();
+    let messages: Vec<ChatMessage> = job
+        .messages
+        .iter()
+        .map(|(role, content)| ChatMessage::new(role.clone(), content.clone()))
+        .collect();
+    // Embedded template first — correct for any model llama.cpp can template.
+    if let Ok(rendered) = model.apply_chat_template(None, &messages, /* add_assistant */ true) {
+        return Ok(rendered);
+    }
+    // Fallback: `minja` could not render the embedded template (Gemma-4). Use a
+    // built-in template keyed on the GGUF arch (the leading token of `desc()`).
+    Ok(crate::templates::builtin_render(&model.desc(), &messages))
 }
 
 /// Return a mutable reference to the cached model bundle for `identity`,

--- a/crates/kx-inference/src/lib.rs
+++ b/crates/kx-inference/src/lib.rs
@@ -48,6 +48,11 @@ mod dispatcher;
 mod cache;
 #[cfg(feature = "llamacpp")]
 mod llama;
+// Built-in chat-template fallbacks (Gemma / ChatML) for models whose embedded
+// GGUF template llama.cpp's `minja` cannot render. Uses `kx_llamacpp` types, so
+// it rides the same `llamacpp` gate as `cache`/`llama`.
+#[cfg(feature = "llamacpp")]
+mod templates;
 mod types;
 
 pub use backend::{BatchItem, EmbeddingBackend, InferenceBackend, TokenSink};

--- a/crates/kx-inference/src/llama.rs
+++ b/crates/kx-inference/src/llama.rs
@@ -409,6 +409,30 @@ impl InferenceBackend for LlamaInferenceBackend {
         self.dispatch_inner(model_id, input, params, warrant, token_sink)
     }
 
+    /// Model-agnostic prompt formatting: render `system` + `user` through the
+    /// model's OWN chat template. Resolves the descriptor (no warrant gate — this
+    /// is pure formatting, not a model route; the route is enforced at `dispatch`)
+    /// and renders on the shared owner thread (where the model is resident),
+    /// reusing the loaded-model LRU. `None` iff the model id is unresolvable or the
+    /// render fails — the caller then falls back to its own formatting.
+    fn render_chat(&self, model_id: &ModelId, system: &str, user: &str) -> Option<String> {
+        let descriptor = self.resolver.resolve(model_id)?;
+        let cache = self
+            .cache
+            .get_or_init(|| ModelCache::spawn(self.cache_capacity));
+        let messages = vec![
+            ("system".to_string(), system.to_string()),
+            ("user".to_string(), user.to_string()),
+        ];
+        cache
+            .render_chat(
+                descriptor.identity_digest,
+                descriptor.gguf_path.clone(),
+                messages,
+            )
+            .ok()
+    }
+
     fn supports(&self, model_id: &ModelId) -> bool {
         self.resolver.resolve(model_id).is_some()
     }

--- a/crates/kx-inference/src/templates.rs
+++ b/crates/kx-inference/src/templates.rs
@@ -1,0 +1,125 @@
+//! Built-in chat templates — the FALLBACK for models whose embedded GGUF
+//! `tokenizer.chat_template` llama.cpp's `minja` engine cannot render.
+//!
+//! The PRIMARY templating path is the model's OWN embedded template, applied via
+//! [`kx_llamacpp::Model::apply_chat_template`] (what `llama-server` does) — that
+//! is model-agnostic and correct for any model llama.cpp can template (Qwen,
+//! Mistral, Llama, …). These built-ins cover the gaps: notably **Gemma-4**, whose
+//! 17 KB tool-calling jinja template `minja` rejects (`rc = -1`), so a faithful
+//! hand-rolled fallback is required.
+//!
+//! Both renders are **pure + deterministic** (no date / random injection), which
+//! preserves the greedy + content-addressed replay contract (R49): the same
+//! messages always produce the same prompt, hence a byte-reproducible completion.
+//!
+//! The render produces a string with the model's control tokens AS TEXT; the
+//! dispatch tokenizer parses them as special tokens (`parse_special = true`),
+//! exactly as the existing hand-rolled `ChatML` path always has — so there is no
+//! new BOS / special-token handling here.
+
+use kx_llamacpp::ChatMessage;
+
+/// Render `messages` with a built-in template keyed on `model_desc`'s leading
+/// architecture token. `model_desc` is `kx_llamacpp::Model::desc()` (llama.cpp's
+/// `llama_model_desc`, e.g. `"gemma4 12B Q4_K - Medium"` → arch `"gemma4"`).
+#[must_use]
+pub(crate) fn builtin_render(model_desc: &str, messages: &[ChatMessage]) -> String {
+    let arch = model_desc.split_whitespace().next().unwrap_or_default();
+    if arch.starts_with("gemma") {
+        gemma(messages)
+    } else {
+        // ChatML is the broad default (Qwen / Yi / many Mistral GGUFs). Reached
+        // only when the embedded template is absent or unrenderable AND the model
+        // is not Gemma — a deliberately conservative last resort.
+        chatml(messages)
+    }
+}
+
+/// Gemma-4 turn format (`<|turn>{role}\n…<turn|>`) + the answer-channel
+/// generation prompt the embedded template emits for `add_generation_prompt` with
+/// `enable_thinking=false`. Gemma's assistant role token is `model`.
+fn gemma(messages: &[ChatMessage]) -> String {
+    let mut s = String::new();
+    for m in messages {
+        let role = if m.role == "assistant" {
+            "model"
+        } else {
+            m.role.as_str()
+        };
+        s.push_str("<|turn>");
+        s.push_str(role);
+        s.push('\n');
+        s.push_str(&m.content);
+        s.push_str("<turn|>\n");
+    }
+    s.push_str("<|turn>model\n<|channel>thought\n<channel|>");
+    s
+}
+
+/// Qwen / `ChatML` format (`<|im_start|>{role}\n…<|im_end|>`) + the assistant
+/// prefix. Byte-identical to the long-standing hand-rolled `chatml()` shape.
+fn chatml(messages: &[ChatMessage]) -> String {
+    let mut s = String::new();
+    for m in messages {
+        s.push_str("<|im_start|>");
+        s.push_str(&m.role);
+        s.push('\n');
+        s.push_str(&m.content);
+        s.push_str("<|im_end|>\n");
+    }
+    s.push_str("<|im_start|>assistant\n");
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msgs() -> Vec<ChatMessage> {
+        vec![ChatMessage::system("be precise"), ChatMessage::user("hi")]
+    }
+
+    #[test]
+    fn gemma_arch_uses_turn_format_with_answer_channel() {
+        let out = builtin_render("gemma4 12B Q4_K - Medium", &msgs());
+        assert_eq!(
+            out,
+            "<|turn>system\nbe precise<turn|>\n<|turn>user\nhi<turn|>\n\
+             <|turn>model\n<|channel>thought\n<channel|>"
+        );
+    }
+
+    #[test]
+    fn gemma3_prefix_also_matches() {
+        assert!(builtin_render("gemma3 4B", &msgs()).starts_with("<|turn>system\n"));
+    }
+
+    #[test]
+    fn non_gemma_falls_back_to_chatml() {
+        let out = builtin_render("qwen3 0.6B Q4_K - Medium", &msgs());
+        assert_eq!(
+            out,
+            "<|im_start|>system\nbe precise<|im_end|>\n\
+             <|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n"
+        );
+    }
+
+    #[test]
+    fn unknown_arch_defaults_to_chatml() {
+        assert!(builtin_render("", &msgs()).starts_with("<|im_start|>"));
+    }
+
+    #[test]
+    fn assistant_role_renders_as_model_for_gemma() {
+        let m = vec![ChatMessage::assistant("prior")];
+        assert!(gemma(&m).starts_with("<|turn>model\nprior<turn|>\n"));
+    }
+
+    #[test]
+    fn deterministic_same_input_same_output() {
+        assert_eq!(
+            builtin_render("gemma4", &msgs()),
+            builtin_render("gemma4", &msgs())
+        );
+    }
+}

--- a/crates/kx-planner/src/decode.rs
+++ b/crates/kx-planner/src/decode.rs
@@ -45,25 +45,57 @@ pub fn max_plan_bytes(warrant: &WarrantSpec) -> usize {
     (warrant.model_route.max_output_tokens as usize).saturating_mul(4)
 }
 
-/// Strip a single leading `<think>…</think>` reasoning block (Qwen3 thinking
-/// mode) so the strict envelope parser sees the JSON plan that follows it.
+/// Extract the JSON envelope a model wrapped in reasoning and/or a markdown code
+/// fence, so the strict parser sees the bare `{ … }`. Removes, in order:
+///   1. a SINGLE leading reasoning block — Qwen3 `<think>…</think>` OR Gemma-4
+///      `<|channel>…<channel|>` (the answer follows the close tag);
+///   2. a surrounding markdown code fence — ```` ```json … ``` ```` (Gemma-4
+///      reliably fences structured output) or a bare ```` ``` … ``` ````.
 ///
-/// ONLY a leading block is removed — never a mid-string scan. An unclosed
-/// `<think>` (reasoning with no closing tag) yields `""`, which fails the
-/// strict parse below (a plan is mandatory) — fail-closed.
-///
-/// Total + panic-free (`find` returns a valid byte boundary; the ASCII close
-/// tag makes the post-tag slice boundary always valid).
+/// Model-agnostic, total + panic-free over arbitrary input. It ONLY strips known
+/// wrappers — the strict, `deny_unknown_fields` serde parse downstream still gates
+/// the envelope (fail-closed), so widening the accepted wrapper set never opens a
+/// smuggling vector (the size cap on the ORIGINAL bytes still bounds the parse,
+/// and extraction can only shrink). An unclosed reasoning tag yields `""`, which
+/// the strict parse rejects (a plan is mandatory).
+fn extract_json_envelope(text: &str) -> &str {
+    strip_code_fence(strip_reasoning_preamble(text))
+}
+
+/// Strip a SINGLE leading reasoning block: Qwen3 `<think>…</think>` or Gemma-4
+/// `<|channel>…<channel|>`. An unclosed tag yields `""`. Total + panic-free (the
+/// ASCII close tag makes every post-tag slice boundary valid).
 fn strip_reasoning_preamble(text: &str) -> &str {
-    const OPEN: &str = "<think>";
-    const CLOSE: &str = "</think>";
     let t = text.trim_start();
-    let Some(rest) = t.strip_prefix(OPEN) else {
+    for (open, close) in [("<think>", "</think>"), ("<|channel>", "<channel|>")] {
+        if let Some(rest) = t.strip_prefix(open) {
+            return match rest.find(close) {
+                Some(i) => rest[i + close.len()..].trim_start(),
+                None => "",
+            };
+        }
+    }
+    t
+}
+
+/// Strip a surrounding markdown code fence (```` ``` ````), optionally with a
+/// language tag (```` ```json ````). Returns the inner content trimmed; no fence
+/// ⇒ `text` trimmed. Total + panic-free (the fence delimiter is ASCII, so every
+/// slice boundary is valid).
+fn strip_code_fence(text: &str) -> &str {
+    let t = text.trim();
+    let Some(rest) = t.strip_prefix("```") else {
         return t;
     };
-    match rest.find(CLOSE) {
-        Some(i) => rest[i + CLOSE.len()..].trim_start(),
-        None => "",
+    // Drop an optional language tag up to the first newline (```json\n…).
+    let inner = match rest.find('\n') {
+        Some(nl) => &rest[nl + 1..],
+        None => rest,
+    };
+    // Drop the trailing closing fence if present.
+    match inner.rfind("```") {
+        Some(i) => inner[..i].trim(),
+        None => inner.trim(),
     }
 }
 
@@ -98,7 +130,7 @@ pub fn decode_plan(bytes: &[u8], max_plan_bytes: usize) -> Result<Plan, PlanErro
     let text = std::str::from_utf8(bytes).map_err(|_| PlanError::Malformed {
         diagnostic: "model output was not valid UTF-8".to_string(),
     })?;
-    let stripped = strip_reasoning_preamble(text);
+    let stripped = extract_json_envelope(text);
     let envelope: Envelope = serde_json::from_str(stripped).map_err(|e| PlanError::Malformed {
         diagnostic: e.to_string(),
     })?;
@@ -165,7 +197,7 @@ pub fn decode_loop_proposal(bytes: &[u8], max_bytes: usize) -> Result<LoopPropos
     let text = std::str::from_utf8(bytes).map_err(|_| PlanError::Malformed {
         diagnostic: "model output was not valid UTF-8".to_string(),
     })?;
-    let stripped = strip_reasoning_preamble(text);
+    let stripped = extract_json_envelope(text);
     let envelope: LoopEnvelope =
         serde_json::from_str(stripped).map_err(|e| PlanError::Malformed {
             diagnostic: e.to_string(),
@@ -226,7 +258,7 @@ pub fn decode_replan_proposal(bytes: &[u8], max_bytes: usize) -> Result<ReplanPr
     let text = std::str::from_utf8(bytes).map_err(|_| PlanError::Malformed {
         diagnostic: "model output was not valid UTF-8".to_string(),
     })?;
-    let stripped = strip_reasoning_preamble(text);
+    let stripped = extract_json_envelope(text);
     let envelope: ReplanEnvelope =
         serde_json::from_str(stripped).map_err(|e| PlanError::Malformed {
             diagnostic: e.to_string(),

--- a/crates/kx-planner/src/tests.rs
+++ b/crates/kx-planner/src/tests.rs
@@ -164,6 +164,26 @@ fn think_preamble_then_plan_decodes() {
 }
 
 #[test]
+fn fenced_plan_decodes() {
+    // Gemma-4 reliably fences structured output in a ```json block.
+    let bytes = json(
+        "```json\n{\"plan\":{\"version\":1,\"steps\":[{\"role\":\"reader\",\"intent\":\"read\"}],\"edges\":[]}}\n```",
+    );
+    let plan = decode_plan(&bytes, 8192).expect("a fenced plan decodes");
+    assert_eq!(plan.steps.len(), 1);
+}
+
+#[test]
+fn gemma_channel_then_fenced_plan_decodes() {
+    // Gemma-4: a `<|channel>thought…<channel|>` reasoning segment then a fenced plan.
+    let bytes = json(
+        "<|channel>thought\nI will produce a plan.<channel|>```json\n{\"plan\":{\"version\":1,\"steps\":[{\"role\":\"reader\",\"intent\":\"read\"}],\"edges\":[]}}\n```",
+    );
+    let plan = decode_plan(&bytes, 8192).expect("channel + fence + plan decodes");
+    assert_eq!(plan.steps.len(), 1);
+}
+
+#[test]
 fn unclosed_think_is_malformed() {
     // An unterminated reasoning block strips to "" ⇒ a plan is mandatory ⇒ Err.
     assert!(matches!(

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -32,26 +32,51 @@ pub fn max_args_bytes(warrant: &WarrantSpec) -> usize {
     (warrant.model_route.max_output_tokens as usize).saturating_mul(4)
 }
 
-/// Strip a single leading `<think>…</think>` reasoning block (Qwen3 thinking
-/// mode) so the strict envelope parser sees the JSON that follows it.
+/// Extract the JSON envelope a model wrapped in reasoning and/or a markdown code
+/// fence, so the strict parser sees the bare `{ … }`. Removes a SINGLE leading
+/// reasoning block — Qwen3 `<think>…</think>` OR Gemma-4 `<|channel>…<channel|>`
+/// — then a surrounding markdown code fence (```` ```json … ``` ````; Gemma-4
+/// reliably fences structured output).
 ///
-/// ONLY a leading block is removed — we never scan for `{` mid-string, which
-/// would reopen the injection vector the strict `starts_with('{')` gate closes.
-/// An unclosed `<think>` (reasoning with no closing tag / no JSON) yields `""`,
-/// which the caller treats as a normal (non-call) completion — fail-closed.
-///
-/// Total + panic-free (`find` returns a valid byte boundary; the close tag is
-/// ASCII so the post-tag slice boundary is always valid).
+/// Leading-block + structural-wrapper ONLY — we NEVER scan for `{` mid-string
+/// (the fence is a defined ```` ``` ```` delimiter, not a `{` search), so the
+/// strict `starts_with('{')` gate below stays the injection boundary (SN-8).
+/// Mirrors `kx_planner::decode`'s extractor — the two trust seams keep the SAME
+/// discipline. Total + panic-free; an unclosed reasoning tag yields `""`, which
+/// the caller treats as a normal (non-call) completion (fail-closed).
+fn extract_json_envelope(text: &str) -> &str {
+    strip_code_fence(strip_reasoning_preamble(text))
+}
+
+/// Strip a SINGLE leading reasoning block: Qwen3 `<think>…</think>` or Gemma-4
+/// `<|channel>…<channel|>`. An unclosed tag yields `""`.
 fn strip_reasoning_preamble(text: &str) -> &str {
-    const OPEN: &str = "<think>";
-    const CLOSE: &str = "</think>";
     let t = text.trim_start();
-    let Some(rest) = t.strip_prefix(OPEN) else {
+    for (open, close) in [("<think>", "</think>"), ("<|channel>", "<channel|>")] {
+        if let Some(rest) = t.strip_prefix(open) {
+            return match rest.find(close) {
+                Some(i) => rest[i + close.len()..].trim_start(),
+                None => "",
+            };
+        }
+    }
+    t
+}
+
+/// Strip a surrounding markdown code fence (```` ``` ````), optionally tagged
+/// (```` ```json ````). No fence ⇒ `text` trimmed. Total + panic-free.
+fn strip_code_fence(text: &str) -> &str {
+    let t = text.trim();
+    let Some(rest) = t.strip_prefix("```") else {
         return t;
     };
-    match rest.find(CLOSE) {
-        Some(i) => rest[i + CLOSE.len()..].trim_start(),
-        None => "",
+    let inner = match rest.find('\n') {
+        Some(nl) => &rest[nl + 1..],
+        None => rest,
+    };
+    match inner.rfind("```") {
+        Some(i) => inner[..i].trim(),
+        None => inner.trim(),
     }
 }
 
@@ -90,9 +115,10 @@ pub fn parse_tool_call(
     let Ok(text) = std::str::from_utf8(bytes) else {
         return Ok(None);
     };
-    // Strip a leading Qwen3 `<think>…</think>` block, then require the remainder
-    // to BEGIN with `{` — leading-block-only; no mid-string scan (SN-8).
-    let trimmed = strip_reasoning_preamble(text);
+    // Strip a leading reasoning block (Qwen3 `<think>` / Gemma-4 `<|channel>`) and
+    // a surrounding ```` ```json ```` fence, then require the remainder to BEGIN
+    // with `{` — leading-block + structural-fence only; no mid-string scan (SN-8).
+    let trimmed = extract_json_envelope(text);
     if !trimmed.starts_with('{') {
         return Ok(None);
     }
@@ -219,6 +245,31 @@ mod tests {
         let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
         assert_eq!(call.name, ToolName("mcp-echo".into()));
         assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn fenced_envelope_is_decoded() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Gemma-4 reliably fences structured output in a ```json block.
+        let env =
+            b"```json\n{\"tool_call\":{\"name\":\"mcp-echo\",\"version\":\"1\",\"args\":{\"q\":\"x\"}}}\n```";
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a fenced call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn gemma_channel_then_fenced_envelope_is_decoded() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Gemma-4: a `<|channel>thought…<channel|>` reasoning segment then a
+        // fenced tool-call.
+        let env = b"<|channel>thought\nI should echo.<channel|>```json\n{\"tool_call\":{\"name\":\"mcp-echo\",\"version\":\"1\",\"args\":{}}}\n```";
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a channel + fence call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
     }
 
     #[test]

--- a/docs/site/docs/models.md
+++ b/docs/site/docs/models.md
@@ -36,6 +36,23 @@ enforces](./security.md#model-proposes-runtime-enforces)).
 - **Older gateway.** A gateway that predates `ListModels` degrades to a
   "not wired" notice rather than a blank screen.
 
+## Local models & prompt formatting
+
+A model-serving gateway loads a local GGUF named by `KX_SERVE_MODEL_GGUF` (plus an
+optional `KX_SERVE_MMPROJ_GGUF` vision projector). The gateway is
+**model-agnostic**: every model is prompted with its OWN chat template — the
+gateway applies the GGUF's embedded `chat_template` through llama.cpp where it
+renders, and falls back to a built-in per-architecture template for models
+llama.cpp cannot render, so a model is never fed another model's format. A
+recipe's structured reply is normalized symmetrically: a leading reasoning block
+or a Markdown code fence around the JSON is stripped before the runtime parses
+it, fail-closed.
+
+The recommended local model is **Gemma-4-12B** (Apache-2.0; omni — `text` +
+`image`). A tiny public **Qwen3-0.6B** stand-in backs the
+[Quickstart](./quickstart.md) and CI. Pull Gemma locally with `just
+fetch-gemma-model` and serve it (text + vision) with `just review-serve-gemma`.
+
 ## Cloud & coming soon
 
 Connecting a managed cloud provider (vendor keys + OAuth) is a **Cloud**

--- a/justfile
+++ b/justfile
@@ -181,6 +181,44 @@ fetch-agent-model:
     echo "     export KX_MODEL_NAME=qwen3-0.6b"
     echo "     export KX_MODEL_HARNESS_GGUF=\"$(pwd)/$DEST\""
 
+# Download the Gemma-4-12B omni model (Q4_K_M GGUF ~7.1 GB + its vision mmproj
+# ~175 MB) from unsloth to target/models/, SHA-256-verified + idempotent. This is
+# the LOCAL / CLOUD real-test + benchmark model going forward (D158); CI stays on
+# the tiny public Qwen3-0.6B (`fetch-agent-model`). REQUIRES the gemma4uv-capable
+# llama.cpp pin (>= d2462f8f7; see crates/kx-llamacpp-sys/PIN.md). Override the
+# quant via KX_GEMMA_MODEL_{URL,SHA,DEST} (a SHA is REQUIRED — never unverified).
+fetch-gemma-model:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    BASE="https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main"
+    dl() {
+      url="$1"; dest="$2"; sha="$3"
+      if [ -f "$dest" ] && [ "$(shasum -a 256 "$dest" | cut -d' ' -f1)" = "$sha" ]; then
+        echo " ✓ already present + verified: $dest"; return 0
+      fi
+      echo "Downloading $url → $dest ..."
+      rm -f "$dest" "$dest.partial"
+      if [ -n "${HF_TOKEN:-}" ]; then
+        curl -fsSL -H "Authorization: Bearer ${HF_TOKEN}" "$url" -o "$dest.partial"
+      else
+        curl -fsSL "$url" -o "$dest.partial"
+      fi
+      got="$(shasum -a 256 "$dest.partial" | cut -d' ' -f1)"
+      if [ "$got" != "$sha" ]; then
+        echo " ✗ SHA-256 mismatch for $dest: expected $sha got $got" >&2
+        rm -f "$dest.partial"; exit 1
+      fi
+      mv "$dest.partial" "$dest"; echo " ✓ verified + saved: $dest"
+    }
+    mkdir -p target/models
+    dl "${KX_GEMMA_MMPROJ_URL:-$BASE/mmproj-F16.gguf}" \
+       "${KX_GEMMA_MMPROJ_DEST:-target/models/gemma-4-12b-it-mmproj-f16.gguf}" \
+       "${KX_GEMMA_MMPROJ_SHA:-91f086971e56d7a7d8d39e271873fccdb49541bd259d6e02c401a4f1cb7a219e}"
+    dl "${KX_GEMMA_MODEL_URL:-$BASE/gemma-4-12b-it-Q4_K_M.gguf}" \
+       "${KX_GEMMA_MODEL_DEST:-target/models/gemma-4-12b-it-q4_k_m.gguf}" \
+       "${KX_GEMMA_MODEL_SHA:-43fec98c5102b1c446b4ddd0a9439f1db3a2e1f2e0b8cd143ce1ea619a9403d6}"
+    echo "   Serve it (text + vision): just review-serve-gemma"
+
 # The ONE-COMMAND inference serve (§2.194 guardrail): fetch the stand-in model
 # if absent (idempotent, checksum-verified), then start `kx serve` with it +
 # the embedded console at :50180. Model paths are DETERMINISTIC
@@ -247,6 +285,50 @@ review-serve journal="target/serve/kx.db" content="target/serve/blobs": fetch-ag
     echo ""
     echo " ✅ REVIEW SERVE READY — console http://127.0.0.1:$PORT/  ·  connect $GRPC"
     echo "    (review in BOTH themes; chat returns a real <think>+answer, never echo)"
+    wait $SERVE_PID
+
+# The Gemma-4-12B omni PR-review serve (TEXT + VISION) — the `review-serve` twin
+# for the local/cloud real-test model (D158). Same three guardrails (FRESH embed ·
+# model loaded · REAL non-echo completion). Sets KX_SERVE_MMPROJ_GGUF so the
+# vision recipe is provisioned (the gemma4uv projector; needs the PIN.md bump).
+# 12B loads slower than the stand-in, so the readiness wait is longer. Review in
+# BOTH themes; chat returns a real answer (Gemma's reasoning channel is collapsed
+# by the model-agnostic templating, never echo).
+review-serve-gemma journal="target/serve/kx.db" content="target/serve/blobs": fetch-gemma-model console-dist
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PORT=50180; GRPC="http://127.0.0.1:50151"
+    MODEL="${KX_GEMMA_MODEL_DEST:-$(pwd)/target/models/gemma-4-12b-it-q4_k_m.gguf}"
+    MMPROJ="${KX_GEMMA_MMPROJ_DEST:-$(pwd)/target/models/gemma-4-12b-it-mmproj-f16.gguf}"
+    test -f "$MODEL" || { echo " ✗ model GGUF missing: $MODEL" >&2; exit 1; }
+    test -f "$MMPROJ" || { echo " ✗ mmproj GGUF missing: $MMPROJ" >&2; exit 1; }
+    cargo build --release -p kx-cli --features inference,hnsw,console --bin kx
+    KX="$(pwd)/target/release/kx"
+    PIDS="$(lsof -ti tcp:$PORT 2>/dev/null || true)"
+    [ -n "$PIDS" ] && { echo " ! killing stale process on :$PORT ($PIDS)"; kill $PIDS 2>/dev/null || true; sleep 1; }
+    mkdir -p "$(dirname "{{journal}}")" "{{content}}"
+    export KX_SERVE_MODEL_GGUF="$MODEL" KX_SERVE_MMPROJ_GGUF="$MMPROJ"
+    echo " ▶ Gemma review serve (model: $MODEL  +  vision mmproj: $MMPROJ)"
+    "$KX" serve --journal "{{journal}}" --content "{{content}}" --dev-allow-local &
+    SERVE_PID=$!; trap 'kill $SERVE_PID 2>/dev/null || true' EXIT
+    for i in $(seq 1 120); do curl -fsS "http://127.0.0.1:$PORT/" -o /dev/null 2>/dev/null && break; sleep 1; done
+    SERVED="$(curl -fsS "http://127.0.0.1:$PORT/" | shasum -a 256 | cut -d' ' -f1)"
+    DISK="$(shasum -a 256 ui/dist/index.html | cut -d' ' -f1)"
+    [ "$SERVED" = "$DISK" ] || { echo " ✗ STALE EMBED: served $SERVED != ui/dist $DISK — rebuild"; exit 1; }
+    echo " ✓ fresh console embed ($SERVED)"
+    "$KX" models list --endpoint "$GRPC" --json \
+      | python3 -c "import json,sys; sys.exit(0 if len(json.load(sys.stdin).get('models',[]))>=1 else 1)" \
+      || { echo " ✗ NO MODEL: ListModels empty — chat would echo. Set KX_SERVE_MODEL_GGUF."; exit 1; }
+    echo " ✓ model loaded (ListModels non-empty)"
+    PROMPT="Reply with only the digit: what is 2+2?"
+    OUT="$("$KX" invoke kx/recipes/chat --args "{\"prompt\":\"$PROMPT\"}" --wait --json --endpoint "$GRPC" \
+      | python3 -c "import json,sys; print(json.load(sys.stdin).get('result_utf8',''))" 2>/dev/null || true)"
+    [ -n "$OUT" ] || { echo " ✗ chat returned no committed result — model not answering."; exit 1; }
+    case "$OUT" in *"$PROMPT"*) echo " ✗ ECHO DETECTED: chat returned the prompt verbatim."; exit 1;; esac
+    echo " ✓ real non-echo Gemma completion: $(printf '%s' "$OUT" | tr '\n' ' ' | head -c 70)"
+    echo ""
+    echo " ✅ GEMMA REVIEW SERVE READY — console http://127.0.0.1:$PORT/  ·  connect $GRPC"
+    echo "    (text + vision; review in BOTH themes; chat returns a real answer, never echo)"
     wait $SERVE_PID
 
 # D139: build the web console's embed input — the TS SDK (the UI's file: dep)


### PR DESCRIPTION
**PR-1 of the Gemma-4 migration** (PR-0 #214 — the llama.cpp `gemma4uv` pin bump — is now merged; this rebases cleanly onto `main`, superseding the auto-closed #215).

## What
Make the serve gateway **model-agnostic**: format every model with its OWN chat template instead of a hardcoded ChatML, and serve **Gemma-4-12B** (omni: text + image) as the recommended local model.

**Is ChatML right for all models? No** — feeding ChatML to Gemma-4 mangles its output into reasoning-channel scaffolding. The design:

### Templating — embedded-first, per-arch fallback
- NEW `InferenceBackend::render_chat` (default `None`) + a `LlamaInferenceBackend` override that applies the GGUF's **embedded** chat template via llama.cpp `apply_chat_template` (model-agnostic — what `llama-server` does), with a built-in **per-architecture fallback** (`kx-inference/src/templates.rs`: Gemma turn-format / ChatML) for models llama.cpp's `minja` cannot render. (Gemma-4's 17 KB tool-calling jinja fails `rc=-1` → fallback; Qwen + most models use their embedded template.) Runs on the model-cache owner thread via a new `OwnerJob::RenderChat` (mirrors `dispatch_embedding`); reuses the loaded-model LRU.
- `model_exec::dispatch_model` routes through `render_chat` with the hand-rolled `chatml()` fallback (the deterministic test stub returns `None` ⇒ byte-identical).

### Output normalization
Generalize the planner + tool-call extractors (`kx-planner/decode.rs`, `kx-toolcall/parse.rs`) to strip a leading reasoning block (Qwen `<think>` **or** Gemma `<|channel>`) **and** a Markdown JSON code fence before the strict, fail-closed, `deny_unknown_fields` parse. Structural wrappers only — never a mid-string `{` scan (the SN-8 `starts_with('{')` boundary holds).

### Serve recipes
`just fetch-gemma-model` (SHA-pinned GGUF + mmproj) + `just review-serve-gemma` (text + vision). **CI stays on Qwen3-0.6B.**

## Verified (Apple-M3, Metal)
- Gemma text → clean `"4"`; Gemma **vision** (`gemma4uv`) → `"Red"` on the red-square fixture; Gemma emits the plan JSON (fenced), decoded by the new extractor
- `real-model-e2e` (Qwen3-0.6B, **now via its embedded template**) clean + greedy-deterministic
- templates 6 + planner 41 + toolcall 16 + gateway 154 unit tests (incl. Gemma fence/channel + D77 / mid-string-injection security tests)
- `clippy --workspace --all-targets` + gateway-inference `-D warnings` clean; canonical digest **`7d22d4bd` invariant**; **frozen-trio `dispatcher.rs` untouched**

## Cloud note
vLLM / SGLang apply the chat template server-side; the `render_chat` seam returns `None` for them. Per-engine templating/config is a Cloud-track item (private cloud plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)