### PR TITLE
PR-7b — context() chains helper + UI Context surface + full docs

### DIFF
--- a/bindings/python/src/kortecx/blueprints.py
+++ b/bindings/python/src/kortecx/blueprints.py
@@ -11,7 +11,7 @@ only changes what is PROPOSED, never what identity it gets.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 from . import hexids
 from .v1 import coordinator_pb2 as _c
@@ -66,6 +66,7 @@ class BlueprintBuilder:
         self._steps: List[StepInput] = []
         self._edges: List[EdgeInput] = []
         self._mode = "frozen"
+        self._context_bundles: List[str] = []
 
     def add_step(self, step: StepInput) -> int:
         self._steps.append(step)
@@ -77,6 +78,13 @@ class BlueprintBuilder:
 
     def mode(self, m: str) -> "BlueprintBuilder":
         self._mode = m
+        return self
+
+    def context_bundles(self, handles: Sequence[str]) -> "BlueprintBuilder":
+        """PR-7: attach context-bundle handles to the run (verbatim order — the
+        SERVER canonicalizes + injects into every entry Mote at bind, SN-8). An
+        empty list ⇒ a request byte-identical to pre-PR-7."""
+        self._context_bundles = list(handles)
         return self
 
     def build(self) -> "_g.SubmitWorkflowRequest":
@@ -112,5 +120,9 @@ class BlueprintBuilder:
             else _g.WorkflowExecutionMode.WORKFLOW_EXECUTION_MODE_FROZEN
         )
         return _g.SubmitWorkflowRequest(
-            seed=self._seed, steps=steps, edges=edges, execution_mode=mode
+            seed=self._seed,
+            steps=steps,
+            edges=edges,
+            execution_mode=mode,
+            context_bundles=list(self._context_bundles),
         )

--- a/bindings/python/src/kortecx/chains.py
+++ b/bindings/python/src/kortecx/chains.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from .blueprints import TOOL_ARGS_KEY, BlueprintBuilder, EdgeInput, StepInput
 from .v1 import gateway_pb2 as _g
@@ -172,14 +172,47 @@ class Chain:
     """A composed chain ready to lower. Build one from operator sugar via
     :meth:`from_node`, or from the string DSL via :func:`chain`."""
 
-    def __init__(self, root: "_Node", *, seed: int = 0) -> None:
+    def __init__(
+        self,
+        root: "_Node",
+        *,
+        seed: int = 0,
+        context_bundles: Optional[Sequence[str]] = None,
+    ) -> None:
         self._root = root
         self._seed = seed
+        # PR-7b: chain-level context-bundle handles (verbatim caller order — the
+        # SERVER canonicalizes the sorted ref-set into each entry Mote at bind, SN-8).
+        self._context: List[str] = list(context_bundles or [])
 
     @classmethod
-    def from_node(cls, node: "_Node", *, seed: int = 0) -> "Chain":
-        """Wrap an operator-sugar AST (``a >> b``, ``a & b``, ...) as a chain."""
-        return cls(_as_node(node), seed=seed)
+    def from_node(
+        cls,
+        node: "_Node",
+        *,
+        seed: int = 0,
+        context: Optional[Sequence[str]] = None,
+    ) -> "Chain":
+        """Wrap an operator-sugar AST (``a >> b``, ``a & b``, ...) as a chain.
+
+        ``context`` is an optional list of context-bundle handles to attach to the
+        run (PR-7b) — chain-level, not a node (see :meth:`context`)."""
+        return cls(_as_node(node), seed=seed, context_bundles=context)
+
+    def context(self, *handles: str) -> "Chain":
+        """Attach context-bundle ``handles`` to this chain (PR-7b), returning a NEW
+        :class:`Chain` (immutable — the existing one is unchanged). Repeated calls
+        APPEND in order; the SERVER resolves each handle to its content-refs and
+        folds the sorted set into every entry Mote's identity-bearing config, so a
+        different attached context ⇒ a different run (exactly-once-per-input+context).
+
+        Context is request-level: it attaches to the chain's ENTRY Motes regardless
+        of where this is called — there is no ``context`` step."""
+        return Chain(
+            self._root,
+            seed=self._seed,
+            context_bundles=[*self._context, *handles],
+        )
 
     # --- lowering -------------------------------------------------------------
     def _lower(self) -> Tuple[List[Task], List[Tuple[int, int]]]:
@@ -251,18 +284,22 @@ class Chain:
             for t in nodes
         ]
         edge_rows = [{"parent": p, "child": c, "edge": "data"} for (p, c) in edges]
-        return {"steps": steps, "edges": edge_rows}
+        # PR-7b: the chain-level context attachment, emitted verbatim (the corpus
+        # pins its byte-identity across surfaces; absent ⇒ []).
+        return {"steps": steps, "edges": edge_rows, "context_bundles": list(self._context)}
 
     def build(self) -> "_g.SubmitWorkflowRequest":
         """Lower → :class:`~kortecx.blueprints.BlueprintBuilder` → the request. Nodes
         feed ``add_step`` in first-appearance order; the sorted deduped data edges
-        feed ``add_edge``; ``seed`` is the chain's seed; mode is ``frozen``."""
+        feed ``add_edge``; ``seed`` is the chain's seed; mode is ``frozen``; the
+        chain's context bundles (if any) ride on the request (PR-7b)."""
         nodes, edges = self._lower()
         builder = BlueprintBuilder(self._seed)
         for t in nodes:
             builder.add_step(t.step)
         for parent, child in edges:
             builder.add_edge(EdgeInput(parent=parent, child=child, edge="data"))
+        builder.context_bundles(self._context)
         return builder.build()
 
 
@@ -397,9 +434,19 @@ def _tokenize(expr: str) -> List[str]:
     return toks
 
 
-def chain(expr: str, tasks: Dict[str, Task], *, seed: int = 0) -> Chain:
+def chain(
+    expr: str,
+    tasks: Dict[str, Task],
+    *,
+    seed: int = 0,
+    context: Optional[Sequence[str]] = None,
+) -> Chain:
     """Parse a chain string expression (the exact grammar in SPEC.md), resolving
     handles via ``tasks``, into a :class:`Chain`.
+
+    ``context`` is an optional list of context-bundle handles to attach (PR-7b) —
+    chain-level grounding the server injects into every entry Mote (see
+    :meth:`Chain.context`); also settable fluently via ``.context(...)``.
 
     Raises :class:`ChainParseError` on an empty/malformed expression or empty
     group, :class:`UnknownHandleError` on a handle absent from ``tasks``, and
@@ -409,4 +456,4 @@ def chain(expr: str, tasks: Dict[str, Task], *, seed: int = 0) -> Chain:
     if not expr.strip():
         raise ChainParseError("empty chain expression")
     root = _Parser(expr, tasks).parse()
-    return Chain(root, seed=seed)
+    return Chain(root, seed=seed, context_bundles=context)

--- a/bindings/python/tests/test_chains.py
+++ b/bindings/python/tests/test_chains.py
@@ -73,16 +73,21 @@ def test_corpus_parity(case: Dict[str, object]) -> None:
     matching error class is raised."""
     tasks = _tasks_from_spec(case["tasks"])
     seed = case.get("seed", 0)
+    context = case.get("context_bundles")  # PR-7b: chain-level attachment (None ⇒ [])
 
     if "error" in case:
         expected_exc = _ERROR_CLASSES[case["error"]]
         with pytest.raises(expected_exc):
             # The cycle check fires at lowering time; parse/handle at parse time.
-            chain(case["dsl"], tasks, seed=seed).lowering()
+            chain(case["dsl"], tasks, seed=seed, context=context).lowering()
         return
 
-    lowered = chain(case["dsl"], tasks, seed=seed).lowering()
-    assert lowered == case["expect"]
+    lowered = chain(case["dsl"], tasks, seed=seed, context=context).lowering()
+    # PR-7b: existing cases omit `context_bundles` in `expect` ⇒ default it to []
+    # (matches the SPEC "absent ⇒ []" rule + Rust `#[serde(default)]`).
+    expected = dict(case["expect"])
+    expected.setdefault("context_bundles", [])
+    assert lowered == expected
 
 
 def test_seed_flows_to_the_request() -> None:
@@ -102,6 +107,50 @@ def test_build_produces_a_frozen_request() -> None:
     # a > b & c : only one edge, a->b (precedence: > tighter than &)
     assert len(req.edges) == 1
     assert (req.edges[0].parent, req.edges[0].child) == (0, 1)
+    # PR-7b: a chain with no attached context carries an empty repeated field
+    # (byte-identical to pre-PR-7).
+    assert list(req.context_bundles) == []
+
+
+# --- PR-7b: context bundles (chain-level attachment) --------------------------
+
+
+def test_context_kwarg_flows_to_the_request() -> None:
+    """``context=`` reaches ``SubmitWorkflowRequest.context_bundles`` verbatim."""
+    req = chain("a > b", {"a": pure(), "b": pure()}, context=["team/ctx/spec"]).build()
+    assert list(req.context_bundles) == ["team/ctx/spec"]
+    assert len(req.steps) == 2  # context is chain-level, NOT a step
+
+
+def test_context_is_emitted_in_the_lowering() -> None:
+    lowered = chain("a", {"a": pure()}, context=["x/y/z"]).lowering()
+    assert lowered["context_bundles"] == ["x/y/z"]
+    assert len(lowered["steps"]) == 1
+
+
+def test_context_order_is_preserved_not_sorted() -> None:
+    """The DSL never sorts/dedups — the SERVER canonicalizes at bind (SN-8)."""
+    handles = ["z/ctx/two", "a/ctx/one"]
+    req = chain("a", {"a": pure()}, context=handles).build()
+    assert list(req.context_bundles) == handles
+
+
+def test_fluent_context_matches_kwarg_and_appends() -> None:
+    base = chain("a > b", {"a": pure(), "b": pure()})
+    via_fluent = base.context("team/ctx/spec").context("team/ctx/notes")
+    via_kwarg = chain(
+        "a > b", {"a": pure(), "b": pure()}, context=["team/ctx/spec", "team/ctx/notes"]
+    )
+    assert via_fluent.lowering() == via_kwarg.lowering()
+    # `.context()` is immutable — the base chain is unchanged.
+    assert base.lowering()["context_bundles"] == []
+
+
+def test_sugar_context_matches_string() -> None:
+    a, b = pure(), pure()
+    sugar = Chain.from_node(a >> b, context=["team/ctx/spec"])
+    string = chain("a > b", {"a": pure(), "b": pure()}, context=["team/ctx/spec"])
+    assert sugar.lowering() == string.lowering()
 
 
 # --- operator sugar lowers identically to the string DSL ----------------------

--- a/bindings/typescript/src/blueprints.ts
+++ b/bindings/typescript/src/blueprints.ts
@@ -63,6 +63,7 @@ export class BlueprintBuilder {
   private readonly _steps: StepInput[] = [];
   private readonly _edges: EdgeInput[] = [];
   private _mode: ExecutionMode = "frozen";
+  private _contextBundles: string[] = [];
 
   constructor(private readonly seed: number = 0) {}
 
@@ -79,6 +80,16 @@ export class BlueprintBuilder {
 
   mode(m: ExecutionMode): this {
     this._mode = m;
+    return this;
+  }
+
+  /**
+   * PR-7: attach context-bundle handles to the run (verbatim order — the SERVER
+   * canonicalizes + injects into every entry Mote at bind, SN-8). An empty list ⇒
+   * a request byte-identical to pre-PR-7.
+   */
+  contextBundles(handles: readonly string[]): this {
+    this._contextBundles = [...handles];
     return this;
   }
 
@@ -103,6 +114,7 @@ export class BlueprintBuilder {
       })),
       executionMode:
         this._mode === "dynamic" ? WorkflowExecutionMode.DYNAMIC : WorkflowExecutionMode.FROZEN,
