### PR TITLE
feat(ui,docs): PR-6a-2 — Tools registry/govern panel + Data Lab Agent Outputs lens + docs

### DIFF
--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -2,19 +2,137 @@
 id: tools
 title: Tools
 sidebar_label: Tools
-description: MCP tool discovery and the ReAct tool loop in Kortecx.
+description: The Kortecx tools registry, the fs-list built-in, the ReAct tool loop, and the OSS/Cloud line.
 ---
 
 # Tools
 
-Kortecx agents call real **MCP tools** inside the live ReAct loop — every tool
-turn committed as a durable fact. Discovery is advisory (`kx tools list` /
-`kx tools score`); authorization is always the runtime's, never a score (see
-[Security](./security.md#model-proposes-runtime-enforces)).
+Kortecx agents call real **tools** inside the live ReAct loop — every tool turn
+committed as a durable fact, exactly-once, replay-re-read. There are two surfaces:
 
-:::note Coming soon
-Full tool documentation — registering tools, the idempotency contract, and the
-`kx/recipes/react` loop — lands with a later docs PR. For now, see the
-[Quickstart agent loop](./quickstart.md#run-the-agent-loop) and the
-[`tools` CLI reference in the README](https://github.com/Kortecx/kortecx/blob/main/README.md#client-commands).
-:::
+- **The durable registry** (`DiscoverTools` / `RegisterTool` / `DeregisterTool`) —
+  the governance inventory: what is registered, with what provenance, status, and
+  egress authority. This is the source of truth for *what tools exist*.
+- **Advisory discovery** (`kx tools list` / `kx tools score`) — a display-only
+  ranking to help *choose* a tool. A score never authorizes anything (SN-8).
+
+> **Authorization is always the runtime's, never a score or a registration.** A
+> tool fires only under a **server-issued warrant**, re-verified by the broker at
+> every call. Registering a tool grants no authority; the `tool_id` is
+> server-derived (a client can never name or forge it). See
+> [Security → model proposes, runtime enforces](./security.md#model-proposes-runtime-enforces).
+
+## The registry (`DiscoverTools` / `RegisterTool` / `DeregisterTool`)
+
+The registry is a durable, off-journal sidecar (`tools.db`) — rebuildable, never a
+projection-digest input. The OSS built-ins (`fs-read@1`, `fs-write@1`,
+`text-summarize@1`) are re-seeded on every open and cannot be deregistered.
+
+### List the inventory
+
+```bash
+kx tools discover --limit 50
+```
+
+```python
+from kortecx import KxClient
+
+client = KxClient("http://localhost:50150", token="…")
+page = client.discover_tools(limit=50)
+for t in page.tools:
+    print(t.tool_name, t.tool_version, t.kind, t.registration_status)
+```
+
+```typescript
+import { KxClient } from "@kortecx/sdk/web";
+
+const client = new KxClient("http://localhost:50150", { token: "…" });
+const page = await client.discoverTools({ limit: 50 });
+```
+
+### Register a declarative external MCP tool
+
+`RegisterTool` records a tool and its **SSRF-vetted** egress host. The host is
+checked at admission (deny-by-default — internal / loopback / link-local /
+metadata endpoints are refused); an optional operator allowlist is
+`KX_SERVE_TOOL_HOST_ALLOWLIST`. Registration **does not dial** the host — dialing
+external MCP servers is a [PR-6b](#whats-next-pr-6b--the-external-mcp-gateway)
+capability.
+
+```bash
+kx tools register --name web-search --version 1 \
+  --server-host mcp.example.com:443 \
+  --description "search the web" --param q:str --param k:int
+```
+
+```python
+tool_id = client.register_tool(
+    name="web-search",
+    version="1",
+    server_host="mcp.example.com:443",
+    description="search the web",
+)
+```
+
+The returned `tool_id` is server-derived. A registered tool is **declared**, not
+yet **fireable**: a tool fires only when this serve actually registers its
+capability on the broker (today that is the bundled `mcp-echo@1` and `fs-list@1`).
+
+### Deregister
+
+```bash
+kx tools deregister --name web-search --version 1
+```
+
+Built-ins are refused (the call returns `removed = false`).
+
+## The `fs-list` built-in
+
+`fs-list@1` is the first real host-side tool — a **read-only** directory lister,
+gated behind the operator flag `KX_SERVE_FS_ROOT` (default-OFF, so the default
+serve is byte-identical without it). When set, the runtime grants the ReAct loop a
+read-only `fs_scope` of exactly that root and seeds the `kx/recipes/react-fs`
+recipe; the model can then list files and reason over the result, committed as a
+durable Observation.
+
+```bash
+KX_SERVE_FS_ROOT=/path/to/readable/dir kx serve --features inference
+```
+
+`fs-list` never reads file *contents* — it returns names only, confined to the
+granted mount (canonicalized; no traversal out).
+
+## Reviewing what agents produce
+
+Every committed tool output (and every model turn) is captured in the **Data Lab →
+Agent Outputs** lens — the Morphic action exhaust, newest-first, previewed in the
+multi-modal viewer (a tool's JSON in Monaco, a model's answer as text, an image
+inline). ReAct turns are badged by turn and branch. This is view-only in OSS;
+cross-run analytics, dashboards, and synthesis are part of Kortecx Cloud.
+
+## The ReAct tool loop
+
+The model proposes a tool call; the runtime parses it through one fail-closed
+authority gate (grant-checked against the step warrant, size-capped), validates
+the arguments against the tool's typed `inputSchema`, and dispatches via the
+capability broker. A prompt-injected call to an **ungranted** tool never fires.
+See the [Quickstart agent loop](./quickstart.md#run-the-agent-loop).
+
+## OSS / Cloud line
+
+Kortecx OSS is the **secure gateway to external MCP** — the runtime is the
+production-grade authority that connects to external MCP servers (which host the
+tools). **No arbitrary code runs in the runtime.** In-runtime sandboxed
+script/skill execution, and OAuth / hosted-marketplace credential connections, are
+Cloud / future capabilities.
+
+## What's next (PR-6b) — the external MCP gateway
+
+The registry stores a vetted `server_host` today; **dialing** it lands in PR-6b:
+a multi-server MCP gateway (stdio + Streamable HTTP) with per-server health,
+discovery into the same registry, a dial-time SSRF gate, per-server
+rate-limit/quota, warrant-gated egress, and secret-less `CredentialRef`
+**Connections** — plus the `tool()` chains-node so an authored DAG can call a tool
+directly. The Connections card in the console is the honest forward stub for that
+work. (Branched write-back over the content-addressed store is the D155
+post-RC epic.)

--- a/ui/e2e/agent-outputs.spec.ts
+++ b/ui/e2e/agent-outputs.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole, runRecipe } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("Data Lab Agent Outputs: a committed run's outputs are reviewable in the multi-modal viewer", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  // Produce committed agent outputs: the 5-node fanout recipe commits several Motes,
+  // each of which folds into the Morphic capture action exhaust (ListCaptureRecords).
+  await runRecipe(page, { handle: "kx/recipes/passthrough-dag" });
+  await expect(page.getByTestId("mote-dag")).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => page.getByTestId("state-pill").filter({ hasText: "COMMITTED" }).count(), {
+      timeout: 60_000,
+    })
+    .toBeGreaterThan(0);
+
+  await page.getByTestId("nav-datasets").click();
+  await expect(page.getByTestId("datasets-section")).toBeVisible();
+  await expect(page.getByTestId("agent-outputs")).toBeVisible();
+
+  // The capture fold is a fast background poller; re-navigate (Monitoring↔Data Lab)
+  // inside the poll to force a fresh fetch until the committed outputs appear (no
+  // page reload — the console token is held in memory only).
+  const rows = page.locator('[data-testid^="agent-output-"]');
+  await expect
+    .poll(
+      async () => {
+        await page.getByTestId("nav-monitor").click();
+        await page.getByTestId("nav-datasets").click();
+        return rows.count();
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0);
+
+  // Open one output → the multi-modal AssetViewer renders its committed content from
+  // the content-addressed store (a blob URL / Monaco — never a remote src).
+  await rows.first().click();
+  await expect(page.getByTestId("asset-viewer")).toBeVisible({ timeout: 30_000 });
+
+  // The "ReAct turns" filter narrows to records that carry a settled branch; a PURE
+  // fanout run has none, so the lens shows its honest empty state (scoped to the
+  // Agent Outputs panel — the Datasets panel renders its own empty state too).
+  await page.getByTestId("agent-outputs-filter-react").click();
+  await expect(page.getByTestId("agent-outputs").getByTestId("empty-state")).toBeVisible();
+});

--- a/ui/e2e/tools-registered.spec.ts
+++ b/ui/e2e/tools-registered.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+test("Tools registry: built-in inventory, disabled built-in deregister, SSRF-refused host, Connections stub", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  await page.getByTestId("nav-tools").click();
+  await expect(page.getByTestId("tools-section")).toBeVisible();
+
+  // The durable registry inventory (DiscoverTools) shows the three OSS built-ins,
+  // re-seeded on open (DISTINCT from the advisory toolscout manifests below).
+  await expect(page.getByTestId("tools-registered-panel")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("registered-tool-fs-read-1")).toBeVisible();
+  await expect(page.getByTestId("registered-tool-fs-write-1")).toBeVisible();
+  await expect(page.getByTestId("registered-tool-text-summarize-1")).toBeVisible();
+
+  // Built-ins are re-seeded on start and NOT deregisterable — the control is disabled.
+  await expect(page.getByTestId("deregister-fs-read-1")).toBeDisabled();
+
+  // Register an internal/loopback host → SSRF admission refuses it (permission_denied
+  // → "Host not permitted"). The inputs are CONTROLLED — click + pressSequentially,
+  // never a bulk fill() (the recorded React-controlled-input e2e gotcha).
+  const name = page.getByTestId("register-tool-name");
+  await name.click();
+  await name.pressSequentially("web-search");
+  const host = page.getByTestId("register-tool-host");
+  await host.click();
+  await host.pressSequentially("127.0.0.1:443");
+  await page.getByTestId("register-tool-submit").click();
+  await expect(page.getByTestId("register-tool-error")).toContainText("Host not permitted", {
+    timeout: 30_000,
+  });
+
+  // The Connections affordance is an HONEST-disabled forward card (no fake control —
+  // live external-MCP dialing + credentialed connections land in PR-6b).
+  await expect(page.getByTestId("tools-connections-disabled")).toBeVisible();
+});

--- a/ui/src/components/datasets/AgentOutputsPanel.tsx
+++ b/ui/src/components/datasets/AgentOutputsPanel.tsx
@@ -1,0 +1,157 @@
+/**
+ * Agent Outputs — review the data agents generate. Sourced from the Morphic
+ * capture action-exhaust (`ListCaptureRecords`): every committed Mote's output,
+ * newest-first, opened in the multi-modal {@link AssetViewer} (a tool's JSON, a
+ * model's text/answer, an image, …). ReAct turns carry a `turn N · <branch>` badge
+ * (the branch is joined onto the TURN mote — `tool` = a tool-call decision,
+ * `answer` = a final answer; an Observation/tool RESULT is its own committed record
+ * with no branch). The "ReAct turns" filter narrows to records that carry a branch.
+ *
+ * Read-only (OSS view, D157/GR19); rendering is from the content-addressed store
+ * ONLY (blob URLs, never a remote `src`, never innerHTML — zero SSRF surface).
+ */
+
+import type { CaptureRecord } from "@kortecx/sdk/web";
+import { m } from "framer-motion";
+import { useMemo, useState } from "react";
+import { fadeUp, hoverLift, stagger } from "../../app/motion";
+import { toUiError } from "../../kx/errors";
+import { useCaptureRecords } from "../../kx/use-capture-records";
+import { useContent } from "../../kx/use-content";
+import { shortHex } from "../../lib/format";
+import { AssetViewer } from "../AssetViewer";
+import { DigestChip } from "../DigestChip";
+import { EmptyState } from "../EmptyState";
+import { ErrorNotice } from "../ErrorNotice";
+import { Badge } from "../ds/Badge";
+import { GlowCard } from "../ds/GlowCard";
+
+/** Branch badge color (mirrors the ReAct-turn vocabulary). */
+function branchColor(branch: string): string {
+  if (branch === "tool") return "var(--primary)";
+  if (branch === "answer") return "var(--success)";
+  if (branch === "dead_lettered") return "var(--error)";
+  if (branch === "pending") return "var(--warning)";
+  return "var(--text-2)";
+}
+
+export function AgentOutputsPanel() {
+  const { records, notWired, isLoading } = useCaptureRecords({ limit: 100 });
+  const [reactOnly, setReactOnly] = useState(false);
+  const [openMote, setOpenMote] = useState<string | null>(null);
+
+  const shown = useMemo(
+    () => (reactOnly ? records.filter((r) => r.reactBranch !== "") : records),
+    [records, reactOnly],
+  );
+
+  if (isLoading) {
+    return <EmptyState title="Loading agent outputs…" />;
+  }
+  if (notWired) {
+    return (
+      <EmptyState
+        title="Agent outputs need a newer gateway"
+        detail="This gateway doesn't expose the capture action stream (an older build)."
+      />
+    );
+  }
+
+  return (
+    <div data-testid="agent-outputs">
+      <div className="chip-row agent-outputs__filter">
+        <button
+          type="button"
+          className={`chip${reactOnly ? "" : " chip--active"}`}
+          data-testid="agent-outputs-filter-all"
+          aria-pressed={!reactOnly}
+          onClick={() => setReactOnly(false)}
+        >
+          <span className="chip__label">All outputs</span>
+        </button>
+        <button
+          type="button"
+          className={`chip${reactOnly ? " chip--active" : ""}`}
+          data-testid="agent-outputs-filter-react"
+          aria-pressed={reactOnly}
+          onClick={() => setReactOnly(true)}
+        >
+          <span className="chip__label">ReAct turns</span>
+        </button>
+      </div>
+      {shown.length === 0 ? (
+        <EmptyState
+          title="No agent outputs yet"
+          detail="Run an agentic workflow — every committed output appears here for review as its Motes commit."
+        />
+      ) : (
+        <m.ul
+          className="agent-outputs-list"
+          data-testid="agent-outputs-panel"
+          variants={stagger()}
+          initial="hidden"
+          animate="show"
+        >
+          {shown.map((record) => (
+            <OutputRow
+              key={record.moteId}
+              record={record}
+              open={openMote === record.moteId}
+              onToggle={() => setOpenMote(openMote === record.moteId ? null : record.moteId)}
+            />
+          ))}
+        </m.ul>
+      )}
+    </div>
+  );
+}
+
+function OutputRow({
+  record,
+  open,
+  onToggle,
+}: {
+  record: CaptureRecord;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const branchLabel =
+    record.reactTurn !== null
+      ? `turn ${record.reactTurn} · ${record.reactBranch}`
+      : record.reactBranch;
+  return (
+    <GlowCard className="agent-output-row" variants={fadeUp} {...hoverLift}>
+      <div className="agent-output-row__head">
+        <button
+          type="button"
+          className="agent-output-row__toggle"
+          data-testid={`agent-output-${record.moteId}`}
+          aria-expanded={open}
+          onClick={onToggle}
+        >
+          <span className="agent-output-row__mote mono">{shortHex(record.moteId)}</span>
+          {record.reactBranch ? (
+            <Badge label={branchLabel} color={branchColor(record.reactBranch)} />
+          ) : null}
+          <Badge label={record.ndClass} color="var(--text-2)" />
+        </button>
+        <DigestChip hex={record.resultRef} label="result" />
+      </div>
+      {open ? <OutputBody instanceId={record.instanceId} contentRef={record.resultRef} /> : null}
+    </GlowCard>
+  );
+}
+
+function OutputBody({ instanceId, contentRef }: { instanceId: string; contentRef: string }) {
+  const content = useContent(instanceId, contentRef);
+  if (content.isLoading) {
+    return <EmptyState title="Loading output…" />;
+  }
+  if (content.error) {
+    return <ErrorNotice error={toUiError(content.error)} onRetry={() => void content.refetch()} />;
+  }
+  if (!content.data) {
+    return null;
+  }
+  return <AssetViewer content={content.data} stem={contentRef.slice(0, 12)} />;
+}

--- a/ui/src/components/sections/DatasetsSection.tsx
+++ b/ui/src/components/sections/DatasetsSection.tsx
@@ -1,6 +1,7 @@
 import { m } from "framer-motion";
 import { useState } from "react";
 import { stagger } from "../../app/motion";
+import { AgentOutputsPanel } from "../datasets/AgentOutputsPanel";
 import { DatasetsPanel } from "../datasets/DatasetsPanel";
 import { IngestPanel } from "../datasets/IngestPanel";
 import { QueryPanel } from "../datasets/QueryPanel";
@@ -48,6 +49,13 @@ export function DatasetsSection() {
         <QueryPanel dataset={selected} />
         <IngestPanel />
       </m.div>
+
+      <h2 className="datasets-cloud__title">Agent Outputs</h2>
+      <p className="muted">
+        The data your agents generate — every committed output (a tool's JSON, a model's answer, an
+        image), newest-first, previewed in the browser. ReAct turns are badged by turn and branch.
+      </p>
+      <AgentOutputsPanel />
 
       <h2 className="datasets-cloud__title">Data engineering</h2>
       <p className="muted">

--- a/ui/src/components/sections/ToolsSection.tsx
+++ b/ui/src/components/sections/ToolsSection.tsx
@@ -4,16 +4,26 @@ import { useScoreBundle, useToolManifests } from "../../kx/use-toolscout";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
 import { BundleComposer } from "../tools/BundleComposer";
+import { ConnectionsCard } from "../tools/ConnectionsCard";
 import { ManifestGrid } from "../tools/ManifestGrid";
+import { RegisterToolForm } from "../tools/RegisterToolForm";
+import { RegisteredToolsPanel } from "../tools/RegisteredToolsPanel";
 import { ScoreLadder } from "../tools/ScoreLadder";
 
 /**
- * Tools (W1.A5 toolscout): the registered tool manifests + an interactive
- * TaskBundle preview — compose an ordered tool sequence, give an intent, and
- * dry-run the advisory scorer. ADVISORY-ONLY BY CONSTRUCTION (SN-8): every
- * score/verdict here is display-only and never authorizes anything — the sole
- * grant gate stays the exact (toolId, toolVersion) check in lowering + the
- * broker. Degrades to a not-wired empty state on older gateways (UNIMPLEMENTED).
+ * Tools — two surfaces over the gateway's tool plane:
+ *
+ * 1. **Registry (governance)** — the DURABLE inventory (`DiscoverTools`): every
+ *    registered tool with its authority/provenance/status + register & deregister
+ *    controls (`RegisterTool` / `DeregisterTool`). Registration grants NO authority
+ *    (SN-8); built-ins are re-seeded + not deregisterable. Live external-MCP dialing
+ *    + Connections is the PR-6b card (honest-disabled — GR19/GR15).
+ * 2. **Discovery & preview (advisory)** — the W1.A5 toolscout: tool manifests + an
+ *    interactive TaskBundle dry-run scorer. ADVISORY-ONLY BY CONSTRUCTION (SN-8):
+ *    every score/verdict is display-only and never authorizes anything — the sole
+ *    grant gate stays the exact (toolId, toolVersion) check in lowering + the broker.
+ *
+ * Both degrade to a not-wired empty state on older gateways (UNIMPLEMENTED).
  */
 export function ToolsSection() {
   const manifests = useToolManifests();
@@ -43,8 +53,28 @@ export function ToolsSection() {
     <section className="screen" data-testid="tools-section">
       <h1>Tools</h1>
       <p className="muted">
-        MCP tool discovery &amp; TaskBundle preview. Advisory by construction (SN-8): ranking scores
-        and dry-run verdicts are display-only — they never authorize a tool.
+        Register, govern, and discover the tools your agents can call. Registration grants no
+        authority (SN-8): a tool fires only under a server-issued warrant, re-verified by the broker
+        at every call.
+      </p>
+
+      <h2>Registry</h2>
+      <p className="muted">
+        The durable tool inventory — what is registered, with what provenance, status, and egress
+        authority. Built-ins are re-seeded on start and cannot be deregistered.
+      </p>
+      <RegisteredToolsPanel />
+      <div className="tools-registry-actions">
+        <RegisterToolForm />
+        <div className="metrics-grid tools-connections">
+          <ConnectionsCard />
+        </div>
+      </div>
+
+      <h2>Discovery &amp; preview</h2>
+      <p className="muted">
+        Advisory by construction (SN-8): ranking scores and dry-run verdicts are display-only — they
+        never authorize a tool.
       </p>
 
       {manifests.isLoading ? <EmptyState title="Loading tools…" /> : null}

--- a/ui/src/components/tools/ConnectionsCard.tsx
+++ b/ui/src/components/tools/ConnectionsCard.tsx
@@ -1,0 +1,22 @@
+/**
+ * The MCP Connections affordance — an HONEST-DISABLED forward card (GR15
+ * don't-fake-gaps / GR19). Registering a tool host (above) records + governs it;
+ * DIALING external MCP servers over stdio / Streamable HTTP, with secret-less
+ * `CredentialRef` connections, lands in PR-6b. This card states that plainly
+ * rather than showing a control with no backend.
+ */
+
+export function ConnectionsCard() {
+  return (
+    <div className="metric-card metric-card--disabled" data-testid="tools-connections-disabled">
+      <span className="metric-card__value">
+        <span className="chip--soon">PR-6b</span>
+      </span>
+      <span className="metric-card__label">MCP Connections</span>
+      <span className="metric-card__sub">
+        Dialing external MCP servers (stdio · Streamable HTTP) and secret-less credential
+        connections arrive in the next batch. Tool registration + governance is live above.
+      </span>
+    </div>
+  );
+}

--- a/ui/src/components/tools/RegisterToolForm.tsx
+++ b/ui/src/components/tools/RegisterToolForm.tsx
@@ -1,0 +1,131 @@
+/**
+ * Register a declarative EXTERNAL MCP tool into the durable registry (`RegisterTool`,
+ * PR-6a). The server SSRF-vets `serverHost`, derives the `toolId` + capability, and
+ * stores it (the client never names/forges identity — SN-8). Registration grants NO
+ * authority and does NOT dial the host (dialing is a Cloud / PR-6b capability). An
+ * internal / link-local / metadata host is refused (`permission_denied`).
+ *
+ * The idempotency class is chosen via CHIP buttons (never a controlled `<select>` —
+ * the UI-3 React-controlled-select e2e gotcha).
+ */
+
+import { type FormEvent, useState } from "react";
+import { fadeUp } from "../../app/motion";
+import { toUiError } from "../../kx/errors";
+import { useRegisterTool } from "../../kx/use-tool-registry";
+import { GlowCard } from "../ds/GlowCard";
+
+/** The closed idempotency-class vocabulary (mirrors the registry's `IdempotencyClass`). */
+const IDEMPOTENCY_CLASSES = ["Token", "Readback", "Staged", "AtLeastOnce"] as const;
+type IdempotencyClass = (typeof IDEMPOTENCY_CLASSES)[number];
+
+export function RegisterToolForm() {
+  const [name, setName] = useState("");
+  const [version, setVersion] = useState("1");
+  const [serverHost, setServerHost] = useState("");
+  const [description, setDescription] = useState("");
+  const [idempotency, setIdempotency] = useState<IdempotencyClass>("Readback");
+  const register = useRegisterTool();
+
+  const canSubmit =
+    name.trim().length > 0 && version.trim().length > 0 && serverHost.trim().length > 0;
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    register.mutate({
+      name: name.trim(),
+      version: version.trim(),
+      serverHost: serverHost.trim(),
+      description: description.trim(),
+      idempotencyClass: idempotency,
+    });
+  };
+
+  const err = register.error ? toUiError(register.error) : null;
+
+  return (
+    <GlowCard hover={false} variants={fadeUp} data-testid="register-tool-panel">
+      <h2>Register an external MCP tool</h2>
+      <p className="muted">
+        Records a declarative tool + its SSRF-vetted egress host in the durable registry. Grants no
+        authority (SN-8); a tool fires only under a server-issued warrant. Dialing the host is a
+        Cloud / PR-6b capability.
+      </p>
+      <form onSubmit={onSubmit} className="register-tool-form">
+        <div className="register-tool-form__row">
+          <input
+            type="text"
+            data-testid="register-tool-name"
+            placeholder="tool name (e.g. web-search)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            aria-label="Tool name"
+          />
+          <input
+            type="text"
+            data-testid="register-tool-version"
+            placeholder="version"
+            value={version}
+            onChange={(e) => setVersion(e.target.value)}
+            aria-label="Tool version"
+          />
+        </div>
+        <input
+          type="text"
+          data-testid="register-tool-host"
+          placeholder="server host (host[:port], e.g. mcp.example.com:443)"
+          value={serverHost}
+          onChange={(e) => setServerHost(e.target.value)}
+          aria-label="Server host"
+        />
+        <input
+          type="text"
+          data-testid="register-tool-description"
+          placeholder="description (optional)"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          aria-label="Description"
+        />
+        <fieldset className="register-tool-form__idempotency">
+          <legend className="muted">Idempotency class</legend>
+          <div className="chip-row">
+            {IDEMPOTENCY_CLASSES.map((cls) => (
+              <button
+                key={cls}
+                type="button"
+                className={`chip${idempotency === cls ? " chip--active" : ""}`}
+                data-testid={`register-tool-idempotency-${cls}`}
+                aria-pressed={idempotency === cls}
+                onClick={() => setIdempotency(cls)}
+              >
+                <span className="chip__label">{cls}</span>
+              </button>
+            ))}
+          </div>
+        </fieldset>
+        <button
+          type="submit"
+          data-testid="register-tool-submit"
+          disabled={register.isPending || !canSubmit}
+        >
+          {register.isPending ? "Registering…" : "Register tool"}
+        </button>
+      </form>
+
+      {err ? (
+        <p className="field-error" data-testid="register-tool-error" role="alert">
+          {err.kind === "forbidden" ? "Host not permitted: " : ""}
+          {err.message}
+        </p>
+      ) : null}
+      {register.isSuccess ? (
+        <p className="register-tool__result" data-testid="register-tool-result">
+          Registered — server-derived tool id <code className="mono">{register.data}</code>
+        </p>
+      ) : null}
+    </GlowCard>
+  );
+}

--- a/ui/src/components/tools/RegisteredToolsPanel.tsx
+++ b/ui/src/components/tools/RegisteredToolsPanel.tsx
@@ -1,0 +1,163 @@
+/**
+ * The durable tools-registry inventory (`DiscoverTools`, PR-6a) — the GOVERNANCE
+ * view: every registered tool with its kind, provenance, status, egress host and
+ * net-scope, plus an operator deregister control. Built-ins are re-seeded on open
+ * and never deregisterable (the control is disabled with a tooltip). Registration
+ * grants NO authority (SN-8); listing leaks none. DIALING a registered external
+ * MCP server is a Cloud / PR-6b capability — this view records + governs only.
+ */
+
+import type { RegisteredTool } from "@kortecx/sdk/web";
+import { m } from "framer-motion";
+import { fadeUp, hoverLift, stagger } from "../../app/motion";
+import { toUiError } from "../../kx/errors";
+import { useDeregisterTool, useDiscoverTools } from "../../kx/use-tool-registry";
+import { EmptyState } from "../EmptyState";
+import { ErrorNotice } from "../ErrorNotice";
+import { Badge } from "../ds/Badge";
+import { GlowCard } from "../ds/GlowCard";
+
+/** Accent stripe keyed by the registry kind (display only). */
+function kindStripe(kind: string): string {
+  if (kind === "Builtin") return "var(--info)";
+  if (kind === "Mcp") return "var(--primary)";
+  return "var(--violet)";
+}
+
+/** A registration-status badge color (Approved = success; pending = warning). */
+function statusColor(status: string): string {
+  return status === "Approved" ? "var(--success)" : "var(--warning)";
+}
+
+export function RegisteredToolsPanel() {
+  const { tools, notWired, isLoading, isError, error, refetch } = useDiscoverTools();
+  const deregister = useDeregisterTool();
+  const deregError = deregister.error ? toUiError(deregister.error) : null;
+
+  if (isLoading) {
+    return <EmptyState title="Loading registry…" />;
+  }
+  if (notWired) {
+    return (
+      <EmptyState
+        title="Tool registry needs a newer gateway"
+        detail="This gateway doesn't expose the durable tools registry (an older build)."
+      />
+    );
+  }
+  if (isError) {
+    return <ErrorNotice error={toUiError(error)} onRetry={() => void refetch()} />;
+  }
+
+  return (
+    <div data-testid="tools-registered">
+      {/* A deregister failure is typically non-retryable (forbidden / not-found),
+          so surface it as a dismissable inline message (the RegisterToolForm
+          pattern) — it clears on the next deregister attempt. */}
+      {deregError ? (
+        <p className="field-error" data-testid="deregister-error" role="alert">
+          {deregError.message}
+        </p>
+      ) : null}
+      {tools.length === 0 ? (
+        <EmptyState
+          title="No tools registered"
+          detail="Register an external MCP tool below — or run with KX_SERVE_FS_ROOT to enable the fs-list built-in."
+        />
+      ) : (
+        <m.ul
+          className="registry-list"
+          data-testid="tools-registered-panel"
+          variants={stagger()}
+          initial="hidden"
+          animate="show"
+        >
+          {tools.map((tool) => {
+            const pending =
+              deregister.isPending &&
+              deregister.variables?.name === tool.toolName &&
+              deregister.variables?.version === tool.toolVersion;
+            return (
+              <RegistryRow
+                key={`${tool.toolName}@${tool.toolVersion}`}
+                tool={tool}
+                pending={pending}
+                onDeregister={() =>
+                  deregister.mutate({ name: tool.toolName, version: tool.toolVersion })
+                }
+              />
+            );
+          })}
+        </m.ul>
+      )}
+    </div>
+  );
+}
+
+function RegistryRow({
+  tool,
+  pending,
+  onDeregister,
+}: {
+  tool: RegisteredTool;
+  pending: boolean;
+  onDeregister: () => void;
+}) {
+  return (
+    <GlowCard
+      className="registry-row"
+      stripe={kindStripe(tool.kind)}
+      variants={fadeUp}
+      {...hoverLift}
+    >
+      <div className="registry-row__main">
+        <div className="registry-row__head">
+          {/* No "online" status dot: a registry entry is DECLARED, not fireable
+              (dialing is PR-6b). The registrationStatus badge carries the state. */}
+          <span
+            className="registry-row__name mono"
+            data-testid={`registered-tool-${tool.toolName}-${tool.toolVersion}`}
+          >
+            {tool.toolName}@{tool.toolVersion}
+          </span>
+          <Badge label={tool.kind} color={kindStripe(tool.kind)} />
+          {tool.isBuiltin ? <Badge label="built-in" color="var(--text-2)" /> : null}
+          <Badge label={tool.registrationStatus} color={statusColor(tool.registrationStatus)} />
+        </div>
+        {tool.description ? <p className="registry-row__desc muted">{tool.description}</p> : null}
+        <dl className="registry-row__meta">
+          <div>
+            <dt className="muted">provenance</dt>
+            <dd>{tool.provenance}</dd>
+          </div>
+          <div>
+            <dt className="muted">idempotency</dt>
+            <dd>{tool.idempotencyClass}</dd>
+          </div>
+          <div>
+            <dt className="muted">egress host</dt>
+            <dd className="mono">{tool.serverHost || "—"}</dd>
+          </div>
+          <div>
+            <dt className="muted">net scope</dt>
+            <dd className="mono">{tool.netScope}</dd>
+          </div>
+        </dl>
+      </div>
+      <button
+        type="button"
+        className="btn-ghost registry-row__deregister"
+        data-testid={`deregister-${tool.toolName}-${tool.toolVersion}`}
+        disabled={tool.isBuiltin || pending}
+        title={
+          tool.isBuiltin
+            ? "Built-in tools are re-seeded on start and cannot be deregistered"
+            : "Deregister this tool"
+        }
+        onClick={onDeregister}
+      >
+        {pending ? "Removing…" : "Deregister"}
+      </button>
+    </GlowCard>
+  );
+}

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -35,6 +35,9 @@ export const queryKeys = {
     ["kx", endpoint, "asset-grants", assetRef] as const,
   /** The advisory tool manifests (`ListToolManifests`) — display-only, never authority. */
   toolManifests: (endpoint: string) => ["kx", endpoint, "tool-manifests"] as const,
+  /** The durable tools-registry inventory (`DiscoverTools`, PR-6a) — the governance
+   *  view (what is registered, with what authority). Registration grants none (SN-8). */
+  discoverTools: (endpoint: string) => ["kx", endpoint, "discover-tools"] as const,
   /** The datasets (RAG corpora) the gateway holds (`ListDatasets`). */
   datasets: (endpoint: string) => ["kx", endpoint, "datasets"] as const,
   /** A dataset query (`QueryDataset`), scoped by dataset + query text + k. */

--- a/ui/src/kx/use-tool-registry.ts
+++ b/ui/src/kx/use-tool-registry.ts
@@ -1,0 +1,72 @@
+/**
+ * The durable tools-registry hooks (PR-6a-1): the inventory view (`DiscoverTools`)
+ * plus the operator register/deregister mutations (`RegisterTool`/`DeregisterTool`).
+ *
+ * DISTINCT from the advisory toolscout view (`use-toolscout.ts`): this is the
+ * durable GOVERNANCE surface — what is registered, by whom, with what authority.
+ * Registration grants NO authority (SN-8); the `toolId` is SERVER-derived. DIALING
+ * a registered external MCP server is a Cloud / PR-6b capability — registering a
+ * host only records it (SSRF-vetted at admission). Degrades to a not-wired empty
+ * state on a gateway without the registry (UNIMPLEMENTED).
+ */
+
+import type { RegisterToolInput, RegisteredToolsPage } from "@kortecx/sdk/web";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { toUiError } from "./errors";
+import { queryKeys } from "./query-keys";
+
+export function useDiscoverTools() {
+  const { client, endpoint, status } = useConnection();
+  const q = useQuery({
+    queryKey: queryKeys.discoverTools(endpoint),
+    enabled: status === "connected" && client !== null,
+    queryFn: async (): Promise<RegisteredToolsPage> => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.discoverTools({});
+    },
+  });
+  return {
+    tools: q.data?.tools ?? [],
+    hasMore: q.data?.hasMore ?? false,
+    notWired: q.isError && toUiError(q.error).kind === "not-wired",
+    isLoading: q.isLoading,
+    isError: q.isError,
+    error: q.error,
+    refetch: q.refetch,
+  };
+}
+
+export function useRegisterTool() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<string, unknown, RegisterToolInput>({
+    mutationFn: async (input) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.registerTool(input);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.discoverTools(endpoint) });
+    },
+  });
+}
+
+export function useDeregisterTool() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<boolean, unknown, { name: string; version: string }>({
+    mutationFn: async ({ name, version }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.deregisterTool(name, version);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.discoverTools(endpoint) });
+    },
+  });
+}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -3119,6 +3119,142 @@ button.card-grid__title:hover {
   font-size: 0.82rem;
 }
 
