### PR TITLE
PR-9a — tool-calling reliability hardening (BUG-27 dead-letter + D66 model-free + tool-fire CI guard)

### DIFF
--- a/crates/kx-coordinator/src/reschedule.rs
+++ b/crates/kx-coordinator/src/reschedule.rs
@@ -73,6 +73,15 @@ impl LeaseTracker {
             .is_some_and(|workers| workers.contains(&worker))
     }
 
+    /// Whether ANY worker currently holds an outstanding lease on `mote`. Used by
+    /// the PR-9a settle-pass dead-letter (BUG-27) to leave an in-flight observation
+    /// to its normal commit/fail lifecycle and dead-letter ONLY a wedged
+    /// (materialized-but-never-leased) one — avoiding a race with a worker about to
+    /// commit. O(1) via the reverse index.
+    pub(crate) fn is_leased(&self, mote: MoteId) -> bool {
+        self.holders.contains_key(&mote)
+    }
+
     /// Remove and return `worker`'s outstanding leases (used when reaping a dead
     /// worker), keeping the reverse index consistent.
     pub(crate) fn take_leases(&mut self, worker: WorkerId) -> BTreeSet<MoteId> {

--- a/crates/kx-coordinator/src/service.rs
+++ b/crates/kx-coordinator/src/service.rs
@@ -69,6 +69,32 @@ impl CoordinatorService {
         )
     }
 
