### PR TITLE
PR-6b-4 — dialed-tool auto-grant (live-warrant rebuild) → CLOSES PR-6

### DIFF
--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -169,8 +169,8 @@ pub use error::GatewayError;
 pub use live_tail::{GlobalLiveTailer, LiveTailer};
 pub use provision::{
     DemoLibrary, HostRecipeBinder, HostRecipeCatalog, HostSignatureCatalog, HostWorkflowAuthor,
-    DEMO_RECIPE_HANDLE, MODEL_RECIPE_HANDLE, PASSTHROUGH_DAG_HANDLE, REACT_FS_RECIPE_HANDLE,
-    REACT_RECIPE_HANDLE, VISION_RECIPE_HANDLE,
+    DEMO_RECIPE_HANDLE, MODEL_RECIPE_HANDLE, PASSTHROUGH_DAG_HANDLE, REACT_AUTO_RECIPE_HANDLE,
+    REACT_FS_RECIPE_HANDLE, REACT_RECIPE_HANDLE, VISION_RECIPE_HANDLE,
 };
 pub use server::{serve, start, RunningGateway};
 pub use teams::{seed_workspace_team, HostGrantView, HostMembershipView, WORKSPACE_TEAM_HANDLE};

--- a/crates/kx-gateway/src/mcp_tool.rs
+++ b/crates/kx-gateway/src/mcp_tool.rs
@@ -171,6 +171,23 @@ pub(crate) fn fs_list_root() -> Option<PathBuf> {
     }
 }
 
+/// PR-6b-4: the operator opt-in for the autonomous-loop tool AUTO-GRANT
+/// (`KX_SERVE_AUTOGRANT`). Default-OFF (unset / `"0"` / `"false"` / empty ⇒
+/// `false`) — mirrors `KX_SERVE_FS_ROOT`'s deny-by-default. ON ⇒ the
+/// `kx/recipes/react-auto` recipe is seeded + the binder rebuilds its warrant
+/// from the LIVE registry at bind (the model picks from ALL registered/dialed
+/// tools). OFF ⇒ react-auto is NOT seeded ⇒ byte-identical serve.
+pub(crate) fn autogrant_enabled() -> bool {
+    match std::env::var_os("KX_SERVE_AUTOGRANT") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true")
+        }
+        None => false,
+    }
+}
+
 /// Resolve the bundled tool binary's path: an explicit `KX_MCP_ECHO_PATH`
 /// override first, then the fixed in-image path, then a dev/test walk up to the
 /// workspace `target/` dir (the `real_body_binary_path` precedent). `None` ⇒

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -170,6 +170,24 @@ pub const REACT_RECIPE_HANDLE: &str = "kx/recipes/react";
 /// the ref never reaches an admitted identity).
 const REACT_LOGIC_REF: [u8; 32] = [0x4e; 32];
 
+/// PR-6b-4: a DISTINCT placeholder `logic_ref` for the `react-fs` seed step. The
+/// recipe body's manifest id is `hash(seed ‖ mote_ids)` and EXCLUDES the warrant
+/// (`Manifest::recipe`), so two react bodies that differ ONLY by their server-built
+/// warrant map to the SAME manifest id but DIFFERENT body bytes — a body-ledger
+/// immutability conflict at seed. `react` (echo grant) + `react-fs` (fs-list grant)
+/// previously shared [`REACT_LOGIC_REF`], so a serve with BOTH the bundled echo bin
+/// AND `KX_SERVE_FS_ROOT` panicked at startup (BUG-25: the bodies differ only by
+/// warrant). A distinct sentinel gives `react-fs` its own manifest id; the seed is
+/// SWAPPED at submit, so the ref never reaches an admitted identity.
+const REACT_FS_LOGIC_REF: [u8; 32] = [0x54; 32];
+
+/// PR-6b-4: a DISTINCT placeholder `logic_ref` for the react-auto seed step (the
+/// same BUG-25 class as [`REACT_FS_LOGIC_REF`] — react-auto's placeholder grant is
+/// empty, which would collide with `kx/recipes/react`). The binder overrides the
+/// bound warrant with the live union; like [`REACT_LOGIC_REF`] the seed is SWAPPED
+/// at submit, so the ref never reaches an admitted identity.
+const REACT_AUTO_LOGIC_REF: [u8; 32] = [0x53; 32];
+
 /// The wire handle of the PR-6a/D155 `react-fs` recipe: a live ReAct loop like
 /// [`REACT_RECIPE_HANDLE`] BUT whose server-built step warrant grants the read-only
 /// `fs-list@1` tool + a `fs_scope` of the operator-granted read root (`KX_SERVE_FS_ROOT`)
@@ -177,7 +195,8 @@ const REACT_LOGIC_REF: [u8; 32] = [0x4e; 32];
 /// canonical `kx/recipes/react` + the projection digest stay byte-unchanged. Seeded only
 /// when a fit serve model resolved AND `KX_SERVE_FS_ROOT` is set (the fs-list capability
 /// registered). Reuses the react free-param contract (instruction / max_turns /
-/// max_tool_calls) + logic ref — only the warrant + handle differ.
+/// max_tool_calls); carries its OWN `REACT_FS_LOGIC_REF` (BUG-25 — a shared logic ref
+/// collides with `kx/recipes/react` at seed) — the warrant + handle + logic ref differ.
 pub const REACT_FS_RECIPE_HANDLE: &str = "kx/recipes/react-fs";
 
 /// Schema-refs of the react recipe's typed free-params.
@@ -281,7 +300,7 @@ impl DemoLibrary {
         exec_class: ExecutorClass,
         parties: &[String],
     ) -> Result<Self, GatewayError> {
-        Self::seed(dir, exec_class, parties, None, None, false, None)
+        Self::seed(dir, exec_class, parties, None, None, false, None, false)
     }
 
     /// Like [`DemoLibrary::open`], plus (when `serve_model` is `Some`) the AL1
@@ -308,6 +327,7 @@ impl DemoLibrary {
             None,
             false,
             None,
+            false,
         )
     }
 