+      contextBundles: [...this._contextBundles],
     };
   }
 }

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -464,6 +464,12 @@ export interface LoweredEdge {
 export interface Lowered {
   steps: LoweredStep[];
   edges: LoweredEdge[];
+  /**
+   * PR-7b: the chain-level context-bundle handles, emitted verbatim (caller order
+   * — the SERVER canonicalizes the sorted ref-set into each entry Mote at bind,
+   * SN-8). Absent on the wire ⇒ `[]`; the corpus pins its byte-identity.
+   */
+  context_bundles: string[];
 }
 
 /** Sort + dedup edge index pairs ascending by (parent, child) — the canonical rule. */
@@ -568,6 +574,12 @@ export interface ChainOptions {
   tasks: Readonly<Record<string, Task>>;
   /** The chain seed (default `0`). */
   seed?: number;
+  /**
+   * PR-7b: context-bundle handles to attach to the run (chain-level grounding the
+   * server injects into every entry Mote; verbatim order). Also settable fluently
+   * via {@link Chain.context}.
+   */
+  context?: readonly string[];
 }
 
 /**
@@ -581,13 +593,29 @@ export class Chain {
     private readonly nodes: readonly Task[],
     private readonly edgePairs: readonly LoweredEdge[],
     readonly seed: number,
+    /** PR-7b: chain-level context-bundle handles (verbatim caller order). */
+    readonly contextBundles: readonly string[] = [],
   ) {}
+
+  /**
+   * Attach context-bundle `handles` to this chain (PR-7b), returning a NEW
+   * {@link Chain} (immutable — this one is unchanged). Repeated calls APPEND in
+   * order; the SERVER resolves each handle to its content-refs and folds the
+   * sorted set into every entry Mote's identity-bearing config, so a different
+   * attached context ⇒ a different run (exactly-once-per-input+context). Context
+   * is request-level — it attaches to the ENTRY Motes regardless of position;
+   * there is no `context` step.
+   */
+  context(...handles: string[]): Chain {
+    return new Chain(this.nodes, this.edgePairs, this.seed, [...this.contextBundles, ...handles]);
+  }
 
   /** The canonical lowering (the corpus snake_case shape; `params` values are strings). */
   lower(): Lowered {
     return {
       steps: this.nodes.map((t) => taskToLoweredStep(t)),
       edges: this.edgePairs.map((e) => ({ ...e })),
+      context_bundles: [...this.contextBundles],
     };
   }
 
@@ -606,15 +634,21 @@ export class Chain {
       const edge: EdgeInput = { parent: e.parent, child: e.child, edge: "data" };
       builder.addEdge(edge);
     }
+    builder.contextBundles(this.contextBundles);
     return builder.build();
   }
 }
 
 /** Assemble a {@link Chain} from resolved node-ordered tasks + canonical edges + seed. */
