### PR TITLE
fix(vision,toolcall): vision image-bytes ceiling (BUG-26) + Gemma-4 native tool-call parsing (BUG-28)

### DIFF
--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -232,6 +232,16 @@ const VISION_MODEL_SCHEMA_REF: [u8; 32] = [0x54; 32];
 /// what actually routes).
 const VISION_MODEL_KEY: &str = "model";
 
+/// The vision recipe's image-payload ceiling (BUG-26). The multimodal dispatch
+/// (`kx-inference` `llama.rs`) gates each fetched image's byte length against the
+/// warrant's `resource_ceiling.mem_bytes`; the text-only [`model_warrant`] leaves
+/// that `0` (no image payload), so the vision recipe MUST raise it or EVERY
+/// `image_ref` fails `scope violation on image_bytes` at dispatch. `seed_recipe`
+/// issues the party `Use` grant from this SAME warrant, so the bind-time narrow
+/// keeps the ceiling (grant ∩ owner-root = this value). 16 MiB comfortably covers
+/// a high-resolution still while bounding the untrusted blob the projector decodes.
+const VISION_MAX_IMAGE_BYTES: u64 = 16 << 20;
+
 /// The vision recipe's image slot name — the binder writes the bound arg into
 /// `config_subset["image_ref"]`, the key the model executor's multimodal arm
 /// reads (exactly the [`PROMPT_KEY`] pattern). Lives here (not in the
