### PR TITLE
PR-9b-1 — `@tool` deterministic-agentic step (authoring contract)

### DIFF
--- a/bindings/python/src/kortecx/blueprints.py
+++ b/bindings/python/src/kortecx/blueprints.py
@@ -30,6 +30,13 @@ _KIND = {
 #: ``is_authored_tool`` discriminant + args source.
 TOOL_ARGS_KEY = "kx.tool.args"
 
+#: PR-9b (D161.1): the canonical ``params`` keys a deterministic-agentic MODEL
+#: step's bounded-loop budget rides under (decimal-string bytes ⇒ canonical-JSON
+#: ``u32``, the form the coordinator's ``react_seed_params`` reads). MUST equal the
+#: Rust ``kx_mote::REACT_MAX_TURNS_KEY`` / ``REACT_MAX_TOOL_CALLS_KEY`` + the TS keys.
+REACT_MAX_TURNS_KEY = "max_turns"
+REACT_MAX_TOOL_CALLS_KEY = "max_tool_calls"
+
 
 @dataclass
 class StepInput:
@@ -41,6 +48,12 @@ class StepInput:
     body_signature_id: Optional[str] = None  # EXEC only: 64-char hex of the body id
     tool_contract: Dict[str, str] = field(default_factory=dict)
     params: Dict[str, Union[bytes, str]] = field(default_factory=dict)
+    #: Agentic MODEL step only (PR-9b, D161.1): the bounded reason→tool→observe loop
+    #: budget. Injected into ``params`` (canonical-JSON ``u32`` keys) at lowering
+    #: when the step is a MODEL step with a non-empty ``tool_contract``; ignored
+    #: otherwise. Absent ⇒ the coordinator default (8 turns / 6 tool calls).
+    max_turns: Optional[int] = None
+    max_tool_calls: Optional[int] = None
 
 
 @dataclass

--- a/bindings/python/src/kortecx/chains.py
+++ b/bindings/python/src/kortecx/chains.py
@@ -28,10 +28,17 @@ Both produce a :class:`Chain`; :meth:`Chain.build` runs the one canonical loweri
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from dataclasses import dataclass, replace
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
-from .blueprints import TOOL_ARGS_KEY, BlueprintBuilder, EdgeInput, StepInput
+from .blueprints import (
+    REACT_MAX_TOOL_CALLS_KEY,
+    REACT_MAX_TURNS_KEY,
+    TOOL_ARGS_KEY,
+    BlueprintBuilder,
+    EdgeInput,
+    StepInput,
+)
 from .v1 import gateway_pb2 as _g
 
 
@@ -49,6 +56,11 @@ class UnknownHandleError(ChainError):
 
 class ChainCycleError(ChainError):
     """The lowered topology has a cycle / self-loop — error class ``cycle``."""
+
+
+class AgenticStepError(ChainError):
+    """`@` tool grants were tagged onto a non-model handle — class
+    ``agentic_non_model`` (the deterministic-agentic step requires a MODEL step)."""
 
 
 # --- Task nodes + the operator AST --------------------------------------------
@@ -130,10 +142,50 @@ def pure(**params: Union[bytes, str]) -> Task:
     return Task(StepInput(kind="pure", params=dict(params)))
 
 
-def model(model_id: str, prompt: str, **params: Union[bytes, str]) -> Task:
+def _grants_to_contract(
+    tools: "Optional[Union[Sequence[str], Mapping[str, str]]]",
+) -> Dict[str, str]:
+    """Normalize an agentic-step tool grant set to a ``{name: version}`` contract: a
+    sequence of names → version ``"1"`` (mirrors the ``@tool`` grammar default), a
+    mapping → verbatim ``{name: version}``. Order-preserving dedup."""
+    if tools is None:
+        return {}
+    if isinstance(tools, Mapping):
+        return {str(k): str(v) for k, v in tools.items()}
+    contract: Dict[str, str] = {}
+    for name in tools:
+        contract.setdefault(str(name), "1")
+    return contract
+
+
+def model(
+    model_id: str,
+    prompt: str,
+    *,
+    tools: "Optional[Union[Sequence[str], Mapping[str, str]]]" = None,
+    max_turns: Optional[int] = None,
+    max_tool_calls: Optional[int] = None,
+    **params: Union[bytes, str],
+) -> Task:
     """A MODEL step. ``model_id`` is the recipe enum the SERVER validates (SN-8);
-    ``prompt`` is the instruction; ``params`` are extra step params."""
-    return Task(StepInput(kind="model", model_id=model_id, prompt=prompt, params=dict(params)))
+    ``prompt`` is the instruction; ``params`` are extra step params.
+
+    PR-9b (D161.1): pass ``tools`` (a list of names → version ``"1"``, or a
+    ``{name: version}`` map) to make this a **deterministic-agentic step** — the
+    model runs a bounded reason→tool→observe loop over the granted tool SET (the
+    same step the string DSL authors as ``handle@tool@tool``). ``max_turns`` /
+    ``max_tool_calls`` bound the loop (default 8 / 6; ignored when no tools)."""
+    return Task(
+        StepInput(
+            kind="model",
+            model_id=model_id,
+            prompt=prompt,
+            tool_contract=_grants_to_contract(tools),
+            params=dict(params),
+            max_turns=max_turns,
+            max_tool_calls=max_tool_calls,
+        )
+    )
 
 
 def _canonical_args_json(args: Dict[str, object]) -> str:
@@ -279,7 +331,7 @@ class Chain:
                 "prompt": t.step.prompt,
                 "body_signature_id": t.step.body_signature_id,
                 "tool_contract": dict(t.step.tool_contract),
-                "params": {k: _as_str(v) for k, v in t.step.params.items()},
+                "params": _effective_params(t.step),
             }
             for t in nodes
         ]
@@ -296,7 +348,7 @@ class Chain:
         nodes, edges = self._lower()
         builder = BlueprintBuilder(self._seed)
         for t in nodes:
-            builder.add_step(t.step)
+            builder.add_step(replace(t.step, params=_effective_params(t.step)))
         for parent, child in edges:
             builder.add_edge(EdgeInput(parent=parent, child=child, edge="data"))
         builder.context_bundles(self._context)
@@ -306,6 +358,21 @@ class Chain:
 def _as_str(v: Union[bytes, str]) -> str:
     """Render a param value as the pre-encoding string the lowering compares."""
     return v if isinstance(v, str) else v.decode("utf-8")
+
+
+def _effective_params(step: StepInput) -> Dict[str, Union[bytes, str]]:
+    """The step's params (as the pre-encoding string form the lowering compares),
+    with the agentic-loop budget injected for a MODEL step carrying a non-empty
+    ``tool_contract`` (PR-9b — mirrors the Rust ``to_request`` + the coordinator's
+    canonical-JSON-``u32`` budget keys). Pure — never mutates the step. Absent budget
+    ⇒ the coordinator default."""
+    params: Dict[str, Union[bytes, str]] = {k: _as_str(v) for k, v in step.params.items()}
+    if step.kind == "model" and step.tool_contract:
+        if step.max_turns is not None:
+            params[REACT_MAX_TURNS_KEY] = str(step.max_turns)
+        if step.max_tool_calls is not None:
+            params[REACT_MAX_TOOL_CALLS_KEY] = str(step.max_tool_calls)
+    return params
 
 
 def _check_acyclic(node_count: int, edges: List[Tuple[int, int]]) -> None:
@@ -342,6 +409,10 @@ class _Parser:
         self._tasks = tasks
         self._toks = _tokenize(expr)
         self._pos = 0
+        # PR-9b: handle → the (copied, possibly grant-augmented) node used in the
+        # AST, so a reused handle is ONE node and `@`-grants accumulate on it
+        # without mutating the caller's `tasks` map.
+        self._nodes: Dict[str, Task] = {}
 
     def _peek(self) -> Optional[str]:
         return self._toks[self._pos] if self._pos < len(self._toks) else None
@@ -394,14 +465,55 @@ class _Parser:
                 raise ChainParseError("expected ']'")
             self._next()
             return inner
-        if tok in ("|", "&", ">", "]"):
+        # `@` at an atom start = a grant with no preceding handle (parse error).
+        if tok in ("|", "&", ">", "]", "@"):
             raise ChainParseError(f"unexpected token {tok!r}")
-        # a handle
+        # a handle, with an optional `@tool@tool` grant suffix (PR-9b)
         handle = self._next()
-        task = self._tasks.get(handle)
-        if task is None:
+        base = self._tasks.get(handle)
+        if base is None:
             raise UnknownHandleError(f"unknown task handle '{handle}'")
-        return task
+        tags = self._take_grants()
+        return self._node_for(handle, base, tags)
+
+    def _take_grants(self) -> List[str]:
+        """Consume a ``grants := ("@" handle)+`` suffix (PR-9b): order-preserving
+        deduped tool names. A stray ``@`` with no tool name is a parse error."""
+        tags: List[str] = []
+        while self._peek() == "@":
+            self._next()  # consume the `@`
+            nxt = self._peek()
+            if nxt is None or nxt in ("|", "&", ">", "[", "]", "@"):
+                raise ChainParseError("unexpected token after '@' (expected a tool name)")
+            tag = self._next()
+            if tag not in tags:
+                tags.append(tag)
+        return tags
+
+    def _node_for(self, handle: str, base: Task, tags: List[str]) -> Task:
+        """Return the AST node for ``handle`` (one COPY per handle so reuse is one
+        node + the caller's ``tasks`` are never mutated), merging any ``@``-grants
+        (version ``"1"``) into a MODEL step's tool_contract; a non-model grant is a
+        fail-closed authoring error."""
+        node = self._nodes.get(handle)
+        if node is None:
+            node = Task(
+                replace(
+                    base.step,
+                    tool_contract=dict(base.step.tool_contract),
+                    params=dict(base.step.params),
+                )
+            )
+            self._nodes[handle] = node
+        if tags:
+            if node.step.kind != "model":
+                raise AgenticStepError(
+                    f"`@` tool grants on a non-model step '{handle}' "
+                    f"(kind '{node.step.kind}'); `@tool` tags require a model step"
+                )
+            for tag in tags:
+                node.step.tool_contract.setdefault(tag, "1")
+        return node
 
 
 _HANDLE_START = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_"
@@ -419,7 +531,7 @@ def _tokenize(expr: str) -> List[str]:
         if ch.isspace():
             i += 1
             continue
-        if ch in "|&>[]":
+        if ch in "|&>[]@":
             toks.append(ch)
             i += 1
             continue

--- a/bindings/python/tests/test_chains.py
+++ b/bindings/python/tests/test_chains.py
@@ -16,6 +16,7 @@ from typing import Dict
 import pytest
 
 from kortecx.chains import (
+    AgenticStepError,
     Chain,
     ChainCycleError,
     ChainParseError,
@@ -36,6 +37,7 @@ _ERROR_CLASSES = {
     "parse": ChainParseError,
     "unknown_handle": UnknownHandleError,
     "cycle": ChainCycleError,
+    "agentic_non_model": AgenticStepError,
 }
 
 
@@ -49,7 +51,14 @@ def _task_from_spec(spec: Dict[str, object]) -> Task:
     kind = spec["kind"]
     params = spec.get("params") or {}
     if kind == "model":
-        return model(str(spec.get("model_id", "")), str(spec.get("prompt", "")), **params)
+        return model(
+            str(spec.get("model_id", "")),
+            str(spec.get("prompt", "")),
+            tools=spec.get("tool_contract"),
+            max_turns=spec.get("max_turns"),
+            max_tool_calls=spec.get("max_tool_calls"),
+            **params,
+        )
     if kind == "pure":
         return pure(**params)
     if kind == "tool":
@@ -236,3 +245,29 @@ def test_sugar_self_loop_raises_cycle() -> None:
     a = pure()
     with pytest.raises(ChainCycleError):
         Chain.from_node(a >> a).lowering()
+
+
+# --- PR-9b: the deterministic-agentic step (`@` grammar / `tools=`) ------------
+
+
+def test_sugar_agentic_step_matches_at_grammar() -> None:
+    """`model(tools=[...])` lowers IDENTICALLY to the string DSL `handle@tool`."""
+    sugar = Chain.from_node(model("kx-serve:qwen3-4b-q4_k_m", "go", tools=["echo"]))
+    string = chain("p@echo", {"p": model("kx-serve:qwen3-4b-q4_k_m", "go")})
+    assert sugar.lowering() == string.lowering()
+    step = sugar.lowering()["steps"][0]
+    assert step["kind"] == "model"
+    assert step["tool_contract"] == {"echo": "1"}
+
+
+def test_agentic_budget_lowers_to_params() -> None:
+    lowered = chain(
+        "p@echo",
+        {"p": model("kx-serve:qwen3-4b-q4_k_m", "go", max_turns=4, max_tool_calls=3)},
+    ).lowering()
+    assert lowered["steps"][0]["params"] == {"max_turns": "4", "max_tool_calls": "3"}
+
+
+def test_agentic_grants_on_non_model_raise() -> None:
+    with pytest.raises(AgenticStepError):
+        chain("p@echo", {"p": pure()}).lowering()

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -1,7 +1,10 @@
 /**
- * The Chains DSL — compose a vetted palette of task handles (`pure` / `model`
- * today) into a Tier-1 DAG via a string expression OR a combinator API, then
- * lower to the EXISTING {@link BlueprintBuilder} for `SubmitWorkflow`. Kept in
+ * The Chains DSL — compose a vetted palette of task handles (`pure` / `model` /
+ * `tool`) into a Tier-1 DAG via a string expression OR a combinator API, then
+ * lower to the EXISTING {@link BlueprintBuilder} for `SubmitWorkflow`. A MODEL
+ * handle may tag tools with the `@` grammar (`plan@web-search@fs-list`, PR-9b /
+ * D161.1) to become a **deterministic-agentic step** (a bounded reason→tool→observe
+ * loop over a server-vetted tool SET). Kept in
  * its own module (the Rust core's module-per-concern discipline); it builds
  * `StepInput`/`EdgeInput` lists and feeds the builder — it NEVER reassembles a
  * `SubmitWorkflowRequest` itself.
@@ -44,6 +47,23 @@ export class ChainCycleError extends Error {
 }
 
 /**
+ * Error class for `@` tool grants tagged onto a non-model handle (PR-9b — the
+ * `agentic_non_model` corpus class). The deterministic-agentic step requires a
+ * MODEL handle.
+ */
+export class ChainAgenticError extends Error {
+  constructor(
+    readonly handle: string,
+    readonly kind: string,
+  ) {
+    super(
+      `\`@\` tool grants on a non-model step '${handle}' (kind '${kind}'); \`@tool\` tags require a model step`,
+    );
+    this.name = "ChainAgenticError";
+  }
+}
+
+/**
  * A task node — a leaf fragment in the DSL. `pure` carries optional params; `model`
  * carries a model id + prompt (+ optional params). Identity is by OBJECT: reusing
  * the same `Task` instance reuses the same node (builds DAGs via fan-in/fan-out).
@@ -56,20 +76,76 @@ export class Task {
     readonly prompt: string,
     /** Pre-encoding lowering form — `params` values are strings (UTF-8-encoded at build). */
     readonly params: Readonly<Record<string, string>>,
-    /** TOOL only (PR-6b-2): the single `{ tool_id: tool_version }` the step fires. */
+    /**
+     * TOOL: the single `{ tool_id: tool_version }` the step fires (PR-6b-2). MODEL:
+     * the agentic grant SET (PR-9b, D161.1) — a non-empty contract makes a model
+     * step a deterministic-agentic step (a bounded reason→tool→observe loop).
+     */
     readonly toolContract: Readonly<Record<string, string>> = {},
+    /** Agentic MODEL step only (PR-9b): the bounded-loop budget (default 8 / 6). */
+    readonly maxTurns?: number,
+    readonly maxToolCalls?: number,
   ) {}
 
-  /** The {@link StepInput} this task lowers to (verbatim, the builder encodes params). */
+  /** The {@link StepInput} this task lowers to (the builder encodes params). */
   toStepInput(): StepInput {
     return {
       kind: this.kind,
       modelId: this.modelId,
       prompt: this.prompt,
       toolContract: { ...this.toolContract },
-      params: { ...this.params },
+      params: effectiveParams(this),
     };
   }
+}
+
+/**
+ * PR-9b (D161.1): the canonical `params` keys a deterministic-agentic MODEL step's
+ * bounded-loop budget rides under (decimal-string ⇒ canonical-JSON `u32`, the form
+ * the coordinator's `react_seed_params` reads). MUST equal the Rust
+ * `kx_mote::REACT_MAX_TURNS_KEY` / `REACT_MAX_TOOL_CALLS_KEY` + the Python keys.
+ */
+export const REACT_MAX_TURNS_KEY = "max_turns";
+export const REACT_MAX_TOOL_CALLS_KEY = "max_tool_calls";
+
+/**
+ * The step's params with the agentic-loop budget injected for a MODEL step carrying
+ * a non-empty `toolContract` (PR-9b — mirrors the Rust `to_request` + the Python
+ * `_effective_params`). Pure; absent budget ⇒ the coordinator default.
+ */
+function effectiveParams(t: Task): Record<string, string> {
+  const params: Record<string, string> = { ...t.params };
+  if (t.kind === "model" && Object.keys(t.toolContract).length > 0) {
+    if (t.maxTurns !== undefined) {
+      params[REACT_MAX_TURNS_KEY] = String(t.maxTurns);
+    }
+    if (t.maxToolCalls !== undefined) {
+      params[REACT_MAX_TOOL_CALLS_KEY] = String(t.maxToolCalls);
+    }
+  }
+  return params;
+}
+
+/**
+ * Normalize an agentic-step tool grant set to a `{ name: version }` contract: an
+ * array of names → version `"1"` (the `@tool` grammar default), a record → verbatim.
+ */
+function grantsToContract(
+  tools?: readonly string[] | Readonly<Record<string, string>>,
+): Record<string, string> {
+  if (tools === undefined) {
+    return {};
+  }
+  if (Array.isArray(tools)) {
+    const contract: Record<string, string> = {};
+    for (const name of tools) {
+      if (!(name in contract)) {
+        contract[name] = "1";
+      }
+    }
+    return contract;
+  }
+  return { ...(tools as Record<string, string>) };
 }
 
 /**
@@ -98,9 +174,33 @@ export const task = {
   pure(params: Readonly<Record<string, string>> = {}): Task {
     return new Task("pure", "", "", { ...params });
   },
-  /** A `model` step: the model id + prompt (+ optional string params). */
-  model(modelId: string, prompt: string, params: Readonly<Record<string, string>> = {}): Task {
-    return new Task("model", modelId, prompt, { ...params });
+  /**
+   * A `model` step: the model id + prompt (+ optional string params). PR-9b
+   * (D161.1): pass `opts.tools` (an array of names → version `"1"`, or a
+   * `{ name: version }` map) to make it a **deterministic-agentic step** — the model
+   * runs a bounded reason→tool→observe loop over the granted tool SET (the same step
+   * the string DSL authors as `handle@tool@tool`). `opts.maxTurns` / `maxToolCalls`
+   * bound the loop (default 8 / 6; ignored with no tools).
+   */
+  model(
+    modelId: string,
+    prompt: string,
+    params: Readonly<Record<string, string>> = {},
+    opts: {
+      tools?: readonly string[] | Readonly<Record<string, string>>;
+      maxTurns?: number;
+      maxToolCalls?: number;
+    } = {},
+  ): Task {
+    return new Task(
+      "model",
+      modelId,
+      prompt,
+      { ...params },
+      grantsToContract(opts.tools),
+      opts.maxTurns,
+      opts.maxToolCalls,
+    );
   },
   /**
    * A `tool` step (PR-6b-2): fire a single REGISTERED tool. `toolId` + `version`
@@ -265,7 +365,8 @@ type Token =
   | { t: "&"; pos: number }
   | { t: "|"; pos: number }
   | { t: "["; pos: number }
-  | { t: "]"; pos: number };
+  | { t: "]"; pos: number }
+  | { t: "@"; pos: number };
 
 const HANDLE_START = /[A-Za-z_]/;
 const HANDLE_REST = /[A-Za-z0-9_-]/;
@@ -283,7 +384,7 @@ function tokenize(expr: string): Token[] {
       i++;
       continue;
     }
-    if (c === ">" || c === "&" || c === "|" || c === "[" || c === "]") {
+    if (c === ">" || c === "&" || c === "|" || c === "[" || c === "]" || c === "@") {
       toks.push({ t: c, pos: i });
       i++;
       continue;
@@ -325,6 +426,9 @@ class Parser {
   readonly order: HandleRef[] = [];
   // Accumulated `>` edges, by handle-ref pair (deduped + sorted at lowering).
   readonly edges: Array<[HandleRef, HandleRef]> = [];
+  // PR-9b: per-handle `@`-tag grants (order-preserving, deduped), applied to the
+  // resolved MODEL Task at lowering.
+  readonly grants = new Map<string, string[]>();
 
   constructor(private readonly toks: Token[]) {}
 
@@ -405,6 +509,7 @@ class Parser {
     if (tok.t === "handle") {
       this.next();
       const r = this.ref(tok.v);
+      this.takeGrants(tok.v); // PR-9b: an optional `@tool@tool` suffix.
       return { entries: [r], exits: [r] };
     }
     if (tok.t === "[") {
@@ -420,6 +525,29 @@ class Parser {
       return inner; // brackets are precedence-only.
     }
     throw new ChainParseError(`expected a handle or '[' at position ${tok.pos}`);
+  }
+
+  // PR-9b: consume a `grants := ("@" handle)+` suffix on the just-parsed handle —
+  // order-preserving deduped tool names recorded for lowering. A stray `@` with no
+  // tool name is a parse error.
+  private takeGrants(handle: string): void {
+    const tags = this.grants.get(handle) ?? [];
+    while (this.peek()?.t === "@") {
+      this.next(); // consume the `@`
+      const nxt = this.peek();
+      if (nxt === undefined || nxt.t !== "handle") {
+        throw new ChainParseError(
+          `expected a tool name after '@' at position ${nxt?.pos ?? this.pos}`,
+        );
+      }
+      this.next(); // consume the tool-name handle
+      if (!tags.includes(nxt.v)) {
+        tags.push(nxt.v);
+      }
+    }
+    if (tags.length > 0) {
+      this.grants.set(handle, tags);
+    }
   }
 
   private mergePar(a: ParseFrag, b: ParseFrag): ParseFrag {
@@ -495,8 +623,34 @@ function taskToLoweredStep(t: Task): LoweredStep {
     prompt: t.prompt,
     body_signature_id: null,
     tool_contract: { ...t.toolContract },
-    params: { ...t.params },
+    params: effectiveParams(t),
   };
+}
+
+/**
+ * PR-9b: derive a granted MODEL Task — merge `@`-tag tool names (version `"1"`)
+ * into a copy of `base`'s tool_contract. A non-model base is a fail-closed
+ * authoring error (the deterministic-agentic step requires a MODEL step).
+ */
+function withGrants(base: Task, handle: string, tags: string[]): Task {
+  if (base.kind !== "model") {
+    throw new ChainAgenticError(handle, base.kind);
+  }
+  const contract: Record<string, string> = { ...base.toolContract };
+  for (const tag of tags) {
+    if (!(tag in contract)) {
+      contract[tag] = "1";
+    }
+  }
+  return new Task(
+    base.kind,
+    base.modelId,
+    base.prompt,
+    { ...base.params },
+    contract,
+    base.maxTurns,
+    base.maxToolCalls,
+  );
 }
 
 /** Kahn topological check — reject a cycle / self-loop (`a > a`, `a>b | b>a`). */
@@ -549,10 +703,13 @@ function lowerParse(
   const refToIndex = new Map<HandleRef, number>();
   const nodes: Task[] = [];
   for (const ref of parser.order) {
-    const t = tasks[ref.handle];
-    if (t === undefined) {
+    const base = tasks[ref.handle];
+    if (base === undefined) {
       throw new ChainUnknownHandleError(ref.handle);
     }
+    // PR-9b: apply any `@`-tag grants for this handle to a derived MODEL Task.
+    const tags = parser.grants.get(ref.handle);
+    const t = tags !== undefined && tags.length > 0 ? withGrants(base, ref.handle, tags) : base;
     refToIndex.set(ref, nodes.length);
     nodes.push(t);
   }

--- a/bindings/typescript/src/gen/kortecx/v1/gateway_pb.ts
+++ b/bindings/typescript/src/gen/kortecx/v1/gateway_pb.ts
@@ -2539,14 +2539,14 @@ export type WorkflowStep = Message<"kortecx.v1.WorkflowStep"> & {
   bodySignatureId: Uint8Array;
 
   /**
-   * tool_id -> tool_version; AUTHORITY still comes only from the party's grant
+   * TOOL: the single {tool_id: version} the step fires. MODEL (PR-9b/D161.1): a non-empty contract = the deterministic-agentic grant SET (`model@tool` in the chains DSL); authored cross-surface in PR-9b-1, the bounded reason→tool→observe LOOP executes in PR-9b-2 (until then the server fails closed). AUTHORITY still comes only from server vetting (client tool_grants stay refused — SN-8).
    *
    * @generated from field: map<string, string> tool_contract = 5;
    */
   toolContract: { [key: string]: string };
 
   /**
-   * free config_subset entries (size-capped server-side)
+   * free config_subset entries (size-capped server-side); an agentic MODEL step carries its bounded-loop budget under params["max_turns"]/["max_tool_calls"] (canonical-JSON u32)
    *
    * @generated from field: map<string, bytes> params = 6;
    */

--- a/bindings/typescript/test/chains.test.ts
+++ b/bindings/typescript/test/chains.test.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   Chain,
+  ChainAgenticError,
   ChainCycleError,
   ChainParseError,
   ChainUnknownHandleError,
@@ -42,9 +43,12 @@ interface CorpusTask {
   model_id?: string;
   prompt?: string;
   params?: Record<string, string>;
-  /** TOOL only: the single `{ tool_id: tool_version }` + the structured args. */
+  /** TOOL: the `{ tool_id: tool_version }`; MODEL (PR-9b): the agentic grant set. */
   tool_contract?: Record<string, string>;
   args?: Record<string, string | number | boolean>;
+  /** Agentic MODEL step only (PR-9b): the bounded-loop budget. */
+  max_turns?: number;
+  max_tool_calls?: number;
 }
 
 interface CorpusCase {
@@ -55,7 +59,7 @@ interface CorpusCase {
   /** PR-7b: chain-level context attachment (absent ⇒ []). */
   context_bundles?: string[];
   expect?: Partial<Lowered>;
-  error?: "parse" | "unknown_handle" | "cycle";
+  error?: "parse" | "unknown_handle" | "cycle" | "agentic_non_model";
 }
 
 /** Build the `Task` resolution map from a corpus case's `tasks` (the SDK's factory shape). */
@@ -63,7 +67,11 @@ function tasksFromCorpus(specs: Record<string, CorpusTask>): Record<string, Task
   const out: Record<string, Task> = {};
   for (const [handle, spec] of Object.entries(specs)) {
     if (spec.kind === "model") {
-      out[handle] = task.model(spec.model_id ?? "", spec.prompt ?? "", spec.params ?? {});
+      out[handle] = task.model(spec.model_id ?? "", spec.prompt ?? "", spec.params ?? {}, {
+        tools: spec.tool_contract,
+        maxTurns: spec.max_turns,
+        maxToolCalls: spec.max_tool_calls,
+      });
     } else if (spec.kind === "tool") {
       const [toolId, version] = Object.entries(spec.tool_contract ?? {})[0] ?? ["", ""];
       out[handle] = task.tool(toolId, version, spec.args ?? {});
@@ -95,7 +103,9 @@ describe("Chains DSL — golden corpus parity", () => {
             ? ChainParseError
             : c.error === "unknown_handle"
               ? ChainUnknownHandleError
-              : ChainCycleError;
+              : c.error === "agentic_non_model"
+                ? ChainAgenticError
+                : ChainCycleError;
         expect(run).toThrow(expectedClass);
       });
     } else {
@@ -171,6 +181,30 @@ describe("Chains DSL — combinator API parity with the string form", () => {
   it("the combinator path rejects a cycle (self-loop via reuse)", () => {
     const a = task.pure();
     expect(() => chainFrom(seq(a, a))).toThrow(ChainCycleError);
+  });
+
+  it("model({tools}) matches the string '@' grammar (PR-9b)", () => {
+    const viaString = chain("p@echo", {
+      tasks: { p: task.model("kx-serve:qwen3-4b-q4_k_m", "go") },
+    }).lower();
+    const viaCombinator = chainFrom(
+      task.model("kx-serve:qwen3-4b-q4_k_m", "go", {}, { tools: ["echo"] }),
+    ).lower();
+    expect(viaCombinator).toEqual(viaString);
+    expect(viaCombinator.steps[0]?.tool_contract).toEqual({ echo: "1" });
+  });
+
+  it("agentic budget lowers to params", () => {
+    const lowered = chain("p@echo", {
+      tasks: {
+        p: task.model("kx-serve:qwen3-4b-q4_k_m", "go", {}, { maxTurns: 4, maxToolCalls: 3 }),
+      },
+    }).lower();
+    expect(lowered.steps[0]?.params).toEqual({ max_turns: "4", max_tool_calls: "3" });
+  });
+
+  it("`@` grants on a non-model step throw ChainAgenticError", () => {
+    expect(() => chain("p@echo", { tasks: { p: task.pure() } })).toThrow(ChainAgenticError);
   });
 });
 

--- a/crates/kx-cli/src/verbs/blueprint.rs
+++ b/crates/kx-cli/src/verbs/blueprint.rs
@@ -19,9 +19,17 @@
 //! }
 //! ```
 //! `params` values are UTF-8 strings (their bytes land in the step's config).
-//! `kind` ∈ {`pure`, `model`} (`exec` is reserved); `edge` ∈ {`data`, `control`}.
-//! `context_bundles` (PR-7, optional) attaches named context bundles to the run —
-//! the server injects them into every entry Mote at bind (SN-8).
+//! `kind` ∈ {`pure`, `model`, `tool`} (`exec` is reserved); `edge` ∈ {`data`,
+//! `control`}. `context_bundles` (PR-7, optional) attaches named context bundles to
+//! the run — the server injects them into every entry Mote at bind (SN-8).
+//!
+//! A `tool` step (PR-6b-2) fires ONE registered tool: it carries `tool_contract`
+//! `{ tool_id: version }` + (optional) `args` (lowered to the canonical `kx.tool.args`
+//! blob). A `model` step carrying a non-empty `tool_contract` is a **deterministic-
+//! agentic step** (PR-9b / D161.1) — the model runs a bounded reason→tool→observe
+//! loop over the granted tool SET, bounded by optional `max_turns` / `max_tool_calls`.
+//! In every case the SERVER resolves the tool(s) in its live registry + builds the
+//! per-step warrant (the client never supplies a warrant or grants — SN-8).
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -63,6 +71,14 @@ pub(crate) struct DagSpec {
 /// identical by the golden corpus). Hardcoded to avoid a `kx-mote` dep on the CLI.
 const TOOL_ARGS_KEY: &str = "kx.tool.args";
 
+/// PR-9b (D161.1): the canonical config keys a deterministic-agentic MODEL step's
+/// bounded-loop budget rides under (decimal-string bytes ⇒ canonical-JSON `u32`,
+/// the form the coordinator's `react_seed_params` reads). MUST equal
+/// `kx_mote::REACT_MAX_TURNS_KEY` / `REACT_MAX_TOOL_CALLS_KEY` (pinned by the
+/// golden corpus). Hardcoded to avoid a `kx-mote` dep on the CLI.
+const REACT_MAX_TURNS_KEY: &str = "max_turns";
+const REACT_MAX_TOOL_CALLS_KEY: &str = "max_tool_calls";
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct StepSpec {
     /// `pure` | `model` | `exec` (reserved) | `tool` (PR-6b-2).
@@ -84,6 +100,15 @@ pub(crate) struct StepSpec {
     /// byte-identical to the Py/TS `tool()` factories. No floats (SN-8).
     #[serde(default)]
     pub(crate) args: BTreeMap<String, serde_json::Value>,
+    /// Agentic MODEL step only (PR-9b, D161.1): the bounded reason→tool→observe
+    /// loop budget. Lowered to canonical-JSON `u32` bytes under
+    /// [`REACT_MAX_TURNS_KEY`] / [`REACT_MAX_TOOL_CALLS_KEY`] in `params` when the
+    /// step is a MODEL step with a non-empty `tool_contract`; ignored otherwise.
+    /// Absent ⇒ the coordinator default (8 turns / 6 tool calls).
+    #[serde(default)]
+    pub(crate) max_turns: Option<u32>,
+    #[serde(default)]
+    pub(crate) max_tool_calls: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -196,6 +221,21 @@ pub(crate) fn to_request(spec: DagSpec) -> Result<proto::SubmitWorkflowRequest, 
             let blob = serde_json::to_string(&s.args)
                 .map_err(|e| CliError::Usage(format!("tool args: {e}")))?;
             params.insert(TOOL_ARGS_KEY.to_string(), blob.into_bytes());
+        }
+        // PR-9b (D161.1): an agentic MODEL step (MODEL + a non-empty tool_contract)
+        // lowers its bounded-loop budget to canonical-JSON `u32` bytes under the
+        // react budget keys (the form `react_seed_params` reads). Absent ⇒ the
+        // coordinator default. The decimal string of a `u32` IS canonical JSON.
+        if kind == proto::WorkflowStepKind::Model && !s.tool_contract.is_empty() {
+            if let Some(n) = s.max_turns {
+                params.insert(REACT_MAX_TURNS_KEY.to_string(), n.to_string().into_bytes());
+            }
+            if let Some(n) = s.max_tool_calls {
+                params.insert(
+                    REACT_MAX_TOOL_CALLS_KEY.to_string(),
+                    n.to_string().into_bytes(),
+                );
+            }
         }
         steps.push(proto::WorkflowStep {
             kind: kind as i32,

--- a/crates/kx-cli/src/verbs/chain.rs
+++ b/crates/kx-cli/src/verbs/chain.rs
@@ -23,6 +23,14 @@
 //! `kx.tool.args` blob). `--context <handle>` (PR-7, repeatable) attaches named
 //! context bundles to the run — the server injects them into every entry Mote at
 //! bind (SN-8); verbatim order, empty ⇒ byte-identical to pre-PR-7.
+//!
+//! PR-9b (D161.1) — the `@` grammar: a MODEL handle may tag tools to become a
+//! **deterministic-agentic step** — `plan@web-search@fs-list > review`. The `@tool`
+//! tags (order-preserving, deduped) merge into the model step's `tool_contract`
+//! (version `"1"`); its bounded reason→tool→observe budget (`max_turns` /
+//! `max_tool_calls`) rides the task spec. The SERVER vets every tagged tool against
+//! its live registry + builds the per-step warrant (SN-8). `@` on a non-model handle
+//! is a fail-closed authoring error.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
@@ -147,6 +155,12 @@ struct Lowered {
     nodes: Vec<String>,
     /// Edges as `(parent_index, child_index)`, deduped + sorted ascending.
     edges: Vec<(u32, u32)>,
+    /// PR-9b (D161.1): per-node `@`-tag tool grants (`node index → ordered, deduped
+    /// tool names`). A `model@tool1@tool2` handle records `[tool1, tool2]` on its
+    /// node; the lowering merges them into the MODEL step's `tool_contract` (version
+    /// `"1"`) so it becomes a deterministic-agentic step (a bounded reason→tool→observe
+    /// loop). Empty for every non-tagged node ⇒ byte-identical to pre-PR-9b.
+    grants: BTreeMap<u32, Vec<String>>,
 }
 
 /// A sub-expression's interface to its neighbours: the node indices a `>` to its
@@ -172,6 +186,9 @@ struct Parser<'a> {
     index_of: HashMap<String, u32>,
     /// The accumulated `(parent, child)` edge set (deduped at insert).
     edges: Vec<(u32, u32)>,
+    /// PR-9b: per-node `@`-tag tool grants, accumulated (order-preserving, deduped)
+    /// across every appearance of a handle. `node index → tool names`.
+    grants: BTreeMap<u32, Vec<String>>,
 }
 
 impl<'a> Parser<'a> {
@@ -182,6 +199,7 @@ impl<'a> Parser<'a> {
             nodes: Vec::new(),
             index_of: HashMap::new(),
             edges: Vec::new(),
+            grants: BTreeMap::new(),
         }
     }
 
@@ -266,7 +284,11 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
-    /// `atom := handle | "[" chain "]"`.
+    /// `atom := handle grants? | "[" chain "]"` — a handle atom may carry a
+    /// `grants := ("@" handle)+` suffix (PR-9b, D161.1): tool names tagged onto a
+    /// MODEL handle to make it a deterministic-agentic step. `@` binds tighter than
+    /// every operator (it is part of the atom). Tags on a group `[…]@t` are a parse
+    /// error (the `@` is left unconsumed ⇒ "unexpected trailing input").
     fn parse_atom(&mut self) -> Result<Fragment, CliError> {
         match self.peek() {
             Some(b'[') => {
@@ -289,6 +311,16 @@ impl<'a> Parser<'a> {
             Some(c) if is_handle_start(c) => {
                 let handle = self.take_handle();
                 let i = self.intern(&handle);
+                // PR-9b: an optional `@tool@tool` grant suffix on this handle.
+                let tags = self.take_grants()?;
+                if !tags.is_empty() {
+                    let entry = self.grants.entry(i).or_default();
+                    for t in tags {
+                        if !entry.contains(&t) {
+                            entry.push(t);
+                        }
+                    }
+                }
                 Ok(Fragment {
                     entries: vec![i],
                     exits: vec![i],
@@ -316,6 +348,39 @@ impl<'a> Parser<'a> {
         }
         // The slice is ASCII handle bytes by construction → valid UTF-8.
         String::from_utf8_lossy(&self.src[start..self.pos]).into_owned()
+    }
+
+    /// Consume a `grants := ("@" handle)+` suffix (PR-9b): zero-or-more `@tool`
+    /// tags, each a tool NAME from the handle charset (the version defaults to
+    /// `"1"`). Order-preserving dedup (`p@x@x` == `p@x`). A stray `@` with no tool
+    /// name (`p@`, `p@@x`) is a parse error ("unexpected …" ⇒ the parse class).
+    fn take_grants(&mut self) -> Result<Vec<String>, CliError> {
+        let mut tags: Vec<String> = Vec::new();
+        while self.peek() == Some(b'@') {
+            self.pos += 1; // consume the `@`
+            match self.peek() {
+                Some(c) if is_handle_start(c) => {
+                    let tag = self.take_handle();
+                    if !tags.contains(&tag) {
+                        tags.push(tag);
+                    }
+                }
+                Some(c) => {
+                    return Err(CliError::Usage(format!(
+                        "unexpected character {:?} after `@` in chain expression \
+                         (expected a tool name)",
+                        c as char
+                    )));
+                }
+                None => {
+                    return Err(CliError::Usage(
+                        "unexpected end of chain expression (expected a tool name after `@`)"
+                            .into(),
+                    ));
+                }
+            }
+        }
+        Ok(tags)
     }
 }
 
@@ -368,8 +433,13 @@ fn lower(dsl: &str) -> Result<Lowered, CliError> {
     let mut edges = parser.edges;
     edges.sort_unstable();
     let nodes = parser.nodes;
+    let grants = parser.grants;
     detect_cycle(nodes.len(), &edges)?;
-    Ok(Lowered { nodes, edges })
+    Ok(Lowered {
+        nodes,
+        edges,
+        grants,
+    })
 }
 
 /// Kahn's algorithm — a cycle (including a `a > a` self-loop, which yields the edge
@@ -413,10 +483,27 @@ fn build_request(
     context_bundles: Vec<String>,
 ) -> Result<kx_proto::proto::SubmitWorkflowRequest, CliError> {
     let mut steps = Vec::with_capacity(lowered.nodes.len());
-    for handle in &lowered.nodes {
-        let step = tasks.remove(handle).ok_or_else(|| {
+    for (idx, handle) in lowered.nodes.iter().enumerate() {
+        let mut step = tasks.remove(handle).ok_or_else(|| {
             CliError::Usage(format!("unknown task handle {handle:?} (not in --tasks)"))
         })?;
+        // PR-9b (D161.1): merge this node's `@`-tag grants into a MODEL step's
+        // tool_contract (version "1"), turning it into a deterministic-agentic step.
+        // `@` tags on a non-model step are a fail-closed authoring error.
+        if let Some(tags) = lowered.grants.get(&u32::try_from(idx).unwrap_or(u32::MAX)) {
+            if step.kind != "model" {
+                return Err(CliError::Usage(format!(
+                    "`@` tool grants on a non-model step {handle:?} (kind {:?}); \
+                     `@tool` tags require a model step (the deterministic-agentic step)",
+                    step.kind
+                )));
+            }
+            for tag in tags {
+                step.tool_contract
+                    .entry(tag.clone())
+                    .or_insert_with(|| "1".to_string());
+            }
+        }
         steps.push(step);
     }
     let edges = lowered
@@ -759,6 +846,11 @@ mod tests {
                     "[{}] expected an unknown_handle error, got: {err}",
                     case.name
                 ),
+                "agentic_non_model" => assert!(
+                    err.contains("non-model") || err.contains("`@` tool grants"),
+                    "[{}] expected an agentic_non_model error, got: {err}",
+                    case.name
+                ),
                 other => panic!("[{}] unknown error class {other:?}", case.name),
             }
         }
@@ -797,5 +889,63 @@ mod tests {
         assert!(lower("a > []").is_err());
         assert!(lower("[a").is_err(), "unbalanced bracket");
         assert!(lower("a]").is_err(), "trailing close bracket");
+    }
+
+    // ---- PR-9b: the `@` deterministic-agentic-step grammar ----
+
+    #[test]
+    fn at_grammar_records_ordered_deduped_grants_on_the_node() {
+        let low = lower("p@web-search@fs-list > r").unwrap();
+        assert_eq!(low.nodes, vec!["p", "r"]);
+        assert_eq!(low.edges, vec![(0, 1)]);
+        // order-preserving, attached to node 0 (`p`).
+        assert_eq!(
+            low.grants.get(&0).cloned(),
+            Some(vec!["web-search".to_string(), "fs-list".to_string()])
+        );
+        assert!(!low.grants.contains_key(&1), "`r` carries no grants");
+        // dedup: `p@x@x` == `p@x`.
+        assert_eq!(
+            lower("p@x@x").unwrap().grants.get(&0).cloned(),
+            Some(vec!["x".to_string()])
+        );
+    }
+
+    #[test]
+    fn at_grammar_lowers_to_a_model_tool_contract() {
+        let mut tasks = BTreeMap::new();
+        tasks.insert(
+            "p".to_string(),
+            serde_json::from_value::<StepSpec>(serde_json::json!({
+                "kind": "model", "model_id": "m", "prompt": "go"
+            }))
+            .unwrap(),
+        );
+        let req = build_request(lower("p@echo").unwrap(), tasks, 0, vec![]).unwrap();
+        assert_eq!(req.steps.len(), 1);
+        assert_eq!(req.steps[0].kind, proto::WorkflowStepKind::Model as i32);
+        assert_eq!(req.steps[0].tool_contract.get("echo").unwrap(), "1");
+    }
+
+    #[test]
+    fn at_grammar_on_a_non_model_step_is_an_error() {
+        let mut tasks = BTreeMap::new();
+        tasks.insert(
+            "p".to_string(),
+            serde_json::from_value::<StepSpec>(serde_json::json!({ "kind": "pure" })).unwrap(),
+        );
+        let err = build_request(lower("p@echo").unwrap(), tasks, 0, vec![])
+            .expect_err("grants on a pure step must fail")
+            .to_string()
+            .to_lowercase();
+        assert!(err.contains("non-model"), "got: {err}");
+    }
+
+    #[test]
+    fn dangling_and_misplaced_at_are_parse_errors() {
+        assert!(lower("p@").is_err(), "trailing @");
+        assert!(lower("p@@x").is_err(), "empty tag");
+        assert!(lower("@echo").is_err(), "@ with no preceding handle");
+        assert!(lower("a > @echo").is_err(), "@ where a handle is expected");
     }
 }

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -1516,6 +1516,26 @@ impl HostWorkflowAuthor {
                         served.0
                     )));
                 }
+                // PR-9b (D161.1): a MODEL step carrying a non-empty tool_contract is a
+                // DETERMINISTIC-AGENTIC step (`model@tool` in the chains DSL). The
+                // AUTHORING contract — the `@` grammar, the SDK `tools=` factory, the
+                // golden corpus, the server-vetted per-step union warrant — ships in
+                // PR-9b-1, but the bounded reason→tool→observe LOOP execution (a new
+                // launch/park/terminal-commit hook in the sole-writer coordinator + a
+                // journal v8→v9 bump + the compound react-chain key + recovery) lands
+                // in PR-9b-2. Until then the server FAILS CLOSED rather than silently
+                // run the step greedy + drop the grant set (GR15): a clear refusal at
+                // authoring, before any Mote is created.
+                if !s.tool_contract.is_empty() {
+                    return Err(BinderError::InvalidArgs(
+                        "the deterministic-agentic step (a MODEL step with `@tool` grants) is \
+                         authored across the chains DSL/SDK/CLI/UI, but its bounded \
+                         reason→tool→observe loop is not yet runnable on this server (lands in \
+                         PR-9b-2); use a standalone tool() step or the `react`/`react-auto` \
+                         recipe for tool-calling today"
+                            .into(),
+                    ));
+                }
                 // P1.1: the step warrant is `base` — and `blueprint_base` now carries
                 // the SERVED model in its `model_route` (see `seed`), so the dispatch
                 // id (served) == the warrant route id (served) and the dispatcher's

--- a/crates/kx-proto/proto/kortecx/v1/gateway.proto
+++ b/crates/kx-proto/proto/kortecx/v1/gateway.proto
@@ -756,8 +756,8 @@ message WorkflowStep {
   string model_id          = 2;          // required for MODEL (must equal the served model); ignored for PURE/EXEC
   string prompt            = 3;          // MODEL prompt (bound into config_subset[PROMPT_KEY]); empty otherwise
   bytes  body_signature_id = 4;          // 32B — EXEC only: the REGISTERED body's content/signature id
-  map<string, string> tool_contract = 5; // tool_id -> tool_version; AUTHORITY still comes only from the party's grant
-  map<string, bytes>  params        = 6; // free config_subset entries (size-capped server-side)
+  map<string, string> tool_contract = 5; // TOOL: the single {tool_id: version} the step fires. MODEL (PR-9b/D161.1): a non-empty contract = the deterministic-agentic grant SET (`model@tool` in the chains DSL); authored cross-surface in PR-9b-1, the bounded reason→tool→observe LOOP executes in PR-9b-2 (until then the server fails closed). AUTHORITY still comes only from server vetting (client tool_grants stay refused — SN-8).
+  map<string, bytes>  params        = 6; // free config_subset entries (size-capped server-side); an agentic MODEL step carries its bounded-loop budget under params["max_turns"]/["max_tool_calls"] (canonical-JSON u32)
 }
 
 // One authored edge between two steps (by their insertion index in steps[]).

--- a/docs/site/docs/blueprint-builder.md
+++ b/docs/site/docs/blueprint-builder.md
@@ -19,15 +19,20 @@ The builder sends only the **topology + params**. The server assigns each step's
 logic from its kind, derives all identity, and builds **every per-step warrant from
 your grants** — the client cannot inject an executable body or a warrant. A tampered
 client DAG only changes what is *proposed*, never the authority it is granted. The
-palette is therefore deliberately small: **PURE** (a deterministic transform) and
-**MODEL** (an agent step routed to the served model). Tool-using ReAct nodes arrive
-with the Tools batch (they need registered tools to call).
+palette is therefore deliberately small: **PURE** (a deterministic transform),
+**MODEL** (an agent step routed to the served model), and **TOOL** (fire one
+registered tool — the server resolves it + builds the per-step warrant). A MODEL
+step can also be tagged with tools in the Chains DSL (`model@tool`) to become a
+[deterministic-agentic step](./chains/dsl-reference.md#the-deterministic-agentic-step--modeltool-pr-9b)
+— authorable across the SDK/CLI today; its bounded-loop execution + a visual editor
+land in PR-9b-2.
 
 ## The visual builder
 
 Open **Blueprints → New blueprint** (`/blueprints/new`):
 
-- **+ Agent** adds a MODEL step; **+ Pure step** adds a PURE step.
+- **+ Agent** adds a MODEL step; **+ Pure step** adds a PURE step; **+ Tool** adds a
+  TOOL step (pick a registered tool + its JSON args).
 - **Drag** to arrange; **drag handle-to-handle** to connect two steps with a data
   edge (the parent's result flows into the child).
 - **Click a node** to open its config drawer — name, model, prompt (Monaco), the

--- a/docs/site/docs/chains/dsl-reference.md
+++ b/docs/site/docs/chains/dsl-reference.md
@@ -25,7 +25,8 @@ chain    := orexpr
 orexpr   := andexpr ( "|" andexpr )*     # parallel — LOOSEST
 andexpr  := seqexpr ( "&" seqexpr )*     # parallel — tighter
 seqexpr  := atom    ( ">" atom    )*     # sequential — tightest binary
-atom     := handle | "[" chain "]"
+atom     := handle grants? | "[" chain "]"
+grants   := ( "@" handle )+              # tool tags on a MODEL handle (PR-9b)
 handle   := [A-Za-z_][A-Za-z0-9_-]*
 ```
 
@@ -37,6 +38,7 @@ Tightest → loosest:
 
 | Operator | Meaning | Precedence | Associativity |
 |---|---|---|---|
+| `@` | tag a tool onto a MODEL handle (PR-9b) | tightest (handle suffix) | — |
 | `[ ]` | grouping (overrides precedence) | tightest | — |
 | `>` | sequential (add data edges) | tighter | left |
 | `&` | parallel merge | looser | left |
@@ -70,6 +72,41 @@ So:
 - `[a & b] > c` **fans in** — `a→c`, `b→c`.
 - `[a & b] > [c & d]` is the full **bipartite join**.
 
+## The deterministic-agentic step — `model@tool` (PR-9b)
+
+A **MODEL** handle can tag tools with `@` to become a **deterministic-agentic
+step** — a frozen-DAG model step that runs a *bounded* reason→tool→observe loop
+over a fixed, author-declared, server-vetted tool-grant SET:
+
+```
+plan@web-search@fs-list > review
+```
+
+Here `plan` is one node (one DAG vertex) granted `{web-search, fs-list}`; `review`
+is a downstream pure/model step. This is the **authored/deterministic** lane — the
+DAG topology and the tool set are fixed at authoring (distinct from the *steered,
+non-deterministic* `react` recipe, where the model picks tools dynamically).
+
+- `@` binds **tighter than every operator** (it is a handle suffix); whitespace
+  around it is insignificant (`p @ echo` == `p@echo`).
+- Each `@tag` is a tool **name** (version defaults to `"1"`); tags are
+  **order-preserving and deduped** (`p@x@x` == `p@x`). They lower into the model
+  step's `tool_contract` (the same field a standalone `tool()` step uses). The
+  **server** resolves each tagged tool in its live registry and builds the per-step
+  warrant — you never supply a warrant or grants (SN-8).
+- The bounded-loop **budget** (`max_turns` / `max_tool_calls`) rides the task spec,
+  not the `@` grammar; absent ⇒ the server default (8 turns / 6 tool calls).
+- `@` on a **non-model** handle (`pure@tool`) is a fail-closed authoring error.
+
+:::info Authoring now, execution in PR-9b-2
+The cross-surface **authoring** of `model@tool` steps (this grammar, the SDK
+`tools=` factory, the golden corpus, the server-vetted per-step warrant) ships in
+**PR-9b-1**. The bounded reason→tool→observe **loop execution** lands in **PR-9b-2**
+— until then the server **fails closed** with a clear refusal when you submit one.
+For tool-calling today, use a standalone `tool()` step or the `react` / `react-auto`
+recipe.
+:::
+
 ## Canonical lowering
 
 A chain lowers deterministically to `(steps, edges)`:
@@ -91,8 +128,10 @@ lowering) and produces a `SubmitWorkflowRequest`.
 | Condition | Error class |
 |---|---|
 | Empty expression, or empty group `[]` | `parse` |
+| A dangling/misplaced `@` (`p@`, `p@@x`, `@tool`) | `parse` |
 | A parsed handle absent from `tasks` (`unknown task handle '<h>'`) | `unknown_handle` |
 | A cycle or self-loop (`a > a`, `a > b | b > a`) | `cycle` |
+| `@` tool grants on a non-model step (`pure@tool`) | `agentic_non_model` |
 
 Tasks that are defined but never used are ignored (lenient). The DSL *can*
 express cycles via handle reuse, so a client-side Kahn topological check rejects

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -12,14 +12,6 @@ The Python SDK (`pip install kortecx`) authors chains two equivalent ways: a
 canonical `(steps, edges)` as the CLI and the TypeScript SDK — see the
 [DSL reference](./dsl-reference.md#canonical-lowering).
 
-:::info API surface is landing
-The string-DSL examples below match the cross-surface contract exactly. The
-Python builder/operator method names are stabilizing across releases — the
-shapes shown are illustrative where noted. Check
-[`bindings/python/README.md`](https://github.com/Kortecx/kortecx/blob/main/bindings/python/README.md)
-for the current signatures.
-:::
-
 ## Install
 
 ```bash
@@ -33,7 +25,7 @@ Compose published task handles into a DAG with a single expression. The `tasks`
 map resolves each handle to a typed step.
 
 ```python
-from kortecx import KxClient, chain  # API landing — see note above
+from kortecx import KxClient, chain
 
 tasks = {
     "a": {"kind": "pure"},
@@ -73,6 +65,42 @@ a >> (b & c)                        # operator sugar — same lowering
 Because `>>` binds tighter than `&`, which binds tighter than `|` — exactly as in
 the [precedence table](./dsl-reference.md#precedence) — `a >> b | c` groups as
 `(a >> b) | c`, matching the string DSL.
+
+## Deterministic-agentic step — `model@tool` (PR-9b)
+
+Tag tools onto a MODEL step to make it a
+[deterministic-agentic step](./dsl-reference.md#the-deterministic-agentic-step--modeltool-pr-9b)
+— a bounded reason→tool→observe loop over a server-vetted tool-grant SET. The
+string DSL `@` grammar and the `model(tools=...)` factory lower **identically**:
+
+```python
+from kortecx import chain
+from kortecx.chains import model, pure
+
+# String DSL: `plan` is granted {web-search, fs-list}; `review` is downstream.
+spec = chain(
+    "plan@web-search@fs-list > review",
+    tasks={
+        "plan": model("kx-serve:my-model", "Research the topic.", max_turns=4, max_tool_calls=3),
+        "review": pure(),
+    },
+)
+
+# The factory form lowers to the same (steps, edges):
+plan = model("kx-serve:my-model", "Research the topic.",
+             tools=["web-search", "fs-list"], max_turns=4, max_tool_calls=3)
+```
+
+`tools=` accepts a list of names (version `"1"`) or a `{name: version}` map; the
+budget (`max_turns` / `max_tool_calls`) defaults to 8 / 6 when omitted. The server
+vets every tagged tool and builds the per-step warrant (SN-8).
+
+:::info Authoring now, execution in PR-9b-2
+Authoring is available across every surface in PR-9b-1; the bounded-loop
+**execution** lands in PR-9b-2 — until then the server fails closed on a submitted
+`model@tool` step. For tool-calling today, use a standalone `tool()` step or the
+`react` / `react-auto` recipe.
+:::
 
 ## A model step
 

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -12,14 +12,6 @@ ways: a **string DSL** and a **combinator API**. Both lower to the same canonica
 `(steps, edges)` as the CLI and the Python SDK — see the
 [DSL reference](./dsl-reference.md#canonical-lowering).
 
-:::info API surface is landing
-The string-DSL examples below match the cross-surface contract exactly. The TS
-builder/combinator names are stabilizing across releases — the shapes shown are
-illustrative where noted. Check
-[`bindings/typescript/README.md`](https://github.com/Kortecx/kortecx/blob/main/bindings/typescript/README.md)
-for the current signatures.
-:::
-
 ## Install
 
 ```bash
@@ -33,7 +25,7 @@ Compose published task handles into a DAG with a single expression. The `tasks`
 map resolves each handle to a typed step.
 
 ```ts
-import { KxClient, chain } from "@kortecx/sdk"; // API landing — see note above
+import { KxClient, chain } from "@kortecx/sdk";
 
 const tasks = {
   a: { kind: "pure" },
@@ -58,7 +50,7 @@ with data edges `0→1` and `0→2`, byte-identical to every other surface.
 For programmatic composition, the combinators map one-to-one onto the operators:
 
 ```ts
-import { seq, par, group } from "@kortecx/sdk"; // API landing — see note above
+import { seq, par, group } from "@kortecx/sdk";
 
 // Equivalent to chain("a > [b & c]")
 const spec = seq("a", group(par("b", "c")));
@@ -73,6 +65,44 @@ const spec = seq("a", group(par("b", "c")));
 Because the string DSL is the canonical contract, prefer `chain("…")` for
 readability; reach for the combinators when you are assembling topology
 dynamically.
+
+## Deterministic-agentic step — `model@tool` (PR-9b)
+
+Tag tools onto a MODEL step to make it a
+[deterministic-agentic step](./dsl-reference.md#the-deterministic-agentic-step--modeltool-pr-9b)
+— a bounded reason→tool→observe loop over a server-vetted tool-grant SET. The
+string DSL `@` grammar and the `task.model(..., { tools })` factory lower
+**identically**:
+
+```ts
+import { chain, task } from "@kortecx/sdk";
+
+// String DSL: `plan` is granted {web-search, fs-list}; `review` is downstream.
+const spec = chain("plan@web-search@fs-list > review", {
+  tasks: {
+    plan: task.model("kx-serve:my-model", "Research the topic.", {}, { maxTurns: 4, maxToolCalls: 3 }),
+    review: task.pure(),
+  },
+});
+
+// The factory form lowers to the same (steps, edges):
+const plan = task.model("kx-serve:my-model", "Research the topic.", {}, {
+  tools: ["web-search", "fs-list"],
+  maxTurns: 4,
+  maxToolCalls: 3,
+});
+```
+
+`tools` accepts an array of names (version `"1"`) or a `{ name: version }` record;
+the budget (`maxTurns` / `maxToolCalls`) defaults to 8 / 6 when omitted. The server
+vets every tagged tool and builds the per-step warrant (SN-8).
+
+:::info Authoring now, execution in PR-9b-2
+Authoring is available across every surface in PR-9b-1; the bounded-loop
+**execution** lands in PR-9b-2 — until then the server fails closed on a submitted
+`model@tool` step. For tool-calling today, use a standalone `tool()` step or the
+`react` / `react-auto` recipe.
+:::
 
 ## A model step
 

--- a/tests/golden/chains/SPEC.md
+++ b/tests/golden/chains/SPEC.md
@@ -21,6 +21,31 @@ so `tool("web-search","1", q="kortecx", n=3)` lowers to `params["kx.tool.args"] 
 byte-identically across Python, TypeScript, and Rust. The coordinator re-derives + validates those
 args against the tool's typed schema fail-closed at every lease (`resolve_authored_tool_args`).
 
+### The deterministic-agentic step (PR-9b, D161.1)
+
+A MODEL handle may carry a `grants := ("@" handle)+` suffix — `plan@web-search@fs-list` — to
+become a **deterministic-agentic step**: a frozen-DAG model step that runs a *bounded*
+reason→tool→observe loop over a FIXED, author-declared, server-vetted tool-grant SET. This is
+the **authored/deterministic** lane (the `kx/recipes/react` recipe is the steered/non-deterministic
+lane). `@` binds **tighter than every operator** (it is part of the atom); whitespace around `@`
+is insignificant (`p @ echo` == `p@echo`).
+
+- Each `@tag` is a tool NAME; the version defaults to `"1"`. Tags are **order-preserving and
+  deduped** (`p@x@x` == `p@x`). The tags lower into the model step's `tool_contract`
+  (`{ tag: "1" }`) — the SAME field the standalone `tool` step uses; the SERVER resolves each
+  tagged tool in its live registry + builds the per-step warrant from the UNION of the declared
+  tools' scopes (the client never supplies a warrant or grants — SN-8).
+- The bounded-loop **budget** (`max_turns` / `max_tool_calls`) rides the task spec (NOT the `@`
+  grammar) and lowers to canonical-JSON `u32` bytes under `params["max_turns"]` /
+  `params["max_tool_calls"]`; absent ⇒ the coordinator default (8 turns / 6 tool calls); validated
+  `0 < max_tool_calls < max_turns ≤ 8`.
+- `@` on a **non-model** handle (`pure@tool`) is a fail-closed authoring error
+  (`agentic_non_model`). A dangling/misplaced `@` (`p@`, `p@@x`, `@tool`, `a > @tool`) is a parse
+  error.
+
+A model step with an EMPTY grant set lowers byte-identically to a plain model step ⇒ no existing
+case moves.
+
 ## Grammar (EBNF)
 
 ```
@@ -28,7 +53,8 @@ chain    := orexpr
 orexpr   := andexpr ( "|" andexpr )*     # parallel — LOOSEST
 andexpr  := seqexpr ( "&" seqexpr )*     # parallel — tighter
 seqexpr  := atom    ( ">" atom    )*     # sequential — tightest binary
-atom     := handle | "[" chain "]"
+atom     := handle grants? | "[" chain "]"
+grants   := ( "@" handle )+              # PR-9b: tool tags on a MODEL handle
 handle   := [A-Za-z_][A-Za-z0-9_-]*
 ```
 
@@ -100,6 +126,8 @@ the cross-surface byte-identity of the attachment is pinned by the corpus.
 - **Cycle / self-loop** (`a > a`, `a > b | b > a`): reject with a cycle error (a Kahn topo check
   client-side; the server compile is the backstop). The DSL CAN express cycles via handle reuse,
   so this check is required.
+- **`@` grants on a non-model step** (`pure@tool`): reject with `agentic_non_model` (the
+  deterministic-agentic step requires a MODEL handle). A dangling/misplaced `@` is a `parse` error.
 
 ## The corpus
 
@@ -126,6 +154,12 @@ to `[]` — so the existing cases stay byte-unchanged. `ctx_multi_order` pins or
 
 `steps` are in node order; `params` values are strings (the pre-encoding lowering form — each SDK
 UTF-8-encodes at `build()` time). An error case carries `"error": "<class>"` instead of `expect`,
-where class ∈ `{parse, unknown_handle, cycle}`. Each implementation's test parses every case, and
-for success cases asserts its lowered `(steps, edges)` deep-equals `expect`; for error cases
-asserts the matching error class is raised.
+where class ∈ `{parse, unknown_handle, cycle, agentic_non_model}`. Each implementation's test parses
+every case, and for success cases asserts its lowered `(steps, edges)` deep-equals `expect`; for
+error cases asserts the matching error class is raised.
+
+A deterministic-agentic step (PR-9b) is authored with the `@` grammar (`p@echo`) or an explicit
+`tool_contract` on a `model` task; its `expect` step is `kind:"model"` with the `tool_contract`
+populated (version `"1"` for `@`-tags) and, if a budget was set, `params["max_turns"]` /
+`params["max_tool_calls"]` = the decimal strings. `agentic_dedup` pins the order-preserving tag
+dedup; `agentic_non_model` pins the non-model rejection.

--- a/tests/golden/chains/corpus.json
+++ b/tests/golden/chains/corpus.json
@@ -436,5 +436,84 @@
       "edges": [],
       "context_bundles": []
     }
+  },
+  {
+    "name": "agentic_single",
+    "dsl": "p@echo",
+    "seed": 0,
+    "tasks": {
+      "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Use the echo tool." }
+    },
+    "expect": {
+      "steps": [
+        { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Use the echo tool.", "body_signature_id": null, "tool_contract": { "echo": "1" }, "params": {} }
+      ],
+      "edges": []
+    }
+  },
+  {
+    "name": "agentic_multi_tool",
+    "dsl": "p@web-search@fs-list > r",
+    "seed": 0,
+    "tasks": {
+      "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Research the topic." },
+      "r": { "kind": "pure" }
+    },
+    "expect": {
+      "steps": [
+        { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Research the topic.", "body_signature_id": null, "tool_contract": { "web-search": "1", "fs-list": "1" }, "params": {} },
+        { "kind": "pure", "model_id": "", "prompt": "", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [ { "parent": 0, "child": 1, "edge": "data" } ]
+    }
+  },
+  {
+    "name": "agentic_with_budget",
+    "dsl": "p@echo",
+    "seed": 0,
+    "tasks": {
+      "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Use the echo tool.", "max_turns": 4, "max_tool_calls": 3 }
+    },
+    "expect": {
+      "steps": [
+        { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Use the echo tool.", "body_signature_id": null, "tool_contract": { "echo": "1" }, "params": { "max_turns": "4", "max_tool_calls": "3" } }
+      ],
+      "edges": []
+    }
+  },
+  {
+    "name": "agentic_dedup",
+    "dsl": "p@echo@echo",
+    "seed": 0,
+    "tasks": {
+      "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Use the echo tool." }
+    },
+    "expect": {
+      "steps": [
+        { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "Use the echo tool.", "body_signature_id": null, "tool_contract": { "echo": "1" }, "params": {} }
+      ],
+      "edges": []
+    }
+  },
+  {
+    "name": "err_agentic_non_model",
+    "dsl": "p@echo",
+    "seed": 0,
+    "tasks": { "p": { "kind": "pure" } },
+    "error": "agentic_non_model"
+  },
+  {
+    "name": "err_agentic_no_handle",
+    "dsl": "@echo",
+    "seed": 0,
+    "tasks": { "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "x" } },
+    "error": "parse"
+  },
+  {
+    "name": "err_agentic_trailing_at",
+    "dsl": "p@",
+    "seed": 0,
+    "tasks": { "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "x" } },
+    "error": "parse"
   }
 ]


### PR DESCRIPTION
## What

The **`@` chains-DSL grammar** (`plan@web-search@fs-list > review`) that authors a **deterministic-agentic MODEL step** — a frozen-DAG model step carrying a fixed, server-vetted tool-grant SET — across **every surface**. This is the **authoring contract** half of PR-9b (D161.1); the bounded reason→tool→observe **loop execution** is the focused follow-up **PR-9b-2** (GR8 risk-isolation; the deep sole-writer-coordinator + journal-v9 + projection change deserves its own review — user-approved split).

**Off the canonical `7d22d4bd` digest by construction** (the PURE 8-mote demo has no agentic steps).

## Changes

- **`@` grammar in all 3 chains parsers** (`crates/kx-cli/src/verbs/chain.rs`, `bindings/python/.../chains.py`, `bindings/typescript/src/chains.ts`): a MODEL handle tags an order-preserving, deduped tool-grant SET (version `"1"`); `@`-on-non-model → `agentic_non_model`, a dangling/misplaced `@` → `parse`. **Golden corpus byte-identical** (`tests/golden/chains/{SPEC.md,corpus.json}`) — **Rust 17 / Python 57 / TS 55** tests pass.
- **SDK factories** `model(tools=…, max_turns=…, max_tool_calls=…)` / `task.model(…, {tools, maxTurns})` lower **identically** to the string DSL; the bounded-loop budget rides `params` as canonical-JSON `u32` (the `react_seed_params` form).
- **Gateway binder** (`provision.rs`): a MODEL step with a non-empty `tool_contract` is **refused fail-closed** at authoring with a clear "lands in PR-9b-2" message — no silent greedy degradation, no dropped grants (GR15). Admit-direct posture for the eventual warrant is recorded in the plan.
- **Proto**: additive `tool_contract`/`params` doc-comment only (no wire change); TS/Python bindings regenerated (`codegen-fresh` idempotent).
- **Docs**: dsl-reference (`@` section + grammar/precedence/validation), python/typescript guides (+ removed the stale `tool()` "API is landing" caveat), blueprint-builder palette fix.

## Deferred to PR-9b-2 (tracked)

Salt-2 identity builders + harness golden · journal v8→v9 `ReactRound.step_salt` + migration · compound `(instance_id, step_salt)` projection key · the launch/park/terminal-commit coordinator hook + the admit-direct union warrant · recovery · real-model in-step e2e. (No UI agentic-step editor here — it rides PR-9b-2 with execution, since authoring-without-execution UI is poor UX.)

## Invariants / gate

- Canonical digest **`7d22d4bd` invariant** (a0_guard + audit_trail + I1.c byte-determinism).
- **Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) `src` diff-EMPTY** (the thesis test).
- `Cargo.lock` unchanged · additive proto + codegen-fresh · SN-8 (server-vetted grants; client warrants refused).
- Full **`just ci` green** (fmt · clippy `-D warnings` · test · deny · doc · ffi-link · build-no-inference · features-guard · check-reproducible · scale-smoke); `ruff`/`mypy`/`biome`/`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JByjTA3QndSzVfqYVNKPt8