### PR TITLE
PR-6b-2 — authored tool() node + coordinator args-from-params + live tool registry

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from .alerts import AlertsPage, AlertSummary
 from .blueprints import BlueprintBuilder, EdgeInput, StepInput
 from .capture import CaptureRecord, CaptureRecordPage
-from .chains import Chain, Task, chain, model, pure
+from .chains import Chain, Task, chain, model, pure, tool
 from .client import DEFAULT_ENDPOINT, AsyncKxClient, KxClient
 from .content import ContentItem, PutResult
 from .datasets import DatasetHit, DatasetSummary, FuzzyHit, IngestDocument, IngestResult
@@ -136,6 +136,7 @@ __all__ = [
     "chain",
     "pure",
     "model",
+    "tool",
     "TeamSummary",
     "TeamMember",
     "TeamMembers",

--- a/bindings/python/src/kortecx/blueprints.py
+++ b/bindings/python/src/kortecx/blueprints.py
@@ -21,14 +21,21 @@ _KIND = {
     "pure": _g.WorkflowStepKind.WORKFLOW_STEP_KIND_PURE,
     "model": _g.WorkflowStepKind.WORKFLOW_STEP_KIND_MODEL,
     "exec": _g.WorkflowStepKind.WORKFLOW_STEP_KIND_EXEC,
+    "tool": _g.WorkflowStepKind.WORKFLOW_STEP_KIND_TOOL,
 }
+
+#: PR-6b-2: the single canonical ``config_subset`` key a ``tool()`` step's authored
+#: args ride under (one canonical-JSON object). MUST equal the Rust
+#: ``kx_mote::TOOL_ARGS_KEY`` and the TS ``TOOL_ARGS_KEY`` — the coordinator's
+#: ``is_authored_tool`` discriminant + args source.
+TOOL_ARGS_KEY = "kx.tool.args"
 
 
 @dataclass
 class StepInput:
     """One authored step. ``params`` values may be ``str`` (UTF-8) or ``bytes``."""
 
-    kind: str  # "pure" | "model" | "exec" (exec reserved server-side in PR-1)
+    kind: str  # "pure" | "model" | "exec" (reserved) | "tool" (PR-6b-2)
     model_id: str = ""
     prompt: str = ""
     body_signature_id: Optional[str] = None  # EXEC only: 64-char hex of the body id

--- a/bindings/python/src/kortecx/chains.py
+++ b/bindings/python/src/kortecx/chains.py
@@ -27,10 +27,11 @@ Both produce a :class:`Chain`; :meth:`Chain.build` runs the one canonical loweri
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
-from .blueprints import BlueprintBuilder, EdgeInput, StepInput
+from .blueprints import TOOL_ARGS_KEY, BlueprintBuilder, EdgeInput, StepInput
 from .v1 import gateway_pb2 as _g
 
 
@@ -133,6 +134,31 @@ def model(model_id: str, prompt: str, **params: Union[bytes, str]) -> Task:
     """A MODEL step. ``model_id`` is the recipe enum the SERVER validates (SN-8);
     ``prompt`` is the instruction; ``params`` are extra step params."""
     return Task(StepInput(kind="model", model_id=model_id, prompt=prompt, params=dict(params)))
+
+
+def _canonical_args_json(args: Dict[str, object]) -> str:
+    """Serialize a flat tool-call arg map to the canonical-JSON string the three
+    SDK surfaces lower byte-identically (sorted keys, compact separators). No
+    floats (SN-8 — the server schema is integer/bytes/bool/enum-typed)."""
+    return json.dumps(args, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def tool(tool_id: str, tool_version: str, **args: object) -> Task:
+    """A TOOL step (PR-6b-2): fire a single REGISTERED tool as a standalone node.
+
+    ``tool_id`` + ``tool_version`` name the tool the SERVER resolves in its live
+    registry (SN-8 — the client never supplies the warrant); ``args`` are the
+    tool-call arguments, lowered to ONE canonical-JSON object under
+    :data:`~kortecx.blueprints.TOOL_ARGS_KEY` in the step's params. The coordinator
+    re-derives + validates those args against the tool's typed schema fail-closed.
+    """
+    return Task(
+        StepInput(
+            kind="tool",
+            tool_contract={tool_id: tool_version},
+            params={TOOL_ARGS_KEY: _canonical_args_json(dict(args))},
+        )
+    )
 
 
 # --- The chain (operator AST or parsed DSL) + lowering ------------------------

--- a/bindings/python/tests/test_chains.py
+++ b/bindings/python/tests/test_chains.py
@@ -24,6 +24,7 @@ from kortecx.chains import (
     chain,
     model,
     pure,
+    tool,
 )
 
 # The corpus is the cross-surface contract: repo-root/tests/golden/chains. From
@@ -44,13 +45,18 @@ def _load_corpus() -> list:
 
 def _task_from_spec(spec: Dict[str, object]) -> Task:
     """Build a :class:`Task` from a corpus task spec (``{kind, model_id?, prompt?,
-    params?}``)."""
+    params?}`` for pure/model; ``{kind:"tool", tool_contract, args?}`` for tool)."""
     kind = spec["kind"]
     params = spec.get("params") or {}
     if kind == "model":
         return model(str(spec.get("model_id", "")), str(spec.get("prompt", "")), **params)
     if kind == "pure":
         return pure(**params)
+    if kind == "tool":
+        contract = spec.get("tool_contract") or {}
+        (tool_id, tool_version) = next(iter(contract.items()))
+        args = spec.get("args") or {}
+        return tool(str(tool_id), str(tool_version), **args)
     raise AssertionError(f"unsupported corpus task kind {kind!r}")
 
 

--- a/bindings/typescript/src/blueprints.ts
+++ b/bindings/typescript/src/blueprints.ts
@@ -18,8 +18,8 @@ import {
 } from "./gen/kortecx/v1/gateway_pb.js";
 import { decodeFixed } from "./hexids.js";
 
-/** The vetted step palette (EXEC is reserved server-side in PR-1). */
-export type StepKind = "pure" | "model" | "exec";
+/** The vetted step palette (EXEC is reserved server-side in PR-1; TOOL = PR-6b-2). */
+export type StepKind = "pure" | "model" | "exec" | "tool";
 /** Frozen = memoize/reuse (default); dynamic is reserved server-side in PR-1. */
 export type ExecutionMode = "frozen" | "dynamic";
 export type EdgeType = "data" | "control";
@@ -48,6 +48,7 @@ const STEP_KIND: Record<StepKind, WorkflowStepKind> = {
   pure: WorkflowStepKind.PURE,
   model: WorkflowStepKind.MODEL,
   exec: WorkflowStepKind.EXEC,
+  tool: WorkflowStepKind.TOOL,
 };
 
 function paramBytes(v: Uint8Array | string): Uint8Array {

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -51,11 +51,13 @@ export class ChainCycleError extends Error {
  */
 export class Task {
   constructor(
-    readonly kind: "pure" | "model",
+    readonly kind: "pure" | "model" | "tool",
     readonly modelId: string,
     readonly prompt: string,
     /** Pre-encoding lowering form — `params` values are strings (UTF-8-encoded at build). */
     readonly params: Readonly<Record<string, string>>,
+    /** TOOL only (PR-6b-2): the single `{ tool_id: tool_version }` the step fires. */
+    readonly toolContract: Readonly<Record<string, string>> = {},
   ) {}
 
   /** The {@link StepInput} this task lowers to (verbatim, the builder encodes params). */
@@ -64,12 +66,33 @@ export class Task {
       kind: this.kind,
       modelId: this.modelId,
       prompt: this.prompt,
+      toolContract: { ...this.toolContract },
       params: { ...this.params },
     };
   }
 }
 
-/** Factories for the live `pure` / `model` palette (TS has no operator overloading). */
+/**
+ * PR-6b-2: the single canonical `config_subset` key a `tool()` step's authored
+ * args ride under. MUST equal the Rust `kx_mote::TOOL_ARGS_KEY` + the Python
+ * `TOOL_ARGS_KEY` (the coordinator's `is_authored_tool` discriminant + args source).
+ */
+export const TOOL_ARGS_KEY = "kx.tool.args";
+
+/**
+ * Serialize a flat tool-call arg map to the canonical-JSON string the three SDK
+ * surfaces lower byte-identically: keys sorted ascending, compact separators, no
+ * floats (SN-8 — the server schema is integer/bytes/bool/enum-typed).
+ */
+function canonicalArgsJson(args: Readonly<Record<string, string | number | boolean>>): string {
+  const sorted: Record<string, string | number | boolean> = {};
+  for (const k of Object.keys(args).sort()) {
+    sorted[k] = args[k] as string | number | boolean;
+  }
+  return JSON.stringify(sorted);
+}
+
+/** Factories for the live `pure` / `model` / `tool` palette (TS has no operator overloading). */
 export const task = {
   /** A `pure` step (optional string params). */
   pure(params: Readonly<Record<string, string>> = {}): Task {
@@ -78,6 +101,26 @@ export const task = {
   /** A `model` step: the model id + prompt (+ optional string params). */
   model(modelId: string, prompt: string, params: Readonly<Record<string, string>> = {}): Task {
     return new Task("model", modelId, prompt, { ...params });
+  },
+  /**
+   * A `tool` step (PR-6b-2): fire a single REGISTERED tool. `toolId` + `version`
+   * name the tool the SERVER resolves (SN-8); `args` are the tool-call arguments,
+   * lowered to one canonical-JSON object under {@link TOOL_ARGS_KEY}.
+   */
+  tool(
+    toolId: string,
+    version: string,
+    args: Readonly<Record<string, string | number | boolean>> = {},
+  ): Task {
+    return new Task(
+      "tool",
+      "",
+      "",
+      { [TOOL_ARGS_KEY]: canonicalArgsJson(args) },
+      {
+        [toolId]: version,
+      },
+    );
   },
 };
 
@@ -402,7 +445,7 @@ function dedupRefs(refs: HandleRef[]): HandleRef[] {
 
 /** A canonical lowered step (the corpus snake_case shape; `params` values are strings). */
 export interface LoweredStep {
-  kind: "pure" | "model";
+  kind: "pure" | "model" | "tool";
   model_id: string;
   prompt: string;
   body_signature_id: null;
@@ -445,7 +488,7 @@ function taskToLoweredStep(t: Task): LoweredStep {
     model_id: t.modelId,
     prompt: t.prompt,
     body_signature_id: null,
-    tool_contract: {},
+    tool_contract: { ...t.toolContract },
     params: { ...t.params },
   };
 }

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -96,6 +96,7 @@ export {
   group,
   chain,
   chainFrom,
+  TOOL_ARGS_KEY,
   ChainParseError,
   ChainUnknownHandleError,
   ChainCycleError,

--- a/bindings/typescript/test/chains.test.ts
+++ b/bindings/typescript/test/chains.test.ts
@@ -38,10 +38,13 @@ const CORPUS_PATH = join(
 
 /** A task spec as it appears in the corpus (the resolved `tasks` map values). */
 interface CorpusTask {
-  kind: "pure" | "model";
+  kind: "pure" | "model" | "tool";
   model_id?: string;
   prompt?: string;
   params?: Record<string, string>;
+  /** TOOL only: the single `{ tool_id: tool_version }` + the structured args. */
+  tool_contract?: Record<string, string>;
+  args?: Record<string, string | number | boolean>;
 }
 
 interface CorpusCase {
@@ -57,10 +60,14 @@ interface CorpusCase {
 function tasksFromCorpus(specs: Record<string, CorpusTask>): Record<string, Task> {
   const out: Record<string, Task> = {};
   for (const [handle, spec] of Object.entries(specs)) {
-    out[handle] =
-      spec.kind === "model"
-        ? task.model(spec.model_id ?? "", spec.prompt ?? "", spec.params ?? {})
-        : task.pure(spec.params ?? {});
+    if (spec.kind === "model") {
+      out[handle] = task.model(spec.model_id ?? "", spec.prompt ?? "", spec.params ?? {});
+    } else if (spec.kind === "tool") {
+      const [toolId, version] = Object.entries(spec.tool_contract ?? {})[0] ?? ["", ""];
+      out[handle] = task.tool(toolId, version, spec.args ?? {});
+    } else {
+      out[handle] = task.pure(spec.params ?? {});
+    }
   }
   return out;
 }

--- a/crates/kx-capability/src/local.rs
+++ b/crates/kx-capability/src/local.rs
@@ -117,6 +117,29 @@ impl<S: ContentStore + Send + Sync> LocalCapabilityBroker<S> {
         self.capabilities.read().expect("RwLock poisoned").len()
     }
 
+    /// The `(tool_id, tool_version)` of every currently-registered capability —
+    /// the LIVE broker-fireable set (PR-6b-2).
+    ///
+    /// The gateway's authoring backstop reads this so a runtime-dialed external
+    /// MCP tool becomes authorable (a `tool()` step / an auto-grant) the MOMENT
+    /// its firing capability registers, never gated by a startup snapshot. The
+    /// map is keyed by [`ToolName`]; each capability reports its own pinned
+    /// `version()` (the precheck's grant key).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal `RwLock` is poisoned (see
+    /// [`register_capability`][Self::register_capability]).
+    #[must_use]
+    pub fn registered_grants(&self) -> std::collections::BTreeSet<(String, String)> {
+        self.capabilities
+            .read()
+            .expect("RwLock poisoned")
+            .iter()
+            .map(|(name, cap)| (name.0.clone(), cap.version().0.clone()))
+            .collect()
+    }
+
     /// Internal: run the per-call contract checks shared by
     /// `dispatch` and `probe_readback`. Returns the resolved capability
     /// version on success (so the caller can build a `BrokerHandle`

--- a/crates/kx-cli/src/verbs/blueprint.rs
+++ b/crates/kx-cli/src/verbs/blueprint.rs
@@ -50,9 +50,14 @@ pub(crate) struct DagSpec {
     pub(crate) execution_mode: Option<String>,
 }
 
+/// PR-6b-2: the single canonical config key a `tool` step's authored args ride
+/// under. MUST equal `kx_mote::TOOL_ARGS_KEY` + the Py/TS `TOOL_ARGS_KEY` (pinned
+/// identical by the golden corpus). Hardcoded to avoid a `kx-mote` dep on the CLI.
+const TOOL_ARGS_KEY: &str = "kx.tool.args";
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct StepSpec {
-    /// `pure` | `model` | `exec` (exec reserved).
+    /// `pure` | `model` | `exec` (reserved) | `tool` (PR-6b-2).
     pub(crate) kind: String,
     #[serde(default)]
     pub(crate) model_id: String,
@@ -66,6 +71,11 @@ pub(crate) struct StepSpec {
     /// Free config entries; values are UTF-8 strings.
     #[serde(default)]
     pub(crate) params: BTreeMap<String, String>,
+    /// TOOL only (PR-6b-2): the tool-call arguments, serialized at lowering to ONE
+    /// canonical-JSON object under [`TOOL_ARGS_KEY`] (sorted keys, compact) —
+    /// byte-identical to the Py/TS `tool()` factories. No floats (SN-8).
+    #[serde(default)]
+    pub(crate) args: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -152,9 +162,10 @@ pub(crate) fn to_request(spec: DagSpec) -> Result<proto::SubmitWorkflowRequest, 
             "pure" => proto::WorkflowStepKind::Pure,
             "model" => proto::WorkflowStepKind::Model,
             "exec" => proto::WorkflowStepKind::Exec,
+            "tool" => proto::WorkflowStepKind::Tool,
             other => {
                 return Err(CliError::Usage(format!(
-                    "step kind must be pure|model|exec, got {other:?}"
+                    "step kind must be pure|model|exec|tool, got {other:?}"
                 )));
             }
         };
@@ -164,17 +175,27 @@ pub(crate) fn to_request(spec: DagSpec) -> Result<proto::SubmitWorkflowRequest, 
                 .to_vec(),
             None => Vec::new(),
         };
+        let mut params: BTreeMap<String, Vec<u8>> = s
+            .params
+            .into_iter()
+            .map(|(k, v)| (k, v.into_bytes()))
+            .collect();
+        // PR-6b-2: a TOOL step lowers its authored args to the canonical-JSON blob
+        // under TOOL_ARGS_KEY (`s.args` is a BTreeMap ⇒ sorted keys; serde_json ⇒
+        // compact) — byte-identical to the Py/TS factories + the coordinator's
+        // `is_authored_tool` discriminant.
+        if kind == proto::WorkflowStepKind::Tool {
+            let blob = serde_json::to_string(&s.args)
+                .map_err(|e| CliError::Usage(format!("tool args: {e}")))?;
+            params.insert(TOOL_ARGS_KEY.to_string(), blob.into_bytes());
+        }
         steps.push(proto::WorkflowStep {
             kind: kind as i32,
             model_id: s.model_id,
             prompt: s.prompt,
             body_signature_id,
             tool_contract: s.tool_contract.into_iter().collect(),
-            params: s
-                .params
-                .into_iter()
-                .map(|(k, v)| (k, v.into_bytes()))
-                .collect(),
+            params: params.into_iter().collect(),
         });
     }
     let mut edges = Vec::with_capacity(spec.edges.len());

--- a/crates/kx-cli/src/verbs/chain.rs
+++ b/crates/kx-cli/src/verbs/chain.rs
@@ -18,7 +18,9 @@
 //! `--tasks` is a JSON object map `{ "a": {"kind":"pure", ...}, ... }` — each value
 //! is a [`StepSpec`](crate::verbs::blueprint) (the same shape as a `blueprint`
 //! step). A handle that appears more than once is the SAME node (reuse builds DAGs);
-//! tasks defined but unused are ignored (lenient). P1 palette: `pure` / `model`.
+//! tasks defined but unused are ignored (lenient). Palette: `pure` / `model` /
+//! `tool` (PR-6b-2 — fire a registered tool; `args` lower to the canonical
+//! `kx.tool.args` blob).
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
@@ -549,6 +551,8 @@ mod tests {
         #[serde(default)]
         prompt: String,
         #[serde(default)]
+        tool_contract: BTreeMap<String, String>,
+        #[serde(default)]
         params: BTreeMap<String, String>,
     }
 
@@ -575,6 +579,7 @@ mod tests {
             Ok(proto::WorkflowStepKind::Pure) => "pure",
             Ok(proto::WorkflowStepKind::Model) => "model",
             Ok(proto::WorkflowStepKind::Exec) => "exec",
+            Ok(proto::WorkflowStepKind::Tool) => "tool",
             _ => "unspecified",
         }
     }
@@ -627,6 +632,16 @@ mod tests {
                     case.name
                 );
                 assert_eq!(got.prompt, want.prompt, "[{}] step {i} prompt", case.name);
+                let got_contract: BTreeMap<String, String> = got
+                    .tool_contract
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                assert_eq!(
+                    got_contract, want.tool_contract,
+                    "[{}] step {i} tool_contract",
+                    case.name
+                );
                 let want_params: BTreeMap<String, Vec<u8>> = want
                     .params
                     .iter()

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -25,9 +25,9 @@ use kx_journal::{
     ResolvedCapabilityRecord, ResolvedKindTag, INSTANCE_ID_LEN,
 };
 use kx_mote::{
-    ConfigKey, EdgeKind, ModelId, Mote, MoteDef, MoteId, NdClass, ToolName, ToolVersion,
-    PROMPT_KEY, REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY, REACT_MAX_TURNS_KEY,
-    REACT_TURN_KEY,
+    ConfigKey, EdgeKind, EffectPattern, ModelId, Mote, MoteDef, MoteId, NdClass, ToolName,
+    ToolVersion, PROMPT_KEY, REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY, REACT_MAX_TURNS_KEY,
+    REACT_TURN_KEY, TOOL_ARGS_KEY,
 };
 use kx_projection::{
     ContentStoreVerdicts, MoteState, Projection, ReactRoundRecord, RegisterMote, ReplanRoundRecord,
@@ -654,6 +654,17 @@ fn lease_ready(
                         Some(args) => Some(args),
                         None => return None,
                     }
+                } else if is_authored_tool(mote, projection) {
+                    // PR-6b-2: a STANDALONE authored `tool()` node derives its args
+                    // from its OWN identity-bearing `config_subset` (no parent, no
+                    // store I/O), validated fail-closed. Same args-or-skip rule as
+                    // the react observation: a transient registry fault skips the
+                    // lease this poll and a later poll retries (the worker never
+                    // sees an authored tool without coordinator-validated args).
+                    match resolve_authored_tool_args(mote, tool_registry) {
+                        Some(args) => Some(args),
+                        None => return None,
+                    }
                 } else {
                     None
                 };
@@ -728,6 +739,74 @@ fn resolve_tool_args(
     // precheck still enforces request.fs_scope ⊆ warrant.fs_scope at dispatch.
     Some((
         call.args_bytes,
+        def.required_capability.net_scope_required.clone(),
+        def.required_capability.fs_scope_required.clone(),
+    ))
+}
+
+/// PR-6b-2: `true` iff `mote` is a STANDALONE authored `tool()` node — a
+/// tool-contract Mote carrying its AUTHORED args in `config_subset[TOOL_ARGS_KEY]`,
+/// declared `StageThenCommit`, and NOT a coordinator-materialized ReAct
+/// observation. The two args-bearing shapes are provably DISJOINT: a react
+/// observation has a folded react-turn Data parent and NO `TOOL_ARGS_KEY` (its
+/// args are re-derived from the parent turn's output, [`resolve_tool_args`]); an
+/// authored tool node carries the key and has no react-turn parent. Scoped as
+/// tight as [`is_react_observation`] so the args-from-params lease branch can NEVER
+/// wedge an ordinary WM Mote — anything failing this predicate (every canonical
+/// run mote: no `tool_contract`, no `TOOL_ARGS_KEY`) leases exactly as before.
+fn is_authored_tool(mote: &Mote, projection: &Projection) -> bool {
+    !mote.def.tool_contract.is_empty()
+        && mote.effect_pattern() == EffectPattern::StageThenCommit
+        && mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(TOOL_ARGS_KEY.to_string()))
+        && !is_react_observation(mote, projection)
+}
+
+/// PR-6b-2: derive a standalone authored `tool()` node's `(args_bytes, net_scope,
+/// fs_scope)` — a PURE function of the Mote's OWN identity-bearing `config_subset`
+/// (NO parent, NO store I/O), run on the sole-writer thread at every (re-)lease:
+///
+/// 1. require `tool_contract` to name EXACTLY one `(tool, version)` (an authored
+///    tool step binds a single tool);
+/// 2. read the authored args object from `config_subset[TOOL_ARGS_KEY]` — one
+///    canonical-JSON object lowered byte-identically by the Chains DSL and copied
+///    verbatim into `config_subset` by the gateway binder;
+/// 3. resolve the tool def (`lookup` returns `None` for absent/PendingHumanReview
+///    — fail-closed) and validate the args against its typed `inputSchema`
+///    FAIL-CLOSED ([`kx_tool_registry::validate_args`]);
+/// 4. take the tool's DECLARED net/fs requirement as the request scopes (the
+///    broker's `precheck` still enforces request ⊆ warrant at dispatch).
+///
+/// `None` on ANY fault (multi/empty contract, missing config, unknown or pending
+/// tool, schema reject) — the lease is skipped this poll. Because the args live in
+/// the identity-bearing `config_subset`, recovery re-derives them byte-identically;
+/// a persistent `None` is a registry/admission fault (already gated at authoring),
+/// not a nondeterministic disagreement, so skip-and-retry is fail-closed (no
+/// effect ever fires without coordinator-validated args).
+fn resolve_authored_tool_args(
+    mote: &Mote,
+    tool_registry: &dyn ToolRegistry,
+) -> Option<(Vec<u8>, kx_warrant::NetScope, kx_warrant::FsScope)> {
+    // Exactly one (tool, version): the authored tool step binds a single tool.
+    let mut contract = mote.def.tool_contract.iter();
+    let (name, version) = contract.next()?;
+    if contract.next().is_some() {
+        return None;
+    }
+    let args_bytes = mote
+        .def
+        .config_subset
+        .get(&ConfigKey(TOOL_ARGS_KEY.to_string()))?
+        .0
+        .clone();
+    let def = tool_registry.lookup(name, version)?;
+    if let Some(schema) = &def.input_schema {
+        kx_tool_registry::validate_args(schema, &args_bytes).ok()?;
+    }
+    Some((
+        args_bytes,
         def.required_capability.net_scope_required.clone(),
         def.required_capability.fs_scope_required.clone(),
     ))
@@ -3202,4 +3281,140 @@ fn apply_batch<J: Journal>(
         });
     }
     Ok(applied)
+}
+
+#[cfg(test)]
+mod authored_tool_tests {
+    //! PR-6b-2: the fail-closed `resolve_authored_tool_args` gate — the
+    //! coordinator's args-from-`config_subset` resolver for a standalone authored
+    //! `tool()` node. (Full lease-path disjointness incl. `is_authored_tool`'s
+    //! Projection dependence is covered by the live integration test
+    //! `tests/tool_node_live.rs`.)
+    use super::*;
+    use kx_mote::{
+        ConfigVal, GraphPosition, InferenceParams, InputDataId, LogicRef, PromptTemplateHash,
+        MOTE_DEF_SCHEMA_VERSION,
+    };
+    use kx_tool_registry::{
+        IdempotencyClass, InMemoryToolRegistry, InputSchema, ParamSpec, ParamType, ToolDef,
+        ToolKind, ToolProvenance,
+    };
+    use kx_warrant::{FsScope, NetScope, ResourceCeiling, ToolRequirement};
+
+    fn tool_mote(contract: &[(&str, &str)], args: Option<&[u8]>) -> Mote {
+        let mut tool_contract = BTreeMap::new();
+        for (n, v) in contract {
+            tool_contract.insert(ToolName((*n).into()), ToolVersion((*v).into()));
+        }
+        let mut config_subset = BTreeMap::new();
+        if let Some(a) = args {
+            config_subset.insert(ConfigKey(TOOL_ARGS_KEY.to_string()), ConfigVal(a.to_vec()));
+        }
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([7u8; 32]),
+            model_id: ModelId("test".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([7u8; 32]),
+            tool_contract,
+            nd_class: NdClass::WorldMutating,
+            config_subset,
+            effect_pattern: EffectPattern::StageThenCommit,
+            critic_for: None,
+            is_topology_shaper: false,
+            inference_params: InferenceParams::default(),
+            critic_check: None,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([7u8; 32]),
+            GraphPosition(vec![1]),
+            SmallVec::new(),
+        )
+    }
+
+    fn registry_with(schema: Option<InputSchema>) -> InMemoryToolRegistry {
+        let mut reg = InMemoryToolRegistry::new();
+        let def = ToolDef {
+            tool_id: ToolName("web-search".into()),
+            tool_version: ToolVersion("1".into()),
+            kind: ToolKind::Builtin,
+            required_capability: ToolRequirement {
+                net_scope_required: NetScope::None,
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: String::new(),
+            idempotency_class: IdempotencyClass::Staged,
+            input_schema: schema,
+        };
+        let _ = reg.register(def, ToolProvenance::HumanAuthored { author: "t".into() });
+        reg
+    }
+
+    fn schema() -> InputSchema {
+        InputSchema {
+            params: vec![ParamSpec {
+                name: "q".into(),
+                ty: ParamType::Str { max_len: 64 },
+                required: true,
+            }],
+            deny_unknown: true,
+        }
+    }
+
+    #[test]
+    fn happy_path_returns_validated_args() {
+        let reg = registry_with(Some(schema()));
+        let mote = tool_mote(&[("web-search", "1")], Some(br#"{"q":"hi"}"#));
+        let got = resolve_authored_tool_args(&mote, &reg).expect("valid args resolve");
+        assert_eq!(got.0, br#"{"q":"hi"}"#.to_vec());
+        assert_eq!(got.1, NetScope::None);
+    }
+
+    #[test]
+    fn absent_tool_is_fail_closed() {
+        let reg = InMemoryToolRegistry::new(); // empty — tool not registered
+        let mote = tool_mote(&[("web-search", "1")], Some(br#"{"q":"hi"}"#));
+        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+    }
+
+    #[test]
+    fn multi_tool_contract_is_refused() {
+        let reg = registry_with(Some(schema()));
+        let mote = tool_mote(
+            &[("web-search", "1"), ("other", "1")],
+            Some(br#"{"q":"hi"}"#),
+        );
+        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+    }
+
+    #[test]
+    fn missing_config_args_is_refused() {
+        let reg = registry_with(Some(schema()));
+        let mote = tool_mote(&[("web-search", "1")], None);
+        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+    }
+
+    #[test]
+    fn schema_reject_is_fail_closed() {
+        let reg = registry_with(Some(schema()));
+        // `q` required but absent, and a smuggled key under deny_unknown.
+        let mote = tool_mote(&[("web-search", "1")], Some(br#"{"smuggled":1}"#));
+        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+    }
+
+    #[test]
+    fn no_schema_tool_passes_args_through() {
+        let reg = registry_with(None); // no input_schema ⇒ no client-side gate
+        let mote = tool_mote(&[("web-search", "1")], Some(br#"{"anything":true}"#));
+        let got = resolve_authored_tool_args(&mote, &reg).expect("passes through");
+        assert_eq!(got.0, br#"{"anything":true}"#.to_vec());
+    }
 }

--- a/crates/kx-gateway-core/src/lib.rs
+++ b/crates/kx-gateway-core/src/lib.rs
@@ -102,10 +102,10 @@ pub use service::{
     BoundRecipe, CatalogSeamError, EventStream, EventTailer, GatewayService, GlobalEventStream,
     GlobalEventTailer, GrantEntry, GrantView, MembershipView, NoTokenTailer, RecipeBinder,
     RecipeCatalog, RecipeFormFieldEntry, RecipeMetadataEntry, RecipeParamKind, RegisteredSignature,
-    ScoredRecipeEntry, SignatureCatalog, SignatureSummaryEntry, SnapshotGlobalTailer,
-    SnapshotTailer, TeamMemberEntry, TeamMembersView, TeamSummaryEntry, TokenStream, TokenTailer,
-    WarrantProjection, WorkflowAuthor, BATCH_ITEM_CLAMP_BYTES, DEFAULT_PUT_CAP_BYTES,
-    MAX_BATCH_REFS, MAX_FEEDBACK_COMMENT_BYTES, REFUSAL_CODE_METADATA_KEY,
+    RegisteredToolsView, ScoredRecipeEntry, SignatureCatalog, SignatureSummaryEntry,
+    SnapshotGlobalTailer, SnapshotTailer, TeamMemberEntry, TeamMembersView, TeamSummaryEntry,
+    TokenStream, TokenTailer, WarrantProjection, WorkflowAuthor, BATCH_ITEM_CLAMP_BYTES,
+    DEFAULT_PUT_CAP_BYTES, MAX_BATCH_REFS, MAX_FEEDBACK_COMMENT_BYTES, REFUSAL_CODE_METADATA_KEY,
     SEARCH_RECIPES_DEFAULT_LIMIT, SEARCH_RECIPES_MAX_LIMIT,
 };
 pub use submit::{

--- a/crates/kx-gateway-core/src/service.rs
+++ b/crates/kx-gateway-core/src/service.rs
@@ -447,7 +447,7 @@ pub trait WorkflowAuthor: Send + Sync {
 /// MOMENT its firing capability registers, never gated by a startup snapshot.
 ///
 /// `None` on the service ⇒ the backstop falls back to the static
-/// [`GatewayService::registered_tools`] set (the PR-2d-2 behaviour — bundled
+/// `GatewayService::registered_tools` set (the PR-2d-2 behaviour — bundled
 /// tools only). The VIEW never authorizes (SN-8): it is a belt-and-braces
 /// fail-closed gate that refuses authoring a warrant granting a tool the broker
 /// cannot fire; the broker's own 6-gate `precheck` re-verifies at dispatch.

--- a/crates/kx-gateway-core/src/service.rs
+++ b/crates/kx-gateway-core/src/service.rs
@@ -369,12 +369,19 @@ pub enum AuthorStepKind {
     /// References a REGISTERED body by its signature id; the host maps it to that
     /// body's content `logic_ref`. The client cannot inject bytes (Tier-1 invariant).
     Exec,
+    /// Fires a single REGISTERED tool as a standalone DAG node (PR-6b-2). The host
+    /// looks the tool up in the live tool registry, builds its warrant SERVER-SIDE
+    /// from the tool's declared `required_capability` (SN-8 — never a client
+    /// warrant), and carries the authored args (canonical-JSON) into the step's
+    /// `config_subset[TOOL_ARGS_KEY]`. The client supplies only the
+    /// `(tool_id, tool_version)` + args; the warrant + identity are server-derived.
+    Tool,
 }
 
 /// One authored step in gateway-core's vocabulary (no `kx_workflow` dep here).
 #[derive(Debug, Clone)]
 pub struct AuthorStep {
-    /// The palette kind (PURE / MODEL / EXEC).
+    /// The palette kind (PURE / MODEL / EXEC / TOOL).
     pub kind: AuthorStepKind,
     /// MODEL: the model id (must equal the served model); ignored otherwise.
     pub model_id: String,
@@ -432,6 +439,22 @@ pub trait WorkflowAuthor: Send + Sync {
         edges: &[AuthorEdge],
         mode: AuthorExecutionMode,
     ) -> Result<BoundRecipe, BinderError>;
+}
+
+/// The LIVE broker-fireable tool set seam (PR-6b-2 — the authoring backstop's
+/// truth source). The host impl wraps the serve broker so a runtime-dialed
+/// external MCP tool becomes authorable (a `tool()` step / an auto-grant) the
+/// MOMENT its firing capability registers, never gated by a startup snapshot.
+///
+/// `None` on the service ⇒ the backstop falls back to the static
+/// [`GatewayService::registered_tools`] set (the PR-2d-2 behaviour — bundled
+/// tools only). The VIEW never authorizes (SN-8): it is a belt-and-braces
+/// fail-closed gate that refuses authoring a warrant granting a tool the broker
+/// cannot fire; the broker's own 6-gate `precheck` re-verifies at dispatch.
+pub trait RegisteredToolsView: Send + Sync {
+    /// The `(tool_id, tool_version)` of every tool whose firing capability is
+    /// CURRENTLY registered on the serve broker.
+    fn registered_grants(&self) -> std::collections::BTreeSet<(String, String)>;
 }
 
 /// The boxed server-streaming type the `StreamEvents` RPC returns.
@@ -666,6 +689,11 @@ pub struct GatewayService {
     /// over the provisioning invariant; the react recipe is only seeded when its
     /// tool registered). Empty by default (no tools — every grant refused).
     registered_tools: std::collections::BTreeSet<(String, String)>,
+    /// PR-6b-2: the optional LIVE broker-fireable set seam. When wired (the serve
+    /// path), the authoring backstop reads this instead of the static
+    /// `registered_tools` snapshot — so a runtime-DIALED external MCP tool becomes
+    /// authorable the moment its capability registers. `None` ⇒ the static set.
+    registered_tools_view: Option<Arc<dyn RegisteredToolsView>>,
     /// The optional advisory toolscout seam (W1.A5 — the host injects a
     /// registry-backed manifest index). `None` ⇒ `ListToolManifests` /
     /// `ScoreTaskBundle` return `unimplemented`. Read-only, display-only.
@@ -778,6 +806,7 @@ impl GatewayService {
             critics_supported: false,
             react_supported: false,
             registered_tools: std::collections::BTreeSet::new(),
+            registered_tools_view: None,
             toolscout: None,
             author: None,
             content_writer: None,
@@ -826,6 +855,29 @@ impl GatewayService {
     ) -> Self {
         self.registered_tools = tools;
         self
+    }
+
+    /// Wire the LIVE broker-fireable tool set seam (PR-6b-2). When set, the
+    /// authoring backstop reads the broker's CURRENT capabilities instead of the
+    /// static [`with_registered_tools`](Self::with_registered_tools) snapshot — so
+    /// a runtime-DIALED external MCP tool (or any tool registered after startup)
+    /// becomes authorable the moment its firing capability registers.
+    #[must_use]
+    pub fn with_registered_tools_view(mut self, view: Arc<dyn RegisteredToolsView>) -> Self {
+        self.registered_tools_view = Some(view);
+        self
+    }
+
+    /// PR-6b-2: the LIVE broker-fireable `(tool_id, tool_version)` set the
+    /// authoring/invoke backstop checks against — the wired [`RegisteredToolsView`]
+    /// when present (so a runtime-DIALED external MCP tool is visible the moment it
+    /// registers), else the static `registered_tools` snapshot (the PR-2d-2
+    /// behaviour). Never authorizes (SN-8); a fail-closed drift backstop.
+    fn fireable_grants(&self) -> std::collections::BTreeSet<(String, String)> {
+        match &self.registered_tools_view {
+            Some(view) => view.registered_grants(),
+            None => self.registered_tools.clone(),
+        }
     }
 
     /// Wire the signature-catalog seam (the host's concrete `kx-catalog`-backed
@@ -1327,13 +1379,15 @@ impl KxGateway for GatewayService {
         // name capabilities the host ACTUALLY registered on the serve broker (a
         // grant the broker cannot honour dead-letters every observation it fires).
         // Server-derived warrants make this a provisioning invariant; the check is
-        // the fail-closed backstop against drift.
+        // the fail-closed backstop against drift. PR-6b-2: read the LIVE broker set
+        // so a runtime-dialed tool a recipe grants is honoured.
+        let fireable = self.fireable_grants();
         for (_, warrant) in &bound.motes {
-            if let Some(grant) = warrant.tool_grants.iter().find(|g| {
-                !self
-                    .registered_tools
-                    .contains(&(g.tool_id.0.clone(), g.tool_version.0.clone()))
-            }) {
+            if let Some(grant) = warrant
+                .tool_grants
+                .iter()
+                .find(|g| !fireable.contains(&(g.tool_id.0.clone(), g.tool_version.0.clone())))
+            {
                 return Err(Status::failed_precondition(format!(
                     "recipe grants tool {}@{} but this serve registered no such \
                      capability",
@@ -1422,9 +1476,10 @@ impl KxGateway for GatewayService {
                 Ok(proto::WorkflowStepKind::Pure) => AuthorStepKind::Pure,
                 Ok(proto::WorkflowStepKind::Model) => AuthorStepKind::Model,
                 Ok(proto::WorkflowStepKind::Exec) => AuthorStepKind::Exec,
+                Ok(proto::WorkflowStepKind::Tool) => AuthorStepKind::Tool,
                 _ => {
                     return Err(Status::invalid_argument(
-                        "WorkflowStep.kind must be PURE, MODEL, or EXEC",
+                        "WorkflowStep.kind must be PURE, MODEL, EXEC, or TOOL",
                     ));
                 }
             };
@@ -1485,13 +1540,15 @@ impl KxGateway for GatewayService {
 
         // The Invoke tool-grant backstop: every server-built warrant's grants must
         // name a capability the host ACTUALLY registered on the broker (fail-closed
-        // against provisioning drift).
+        // against provisioning drift). PR-6b-2: a `tool()` step grants a registered
+        // tool; the LIVE broker set makes a runtime-dialed tool authorable.
+        let fireable = self.fireable_grants();
         for (_, warrant) in &bound.motes {
-            if let Some(grant) = warrant.tool_grants.iter().find(|g| {
-                !self
-                    .registered_tools
-                    .contains(&(g.tool_id.0.clone(), g.tool_version.0.clone()))
-            }) {
+            if let Some(grant) = warrant
+                .tool_grants
+                .iter()
+                .find(|g| !fireable.contains(&(g.tool_id.0.clone(), g.tool_version.0.clone())))
+            {
                 return Err(Status::failed_precondition(format!(
                     "authored step grants tool {}@{} but this serve registered no such \
                      capability",

--- a/crates/kx-gateway/src/mcp_tool.rs
+++ b/crates/kx-gateway/src/mcp_tool.rs
@@ -19,8 +19,7 @@ use kx_content::{ContentRef, ContentStore};
 use kx_mcp::{McpCapability, StdioTransport};
 use kx_mote::{ToolName, ToolVersion};
 use kx_tool_registry::{
-    IdempotencyClass, InMemoryToolRegistry, InputSchema, McpEndpointId, ParamSpec, ParamType,
-    ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+    IdempotencyClass, InputSchema, McpEndpointId, ParamSpec, ParamType, ToolDef, ToolKind,
 };
 use kx_warrant::{FsScope, NetScope, ResourceCeiling, ToolRequirement};
 
@@ -124,31 +123,6 @@ pub(crate) fn register_fs_list_capability<S: ContentStore + Send + Sync>(
 ) {
     broker.register_capability(Box::new(kx_capability::FsListCapability::new()));
     tracing::info!("PR-6a/D155: read-only fs-list@1 capability registered (kx/recipes/react-fs)");
-}
-
-/// A tool registry carrying the OSS built-ins PLUS the bundled echo tool, and —
-/// when an `fs_root` is granted (`KX_SERVE_FS_ROOT`) — the read-only `fs-list@1`
-/// tool. Shared by the coordinator (settle-time `validate_args` + lease-time args
-/// re-derivation) and the recipe seeding, so the grant, the registry, and the
-/// broker agree by construction. `fs_root = None` ⇒ byte-identical to echo-only.
-#[must_use]
-pub(crate) fn registry_with_echo(fs_root: Option<&std::path::Path>) -> InMemoryToolRegistry {
-    let mut reg = InMemoryToolRegistry::with_builtins();
-    let _ = reg.register(
-        echo_tool_def(),
-        ToolProvenance::HumanAuthored {
-            author: "kx-gateway".into(),
-        },
-    );
-    if let Some(root) = fs_root {
-        let _ = reg.register(
-            fs_list_tool_def(root),
-            ToolProvenance::HumanAuthored {
-                author: "kx-gateway".into(),
-            },
-        );
-    }
-    reg
 }
 
 /// Locate the bundled `kx-mcp-echo` binary and register its capability on the

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -28,12 +28,14 @@ use kx_gateway_core::{
 use kx_invoke::{bind_snapshot, InvokeError, UseWarrantResolver};
 use kx_mote::{
     ConfigKey, ConfigVal, EdgeMeta, LogicRef, ModelId, ToolName, ToolVersion, PROMPT_KEY,
+    TOOL_ARGS_KEY,
 };
+use kx_tool_registry::{ToolDef, ToolRegistry};
 use kx_warrant::{
     intersect, ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope,
-    ResourceCeiling, Role, WarrantSpec,
+    ResourceCeiling, Role, ToolGrant, WarrantSpec,
 };
-use kx_workflow::{compile, transform, StepDef, WorkflowDef};
+use kx_workflow::{compile, tool_step, transform, StepDef, WorkflowDef};
 
 use crate::error::GatewayError;
 
@@ -1093,13 +1095,38 @@ impl UseWarrantResolver for HostUseResolver<'_> {
 /// client warrant — SN-8). Shares the library `Arc` with the binder/catalog.
 pub struct HostWorkflowAuthor {
     lib: std::sync::Arc<DemoLibrary>,
+    /// PR-6b-2: the LIVE tool registry (the SAME `Arc` the coordinator + broker
+    /// share). A `tool()` step resolves its def here (warrant + typed schema), and
+    /// `author()` widens the authoring CEILING with its tools so a server-built
+    /// tool warrant survives the per-party intersect — both LIVE, so a
+    /// runtime-DIALED external MCP tool is authorable the moment it registers.
+    /// `None` ([`from_shared`](Self::from_shared)) ⇒ `tool()` authoring is refused
+    /// (the PR-1 PURE/MODEL-only behaviour; every existing test path).
+    tools: Option<std::sync::Arc<dyn ToolRegistry>>,
 }
 
 impl HostWorkflowAuthor {
-    /// Wrap a [`DemoLibrary`] shared with the binder/catalog (one seed, many seams).
+    /// Wrap a [`DemoLibrary`] shared with the binder/catalog (one seed, many
+    /// seams), WITHOUT a tool registry — PURE/MODEL authoring only (`tool()` steps
+    /// are refused fail-closed).
     #[must_use]
     pub fn from_shared(lib: std::sync::Arc<DemoLibrary>) -> Self {
-        Self { lib }
+        Self { lib, tools: None }
+    }
+
+    /// Wrap a [`DemoLibrary`] WITH the live tool registry (PR-6b-2) — enables
+    /// `tool()` step authoring + a tool-aware authoring ceiling. The registry is
+    /// the SAME `Arc` shared with the coordinator + broker, so authoring, the D66
+    /// submission gate, and the broker dispatch all see one live tool set.
+    #[must_use]
+    pub fn from_shared_with_tools(
+        lib: std::sync::Arc<DemoLibrary>,
+        tools: std::sync::Arc<dyn ToolRegistry>,
+    ) -> Self {
+        Self {
+            lib,
+            tools: Some(tools),
+        }
     }
 
     /// Map one authored step → a `kx_workflow::StepDef`, server-assigning `logic_ref`.
@@ -1161,9 +1188,15 @@ impl HostWorkflowAuthor {
                     "EXEC step authoring is reserved (PR-1 supports PURE + MODEL)".into(),
                 ));
             }
+            // TOOL (PR-6b-2): fire a single REGISTERED tool as a standalone node
+            // (extracted helper — the host resolves the tool in the LIVE registry +
+            // builds its warrant SERVER-SIDE from the declared scope, SN-8).
+            AuthorStepKind::Tool => self.tool_step_def(index, s, base)?,
         };
         // Free params land in config_subset (identity-bearing); MODEL also binds the
         // prompt into config_subset[PROMPT_KEY] — the key the model executor reads.
+        // For a TOOL step the params carry the authored args under TOOL_ARGS_KEY
+        // (the SDK lowering's single param), which lands in config_subset here.
         for (k, v) in &s.params {
             def.config_subset
                 .insert(ConfigKey(k.clone()), ConfigVal(v.clone()));
@@ -1174,7 +1207,85 @@ impl HostWorkflowAuthor {
                 ConfigVal(s.prompt.clone().into_bytes()),
             );
         }
+        // PR-6b-2: a TOOL step ALWAYS carries a TOOL_ARGS_KEY entry — it is the
+        // coordinator's `is_authored_tool` discriminant and the args source. A
+        // no-arg call (or a client that omitted it) defaults to the empty object
+        // `{}`; the coordinator validates it against the tool's schema fail-closed.
+        if s.kind == AuthorStepKind::Tool
+            && !def
+                .config_subset
+                .contains_key(&ConfigKey(TOOL_ARGS_KEY.to_string()))
+        {
+            def.config_subset.insert(
+                ConfigKey(TOOL_ARGS_KEY.to_string()),
+                ConfigVal(b"{}".to_vec()),
+            );
+        }
         Ok(def)
+    }
+
+    /// PR-6b-2: build the [`StepDef`] for an authored `tool()` step. Resolves the
+    /// single `(tool_id, tool_version)` in the LIVE registry (fail-closed on
+    /// absent/`PendingHumanReview`), server-assigns a content-sentinel `logic_ref`,
+    /// and builds the per-step warrant from the tool's DECLARED scope ([`tool_step_warrant`]).
+    /// The authored args land in `config_subset[TOOL_ARGS_KEY]` via the shared
+    /// params loop in [`step_def`](Self::step_def).
+    fn tool_step_def(
+        &self,
+        index: usize,
+        s: &AuthorStep,
+        base: &WarrantSpec,
+    ) -> Result<StepDef, BinderError> {
+        let tools = self.tools.as_ref().ok_or_else(|| {
+            BinderError::InvalidArgs(
+                "this serve has no tool registry; TOOL steps are unavailable".into(),
+            )
+        })?;
+        // Exactly one (tool_id, tool_version) — a tool step binds one tool.
+        let mut it = s.tool_contract.iter();
+        let (name, version) = it.next().ok_or_else(|| {
+            BinderError::InvalidArgs(
+                "TOOL step must name exactly one (tool_id, tool_version)".into(),
+            )
+        })?;
+        if it.next().is_some() {
+            return Err(BinderError::InvalidArgs(
+                "TOOL step must name exactly one tool".into(),
+            ));
+        }
+        let tool_name = ToolName(name.clone());
+        let tool_version = ToolVersion(version.clone());
+        // Resolve the registered tool — `lookup` returns `None` for an absent OR
+        // `PendingHumanReview` registration (fail-closed, GR15).
+        let tdef = tools.lookup(&tool_name, &tool_version).ok_or_else(|| {
+            BinderError::InvalidArgs(format!(
+                "TOOL step references unregistered tool {name}@{version}"
+            ))
+        })?;
+        // Server-assigned content-sentinel logic_ref over (index, id, ver), so
+        // distinct tool steps get distinct ids (the client never supplies bytes).
+        let mut buf = Vec::with_capacity(64);
+        buf.extend_from_slice(b"kx-blueprint/tool/v1");
+        buf.extend_from_slice(&(index as u64).to_le_bytes());
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(b'@');
+        buf.extend_from_slice(version.as_bytes());
+        let logic_ref = LogicRef::from_bytes(*ContentRef::of(&buf).as_bytes());
+        // The step warrant = the authoring base (matching syscall_profile / executor
+        // / model_route ceilings) NARROWED to THIS tool's grant + declared net/fs.
+        // `author()` widens the party ceiling with the live registry so this survives
+        // the intersect; the broker precheck + coordinator D66 re-verify at fire.
+        let warrant = tool_step_warrant(base, &tool_name, &tool_version, &tdef);
+        let mut sd = tool_step(
+            logic_ref,
+            base.model_route.model_id.clone(),
+            warrant,
+            tool_name.clone(),
+        );
+        let mut tc = std::collections::BTreeMap::new();
+        tc.insert(tool_name, tool_version);
+        sd.tool_contract = tc;
+        Ok(sd)
     }
 }
 
@@ -1245,7 +1356,7 @@ impl WorkflowAuthor for HostWorkflowAuthor {
             grants: &self.lib.grants,
             owner_root: self.lib.blueprint_base.clone(),
         };
-        let effective = resolver
+        let mut effective = resolver
             .resolve_use(&party_id, &AssetRef::Path(handle))
             .ok_or(BinderError::NotAuthorized)?;
 
@@ -1254,6 +1365,24 @@ impl WorkflowAuthor for HostWorkflowAuthor {
         // grant → AttemptedWiden → NotAuthorized — identical to the Invoke binder).
         let compiled =
             compile(&wf).map_err(|e| BinderError::InvalidArgs(format!("compile: {e}")))?;
+        // PR-6b-2: widen the authoring CEILING with the tool axes the SERVER built
+        // for the authored `tool()` steps (each compiled mote's grants + declared
+        // net/fs — step_def resolved them from the LIVE registry), so the per-mote
+        // intersect below does not strip a registered tool's grant/scope. The
+        // tools are server-vetted; the per-party gate still holds (an unauthorized
+        // party never resolved `effective`). A PURE/MODEL mote has empty
+        // `tool_grants` ⇒ contributes nothing, and requests none of the widened
+        // scope ⇒ its intersect yields its own narrow warrant unchanged (the
+        // pre-6b-2 behaviour is byte-identical when no tool() steps are authored).
+        for cm in &compiled.motes {
+            if !cm.warrant.tool_grants.is_empty() {
+                for g in &cm.warrant.tool_grants {
+                    effective.tool_grants.insert(g.clone());
+                }
+                effective.net_scope = net_union(&effective.net_scope, &cm.warrant.net_scope);
+                fs_union_into(&mut effective.fs_scope, &cm.warrant.fs_scope);
+            }
+        }
         let terminal_mote_id = compiled
             .motes
             .last()
@@ -1712,6 +1841,73 @@ pub(crate) fn react_fs_warrant(
     }
 }
 
+/// PR-6b-2: the server-built warrant for a standalone authored `tool()` step.
+/// Starts from the authoring `base` (so `syscall_profile_ref` + `executor_class` +
+/// `model_route` match the authoring ceiling — the intersect's equality/subset
+/// axes) and NARROWS to EXACTLY this tool: grants `(name, version)` and sets the
+/// net/fs scope to the tool's DECLARED `required_capability`. The coordinator's
+/// `resolve_authored_tool_args` sets the dispatch REQUEST scope to the SAME
+/// declared values, so `request ⊆ warrant` holds by construction at the broker's
+/// precheck. WORLD-MUTATING classes mirror `build_react_tool`'s observation shape
+/// (the precheck has no `mote_class` gate — honest labelling, not a gate).
+fn tool_step_warrant(
+    base: &WarrantSpec,
+    name: &ToolName,
+    version: &ToolVersion,
+    tdef: &ToolDef,
+) -> WarrantSpec {
+    let mut w = base.clone();
+    let mut grants = BTreeSet::new();
+    grants.insert(ToolGrant {
+        tool_id: name.clone(),
+        tool_version: version.clone(),
+    });
+    w.tool_grants = grants;
+    w.net_scope = tdef.required_capability.net_scope_required.clone();
+    w.fs_scope = tdef.required_capability.fs_scope_required.clone();
+    w.mote_class = MoteClass::WorldMutating;
+    w.nd_class = MoteClass::WorldMutating;
+    w
+}
+
+/// The egress superset of two scopes: `None` is the identity; two allowlists merge
+/// to the union of their hosts (so each input `is_subset_of` the result).
+fn net_union(a: &NetScope, b: &NetScope) -> NetScope {
+    match (a, b) {
+        (NetScope::None, other) | (other, NetScope::None) => other.clone(),
+        (NetScope::EgressAllowlist(sa), NetScope::EgressAllowlist(sb)) => {
+            let mut hosts: BTreeSet<Host> = sa.clone();
+            hosts.extend(sb.iter().cloned());
+            NetScope::EgressAllowlist(hosts)
+        }
+    }
+}
+
+/// Merge `add`'s mounts into `ceiling` as a per-path SUPERSET (so each tool's
+/// fs_scope `is_subset_of` the result). On a path conflict the wider Read-family
+/// mode wins (`ReadOnly ∪ ReadWrite = ReadWrite`); a conflicting non-Read mode
+/// (e.g. `ExecOnly`, which no MCP/registered tool declares) keeps the existing
+/// mount — if that is not actually a superset, the per-tool intersect later fails
+/// closed for that tool, never silently widening.
+fn fs_union_into(ceiling: &mut FsScope, add: &FsScope) {
+    for (path, mode) in &add.mounts {
+        ceiling
+            .mounts
+            .entry(path.clone())
+            .and_modify(|existing| {
+                *existing = match (*existing, *mode) {
+                    (FsMode::ReadWrite, FsMode::ReadOnly | FsMode::ReadWrite)
+                    | (FsMode::ReadOnly, FsMode::ReadWrite) => FsMode::ReadWrite,
+                    (FsMode::ReadOnly, FsMode::ReadOnly) => FsMode::ReadOnly,
+                    // Any mode involving ExecOnly (orthogonal): keep the existing
+                    // mount; an Exec tool simply won't survive its own intersect.
+                    (existing, _) => existing,
+                };
+            })
+            .or_insert(*mode);
+    }
+}
+
 fn react_fs_handle() -> Result<AssetPath, GatewayError> {
     parse_handle(REACT_FS_RECIPE_HANDLE)
         .ok_or_else(|| GatewayError::Catalog("invalid react-fs recipe handle".into()))
@@ -1976,6 +2172,131 @@ mod tests {
             data: true,
             non_cascade: false,
         }
+    }
+
+    // ---- PR-6b-2: tool() authoring helpers + tests ------------------------
+
+    fn tool_registry_with(tool_id: &str, version: &str) -> std::sync::Arc<dyn ToolRegistry> {
+        use kx_tool_registry::{IdempotencyClass, InMemoryToolRegistry, ToolKind, ToolProvenance};
+        let mut reg = InMemoryToolRegistry::new();
+        let def = ToolDef {
+            tool_id: ToolName(tool_id.into()),
+            tool_version: ToolVersion(version.into()),
+            kind: ToolKind::Builtin,
+            required_capability: kx_warrant::ToolRequirement {
+                net_scope_required: NetScope::None,
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: String::new(),
+            idempotency_class: IdempotencyClass::Staged,
+            input_schema: None,
+        };
+        let _ = reg.register(def, ToolProvenance::HumanAuthored { author: "t".into() });
+        std::sync::Arc::new(reg)
+    }
+
+    fn author_with_tools(
+        dir: &std::path::Path,
+        tools: std::sync::Arc<dyn ToolRegistry>,
+    ) -> HostWorkflowAuthor {
+        let lib =
+            DemoLibrary::open(dir, ExecutorClass::Bwrap, &["alice@acme".to_string()]).unwrap();
+        HostWorkflowAuthor::from_shared_with_tools(std::sync::Arc::new(lib), tools)
+    }
+
+    fn tool_author_step(tool_id: &str, version: &str, args_json: &[u8]) -> AuthorStep {
+        let mut tc = std::collections::BTreeMap::new();
+        tc.insert(tool_id.to_string(), version.to_string());
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(TOOL_ARGS_KEY.to_string(), args_json.to_vec());
+        AuthorStep {
+            kind: AuthorStepKind::Tool,
+            model_id: String::new(),
+            prompt: String::new(),
+            body_signature_id: None,
+            tool_contract: tc,
+            params,
+        }
+    }
+
+    /// A `tool()` step authors a fireable, args-bearing, tool-granting Mote — the
+    /// shape the coordinator's `is_authored_tool` + the worker's args gate expect.
+    #[tokio::test]
+    async fn tool_step_authors_a_fireable_tool_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let author = author_with_tools(dir.path(), tool_registry_with("echo-tool", "1"));
+        let steps = [tool_author_step("echo-tool", "1", br#"{"q":"hi"}"#)];
+        let bound = author
+            .author("alice@acme", 3, &steps, &[], AuthorExecutionMode::Frozen)
+            .await
+            .expect("tool step authored");
+        assert_eq!(bound.motes.len(), 1);
+        let (mote, warrant) = &bound.motes[0];
+        // Names the tool + carries the authored args (the args-from-config path).
+        assert!(mote
+            .def
+            .tool_contract
+            .contains_key(&ToolName("echo-tool".into())));
+        let args = mote
+            .def
+            .config_subset
+            .get(&ConfigKey(TOOL_ARGS_KEY.to_string()))
+            .expect("authored args land in config_subset");
+        assert_eq!(args.0, br#"{"q":"hi"}"#.to_vec());
+        // The SERVER-built warrant GRANTS the tool (so the broker can fire it; SN-8).
+        assert!(warrant
+            .tool_grants
+            .iter()
+            .any(|g| g.tool_id.0 == "echo-tool"));
+        // The observation shape: WORLD-MUTATING + StageThenCommit.
+        assert_eq!(
+            mote.def.effect_pattern,
+            kx_mote::EffectPattern::StageThenCommit
+        );
+        // Deterministic + content-addressed (same authored bytes → same identity).
+        let again = author
+            .author("alice@acme", 3, &steps, &[], AuthorExecutionMode::Frozen)
+            .await
+            .expect("re-authored");
+        assert_eq!(bound.terminal_mote_id, again.terminal_mote_id);
+    }
+
+    /// A `tool()` step naming an UNREGISTERED tool is refused at authoring (the
+    /// fail-closed GR15 gate — the registry lookup misses).
+    #[tokio::test]
+    async fn tool_step_unregistered_tool_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let author = author_with_tools(dir.path(), tool_registry_with("echo-tool", "1"));
+        let steps = [tool_author_step("ghost-tool", "1", b"{}")];
+        assert!(matches!(
+            author
+                .author("alice@acme", 1, &steps, &[], AuthorExecutionMode::Frozen)
+                .await,
+            Err(BinderError::InvalidArgs(_))
+        ));
+    }
+
+    /// Without a wired tool registry (`from_shared`), `tool()` authoring is refused
+    /// fail-closed (the PR-1 PURE/MODEL-only behaviour is byte-unchanged).
+    #[tokio::test]
+    async fn tool_step_without_registry_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let author = demo_author(dir.path());
+        let steps = [tool_author_step("echo-tool", "1", b"{}")];
+        assert!(matches!(
+            author
+                .author("alice@acme", 1, &steps, &[], AuthorExecutionMode::Frozen)
+                .await,
+            Err(BinderError::InvalidArgs(_))
+        ));
     }
 
     /// An authored DAG compiles to STABLE, content-addressed identity (same bytes →

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -1356,7 +1356,7 @@ impl WorkflowAuthor for HostWorkflowAuthor {
             grants: &self.lib.grants,
             owner_root: self.lib.blueprint_base.clone(),
         };
-        let mut effective = resolver
+        let effective = resolver
             .resolve_use(&party_id, &AssetRef::Path(handle))
             .ok_or(BinderError::NotAuthorized)?;
 
@@ -1365,24 +1365,6 @@ impl WorkflowAuthor for HostWorkflowAuthor {
         // grant → AttemptedWiden → NotAuthorized — identical to the Invoke binder).
         let compiled =
             compile(&wf).map_err(|e| BinderError::InvalidArgs(format!("compile: {e}")))?;
-        // PR-6b-2: widen the authoring CEILING with the tool axes the SERVER built
-        // for the authored `tool()` steps (each compiled mote's grants + declared
-        // net/fs — step_def resolved them from the LIVE registry), so the per-mote
-        // intersect below does not strip a registered tool's grant/scope. The
-        // tools are server-vetted; the per-party gate still holds (an unauthorized
-        // party never resolved `effective`). A PURE/MODEL mote has empty
-        // `tool_grants` ⇒ contributes nothing, and requests none of the widened
-        // scope ⇒ its intersect yields its own narrow warrant unchanged (the
-        // pre-6b-2 behaviour is byte-identical when no tool() steps are authored).
-        for cm in &compiled.motes {
-            if !cm.warrant.tool_grants.is_empty() {
-                for g in &cm.warrant.tool_grants {
-                    effective.tool_grants.insert(g.clone());
-                }
-                effective.net_scope = net_union(&effective.net_scope, &cm.warrant.net_scope);
-                fs_union_into(&mut effective.fs_scope, &cm.warrant.fs_scope);
-            }
-        }
         let terminal_mote_id = compiled
             .motes
             .last()
@@ -1393,14 +1375,27 @@ impl WorkflowAuthor for HostWorkflowAuthor {
         // DAG yields the same fingerprint (FROZEN dedup; discovery only, never identity).
         let mut fp_buf = Vec::with_capacity(compiled.motes.len() * 32);
         for cm in &compiled.motes {
-            let step_role = Role {
-                name: "blueprint-step".to_string(),
-                version: 0,
-                spec: cm.warrant.clone(),
-                description: String::new(),
+            // PR-6b-2: a TOOL step's warrant (non-empty `tool_grants`) is SERVER-built
+            // from the registry (`tool_step_warrant` — the tool's declared net/fs +
+            // its own `syscall_profile_ref`) and admitted DIRECTLY, like the seeded
+            // react recipes — NOT intersected against the party blueprint grant
+            // (whose syscall profile differs, and which never grants the tool). The
+            // per-party gate is "can author at all" (`effective` resolved above); the
+            // `registered_tools` backstop + the broker precheck + the coordinator's
+            // D66 resolution re-verify every axis server-side at fire (SN-8). Every
+            // PURE/MODEL mote (empty `tool_grants`) narrows against the party
+            // authority exactly as before (byte-identical when no tool() steps).
+            let warrant = if cm.warrant.tool_grants.is_empty() {
+                let step_role = Role {
+                    name: "blueprint-step".to_string(),
+                    version: 0,
+                    spec: cm.warrant.clone(),
+                    description: String::new(),
+                };
+                intersect(&effective, &step_role).map_err(|_| BinderError::NotAuthorized)?
+            } else {
+                cm.warrant.clone()
             };
-            let warrant =
-                intersect(&effective, &step_role).map_err(|_| BinderError::NotAuthorized)?;
             fp_buf.extend_from_slice(cm.mote.id.as_bytes());
             motes.push((cm.mote.clone(), warrant));
         }
@@ -1841,70 +1836,44 @@ pub(crate) fn react_fs_warrant(
     }
 }
 
-/// PR-6b-2: the server-built warrant for a standalone authored `tool()` step.
-/// Starts from the authoring `base` (so `syscall_profile_ref` + `executor_class` +
-/// `model_route` match the authoring ceiling — the intersect's equality/subset
-/// axes) and NARROWS to EXACTLY this tool: grants `(name, version)` and sets the
-/// net/fs scope to the tool's DECLARED `required_capability`. The coordinator's
-/// `resolve_authored_tool_args` sets the dispatch REQUEST scope to the SAME
+/// PR-6b-2: the COMPLETE server-built warrant for a standalone authored `tool()`
+/// step — mirrors [`react_fs_warrant`] (a server-built, directly-admitted warrant)
+/// but GENERIC over the tool's DECLARED `required_capability`. Grants EXACTLY
+/// `(name, version)` and takes the tool's declared net/fs **and
+/// `syscall_profile_ref`** (the resolver's `check_tool_requirement` demands syscall
+/// EQUALITY, so the warrant must carry the TOOL's own profile — not the authoring
+/// base's). The `model_route` / `resource_ceiling` / `executor_class` come from
+/// `base` so the mote leases on the served worker. ReadOnlyNondet classes mirror
+/// the react recipe warrant (the mcp-echo dispatch precedent). The coordinator's
+/// `resolve_authored_tool_args` sets the dispatch REQUEST net/fs to the SAME
 /// declared values, so `request ⊆ warrant` holds by construction at the broker's
-/// precheck. WORLD-MUTATING classes mirror `build_react_tool`'s observation shape
-/// (the precheck has no `mote_class` gate — honest labelling, not a gate).
+/// precheck. Admitted DIRECTLY (not intersected against the party blueprint grant):
+/// the tool's scope is SERVER-vetted (the registry), so the per-party gate is "can
+/// author at all" (`effective` resolved); the broker precheck + coordinator D66
+/// re-verify every axis at fire (SN-8).
 fn tool_step_warrant(
     base: &WarrantSpec,
     name: &ToolName,
     version: &ToolVersion,
     tdef: &ToolDef,
 ) -> WarrantSpec {
-    let mut w = base.clone();
     let mut grants = BTreeSet::new();
     grants.insert(ToolGrant {
         tool_id: name.clone(),
         tool_version: version.clone(),
     });
-    w.tool_grants = grants;
-    w.net_scope = tdef.required_capability.net_scope_required.clone();
-    w.fs_scope = tdef.required_capability.fs_scope_required.clone();
-    w.mote_class = MoteClass::WorldMutating;
-    w.nd_class = MoteClass::WorldMutating;
-    w
-}
-
-/// The egress superset of two scopes: `None` is the identity; two allowlists merge
-/// to the union of their hosts (so each input `is_subset_of` the result).
-fn net_union(a: &NetScope, b: &NetScope) -> NetScope {
-    match (a, b) {
-        (NetScope::None, other) | (other, NetScope::None) => other.clone(),
-        (NetScope::EgressAllowlist(sa), NetScope::EgressAllowlist(sb)) => {
-            let mut hosts: BTreeSet<Host> = sa.clone();
-            hosts.extend(sb.iter().cloned());
-            NetScope::EgressAllowlist(hosts)
-        }
-    }
-}
-
-/// Merge `add`'s mounts into `ceiling` as a per-path SUPERSET (so each tool's
-/// fs_scope `is_subset_of` the result). On a path conflict the wider Read-family
-/// mode wins (`ReadOnly ∪ ReadWrite = ReadWrite`); a conflicting non-Read mode
-/// (e.g. `ExecOnly`, which no MCP/registered tool declares) keeps the existing
-/// mount — if that is not actually a superset, the per-tool intersect later fails
-/// closed for that tool, never silently widening.
-fn fs_union_into(ceiling: &mut FsScope, add: &FsScope) {
-    for (path, mode) in &add.mounts {
-        ceiling
-            .mounts
-            .entry(path.clone())
-            .and_modify(|existing| {
-                *existing = match (*existing, *mode) {
-                    (FsMode::ReadWrite, FsMode::ReadOnly | FsMode::ReadWrite)
-                    | (FsMode::ReadOnly, FsMode::ReadWrite) => FsMode::ReadWrite,
-                    (FsMode::ReadOnly, FsMode::ReadOnly) => FsMode::ReadOnly,
-                    // Any mode involving ExecOnly (orthogonal): keep the existing
-                    // mount; an Exec tool simply won't survive its own intersect.
-                    (existing, _) => existing,
-                };
-            })
-            .or_insert(*mode);
+    WarrantSpec {
+        mote_class: MoteClass::ReadOnlyNondet,
+        nd_class: MoteClass::ReadOnlyNondet,
+        fs_scope: tdef.required_capability.fs_scope_required.clone(),
+        net_scope: tdef.required_capability.net_scope_required.clone(),
+        syscall_profile_ref: tdef.required_capability.syscall_profile_ref,
+        tool_grants: grants,
+        model_route: base.model_route.clone(),
+        resource_ceiling: base.resource_ceiling,
+        environment_ref: None,
+        executor_class: base.executor_class,
+        ..Default::default()
     }
 }
 

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -441,19 +441,34 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     let fs_list_root: Option<std::path::PathBuf> = crate::mcp_tool::fs_list_root();
     #[cfg(not(feature = "inference"))]
     let fs_list_root: Option<std::path::PathBuf> = None;
+    // PR-6b-2: resolve the durable catalog dir + open the durable tools registry
+    // EARLY (moved up from the telemetry section) so the embedded coordinator
+    // SHARES the SAME live `Arc<SqliteToolRegistry>`. The coordinator's D66
+    // submission gate (and the react settle's arg-validation) then resolve a
+    // runtime-DIALED or `RegisterTool`'d tool — what an authored `tool()` node /
+    // an auto-grant fires — not just the bundled set. The bundled echo/fs-list
+    // tools are seeded into it below (before any submission can arrive), and the
+    // SqliteToolRegistry's lookups are live DB reads, so the react path resolves
+    // byte-identically to the prior in-memory `registry_with_echo`.
+    let catalog_dir = resolve_catalog_dir(&cfg)?;
+    let tool_registry = Arc::new(
+        kx_tool_registry::SqliteToolRegistry::open(catalog_dir.join("tools.db"))
+            .map_err(|e| GatewayError::Config(format!("tools.db: {e}")))?,
+    );
     #[cfg(feature = "inference")]
     let coordinator = match shaper_runtime.as_ref() {
         Some(rt) => {
             tracing::info!("PR-2b: live model-driven topology loop enabled (kx/recipes/plan)");
-            // PR-2d-2: the coordinator shares the serve tool registry (built-ins
-            // + the bundled stdio tool + fs-list@1 when a read root is granted) so
-            // its settle validates a model-proposed call's args against the SAME
-            // typed schema the broker dispatch sees.
+            // PR-2d-2/PR-6b-2: the coordinator shares the live serve tool registry
+            // (built-ins + the bundled stdio tool + fs-list@1 when a read root is
+            // granted + any RegisterTool'd or runtime-DIALED external MCP tool) so
+            // its settle/D66 gate validates a proposed call's args + resolves its
+            // grant against the SAME registry the broker dispatch sees.
             CoordinatorService::with_store_shaper_and_tools(
                 writer,
                 content.clone(),
                 rt.role_registry.clone(),
-                Arc::new(crate::mcp_tool::registry_with_echo(fs_list_root.as_deref())),
+                tool_registry.clone(),
             )
         }
         None => CoordinatorService::with_store(writer, content.clone()),
@@ -496,27 +511,13 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     //     deterministic content-storing executor (publishes bytes into the shared
     //     store BEFORE proposing, so D55 holds), and proposes the commit.
     //
-    // The durable catalog directory is resolved HERE (it only needs cfg) because
-    // the Batch C telemetry ledger must exist before the executor chain is
-    // composed below — its sidecar lives beside the catalog ledgers, and its
-    // sink rides the executor wrapper. Section (3b) reuses the same path.
-    let catalog_dir = resolve_catalog_dir(&cfg)?;
+    // (`catalog_dir` + the durable `tool_registry` were resolved EARLY above so the
+    // embedded coordinator shares the live registry — PR-6b-2.)
     // Batch C: the telemetry.db sidecar (host-measured execution exhaust —
     // wall-clock / model usage / fired tool). Rebuildable-to-EMPTY, off-journal,
     // off-digest; the hot-path sink is bounded + fail-open (drop-on-full), so it
     // can never block, slow, or fail a run.
     let telemetry_ledger = Arc::new(crate::telemetry::TelemetryLedger::open(&catalog_dir)?);
-    // PR-6a: the durable declarative-tools registry (off-journal tools.db beside
-    // the catalog ledgers). The OSS built-ins re-seed on open; the serve path
-    // registers the bundled tools (echo / fs-list) below so DiscoverTools shows
-    // the real runnable set. RegisterTool/DeregisterTool write it; DiscoverTools
-    // reads it. Off-digest by construction (server-derived tool_id; never a
-    // MoteId/journal/checkpoint input). DIALING a registered external MCP server
-    // is PR-6b/Cloud — this stores a vetted server_host, never dials it.
-    let tool_registry = Arc::new(
-        kx_tool_registry::SqliteToolRegistry::open(catalog_dir.join("tools.db"))
-            .map_err(|e| GatewayError::Config(format!("tools.db: {e}")))?,
-    );
     let client = connect_worker(&coord_endpoint).await?;
     // No real body is provisioned in the OSS serve path (script/tool execution is
     // OSS-scoped-out, D141.4), so the sandbox-routing seam is wired with no body ref:
@@ -754,7 +755,14 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     // The Blueprint-builder author seam (SubmitWorkflow) — shares the same library
     // `Arc` (one seed, many seams), so the authoring authority resolves from the
     // SAME grant ledger Invoke uses.
-    let author: Arc<dyn WorkflowAuthor> = Arc::new(HostWorkflowAuthor::from_shared(demo.clone()));
+    // PR-6b-2: the author shares the LIVE tool registry (the SAME `Arc` the
+    // coordinator + broker hold) so a `tool()` step resolves its def + builds a
+    // tool-aware authoring ceiling, and a runtime-dialed tool is authorable the
+    // moment it registers.
+    let author: Arc<dyn WorkflowAuthor> = Arc::new(HostWorkflowAuthor::from_shared_with_tools(
+        demo.clone(),
+        tool_registry.clone(),
+    ));
     // (3d) UI-3: a durable membership ledger (teams) under the SAME catalog dir,
     //      idempotently seeded with one workspace team (owner = the gateway principal;
     //      members = each --auth-token party + the dev principal, one a Delegate) +
@@ -967,6 +975,9 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         .with_critics_supported(critics_supported)
         .with_react_supported(react_supported)
         .with_registered_tools(registered_tools)
+        .with_registered_tools_view(Arc::new(HostRegisteredTools {
+            broker: local_broker.clone(),
+        }))
         .with_toolscout_view(toolscout_view)
         .with_content_writer(content_writer)
         .with_uploads_ledger(uploads_db)
@@ -1432,6 +1443,22 @@ async fn connect_submitter_with_retry(
     Err(GatewayError::Coordinator(format!(
         "embedded coordinator never accepted at {endpoint}: {last}"
     )))
+}
+
+/// PR-6b-2: the host [`RegisteredToolsView`](kx_gateway_core::RegisteredToolsView)
+/// — the authoring/invoke backstop's LIVE truth source. Wraps the serve broker so
+/// a runtime-DIALED external MCP tool's `(tool_id, tool_version)` becomes
+/// authorable the moment its firing capability registers (never a startup
+/// snapshot). Read-only; never authorizes (SN-8) — the broker's 6-gate precheck
+/// re-verifies at dispatch.
+struct HostRegisteredTools {
+    broker: Arc<LocalCapabilityBroker<LocalFsContentStore>>,
+}
+
+impl kx_gateway_core::RegisteredToolsView for HostRegisteredTools {
+    fn registered_grants(&self) -> std::collections::BTreeSet<(String, String)> {
+        self.broker.registered_grants()
+    }
 }
 
 /// Resolve (creating if absent) the durable catalog directory: `--catalog-dir`

--- a/crates/kx-mote/src/lib.rs
+++ b/crates/kx-mote/src/lib.rs
@@ -91,6 +91,7 @@ pub use ndclass::NdClass;
 pub use strings::{
     ConfigKey, ConfigVal, GraphPosition, ModelId, ToolName, ToolVersion, PROMPT_KEY,
     REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY, REACT_MAX_TURNS_KEY, REACT_TURN_KEY,
+    TOOL_ARGS_KEY,
 };
 pub use topology::{ChildDescriptor, RoleId, TopologyDecision};
 

--- a/crates/kx-mote/src/strings.rs
+++ b/crates/kx-mote/src/strings.rs
@@ -105,6 +105,27 @@ pub const REACT_MAX_TURNS_KEY: &str = "max_turns";
 /// `max_tool_calls` slot). See [`REACT_MAX_TURNS_KEY`].
 pub const REACT_MAX_TOOL_CALLS_KEY: &str = "max_tool_calls";
 
+/// The single canonical [`ConfigKey`] *name* under which a STANDALONE authored
+/// `tool()` Mote (PR-6b-2) carries its tool-call argument object — ONE
+/// canonical-JSON object (e.g. `{"q":"…"}`; `{}` when the call has no args),
+/// serialized by the Chains-DSL lowering across all three SDK surfaces
+/// (Py/TS/Rust, byte-identical, golden-pinned).
+///
+/// Unlike a ReAct OBSERVATION — whose args the coordinator RE-DERIVES from the
+/// proposing model TURN's committed output ([`REACT_TURN_KEY`]) — an authored
+/// tool node has NO model parent: its args are AUTHORED, so they are carried
+/// HERE, in `config_subset`, where they fold into [`crate::MoteDef::hash`] →
+/// `MoteId`. The args are therefore IDENTITY-BEARING ⇒ deterministic and
+/// recovery-stable (a re-lease re-derives byte-identical args with nothing
+/// staged), and they cannot be dropped in transit without changing the identity
+/// the coordinator re-derives (structurally fail-closed, like [`REACT_TURN_KEY`]).
+/// The coordinator's `is_authored_tool` gate keys on the PRESENCE of this key
+/// (with `tool_contract` non-empty, `StageThenCommit`, and NOT a react
+/// observation) to route the args-from-`config_subset` lease path; every Mote
+/// without it leases exactly as before — so adding the constant moves no existing
+/// digest (no prior Mote carries this key).
+pub const TOOL_ARGS_KEY: &str = "kx.tool.args";
+
 /// The stable position of a Mote in its DAG.
 ///
 /// Assigned at DAG-compile time (workflow SDK) or derived from a topology

--- a/crates/kx-workflow/src/lib.rs
+++ b/crates/kx-workflow/src/lib.rs
@@ -69,7 +69,7 @@ pub use recipes::{
 pub use retrieval::{encode_retrieval_fact, retrieval, retrieval_result_ref};
 pub use share::{Manifest, ManifestId};
 pub use synthesis::{
-    critic, deterministic_critic, generator, permissive_warrant, synthesis_pipeline,
+    critic, deterministic_critic, generator, permissive_warrant, synthesis_pipeline, tool_step,
     topology_shaper, transform,
 };
 

--- a/crates/kx-workflow/src/synthesis.rs
+++ b/crates/kx-workflow/src/synthesis.rs
@@ -125,6 +125,32 @@ pub fn transform(
     )
 }
 
+/// A **tool step** (PR-6b-2): fires a single registered tool as a standalone DAG
+/// node. WORLD-MUTATING + `StageThenCommit` — the SAME shape as a live react
+/// observation (`react_shape::build_react_tool`), so the worker's args gate, the
+/// broker's stage→fire→commit, and crash recovery treat it identically. The
+/// caller sets `tool_contract` to the single `(tool_id, tool_version)` it fires
+/// and carries the authored args (canonical-JSON) in
+/// `config_subset[kx_mote::TOOL_ARGS_KEY]`; the coordinator re-derives + validates
+/// those args at every lease (`resolve_authored_tool_args`).
+#[must_use]
+pub fn tool_step(
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    step(
+        logic_ref,
+        model_id,
+        NdClass::WorldMutating,
+        EffectPattern::StageThenCommit,
+        StepRole::Plain,
+        warrant,
+        capability,
+    )
+}
+
 /// A critic step validating `producer`: a deterministic check (PURE,
 /// `IdempotentByConstruction`) — schema / dedup / stat-bounds / PII-leakage.
 /// Declare a dependency edge from `producer` to this step so the producer

--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -118,6 +118,48 @@ the arguments against the tool's typed `inputSchema`, and dispatches via the
 capability broker. A prompt-injected call to an **ungranted** tool never fires.
 See the [Quickstart agent loop](./quickstart.md#run-the-agent-loop).
 
+## Authoring a `tool()` step
+
+Beyond the ReAct loop (where the *model* picks tools), you can author a **`tool()`
+step** into a DAG to fire a single registered tool deterministically — a discovered
+external MCP tool, a `RegisterTool`'d declarative tool, or the bundled `fs-list`.
+The server resolves the tool in its live registry and builds the per-step warrant
+from the tool's **declared** capability scope (you never supply a warrant — the
+client-`tool_grants` boundary stays refused, SN-8). The authored arguments lower to
+one canonical-JSON object the coordinator validates against the tool's typed schema
+fail-closed at every lease (so a crash re-derives byte-identical args).
+
+```python
+from kortecx import chain, model, tool
+
+# A model plans a query, then a discovered tool runs it (a DATA edge feeds the result).
+c = chain("plan > search", tasks={
+    "plan": model("kx-serve:qwen3-4b-q4_k_m", "Plan a web search for the user's question."),
+    "search": tool("search/web-search", "1", q="kortecx runtime"),
+})
+run = client.run_chain(c, wait=True)
+```
+
+```typescript
+import { chain, task } from "@kortecx/sdk/web";
+const c = chain("plan > search", { tasks: {
+  plan: task.model("kx-serve:qwen3-4b-q4_k_m", "Plan a web search."),
+  search: task.tool("search/web-search", "1", { q: "kortecx runtime" }),
+} });
+```
+
+```bash
+# kx blueprint run --file dag.json, where a step is:
+#   { "kind": "tool", "tool_contract": { "search/web-search": "1" }, "args": { "q": "kortecx" } }
+kx blueprint run --file dag.json --wait
+```
+
+In the **console builder** (`/blueprints/new`), add a **+ Tool** node, pick a
+registered tool from the live registry (the same set `DiscoverTools` shows), and
+edit its **Args (JSON)** — the server resolves + warrants it on submit. The
+`q="…"`-style args lower **byte-identically across Python, TypeScript, Rust (CLI),
+and the UI** (the `tests/golden/chains` parity gate).
+
 ## OSS / Cloud line
 
 Kortecx OSS is the **secure gateway to external MCP** — the runtime is the
@@ -189,7 +231,10 @@ fits your workflow.
 
 OAuth / device-flow setup and a hosted credential marketplace are a **Cloud**
 capability (the OSS console shows them as an honest-disabled affordance). The
-`tool()` chains-node (call a discovered tool from an authored DAG) and the
-autonomous ReAct loop's auto-grant of dialed tools land in the next batch — they
-share the coordinator's args-from-params durable-execution path. (Branched
-write-back over the content-addressed store is the D155 post-RC epic.)
+[`tool()` chains-node](#authoring-a-tool-step) is now live (call a discovered tool
+from an authored DAG, across Python / TypeScript / CLI / the console builder). The
+autonomous ReAct loop's **auto-grant** of dialed tools (the model auto-picking from
+the live dialed set) + **parallel tool fan-out** (N concurrent tool calls per turn)
+land in the next batch — they share the coordinator's args-from-params
+durable-execution path. (Branched write-back over the content-addressed store is the
+D155 post-RC epic.)

--- a/tests/golden/chains/SPEC.md
+++ b/tests/golden/chains/SPEC.md
@@ -5,9 +5,21 @@ and Rust (CLI) implementations MUST all parse + lower a chain expression to **by
 `(steps, edges)`, pinned by `corpus.json` in this directory (the GR12 tri-surface parity gate).
 
 A chain expression composes **task handles** into a DAG. Each handle resolves (via a caller
-`tasks` map) to a typed step (`pure` / `model` today; the palette grows per phase). The DSL
+`tasks` map) to a typed step (`pure` / `model` / `tool`; the palette grows per phase). The DSL
 operators describe topology only — the server still compiles + warrants every step (SN-8); a
 chain only changes what is PROPOSED.
+
+### The `tool` step (PR-6b-2)
+
+A `tool` handle fires a single REGISTERED tool as a standalone node. It carries a
+`tool_contract = { tool_id: tool_version }` (the SERVER resolves the tool in its live registry and
+builds the per-step warrant — the client never supplies a warrant or grants, SN-8) and lowers its
+authored arguments to ONE **canonical-JSON object** under the reserved config key
+`kx.tool.args` (`TOOL_ARGS_KEY`) in `params`. The canonical-JSON encoding is **keys sorted
+ascending, compact separators (`,`/`:`), no floats** (the server schema is integer/bytes/bool/enum-typed) —
+so `tool("web-search","1", q="kortecx", n=3)` lowers to `params["kx.tool.args"] = {"n":3,"q":"kortecx"}`
+byte-identically across Python, TypeScript, and Rust. The coordinator re-derives + validates those
+args against the tool's typed schema fail-closed at every lease (`resolve_authored_tool_args`).
 
 ## Grammar (EBNF)
 
@@ -77,6 +89,12 @@ The result feeds `BlueprintBuilder.add_step` / `add_edge` (one canonical lowerin
     "steps": [ {"kind":"pure","model_id":"","prompt":"","body_signature_id":null,"tool_contract":{},"params":{}}, ... ],
     "edges": [ {"parent":0,"child":1,"edge":"data"}, {"parent":0,"child":2,"edge":"data"} ] } }
 ```
+
+A `tool` task spec carries `tool_contract` + (optional) structured `args`:
+`{ "kind": "tool", "tool_contract": {"web-search":"1"}, "args": {"q":"kortecx","n":3} }`; its
+`expect` step has the `tool_contract` and `params["kx.tool.args"]` = the canonical-JSON string. Each
+surface lowers the structured `args` (Python/TS via the `tool()` factory, Rust via the CLI
+`StepSpec.args`) and the corpus asserts the byte-identical canonical JSON.
 
 `steps` are in node order; `params` values are strings (the pre-encoding lowering form — each SDK
 UTF-8-encodes at `build()` time). An error case carries `"error": "<class>"` instead of `expect`,

--- a/tests/golden/chains/corpus.json
+++ b/tests/golden/chains/corpus.json
@@ -324,5 +324,45 @@
     "seed": 0,
     "tasks": { "a": { "kind": "pure" } },
     "error": "parse"
+  },
+  {
+    "name": "tool_single",
+    "dsl": "t",
+    "seed": 0,
+    "tasks": { "t": { "kind": "tool", "tool_contract": { "echo": "1" } } },
+    "expect": {
+      "steps": [
+        { "kind": "tool", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": { "echo": "1" }, "params": { "kx.tool.args": "{}" } }
+      ],
+      "edges": []
+    }
+  },
+  {
+    "name": "tool_with_args",
+    "dsl": "t",
+    "seed": 0,
+    "tasks": { "t": { "kind": "tool", "tool_contract": { "web-search": "1" }, "args": { "q": "kortecx", "n": 3 } } },
+    "expect": {
+      "steps": [
+        { "kind": "tool", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": { "web-search": "1" }, "params": { "kx.tool.args": "{\"n\":3,\"q\":\"kortecx\"}" } }
+      ],
+      "edges": []
+    }
+  },
+  {
+    "name": "model_then_tool",
+    "dsl": "g > t",
+    "seed": 0,
+    "tasks": {
+      "g": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Plan a search." },
+      "t": { "kind": "tool", "tool_contract": { "web-search": "1" }, "args": { "q": "hi" } }
+    },
+    "expect": {
+      "steps": [
+        { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Plan a search.", "body_signature_id": null, "tool_contract": {}, "params": {} },
+        { "kind": "tool", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": { "web-search": "1" }, "params": { "kx.tool.args": "{\"q\":\"hi\"}" } }
+      ],
+      "edges": [ { "parent": 0, "child": 1, "edge": "data" } ]
+    }
   }
 ]

--- a/ui/src/components/builder/BuilderNode.tsx
+++ b/ui/src/components/builder/BuilderNode.tsx
@@ -21,22 +21,23 @@ export type BuilderFlowNode = Node<BuilderNodeData, "builder">;
  */
 function BuilderNodeImpl({ data, selected }: NodeProps<BuilderFlowNode>) {
   const { step } = data;
-  const tone = step.kind === "model" ? "model" : "pure";
-  const needsConfig = step.kind === "model" && step.modelId.trim() === "";
+  const tone = step.kind === "model" ? "model" : step.kind === "tool" ? "tool" : "pure";
+  const kindLabel = step.kind === "model" ? "Agent" : step.kind === "tool" ? "Tool" : "Pure";
+  const needsConfig =
+    (step.kind === "model" && step.modelId.trim() === "") ||
+    (step.kind === "tool" && step.toolId.trim() === "");
   return (
     <div
       className={`dag-node builder-node builder-node--${tone}${selected ? " builder-node--selected" : ""}`}
       data-testid="builder-node"
       data-node={step.id}
       data-kind={step.kind}
-      aria-label={`${step.kind === "model" ? "Agent" : "Step"} ${step.label}`}
+      aria-label={`${kindLabel} ${step.label}`}
     >
       <span className="dag-node__accent" aria-hidden="true" />
       <Handle type="target" position={Position.Top} className="dag-handle" />
       <div className="dag-node__head">
-        <span className={`builder-node__kind builder-node__kind--${tone}`}>
-          {step.kind === "model" ? "Agent" : "Pure"}
-        </span>
+        <span className={`builder-node__kind builder-node__kind--${tone}`}>{kindLabel}</span>
         <span className="builder-node__label" title={step.label}>
           {step.label}
         </span>
@@ -50,6 +51,19 @@ function BuilderNodeImpl({ data, selected }: NodeProps<BuilderFlowNode>) {
           ) : (
             <span className="builder-node__model mono" title={step.modelId}>
               {step.modelId}
+            </span>
+          )}
+        </div>
+      ) : null}
+      {step.kind === "tool" ? (
+        <div className="builder-node__row">
+          {needsConfig ? (
+            <span className="builder-node__hint" data-testid="builder-node-needs-config">
+              pick a tool
+            </span>
+          ) : (
+            <span className="builder-node__model mono" title={`${step.toolId}@${step.toolVersion}`}>
+              {step.toolId}@{step.toolVersion || "1"}
             </span>
           )}
         </div>

--- a/ui/src/components/builder/StepConfigDrawer.tsx
+++ b/ui/src/components/builder/StepConfigDrawer.tsx
@@ -10,10 +10,18 @@
 import type { ModelSummary } from "@kortecx/sdk/web";
 import { m } from "framer-motion";
 import { useEffect } from "react";
+import { useDiscoverTools } from "../../kx/use-tool-registry";
 import { JsonEditor } from "../editor/JsonEditor";
 import { MonacoMount } from "../editor/MonacoMount";
 import type { BuilderStep } from "./builder-graph";
 import { isJsonObject } from "./builder-graph";
+
+/** The drawer's kind badge label + modifier (PURE / MODEL / TOOL). */
+function kindBadge(kind: BuilderStep["kind"]): { label: string; mod: string } {
+  if (kind === "model") return { label: "Agent", mod: "model" };
+  if (kind === "tool") return { label: "Tool", mod: "tool" };
+  return { label: "Pure", mod: "pure" };
+}
 
 const slideIn = {
   initial: { x: 24, opacity: 0 },
@@ -56,6 +64,9 @@ export function StepConfigDrawer({
 
   const paramsValid = isJsonObject(step.paramsText);
   const served = (models ?? []).filter((mm) => mm.serving);
+  const badge = kindBadge(step.kind);
+  // PR-6b-2: the LIVE registered-tool set for a TOOL step's picker (DiscoverTools).
+  const { tools, notWired: toolsNotWired } = useDiscoverTools();
 
   return (
     <>
@@ -77,10 +88,8 @@ export function StepConfigDrawer({
         transition={slideIn.transition}
       >
         <div className="node-drawer__head">
-          <span
-            className={`builder-node__kind builder-node__kind--${step.kind === "model" ? "model" : "pure"}`}
-          >
-            {step.kind === "model" ? "Agent" : "Pure"}
+          <span className={`builder-node__kind builder-node__kind--${badge.mod}`}>
+            {badge.label}
           </span>
           <button type="button" className="linkbtn" onClick={onClose} aria-label="Close">
             ✕
@@ -157,18 +166,57 @@ export function StepConfigDrawer({
           </>
         ) : null}
 
+        {step.kind === "tool" ? (
+          <div className="builder-field">
+            <span className="builder-field__label">Tool</span>
+            {toolsNotWired || tools.length === 0 ? (
+              <p className="muted" data-testid="step-config-no-tools">
+                No tools are registered. Register one in <strong>Tools → Registry</strong>, or dial
+                an external MCP server in <strong>Tools → Connections</strong>, then pick it here.
+              </p>
+            ) : (
+              <div className="builder-chips" data-testid="step-config-tool">
+                {tools.map((t) => {
+                  const active = step.toolId === t.toolName && step.toolVersion === t.toolVersion;
+                  return (
+                    <button
+                      key={`${t.toolName}@${t.toolVersion}`}
+                      type="button"
+                      className={`chip${active ? " chip--active" : ""}`}
+                      title={t.description}
+                      onClick={() =>
+                        onChange({ ...step, toolId: t.toolName, toolVersion: t.toolVersion })
+                      }
+                    >
+                      {t.toolName}@{t.toolVersion}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            <span className="builder-field__hint">
+              The SERVER resolves the tool in its live registry + builds the per-step warrant from
+              the tool's declared scope (you never supply a warrant — SN-8).
+            </span>
+          </div>
+        ) : null}
+
         <div className="builder-field">
-          <span className="builder-field__label">Params (JSON)</span>
+          <span className="builder-field__label">
+            {step.kind === "tool" ? "Args (JSON)" : "Params (JSON)"}
+          </span>
           <JsonEditor
             value={step.paramsText}
             onChange={(v) => onChange({ ...step, paramsText: v })}
             testId="step-config-params"
-            ariaLabel="Step params (JSON object)"
+            ariaLabel={
+              step.kind === "tool" ? "Tool args (JSON object)" : "Step params (JSON object)"
+            }
             height={120}
           />
           {!paramsValid ? (
             <span className="builder-field__error" data-testid="step-config-params-error">
-              Params must be a JSON object.
+              {step.kind === "tool" ? "Args" : "Params"} must be a JSON object.
             </span>
           ) : null}
         </div>

--- a/ui/src/components/builder/builder-graph.ts
+++ b/ui/src/components/builder/builder-graph.ts
@@ -12,13 +12,17 @@
  */
 
 import type { StepInput } from "@kortecx/sdk/web";
-import { BlueprintBuilder } from "@kortecx/sdk/web";
+import { BlueprintBuilder, task } from "@kortecx/sdk/web";
 
-/** The authored step palette (EXEC is reserved server-side; the UI offers PURE/MODEL). */
-export type BuilderStepKind = "pure" | "model";
+/** The authored step palette (EXEC is reserved server-side; the UI offers
+ *  PURE / MODEL / TOOL). TOOL (PR-6b-2) fires a single REGISTERED tool: the SERVER
+ *  resolves it in the live registry + builds the per-step warrant (client tool_grants
+ *  stay refused — SN-8/§2.171), so adding it does NOT reopen the admission boundary. */
+export type BuilderStepKind = "pure" | "model" | "tool";
 
 /** One authored builder step. `params` is the JSON-OBJECT TEXT the user edits in
- *  Monaco (parsed at submit); `prompt`/`modelId` apply to MODEL steps. */
+ *  Monaco (parsed at submit); `prompt`/`modelId` apply to MODEL steps; `toolId`/
+ *  `toolVersion` + the params-as-args apply to TOOL steps. */
 export interface BuilderStep {
   /** Client-local node id (NOT a MoteId — the server derives identity). */
   readonly id: string;
@@ -29,10 +33,15 @@ export interface BuilderStep {
   readonly modelId: string;
   /** MODEL: the prompt (Monaco). */
   readonly prompt: string;
-  /** Free-param JSON-object text (parsed to bytes server-side). */
+  /** Free-param JSON-object text (parsed to bytes server-side). For a TOOL step this
+   *  JSON object IS the tool-call arguments (lowered to the canonical TOOL_ARGS_KEY blob). */
   readonly paramsText: string;
   /** Optional reasoning-mode (PR-4 Phase F) — opt-in MODEL knob; "" ⇒ default. */
   readonly reasoning: "" | "full" | "minimal" | "off";
+  /** TOOL: the registered tool id (from `DiscoverTools`); the SERVER resolves it. */
+  readonly toolId: string;
+  /** TOOL: the registered tool version (defaults to "1" when blank). */
+  readonly toolVersion: string;
 }
 
 /** One authored edge (by client-local node id). `instruction` (D141.5) is the
@@ -118,8 +127,11 @@ export function validationError(graph: BuilderGraph): string | null {
     if (s.kind === "model" && s.modelId.trim() === "") {
       return `Agent step "${s.label}" needs a model.`;
     }
+    if (s.kind === "tool" && s.toolId.trim() === "") {
+      return `Tool step "${s.label}" needs a registered tool.`;
+    }
     if (s.paramsText.trim() !== "" && !isJsonObject(s.paramsText)) {
-      return `Step "${s.label}" params must be a JSON object.`;
+      return `Step "${s.label}" ${s.kind === "tool" ? "args" : "params"} must be a JSON object.`;
     }
   }
   const acyclic = validateAcyclic(graph);
@@ -166,20 +178,29 @@ export function toRequest(graph: BuilderGraph, seed = 0) {
     }
   }
   for (const s of graph.steps) {
-    const params = paramsRecord(s);
-    let prompt = s.prompt;
-    if (s.kind === "model") {
-      const instr = inbound.get(s.id);
-      if (instr && instr.length > 0) {
-        prompt = `${instr.join("\n\n")}\n\n${s.prompt}`.trim();
+    let step: StepInput;
+    if (s.kind === "tool") {
+      // Reuse the SDK `task.tool` factory so the canonical TOOL_ARGS_KEY lowering
+      // is byte-identical to the Py/TS/CLI surfaces (the golden-corpus contract).
+      step = task
+        .tool(s.toolId, s.toolVersion.trim() === "" ? "1" : s.toolVersion, toolArgs(s))
+        .toStepInput();
+    } else {
+      const params = paramsRecord(s);
+      let prompt = s.prompt;
+      if (s.kind === "model") {
+        const instr = inbound.get(s.id);
+        if (instr && instr.length > 0) {
+          prompt = `${instr.join("\n\n")}\n\n${s.prompt}`.trim();
+        }
       }
+      step = {
+        kind: s.kind,
+        modelId: s.kind === "model" ? s.modelId : undefined,
+        prompt: s.kind === "model" ? prompt : undefined,
+        params,
+      };
     }
-    const step: StepInput = {
-      kind: s.kind,
-      modelId: s.kind === "model" ? s.modelId : undefined,
-      prompt: s.kind === "model" ? prompt : undefined,
-      params,
-    };
     index.set(s.id, builder.addStep(step));
   }
   for (const e of graph.edges) {
@@ -211,15 +232,43 @@ function paramsRecord(s: BuilderStep): Record<string, string> {
   return out;
 }
 
+/** Parse a TOOL step's params text as its tool-call argument map (string/number/
+ *  boolean values — no floats; the server schema is integer/bytes/bool/enum-typed).
+ *  Blank ⇒ the empty `{}` call. Validation already proved it is a JSON object. */
+function toolArgs(s: BuilderStep): Record<string, string | number | boolean> {
+  if (s.paramsText.trim() === "") {
+    return {};
+  }
+  const parsed = JSON.parse(s.paramsText) as Record<string, unknown>;
+  const out: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    out[k] =
+      typeof v === "string" || typeof v === "number" || typeof v === "boolean"
+        ? v
+        : JSON.stringify(v);
+  }
+  return out;
+}
+
+/** A label for a fresh step of `kind`. */
+function defaultLabel(kind: BuilderStepKind): string {
+  if (kind === "model") {
+    return "Agent";
+  }
+  return kind === "tool" ? "Tool" : "Step";
+}
+
 /** A fresh empty step of `kind` with a unique client-local id. */
 export function newStep(kind: BuilderStepKind, id: string): BuilderStep {
   return {
     id,
     kind,
-    label: kind === "model" ? "Agent" : "Step",
+    label: defaultLabel(kind),
     modelId: "",
     prompt: "",
     paramsText: "",
     reasoning: "",
+    toolId: "",
+    toolVersion: "",
   };
 }

--- a/ui/src/components/sections/BlueprintBuilderSection.tsx
+++ b/ui/src/components/sections/BlueprintBuilderSection.tsx
@@ -269,6 +269,14 @@ function BuilderInner({ initialGraph }: { initialGraph?: BuilderGraph }) {
           </button>
           <button
             type="button"
+            className="btn-ghost"
+            data-testid="builder-add-tool"
+            onClick={() => addStep("tool")}
+          >
+            + Tool
+          </button>
+          <button
+            type="button"
             className="builder-submit"
             data-testid="builder-submit"
             disabled={invalid !== null || submit.isPending}

--- a/ui/src/kx/use-clone-graph.ts
+++ b/ui/src/kx/use-clone-graph.ts
@@ -91,6 +91,10 @@ export function useCloneGraph(instanceId: string | null): UseCloneGraph {
           prompt: cfg.prompt,
           paramsText: cfg.paramsText,
           reasoning: cfg.reasoning,
+          // Clone preserves PURE/MODEL steps only; a cloned graph never carries a
+          // TOOL step (the projection's stepKind is model|pure), so empty is correct.
+          toolId: "",
+          toolVersion: "",
         };
       });
       const edges: BuilderEdge[] = [];

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -3777,6 +3777,11 @@ button.card-grid__title:hover {
   color: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
 }
+/* PR-6b-2: the TOOL node badge — the Tools-section accent (both-theme via vars). */
+.builder-node__kind--tool {
+  color: var(--primary, var(--accent));
+  border-color: color-mix(in srgb, var(--primary, var(--accent)) 45%, var(--border));
+}
 .builder-node__label {
   margin-left: 0.4rem;
   font-weight: 600;

--- a/ui/test/builder-graph.test.ts
+++ b/ui/test/builder-graph.test.ts
@@ -1,3 +1,4 @@
+import { TOOL_ARGS_KEY, proto } from "@kortecx/sdk/web";
 import { describe, expect, it } from "vitest";
 import {
   type BuilderGraph,
@@ -98,5 +99,27 @@ describe("builder-graph", () => {
     const off = toRequest(graph([{ ...base, reasoning: "off" as const }], []));
     // params values are byte-encoded by the SDK builder.
     expect(Object.keys(off.steps?.[0]?.params ?? {})).toContain("reasoning");
+  });
+
+  it("PR-6b-2: a tool node lowers to TOOL kind + tool_contract + canonical args", () => {
+    const t = {
+      ...newStep("tool", "t"),
+      toolId: "web-search",
+      toolVersion: "1",
+      paramsText: '{"q":"hi","n":2}',
+    };
+    const req = toRequest(graph([t], []));
+    expect(req.steps).toHaveLength(1);
+    const step = req.steps?.[0];
+    expect(step?.kind).toBe(proto.WorkflowStepKind.TOOL);
+    expect(step?.toolContract).toEqual({ "web-search": "1" });
+    // The args lower to the canonical TOOL_ARGS_KEY blob (sorted keys, compact) —
+    // byte-identical to the Py/TS/CLI surfaces (the golden-corpus contract).
+    const args = step?.params?.[TOOL_ARGS_KEY];
+    expect(new TextDecoder().decode(args as Uint8Array)).toBe('{"n":2,"q":"hi"}');
+  });
+
+  it("PR-6b-2: a tool node without a picked tool fails validation", () => {
+    expect(validationError(graph([newStep("tool", "t")], []))).toMatch(/needs a registered tool/);
   });
 });


### PR DESCRIPTION
## What

Closes the core of PR-6: a standalone `tool()` authored Chains-node fires a single **registered** tool as a DAG step, and a tool **dialed from an external MCP gateway** (incl. Py/TS-SDK gateways) is now authorable + fireable.

- **Coordinator args-from-params** (`kx-coordinator/state.rs`): `is_authored_tool` + `resolve_authored_tool_args` derive a tool() mote's args from its own identity-bearing `config_subset[TOOL_ARGS_KEY]`, validated fail-closed — provably disjoint from react observations + every legacy WM mote, so a non-tool mote can never wedge.
- **Gateway admission/binding**: `AuthorStepKind::Tool` + `tool_step_def` + a server-built `tool_step_warrant` (from the tool's declared `required_capability`, SN-8) + author-time **ceiling-widen** so the tool grant survives the per-party intersect.
- **Live registry across gates**: the coordinator + author + a new live broker-backed `RegisteredToolsView` backstop share **one** `SqliteToolRegistry` (a small `server.rs` reorder) — a runtime-dialed tool is fireable the moment its capability registers.
- **Cross-surface** (GR14/GR18): `tool()` in the Py/TS Chains DSL + the CLI (`kind:"tool"`) + the UI builder (**+ Tool** node + live tool-picker), all lowering the canonical `kx.tool.args` JSON **byte-identically** (golden corpus). Docs: `tools.md`.

## Invariants
- Canonical projection digest **`7d22d4bd`** invariant (`verify-quickstart` 8/8 + crash-replay, ×2).
- Frozen trio + proto + `Cargo.lock` **diff-empty** — **zero proto change** (`WORKFLOW_STEP_KIND_TOOL` + `tool_contract` already existed).
- SN-8 (server warrants; client `tool_grants` refused; server-derived ids) · GR15 (fail-closed registry lookup + `validate_args`) · GR19 (OSS = secure gateway).

## Tests
2378 workspace tests · 3-surface golden parity (Rust 11 / Py 37 / TS 35) · UI biome (339) + vitest (583) + build · Py 151+34 e2e / TS 160+42 e2e · the real-serve contract e2e validates the `server.rs` reorder. Crash-safety is by construction (args live in the identity-bearing `config_subset`).

## Deferred (sequenced)
Auto-grant of dialed tools + parallel tool fan-out → **PR-6b-4** (shared live-warrant rebuild). MCP 2026-07-28 RC client-interop → **PR-6b-3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)