-function chainOf(nodes: Task[], edgePairs: Array<[number, number]>, seed: number): Chain {
+function chainOf(
+  nodes: Task[],
+  edgePairs: Array<[number, number]>,
+  seed: number,
+  contextBundles: readonly string[] = [],
+): Chain {
   const edges = canonicalizeEdges(edgePairs);
   assertAcyclic(nodes.length, edges);
-  return new Chain(nodes, edges, seed);
+  return new Chain(nodes, edges, seed, contextBundles);
 }
 
 /**
@@ -632,7 +666,7 @@ export function chain(expr: string, opts: ChainOptions): Chain {
   const parser = new Parser(tokenize(expr));
   parser.parse();
   const { nodes, edgePairs } = lowerParse(parser, opts.tasks);
-  return chainOf(nodes, edgePairs, opts.seed ?? 0);
+  return chainOf(nodes, edgePairs, opts.seed ?? 0, opts.context ?? []);
 }
 
 /**
@@ -646,12 +680,15 @@ export function chain(expr: string, opts: ChainOptions): Chain {
  * chainFrom(seq(a, par(b, c)));          // == chain("a > [b & c]", ...)
  * ```
  */
-export function chainFrom(frag: Frag, opts: { seed?: number } = {}): Chain {
+export function chainFrom(
+  frag: Frag,
+  opts: { seed?: number; context?: readonly string[] } = {},
+): Chain {
   const acc = new NodeAccumulator() as EdgeRecordingAccumulator;
   evalFrag(frag, acc);
   const edgePairs: Array<[number, number]> = (acc.edges ?? []).map(([p, c]) => [
     acc.index(p),
     acc.index(c),
   ]);
-  return chainOf([...acc.nodes], edgePairs, opts.seed ?? 0);
+  return chainOf([...acc.nodes], edgePairs, opts.seed ?? 0, opts.context ?? []);
 }

--- a/bindings/typescript/test/chains.test.ts
+++ b/bindings/typescript/test/chains.test.ts
@@ -52,7 +52,9 @@ interface CorpusCase {
   dsl: string;
   seed: number;
   tasks: Record<string, CorpusTask>;
-  expect?: Lowered;
+  /** PR-7b: chain-level context attachment (absent ⇒ []). */
+  context_bundles?: string[];
+  expect?: Partial<Lowered>;
   error?: "parse" | "unknown_handle" | "cycle";
 }
 
@@ -82,7 +84,12 @@ describe("Chains DSL — golden corpus parity", () => {
   for (const c of corpus) {
     if (c.error !== undefined) {
       it(`${c.name}: rejects with the '${c.error}' error class`, () => {
-        const run = () => chain(c.dsl, { tasks: tasksFromCorpus(c.tasks), seed: c.seed });
+        const run = () =>
+          chain(c.dsl, {
+            tasks: tasksFromCorpus(c.tasks),
+            seed: c.seed,
+            context: c.context_bundles,
+          });
         const expectedClass =
           c.error === "parse"
             ? ChainParseError
@@ -92,9 +99,15 @@ describe("Chains DSL — golden corpus parity", () => {
         expect(run).toThrow(expectedClass);
       });
     } else {
-      it(`${c.name}: lowers to the canonical (steps, edges)`, () => {
-        const lowered = chain(c.dsl, { tasks: tasksFromCorpus(c.tasks), seed: c.seed }).lower();
-        expect(lowered).toEqual(c.expect);
+      it(`${c.name}: lowers to the canonical (steps, edges, context_bundles)`, () => {
+        const lowered = chain(c.dsl, {
+          tasks: tasksFromCorpus(c.tasks),
+          seed: c.seed,
+          context: c.context_bundles,
+        }).lower();
+        // PR-7b: existing cases omit `context_bundles` in `expect` ⇒ default to []
+        // (matches the SPEC "absent ⇒ []" rule + Rust `#[serde(default)]`).
+        expect(lowered).toEqual({ context_bundles: [], ...c.expect });
       });
     }
   }
@@ -172,6 +185,52 @@ describe("Chains DSL — build() feeds the BlueprintBuilder", () => {
     expect(req.edges).toHaveLength(1);
     // The builder UTF-8-encodes params at build time.
     expect(req.steps?.[0]?.params?.topic).toEqual(new TextEncoder().encode("hi"));
+    // PR-7b: a chain with no attached context carries an empty repeated field.
+    expect(req.contextBundles ?? []).toEqual([]);
     expect(c).toBeInstanceOf(Chain);
+  });
+});
+
+describe("Chains DSL — context bundles (PR-7b, chain-level attachment)", () => {
+  it("the context option flows to the request verbatim", () => {
+    const a = task.pure();
+    const b = task.pure();
+    const req = chain("a > b", { tasks: { a, b }, context: ["team/ctx/spec"] }).build();
+    expect(req.contextBundles).toEqual(["team/ctx/spec"]);
+    expect(req.steps).toHaveLength(2); // context is chain-level, NOT a step
+  });
+
+  it("emits context_bundles in the lowering", () => {
+    const a = task.pure();
+    const lowered = chain("a", { tasks: { a }, context: ["x/y/z"] }).lower();
+    expect(lowered.context_bundles).toEqual(["x/y/z"]);
+  });
+
+  it("preserves caller order (no DSL-side sort/dedup — the server canonicalizes)", () => {
+    const a = task.pure();
+    const handles = ["z/ctx/two", "a/ctx/one"];
+    const req = chain("a", { tasks: { a }, context: handles }).build();
+    expect(req.contextBundles).toEqual(handles);
+  });
+
+  it("fluent .context() matches the option and appends (immutable)", () => {
+    const a = task.pure();
+    const b = task.pure();
+    const base = chain("a > b", { tasks: { a, b } });
+    const viaFluent = base.context("team/ctx/spec").context("team/ctx/notes");
+    const viaOption = chain("a > b", {
+      tasks: { a, b },
+      context: ["team/ctx/spec", "team/ctx/notes"],
+    });
+    expect(viaFluent.lower()).toEqual(viaOption.lower());
+    expect(base.lower().context_bundles).toEqual([]); // base unchanged
+  });
+
+  it("chainFrom carries context and matches the string form", () => {
+    const a = task.pure();
+    const b = task.pure();
+    const viaString = chain("a > b", { tasks: { a, b }, context: ["c/c/c"] }).lower();
+    const viaCombinator = chainFrom(seq(a, b), { context: ["c/c/c"] }).lower();
+    expect(viaCombinator).toEqual(viaString);
   });
 });

--- a/crates/kx-cli/src/verbs/blueprint.rs
+++ b/crates/kx-cli/src/verbs/blueprint.rs
@@ -14,11 +14,14 @@
 //!     { "kind": "pure" }
 //!   ],
 //!   "edges": [ { "parent": 0, "child": 1, "edge": "data" } ],
-//!   "execution_mode": "frozen"
+//!   "execution_mode": "frozen",
+//!   "context_bundles": [ "team/ctx/spec" ]
 //! }
 //! ```
 //! `params` values are UTF-8 strings (their bytes land in the step's config).
 //! `kind` ∈ {`pure`, `model`} (`exec` is reserved); `edge` ∈ {`data`, `control`}.
+//! `context_bundles` (PR-7, optional) attaches named context bundles to the run —
+//! the server injects them into every entry Mote at bind (SN-8).
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -48,6 +51,11 @@ pub(crate) struct DagSpec {
     pub(crate) edges: Vec<EdgeSpec>,
     #[serde(default)]
     pub(crate) execution_mode: Option<String>,
+    /// PR-7: context-bundle handles to attach to the run (chain-level grounding the
+    /// SERVER resolves + injects into every entry Mote at bind, SN-8). Verbatim
+    /// order; empty ⇒ byte-identical to pre-PR-7.
+    #[serde(default)]
+    pub(crate) context_bundles: Vec<String>,
 }
 
 /// PR-6b-2: the single canonical config key a `tool` step's authored args ride
@@ -225,7 +233,7 @@ pub(crate) fn to_request(spec: DagSpec) -> Result<proto::SubmitWorkflowRequest, 
         steps,
         edges,
         execution_mode: execution_mode as i32,
-        context_bundles: vec![],
+        context_bundles: spec.context_bundles,
     })
 }
 

--- a/crates/kx-cli/src/verbs/chain.rs
+++ b/crates/kx-cli/src/verbs/chain.rs
@@ -13,14 +13,16 @@
 //! Python / TypeScript SDKs lower an identical chain to byte-identical topology.
 //!
 //! ```text
-//! kx chain run "a > [b & c]" --tasks tasks.json --wait
+//! kx chain run "a > [b & c]" --tasks tasks.json --context team/ctx/spec --wait
 //! ```
 //! `--tasks` is a JSON object map `{ "a": {"kind":"pure", ...}, ... }` — each value
 //! is a [`StepSpec`](crate::verbs::blueprint) (the same shape as a `blueprint`
 //! step). A handle that appears more than once is the SAME node (reuse builds DAGs);
 //! tasks defined but unused are ignored (lenient). Palette: `pure` / `model` /
 //! `tool` (PR-6b-2 — fire a registered tool; `args` lower to the canonical
-//! `kx.tool.args` blob).
+//! `kx.tool.args` blob). `--context <handle>` (PR-7, repeatable) attaches named
+//! context bundles to the run — the server injects them into every entry Mote at
+//! bind (SN-8); verbatim order, empty ⇒ byte-identical to pre-PR-7.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
@@ -48,6 +50,9 @@ pub struct ChainArgs {
     pub tasks: PathBuf,
     /// The chain seed (`--seed`, default 0; folds into entrypoint identity).
     pub seed: u32,
+    /// PR-7: context-bundle handles to attach (`--context <handle>`, repeatable).
+    /// Verbatim order; the server resolves + injects into every entry Mote (SN-8).
+    pub context: Vec<String>,
     /// Run to completion and print the committed result (`--wait`).
     pub wait: bool,
     /// `--wait` timeout in seconds.
@@ -72,6 +77,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
     let mut dsl: Option<String> = None;
     let mut tasks: Option<PathBuf> = None;
     let mut seed: u32 = 0;
+    let mut context: Vec<String> = Vec::new();
     let mut wait = false;
     let mut timeout_secs = DEFAULT_TIMEOUT_SECS;
     let mut out: Option<PathBuf> = None;
@@ -89,6 +95,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
                     CliError::Usage(format!("--seed expects an integer, got {v:?}"))
                 })?;
             }
+            "--context" => context.push(next_value(&mut args, "--context")?),
             "--wait" => wait = true,
             "--timeout-secs" => {
                 let v = next_value(&mut args, "--timeout-secs")?;
@@ -123,6 +130,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
         dsl,
         tasks,
         seed,
+        context,
         wait,
         timeout_secs,
         out,
@@ -402,6 +410,7 @@ fn build_request(
     lowered: Lowered,
     mut tasks: BTreeMap<String, StepSpec>,
     seed: u32,
+    context_bundles: Vec<String>,
 ) -> Result<kx_proto::proto::SubmitWorkflowRequest, CliError> {
     let mut steps = Vec::with_capacity(lowered.nodes.len());
     for handle in &lowered.nodes {
@@ -426,6 +435,8 @@ fn build_request(
         edges,
         // The DSL fixes the mode to frozen (the deterministic canonical lowering).
         execution_mode: Some("frozen".to_string()),
+        // PR-7: chain-level context attachment, verbatim (the server canonicalizes).
+        context_bundles,
     };
     crate::verbs::blueprint::to_request(spec)
 }
@@ -438,7 +449,7 @@ pub async fn execute(args: ChainArgs) -> Result<(), CliError> {
         .map_err(|e| CliError::Usage(format!("invalid --tasks JSON: {e}")))?;
 
     let lowered = lower(&args.dsl)?;
-    let req = build_request(lowered, tasks, args.seed)?;
+    let req = build_request(lowered, tasks, args.seed, args.context)?;
 
     let resolved = args.common.resolve()?;
     let mut client = resolved.connect().await?;
@@ -495,6 +506,10 @@ mod tests {
             "tasks.json",
             "--seed",
             "7",
+            "--context",
+            "team/ctx/spec",
+            "--context",
+            "team/ctx/notes",
             "--wait",
             "--json",
             "--timeout-secs",
@@ -504,8 +519,36 @@ mod tests {
         assert_eq!(a.dsl, "a > [b & c]");
         assert_eq!(a.tasks, PathBuf::from("tasks.json"));
         assert_eq!(a.seed, 7);
+        // PR-7: --context is repeatable, captured verbatim in order.
+        assert_eq!(a.context, vec!["team/ctx/spec", "team/ctx/notes"]);
         assert!(a.wait && a.common.json);
         assert_eq!(a.timeout_secs, 30);
+    }
+
+    #[test]
+    fn no_context_flag_yields_an_empty_attachment() {
+        let a = p(&["run", "a > b", "--tasks", "t.json"]).unwrap();
+        assert!(a.context.is_empty());
+    }
+
+    #[test]
+    fn context_flows_through_build_request() {
+        // PR-7: a chain with --context lowers to a request carrying the handles
+        // verbatim; context is chain-level (the step count is unchanged).
+        let mut tasks = BTreeMap::new();
+        tasks.insert(
+            "a".to_string(),
+            serde_json::from_value::<StepSpec>(serde_json::json!({ "kind": "pure" })).unwrap(),
+        );
+        let req = build_request(
+            lower("a").unwrap(),
+            tasks,
+            0,
+            vec!["z/ctx/two".to_string(), "a/ctx/one".to_string()],
+        )
+        .unwrap();
+        assert_eq!(req.steps.len(), 1);
+        assert_eq!(req.context_bundles, vec!["z/ctx/two", "a/ctx/one"]);
     }
 
     #[test]
@@ -530,6 +573,8 @@ mod tests {
         dsl: String,
         #[serde(default)]
         seed: u32,
+        #[serde(default)]
+        context_bundles: Vec<String>,
         tasks: BTreeMap<String, StepSpec>,
         #[serde(default)]
         expect: Option<Expect>,
@@ -541,6 +586,8 @@ mod tests {
     struct Expect {
         steps: Vec<ExpectStep>,
         edges: Vec<ExpectEdge>,
+        #[serde(default)]
+        context_bundles: Vec<String>,
     }
 
     #[derive(Debug, Deserialize)]
@@ -600,11 +647,18 @@ mod tests {
                 lower(&case.dsl).unwrap_or_else(|e| panic!("[{}] lower failed: {e}", case.name)),
                 case.tasks,
                 case.seed,
+                case.context_bundles,
             )
             .unwrap_or_else(|e| panic!("[{}] build_request failed: {e}", case.name));
 
             // seed + frozen mode are part of the canonical lowering.
             assert_eq!(req.seed, case.seed, "[{}] seed", case.name);
+            // PR-7b: chain-level context attachment, verbatim order (absent ⇒ []).
+            assert_eq!(
+                req.context_bundles, expect.context_bundles,
+                "[{}] context_bundles",
+                case.name
+            );
             assert_eq!(
                 req.execution_mode,
                 proto::WorkflowExecutionMode::Frozen as i32,
@@ -679,8 +733,9 @@ mod tests {
             let class = case.error.expect("filtered to error cases");
             // Parse/cycle errors surface from `lower`; unknown_handle from the tasks
             // resolution in `build_request`.
-            let result = lower(&case.dsl)
-                .and_then(|low| build_request(low, case.tasks, case.seed).map(|_| ()));
+            let result = lower(&case.dsl).and_then(|low| {
+                build_request(low, case.tasks, case.seed, case.context_bundles).map(|_| ())
+            });
             let err = result
                 .expect_err(&format!("[{}] expected an error", case.name))
                 .to_string()

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -2535,6 +2535,89 @@ mod tests {
         assert!(cross_party.is_ok(), "alice resolves her own bundle");
     }
 
+    /// The SAME identity-bearing + fail-closed guarantees on the AUTHOR
+    /// (`SubmitWorkflow` / Chains `context()`) path — the binder test above covers
+    /// only `HostRecipeBinder` (Invoke). Both paths fold the resolved ref-set into
+    /// the entry Mote's `config_subset` before `compile`, so attaching a bundle
+    /// yields a different entry `MoteId` (exactly-once-per-(input+context)).
+    #[tokio::test]
+    async fn author_context_injection_is_identity_bearing_and_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+        )
+        .unwrap();
+        let bundles = std::sync::Arc::new(crate::bundles::BundlesDb::open(dir.path()).unwrap());
+        bundles
+            .upsert(
+                "alice@acme",
+                "team/ctx/notes",
+                "alice's notes",
+                &[kx_gateway_core::BundleItemRecord {
+                    name: "doc".into(),
+                    content_ref: [0xab; 32],
+                    media_type: String::new(),
+                }],
+            )
+            .unwrap();
+        let author = HostWorkflowAuthor::from_shared_with_tools(
+            std::sync::Arc::new(lib),
+            tool_registry_with("echo-tool", "1"),
+        )
+        .with_bundles(bundles);
+
+        let pure_step = AuthorStep {
+            kind: AuthorStepKind::Pure,
+            model_id: String::new(),
+            prompt: String::new(),
+            body_signature_id: None,
+            tool_contract: std::collections::BTreeMap::new(),
+            params: std::collections::BTreeMap::new(),
+        };
+        let author_run = |ctx: Vec<String>| {
+            let a = &author;
+            let step = pure_step.clone();
+            async move {
+                a.author(
+                    "alice@acme",
+                    0,
+                    std::slice::from_ref(&step),
+                    &[],
+                    AuthorExecutionMode::Frozen,
+                    &ctx,
+                )
+                .await
+            }
+        };
+
+        let plain = author_run(vec![]).await.expect("authors without context");
+        let grounded = author_run(vec!["team/ctx/notes".to_string()])
+            .await
+            .expect("authors with context");
+        assert_ne!(
+            plain.terminal_mote_id, grounded.terminal_mote_id,
+            "attaching a context bundle changes the entry MoteId on the author path"
+        );
+
+        // Identical (input + context) ⇒ identical identity (idempotent).
+        let grounded2 = author_run(vec!["team/ctx/notes".to_string()])
+            .await
+            .expect("re-authors with the same context");
+        assert_eq!(
+            grounded.terminal_mote_id, grounded2.terminal_mote_id,
+            "same input+context ⇒ same identity"
+        );
+
+        // An unknown handle FAILS CLOSED (never silently drops requested context).
+        let unknown = author_run(vec!["team/ctx/missing".to_string()]).await;
+        assert!(
+            matches!(unknown, Err(BinderError::InvalidArgs(_))),
+            "an unknown context bundle is refused at admission"
+        );
+    }
+
     #[tokio::test]
     async fn context_bundles_without_a_store_fail_closed() {
         // A binder with NO bundle store wired (the default) refuses a non-empty

--- a/docs/site/docs/chains/dsl-reference.md
+++ b/docs/site/docs/chains/dsl-reference.md
@@ -147,6 +147,32 @@ step's `model_id` and `prompt` are carried into its `StepInput`; the pure step
 carries its `params`. Params values are strings in the lowering form — each SDK
 UTF-8-encodes them at `build()` time.
 
+### Attaching context bundles
+
+A chain can attach [context bundles](../context.md) — named, content-addressed
+grounding the model reasons over. Context is **chain-level, not a node**: the
+server injects it into the chain's entry step(s), so position is irrelevant.
+Attach handles via the `context` option (or the fluent `.context(...)`, or the CLI
+`--context` flag, repeatable):
+
+```python
+chain("plan > write", tasks=tasks, context=["team/ctx/spec"])
+```
+
+```ts
+chain("plan > write", { tasks, context: ["team/ctx/spec"] });
+```
+
+```bash
+kx chain run "plan > write" --tasks tasks.json --context team/ctx/spec
+```
+
+The handles lower **verbatim** into the request's `context_bundles` (no DSL-side
+sort or dedup — the server canonicalizes the sorted ref-set at bind, SN-8). A
+chain with no attached context lowers byte-identically to pre-context-bundle, and
+the attachment's byte-identity across Python, TypeScript, and the CLI is pinned by
+the golden corpus alongside the topology.
+
 ## Per-language authoring
 
 - **[Chains in Python](./python.md)** — the `chain()` string DSL plus the

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -91,6 +91,20 @@ tasks = {
 spec = chain("gen > sum", tasks=tasks)   # two steps, edge 0→1
 ```
 
+## Attaching context bundles
+
+Ground the chain with [context bundles](../context.md) via the `context=` argument,
+or the fluent `.context(...)` (which appends and returns a new chain). Context is
+chain-level — the server injects it into the chain's entry step(s):
+
+```python
+chain("gen > sum", tasks=tasks, context=["team/ctx/spec"])
+chain("gen > sum", tasks=tasks).context("team/ctx/spec", "team/ctx/notes")
+```
+
+Handles ride verbatim into the request (the server canonicalizes at bind). A chain
+with no attached context is byte-identical to one authored before context bundles.
+
 ## Validation
 
 The same fail-closed rules as the [DSL reference](./dsl-reference.md#validation-fail-closed)

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -91,6 +91,21 @@ const tasks = {
 const spec = chain("gen > sum", { tasks });   // two steps, edge 0→1
 ```
 
+## Attaching context bundles
+
+Ground the chain with [context bundles](../context.md) via the `context` option,
+or the fluent `.context(...)` (which appends and returns a new chain). Context is
+chain-level — the server injects it into the chain's entry step(s):
+
+```ts
+chain("gen > sum", { tasks, context: ["team/ctx/spec"] });
+chain("gen > sum", { tasks }).context("team/ctx/spec", "team/ctx/notes");
+chainFrom(seq(gen, sum), { context: ["team/ctx/spec"] });
+```
+
+Handles ride verbatim into the request (the server canonicalizes at bind). A chain
+with no attached context is byte-identical to one authored before context bundles.
+
 ## Validation
 
 The same fail-closed rules as the [DSL reference](./dsl-reference.md#validation-fail-closed)

--- a/docs/site/docs/context.md
+++ b/docs/site/docs/context.md
@@ -85,6 +85,60 @@ const run = await kx.invoke("kx/recipes/react",
                             { context: ["team/ctx/spec"], wait: true });
 ```
 
+## Attach a bundle to a chain
+
+A [Chain](./chains/dsl-reference.md) carries context **at the chain level** — the
+server attaches it to the chain's entry step(s), so position in the chain is
+irrelevant (there is no `context` node). Pass the handles via the `context`
+option, the fluent `.context(...)`, or the CLI `--context` flag (repeatable):
+
+```python
+from kortecx.chains import chain, model
+
+c = chain("plan > write",
+          {"plan": model("kx-serve:qwen3", "Plan the doc."),
+           "write": model("kx-serve:qwen3", "Write it.")},
+          context=["team/ctx/spec"])           # or: .context("team/ctx/spec")
+run = kx.run_chain(c, wait=True)
+```
+
+```ts
+import { chain, task } from "@kortecx/sdk/chains";
+
+const c = chain("plan > write", {
+  tasks: { plan: task.model("kx-serve:qwen3", "Plan the doc."),
+           write: task.model("kx-serve:qwen3", "Write it.") },
+  context: ["team/ctx/spec"],                   // or: .context("team/ctx/spec")
+});
+await kx.runChain(c, { wait: true });
+```
+
+```bash
+kx chain run "plan > write" --tasks tasks.json --context team/ctx/spec --wait
+```
+
+The handles lower **verbatim** into the request's `context_bundles` (no client-side
+sort/dedup — the server owns canonicalization). The lowering is pinned
+byte-identical across Python, TypeScript, and the CLI by the
+[Chains golden corpus](./chains/dsl-reference.md).
+
+## Manage bundles in the Console
+
+The console's **Context** section (left nav → Context) is the OSS author + govern
+surface:
+
+- **Author** a bundle: a handle + a description + items added by uploading files
+  (each upload is a `PutContent`) or by naming an existing content ref.
+- **Review** every bundle you authored — its items (each a content ref) and the
+  server-derived bundle ref.
+- **Delete** a bundle (unbinds the handle; the content-store blobs stay).
+
+In **Chat**, the composer's attach menu has a live **Context** category: pick one
+or more bundles to ground the next turn. The attached bundles show as chips above
+the composer and ride that turn's run (the same identity-bearing attachment as
+`--context`). The section degrades to an honest "needs a newer gateway" state when
+the bundle store is absent (never a mock).
+
 ## How delivery works
 
 At bind, the runtime resolves each attached handle to its item refs (caller-scoped,

--- a/tests/golden/chains/SPEC.md
+++ b/tests/golden/chains/SPEC.md
@@ -69,6 +69,29 @@ So `a > [b & c]` fans OUT (`a→b`, `a→c`); `[a & b] > c` fans IN (`a→c`, `b
 The result feeds `BlueprintBuilder.add_step` / `add_edge` (one canonical lowering) →
 `SubmitWorkflowRequest`.
 
+## Context bundles (PR-7b)
+
+A chain may carry an ordered list of **context-bundle handles** (`namespace/collection/name`
+strings) — named, content-addressed grounding the caller attaches to the run. Context is
+**chain-level, NOT a node**: it is `repeated string context_bundles` on `SubmitWorkflowRequest`
+(field 5), and the SERVER injects the resolved item-refs into EVERY entry (parentless) Mote's
+identity-bearing `config_subset` at bind (a different attached context ⇒ a different entry MoteId
+⇒ exactly-once-per-`(input + context)`). Position in the chain is irrelevant — there is no
+`context()` step.
+
+- **Front doors**: the string `chain(expr, tasks, context=[...])`, the operator/combinator form
+  (`Chain.from_node(node, context=[...])` / `chainFrom(frag, {context})`), the fluent
+  `.context(*handles)` (appends, returns an immutable copy), and the CLI `--context <handle>`
+  (repeatable). `blueprint run --file` accepts a top-level `"context_bundles": [...]`.
+- **Lowering rule**: `context_bundles` are emitted **verbatim in caller-supplied order — NOT
+  sorted, NOT deduped at the DSL layer**. The server owns canonicalization (it folds the SORTED,
+  deduped ref-set into `config_subset` at bind, SN-8); the DSL only PROPOSES the handle list.
+- **Default**: absent ⇒ `[]`. A chain that attaches no context lowers byte-identically to
+  pre-PR-7 (the empty repeated field serializes away), so the canonical reference run is unmoved.
+
+The lowering inspector (`lowering()` / `lower()`) includes a top-level `context_bundles` array so
+the cross-surface byte-identity of the attachment is pinned by the corpus.
+
 ## Validation (errors, fail-closed)
 
 - **Empty expression** or **empty group `[]`** → parse error.
@@ -95,6 +118,11 @@ A `tool` task spec carries `tool_contract` + (optional) structured `args`:
 `expect` step has the `tool_contract` and `params["kx.tool.args"]` = the canonical-JSON string. Each
 surface lowers the structured `args` (Python/TS via the `tool()` factory, Rust via the CLI
 `StepSpec.args`) and the corpus asserts the byte-identical canonical JSON.
+
+A case MAY carry a top-level `"context_bundles": [<handle>, ...]` (the chain-level attachment);
+its `expect` then carries the SAME array (verbatim order). When absent, each surface defaults it
+to `[]` — so the existing cases stay byte-unchanged. `ctx_multi_order` pins order-preservation
+(its input order is NOT sorted, and `expect.context_bundles` matches it).
 
 `steps` are in node order; `params` values are strings (the pre-encoding lowering form — each SDK
 UTF-8-encodes at `build()` time). An error case carries `"error": "<class>"` instead of `expect`,

--- a/tests/golden/chains/corpus.json
+++ b/tests/golden/chains/corpus.json
@@ -364,5 +364,77 @@
       ],
       "edges": [ { "parent": 0, "child": 1, "edge": "data" } ]
     }
+  },
+  {
+    "name": "ctx_single",
+    "dsl": "a",
+    "seed": 0,
+    "context_bundles": [ "team/ctx/spec" ],
+    "tasks": { "a": { "kind": "pure" } },
+    "expect": {
+      "steps": [
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [],
+      "context_bundles": [ "team/ctx/spec" ]
+    }
+  },
+  {
+    "name": "ctx_multi_order",
+    "dsl": "a",
+    "seed": 0,
+    "context_bundles": [ "z/ctx/two", "a/ctx/one" ],
+    "tasks": { "a": { "kind": "pure" } },
+    "expect": {
+      "steps": [
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [],
+      "context_bundles": [ "z/ctx/two", "a/ctx/one" ]
+    }
+  },
+  {
+    "name": "ctx_seq",
+    "dsl": "a > b",
+    "seed": 0,
+    "context_bundles": [ "team/ctx/spec" ],
+    "tasks": { "a": { "kind": "pure" }, "b": { "kind": "pure" } },
+    "expect": {
+      "steps": [
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} },
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [ { "parent": 0, "child": 1, "edge": "data" } ],
+      "context_bundles": [ "team/ctx/spec" ]
+    }
+  },
+  {
+    "name": "ctx_with_seed",
+    "dsl": "a > b",
+    "seed": 7,
+    "context_bundles": [ "team/ctx/spec", "team/ctx/notes" ],
+    "tasks": { "a": { "kind": "pure" }, "b": { "kind": "pure" } },
+    "expect": {
+      "steps": [
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} },
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [ { "parent": 0, "child": 1, "edge": "data" } ],
+      "context_bundles": [ "team/ctx/spec", "team/ctx/notes" ]
+    }
+  },
+  {
+    "name": "ctx_empty_explicit",
+    "dsl": "a",
+    "seed": 0,
+    "context_bundles": [],
+    "tasks": { "a": { "kind": "pure" } },
+    "expect": {
+      "steps": [
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [],
+      "context_bundles": []
+    }
   }
 ]

--- a/ui/e2e/chat-feedback.spec.ts
+++ b/ui/e2e/chat-feedback.spec.ts
@@ -56,7 +56,7 @@ test("a settled answer carries copy + 👍/👎; rating SENDS SubmitFeedback to 
   await page.getByTestId("msg-copy").click();
 });
 
-test("the attach button opens a menu: Upload is live, Context is honest-disabled", async ({
+test("the attach button opens a menu: Upload + Context are live, Blueprint/Dataset/Tool are honest-disabled", async ({
   page,
 }) => {
   gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
@@ -67,7 +67,12 @@ test("the attach button opens a menu: Upload is live, Context is honest-disabled
   await page.getByTestId("attach-btn").click();
   await expect(page.getByTestId("attach-menu")).toBeVisible();
   await expect(page.getByTestId("attach-upload")).toBeEnabled();
-  await expect(page.getByTestId("attach-context")).toBeDisabled();
+  // PR-7b: the Context category is LIVE — on a fresh serve (no bundles authored)
+  // it shows the honest "no bundles" row, never a fake.
+  await expect(page.getByTestId("attach-context-group")).toBeVisible();
+  await expect(page.getByTestId("attach-context-empty")).toBeVisible();
+  // The remaining not-yet-wired categories stay honest-disabled (don't-fake-gaps).
+  await expect(page.getByTestId("attach-tool")).toBeDisabled();
 
   // Escape closes the menu.
   await page.keyboard.press("Escape");

--- a/ui/e2e/context.spec.ts
+++ b/ui/e2e/context.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+import { connectConsole } from "./fixtures/connect";
+import { type Gateway, SPA_ORIGIN, spawnGateway } from "./fixtures/serve";
+
+let gw: Gateway | undefined;
+
+test.afterEach(() => {
+  gw?.stop();
+  gw = undefined;
+});
+
+const SPEC_FILE = Buffer.from("The launch codename is FALCON-NINE-ZULU.\n", "utf-8");
+const HANDLE = "team/ctx/spec";
+
+test("Context: author a bundle from an uploaded file, see it listed, attach it in chat, then delete", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  // The section opens to an honest empty state on a fresh (per-spawn) gateway.
+  await page.getByTestId("nav-context").click();
+  await expect(page.getByTestId("context-section")).toBeVisible();
+  await expect(page.getByTestId("context-bundles")).toContainText("No context bundles yet", {
+    timeout: 30_000,
+  });
+
+  // Author a bundle: a handle + one uploaded file (PutContent → server-derived ref).
+  // The handle input is React-controlled — click + pressSequentially, never fill().
+  const handle = page.getByTestId("context-bundle-handle");
+  await handle.click();
+  await handle.pressSequentially(HANDLE);
+  await page.getByTestId("context-bundle-file-input").setInputFiles({
+    name: "spec.md",
+    mimeType: "text/markdown",
+    buffer: SPEC_FILE,
+  });
+  // The staged item appears once the upload lands (with its DigestChip).
+  await expect(page.getByTestId("context-bundle-staged")).toBeVisible({ timeout: 15_000 });
+  await page.getByTestId("context-bundle-submit").click();
+
+  // The bundle now lists with its server-derived bundle ref + the item.
+  const card = page.getByTestId(`context-bundle-${HANDLE}`);
+  await expect(card).toBeVisible({ timeout: 30_000 });
+  await expect(card.getByTestId("digest-chip").first()).toBeVisible();
+  await expect(card).toContainText("spec.md");
+
+  // The chat composer's LIVE Context attach category lists the bundle; attaching
+  // it shows the pending-context chip (the wire from the section to the turn).
+  await page.getByTestId("nav-chat").click();
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+  await page.getByTestId("attach-btn").click();
+  await expect(page.getByTestId("attach-context-group")).toBeVisible();
+  await page.getByTestId(`attach-context-option-${HANDLE}`).click();
+  await expect(page.getByTestId(`chat-context-${HANDLE}`)).toBeVisible();
+  // Detaching clears the chip.
+  await page.getByTestId(`chat-context-remove-${HANDLE}`).click();
+  await expect(page.getByTestId(`chat-context-${HANDLE}`)).toHaveCount(0);
+
+  // Delete the bundle from the section → it leaves the list.
+  await page.getByTestId("nav-context").click();
+  await page.getByTestId(`context-bundle-delete-${HANDLE}`).click();
+  await expect(page.getByTestId(`context-bundle-${HANDLE}`)).toHaveCount(0, { timeout: 30_000 });
+});

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { fadeUp } from "../../app/motion";
 import { useConnection } from "../../kx/connection-context";
 import { useAttachments } from "../../kx/use-attachments";
 import { REACT_RECIPE_HANDLE, useChat } from "../../kx/use-chat";
+import { useContextBundles } from "../../kx/use-context-bundles";
 import { useModels } from "../../kx/use-models";
 import { useRecipes } from "../../kx/use-recipes";
 import {
@@ -75,6 +76,15 @@ export function ChatPanel() {
     agentMode: agentMode && agentAvailable,
   });
   const attach = useAttachments();
+  // PR-7b: the party's authored context bundles + the handles attached to the
+  // NEXT turn (multi-select via the composer attach-menu Context category).
+  const contextBundles = useContextBundles();
+  const [pendingContext, setPendingContext] = useState<readonly string[]>([]);
+  function toggleContext(handle: string): void {
+    setPendingContext((prev) =>
+      prev.includes(handle) ? prev.filter((h) => h !== handle) : [...prev, handle],
+    );
+  }
   const [historyOpen, setHistoryOpen] = useState(false);
   // The identity the autosave upserts under; a new id per fresh/restored thread.
   const chatIdRef = useRef<string>(crypto.randomUUID());
@@ -153,8 +163,9 @@ export function ChatPanel() {
         mediaType: a.mediaType,
         objectUrl: a.objectUrl,
       }));
-    void chat.send(text, ready);
+    void chat.send(text, ready, pendingContext);
     attach.clear();
+    setPendingContext([]);
   }
 
   return (
@@ -294,11 +305,40 @@ export function ChatPanel() {
         />
       </div>
       <AttachmentStrip attachments={attach.attachments} onRemove={attach.remove} />
+      {pendingContext.length > 0 ? (
+        <div className="context-strip" data-testid="chat-context-strip">
+          <span className="context-strip__label muted">Context:</span>
+          {pendingContext.map((handle) => (
+            <span
+              key={handle}
+              className="context-strip__chip"
+              data-testid={`chat-context-${handle}`}
+            >
+              <span className="mono">{handle}</span>
+              <button
+                type="button"
+                className="context-strip__remove"
+                aria-label={`Detach ${handle}`}
+                data-testid={`chat-context-remove-${handle}`}
+                onClick={() => toggleContext(handle)}
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
       <Composer
         disabled={chat.busy}
         sendBlocked={attach.uploading}
         onSend={sendWithAttachments}
         onPickFiles={attach.addFiles}
+        context={{
+          bundles: contextBundles.bundles.map((b) => b.handle),
+          attached: pendingContext,
+          notWired: contextBundles.notWired,
+          onToggle: toggleContext,
+        }}
       />
 
       <ChatHistory

--- a/ui/src/components/chat/Composer.tsx
+++ b/ui/src/components/chat/Composer.tsx
@@ -4,15 +4,24 @@ import { MonacoMount } from "../editor/MonacoMount";
 import { Icon } from "../shell/Icon";
 import { Popover } from "../shell/Popover";
 
-/** Attach categories that need Context bundles (PR-7) to ride a message — shown
- *  in the menu as honest-disabled rows so the surface is complete but never fakes
- *  a capability that does not exist yet (D142 don't-fake-gaps). */
+/** Attach categories not yet wired — shown in the menu as honest-disabled rows so
+ *  the surface is complete but never fakes a capability that does not exist yet
+ *  (D142 don't-fake-gaps). Context is LIVE (PR-7b) and rendered separately. */
 const SOON_CATEGORIES: ReadonlyArray<{ label: string; testId: string }> = [
   { label: "Blueprint", testId: "attach-blueprint" },
   { label: "Dataset", testId: "attach-dataset" },
   { label: "Tool", testId: "attach-tool" },
-  { label: "Context", testId: "attach-context" },
 ];
+
+/** PR-7b: the context-bundle picker state the parent (ChatPanel) owns + passes in.
+ *  `bundles` are the party's authored handles; toggling attaches/detaches a handle
+ *  to the NEXT turn (multi-select — the menu stays open). Absent ⇒ no picker. */
+export interface ContextPickerProps {
+  readonly bundles: readonly string[];
+  readonly attached: readonly string[];
+  readonly notWired: boolean;
+  readonly onToggle: (handle: string) => void;
+}
 
 /**
  * The message input — a Monaco surface with MARKDOWN highlighting (D141.2's
@@ -26,12 +35,15 @@ export function Composer({
   sendBlocked,
   onSend,
   onPickFiles,
+  context,
 }: {
   disabled: boolean;
   /** Extra send-only block (e.g. an attachment upload still in flight). */
   sendBlocked?: boolean;
   onSend: (text: string) => void;
   onPickFiles?: (files: ArrayLike<File>) => void;
+  /** PR-7b: the context-bundle picker (the attach-menu "Context" category). */
+  context?: ContextPickerProps;
 }) {
   const [text, setText] = useState("");
   const fileRef = useRef<HTMLInputElement>(null);
@@ -110,9 +122,63 @@ export function Composer({
                     <Icon name="attach" size={15} />
                     <span>Upload a file</span>
                   </button>
-                  {/* Attaching a Blueprint/Dataset/Tool/Context as message context
-                      rides the Context-bundle work (PR-7) — shown but honest-
-                      disabled so the menu is complete without faking the gap. */}
+                  {/* PR-7b: the LIVE Context category — pick authored bundles to
+                      ground the next turn (multi-select; the menu stays open). */}
+                  {context ? (
+                    <div className="popover__group" data-testid="attach-context-group">
+                      <div className="popover__group-label">Context</div>
+                      {context.notWired ? (
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="popover__item popover__item--disabled"
+                          data-testid="attach-context-not-wired"
+                          disabled
+                          aria-disabled="true"
+                          title="Context bundles need a newer gateway"
+                        >
+                          <span>Needs a newer gateway</span>
+                        </button>
+                      ) : context.bundles.length === 0 ? (
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="popover__item popover__item--disabled"
+                          data-testid="attach-context-empty"
+                          disabled
+                          aria-disabled="true"
+                          title="Author bundles in the Context section"
+                        >
+                          <span>No bundles — author in Context</span>
+                        </button>
+                      ) : (
+                        context.bundles.map((handle) => {
+                          const on = context.attached.includes(handle);
+                          return (
+                            <button
+                              key={handle}
+                              type="button"
+                              role="menuitemcheckbox"
+                              aria-checked={on}
+                              className={`popover__item${on ? " popover__item--active" : ""}`}
+                              data-testid={`attach-context-option-${handle}`}
+                              onClick={() => context.onToggle(handle)}
+                            >
+                              <span className="mono">{handle}</span>
+                              {on ? (
+                                <span className="popover__check" aria-hidden="true">
+                                  ✓
+                                </span>
+                              ) : null}
+                            </button>
+                          );
+                        })
+                      )}
+                    </div>
+                  ) : null}
+                  {/* Attaching a Blueprint/Dataset/Tool as message context is not yet
+                      wired — shown but honest-disabled so the menu is complete
+                      without faking the gap. */}
                   {SOON_CATEGORIES.map((c) => (
                     <button
                       key={c.testId}

--- a/ui/src/components/context/ContextBundleList.tsx
+++ b/ui/src/components/context/ContextBundleList.tsx
@@ -1,0 +1,145 @@
+/**
+ * The context-bundle inventory (`ListContextBundles`, PR-7) — the GOVERNANCE +
+ * review view: every bundle this party authored, its items (each a content-store
+ * ref shown via {@link DigestChip}), the server-derived `bundleRef`, and an
+ * operator delete control (unbinds the handle; the CAS blobs stay). Caller-scoped
+ * (SN-8 — no cross-party listing). Degrades to a not-wired empty state on an older
+ * gateway (UNIMPLEMENTED).
+ */
+
+import { m } from "framer-motion";
+import { fadeUp, hoverLift, stagger } from "../../app/motion";
+import { toUiError } from "../../kx/errors";
+import { useContextBundles, useDeleteContextBundle } from "../../kx/use-context-bundles";
+import { DigestChip } from "../DigestChip";
+import { EmptyState } from "../EmptyState";
+import { ErrorNotice } from "../ErrorNotice";
+import { Badge } from "../ds/Badge";
+import { GlowCard } from "../ds/GlowCard";
+
+export function ContextBundleList() {
+  const { bundles, notWired, isLoading, isError, error, refetch } = useContextBundles();
+  const remove = useDeleteContextBundle();
+  const removeError = remove.error ? toUiError(remove.error) : null;
+
+  if (isLoading) {
+    return <EmptyState title="Loading context bundles…" />;
+  }
+  if (notWired) {
+    return (
+      <EmptyState
+        title="Context bundles need a newer gateway"
+        detail="This gateway doesn't expose the context-bundle store (an older build)."
+      />
+    );
+  }
+  if (isError) {
+    return <ErrorNotice error={toUiError(error)} onRetry={() => void refetch()} />;
+  }
+
+  return (
+    <div data-testid="context-bundles">
+      {removeError ? (
+        <p className="field-error" data-testid="context-bundle-delete-error" role="alert">
+          {removeError.message}
+        </p>
+      ) : null}
+      {bundles.length === 0 ? (
+        <EmptyState
+          title="No context bundles yet"
+          detail="Author one below — attach files or content refs under a handle, then attach it to a chat or chain."
+        />
+      ) : (
+        <m.ul
+          className="registry-list"
+          data-testid="context-bundles-panel"
+          variants={stagger()}
+          initial="hidden"
+          animate="show"
+        >
+          {bundles.map((b) => {
+            const pending = remove.isPending && remove.variables?.handle === b.handle;
+            return (
+              <BundleRow
+                key={b.handle}
+                handle={b.handle}
+                bundleRef={b.bundleRef}
+                description={b.description}
+                itemCount={b.itemCount}
+                items={b.items}
+                pending={pending}
+                onDelete={() => remove.mutate({ handle: b.handle })}
+              />
+            );
+          })}
+        </m.ul>
+      )}
+    </div>
+  );
+}
+
+interface BundleItemView {
+  readonly name: string;
+  readonly contentRef: string;
+  readonly mediaType: string;
+}
+
+function BundleRow({
+  handle,
+  bundleRef,
+  description,
+  itemCount,
+  items,
+  pending,
+  onDelete,
+}: {
+  handle: string;
+  bundleRef: string;
+  description: string;
+  itemCount: number;
+  items: readonly BundleItemView[];
+  pending: boolean;
+  onDelete: () => void;
+}) {
+  return (
+    <GlowCard
+      className="registry-row"
+      stripe="var(--teal)"
+      variants={fadeUp}
+      data-testid={`context-bundle-${handle}`}
+      {...hoverLift}
+    >
+      <div className="registry-row__main">
+        <div className="registry-row__head">
+          <span className="registry-row__name mono">{handle}</span>
+          <Badge label={`${itemCount} item${itemCount === 1 ? "" : "s"}`} color="var(--teal)" />
+          <DigestChip hex={bundleRef} label={`${handle} bundle ref`} />
+        </div>
+        {description ? <p className="registry-row__desc muted">{description}</p> : null}
+        {items.length > 0 ? (
+          <ul className="context-bundle__items">
+            {items.map((it) => (
+              <li key={`${it.name}:${it.contentRef}`} className="context-bundle__item">
+                <span className="context-bundle__item-name">{it.name || "(unnamed)"}</span>
+                {it.mediaType ? (
+                  <span className="context-bundle__item-type muted mono">{it.mediaType}</span>
+                ) : null}
+                <DigestChip hex={it.contentRef} label={it.name} />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="btn-ghost registry-row__deregister"
+        data-testid={`context-bundle-delete-${handle}`}
+        disabled={pending}
+        title="Unbind this bundle (its content-store blobs stay)"
+        onClick={onDelete}
+      >
+        {pending ? "Removing…" : "Delete"}
+      </button>
+    </GlowCard>
+  );
+}

--- a/ui/src/components/context/NewContextBundleForm.tsx
+++ b/ui/src/components/context/NewContextBundleForm.tsx
@@ -1,0 +1,244 @@
+/**
+ * Author (upsert) a context bundle (`PutContextBundle`, PR-7). Items are content
+ * refs already in the store: either uploaded here (file → `PutContent` → ref, the
+ * chat-attach path) or named by an existing 64-hex ref (the `kx context add
+ * --item` power path). The server derives `bundleRef` (SN-8) and folds the bundle
+ * into the entry Mote at bind. Mirrors `RegisterToolForm` (GlowCard + chip/inline
+ * controls, never a controlled `<select>`).
+ */
+
+import { type FormEvent, useRef, useState } from "react";
+import { fadeUp } from "../../app/motion";
+import { toUiError } from "../../kx/errors";
+import { usePutContextBundle } from "../../kx/use-context-bundles";
+import { usePutContent } from "../../kx/use-put-content";
+import { DigestChip } from "../DigestChip";
+import { GlowCard } from "../ds/GlowCard";
+
+interface StagedItem {
+  name: string;
+  contentRef: string;
+  mediaType: string;
+}
+
+/** A content ref is the 32-byte blake3 store id rendered as 64 lowercase hex. */
+const HEX64 = /^[0-9a-f]{64}$/;
+
+export function NewContextBundleForm() {
+  const [handle, setHandle] = useState("");
+  const [description, setDescription] = useState("");
+  const [items, setItems] = useState<StagedItem[]>([]);
+  const [refName, setRefName] = useState("");
+  const [refHex, setRefHex] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const put = usePutContextBundle();
+  const upload = usePutContent();
+
+  const canSubmit = handle.trim().length > 0 && items.length > 0 && !upload.isPending;
+
+  function addItem(item: StagedItem): void {
+    setItems((prev) =>
+      prev.some((p) => p.contentRef === item.contentRef && p.name === item.name)
+        ? prev
+        : [...prev, item],
+    );
+  }
+
+  function removeItem(idx: number): void {
+    setItems((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function onFiles(files: FileList | null): Promise<void> {
+    if (!files) {
+      return;
+    }
+    setLocalError(null);
+    for (const file of Array.from(files)) {
+      try {
+        const payload = new Uint8Array(await file.arrayBuffer());
+        const result = await upload.mutateAsync({
+          payload,
+          mediaType: file.type || "application/octet-stream",
+          filename: file.name,
+        });
+        addItem({ name: file.name, contentRef: result.contentRef, mediaType: file.type });
+      } catch (e) {
+        setLocalError(toUiError(e).message);
+      }
+    }
+    if (fileInput.current) {
+      fileInput.current.value = "";
+    }
+  }
+
+  function onAddRef(): void {
+    const hex = refHex.trim().toLowerCase();
+    if (!HEX64.test(hex)) {
+      setLocalError("A content ref is 64 hex characters (a 32-byte store id).");
+      return;
+    }
+    setLocalError(null);
+    addItem({ name: refName.trim(), contentRef: hex, mediaType: "" });
+    setRefName("");
+    setRefHex("");
+  }
+
+  function onSubmit(e: FormEvent): void {
+    e.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    put.mutate(
+      {
+        handle: handle.trim(),
+        description: description.trim(),
+        items: items.map((i) => ({
+          name: i.name,
+          contentRef: i.contentRef,
+          mediaType: i.mediaType || undefined,
+        })),
+      },
+      {
+        onSuccess: () => {
+          setHandle("");
+          setDescription("");
+          setItems([]);
+        },
+      },
+    );
+  }
+
+  const err = put.error ? toUiError(put.error) : null;
+
+  return (
+    <GlowCard hover={false} variants={fadeUp} data-testid="context-bundle-new">
+      <h2>New context bundle</h2>
+      <p className="muted">
+        Group files or content refs under a handle, then attach it to a chat or chain. The server
+        derives the bundle ref (SN-8) and injects the items into the run's entry step — a different
+        attached context is a different, independently-cached run.
+      </p>
+      <form onSubmit={onSubmit} className="register-tool-form">
+        <div className="register-tool-form__row">
+          <input
+            type="text"
+            data-testid="context-bundle-handle"
+            placeholder="handle (e.g. team/ctx/spec)"
+            value={handle}
+            onChange={(e) => setHandle(e.target.value)}
+            aria-label="Bundle handle"
+          />
+          <input
+            type="text"
+            data-testid="context-bundle-description"
+            placeholder="description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            aria-label="Bundle description"
+          />
+        </div>
+
+        <fieldset className="register-tool-form__idempotency">
+          <legend className="muted">Items</legend>
+          <div className="context-bundle-form__add">
+            <button
+              type="button"
+              className="chip"
+              data-testid="context-bundle-upload"
+              disabled={upload.isPending}
+              onClick={() => fileInput.current?.click()}
+            >
+              <span className="chip__label">
+                {upload.isPending ? "Uploading…" : "+ Upload file"}
+              </span>
+            </button>
+            <input
+              ref={fileInput}
+              type="file"
+              multiple
+              hidden
+              data-testid="context-bundle-file-input"
+              onChange={(e) => void onFiles(e.target.files)}
+            />
+          </div>
+          <div className="context-bundle-form__ref">
+            <input
+              type="text"
+              data-testid="context-bundle-ref-name"
+              placeholder="ref label (optional)"
+              value={refName}
+              onChange={(e) => setRefName(e.target.value)}
+              aria-label="Content ref label"
+            />
+            <input
+              type="text"
+              className="mono"
+              data-testid="context-bundle-ref-hex"
+              placeholder="content ref (64 hex)"
+              value={refHex}
+              onChange={(e) => setRefHex(e.target.value)}
+              aria-label="Content ref (64 hex)"
+            />
+            <button
+              type="button"
+              className="chip"
+              data-testid="context-bundle-add-ref"
+              onClick={onAddRef}
+            >
+              <span className="chip__label">+ Add ref</span>
+            </button>
+          </div>
+
+          {items.length > 0 ? (
+            <ul className="context-bundle__items" data-testid="context-bundle-staged">
+              {items.map((it, idx) => (
+                <li key={`${it.name}:${it.contentRef}`} className="context-bundle__item">
+                  <span className="context-bundle__item-name">{it.name || "(unnamed)"}</span>
+                  <DigestChip hex={it.contentRef} label={it.name} />
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    data-testid={`context-bundle-staged-remove-${idx}`}
+                    aria-label={`Remove ${it.name || "item"}`}
+                    onClick={() => removeItem(idx)}
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted">No items yet — upload a file or add a content ref.</p>
+          )}
+        </fieldset>
+
+        <button
+          type="submit"
+          data-testid="context-bundle-submit"
+          disabled={put.isPending || !canSubmit}
+        >
+          {put.isPending ? "Saving…" : "Save bundle"}
+        </button>
+      </form>
+
+      {localError ? (
+        <p className="field-error" data-testid="context-bundle-local-error" role="alert">
+          {localError}
+        </p>
+      ) : null}
+      {err ? (
+        <p className="field-error" data-testid="context-bundle-error" role="alert">
+          {err.message}
+        </p>
+      ) : null}
+      {put.isSuccess ? (
+        <p className="register-tool__result" data-testid="context-bundle-result">
+          Saved <code className="mono">{put.data?.handle}</code>
+          {put.data?.deduplicated ? " (unchanged — identical manifest)" : ""}
+        </p>
+      ) : null}
+    </GlowCard>
+  );
+}

--- a/ui/src/components/sections/ContextSection.tsx
+++ b/ui/src/components/sections/ContextSection.tsx
@@ -1,0 +1,39 @@
+import { ContextBundleList } from "../context/ContextBundleList";
+import { NewContextBundleForm } from "../context/NewContextBundleForm";
+
+/**
+ * Context — named, content-addressed bundles a caller attaches to a run (PR-7) so
+ * a model reasons over its grounding. Two surfaces over the gateway's bundle store:
+ *
+ * 1. **Your bundles (govern/review)** — the durable inventory (`ListContextBundles`):
+ *    every bundle this party authored, its items (each a content-store ref), the
+ *    server-derived `bundleRef`, and a delete control (unbinds the handle; the CAS
+ *    blobs stay). Caller-scoped (SN-8 — no cross-party listing).
+ * 2. **Author** — upsert a bundle (`PutContextBundle`) from uploaded files or
+ *    existing content refs. Attach it in chat (the composer attach-menu) or a chain
+ *    (`kx chain run --context`, `chain(...).context(...)`).
+ *
+ * Both degrade to a not-wired empty state on older gateways (UNIMPLEMENTED).
+ * Cross-party sharing + a bundle marketplace are a Cloud capability (GR19).
+ */
+export function ContextSection() {
+  return (
+    <section className="screen" data-testid="context-section">
+      <h1>Context</h1>
+      <p className="muted">
+        Reusable instruction &amp; file bundles you attach to chats and chains. The server resolves
+        each bundle to its content refs and folds them into the run's entry step — identity-bearing,
+        so a different attached context is a different, independently-cached run (SN-8).
+      </p>
+
+      <h2>Your bundles</h2>
+      <p className="muted">
+        Every bundle you authored, with its items and the server-derived bundle ref. Deleting
+        unbinds the handle; the content-store blobs stay.
+      </p>
+      <ContextBundleList />
+
+      <NewContextBundleForm />
+    </section>
+  );
+}

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -41,6 +41,9 @@ export const queryKeys = {
   /** The registered external MCP servers (`ListMcpServers`, PR-6b-1) — the live
    *  Connections govern surface. Server-derived ids; credentials by NAME only. */
   mcpServers: (endpoint: string) => ["kx", endpoint, "mcp-servers"] as const,
+  /** This party's context bundles (`ListContextBundles`, PR-7) — named,
+   *  content-addressed grounding. Caller-scoped; `bundleRef` is server-derived (SN-8). */
+  contextBundles: (endpoint: string) => ["kx", endpoint, "context-bundles"] as const,
   /** The datasets (RAG corpora) the gateway holds (`ListDatasets`). */
   datasets: (endpoint: string) => ["kx", endpoint, "datasets"] as const,
   /** A dataset query (`QueryDataset`), scoped by dataset + query text + k. */

--- a/ui/src/kx/use-chat.ts
+++ b/ui/src/kx/use-chat.ts
@@ -83,7 +83,11 @@ export interface UseChat {
   readonly activeAssistantId: string | undefined;
   /** The in-flight AGENT turn's loop progress (react turns), if any. */
   readonly reactTurns: readonly ReactTurnVM[] | undefined;
-  send(text: string, attachments?: readonly MessageAttachment[]): Promise<void>;
+  send(
+    text: string,
+    attachments?: readonly MessageAttachment[],
+    context?: readonly string[],
+  ): Promise<void>;
   /** Re-dispatch a FAILED turn with its identical args. */
   retry(assistantId: string): Promise<void>;
   /** Restore a saved thread (chat history) — replaces the live one. */
@@ -370,10 +374,16 @@ export function useChat({ handle, promptKey, modelId, agentMode }: UseChatOption
       assistantId: string,
       text: string,
       attachments: readonly MessageAttachment[],
+      context: readonly string[],
     ): Promise<void> => {
       try {
         const plan = await planTurn(text, attachments);
-        const { instanceId, terminalMoteId } = await invoke.mutateAsync(plan);
+        // PR-7b: context is request-level — it attaches to the run regardless of
+        // which recipe route (chat / vision / react) the plan picked.
+        const { instanceId, terminalMoteId } = await invoke.mutateAsync({
+          ...plan,
+          context: context.length > 0 ? context : undefined,
+        });
         dispatch({ type: "turn_started", assistantId, instanceId, terminalMoteId });
         // A retried assistant id must be re-finalizable.
         if (finalizedRef.current === assistantId) {
@@ -397,7 +407,11 @@ export function useChat({ handle, promptKey, modelId, agentMode }: UseChatOption
   );
 
   const send = useCallback(
-    async (text: string, attachments: readonly MessageAttachment[] = []): Promise<void> => {
+    async (
+      text: string,
+      attachments: readonly MessageAttachment[] = [],
+      context: readonly string[] = [],
+    ): Promise<void> => {
       const trimmed = text.trim();
       if (trimmed === "") {
         return;
@@ -411,8 +425,9 @@ export function useChat({ handle, promptKey, modelId, agentMode }: UseChatOption
         assistantId,
         text: trimmed,
         attachments: attachments.length > 0 ? attachments : undefined,
+        context: context.length > 0 ? context : undefined,
       });
-      await startTurn(assistantId, trimmed, attachments);
+      await startTurn(assistantId, trimmed, attachments, context);
     },
     [startTurn],
   );
@@ -425,7 +440,7 @@ export function useChat({ handle, promptKey, modelId, agentMode }: UseChatOption
       }
       setDegraded(null);
       dispatch({ type: "turn_retry", assistantId });
-      await startTurn(assistantId, source.text, source.attachments);
+      await startTurn(assistantId, source.text, source.attachments, source.context);
     },
     [thread, startTurn],
   );

--- a/ui/src/kx/use-context-bundles.ts
+++ b/ui/src/kx/use-context-bundles.ts
@@ -1,0 +1,78 @@
+/**
+ * The context-bundle hooks (PR-7) — the inventory view (`ListContextBundles`)
+ * plus the author/delete mutations (`PutContextBundle` / `DeleteContextBundle`).
+ *
+ * A context bundle is named, content-addressed grounding the caller attaches to a
+ * run (`invoke(handle, args, { context: [handle] })`); the server resolves it to
+ * its content-refs and folds them into the entry Mote's identity-bearing config,
+ * so a different attached context ⇒ a different run. SN-8: `bundleRef` is
+ * SERVER-derived; bundles are caller-scoped (a not-found / not-owned bundle is
+ * uniform — no cross-party existence oracle). Degrades to a not-wired empty state
+ * on a gateway without the bundle store (UNIMPLEMENTED).
+ */
+
+import type { ContextBundle, ContextItemInput } from "@kortecx/sdk/web";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { toUiError } from "./errors";
+import { queryKeys } from "./query-keys";
+
+export function useContextBundles() {
+  const { client, endpoint, status } = useConnection();
+  const q = useQuery({
+    queryKey: queryKeys.contextBundles(endpoint),
+    enabled: status === "connected" && client !== null,
+    queryFn: async (): Promise<ContextBundle[]> => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.listContextBundles();
+    },
+  });
+  return {
+    bundles: q.data ?? [],
+    notWired: q.isError && toUiError(q.error).kind === "not-wired",
+    isLoading: q.isLoading,
+    isError: q.isError,
+    error: q.error,
+    refetch: q.refetch,
+  };
+}
+
+export interface PutContextBundleVars {
+  readonly handle: string;
+  readonly items: readonly ContextItemInput[];
+  readonly description?: string;
+}
+
+export function usePutContextBundle() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ handle, items, description }: PutContextBundleVars) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.putContextBundle(handle, items, { description });
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });
+    },
+  });
+}
+
+export function useDeleteContextBundle() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<boolean, unknown, { handle: string }>({
+    mutationFn: async ({ handle }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.deleteContextBundle(handle);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });
+    },
+  });
+}

--- a/ui/src/kx/use-invoke.ts
+++ b/ui/src/kx/use-invoke.ts
@@ -13,6 +13,12 @@ import { useConnection } from "./connection-context";
 export interface InvokeVars {
   handle: string;
   args: Record<string, unknown>;
+  /**
+   * PR-7b: context-bundle handles to attach to this run. The server resolves each
+   * to its content refs and folds them into the entry Mote's identity-bearing
+   * config, so a different attached context ⇒ a different run.
+   */
+  context?: readonly string[];
 }
 
 /** The server-derived handles for a started run (all hex; the client never derives an id). */
@@ -26,11 +32,15 @@ export interface StartedRun {
 export function useInvoke() {
   const { client } = useConnection();
   return useMutation<StartedRun, unknown, InvokeVars>({
-    mutationFn: async ({ handle, args }) => {
+    mutationFn: async ({ handle, args, context }) => {
       if (!client) {
         throw new Error("not connected");
       }
-      const run = (await client.invoke(handle, args)) as Run;
+      // Only carry the opts arg when context is attached — a plain turn keeps the
+      // exact `invoke(handle, args)` call (PR-7b is additive, never perturbs it).
+      const run = (await (context && context.length > 0
+        ? client.invoke(handle, args, { context })
+        : client.invoke(handle, args))) as Run;
       return {
         instanceId: run.instanceId,
         terminalMoteId: run.terminalMoteId,

--- a/ui/src/lib/chat-thread.ts
+++ b/ui/src/lib/chat-thread.ts
@@ -31,6 +31,10 @@ export interface ChatMessage {
   readonly status: ChatStatus;
   /** The uploads attached to a user message (display + the vision arg source). */
   readonly attachments?: readonly MessageAttachment[];
+  /** PR-7b: the context-bundle handles attached to a user turn (display + the
+   *  retry source). Threaded into the turn's Invoke `context`; a different attached
+   *  context ⇒ a different, independently-cached run. */
+  readonly context?: readonly string[];
   /** The paired user message id on an assistant turn (the retry join key). */
   readonly forUserId?: string;
   /** The run backing an assistant turn (set once Invoke returns). */
@@ -58,6 +62,7 @@ export type ChatAction =
       assistantId: string;
       text: string;
       attachments?: readonly MessageAttachment[];
+      context?: readonly string[];
     }
   | { type: "turn_started"; assistantId: string; instanceId: string; terminalMoteId: string }
   | { type: "turn_thinking"; assistantId: string }
@@ -89,6 +94,7 @@ export function chatReducer(state: ChatThread, action: ChatAction): ChatThread {
         text: action.text,
         status: "done",
         attachments: action.attachments,
+        context: action.context,
       };
       const assistant: ChatMessage = {
         id: action.assistantId,
@@ -155,7 +161,11 @@ export function chatReducer(state: ChatThread, action: ChatAction): ChatThread {
 export function retrySource(
   state: ChatThread,
   assistantId: string,
-): { text: string; attachments: readonly MessageAttachment[] } | null {
+): {
+  text: string;
+  attachments: readonly MessageAttachment[];
+  context: readonly string[];
+} | null {
   const assistant = state.messages.find((m) => m.id === assistantId);
   if (!assistant || assistant.role !== "assistant" || assistant.status !== "failed") {
     return null;
@@ -164,7 +174,7 @@ export function retrySource(
   if (!user) {
     return null;
   }
-  return { text: user.text, attachments: user.attachments ?? [] };
+  return { text: user.text, attachments: user.attachments ?? [], context: user.context ?? [] };
 }
 
 /** True while any assistant turn is still in flight (composer stays disabled). */

--- a/ui/src/router/routes/context.tsx
+++ b/ui/src/router/routes/context.tsx
@@ -1,31 +1,28 @@
 import { createRoute } from "@tanstack/react-router";
+import { Suspense, lazy } from "react";
 import { ConnectGate } from "../../components/ConnectGate";
 import { EmptyState } from "../../components/EmptyState";
 import { useConnection } from "../../kx/connection-context";
 import { rootRoute } from "./__root";
 
 /**
- * Context — reusable instruction & file bundles (the spec's eighth-IA section).
- * The gateway exposes NO context-bundle surface yet (the bundle store + the
- * attach-to-invoke wire land with the Context backend), so this section renders
- * an HONEST not-wired state — never a mock (don't-fake-gaps).
+ * Context — named, content-addressed bundles a caller attaches to a run (PR-7).
+ * The section view (author + govern) loads lazily; it degrades to a not-wired
+ * empty state on a gateway without the bundle store (don't-fake-gaps, GR15).
  */
+const ContextSection = lazy(() =>
+  import("../../components/sections/ContextSection").then((m) => ({ default: m.ContextSection })),
+);
+
 function ContextScreen() {
   const { status } = useConnection();
   if (status !== "connected") {
     return <ConnectGate />;
   }
   return (
-    <section className="screen" data-testid="context-section">
-      <h1>Context</h1>
-      <p className="muted">
-        Reusable instruction &amp; file bundles you can attach to chats and workflows.
-      </p>
-      <EmptyState
-        title="No context-bundle surface on this gateway yet"
-        detail="Bundles (skills, instructions, files) become attachable once the gateway ships its context backend — nothing is faked in the meantime."
-      />
-    </section>
+    <Suspense fallback={<EmptyState title="Loading…" />}>
+      <ContextSection />
+    </Suspense>
   );
 }
 

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -2045,6 +2045,26 @@ select {
   color: var(--fg-muted);
   cursor: not-allowed;
 }
+/* PR-7b: the LIVE Context picker group + an attached (checked) bundle row. */
+.popover__group {
+  border-top: 1px solid var(--border);
+  margin-top: 0.25rem;
+  padding-top: 0.25rem;
+}
+.popover__group-label {
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  padding: 0.2rem 0.6rem;
+}
+.popover__item--active {
+  color: var(--teal);
+}
+.popover__check {
+  margin-left: auto;
+  color: var(--teal);
+}
 .popover__item .chip--soon {
   margin-left: auto;
 }
@@ -3234,6 +3254,78 @@ button.card-grid__title:hover {
   margin: 0.5rem 0 0;
   color: var(--fg-muted);
   font-size: 0.9rem;
+}
+
+/* ---- Context bundles (PR-7b: items list + author form) ---- */
+.context-bundle__items {
+  list-style: none;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.context-bundle__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+.context-bundle__item-name {
+  font-weight: 600;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.context-bundle__item-type {
+  font-size: 0.75rem;
+}
+.context-bundle-form__add {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+.context-bundle-form__ref {
+  display: grid;
+  grid-template-columns: 0.6fr 1.4fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+@media (max-width: 720px) {
+  .context-bundle-form__ref {
+    grid-template-columns: 1fr;
+  }
+}
+/* PR-7b: the chat composer's attached-context chip strip (above the input). */
+.context-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0.3rem 0;
+}
+.context-strip__label {
+  font-size: 0.78rem;
+}
+.context-strip__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  padding: 0.1rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--teal) 9%, transparent);
+}
+.context-strip__remove {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--fg-muted);
+  padding: 0;
+  line-height: 1;
+}
+.context-strip__remove:hover {
+  color: var(--fg);
 }
 
 /* ---- MCP Connections (PR-6b-1: the live external-MCP-gateway govern surface) ---- */

--- a/ui/test/component/use-context-bundles.test.tsx
+++ b/ui/test/component/use-context-bundles.test.tsx
@@ -1,0 +1,75 @@
+import { KxUnimplemented } from "@kortecx/sdk/web";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  useContextBundles,
+  useDeleteContextBundle,
+  usePutContextBundle,
+} from "../../src/kx/use-context-bundles";
+import { connectedWrapper } from "../mocks/harness";
+import { makeMockClient } from "../mocks/kx-client";
+
+const BUNDLE = {
+  bundleRef: "ab".repeat(8),
+  handle: "team/ctx/spec",
+  description: "the spec",
+  itemCount: 1,
+  items: [{ name: "design.md", contentRef: "cd".repeat(32), mediaType: "text/markdown" }],
+};
+
+describe("useContextBundles", () => {
+  it("lists the party's bundles", async () => {
+    const { client } = makeMockClient({ listContextBundles: async () => [BUNDLE] });
+    const { result } = renderHook(() => useContextBundles(), {
+      wrapper: connectedWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.bundles).toEqual([BUNDLE]);
+    expect(result.current.notWired).toBe(false);
+  });
+
+  it("degrades to notWired on an UNIMPLEMENTED gateway", async () => {
+    const { client } = makeMockClient({
+      listContextBundles: async () => {
+        throw new KxUnimplemented("context bundles not wired");
+      },
+    });
+    const { result } = renderHook(() => useContextBundles(), {
+      wrapper: connectedWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.notWired).toBe(true);
+  });
+});
+
+describe("usePutContextBundle / useDeleteContextBundle", () => {
+  it("upserts a bundle with its items + description", async () => {
+    const { client, putContextBundle } = makeMockClient();
+    const { result } = renderHook(() => usePutContextBundle(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({
+        handle: "team/ctx/spec",
+        items: [{ name: "design.md", contentRef: "cd".repeat(32) }],
+        description: "the spec",
+      });
+    });
+    expect(putContextBundle).toHaveBeenCalledWith(
+      "team/ctx/spec",
+      [{ name: "design.md", contentRef: "cd".repeat(32) }],
+      { description: "the spec" },
+    );
+  });
+
+  it("deletes a bundle by handle", async () => {
+    const { client, deleteContextBundle } = makeMockClient();
+    const { result } = renderHook(() => useDeleteContextBundle(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ handle: "team/ctx/spec" });
+    });
+    expect(deleteContextBundle).toHaveBeenCalledWith("team/ctx/spec");
+  });
+});

--- a/ui/test/mocks/kx-client.ts
+++ b/ui/test/mocks/kx-client.ts
@@ -26,6 +26,9 @@ export interface MockClientImpl {
   getMoteDetail?: (...args: unknown[]) => Promise<unknown>;
   getContentBatch?: (...args: unknown[]) => Promise<unknown>;
   listModels?: (...args: unknown[]) => Promise<unknown>;
+  listContextBundles?: (...args: unknown[]) => Promise<unknown>;
+  putContextBundle?: (...args: unknown[]) => Promise<unknown>;
+  deleteContextBundle?: (...args: unknown[]) => Promise<unknown>;
 }
 
 export function makeMockClient(impl: MockClientImpl = {}) {
@@ -89,6 +92,12 @@ export function makeMockClient(impl: MockClientImpl = {}) {
   );
   const getContentBatch = vi.fn(impl.getContentBatch ?? (async () => []));
   const listModels = vi.fn(impl.listModels ?? (async () => []));
+  const listContextBundles = vi.fn(impl.listContextBundles ?? (async () => []));
+  const putContextBundle = vi.fn(
+    impl.putContextBundle ??
+      (async () => ({ bundleRef: "ab".repeat(8), handle: "", deduplicated: false })),
+  );
+  const deleteContextBundle = vi.fn(impl.deleteContextBundle ?? (async () => true));
   const close = vi.fn();
   const client = {
     listSignatures,
@@ -111,6 +120,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     getMoteDetail,
     getContentBatch,
     listModels,
+    listContextBundles,
+    putContextBundle,
+    deleteContextBundle,
     close,
     submitRun: vi.fn(),
     registerSignature: vi.fn(),
@@ -137,6 +149,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     getMoteDetail,
     getContentBatch,
     listModels,
+    listContextBundles,
+    putContextBundle,
+    deleteContextBundle,
     close,
   };
 }

--- a/ui/test/unit/chat-attachments.test.ts
+++ b/ui/test/unit/chat-attachments.test.ts
@@ -62,6 +62,7 @@ describe("chatReducer attachments + retry", () => {
     expect(retrySource(failed, "a1")).toEqual({
       text: "what is this?",
       attachments: [ATT],
+      context: [],
     });
     // Not failed ⇒ no source.
     expect(retrySource(sendWithAttachment(EMPTY_THREAD), "a1")).toBeNull();

--- a/ui/test/unit/chat-thread.test.ts
+++ b/ui/test/unit/chat-thread.test.ts
@@ -5,6 +5,7 @@ import {
   EMPTY_THREAD,
   chatReducer,
   isTurnInFlight,
+  retrySource,
 } from "../../src/lib/chat-thread";
 
 const ERR: UiError = {
@@ -158,6 +159,41 @@ describe("chatReducer", () => {
 
   it("reset clears the thread", () => {
     expect(chatReducer(send(EMPTY_THREAD), { type: "reset" })).toBe(EMPTY_THREAD);
+  });
+});
+
+describe("context bundles (PR-7b)", () => {
+  it("user_send stores the attached context handles on the user message", () => {
+    const s = chatReducer(EMPTY_THREAD, {
+      type: "user_send",
+      userId: "u1",
+      assistantId: "a1",
+      text: "hi",
+      context: ["team/ctx/spec", "team/ctx/notes"],
+    });
+    expect(s.messages[0]?.context).toEqual(["team/ctx/spec", "team/ctx/notes"]);
+  });
+
+  it("retrySource returns the failed turn's context so a retry re-attaches it", () => {
+    let s = chatReducer(EMPTY_THREAD, {
+      type: "user_send",
+      userId: "u1",
+      assistantId: "a1",
+      text: "hi",
+      context: ["team/ctx/spec"],
+    });
+    s = chatReducer(s, { type: "turn_failed", assistantId: "a1", error: ERR });
+    expect(retrySource(s, "a1")).toEqual({
+      text: "hi",
+      attachments: [],
+      context: ["team/ctx/spec"],
+    });
+  });
+
+  it("retrySource defaults context to [] when none was attached", () => {
+    let s = send(EMPTY_THREAD);
+    s = chatReducer(s, { type: "turn_failed", assistantId: "a1", error: ERR });
+    expect(retrySource(s, "a1")?.context).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Final cross-surface half of **PR-7** (context bundles). PR-7a (#224) shipped the runtime/proto/CLI/SDK; PR-7b wires the **Chains DSL**, the **console**, and the **full docs** on top so context bundles are reachable on every surface (GR14). Next RC item after Tools.

## What's in it
- **Chains DSL — chain-level `context()` attachment** (request-level, not a graph node — the server injects into the entry Motes regardless of position; the string grammar `a > b` has no slot for a non-step node — user-confirmed design):
  - Python: `chain(expr, tasks, context=[...])` · fluent `.context(*handles)` · `Chain.from_node(..., context=)`
  - TypeScript: `chain(expr, {tasks, context})` · `chainFrom(frag, {context})` · `.context(...)`
  - CLI: `kx chain run "…" --context <handle>` (repeatable) · `kx blueprint run --file` `context_bundles`
  - Pinned **byte-identical across Rust/Py/TS** by 5 new golden-corpus cases (`ctx_*`); the server canonicalizes (no DSL-side sort/dedup).
- **UI — full author + manage** `/context` section (upload files / add content refs · list · view via DigestChip · delete) + the **live chat attach-menu Context category** + attached-context chips, threaded `use-chat → use-invoke {context}`; the turn's bundles survive retry. Both-theme live console review done.
- **Docs** — `context.md` (Attach via a Chain · Manage in the Console) + `chains/{dsl-reference,python,typescript}` `context()` examples.
- **Regression test (test-only)** — `author_context_injection_is_identity_bearing_and_fail_closed`. PR-7a's identity-bearing test covered only `HostRecipeBinder` (Invoke), never `HostWorkflowAuthor` (SubmitWorkflow/chain). Closes that gap; production code is byte-identical to main.

## Verification
- Unit: Py 47 · TS 45 · kx-cli 130 · kx-gateway 145 · UI 593 (incl. new context hook + chat-thread tests)
- Tri-surface golden-corpus parity · Playwright `/context` e2e (author → list → attach-in-chat → delete vs a real serve)
- **Live**: `kx chain run --context` is identity-bearing end-to-end (distinct entry MoteId with vs without context)
- Lint: ruff/mypy · biome/tsc (SDK + UI) · cargo fmt/clippy/rustdoc — all clean

## Invariants (GR8)
- Canonical digest `7d22d4bd` **invariant** (`verify-quickstart`) · frozen trio untouched · `Cargo.lock` **unchanged** · **zero proto change** · additive-only · SN-8 throughout
- OSS/Cloud (GR19): authoring/viewing/deterministic injection = OSS; cross-party sharing/marketplace = Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)