@@ -456,7 +466,13 @@ impl DemoLibrary {
         // selection is a server-validated free-param, never a client warrant).
         // Seeded only when the serve model registered IMAGE-capable.
         if let Some(model_id) = serve_model.filter(|_| vision) {
-            let vision_w = model_warrant(exec_class, model_id);
+            // BUG-26: the multimodal dispatch caps each image against `mem_bytes`,
+            // which the text-only `model_warrant` leaves 0 — raise it to the vision
+            // image ceiling or every `image_ref` fails `scope violation on
+            // image_bytes`. Set BEFORE any use so the owner-root, the recipe body's
+            // step warrant, and the party `Use` grant all carry the same ceiling.
+            let mut vision_w = model_warrant(exec_class, model_id);
+            vision_w.resource_ceiling.mem_bytes = VISION_MAX_IMAGE_BYTES;
             let vision_h = vision_handle()?;
             seed_recipe(
                 &versions,

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -80,6 +80,112 @@ fn strip_code_fence(text: &str) -> &str {
     }
 }
 
+/// Gemma-4's NATIVE tool-call open delimiter (`<|tool_call>call:NAME{ARGS}<tool_call|>`).
+const GEMMA_TOOL_OPEN: &str = "<|tool_call>";
+/// The optional `call:` marker after the open delimiter (observed: `call:fs_list{}`).
+const GEMMA_CALL_MARKER: &str = "call:";
+
+/// A model-NATIVE (non-envelope) call shape, post-extraction: the raw tool name
+/// and the verbatim args-object bytes. The version is resolved against the grant
+/// set by the caller (Gemma emits no version).
+struct NativeCall<'a> {
+    raw_name: &'a str,
+    args: &'a str,
+}
+
+/// Extract a Gemma-4 native `<|tool_call>call:NAME{ARGS}<tool_call|>` call from the
+/// (reasoning-stripped) text, or `None` if the text is not this shape. NAME is the
+/// run after the (optional) `call:` marker up to the FIRST `{` — a DEFINED
+/// NAME/ARGS boundary, exactly like the markdown fence (NEVER a mid-string `{`
+/// search, so the SN-8 injection boundary is unchanged: only bytes the model
+/// fenced inside `<|tool_call>…` are promoted to a call). The `<tool_call|>` close
+/// is optional (truncation-tolerant) — `balanced_object` bounds the args object so
+/// trailing prose / the close delim can never leak in. Total + panic-free.
+fn extract_gemma_native(text: &str) -> Option<NativeCall<'_>> {
+    let after_open = text.trim_start().strip_prefix(GEMMA_TOOL_OPEN)?;
+    let after_marker = after_open
+        .trim_start()
+        .strip_prefix(GEMMA_CALL_MARKER)
+        .unwrap_or_else(|| after_open.trim_start());
+    let brace = after_marker.find('{')?;
+    let raw_name = after_marker[..brace].trim();
+    if raw_name.is_empty() {
+        return None;
+    }
+    let args = balanced_object(&after_marker[brace..])?;
+    Some(NativeCall { raw_name, args })
+}
+
+/// Return the prefix of `s` (which MUST start with `{`) spanning the first
+/// brace-balanced JSON object, ignoring braces inside double-quoted strings
+/// (with `\"` escapes). `None` if unbalanced or past `MAX_DEPTH`. Total +
+/// panic-free; the depth bound rejects pathological nesting cheaply (serde
+/// re-parses for shape downstream).
+fn balanced_object(s: &str) -> Option<&str> {
+    const MAX_DEPTH: usize = 64;
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'{') {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut in_str = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_str = true,
+            b'{' => {
+                depth += 1;
+                if depth > MAX_DEPTH {
+                    return None;
+                }
+            }
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&s[..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Resolve a model-emitted (often separator-variant, version-less) tool name to a
+/// GRANTED `(ToolName, ToolVersion)`, SN-8-safe. Normalization is SEPARATOR-ONLY
+/// (`_`→`-`, matching how Gemma renders `fs-list` as `fs_list`) — never an
+/// arbitrary remap. Resolution = the UNIQUE granted tool whose name, after the
+/// SAME separator-normalization on BOTH sides, equals the model's. Ambiguity (two
+/// granted tools collapsing to one normalized name) ⇒ `None` (fail-closed — no
+/// guessing). The returned version is whatever the grant pins, so the downstream
+/// `tool_grants.contains` check is exact by construction.
+fn resolve_granted_name(raw_name: &str, warrant: &WarrantSpec) -> Option<ToolGrant> {
+    fn norm(s: &str) -> String {
+        s.replace('_', "-")
+    }
+    let target = norm(raw_name);
+    let mut hit: Option<&ToolGrant> = None;
+    for g in &warrant.tool_grants {
+        if norm(&g.tool_id.0) == target {
+            if hit.is_some() {
+                return None; // ambiguous ⇒ fail-closed
+            }
+            hit = Some(g);
+        }
+    }
+    hit.cloned()
+}
+
 /// Decode a model-proposed tool call from raw model output, fail-closed.
 ///
 /// Returns `Ok(None)` for a normal completion (prose, non-envelope JSON, or — the
@@ -119,6 +225,37 @@ pub fn parse_tool_call(
     // a surrounding ```` ```json ```` fence, then require the remainder to BEGIN
     // with `{` — leading-block + structural-fence only; no mid-string scan (SN-8).
     let trimmed = extract_json_envelope(text);
+
+    // (1a) Gemma-4 NATIVE shape: `<|tool_call>call:NAME{ARGS}<tool_call|>`. A SECOND
+    //      DEFINED delimiter set (not a `{` search) — recognized BEFORE the JSON
+    //      gate. Version-less + separator-variant names (`fs_list`) are resolved
+    //      against the grant set, and the result is gated by the SAME exact
+    //      `tool_grants` equality (SN-8). Anything not opening with this exact
+    //      delimiter falls through to the JSON envelope path, byte-identical for
+    //      every existing row (no current input begins with `<|tool_call>`).
+    if let Some(native) = extract_gemma_native(trimmed) {
+        let Some(grant) = resolve_granted_name(native.raw_name, warrant) else {
+            // The model COMMITTED to a native call but named an unknown/ambiguous
+            // tool ⇒ fail-closed (a bad name is a refusal, never silent prose).
+            return Err(DecodeError::UngrantedTool {
+                name: ToolName(native.raw_name.to_string()),
+                version: ToolVersion(String::new()),
+            });
+        };
+        let args_bytes = native.args.as_bytes().to_vec();
+        if args_bytes.len() > max_args_bytes {
+            return Err(DecodeError::Oversize {
+                got: args_bytes.len(),
+                max: max_args_bytes,
+            });
+        }
+        return Ok(Some(ToolCall {
+            name: grant.tool_id,
+            version: grant.tool_version,
+            args_bytes,
+        }));
+    }
+
     if !trimmed.starts_with('{') {
         return Ok(None);
     }
@@ -367,5 +504,101 @@ mod tests {
             .unwrap()
             .expect("a call");
         assert_eq!(call.args_bytes, args_src.as_bytes().to_vec());
+    }
+
+    // ---- BUG-28: Gemma-4 native `<|tool_call>call:NAME{ARGS}<tool_call|>` arm ----
+
+    #[test]
+    fn gemma_native_call_is_decoded_name_normalized_version_resolved() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        // Gemma's native syntax: underscore name, no version, empty args.
+        let env = b"<|tool_call>call:fs_list{}<tool_call|>";
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a native call");
+        assert_eq!(call.name, ToolName("fs-list".into())); // `_`→`-` normalized
+        assert_eq!(call.version, ToolVersion("1".into())); // resolved from the grant
+        assert_eq!(call.args_bytes, b"{}".to_vec());
+    }
+
+    #[test]
+    fn gemma_native_call_with_args_carries_bytes_verbatim() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        let env = br#"<|tool_call>call:fs_list{"path":"sub"}<tool_call|>"#;
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a native call");
+        assert_eq!(call.args_bytes, br#"{"path":"sub"}"#.to_vec());
+    }
+
+    #[test]
+    fn gemma_native_tolerates_missing_close_delim() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        // Truncated close delimiter — brace-balancing still bounds the args object.
+        let env = br#"<|tool_call>call:fs_list{"path":"x"}"#;
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a native call");
+        assert_eq!(call.args_bytes, br#"{"path":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn gemma_native_after_channel_reasoning_is_decoded() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        // The `<|channel>` reasoning block is stripped first, then the native shape.
+        let env = b"<|channel>thinking<channel|><|tool_call>call:fs_list{}<tool_call|>";
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a native call");
+        assert_eq!(call.name, ToolName("fs-list".into()));
+    }
+
+    #[test]
+    fn gemma_native_ungranted_tool_is_refused() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        let env = b"<|tool_call>call:rm_rf{}<tool_call|>";
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn gemma_native_empty_grants_is_none() {
+        let w = warrant_granting(None); // step (0) short-circuits before any parse
+        let env = b"<|tool_call>call:fs_list{}<tool_call|>";
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn gemma_native_oversize_args_refused() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        let big = "x".repeat(100);
+        let env = format!(r#"<|tool_call>call:fs_list{{"p":"{big}"}}<tool_call|>"#);
+        assert!(matches!(
+            parse_tool_call(env.as_bytes(), &w, 8),
+            Err(DecodeError::Oversize { .. })
+        ));
+    }
+
+    #[test]
+    fn gemma_native_overdeep_args_falls_through_to_none() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        let deep = format!(
+            "<|tool_call>call:fs_list{}{}",
+            "{".repeat(80),
+            "}".repeat(80)
+        );
+        // balanced_object returns None past MAX_DEPTH ⇒ not a native call ⇒ falls to
+        // the JSON gate, which sees a non-`{` start ⇒ Ok(None) (fail-closed).
+        assert_eq!(parse_tool_call(deep.as_bytes(), &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn gemma_native_no_brace_is_not_a_call() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        // Open delim but no `{` ⇒ not extractable ⇒ falls through ⇒ Ok(None).
+        let env = b"<|tool_call>call:fs_list no args here";
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
     }
 }


### PR DESCRIPTION
Two real-model integration fixes found by the **comprehensive Gemma-4-12B multimodal + tools deep-test pass** (real-capable-model cross-surface sweep). Both live-verified on Gemma-4-12B (Apple-M3/Metal).

## BUG-26 — vision recipe image-bytes ceiling 0
`kx/recipes/vision` built its warrant from the text-only `model_warrant` (`mem_bytes: 0`), but the multimodal dispatch (`kx-inference/src/llama.rs:239`) uses `mem_bytes` as the **per-image byte ceiling** — so *every* vision invoke failed `scope violation on image_bytes: requested N, ceiling 0`. The vision RECIPE path had never been exercised e2e (§2.223 verified vision via the raw `kx-llamacpp` smoke path, not the recipe warrant).

**Fix:** `provision.rs` — `VISION_MAX_IMAGE_BYTES = 16 MiB`; the vision seed sets `vision_w.resource_ceiling.mem_bytes` before use. `seed_recipe` issues the party `Use` grant from the same warrant, so the bind-time narrow keeps the ceiling (grant ∩ owner-root). **Live:** red_square→"Red"; a real photo→an accurate caption.

## BUG-28 — Gemma-4 native tool-call format unparsed
Gemma-4 emits its native syntax `<|tool_call>call:fs_list{}<tool_call|>`, which `kx_toolcall::parse_tool_call` (JSON-envelope only) never recognized — so the **live ReAct tool loop never fired a tool with Gemma-4** (masked because CI uses tiny Qwen3-0.6B and no e2e asserts a real-model tool-FIRE).

**Fix:** a Gemma-native arm in `parse.rs` — `extract_gemma_native` + `balanced_object` (brace-balanced args, depth-bound 64, truncation-tolerant) + `resolve_granted_name` (separator-only `_`→`-`, resolved against the grant set; **exact `tool_grants` equality preserved; ambiguity fail-closed**). Recognized before the JSON gate; non-`<|tool_call>` input falls through byte-identically. 9 new gate tests + the 13 originals pass. **Live on Gemma-4:** react-fs fires fs-list (a `world_mutating` observation commits at 3s).

## Invariants
- **digest `7d22d4bd…` INVARIANT** (verify-quickstart 8/8; both changes off the no-tool echo digest path) · **frozen trio untouched** · **no proto/Cargo.lock change**.
- SN-8 preserved (the Gemma arm uses only defined delimiters; exact grant equality; separator-only name normalization, never an arbitrary remap).
- Gate: fmt + clippy `-D warnings` + workspace test + verify-quickstart all green.

Full pass detail + 3 bugs (BUG-26/27/28) + GR10 numbers captured in the private corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)