+/* ---- Tools registry (PR-6a-2: DiscoverTools governance + RegisterTool) ---- */
+.registry-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.registry-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 0.85rem;
+}
+.registry-row__main {
+  min-width: 0;
+}
+.registry-row__head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.registry-row__name {
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+.registry-row__desc {
+  margin: 0.35rem 0 0;
+  font-size: 0.82rem;
+}
+.registry-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.2rem;
+  margin: 0.5rem 0 0;
+}
+.registry-row__meta > div {
+  display: flex;
+  flex-direction: column;
+}
+.registry-row__meta dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.registry-row__meta dd {
+  margin: 0;
+  font-size: 0.82rem;
+}
+.registry-row__deregister {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.tools-registry-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+  margin-top: 0.75rem;
+}
+@media (max-width: 720px) {
+  .tools-registry-actions {
+    grid-template-columns: 1fr;
+  }
+}
+.tools-connections {
+  margin: 0;
+}
+.register-tool-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0.6rem 0 0;
+}
+.register-tool-form__row {
+  display: grid;
+  grid-template-columns: 1fr 0.4fr;
+  gap: 0.5rem;
+}
+.register-tool-form__idempotency {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+.register-tool-form__idempotency legend {
+  font-size: 0.75rem;
+  padding: 0;
+  margin-bottom: 0.3rem;
+}
+.register-tool__result {
+  margin: 0.5rem 0 0;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+/* ---- Data Lab: Agent Outputs (PR-6a-2: capture action-exhaust review) ---- */
+.agent-outputs__filter {
+  margin: 0.25rem 0 0.6rem;
+}
+.agent-outputs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.agent-output-row {
+  padding: 0.55rem 0.75rem;
+}
+.agent-output-row__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.agent-output-row__toggle {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  min-width: 0;
+}
+.agent-output-row__mote {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
 /* ---- editor surfaces (Monaco + the headless fallback) ---- */
 .editor-surface {
   border: 1px solid var(--border);


### PR DESCRIPTION
## PR-6a-2 — the polish (UI + docs over the PR-6a-1 durable tools registry)

The cross-surface UI + docs layer over the PR-6a-1 backend. **Zero Rust / proto / Cargo changes** ⇒ canonical digest `7d22d4bd` and the frozen trio are invariant by construction.

### What ships
- **Tools → Registry (governance):** a panel over `DiscoverTools` (name@version · kind · provenance · status · server_host · net_scope · built-in badge) with **register / deregister** controls (chip/button — never a controlled `<select>`). Built-ins are disabled with a tooltip; an SSRF-refused host surfaces as **"Host not permitted"**. The **Connections** affordance is an honest-disabled PR-6b card (no fake control — GR19).
- **Data Lab → Agent Outputs:** a read-only lens over the Morphic capture action-exhaust (`ListCaptureRecords`), each committed output opened in the multi-modal `AssetViewer`; ReAct turns badged by `turn · branch`; a "ReAct turns" filter. **No new RPC** (thin reuse of existing reads).
- **Docs** (`docs/site/docs/tools.md`): register/discover across CLI/Py/TS · `fs-list` + `KX_SERVE_FS_ROOT` · the ReAct loop · the OSS/Cloud line (GR19) · a forward pointer to PR-6b.

### Deferred to PR-6b (GR8 finding)
The **`tool()` Chains-node** is deferred: a standalone tool node cannot fire today — author-supplied tool args have no path to the worker outside a ReAct observation (`state.rs::resolve_tool_args` derives args from a parent model turn). Making it fireable needs a new coordinator args-from-params path, which lands with PR-6b's tool-dispatch machinery. The PR-6b B-spec (external MCP gateway + Connections + the `tool()` node + the coordinator path) is written in the private corpus.

### Invariants
- Digest `7d22d4bd` + frozen trio (`kx-scheduler`/`kx-executor`/`dispatcher.rs`) — invariant by construction (no Rust changes).
- Additive-only (none needed); `Cargo.lock` untouched; SN-8 (registration grants no authority; `tool_id` server-derived); GR13/D142 (both themes, chip controls, honest empty/disabled states, testids).

### Verification
- `tsc` ✅ · `biome ci .` (337 files) ✅ · `vitest` (575) ✅
- Playwright: **new** `tools-registered` + `agent-outputs` ✅ (against a real serve), `tools-toolscout` (no regression) ✅, `datasets` ✅, `theme` ✅
- `docusaurus build` (onBrokenLinks: throw) ✅
- Adversarial multi-agent review → 3 findings fixed (Python docs snippet API, deregister-error dismissability, honest registry status dot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)