+    /// As [`with_store`](Self::with_store), but injects the live [`ToolRegistry`]
+    /// the coordinator resolves a warrant's `tool_grants` against at the D66
+    /// admission gate (PR-9a). The MODEL-FREE serve arms use this so a tool that
+    /// was DIALED from an external MCP server, registered via `RegisterTool`, or
+    /// bundled (echo) is resolvable against the SAME durable registry the broker +
+    /// the `RegisterTool` admin write into — closing the D66-on-a-model-free-serve
+    /// gap (the inference-shaper arm already shares the live registry via
+    /// [`with_store_shaper_and_tools`]). The topology/materialization path stays
+    /// inert (no shaper roles), byte-identical to [`with_store`](Self::with_store).
+    ///
+    /// [`with_store_shaper_and_tools`]: CoordinatorService::with_store_shaper_and_tools
+    pub fn with_store_and_tools<J: Journal + Send + 'static>(
+        journal: J,
+        store: Arc<LocalFsContentStore>,
+        tool_registry: Arc<dyn ToolRegistry>,
+    ) -> Self {
+        Self::with_tool_registry_and_seams(
+            journal,
+            Arc::new(InMemoryWorkerRegistry::new()),
+            Some(store),
+            Arc::new(SystemClock),
+            Arc::new(OsRandomNonce),
+            tool_registry,
+        )
+    }
+
     /// Build a coordinator with **both** a caller-supplied worker registry and the
     /// shared content store (the `with_registry` + `with_store` combination). Used
     /// where a test needs a clock-injected registry (worker-death detection, P3.1)

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -651,19 +651,31 @@ fn lease_ready(
                 // observation without args. Every other Mote: `None`, unchanged.
                 let tool_args = if is_react_observation(mote, projection) {
                     match resolve_tool_args(mote, warrant, projection, store, tool_registry) {
-                        Some(args) => Some(args),
-                        None => return None,
+                        ArgResolution::Resolved(args) => Some(args),
+                        // PR-9a: lease selection is READ-ONLY (it must not append a
+                        // journal fact). A Transient fault skips this poll (retry). A
+                        // Permanent fault ALSO skips here — the settle pass
+                        // (`progress_tool_round`) is what appends the terminal
+                        // `DeadLettered` branch + retires the wedged observation.
+                        ArgResolution::Transient | ArgResolution::Permanent { .. } => {
+                            return None;
+                        }
                     }
                 } else if is_authored_tool(mote, projection) {
                     // PR-6b-2: a STANDALONE authored `tool()` node derives its args
                     // from its OWN identity-bearing `config_subset` (no parent, no
-                    // store I/O), validated fail-closed. Same args-or-skip rule as
-                    // the react observation: a transient registry fault skips the
-                    // lease this poll and a later poll retries (the worker never
-                    // sees an authored tool without coordinator-validated args).
+                    // store I/O), validated fail-closed.
                     match resolve_authored_tool_args(mote, tool_registry) {
-                        Some(args) => Some(args),
-                        None => return None,
+                        ArgResolution::Resolved(args) => Some(args),
+                        // PR-9a: the primary fault (schema mismatch) is refused at
+                        // AUTHORING (BUG-27 Path 1); a Permanent here is the rare
+                        // deregister-after-authoring residual — skip defensively (a
+                        // standalone node has no settle pass; the follow-up ticket
+                        // closes it with a coordinator-self dead-letter). Transient
+                        // never occurs (args are in the identity-bearing config).
+                        ArgResolution::Transient | ArgResolution::Permanent { .. } => {
+                            return None;
+                        }
                     }
                 } else {
                     None
@@ -692,6 +704,47 @@ fn is_react_observation(mote: &Mote, projection: &Projection) -> bool {
     projection.is_react_turn_mote(&mote.parents[0].parent_id)
 }
 
+/// PR-9a (BUG-27): the outcome of re-deriving a tool-firing Mote's args on the
+/// sole-writer thread. The pre-PR-9a resolvers returned `Option`, collapsing
+/// EVERY fault to `None` — an infinite fail-safe lease skip even for a fault that
+/// can never resolve (a silent wedge: a `tool()` run / ReAct chain stuck "in
+/// progress" forever with no error). Splitting into three lets a PERMANENT fault
+/// become a LOUD terminal dead-letter while a TRANSIENT fault keeps the fail-safe
+/// retry:
+///
+/// - [`Resolved`](ArgResolution::Resolved) — `(args_bytes, net_scope, fs_scope)`;
+///   lease / materialize exactly as before.
+/// - [`Transient`](ArgResolution::Transient) — a retryable I/O fault (store
+///   absent / store read error / a not-yet-folded parent): skip this poll, a
+///   later pass retries.
+/// - [`Permanent`](ArgResolution::Permanent) — a DETERMINISTIC fault that can
+///   never resolve: a schema reject, an unknown / DEREGISTERED tool, a declared
+///   version mismatch, a malformed contract, or a committed turn that no longer
+///   decodes to the granted call. The chain / run must dead-letter, never retry.
+///   `reason` is a human diagnostic for the trace log (the durable terminal is
+///   the existing `DeadLettered` fact — the branch carries no reason field).
+enum ArgResolution {
+    Resolved((Vec<u8>, kx_warrant::NetScope, kx_warrant::FsScope)),
+    Transient,
+    Permanent { reason: String },
+}
+
+#[cfg(test)]
+impl ArgResolution {
+    /// The resolved tuple, or `None` for a Transient/Permanent fault (test ergonomics).
+    fn into_resolved(self) -> Option<(Vec<u8>, kx_warrant::NetScope, kx_warrant::FsScope)> {
+        match self {
+            ArgResolution::Resolved(tuple) => Some(tuple),
+            _ => None,
+        }
+    }
+
+    /// Whether the resolution is a permanent (terminal, dead-letterable) fault.
+    fn is_permanent(&self) -> bool {
+        matches!(self, ArgResolution::Permanent { .. })
+    }
+}
+
 /// PR-2d-2: re-derive a ReAct observation's `(args_bytes, net_scope)` — a PURE
 /// function of committed facts, run on the sole-writer thread at every
 /// (re-)lease:
@@ -708,36 +761,97 @@ fn is_react_observation(mote: &Mote, projection: &Projection) -> bool {
 ///    the tool's DECLARED egress requirement as the request's `net_scope` (the
 ///    broker's `precheck` still enforces request ⊆ warrant at dispatch).
 ///
-/// `None` on ANY fault — the caller skips the lease this poll and a later poll
-/// retries (the settle already validated these args once, so a persistent
-/// `None` here is a store/registry fault, not a decode disagreement).
+/// Returns an [`ArgResolution`] (PR-9a): an I/O fault (missing store / store read
+/// error / a not-yet-folded parent) is [`Transient`](ArgResolution::Transient)
+/// (skip + retry — the settle validated these args once, so I/O is the only
+/// fail-safe-retryable cause); a DETERMINISTIC fault (the committed turn no longer
+/// decodes to a granted call, a tool/version/schema disagreement, or the granted
+/// tool was DEREGISTERED since the `Tool` branch froze) is
+/// [`Permanent`](ArgResolution::Permanent) — the settle pass dead-letters the chain
+/// instead of skipping forever (BUG-27).
 fn resolve_tool_args(
     mote: &Mote,
     warrant: &WarrantSpec,
     projection: &Projection,
     store: Option<&LocalFsContentStore>,
     tool_registry: &dyn ToolRegistry,
-) -> Option<(Vec<u8>, kx_warrant::NetScope, kx_warrant::FsScope)> {
-    let store = store?;
-    let parent = mote.parents.first()?.parent_id;
-    let result_ref = projection.result_ref_of(&parent)?;
-    let raw = store.get(&result_ref).ok()?;
-    let call =
-        kx_toolcall::parse_tool_call(raw.as_ref(), warrant, kx_toolcall::max_args_bytes(warrant))
-            .ok()
-            .flatten()?;
-    let declared_version = mote.def.tool_contract.get(&call.name)?;
+) -> ArgResolution {
+    // Transient I/O: a missing store, a parent not yet folded, or a store read
+    // error — a later pass retries (never a terminal decision).
+    let Some(store) = store else {
+        return ArgResolution::Transient;
+    };
+    let Some(parent) = mote.parents.first().map(|p| p.parent_id) else {
+        return ArgResolution::Transient;
+    };
+    let Some(result_ref) = projection.result_ref_of(&parent) else {
+        return ArgResolution::Transient;
+    };
+    let Ok(raw) = store.get(&result_ref) else {
+        return ArgResolution::Transient;
+    };
+    // The committed turn + the immutable chain warrant produced this `Tool` branch
+    // at freeze. If the SAME bytes no longer decode to a granted call, or the
+    // decoded call disagrees with the frozen contract, the facts are inconsistent —
+    // a permanent fault, never a transient skip.
+    let call = match kx_toolcall::parse_tool_call(
+        raw.as_ref(),
+        warrant,
+        kx_toolcall::max_args_bytes(warrant),
+    ) {
+        Ok(Some(call)) => call,
+        Ok(None) => {
+            return ArgResolution::Permanent {
+                reason: "committed turn output no longer decodes to a granted tool call"
+                    .to_string(),
+            };
+        }
+        Err(error) => {
+            return ArgResolution::Permanent {
+                reason: format!("tool-call decode rejected: {error:?}"),
+            };
+        }
+    };
+    let Some(declared_version) = mote.def.tool_contract.get(&call.name) else {
+        return ArgResolution::Permanent {
+            reason: format!(
+                "decoded tool {} is not in the observation contract",
+                call.name.0
+            ),
+        };
+    };
     if declared_version != &call.version {
-        return None;
+        return ArgResolution::Permanent {
+            reason: format!(
+                "tool {} version mismatch (contract {} vs call {})",
+                call.name.0, declared_version.0, call.version.0
+            ),
+        };
     }
-    let def = tool_registry.lookup(&call.name, &call.version)?;
+    // Validated + present at branch-freeze; absent now ⇒ DEREGISTERED (or moved to
+    // PendingHumanReview) — a permanent registry mutation, the BUG-27 wedge cause.
+    let Some(def) = tool_registry.lookup(&call.name, &call.version) else {
+        return ArgResolution::Permanent {
+            reason: format!(
+                "tool {}@{} is no longer registered (deregistered or pending review)",
+                call.name.0, call.version.0
+            ),
+        };
+    };
     if let Some(schema) = &def.input_schema {
-        kx_tool_registry::validate_args(schema, &call.args_bytes).ok()?;
+        if let Err(error) = kx_tool_registry::validate_args(schema, &call.args_bytes) {
+            return ArgResolution::Permanent {
+                reason: format!(
+                    "args do not match {}@{} inputSchema: {error}",
+                    call.name.0, call.version.0
+                ),
+            };
+        }
     }
     // PR-6a/D155 (fs-list): the resolved tool's declared fs requirement is taken
     // as the request's fs_scope (empty for echo ⇒ byte-identical). The broker's
     // precheck still enforces request.fs_scope ⊆ warrant.fs_scope at dispatch.
-    Some((
+    ArgResolution::Resolved((
         call.args_bytes,
         def.required_capability.net_scope_required.clone(),
         def.required_capability.fs_scope_required.clone(),
@@ -779,33 +893,57 @@ fn is_authored_tool(mote: &Mote, projection: &Projection) -> bool {
 /// 4. take the tool's DECLARED net/fs requirement as the request scopes (the
 ///    broker's `precheck` still enforces request ⊆ warrant at dispatch).
 ///
-/// `None` on ANY fault (multi/empty contract, missing config, unknown or pending
-/// tool, schema reject) — the lease is skipped this poll. Because the args live in
-/// the identity-bearing `config_subset`, recovery re-derives them byte-identically;
-/// a persistent `None` is a registry/admission fault (already gated at authoring),
-/// not a nondeterministic disagreement, so skip-and-retry is fail-closed (no
-/// effect ever fires without coordinator-validated args).
-fn resolve_authored_tool_args(
-    mote: &Mote,
-    tool_registry: &dyn ToolRegistry,
-) -> Option<(Vec<u8>, kx_warrant::NetScope, kx_warrant::FsScope)> {
+/// Returns an [`ArgResolution`] (PR-9a). Because the args live in the
+/// identity-bearing `config_subset` (no store I/O), EVERY fault here is
+/// DETERMINISTIC and therefore [`Permanent`](ArgResolution::Permanent) — there is
+/// no transient cause. The primary fault (args that do not match the tool's
+/// `inputSchema`) is refused at AUTHORING (the gateway's `tool_step_def`) so a
+/// wedge can never be authored into existence (BUG-27); a `Permanent` here is the
+/// rare DEREGISTER-after-authoring residual (the tool was removed between admit
+/// and lease) — the lease arm skips it (a standalone authored node has no settle
+/// pass to dead-letter it; closing that residual is a flagged follow-up).
+fn resolve_authored_tool_args(mote: &Mote, tool_registry: &dyn ToolRegistry) -> ArgResolution {
     // Exactly one (tool, version): the authored tool step binds a single tool.
     let mut contract = mote.def.tool_contract.iter();
-    let (name, version) = contract.next()?;
+    let Some((name, version)) = contract.next() else {
+        return ArgResolution::Permanent {
+            reason: "authored tool node has an empty tool_contract".to_string(),
+        };
+    };
     if contract.next().is_some() {
-        return None;
+        return ArgResolution::Permanent {
+            reason: "authored tool node binds more than one tool".to_string(),
+        };
     }
-    let args_bytes = mote
+    let Some(args) = mote
         .def
         .config_subset
-        .get(&ConfigKey(TOOL_ARGS_KEY.to_string()))?
-        .0
-        .clone();
-    let def = tool_registry.lookup(name, version)?;
+        .get(&ConfigKey(TOOL_ARGS_KEY.to_string()))
+    else {
+        return ArgResolution::Permanent {
+            reason: "authored tool node is missing its kx.tool.args config".to_string(),
+        };
+    };
+    let args_bytes = args.0.clone();
+    let Some(def) = tool_registry.lookup(name, version) else {
+        return ArgResolution::Permanent {
+            reason: format!(
+                "tool {}@{} is not registered (deregistered or pending review)",
+                name.0, version.0
+            ),
+        };
+    };
     if let Some(schema) = &def.input_schema {
-        kx_tool_registry::validate_args(schema, &args_bytes).ok()?;
+        if let Err(error) = kx_tool_registry::validate_args(schema, &args_bytes) {
+            return ArgResolution::Permanent {
+                reason: format!(
+                    "authored args do not match {}@{} inputSchema: {error}",
+                    name.0, version.0
+                ),
+            };
+        }
     }
-    Some((
+    ArgResolution::Resolved((
         args_bytes,
         def.required_capability.net_scope_required.clone(),
         def.required_capability.fs_scope_required.clone(),
@@ -2482,6 +2620,7 @@ fn settle_react_chain<J: Journal>(
                 tool_version: tool_version.clone(),
                 turn_mote_id: latest.turn_mote_id,
             },
+            tool_registry,
         ),
         // The in-flight turn: settle it once its Mote reaches a terminal state.
         ReactBranch::Pending => {
@@ -2614,6 +2753,7 @@ fn settle_react_chain<J: Journal>(
                     &rounds,
                     turn,
                     &round,
+                    tool_registry,
                 )
             } else {
                 // Answer / DeadLettered just froze — the chain is done.
@@ -2670,6 +2810,7 @@ fn progress_tool_round<J: Journal>(
     rounds: &[ReactRoundRecord],
     turn: u32,
     round: &ToolRound,
+    tool_registry: &dyn ToolRegistry,
 ) -> ReactChainStatus {
     let obs = crate::react_shape::build_react_tool(
         &ModelId(anchor.model_id.clone()),
@@ -2722,6 +2863,45 @@ fn progress_tool_round<J: Journal>(
     let Ok(warrant) = decode_warrant(warrant_bytes.as_ref()) else {
         return ReactChainStatus::Active;
     };
+    // PR-9a (BUG-27): an observation materialized but UNLEASEABLE — its args can no
+    // longer resolve because the granted tool was DEREGISTERED / re-schema'd since
+    // the `Tool` branch froze — would otherwise be skipped by the lease arm on
+    // every poll and re-materialized here FOREVER (a silent infinite-Active wedge).
+    // Re-derive on the sole-writer thread; on a PERMANENT fault, dead-letter the
+    // chain instead of wedging. Guarded by `!is_leased`: an observation a worker is
+    // already executing is left to its normal commit/fail lifecycle (no race with a
+    // worker about to commit — the broker capability is separate from this registry
+    // lookup); a TRANSIENT fault falls through to (re-)materialize + retry.
+    if !dispatch.tracker.is_leased(obs.id) {
+        if let ArgResolution::Permanent { reason } =
+            resolve_tool_args(&obs, &warrant, projection, Some(store), tool_registry)
+        {
+            tracing::warn!(
+                turn,
+                observation = ?obs.id,
+                tool = %round.tool_id,
+                %reason,
+                "react observation can never resolve its args — dead-lettering the chain (BUG-27)"
+            );
+            append_react_branch(
+                journal,
+                projection,
+                folded_through,
+                anchor,
+                round.turn_mote_id,
+                turn,
+                ReactBranch::DeadLettered,
+            );
+            // Retire the orphaned (never-leased) observation so it leaves the
+            // ready-set — mirror `dead_letter_failure`'s dispatch cleanup. The
+            // observation is never journaled, so a restart simply does not re-create
+            // it; the durable terminal is the `DeadLettered` chain branch.
+            dispatch.submitted.remove(&obs.id);
+            dispatch.defs.remove(&obs.id);
+            dispatch.tracker.resolve_committed(obs.id);
+            return ReactChainStatus::Settled;
+        }
+    }
     materialize_react_tool(
         projection,
         dispatch,
@@ -3373,7 +3553,9 @@ mod authored_tool_tests {
     fn happy_path_returns_validated_args() {
         let reg = registry_with(Some(schema()));
         let mote = tool_mote(&[("web-search", "1")], Some(br#"{"q":"hi"}"#));
-        let got = resolve_authored_tool_args(&mote, &reg).expect("valid args resolve");
+        let got = resolve_authored_tool_args(&mote, &reg)
+            .into_resolved()
+            .expect("valid args resolve");
         assert_eq!(got.0, br#"{"q":"hi"}"#.to_vec());
         assert_eq!(got.1, NetScope::None);
     }
@@ -3382,7 +3564,9 @@ mod authored_tool_tests {
     fn absent_tool_is_fail_closed() {
         let reg = InMemoryToolRegistry::new(); // empty — tool not registered
         let mote = tool_mote(&[("web-search", "1")], Some(br#"{"q":"hi"}"#));
-        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+        // PR-9a: an absent tool is a PERMANENT fault (deregister-after-authoring),
+        // not a transient skip — the loud terminal, never a silent wedge.
+        assert!(resolve_authored_tool_args(&mote, &reg).is_permanent());
     }
 
     #[test]
@@ -3392,14 +3576,14 @@ mod authored_tool_tests {
             &[("web-search", "1"), ("other", "1")],
             Some(br#"{"q":"hi"}"#),
         );
-        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+        assert!(resolve_authored_tool_args(&mote, &reg).is_permanent());
     }
 
     #[test]
     fn missing_config_args_is_refused() {
         let reg = registry_with(Some(schema()));
         let mote = tool_mote(&[("web-search", "1")], None);
-        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+        assert!(resolve_authored_tool_args(&mote, &reg).is_permanent());
     }
 
     #[test]
@@ -3407,14 +3591,18 @@ mod authored_tool_tests {
         let reg = registry_with(Some(schema()));
         // `q` required but absent, and a smuggled key under deny_unknown.
         let mote = tool_mote(&[("web-search", "1")], Some(br#"{"smuggled":1}"#));
-        assert!(resolve_authored_tool_args(&mote, &reg).is_none());
+        // PR-9a: a schema reject is PERMANENT — at the coordinator it is now a
+        // dead-letter signal (it is also refused earlier, at authoring).
+        assert!(resolve_authored_tool_args(&mote, &reg).is_permanent());
     }
 
     #[test]
     fn no_schema_tool_passes_args_through() {
         let reg = registry_with(None); // no input_schema ⇒ no client-side gate
         let mote = tool_mote(&[("web-search", "1")], Some(br#"{"anything":true}"#));
-        let got = resolve_authored_tool_args(&mote, &reg).expect("passes through");
+        let got = resolve_authored_tool_args(&mote, &reg)
+            .into_resolved()
+            .expect("passes through");
         assert_eq!(got.0, br#"{"anything":true}"#.to_vec());
     }
 }

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -41,6 +41,13 @@ const MAC: ProtoExecutorClass = ProtoExecutorClass::MacosSandbox;
 const INSTRUCTION: &str = "List the files, then answer.";
 const MODEL: &str = "react-v1";
 const TOOL_ENVELOPE: &[u8] = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{"q":"x"}}}"#;
+/// PR-9a (the BUG-28 regression pin): Gemma-4's NATIVE tool-call shape
+/// (`<|tool_call>call:NAME{ARGS}<tool_call|>`) — `mcp_echo` (underscore) exercises
+/// the parser's separator-only `_`→`-` name normalization. BUG-28 was a real-model
+/// tool loop that NEVER fired because no e2e drove this shape through the settle's
+/// decode→Tool-freeze→observation-fire→commit path; this const lets the fire-commits
+/// test assert that invariant for BOTH the JSON envelope and the native shape.
+const GEMMA_NATIVE: &[u8] = br#"<|tool_call>call:mcp_echo{"q":"x"}<tool_call|>"#;
 
 /// The client's SEED Mote: an ordinary ROND model Mote carrying the instruction.
 /// Its identity is advisory — the coordinator swaps in the run-salted turn 0.
@@ -108,47 +115,52 @@ fn warrant(granted: bool) -> WarrantSpec {
     }
 }
 
-/// The builtins PLUS `mcp-echo@1` (typed schema: one required `q: Str`) — the
-/// settle's validate-at-freeze (PR-2d-2) resolves the proposed tool against the
-/// registry BEFORE freezing a `Tool` fact, so the tool the tests propose must
-/// be registered (the harness `registry_with_mcp` mirror).
-fn registry_with_mcp() -> Arc<dyn kx_tool_registry::ToolRegistry> {
+/// The `mcp-echo@1` ToolDef (typed schema: one required `q: Str`) the live tests
+/// register — the settle's validate-at-freeze (PR-2d-2) resolves a proposed tool
+/// against the registry BEFORE freezing a `Tool` fact, so the tool the tests
+/// propose must be registered. Extracted so the PR-9a deregister-mid-chain test
+/// can register it durably (deregisterable) and remove it after the freeze.
+fn echo_tool_def() -> kx_tool_registry::ToolDef {
     use kx_tool_registry::{
-        IdempotencyClass, InMemoryToolRegistry, InputSchema, McpEndpointId, ParamSpec, ParamType,
-        ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+        IdempotencyClass, InputSchema, McpEndpointId, ParamSpec, ParamType, ToolDef, ToolKind,
     };
+    ToolDef {
+        tool_id: kx_mote::ToolName("mcp-echo".into()),
+        tool_version: kx_mote::ToolVersion("1".into()),
+        kind: ToolKind::Mcp {
+            endpoint: McpEndpointId("stdio://test".into()),
+            remote_name: "echo".into(),
+        },
+        required_capability: kx_warrant::ToolRequirement {
+            net_scope_required: NetScope::None,
+            fs_scope_required: FsScope::empty(),
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+        },
+        description: "deterministic echo (ReAct live tests).".into(),
+        idempotency_class: IdempotencyClass::Staged,
+        input_schema: Some(InputSchema {
+            params: vec![ParamSpec {
+                name: "q".into(),
+                ty: ParamType::Str { max_len: 256 },
+                required: true,
+            }],
+            deny_unknown: true,
+        }),
+    }
+}
+
+fn registry_with_mcp() -> Arc<dyn kx_tool_registry::ToolRegistry> {
+    use kx_tool_registry::{InMemoryToolRegistry, ToolProvenance, ToolRegistry};
     let mut reg = InMemoryToolRegistry::with_builtins();
     let _ = reg.register(
-        ToolDef {
-            tool_id: kx_mote::ToolName("mcp-echo".into()),
-            tool_version: kx_mote::ToolVersion("1".into()),
-            kind: ToolKind::Mcp {
-                endpoint: McpEndpointId("stdio://test".into()),
-                remote_name: "echo".into(),
-            },
-            required_capability: kx_warrant::ToolRequirement {
-                net_scope_required: NetScope::None,
-                fs_scope_required: FsScope::empty(),
-                syscall_profile_ref: ContentRef::from_bytes([0; 32]),
-                min_resource_ceiling: ResourceCeiling {
-                    cpu_milli: 0,
-                    mem_bytes: 0,
-                    wall_clock_ms: 0,
-                    fd_count: 0,
-                    disk_bytes: 0,
-                },
-            },
-            description: "deterministic echo (ReAct live tests).".into(),
-            idempotency_class: IdempotencyClass::Staged,
-            input_schema: Some(InputSchema {
-                params: vec![ParamSpec {
-                    name: "q".into(),
-                    ty: ParamType::Str { max_len: 256 },
-                    required: true,
-                }],
-                deny_unknown: true,
-            }),
-        },
+        echo_tool_def(),
         ToolProvenance::HumanAuthored {
             author: "test".into(),
         },
@@ -156,7 +168,10 @@ fn registry_with_mcp() -> Arc<dyn kx_tool_registry::ToolRegistry> {
     Arc::new(reg)
 }
 
-fn coordinator(dir: &TempDir) -> (CoordinatorService, Arc<LocalFsContentStore>) {
+fn coordinator_with(
+    dir: &TempDir,
+    tool_registry: Arc<dyn kx_tool_registry::ToolRegistry>,
+) -> (CoordinatorService, Arc<LocalFsContentStore>) {
     let store = Arc::new(LocalFsContentStore::open(dir.path().join("content")).unwrap());
     let journal = SqliteJournal::open(dir.path().join("journal.db")).unwrap();
     let registry: Arc<dyn WorkerRegistry> = Arc::new(InMemoryWorkerRegistry::new());
@@ -166,10 +181,14 @@ fn coordinator(dir: &TempDir) -> (CoordinatorService, Arc<LocalFsContentStore>) 
         store.clone(),
         Arc::new(kx_coordinator::SystemClock),
         Arc::new(kx_coordinator::OsRandomNonce),
-        registry_with_mcp(),
+        tool_registry,
         Arc::new(kx_warrant::InMemoryRoleRegistry::new()),
     );
     (svc, store)
+}
+
+fn coordinator(dir: &TempDir) -> (CoordinatorService, Arc<LocalFsContentStore>) {
+    coordinator_with(dir, registry_with_mcp())
 }
 
 /// Submit `mote` with `react_seed = true`; returns `(turn0_mote_id, instance_id)`.
@@ -526,6 +545,207 @@ async fn tool_branch_advances_the_chain_with_trajectory() {
         ))
         .unwrap();
     assert_eq!(served_obs.as_ref(), br#"{"echoed":{"q":"x"}}"#);
+}
+
+/// PR-9a (the BUG-28 regression pin, model-free + deterministic): the SAME
+/// fire-commits invariant as `tool_branch_advances_the_chain_with_trajectory`, but
+/// the turn-0 output is Gemma-4's NATIVE shape (`<|tool_call>call:mcp_echo{…}`).
+/// This drives the REAL coordinator settle — which calls `kx-toolcall` to decode
+/// the staged bytes — and asserts the native shape (a) freezes a `Tool` fact for
+/// `mcp-echo@1` (name separator-normalized), (b) the observation leases WITH the
+/// args decoded from the native shape, and (c) the observation commits ⇒ turn 1
+/// spawns. BUG-28 was exactly this path being silently dead: the loop only ever
+/// asserted an ANSWER settling, never a tool FIRING through the native arm.
+#[tokio::test]
+async fn tool_branch_fires_and_commits_via_gemma_native_shape() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true); // mcp-echo@1 GRANTED
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    // Stage the NATIVE shape (not the JSON envelope) — the settle must decode it.
+    commit_raw(&svc, &store, &turn0, &w, GEMMA_NATIVE, worker).await;
+
+    // (a) the settle froze a `Tool` fact for the separator-normalized `mcp-echo@1`.
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(
+        facts.len(),
+        2,
+        "anchor + the Tool settle (the native shape FIRED)"
+    );
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Tool { tool_id, tool_version },
+                ..
+            } if tool_id == "mcp-echo" && tool_version == "1"
+        ),
+        "the Gemma-native `<|tool_call>call:mcp_echo{{…}}` decodes + freezes a Tool fact"
+    );
+
+    // (b) the observation leases WITH the args decoded from the native shape.
+    let (obs, args) = lease_observation(&svc, worker, &turn0).await;
+    assert_eq!(
+        args,
+        br#"{"q":"x"}"#.to_vec(),
+        "args decode from the native shape"
+    );
+
+    // (c) the observation commits (the tool FIRED) ⇒ turn 1 spawns — the world
+    // mutating observation reaching Committed is the BUG-28 invariant.
+    commit_raw(&svc, &store, &obs, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(
+        facts.len(),
+        3,
+        "anchor + Tool + turn-1 Pending (the fire advanced the chain)"
+    );
+    assert!(matches!(
+        &facts[2],
+        JournalEntry::ReactRound {
+            turn: 1,
+            branch: ReactBranch::Pending,
+            ..
+        }
+    ));
+    assert_eq!(
+        svc.state_of(obs.id).await.unwrap(),
+        MoteState::Committed,
+        "the world-mutating observation COMMITTED — a tool genuinely fired"
+    );
+}
+
+/// PR-9a (the format-drift fail-closed invariant): an UNRECOGNIZED tool-shaped
+/// completion under a GRANTING warrant commits as an ANSWER and fires NOTHING —
+/// the SN-8 default. This is the durable invariant a format guard can hold: a
+/// future model's novel tool-call syntax that NO parser arm recognizes never
+/// mis-fires a tool; it degrades to an honest, committed answer (vs. the two
+/// RECOGNIZED shapes — the JSON envelope and the Gemma-native delimiter — which DO
+/// fire, proven by the two tests above).
+#[tokio::test]
+async fn unrecognized_tool_shape_under_grant_answers_and_fires_nothing() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true); // mcp-echo@1 GRANTED — yet an unparseable shape must NOT fire
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    // A made-up "tool call" in a format no parser arm recognizes — neither the JSON
+    // envelope (must start with `{`) nor the Gemma-native `<|tool_call>` delimiter.
+    commit_raw(
+        &svc,
+        &store,
+        &turn0,
+        &w,
+        b"TOOL: mcp-echo(q=x)  # please run this for me",
+        worker,
+    )
+    .await;
+
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(facts.len(), 2, "anchor + the Answer settle");
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Answer,
+                ..
+            }
+        ),
+        "an unrecognized tool-shape under a grant ANSWERS — it never mis-fires a tool"
+    );
+    assert!(
+        common::lease_work(&svc, worker, MAC, 16).await.is_empty(),
+        "Answer is terminal — no observation was materialized, no tool fired"
+    );
+}
+
+/// PR-9a (BUG-27 Path 2, end-to-end): when the tool a frozen `Tool` branch
+/// references is DEREGISTERED before its observation can lease, the chain
+/// DEAD-LETTERS (a loud terminal) instead of WEDGING forever — the pre-PR-9a
+/// behavior re-materialized an unleaseable observation on every settle pass with
+/// no terminal. Uses a `SqliteToolRegistry` (interior-mutable deregistration) so
+/// the tool can be removed AFTER the settle freezes the `Tool` fact.
+#[tokio::test]
+async fn deregistering_a_tool_mid_chain_dead_letters_instead_of_wedging() {
+    let dir = TempDir::new().unwrap();
+    let reg =
+        Arc::new(kx_tool_registry::SqliteToolRegistry::open(dir.path().join("tools.db")).unwrap());
+    // Register mcp-echo@1 DURABLY (deregisterable — not a non-removable built-in).
+    reg.register_durable(
+        echo_tool_def(),
+        kx_tool_registry::ToolProvenance::HumanAuthored {
+            author: "test".into(),
+        },
+        None,
+    )
+    .unwrap();
+    let (svc, store) = coordinator_with(&dir, reg.clone());
+    let w = warrant(true);
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    // Turn 0 proposes the tool ⇒ the settle freezes a Tool branch + materializes
+    // the observation (Pending, NOT yet leased) — the tool is still registered.
+    commit_raw(&svc, &store, &turn0, &w, TOOL_ENVELOPE, worker).await;
+    let facts = react_facts(&svc, &dir).await;
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Tool { .. },
+                ..
+            }
+        ),
+        "the tool proposal froze a Tool branch"
+    );
+
+    // DEREGISTER the tool: the frozen branch now references a tool that is gone, so
+    // the observation's args can never resolve (a PERMANENT fault).
+    assert!(
+        reg.deregister(
+            &kx_mote::ToolName("mcp-echo".into()),
+            &kx_mote::ToolVersion("1".into())
+        )
+        .unwrap(),
+        "the tool was deregistered"
+    );
+
+    // The next drain: the lease arm skips the unresolvable observation (Permanent),
+    // and the settle pass DEAD-LETTERS the chain (instead of re-materializing it
+    // forever). The observation is never leased.
+    let leased_after = common::lease_work(&svc, worker, MAC, 16).await;
+    assert!(
+        leased_after.is_empty(),
+        "the unresolvable observation is never leased"
+    );
+    let facts = react_facts(&svc, &dir).await;
+    assert!(
+        facts.iter().any(|f| matches!(
+            f,
+            JournalEntry::ReactRound {
+                branch: ReactBranch::DeadLettered,
+                ..
+            }
+        )),
+        "the chain DEAD-LETTERED instead of wedging (BUG-27)"
+    );
+    // Terminal: bounded, no runaway re-lease of the retired observation.
+    assert!(
+        common::lease_work(&svc, worker, MAC, 16).await.is_empty(),
+        "terminal — the retired observation never re-enters the ready set"
+    );
 }
 
 /// A dead-lettered turn settles the chain `DeadLettered` (terminal — no next turn).

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -1611,6 +1611,21 @@ impl HostWorkflowAuthor {
                 "TOOL step references unregistered tool {name}@{version}"
             ))
         })?;
+        // PR-9a (BUG-27 Path 1): validate the authored args against the tool's
+        // typed `inputSchema` AT AUTHORING and refuse with a clear invalid_argument
+        // BEFORE any Mote is created. The args are a DETERMINISTIC part of the
+        // step's identity-bearing `config_subset`, so a schema mismatch is a
+        // PERMANENT fault — without this gate it was admitted and then SKIPPED
+        // forever at the coordinator lease (a silent "in progress" wedge). Validate
+        // the EXACT bytes the coordinator's `resolve_authored_tool_args` will read:
+        // `s.params[TOOL_ARGS_KEY]` defaulting to the empty object `{}` (mirroring
+        // the empty-default insert in `step_def`).
+        if let Some(schema) = &tdef.input_schema {
+            let args: &[u8] = s.params.get(TOOL_ARGS_KEY).map_or(b"{}", Vec::as_slice);
+            kx_tool_registry::validate_args(schema, args).map_err(|e| {
+                BinderError::InvalidArgs(format!("tool args invalid for {name}@{version}: {e}"))
+            })?;
+        }
         // Server-assigned content-sentinel logic_ref over (index, id, ver), so
         // distinct tool steps get distinct ids (the client never supplies bytes).
         let mut buf = Vec::with_capacity(64);
@@ -3073,6 +3088,45 @@ mod tests {
         std::sync::Arc::new(reg)
     }
 
+    /// As [`tool_registry_with`], but the tool declares a typed `inputSchema` (one
+    /// required `q: Str`, `deny_unknown`) — for the PR-9a validate-at-authoring tests.
+    fn tool_registry_with_schema(tool_id: &str, version: &str) -> std::sync::Arc<dyn ToolRegistry> {
+        use kx_tool_registry::{
+            IdempotencyClass, InMemoryToolRegistry, InputSchema, ParamSpec, ParamType, ToolKind,
+            ToolProvenance,
+        };
+        let mut reg = InMemoryToolRegistry::new();
+        let def = ToolDef {
+            tool_id: ToolName(tool_id.into()),
+            tool_version: ToolVersion(version.into()),
+            kind: ToolKind::Builtin,
+            required_capability: kx_warrant::ToolRequirement {
+                net_scope_required: NetScope::None,
+                fs_scope_required: FsScope::empty(),
+                syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+                min_resource_ceiling: ResourceCeiling {
+                    cpu_milli: 0,
+                    mem_bytes: 0,
+                    wall_clock_ms: 0,
+                    fd_count: 0,
+                    disk_bytes: 0,
+                },
+            },
+            description: String::new(),
+            idempotency_class: IdempotencyClass::Staged,
+            input_schema: Some(InputSchema {
+                params: vec![ParamSpec {
+                    name: "q".into(),
+                    ty: ParamType::Str { max_len: 64 },
+                    required: true,
+                }],
+                deny_unknown: true,
+            }),
+        };
+        let _ = reg.register(def, ToolProvenance::HumanAuthored { author: "t".into() });
+        std::sync::Arc::new(reg)
+    }
+
     fn author_with_tools(
         dir: &std::path::Path,
         tools: std::sync::Arc<dyn ToolRegistry>,
@@ -3173,6 +3227,64 @@ mod tests {
                 .await,
             Err(BinderError::InvalidArgs(_))
         ));
+    }
+
+    /// PR-9a (BUG-27 Path 1): a `tool()` step whose authored args violate the
+    /// tool's typed `inputSchema` is refused AT AUTHORING with `InvalidArgs` naming
+    /// the tool@version — BEFORE any Mote is created. Without this gate the
+    /// malformed step was admitted and then SKIPPED forever at the coordinator
+    /// lease (a silent "in progress" wedge).
+    #[tokio::test]
+    async fn tool_step_schema_invalid_args_refused_at_authoring() {
+        let dir = tempfile::tempdir().unwrap();
+        let author = author_with_tools(dir.path(), tool_registry_with_schema("echo-tool", "1"));
+        // `q` is required (Str) but absent, plus a smuggled key under deny_unknown.
+        let steps = [tool_author_step("echo-tool", "1", br#"{"smuggled":1}"#)];
+        let result = author
+            .author(
+                "alice@acme",
+                1,
+                &steps,
+                &[],
+                AuthorExecutionMode::Frozen,
+                &[],
+            )
+            .await;
+        match result {
+            Err(BinderError::InvalidArgs(msg)) => {
+                assert!(
+                    msg.contains("echo-tool@1"),
+                    "the refusal names the tool@version: {msg}"
+                );
+                assert!(
+                    msg.contains("tool args invalid"),
+                    "the refusal explains the cause: {msg}"
+                );
+            }
+            Err(other) => panic!("expected InvalidArgs, got {other:?}"),
+            Ok(_) => panic!("expected a refusal, but authoring succeeded (the wedge gate is open)"),
+        }
+    }
+
+    /// PR-9a regression: VALID authored args still author cleanly under a schema
+    /// (Path 1 refuses ONLY the malformed case; the happy path is unchanged).
+    #[tokio::test]
+    async fn tool_step_schema_valid_args_author_cleanly() {
+        let dir = tempfile::tempdir().unwrap();
+        let author = author_with_tools(dir.path(), tool_registry_with_schema("echo-tool", "1"));
+        let steps = [tool_author_step("echo-tool", "1", br#"{"q":"hi"}"#)];
+        let bound = author
+            .author(
+                "alice@acme",
+                1,
+                &steps,
+                &[],
+                AuthorExecutionMode::Frozen,
+                &[],
+            )
+            .await
+            .expect("valid authored args author cleanly under a schema");
+        assert_eq!(bound.motes.len(), 1);
     }
 
     /// Without a wired tool registry (`from_shared`), `tool()` authoring is refused

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -475,10 +475,22 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
                 tool_registry.clone(),
             )
         }
-        None => CoordinatorService::with_store(writer, content.clone()),
+        // PR-9a (D66 model-free): a model-free serve (no shaper runtime) still
+        // accumulates DIALED + RegisterTool'd tools in the SAME `tool_registry`
+        // (both write paths are off the `inference` feature). Resolve the D66
+        // admission gate against the live registry — not the echo-less in-memory
+        // built-ins `with_store` would default to — so an authored/dialed `tool()`
+        // is admissible without a served model.
+        None => {
+            CoordinatorService::with_store_and_tools(writer, content.clone(), tool_registry.clone())
+        }
     };
+    // PR-9a (D66 model-free): the FFI-free serve shares the live tool registry too,
+    // so a dialed/RegisterTool'd `tool()` resolves at the coordinator D66 gate
+    // (parity with the inference-shaper arm; the topology path stays inert).
     #[cfg(not(feature = "inference"))]
-    let coordinator = CoordinatorService::with_store(writer, content.clone());
+    let coordinator =
+        CoordinatorService::with_store_and_tools(writer, content.clone(), tool_registry.clone());
     // W1a (T-OBS1): build the optional serve-path operator audit sink ONCE. Opened
     // in APPEND mode so the JSONL trail accumulates across restarts; a bad/unwritable
     // path fails `start` LOUDLY (never a silently-dropped audit). Kept as a shared

--- a/crates/kx-tool-registry/src/param_schema.rs
+++ b/crates/kx-tool-registry/src/param_schema.rs
@@ -118,6 +118,33 @@ pub enum SchemaError {
     },
 }
 
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaError::NotAnObject => write!(f, "args are not a JSON object"),
+            SchemaError::MissingRequired { name } => {
+                write!(f, "missing required parameter `{name}`")
+            }
+            SchemaError::UnknownParam { name } => {
+                write!(f, "unknown parameter `{name}` (deny_unknown)")
+            }
+            SchemaError::TypeMismatch { name, expected } => {
+                write!(f, "parameter `{name}` is not a {expected}")
+            }
+            SchemaError::OutOfRange { name } => write!(f, "parameter `{name}` is out of range"),
+            SchemaError::TooLong { name, max } => {
+                write!(f, "parameter `{name}` exceeds max length {max}")
+            }
+            SchemaError::NotAllowed { name } => {
+                write!(f, "parameter `{name}` is not an allowed value")
+            }
+            SchemaError::Malformed { diagnostic } => write!(f, "malformed args: {diagnostic}"),
+        }
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
 /// Validate a model's proposed tool-call `args_bytes` against `schema`,
 /// **fail-closed**. Total + panic-free over arbitrary bytes: the args are parsed
 /// as a SHALLOW one-level map of raw values (never a recursive dynamic `Value`,

--- a/justfile
+++ b/justfile
@@ -570,6 +570,23 @@ real-model-e2e: fetch-agent-model
     # one inference at a time = full CPU each.
     cargo test -p kx-gateway --features inference --test al1_serve -- --ignored --nocapture --test-threads=1
 
+# LOCAL / manual witness (NOT a CI job): drive a LIVE ReAct chain that FIRES a real
+# tool on a capable model. The DETERMINISTIC, CI-runnable regression guard for this
+# lives model-free in `crates/kx-coordinator/tests/react_live.rs` — it pins the
+# fire-commits invariant (a `world_mutating` observation COMMITS) for BOTH the JSON
+# envelope AND the Gemma-native `<|tool_call>` shape, closing the BUG-28 gap (no e2e
+# ever asserted a tool FIRES, only that an answer settled). This recipe is the
+# real-model witness on top: it serves `kx/recipes/react-auto` (`KX_SERVE_AUTOGRANT`)
+# with the bundled `mcp-echo`, so the live loop has a tool to call. Set
+# `KX_SERVE_MODEL_GGUF=<gemma.gguf>` to exercise the Gemma-native format (the BUG-28
+# scenario); the default Qwen3 stand-in fires via the JSON envelope. The full
+# cross-surface `world_mutating`-fire assertion is the deep-test campaign's "ReAct
+# tool-calling" matrix row.
+react-fire-local: fetch-agent-model
+    cargo build -p kx-mcp # the bundled kx-mcp-echo firing bin (or set KX_MCP_ECHO_PATH)
+    KX_SERVE_AUTOGRANT=1 cargo test -p kx-gateway --features inference \
+        --test react_auto_serve -- --ignored --nocapture --test-threads=1
+
 # LOCAL / manual gate (NOT a CI job): exercise the safe-wrapper inference pipeline
 # with GPU offload forced ON (`KX_N_GPU_LAYERS=-1`) so an Apple-Silicon dev sees
 # Metal actually used (look for `offloaded N/N layers to GPU` + `ggml_metal_*`),


### PR DESCRIPTION
## What & why

The first slice of **PR-9** (the agent-runner omnibus): make the tool-firing substrate **reliable** across CLI/SDK/UI before stacking new tool capability on it (GR8 risk-last). Closes the §2.230 tool-reliability tickets. **Off the canonical digest by construction** (tool/react motes are not in the PURE 8-mote demo).

## Changes

**BUG-27 — a permanent tool-arg fault no longer wedges silently; it dead-letters loudly**
- **Path 1 (authored `tool()` node):** validate the authored args against the tool's typed `inputSchema` **at authoring** (`kx-gateway` `provision::tool_step_def`) → `BinderError::InvalidArgs` naming `tool@version`, **before any Mote is created**. + a `SchemaError: Display` impl for a clean refusal message.
- **Path 2 (ReAct observation):** a new 3-way `ArgResolution {Resolved|Transient|Permanent}` replaces the fault-collapsing `Option` in `resolve_tool_args`/`resolve_authored_tool_args`. `progress_tool_round` dead-letters a `Permanent` fault (the granted tool deregistered/re-schema'd since the `Tool` branch froze) via the **existing** `append_react_branch(DeadLettered)` + retires the orphaned observation — guarded by `!is_leased` so an in-flight observation is left to its normal lifecycle (race-free). **No new journal kind.**

**D66 (model-free serve):** add `CoordinatorService::with_store_and_tools` and route both model-free coordinator arms to the live shared `SqliteToolRegistry`, so a dialed / `RegisterTool`'d `tool()` resolves at the D66 admission gate without a served model (parity with the inference-shaper arm).

**CI tool-fire / format-drift guard** (closes the gap that masked BUG-28 — no e2e ever asserted a tool *fires*, only that an answer settled): 3 deterministic, model-free tests in `kx-coordinator/tests/react_live.rs` — a `world_mutating` observation **commits** for **both** the JSON envelope **and** the Gemma-native `<|tool_call>` shape; an unrecognized tool-shape under a grant **answers and fires nothing** (fail-closed); deregister-mid-chain dead-letters. + a local `just react-fire-local` real-model witness. `kx_planner::decode` audited (JSON-only by design → follow-up ticket only).

## Invariants (verified locally)

- ✅ Canonical projection digest **`7d22d4bd` INVARIANT** (`a0_guard` + `audit_trail`)
- ✅ Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) **diff-EMPTY**
- ✅ `Cargo.lock` + proto **UNCHANGED**
- ✅ `fmt` / `clippy --workspace --all-targets -D warnings` / `doc -D warnings` / `deny` / `features-guard` green
- ✅ **2467 workspace tests pass, 0 failures**

## Deferred follow-ups (recorded)

1. **Model-agnostic FORMAT steering directive** — every clean placement risks the §2.170 cmp-proven `build_react_turn` golden / the assembler proptest / the `al1_serve` chat gate. It's a *steering nudge* (the two formats models actually emit are already parsed); its own dual-path batch.
2. **Bundled-echo def-seed lift** — echo can't *fire* model-free anyway; un-gating its seed touches the inference seeding path (own PR, GR1). The load-bearing D66 fix (dialed/RegisterTool'd) is done here.
3. **Standalone `tool()` deregister-after-authoring residual** — validate-at-authoring fixes the primary bug; a much narrower window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)