@@ -329,6 +349,7 @@ impl DemoLibrary {
         react_tool: Option<&(ToolName, ToolVersion)>,
         vision: bool,
         fs_list: Option<(&(ToolName, ToolVersion), &Path)>,
+        autogrant: bool,
     ) -> Result<Self, GatewayError> {
         Self::seed(
             dir,
@@ -338,6 +359,7 @@ impl DemoLibrary {
             react_tool,
             vision,
             fs_list,
+            autogrant,
         )
     }
 
@@ -357,6 +379,7 @@ impl DemoLibrary {
         react_tool: Option<&(ToolName, ToolVersion)>,
         vision: bool,
         fs_list: Option<(&(ToolName, ToolVersion), &Path)>,
+        autogrant: bool,
     ) -> Result<Self, GatewayError> {
         let cat = |e: String| GatewayError::Catalog(e);
         let versions =
@@ -499,7 +522,8 @@ impl DemoLibrary {
         // read root (`KX_SERVE_FS_ROOT`) — the first recipe that produces REAL
         // agent data (a directory listing committed as the Observation result_ref).
         // Seeded only when a model is served AND fs-list is available; reuses the
-        // react logic ref + free-param contract (only the warrant + handle differ),
+        // react free-param contract but carries its OWN logic ref (BUG-25 — a shared
+        // logic ref collides with `kx/recipes/react` at seed when both are present),
         // so the canonical `kx/recipes/react` + the digest stay byte-unchanged.
         if let (Some(model_id), Some((fs_tool, fs_root))) = (serve_model, fs_list) {
             let react_fs_w = react_fs_warrant(exec_class, model_id, fs_tool, fs_root);
@@ -512,7 +536,7 @@ impl DemoLibrary {
                 parties,
                 &react_fs_h,
                 recipe_body(
-                    LogicRef::from_bytes(REACT_LOGIC_REF),
+                    LogicRef::from_bytes(REACT_FS_LOGIC_REF),
                     &react_fs_w,
                     &[
                         kx_mote::REACT_INSTRUCTION_KEY,
@@ -526,6 +550,47 @@ impl DemoLibrary {
                 react_fs_h,
                 RecipeMeta {
                     owner_root: react_fs_w,
+                    free_params: react_contract(),
+                },
+            ));
+        }
+
+        // (react-auto) PR-6b-4: a SEPARATE live ReAct recipe whose warrant is
+        // REBUILT at bind from the LIVE registry to auto-grant the registered/
+        // dialed tool set (a union warrant, ≤ AUTOGRANT_MAX_TOOLS) — so the
+        // autonomous loop can pick from ALL live tools, not just one bundled seed
+        // tool. The seed-time `owner_root` here is a PLACEHOLDER (empty tool_grants);
+        // the host binder overrides the bound seed Mote's warrant with the live
+        // union (the dialed tool registers at runtime, after seed). A separate
+        // recipe (the react-fs precedent) keeps the canonical react recipe + the
+        // digest byte-unchanged. Seeded only when a model is served AND the operator
+        // opted in via `KX_SERVE_AUTOGRANT`; reuses the react logic ref + free-param
+        // contract (only the warrant + handle differ).
+        if let Some(model_id) = serve_model.filter(|_| autogrant) {
+            let react_auto_w = react_auto_base_warrant(exec_class, model_id);
+            let react_auto_h = react_auto_handle()?;
+            seed_recipe(
+                &versions,
+                &bodies,
+                &grants,
+                &owner,
+                parties,
+                &react_auto_h,
+                recipe_body(
+                    LogicRef::from_bytes(REACT_AUTO_LOGIC_REF),
+                    &react_auto_w,
+                    &[
+                        kx_mote::REACT_INSTRUCTION_KEY,
+                        kx_mote::REACT_MAX_TURNS_KEY,
+                        kx_mote::REACT_MAX_TOOL_CALLS_KEY,
+                    ],
+                ),
+                &react_auto_w,
+            )?;
+            recipes.push((
+                react_auto_h,
+                RecipeMeta {
+                    owner_root: react_auto_w,
                     free_params: react_contract(),
                 },
             ));
@@ -784,6 +849,10 @@ fn recipe_advisory(handle: &str) -> (&'static str, &'static [&'static str]) {
             "ReAct-FS — a live agent loop with a read-only filesystem tool (lists files under the granted root).",
             &["agent", "react", "tools", "filesystem", "fs-list"],
         ),
+        REACT_AUTO_RECIPE_HANDLE => (
+            "ReAct-Auto — a live agent loop that auto-grants the registered/dialed tool set (the model picks from all live tools).",
+            &["agent", "react", "tools", "auto-grant", "mcp"],
+        ),
         VISION_RECIPE_HANDLE => (
             "Vision — a multimodal completion over an attached image.",
             &["model", "vision", "image", "multimodal", "agent"],
@@ -957,6 +1026,23 @@ fn seed_recipe(
 /// execution surface).
 pub struct HostRecipeBinder {
     lib: std::sync::Arc<DemoLibrary>,
+    /// PR-6b-4: present iff `KX_SERVE_AUTOGRANT` is on AND a model is served. When
+    /// `Some`, a bind of [`REACT_AUTO_RECIPE_HANDLE`] OVERRIDES the bound seed
+    /// Mote's warrant with [`tool_union_warrant`] rebuilt from the LIVE registry
+    /// (admit-direct — the dialed-tool live-warrant rebuild). `None` ⇒ every
+    /// existing path is byte-identical (react-auto is not seeded, so `bind` never
+    /// reaches the override).
+    autogrant: Option<AutoGrant>,
+}
+
+/// PR-6b-4: the two LIVE seams the react-auto bind override reads — the SAME
+/// shared `Arc`s the coordinator/author/broker use, so a runtime-DIALED tool is
+/// auto-grantable the moment its firing capability registers.
+struct AutoGrant {
+    /// The live tool registry (full `ToolDef`s — net/fs/syscall per tool).
+    tools: std::sync::Arc<dyn ToolRegistry>,
+    /// The live broker-fireable `(id, version)` set (PR-6b-2 backstop).
+    registered: std::sync::Arc<dyn kx_gateway_core::RegisteredToolsView>,
 }
 
 impl HostRecipeBinder {
@@ -964,13 +1050,57 @@ impl HostRecipeBinder {
     pub fn new(lib: DemoLibrary) -> Self {
         Self {
             lib: std::sync::Arc::new(lib),
+            autogrant: None,
         }
     }
 
     /// Wrap a [`DemoLibrary`] SHARED with a [`HostRecipeCatalog`] (one seed, two
     /// seams) — the server wires both over the same `Arc<DemoLibrary>`.
     pub fn from_shared(lib: std::sync::Arc<DemoLibrary>) -> Self {
-        Self { lib }
+        Self {
+            lib,
+            autogrant: None,
+        }
+    }
+
+    /// PR-6b-4: wrap a shared [`DemoLibrary`] WITH the live auto-grant seams — a
+    /// bind of [`REACT_AUTO_RECIPE_HANDLE`] rebuilds the union warrant from the
+    /// live registry at bind. The server uses this only when `KX_SERVE_AUTOGRANT`
+    /// is on; the `tools` registry + `registered` view are the SAME `Arc`s the
+    /// coordinator + broker share (one live tool set across authoring, the D66
+    /// submit gate, and dispatch).
+    pub fn from_shared_with_autogrant(
+        lib: std::sync::Arc<DemoLibrary>,
+        tools: std::sync::Arc<dyn ToolRegistry>,
+        registered: std::sync::Arc<dyn kx_gateway_core::RegisteredToolsView>,
+    ) -> Self {
+        Self {
+            lib,
+            autogrant: Some(AutoGrant { tools, registered }),
+        }
+    }
+
+    /// PR-6b-4: rebuild the auto-grant union warrant from the LIVE registry for a
+    /// react-auto bind. `base` is the recipe's seed-time `owner_root` (model_route
+    /// / resource_ceiling / executor_class). Reads the broker-fireable `(id,ver)`
+    /// set and looks each up for its full `ToolDef`; a tool whose capability is
+    /// registered but whose def is no longer resolvable is simply skipped (the
+    /// union is best-effort + re-verified per-fire). `None` ⇒ no autogrant seam
+    /// (unreachable for a seeded react-auto, but a safe fallthrough).
+    fn react_auto_union(&self, base: &WarrantSpec) -> Option<WarrantSpec> {
+        let ag = self.autogrant.as_ref()?;
+        let defs: std::collections::BTreeMap<(ToolName, ToolVersion), ToolDef> = ag
+            .registered
+            .registered_grants()
+            .into_iter()
+            .filter_map(|(id, ver)| {
+                let (name, version) = (ToolName(id), ToolVersion(ver));
+                ag.tools
+                    .lookup(&name, &version)
+                    .map(|def| ((name, version), def))
+            })
+            .collect();
+        Some(tool_union_warrant(base, &defs))
     }
 }
 
@@ -1056,18 +1186,40 @@ impl RecipeBinder for HostRecipeBinder {
             args,
         )
         .map_err(map_invoke_err)?;
+        // PR-6b-4: react-auto's bound seed Mote warrant is the seed-time PLACEHOLDER
+        // (empty tool_grants). OVERRIDE it with the union warrant rebuilt from the
+        // LIVE registry (admit-direct — the bound mote is byte-identical except its
+        // separate WarrantSpec, which is off the MoteDef/MoteId/digest). `bind_snapshot`
+        // already gated the party's Use authorization + bound the free-params, so a
+        // party without a Use grant on react-auto never reaches here. The union flows
+        // durably to every turn/observation via the chain's `anchor.warrant_ref`; the
+        // broker precheck + coordinator D66 re-verify every axis at each fire (SN-8).
+        let is_react_auto = parse_handle(REACT_AUTO_RECIPE_HANDLE).is_some_and(|p| p == asset_path);
+        let motes = match (is_react_auto, self.react_auto_union(&meta.owner_root)) {
+            (true, Some(union)) => bound
+                .motes
+                .into_iter()
+                .map(|(m, _w)| (m, union.clone()))
+                .collect(),
+            _ => bound.motes,
+        };
         Ok(BoundRecipe {
             recipe_fingerprint: bound.recipe_fingerprint,
-            motes: bound.motes,
+            motes,
             terminal_mote_id: bound.terminal_mote_id,
             // PR-2d-2: the react recipe seeds a live ReAct chain — the Invoke
             // arm submits its (single) bound Mote with `react_seed = true`,
             // triggering the coordinator's run-salted seed-swap + durable anchor.
             // PR-6a/D155: react-fs is ALSO a live ReAct chain (same machinery,
             // fs-list grant) ⇒ it MUST set react_seed too, else the loop never runs.
-            react_seed: [REACT_RECIPE_HANDLE, REACT_FS_RECIPE_HANDLE]
-                .iter()
-                .any(|h| parse_handle(h).is_some_and(|p| p == asset_path)),
+            // PR-6b-4: react-auto is the same machinery (union tool grant).
+            react_seed: [
+                REACT_RECIPE_HANDLE,
+                REACT_FS_RECIPE_HANDLE,
+                REACT_AUTO_RECIPE_HANDLE,
+            ]
+            .iter()
+            .any(|h| parse_handle(h).is_some_and(|p| p == asset_path)),
         })
     }
 }
@@ -1882,6 +2034,179 @@ fn react_fs_handle() -> Result<AssetPath, GatewayError> {
         .ok_or_else(|| GatewayError::Catalog("invalid react-fs recipe handle".into()))
 }
 
+/// PR-6b-4: the cap on the auto-grant union warrant's tool set — bounds the
+/// model's tool menu (prompt size) AND the union warrant's scope breadth. When
+/// more than this many tools are registered, a deterministic `(id, version)`
+/// prefix is granted (the rest are still authorable via an explicit `tool()`
+/// node). 16 is generous for the live ReAct menu and keeps the prompt bounded.
+const AUTOGRANT_MAX_TOOLS: usize = 16;
+
+/// The "no syscall profile" sentinel every in-scope tool declares (MCP / stdio /
+/// host-read tools do not run sandboxed body-exec). The auto-grant union FILTERS
+/// to this profile so the union warrant's single `syscall_profile_ref` satisfies
+/// the registry resolver's per-tool EQUALITY gate (`check_tool_requirement`) for
+/// every granted tool (cf. BUG-24). A future sandboxed tool with a different
+/// profile is simply excluded from auto-grant (still fireable via `tool()`).
+const EMPTY_SYSCALL_PROFILE: [u8; 32] = [0u8; 32];
+
+/// Union of two [`NetScope`]s — the identity is [`NetScope::None`] (`None ∪ X =
+/// X`); two allowlists merge their host sets. A widening op (the dual of
+/// `is_subset_of`), used ONLY to build the server's auto-grant union warrant from
+/// already-vetted tool scopes — never to narrow a caller's authority.
+fn net_scope_union(a: &NetScope, b: &NetScope) -> NetScope {
+    match (a, b) {
+        (NetScope::None, other) | (other, NetScope::None) => other.clone(),
+        (NetScope::EgressAllowlist(x), NetScope::EgressAllowlist(y)) => {
+            let mut hosts: BTreeSet<Host> = x.clone();
+            hosts.extend(y.iter().cloned());
+            NetScope::EgressAllowlist(hosts)
+        }
+    }
+}
+
+/// Per-path least-upper-bound merge of two [`FsScope`]s under the [`FsMode`]
+/// subset order. Disjoint paths union; a shared path takes the wider mode.
+/// Returns `None` (fail-closed) iff any shared path has INCOMPARABLE modes
+/// (e.g. `ReadWrite` vs `ExecOnly` — neither is a subset of the other), so the
+/// caller drops that tool from the union rather than fabricate a phantom
+/// superset. In-scope tools are all `ReadOnly`/empty, so this never fires today;
+/// the check is the forward-safety guard.
+fn fs_scope_union(a: &FsScope, b: &FsScope) -> Option<FsScope> {
+    let mut mounts = a.mounts.clone();
+    for (path, mode_b) in &b.mounts {
+        match mounts.get(path) {
+            None => {
+                mounts.insert(path.clone(), *mode_b);
+            }
+            Some(mode_a) => {
+                // The least upper bound under `is_subset_of`: whichever mode the
+                // other is a subset of. Incomparable ⇒ fail closed.
+                let lub = if mode_a.is_subset_of(*mode_b) {
+                    *mode_b
+                } else if mode_b.is_subset_of(*mode_a) {
+                    *mode_a
+                } else {
+                    return None;
+                };
+                mounts.insert(path.clone(), lub);
+            }
+        }
+    }
+    Some(FsScope { mounts })
+}
+
+/// PR-6b-4: the SERVER-built UNION warrant for the autonomous `react-auto` loop —
+/// auto-grants the LIVE set of registered/dialed tools so the model can pick from
+/// ALL of them (not just one bundled seed tool). `defs` is the live broker-fireable
+/// `(id, version) → ToolDef` set; the union is rebuilt at BIND (a dialed tool
+/// registers at runtime, after seed). Filters to [`EMPTY_SYSCALL_PROFILE`] (so the
+/// per-tool syscall EQUALITY gate passes — BUG-24) AND to fs-union-compatible tools;
+/// caps at [`AUTOGRANT_MAX_TOOLS`] by a deterministic `(id, version)` sort + prefix.
+/// `tool_grants` = that set; `net_scope` / `fs_scope` = the UNION of their declared
+/// `required_capability` scopes (so the broker `precheck` `request ⊆ warrant` passes
+/// for EVERY granted tool, the per-call request carrying THAT tool's own scope);
+/// `syscall_profile_ref` = the empty sentinel; `model_route` / `resource_ceiling` /
+/// `executor_class` from `base` (the react-auto seed warrant) so the chain leases on
+/// the served worker. Admitted DIRECTLY at bind (mirrors [`tool_step_warrant`] / the
+/// PR-6b-2 `author()` precedent): the tool scopes are SERVER-vetted (SSRF-vetted at
+/// dial, the registry the source of truth) and the operator opt-in (`KX_SERVE_AUTOGRANT`)
+/// is the OSS ceiling; the broker precheck + coordinator D66 re-verify every axis at
+/// each fire (SN-8). Client `tool_grants` are NEVER accepted.
+pub(crate) fn tool_union_warrant(
+    base: &WarrantSpec,
+    defs: &std::collections::BTreeMap<(ToolName, ToolVersion), ToolDef>,
+) -> WarrantSpec {
+    // Deterministic order: BTreeMap already iterates by (ToolName, ToolVersion),
+    // so the cap takes a stable prefix and the warrant is byte-reproducible.
+    let mut tool_grants: BTreeSet<ToolGrant> = BTreeSet::new();
+    let mut net_scope = NetScope::None;
+    let mut fs_scope = FsScope::empty();
+    for ((name, version), def) in defs {
+        if tool_grants.len() >= AUTOGRANT_MAX_TOOLS {
+            break;
+        }
+        let cap = &def.required_capability;
+        // Only tools with the empty syscall profile can share one union warrant.
+        if cap.syscall_profile_ref != ContentRef::from_bytes(EMPTY_SYSCALL_PROFILE) {
+            continue;
+        }
+        // A tool whose fs scope is incomparable with the running union is skipped
+        // (never poisons the whole union); echo/fs-list/MCP tools never trip this.
+        let Some(merged_fs) = fs_scope_union(&fs_scope, &cap.fs_scope_required) else {
+            continue;
+        };
+        fs_scope = merged_fs;
+        net_scope = net_scope_union(&net_scope, &cap.net_scope_required);
+        tool_grants.insert(ToolGrant {
+            tool_id: name.clone(),
+            tool_version: version.clone(),
+        });
+    }
+    WarrantSpec {
+        mote_class: MoteClass::ReadOnlyNondet,
+        nd_class: MoteClass::ReadOnlyNondet,
+        fs_scope,
+        net_scope,
+        syscall_profile_ref: ContentRef::from_bytes(EMPTY_SYSCALL_PROFILE),
+        tool_grants,
+        model_route: base.model_route.clone(),
+        resource_ceiling: base.resource_ceiling,
+        environment_ref: None,
+        executor_class: base.executor_class,
+        ..Default::default()
+    }
+}
+
+/// PR-6b-4: the seed-time PLACEHOLDER warrant for `kx/recipes/react-auto`. Mirrors
+/// [`react_warrant`] but with EMPTY `tool_grants` (no bundled tool) — at bind the
+/// host binder OVERRIDES the bound seed Mote's warrant with [`tool_union_warrant`]
+/// rebuilt from the LIVE registry. This base supplies the `model_route` /
+/// `resource_ceiling` / `executor_class` so the recipe is structurally valid + the
+/// chain leases on the served worker, and it is the `base` passed to the union
+/// builder at bind.
+pub(crate) fn react_auto_base_warrant(
+    exec_class: ExecutorClass,
+    model_id: &ModelId,
+) -> WarrantSpec {
+    WarrantSpec {
+        mote_class: MoteClass::ReadOnlyNondet,
+        nd_class: MoteClass::ReadOnlyNondet,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes(EMPTY_SYSCALL_PROFILE),
+        tool_grants: BTreeSet::new(),
+        model_route: ModelRoute {
+            model_id: model_id.clone(),
+            max_input_tokens: 4_096,
+            max_output_tokens: 512,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 120_000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: exec_class,
+        ..Default::default()
+    }
+}
+
+/// The wire handle of the PR-6b-4 `react-auto` recipe: a live ReAct loop like
+/// [`REACT_RECIPE_HANDLE`] BUT whose warrant is REBUILT at bind from the LIVE
+/// registry to auto-grant the registered/dialed tool set (a union warrant, ≤
+/// `AUTOGRANT_MAX_TOOLS`). A SEPARATE recipe (the react-fs precedent) so the
+/// canonical `kx/recipes/react` + the projection digest stay byte-unchanged.
+/// Seeded only when a fit serve model resolved AND `KX_SERVE_AUTOGRANT` is on.
+pub const REACT_AUTO_RECIPE_HANDLE: &str = "kx/recipes/react-auto";
+
+fn react_auto_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(REACT_AUTO_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid react-auto recipe handle".into()))
+}
+
 /// The PURE demo recipe warrant. Its `executor_class` MUST equal the embedded
 /// worker's (`default_executor_class()`); used identically as the owner root,
 /// the grant runtime scope, and the recipe step warrant, so every `intersect`
@@ -2680,6 +3005,7 @@ mod tests {
             None,
             false,
             None,
+            false,
         )
         .unwrap();
         assert!(!lib
@@ -2697,6 +3023,7 @@ mod tests {
             None,
             true,
             None,
+            false,
         )
         .unwrap();
         let form = lib
@@ -2734,6 +3061,7 @@ mod tests {
             None,
             false,
             Some((&fs_tool, root.path())),
+            false,
         )
         .unwrap();
         assert!(lib
@@ -2755,11 +3083,110 @@ mod tests {
             None,
             false,
             None,
+            false,
         )
         .unwrap();
         assert!(!lib2
             .recipe_handles()
             .contains(&REACT_FS_RECIPE_HANDLE.to_string()));
+    }
+
+    #[test]
+    fn react_variants_coexist_without_a_body_id_collision() {
+        // BUG-25 regression: react (echo), react-fs (fs-list), and react-auto all
+        // seed live ReAct chains whose recipe bodies differ ONLY by their
+        // server-built warrant. The body manifest id is `hash(seed ‖ mote_ids)` and
+        // EXCLUDES the warrant, so a shared logic ref makes the second seed a
+        // body-ledger immutability conflict (a startup panic). Each carries its OWN
+        // logic ref, so a serve with the echo bin + KX_SERVE_FS_ROOT + autogrant
+        // provisions ALL of them without conflict.
+        let model = ModelId("kx-serve:m".to_string());
+        let echo = (ToolName("mcp-echo".into()), ToolVersion("1".into()));
+        let fs_tool = (ToolName("fs-list".into()), ToolVersion("1".into()));
+        let root = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open_complete(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            Some(&model),
+            Some(&echo), // react
+            false,
+            Some((&fs_tool, root.path())), // react-fs
+            true,                          // react-auto
+        )
+        .expect("all three react variants seed without a body-id collision");
+        let handles = lib.recipe_handles();
+        assert!(handles.contains(&REACT_RECIPE_HANDLE.to_string()));
+        assert!(handles.contains(&REACT_FS_RECIPE_HANDLE.to_string()));
+        assert!(handles.contains(&REACT_AUTO_RECIPE_HANDLE.to_string()));
+        // Each has a DISTINCT recipe fingerprint (the distinct logic refs).
+        let fp = |h: &str| lib.recipe_fingerprint(h).unwrap();
+        assert_ne!(fp(REACT_RECIPE_HANDLE), fp(REACT_FS_RECIPE_HANDLE));
+        assert_ne!(fp(REACT_RECIPE_HANDLE), fp(REACT_AUTO_RECIPE_HANDLE));
+        assert_ne!(fp(REACT_FS_RECIPE_HANDLE), fp(REACT_AUTO_RECIPE_HANDLE));
+    }
+
+    #[test]
+    fn react_auto_recipe_seeded_only_with_the_autogrant_flag() {
+        // PR-6b-4: react-auto is a SEPARATE recipe, seeded only when a model is
+        // served AND the operator opted in — default-OFF keeps the canonical set.
+        let model = ModelId("kx-serve:m".to_string());
+
+        // autogrant ON ⇒ seeded; the published form is the react contract.
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open_complete(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            Some(&model),
+            None,
+            false,
+            None,
+            true,
+        )
+        .unwrap();
+        assert!(lib
+            .recipe_handles()
+            .contains(&REACT_AUTO_RECIPE_HANDLE.to_string()));
+        let form = lib
+            .recipe_form(REACT_AUTO_RECIPE_HANDLE)
+            .expect("react-auto is provisioned");
+        assert_eq!(form.len(), 3, "instruction + the two budget caps");
+
+        // autogrant OFF (default) ⇒ NOT seeded.
+        let dir2 = tempfile::tempdir().unwrap();
+        let lib2 = DemoLibrary::open_complete(
+            dir2.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            Some(&model),
+            None,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(!lib2
+            .recipe_handles()
+            .contains(&REACT_AUTO_RECIPE_HANDLE.to_string()));
+
+        // No served model ⇒ NOT seeded even with the flag on.
+        let dir3 = tempfile::tempdir().unwrap();
+        let lib3 = DemoLibrary::open_complete(
+            dir3.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            None,
+            None,
+            false,
+            None,
+            true,
+        )
+        .unwrap();
+        assert!(!lib3
+            .recipe_handles()
+            .contains(&REACT_AUTO_RECIPE_HANDLE.to_string()));
     }
 
     #[test]
@@ -2778,6 +3205,143 @@ mod tests {
             "the grant's fs_scope must equal the tool's declared scope (precheck subset)"
         );
         assert_eq!(w.net_scope, NetScope::None, "fs-list has no egress");
+    }
+
+    // ---- PR-6b-4: auto-grant union warrant -------------------------------
+
+    fn host(h: &str) -> Host {
+        Host(h.to_string())
+    }
+
+    fn tool_def_with(net: NetScope, fs: FsScope, syscall: [u8; 32]) -> ToolDef {
+        ToolDef {
+            tool_id: ToolName("t".into()),
+            tool_version: ToolVersion("1".into()),
+            kind: kx_tool_registry::ToolKind::Builtin,
+            required_capability: kx_warrant::ToolRequirement {
+                net_scope_required: net,
+                fs_scope_required: fs,
+                syscall_profile_ref: ContentRef::from_bytes(syscall),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: String::new(),
+            idempotency_class: kx_tool_registry::IdempotencyClass::Staged,
+            input_schema: None,
+        }
+    }
+
+    #[test]
+    fn net_scope_union_treats_none_as_identity_and_merges_allowlists() {
+        let a = NetScope::EgressAllowlist([host("api.example.com")].into_iter().collect());
+        assert_eq!(net_scope_union(&NetScope::None, &a), a, "None ∪ X = X");
+        assert_eq!(net_scope_union(&a, &NetScope::None), a, "X ∪ None = X");
+        assert_eq!(
+            net_scope_union(&NetScope::None, &NetScope::None),
+            NetScope::None
+        );
+        let b = NetScope::EgressAllowlist([host("b.example.com")].into_iter().collect());
+        let merged = net_scope_union(&a, &b);
+        match merged {
+            NetScope::EgressAllowlist(hosts) => {
+                assert!(hosts.contains(&host("api.example.com")));
+                assert!(hosts.contains(&host("b.example.com")));
+            }
+            NetScope::None => panic!("merge of two allowlists must be an allowlist"),
+        }
+    }
+
+    #[test]
+    fn fs_scope_union_takes_lub_and_fails_closed_on_incomparable_modes() {
+        let p = std::path::PathBuf::from("/data");
+        let ro = FsScope {
+            mounts: [(p.clone(), FsMode::ReadOnly)].into_iter().collect(),
+        };
+        let rw = FsScope {
+            mounts: [(p.clone(), FsMode::ReadWrite)].into_iter().collect(),
+        };
+        // ReadWrite is the wider mode (ReadOnly ⊆ ReadWrite) ⇒ LUB = ReadWrite.
+        let lub = fs_scope_union(&ro, &rw).expect("comparable modes union");
+        assert_eq!(lub.mounts.get(&p), Some(&FsMode::ReadWrite));
+        // Disjoint paths simply union.
+        let q = std::path::PathBuf::from("/etc");
+        let other = FsScope {
+            mounts: [(q.clone(), FsMode::ReadOnly)].into_iter().collect(),
+        };
+        let merged = fs_scope_union(&ro, &other).expect("disjoint union");
+        assert_eq!(merged.mounts.len(), 2);
+        // ExecOnly ⟂ ReadWrite ⇒ incomparable ⇒ fail-closed None.
+        let exec = FsScope {
+            mounts: [(p.clone(), FsMode::ExecOnly)].into_iter().collect(),
+        };
+        assert_eq!(fs_scope_union(&exec, &rw), None, "incomparable ⇒ None");
+    }
+
+    #[test]
+    fn tool_union_warrant_grants_unions_caps_and_filters() {
+        let base = react_auto_base_warrant(ExecutorClass::Bwrap, &ModelId("m".into()));
+        // Two egress tools to different hosts + one non-empty-syscall tool (excluded).
+        let mut defs: std::collections::BTreeMap<(ToolName, ToolVersion), ToolDef> =
+            std::collections::BTreeMap::new();
+        let net_a = NetScope::EgressAllowlist([host("a.example.com")].into_iter().collect());
+        let net_b = NetScope::EgressAllowlist([host("b.example.com")].into_iter().collect());
+        defs.insert(
+            (ToolName("alpha".into()), ToolVersion("1".into())),
+            tool_def_with(net_a, FsScope::empty(), EMPTY_SYSCALL_PROFILE),
+        );
+        defs.insert(
+            (ToolName("bravo".into()), ToolVersion("1".into())),
+            tool_def_with(net_b, FsScope::empty(), EMPTY_SYSCALL_PROFILE),
+        );
+        defs.insert(
+            (ToolName("sandboxed".into()), ToolVersion("1".into())),
+            tool_def_with(NetScope::None, FsScope::empty(), [9u8; 32]),
+        );
+        let w = tool_union_warrant(&base, &defs);
+        // alpha + bravo granted; the non-empty-syscall tool is FILTERED out.
+        assert_eq!(w.tool_grants.len(), 2);
+        assert!(w.tool_grants.iter().any(|g| g.tool_id.0 == "alpha"));
+        assert!(w.tool_grants.iter().any(|g| g.tool_id.0 == "bravo"));
+        assert!(!w.tool_grants.iter().any(|g| g.tool_id.0 == "sandboxed"));
+        // net_scope is the UNION of the two hosts.
+        match &w.net_scope {
+            NetScope::EgressAllowlist(hosts) => {
+                assert!(hosts.contains(&host("a.example.com")));
+                assert!(hosts.contains(&host("b.example.com")));
+            }
+            NetScope::None => panic!("union of two egress tools must be an allowlist"),
+        }
+        // syscall is the empty sentinel; classes + model_route inherit the base.
+        assert_eq!(w.syscall_profile_ref, ContentRef::from_bytes([0u8; 32]));
+        assert_eq!(w.model_route.model_id, ModelId("m".into()));
+        // Determinism: same input ⇒ byte-identical warrant.
+        assert_eq!(w, tool_union_warrant(&base, &defs));
+    }
+
+    #[test]
+    fn tool_union_warrant_caps_at_the_max() {
+        let base = react_auto_base_warrant(ExecutorClass::Bwrap, &ModelId("m".into()));
+        let mut defs: std::collections::BTreeMap<(ToolName, ToolVersion), ToolDef> =
+            std::collections::BTreeMap::new();
+        for i in 0..(AUTOGRANT_MAX_TOOLS + 4) {
+            defs.insert(
+                (ToolName(format!("tool-{i:02}")), ToolVersion("1".into())),
+                tool_def_with(NetScope::None, FsScope::empty(), EMPTY_SYSCALL_PROFILE),
+            );
+        }
+        let w = tool_union_warrant(&base, &defs);
+        assert_eq!(w.tool_grants.len(), AUTOGRANT_MAX_TOOLS, "capped");
+        // The deterministic prefix is the first AUTOGRANT_MAX_TOOLS by (id, ver).
+        assert!(w.tool_grants.iter().any(|g| g.tool_id.0 == "tool-00"));
+        assert!(!w
+            .tool_grants
+            .iter()
+            .any(|g| g.tool_id.0 == format!("tool-{:02}", AUTOGRANT_MAX_TOOLS + 3)));
     }
 
     #[test]

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -620,6 +620,14 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         };
     #[cfg(not(feature = "inference"))]
     let fs_list_tool: Option<(kx_mote::ToolName, kx_mote::ToolVersion)> = None;
+    // PR-6b-4 (auto-grant): the operator opt-in (`KX_SERVE_AUTOGRANT`, default-OFF)
+    // for the autonomous-loop tool auto-grant — gates seeding `kx/recipes/react-auto`
+    // AND wiring the binder's live-warrant rebuild. Requires a served model (no model
+    // ⇒ no react chain to drive). OFF ⇒ byte-identical serve (react-auto absent).
+    #[cfg(feature = "inference")]
+    let autogrant = serve_model.is_some() && crate::mcp_tool::autogrant_enabled();
+    #[cfg(not(feature = "inference"))]
+    let autogrant = false;
     let broker: Arc<dyn CapabilityBroker> = local_broker.clone();
     let worker = Worker::register(
         client,
@@ -746,11 +754,32 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         react_tool.as_ref(),
         vision_supported,
         fs_list_binding,
+        autogrant,
     )?);
     // One seed, two seams: the binder (Invoke) and the recipe catalog (ListRecipes
     // / GetRecipeForm) share the SAME library, so the published form and the
     // executable bind agree by construction.
-    let binder: Arc<dyn RecipeBinder> = Arc::new(HostRecipeBinder::from_shared(demo.clone()));
+    // PR-6b-4: when the operator opted into auto-grant, the binder gets the LIVE
+    // tool registry + broker-fireable view so a bind of `kx/recipes/react-auto`
+    // rebuilds its union warrant from the live (incl. runtime-dialed) tool set.
+    let binder: Arc<dyn RecipeBinder> = if autogrant {
+        let registered: Arc<dyn kx_gateway_core::RegisteredToolsView> =
+            Arc::new(HostRegisteredTools {
+                broker: local_broker.clone(),
+            });
+        Arc::new(HostRecipeBinder::from_shared_with_autogrant(
+            demo.clone(),
+            tool_registry.clone(),
+            registered,
+        ))
+    } else {
+        Arc::new(HostRecipeBinder::from_shared(demo.clone()))
+    };
+    if autogrant {
+        tracing::info!(
+            "PR-6b-4: KX_SERVE_AUTOGRANT on — kx/recipes/react-auto live (auto-grants the registered/dialed tool set to the autonomous loop, capped)"
+        );
+    }
     let recipe_catalog: Arc<dyn RecipeCatalog> = Arc::new(HostRecipeCatalog::new(demo.clone()));
     // The Blueprint-builder author seam (SubmitWorkflow) — shares the same library
     // `Arc` (one seed, many seams), so the authoring authority resolves from the

--- a/crates/kx-gateway/tests/react_auto_bind.rs
+++ b/crates/kx-gateway/tests/react_auto_bind.rs
@@ -1,0 +1,192 @@
+//! PR-6b-4 — the react-auto live-warrant-rebuild bind override, model-free.
+//!
+//! A bind of `kx/recipes/react-auto` admits a SERVER-built UNION warrant rebuilt
+//! from the LIVE registry (admit-direct), so the autonomous loop can fire ANY
+//! registered/dialed tool — not just one bundled seed tool. This test pins the
+//! bind layer WITHOUT a live model (seeding only records a model id; bind does no
+//! inference): the union grants the live set, the seed Mote's IDENTITY is
+//! unchanged by the warrant override, `react_seed` is set, and a party without a
+//! `Use` grant is refused. The full live drive lives in `react_auto_serve.rs`
+//! (`#[ignore]`, real GGUF).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use kx_gateway::{DemoLibrary, HostRecipeBinder, REACT_AUTO_RECIPE_HANDLE};
+use kx_gateway_core::{RecipeBinder, RegisteredToolsView};
+use kx_mote::{ModelId, ToolName, ToolVersion};
+use kx_tool_registry::{
+    IdempotencyClass, SqliteToolRegistry, ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+};
+use kx_warrant::{ExecutorClass, FsScope, Host, NetScope, ResourceCeiling, ToolRequirement};
+
+/// A stub broker-fireable view returning a fixed `(id, version)` set.
+struct StubRegistered(BTreeSet<(String, String)>);
+impl RegisteredToolsView for StubRegistered {
+    fn registered_grants(&self) -> BTreeSet<(String, String)> {
+        self.0.clone()
+    }
+}
+
+fn mcp_tool(name: &str, net: NetScope) -> ToolDef {
+    ToolDef {
+        tool_id: ToolName(name.into()),
+        tool_version: ToolVersion("1".into()),
+        kind: ToolKind::Builtin,
+        required_capability: ToolRequirement {
+            net_scope_required: net,
+            fs_scope_required: FsScope::empty(),
+            syscall_profile_ref: kx_content::ContentRef::from_bytes([0u8; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+        },
+        description: String::new(),
+        idempotency_class: IdempotencyClass::Staged,
+        input_schema: None,
+    }
+}
+
+const ARGS: &[u8] = br#"{"instruction":"list files","max_turns":4,"max_tool_calls":2}"#;
+
+/// Build a react-auto-seeded library + a registry holding `echo` + a dialed
+/// egress tool, plus a view that reports both as broker-fireable.
+fn fixture(
+    dir: &std::path::Path,
+) -> (
+    Arc<DemoLibrary>,
+    Arc<dyn ToolRegistry>,
+    Arc<dyn RegisteredToolsView>,
+) {
+    let lib = Arc::new(
+        DemoLibrary::open_complete(
+            dir,
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            Some(&ModelId("kx-serve:test".into())),
+            None,
+            false,
+            None,
+            true, // autogrant ON ⇒ react-auto seeded
+        )
+        .unwrap(),
+    );
+    let registry = Arc::new(SqliteToolRegistry::open(dir.join("tools.db")).unwrap());
+    registry
+        .register_durable(
+            mcp_tool("mcp-echo", NetScope::None),
+            ToolProvenance::HumanAuthored {
+                author: "test".into(),
+            },
+            None,
+        )
+        .unwrap();
+    registry
+        .register_durable(
+            mcp_tool(
+                "github/search",
+                NetScope::EgressAllowlist([Host("api.github.com".into())].into_iter().collect()),
+            ),
+            ToolProvenance::HumanAuthored {
+                author: "mcp-gateway:github".into(),
+            },
+            Some("api.github.com".into()),
+        )
+        .unwrap();
+    let view: Arc<dyn RegisteredToolsView> = Arc::new(StubRegistered(
+        [
+            ("mcp-echo".to_string(), "1".to_string()),
+            ("github/search".to_string(), "1".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+    (lib, registry, view)
+}
+
+#[tokio::test]
+async fn react_auto_bind_admits_the_live_union_warrant() {
+    let dir = tempfile::tempdir().unwrap();
+    let (lib, registry, view) = fixture(dir.path());
+    let binder = HostRecipeBinder::from_shared_with_autogrant(lib, registry, view);
+
+    let bound = binder
+        .bind("alice@acme", REACT_AUTO_RECIPE_HANDLE, ARGS)
+        .await
+        .expect("alice holds Use on react-auto");
+
+    // react-auto seeds a live chain.
+    assert!(bound.react_seed, "react-auto must submit with react_seed");
+    let (_mote, warrant) = &bound.motes[0];
+    // The bound warrant auto-grants BOTH live tools (the union), not one seed tool.
+    let granted: BTreeSet<String> = warrant
+        .tool_grants
+        .iter()
+        .map(|g| g.tool_id.0.clone())
+        .collect();
+    assert!(granted.contains("mcp-echo"), "echo auto-granted");
+    assert!(
+        granted.contains("github/search"),
+        "dialed tool auto-granted"
+    );
+    // The egress scope is the UNION (the dialed tool's host is reachable).
+    match &warrant.net_scope {
+        NetScope::EgressAllowlist(hosts) => {
+            assert!(hosts.contains(&Host("api.github.com".into())));
+        }
+        NetScope::None => panic!("the union must convey the dialed tool's egress"),
+    }
+}
+
+#[tokio::test]
+async fn react_auto_override_preserves_the_seed_mote_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let (lib, registry, view) = fixture(dir.path());
+
+    // WITHOUT autogrant: the placeholder warrant (empty tool_grants) binds.
+    let plain = HostRecipeBinder::from_shared(lib.clone());
+    let bound_plain = plain
+        .bind("alice@acme", REACT_AUTO_RECIPE_HANDLE, ARGS)
+        .await
+        .unwrap();
+    // WITH autogrant: the union warrant overrides.
+    let auto = HostRecipeBinder::from_shared_with_autogrant(lib, registry, view);
+    let bound_auto = auto
+        .bind("alice@acme", REACT_AUTO_RECIPE_HANDLE, ARGS)
+        .await
+        .unwrap();
+
+    // MoteId is warrant-INDEPENDENT (derived from the def/input/position), so the
+    // override changes the warrant but never the Mote identity — the run-salted
+    // seed-swap + durable anchor are unaffected.
+    assert_eq!(
+        bound_plain.motes[0].0.id, bound_auto.motes[0].0.id,
+        "overriding the warrant must not change the seed Mote identity"
+    );
+    // The warrants DO differ (placeholder empty grants vs the live union).
+    assert!(bound_plain.motes[0].1.tool_grants.is_empty());
+    assert_eq!(bound_auto.motes[0].1.tool_grants.len(), 2);
+}
+
+#[tokio::test]
+async fn react_auto_refuses_a_party_without_use() {
+    let dir = tempfile::tempdir().unwrap();
+    let (lib, registry, view) = fixture(dir.path());
+    let binder = HostRecipeBinder::from_shared_with_autogrant(lib, registry, view);
+
+    // The pre-override `bind_snapshot` gate still fires: a party with no `Use`
+    // grant on react-auto is refused (the override never widens authorization).
+    let outcome = binder
+        .bind("mallory@evil", REACT_AUTO_RECIPE_HANDLE, ARGS)
+        .await;
+    assert!(
+        matches!(outcome, Err(kx_gateway_core::BinderError::NotAuthorized)),
+        "unauthorized party ⇒ NotAuthorized (no existence oracle)"
+    );
+}

--- a/crates/kx-gateway/tests/react_auto_serve.rs
+++ b/crates/kx-gateway/tests/react_auto_serve.rs
@@ -1,0 +1,143 @@
+//! PR-6b-4 e2e witness: `KX_SERVE_AUTOGRANT=1 kx serve --features inference`
+//! provisions `kx/recipes/react-auto` and drives a LIVE `ReAct` chain through it.
+//!
+//! With the operator opt-in, the serve seeds `kx/recipes/react-auto`; the binder
+//! rebuilds its warrant from the LIVE registry at bind (auto-granting the
+//! registered/dialed tool set, capped) and submits with `react_seed = true` → the
+//! coordinator anchors the run-salted chain → the embedded worker drives REAL
+//! greedy inference → the settle freezes the terminal branch, surfaced via
+//! `ListReactTurns`. The bind-layer override (union warrant, `MoteId` invariance,
+//! auth gate) is pinned model-free in `react_auto_bind.rs`; this proves the SERVE
+//! wiring under the flag (recipe provisioning, the form, the live drive).
+//!
+//! Gated `#[cfg(feature = "inference")]` AND `#[ignore]`; runtime-skips without a
+//! `GGUF` (`just fetch-agent-model` or `KX_SERVE_MODEL_GGUF`) or the bundled
+//! `kx-mcp-echo` bin (`cargo build -p kx-mcp`, or `KX_MCP_ECHO_PATH`).
+
+#![cfg(feature = "inference")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_gateway::{start, REACT_AUTO_RECIPE_HANDLE, REACT_RECIPE_HANDLE};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+fn serve_model() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("KX_SERVE_MODEL_GGUF") {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let standin = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/models/qwen3-0.6b-q4_k_m.gguf");
+    standin.is_file().then_some(standin)
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real in-process LLM inference; needs a GGUF (just fetch-agent-model); opt in with --ignored"]
+async fn autogrant_serve_provisions_react_auto_and_drives_a_live_chain() {
+    let Some(gguf) = serve_model() else {
+        eprintln!(
+            "skipping: no serve model — run `just fetch-agent-model` (or set KX_SERVE_MODEL_GGUF)"
+        );
+        return;
+    };
+    std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+    std::env::set_var("KX_SERVE_AUTOGRANT", "1");
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    // react-auto requires the model + the bundled echo capability (same gate as
+    // react). If react itself didn't provision, the bundled bin is absent — skip.
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: kx/recipes/react not provisioned — bundled kx-mcp-echo missing");
+        running.shutdown().await.unwrap();
+        std::env::remove_var("KX_SERVE_AUTOGRANT");
+        return;
+    }
+    assert!(
+        recipes
+            .recipes
+            .iter()
+            .any(|r| r.handle == REACT_AUTO_RECIPE_HANDLE),
+        "KX_SERVE_AUTOGRANT on ⇒ kx/recipes/react-auto is provisioned"
+    );
+
+    // The form is the react contract (instruction + the two budget caps).
+    let form = c
+        .get_recipe_form(proto::GetRecipeFormRequest {
+            handle: REACT_AUTO_RECIPE_HANDLE.to_string(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let names: Vec<&str> = form.fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"instruction"));
+    assert!(names.contains(&"max_turns"));
+    assert!(names.contains(&"max_tool_calls"));
+
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_AUTO_RECIPE_HANDLE.to_string(),
+            args: br#"{"instruction":"What is 2+2? Answer briefly in prose.","max_turns":4,"max_tool_calls":2}"#
+                .to_vec(),
+        })
+        .await
+        .expect("invoke kx/recipes/react-auto")
+        .into_inner();
+    assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
+
+    let mut answered = false;
+    for _ in 0..600 {
+        let turns = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if turns.turns.iter().any(|t| t.branch == "answer") {
+            answered = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        answered,
+        "the react-auto chain settled a terminal Answer fact"
+    );
+
+    running.shutdown().await.unwrap();
+    std::env::remove_var("KX_SERVE_AUTOGRANT");
+}

--- a/ui/src/components/sections/ToolsSection.tsx
+++ b/ui/src/components/sections/ToolsSection.tsx
@@ -3,6 +3,7 @@ import { toUiError } from "../../kx/errors";
 import { useScoreBundle, useToolManifests } from "../../kx/use-toolscout";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
+import { AutoGrantStatus } from "../tools/AutoGrantStatus";
 import { BundleComposer } from "../tools/BundleComposer";
 import { ConnectionsPanel } from "../tools/ConnectionsPanel";
 import { ManifestGrid } from "../tools/ManifestGrid";
@@ -76,6 +77,14 @@ export function ToolsSection() {
         capability).
       </p>
       <ConnectionsPanel />
+
+      <h2>Autonomous tool access</h2>
+      <p className="muted">
+        Whether the autonomous agent loop may auto-grant the registered and dialed tool set. The
+        runtime is the source of truth — OSS exposes no toggle here; the operator enables it at
+        startup (<span className="mono">KX_SERVE_AUTOGRANT</span>).
+      </p>
+      <AutoGrantStatus />
 
       <h2>Discovery &amp; preview</h2>
       <p className="muted">

--- a/ui/src/components/tools/AutoGrantStatus.tsx
+++ b/ui/src/components/tools/AutoGrantStatus.tsx
@@ -1,0 +1,37 @@
+import { REACT_AUTO_RECIPE_HANDLE } from "../../kx/use-chat";
+import { useRecipes } from "../../kx/use-recipes";
+
+/**
+ * PR-6b-4 — the honest auto-grant status row. When the operator runs with
+ * `KX_SERVE_AUTOGRANT`, the runtime seeds `kx/recipes/react-auto` (a live ReAct
+ * loop that auto-grants the registered/dialed tool set, capped). Its presence in
+ * `ListRecipes` is the source of truth, so this row reflects the REAL serve
+ * posture — never a faked control (SN-8 / GR15): OSS exposes no toggle; enabling
+ * it is an operator/Cloud concern. Absent / loading / unwired all read OFF (the
+ * recipe genuinely isn't live), which is the honest default-OFF.
+ */
+export function AutoGrantStatus() {
+  const recipes = useRecipes();
+  const on = (recipes.data ?? []).includes(REACT_AUTO_RECIPE_HANDLE);
+
+  return (
+    <div className="autogrant-status" data-testid="autogrant-status">
+      <span
+        className={`status-dot ${on ? "status-dot--online" : "status-dot--offline"}`}
+        aria-hidden="true"
+      />
+      <span className="autogrant-status__label">Auto-grant</span>
+      <span
+        className={`pill ${on ? "pill--committed" : "pill--unknown"}`}
+        data-testid="autogrant-pill"
+      >
+        {on ? "ON" : "OFF"}
+      </span>
+      <span className="muted autogrant-status__detail">
+        {on
+          ? "kx/recipes/react-auto is live — the autonomous loop may fire any registered or dialed tool (capped, re-verified per call)."
+          : "Run with KX_SERVE_AUTOGRANT to let the autonomous loop auto-grant the registered/dialed tool set (kx/recipes/react-auto)."}
+      </span>
+    </div>
+  );
+}

--- a/ui/src/kx/use-chat.ts
+++ b/ui/src/kx/use-chat.ts
@@ -43,6 +43,12 @@ export const VISION_RECIPE_HANDLE = "kx/recipes/vision";
  *  with the bundled tool — the PR-2.1 agent mode's backend). */
 export const REACT_RECIPE_HANDLE = "kx/recipes/react";
 
+/** The PR-6b-4 auto-grant ReAct loop — provisioned only when the operator opts
+ *  in via `KX_SERVE_AUTOGRANT`. Its presence in `ListRecipes` is the honest
+ *  ON/OFF signal the Tools section reflects (the runtime is the source of truth;
+ *  OSS exposes no toggle — enabling it is an operator/Cloud concern). */
+export const REACT_AUTO_RECIPE_HANDLE = "kx/recipes/react-auto";
+
 interface ActiveTurn {
   readonly assistantId: string;
   readonly instanceId: string;

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -3190,6 +3190,25 @@ button.card-grid__title:hover {
 .tools-connections {
   margin: 0;
 }
+/* PR-6b-4: the honest auto-grant status row (read-only — reflects the serve). */
+.autogrant-status {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-elev, var(--surface));
+}
+.autogrant-status__label {
+  font-weight: 600;
+}
+.autogrant-status__detail {
+  flex: 1 1 16rem;
+  min-width: 0;
+  font-size: 0.82rem;
+}
 .register-tool-form {
   display: flex;
   flex-direction: column;

--- a/ui/test/component/AutoGrantStatus.test.tsx
+++ b/ui/test/component/AutoGrantStatus.test.tsx
@@ -1,0 +1,40 @@
+/** PR-6b-4 AutoGrantStatus — the honest auto-grant status row. `useRecipes` is
+ *  mocked so the test is a pure render check: ON iff `kx/recipes/react-auto` is
+ *  in the recipe catalog, OFF (the default) otherwise. */
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const recipesState = {
+  data: undefined as string[] | undefined,
+};
+
+vi.mock("../../src/kx/use-recipes", () => ({
+  useRecipes: () => recipesState,
+}));
+
+import { AutoGrantStatus } from "../../src/components/tools/AutoGrantStatus";
+
+afterEach(() => {
+  recipesState.data = undefined;
+});
+
+describe("AutoGrantStatus", () => {
+  it("reads OFF when react-auto is absent (the default-OFF posture)", () => {
+    recipesState.data = ["kx/recipes/echo", "kx/recipes/react"];
+    render(<AutoGrantStatus />);
+    expect(screen.getByTestId("autogrant-pill")).toHaveTextContent("OFF");
+  });
+
+  it("reads OFF while the catalog is loading / unwired", () => {
+    recipesState.data = undefined;
+    render(<AutoGrantStatus />);
+    expect(screen.getByTestId("autogrant-pill")).toHaveTextContent("OFF");
+  });
+
+  it("reads ON when react-auto is provisioned", () => {
+    recipesState.data = ["kx/recipes/react", "kx/recipes/react-auto"];
+    render(<AutoGrantStatus />);
+    expect(screen.getByTestId("autogrant-pill")).toHaveTextContent("ON");
+  });
+});


### PR DESCRIPTION
## What

Lets the **autonomous ReAct loop auto-grant the live set of registered/dialed tools** so the model can pick from ALL of them — making dialed external MCP tools usable from the *autonomous* loop, not just authored blueprints. New separate recipe `kx/recipes/react-auto`, gated behind **`KX_SERVE_AUTOGRANT`** (default-OFF), capped at 16 tools. **Closes PR-6** (tools production-grade).

## The crux — the live-warrant rebuild

A seeded recipe's warrant is **frozen at seed time** and the bind path only **narrows** (`intersect`), but `tool_grants`/egress-hosts for runtime-dialed tools can't be pre-enumerated at seed — so the union can't flow through the generic narrowing path. The binder **rebuilds the union warrant from the live `SqliteToolRegistry` at bind** and overrides the bound seed Mote's warrant **directly** (admit-direct — mirrors the PR-6b-2 `tool()` precedent).

- **MoteId is warrant-independent** → the override is identity-safe (the run-salted seed-swap + durable anchor are unaffected).
- The union flows durably to every turn/observation via the chain's **`anchor.warrant_ref`**, so **recovery is deterministic** (a run's tool set is frozen at its bind, never a live rebuild even if the registry changed).
- The union filters to the empty syscall profile (every in-scope MCP/dialed/builtin tool shares `[0;32]` — **BUG-24 resolved by construction**) and unions net/fs scopes (fail-closed on incomparable `FsMode`).

## Decisions (user-confirmed)

1. **Admit-direct authority** — server builds the union from the SSRF-vetted registry and admits it directly. OSS ceiling = `KX_SERVE_AUTOGRANT` opt-in + the 16-tool cap + dial-time SSRF vetting + broker precheck/D66 re-verify. Per-party net/fs ceilings stay a Cloud/GR19 concern (mirrors PR-6b-2 `author()`).
2. **Infer-from-`ListRecipes`** — the UI Tools-section auto-grant status row reads whether `kx/recipes/react-auto` is provisioned (no proto change → digest/proto invariant).

## Cross-surface (one batch, GR14/GR18)

- **core**: `tool_union_warrant` + `net_scope_union`/`fs_scope_union` + `react_auto_base_warrant` + the `react-auto` recipe + the `KX_SERVE_AUTOGRANT` flag + the binder override + a startup banner line.
- **UI**: honest read-only "Auto-grant: ON/OFF" status row in Tools (display-only, both themes, D142/GR13).
- **CLI/SDK**: react-auto is just another recipe handle to `invoke` — no change.

## Also fixes BUG-25 (found in the process)

`react` + `react-fs` shared one `logic_ref`, so a serve with the echo bin **AND** `KX_SERVE_FS_ROOT` **panicked at startup** (the body manifest id = `hash(seed ‖ mote_ids)` excludes the warrant, so two react bodies differing only by warrant collide in the body ledger). Each react variant now carries its own `logic_ref`. No durable state to migrate (react-fs never successfully co-seeded with react). GR16 class: shared-logic-ref manifest-id collision.

## Invariants (CI-verified)

- digest **`7d22d4bd`** invariant (react-auto is serve-only, default-OFF, off the canonical FFI-free run) · **frozen-trio diff-EMPTY** · **no proto/`Cargo.lock` change**.
- **SN-8**: server-built union; client `tool_grants` refused; operator opt-in; `[0;32]`-filter + cap; broker precheck + coordinator D66 re-verify per fire.
- GR15 · GR19 · forward/back-compat (an in-flight react-auto run recovers from its durable anchor even on a binary without the flag).

## Tests

- **unit**: net/fs scope union (incl. incomparable → fail-closed); `tool_union_warrant` grant/cap/filter/determinism; react-variant coexistence (BUG-25 regression); react-auto seeding gate (flag + model required).
- **integration** (`react_auto_bind.rs`, model-free): bind admits the live union; MoteId invariance with/without override; party-without-`Use` refused.
- **live e2e** (`react_auto_serve.rs`, `#[ignore]`): `KX_SERVE_AUTOGRANT=1` serve provisions react-auto and drives a real Qwen3-0.6B chain to a terminal Answer — **verified locally** (passed).
- Full local gate green: fmt · clippy `--workspace --all-targets -D warnings` · `cargo test --workspace` · `cargo doc -D warnings` · build-no-inference · digest 7d22d4bd (8/8) · UI biome ci (341) + vitest (586) + tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)