### PR TITLE
SDK ergonomics Batch A — authoring veneers (kind-inference + inline tasks + default_model + reasoning=)

### DIFF
--- a/bindings/python/src/kortecx/blueprints.py
+++ b/bindings/python/src/kortecx/blueprints.py
@@ -37,6 +37,13 @@ TOOL_ARGS_KEY = "kx.tool.args"
 REACT_MAX_TURNS_KEY = "max_turns"
 REACT_MAX_TOOL_CALLS_KEY = "max_tool_calls"
 
+#: Batch A: the canonical ``params`` key for the opt-in reasoning mode. The SERVER
+#: reads ``config_subset["reasoning"]`` (``kx-gateway`` ``REASONING_KEY``); a value of
+#: ``full`` / ``minimal`` / ``off`` / ``strip`` steers the model's native think mode,
+#: any other / absent ⇒ the model's own behavior. Setting it ⇒ a new MoteId; absent ⇒
+#: byte-identical (the ``PROMPT_KEY`` / budget-key property).
+REASONING_KEY = "reasoning"
+
 
 @dataclass
 class StepInput:

--- a/bindings/python/src/kortecx/chains.py
+++ b/bindings/python/src/kortecx/chains.py
@@ -34,6 +34,7 @@ from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
 from .blueprints import (
     REACT_MAX_TOOL_CALLS_KEY,
     REACT_MAX_TURNS_KEY,
+    REASONING_KEY,
     TOOL_ARGS_KEY,
     BlueprintBuilder,
     EdgeInput,
@@ -158,30 +159,52 @@ def _grants_to_contract(
     return contract
 
 
+#: Batch A: the opt-in reasoning modes a ``reasoning=`` kwarg accepts (the SERVER reads
+#: ``config_subset["reasoning"]``). Any other value is a client-side error (fail-closed
+#: at authoring rather than a silent server no-op).
+_REASONING_MODES = frozenset({"full", "minimal", "off", "strip"})
+
+
+def _validate_reasoning(reasoning: str) -> str:
+    if reasoning not in _REASONING_MODES:
+        raise ChainError(f"reasoning must be one of {sorted(_REASONING_MODES)}, got {reasoning!r}")
+    return reasoning
+
+
 def model(
-    model_id: str,
-    prompt: str,
+    model_id: str = "",
+    prompt: str = "",
     *,
     tools: "Optional[Union[Sequence[str], Mapping[str, str]]]" = None,
     max_turns: Optional[int] = None,
     max_tool_calls: Optional[int] = None,
+    reasoning: Optional[str] = None,
     **params: Union[bytes, str],
 ) -> Task:
-    """A MODEL step. ``model_id`` is the recipe enum the SERVER validates (SN-8);
-    ``prompt`` is the instruction; ``params`` are extra step params.
+    """A MODEL step. ``prompt`` is the instruction; ``params`` are extra step params.
+
+    Batch A: ``model_id`` is OPTIONAL — omit it (or pass ``""``) and the SERVER binds
+    the served model (SN-8); set a client ``default_model`` to fill it client-side, or
+    name a specific served model. ``reasoning`` (``"full"`` / ``"minimal"`` / ``"off"``
+    / ``"strip"``) sets the opt-in reasoning mode — absent ⇒ the model's own behavior
+    (and a byte-identical MoteId). Use ``reasoning=`` as the typed knob rather than a
+    raw ``params`` magic-string.
 
     PR-9b (D161.1): pass ``tools`` (a list of names → version ``"1"``, or a
     ``{name: version}`` map) to make this a **deterministic-agentic step** — the
     model runs a bounded reason→tool→observe loop over the granted tool SET (the
     same step the string DSL authors as ``handle@tool@tool``). ``max_turns`` /
     ``max_tool_calls`` bound the loop (default 8 / 6; ignored when no tools)."""
+    step_params: Dict[str, Union[bytes, str]] = dict(params)
+    if reasoning is not None:
+        step_params[REASONING_KEY] = _validate_reasoning(reasoning)
     return Task(
         StepInput(
             kind="model",
             model_id=model_id,
             prompt=prompt,
             tool_contract=_grants_to_contract(tools),
-            params=dict(params),
+            params=step_params,
             max_turns=max_turns,
             max_tool_calls=max_tool_calls,
         )

--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -63,6 +63,27 @@ from .v1 import gateway_pb2_grpc as _gg
 #: The conventional gateway endpoint (matches ``kx serve`` / the CLI default).
 DEFAULT_ENDPOINT = "http://127.0.0.1:50151"
 
+#: Batch A: the env var a client reads for its default model when none is passed.
+DEFAULT_MODEL_ENV = "KX_DEFAULT_MODEL"
+
+
+def _fill_default_model(
+    request: "_g.SubmitWorkflowRequest", default_model: str
+) -> "_g.SubmitWorkflowRequest":
+    """Batch A: fill any MODEL step that left ``model_id`` empty with the client's
+    ``default_model``, in place, just before submit. A no-op when ``default_model`` is
+    unset OR no step omitted its model — so the canonical lowering (which the corpus
+    pins, client-free) is untouched and the server still binds ``""`` → the served
+    model (SN-8) when neither is set. Returns ``request`` for chaining."""
+    if not default_model:
+        return request
+    model_kind = _g.WorkflowStepKind.WORKFLOW_STEP_KIND_MODEL
+    for step in request.steps:
+        if step.kind == model_kind and not step.model_id:
+            step.model_id = default_model
+    return request
+
+
 #: The canonical ReAct recipe handle. A react run has NO statically-known terminal
 #: Mote (the gateway hands back a run-salted turn-0 id that never commits, and the
 #: settled Answer turn isn't known until the model emits it), so ``invoke(wait=True)``
@@ -170,10 +191,15 @@ class KxClient:
         *,
         token: Optional[str] = None,
         token_file: Optional[str] = None,
+        default_model: str = "",
         channel_options: Optional[list] = None,
     ) -> None:
         self.endpoint = endpoint
         self._token = _resolve_token(endpoint, token, token_file)
+        # Batch A: the default model to fill into MODEL steps that omit `model_id`
+        # (a multi-model convenience; the server binds `""` → served when unset). An
+        # explicit arg wins over the `KX_DEFAULT_MODEL` env fallback.
+        self.default_model = default_model or os.environ.get(DEFAULT_MODEL_ENV, "")
         self._md = [("authorization", f"Bearer {self._token}")] if self._token else []
         if endpoint.startswith("https://"):
             self._channel = grpc.secure_channel(
@@ -278,6 +304,7 @@ class KxClient:
         from the party's grants (SN-8) — the client sends only the topology + params.
         Returns the ``RunHandle``, or — with ``wait=True`` — the first committed
         :class:`Result`. An old gateway without the seam raises ``KxUnimplemented``."""
+        _fill_default_model(request, self.default_model)
         handle = self._call(lambda: self._stub.SubmitWorkflow(request, metadata=self._md))
         if not wait:
             return handle
@@ -1202,10 +1229,13 @@ class AsyncKxClient:
         *,
         token: Optional[str] = None,
         token_file: Optional[str] = None,
+        default_model: str = "",
         channel_options: Optional[list] = None,
     ) -> None:
         self.endpoint = endpoint
         self._token = _resolve_token(endpoint, token, token_file)
+        # Batch A: see `KxClient.default_model`.
+        self.default_model = default_model or os.environ.get(DEFAULT_MODEL_ENV, "")
         self._md = [("authorization", f"Bearer {self._token}")] if self._token else []
         if endpoint.startswith("https://"):
             self._channel = grpc.aio.secure_channel(
@@ -1279,6 +1309,7 @@ class AsyncKxClient:
     async def submit_workflow(
         self, request: "_g.SubmitWorkflowRequest", *, wait: bool = False, timeout: float = 120.0
     ) -> Union["_g.RunHandle", Result]:
+        _fill_default_model(request, self.default_model)
         handle = await self._acall(self._stub.SubmitWorkflow(request, metadata=self._md))
         if not wait:
             return handle

--- a/bindings/python/tests/test_chains.py
+++ b/bindings/python/tests/test_chains.py
@@ -19,6 +19,7 @@ from kortecx.chains import (
     AgenticStepError,
     Chain,
     ChainCycleError,
+    ChainError,
     ChainParseError,
     Task,
     UnknownHandleError,
@@ -271,3 +272,51 @@ def test_agentic_budget_lowers_to_params() -> None:
 def test_agentic_grants_on_non_model_raise() -> None:
     with pytest.raises(AgenticStepError):
         chain("p@echo", {"p": pure()}).lowering()
+
+
+# ---- Batch A: omittable model_id + reasoning= veneer ----
+
+
+def test_model_id_is_optional_and_lowers_to_empty() -> None:
+    # Omit model_id (prompt-only) — the server binds the served model (SN-8). The
+    # lowering carries an empty model_id; a default_model fills it client-side at submit.
+    lowered = chain("p > q", {"p": model(prompt="go"), "q": pure()}).lowering()
+    assert lowered["steps"][0]["kind"] == "model"
+    assert lowered["steps"][0]["model_id"] == ""
+    # A named model still lowers verbatim (positional, unchanged).
+    lowered2 = chain("p", {"p": model("kx-serve:m", "go")}).lowering()
+    assert lowered2["steps"][0]["model_id"] == "kx-serve:m"
+
+
+def test_reasoning_kwarg_lowers_to_params() -> None:
+    for mode in ("full", "minimal", "off", "strip"):
+        lowered = chain("p", {"p": model("kx-serve:m", "go", reasoning=mode)}).lowering()
+        assert lowered["steps"][0]["params"] == {"reasoning": mode}
+    # Absent ⇒ byte-identical (no reasoning key).
+    assert chain("p", {"p": model("kx-serve:m", "go")}).lowering()["steps"][0]["params"] == {}
+
+
+def test_reasoning_invalid_value_is_rejected() -> None:
+    with pytest.raises(ChainError):
+        model("kx-serve:m", "go", reasoning="loud")
+
+
+def test_fill_default_model_fills_only_empty_model_steps() -> None:
+    from kortecx.client import _fill_default_model
+
+    req = chain(
+        "p > q > r",
+        {
+            "p": model(prompt="go"),  # empty model_id ⇒ filled
+            "q": model("kx-serve:explicit", "go"),  # named ⇒ untouched
+            "r": pure(),  # pure ⇒ untouched
+        },
+    ).build()
+    _fill_default_model(req, "kx-serve:default")
+    assert req.steps[0].model_id == "kx-serve:default"
+    assert req.steps[1].model_id == "kx-serve:explicit"
+    assert req.steps[2].model_id == ""
+    # No default ⇒ no-op (server binds "" → served).
+    req2 = chain("p", {"p": model(prompt="go")}).build()
+    _fill_default_model(req2, "")
+    assert req2.steps[0].model_id == ""

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -109,6 +109,27 @@ export const REACT_MAX_TURNS_KEY = "max_turns";
 export const REACT_MAX_TOOL_CALLS_KEY = "max_tool_calls";
 
 /**
+ * Batch A: the canonical `params` key for the opt-in reasoning mode. The SERVER reads
+ * `config_subset["reasoning"]` (`kx-gateway` `REASONING_KEY`); `full` / `minimal` /
+ * `off` / `strip` steer the model's native think mode, any other / absent ⇒ the
+ * model's own behavior. Setting it ⇒ a new MoteId; absent ⇒ byte-identical.
+ */
+export const REASONING_KEY = "reasoning";
+
+const REASONING_MODES = ["full", "minimal", "off", "strip"] as const;
+/** The opt-in reasoning modes the `reasoning` kwarg accepts. */
+export type ReasoningMode = (typeof REASONING_MODES)[number];
+
+function validateReasoning(reasoning: string): string {
+  if (!(REASONING_MODES as readonly string[]).includes(reasoning)) {
+    throw new ChainParseError(
+      `reasoning must be one of ${REASONING_MODES.join(", ")}, got '${reasoning}'`,
+    );
+  }
+  return reasoning;
+}
+
+/**
  * The step's params with the agentic-loop budget injected for a MODEL step carrying
  * a non-empty `toolContract` (PR-9b — mirrors the Rust `to_request` + the Python
  * `_effective_params`). Pure; absent budget ⇒ the coordinator default.
@@ -175,28 +196,36 @@ export const task = {
     return new Task("pure", "", "", { ...params });
   },
   /**
-   * A `model` step: the model id + prompt (+ optional string params). PR-9b
-   * (D161.1): pass `opts.tools` (an array of names → version `"1"`, or a
+   * A `model` step. Batch A: `modelId` is OPTIONAL — omit it (or pass `""`) and the
+   * SERVER binds the served model (SN-8); set a client `defaultModel` to fill it, or
+   * name a specific served model. `opts.reasoning` (`full`/`minimal`/`off`/`strip`)
+   * sets the opt-in reasoning mode (absent ⇒ the model's own behavior + a byte-identical
+   * MoteId). PR-9b (D161.1): pass `opts.tools` (an array of names → version `"1"`, or a
    * `{ name: version }` map) to make it a **deterministic-agentic step** — the model
    * runs a bounded reason→tool→observe loop over the granted tool SET (the same step
    * the string DSL authors as `handle@tool@tool`). `opts.maxTurns` / `maxToolCalls`
    * bound the loop (default 8 / 6; ignored with no tools).
    */
   model(
-    modelId: string,
-    prompt: string,
+    modelId = "",
+    prompt = "",
     params: Readonly<Record<string, string>> = {},
     opts: {
       tools?: readonly string[] | Readonly<Record<string, string>>;
       maxTurns?: number;
       maxToolCalls?: number;
+      reasoning?: ReasoningMode;
     } = {},
   ): Task {
+    const stepParams: Record<string, string> = { ...params };
+    if (opts.reasoning !== undefined) {
+      stepParams[REASONING_KEY] = validateReasoning(opts.reasoning);
+    }
     return new Task(
       "model",
       modelId,
       prompt,
-      { ...params },
+      stepParams,
       grantsToContract(opts.tools),
       opts.maxTurns,
       opts.maxToolCalls,

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -37,6 +37,7 @@ import {
   KxGateway,
   type SubmitRunRequestSchema,
   type SubmitWorkflowRequestSchema,
+  WorkflowStepKind,
 } from "./gen/kortecx/v1/gateway_pb.js";
 import { AssetGrants } from "./grants.js";
 import { INSTANCE_LEN, REF_LEN, asBytes, encode } from "./hexids.js";
@@ -95,6 +96,30 @@ export interface KxClientOptions {
   transport?: Transport;
   /** Explicit WS bridge endpoint for `wsEvents` (else derived from the gRPC one). */
   wsEndpoint?: string;
+  /**
+   * Batch A: the default model to fill into MODEL steps that omit `modelId` (a
+   * multi-model convenience; the server binds `""` → served when unset). On Node an
+   * explicit value wins over the `KX_DEFAULT_MODEL` env fallback.
+   */
+  defaultModel?: string;
+}
+
+/**
+ * Batch A: fill any MODEL step that left `modelId` empty with `defaultModel`, in
+ * place, just before submit. A no-op when `defaultModel` is unset OR no step omitted
+ * its model — so the canonical lowering (corpus-pinned, client-free) is untouched and
+ * the server still binds `""` → served (SN-8) when neither is set.
+ */
+export function fillDefaultModel(
+  request: MessageInitShape<typeof SubmitWorkflowRequestSchema>,
+  defaultModel: string,
+): void {
+  if (!defaultModel || !request.steps) return;
+  for (const step of request.steps) {
+    if (step.kind === WorkflowStepKind.MODEL && !step.modelId) {
+      step.modelId = defaultModel;
+    }
+  }
 }
 
 /** Options for {@link KxClientBase.invoke}. */
@@ -123,16 +148,19 @@ export abstract class KxClientBase {
   readonly endpoint: string;
   protected readonly token: string | undefined;
   protected readonly wsEndpoint: string | undefined;
+  /** Batch A: the default model filled into MODEL steps that omit `modelId`. */
+  readonly defaultModel: string;
   protected readonly grpc: Client<typeof KxGateway>;
 
   protected constructor(
     endpoint: string,
     transport: Transport,
-    opts: { token?: string; wsEndpoint?: string },
+    opts: { token?: string; wsEndpoint?: string; defaultModel?: string },
   ) {
     this.endpoint = endpoint;
     this.token = opts.token;
     this.wsEndpoint = opts.wsEndpoint;
+    this.defaultModel = opts.defaultModel ?? "";
     this.grpc = createClient(KxGateway, transport);
   }
 
@@ -205,6 +233,7 @@ export abstract class KxClientBase {
     request: MessageInitShape<typeof SubmitWorkflowRequestSchema>,
     opts: { wait?: boolean; timeoutMs?: number } = {},
   ): Promise<{ instanceId: Uint8Array; recipeFingerprint: Uint8Array } | Result> {
+    fillDefaultModel(request, this.defaultModel);
     const handle = await rpc(this.grpc.submitWorkflow(request));
     if (!opts.wait) return handle;
     const outcome = await pollAny(this.grpc, handle.instanceId, opts.timeoutMs ?? 120_000);

--- a/bindings/typescript/src/node.ts
+++ b/bindings/typescript/src/node.ts
@@ -54,7 +54,9 @@ export class KxClient extends KxClientBase {
         readMaxBytes: READ_MAX_BYTES,
         writeMaxBytes: WRITE_MAX_BYTES,
       });
-    super(endpoint, transport, { token, wsEndpoint: opts.wsEndpoint });
+    // Batch A: an explicit defaultModel wins over the KX_DEFAULT_MODEL env fallback.
+    const defaultModel = opts.defaultModel ?? process.env.KX_DEFAULT_MODEL ?? "";
+    super(endpoint, transport, { token, wsEndpoint: opts.wsEndpoint, defaultModel });
   }
 
   protected async *openWsMessages(url: string, token: string | undefined): AsyncIterable<string> {

--- a/bindings/typescript/src/web.ts
+++ b/bindings/typescript/src/web.ts
@@ -44,7 +44,12 @@ export class KxClient extends KxClientBase {
         baseUrl: normalizeBaseUrl(endpoint),
         interceptors: [bearerInterceptor(token)],
       });
-    super(endpoint, transport, { token, wsEndpoint: opts.wsEndpoint });
+    // Batch A: no env fallback in the browser (no `process.env`).
+    super(endpoint, transport, {
+      token,
+      wsEndpoint: opts.wsEndpoint,
+      defaultModel: opts.defaultModel,
+    });
   }
 
   protected openWsMessages(url: string, token: string | undefined): AsyncIterable<string> {

--- a/bindings/typescript/test/chains.test.ts
+++ b/bindings/typescript/test/chains.test.ts
@@ -24,6 +24,7 @@ import {
   task,
 } from "../src/chains.js";
 import type { Lowered, Task } from "../src/chains.js";
+import { fillDefaultModel } from "../src/client.js";
 
 // The golden corpus lives at the repo root; this test file is bindings/typescript/test.
 const CORPUS_PATH = join(
@@ -266,5 +267,52 @@ describe("Chains DSL — context bundles (PR-7b, chain-level attachment)", () =>
     const viaString = chain("a > b", { tasks: { a, b }, context: ["c/c/c"] }).lower();
     const viaCombinator = chainFrom(seq(a, b), { context: ["c/c/c"] }).lower();
     expect(viaCombinator).toEqual(viaString);
+  });
+});
+
+describe("Chains DSL — Batch A authoring veneers", () => {
+  it("modelId is optional and lowers to empty (server binds served)", () => {
+    const lowered = chain("p > q", {
+      tasks: { p: task.model("", "go"), q: task.pure() },
+    }).lower();
+    expect(lowered.steps[0]?.kind).toBe("model");
+    expect(lowered.steps[0]?.model_id).toBe("");
+    // A named model lowers verbatim.
+    const named = chain("p", { tasks: { p: task.model("kx-serve:m", "go") } }).lower();
+    expect(named.steps[0]?.model_id).toBe("kx-serve:m");
+  });
+
+  it("reasoning lowers to params; absent ⇒ byte-identical", () => {
+    for (const mode of ["full", "minimal", "off", "strip"] as const) {
+      const lowered = chain("p", {
+        tasks: { p: task.model("kx-serve:m", "go", {}, { reasoning: mode }) },
+      }).lower();
+      expect(lowered.steps[0]?.params).toEqual({ reasoning: mode });
+    }
+    const plain = chain("p", { tasks: { p: task.model("kx-serve:m", "go") } }).lower();
+    expect(plain.steps[0]?.params).toEqual({});
+  });
+
+  it("an invalid reasoning value throws", () => {
+    // @ts-expect-error — `loud` is not a ReasoningMode
+    expect(() => task.model("kx-serve:m", "go", {}, { reasoning: "loud" })).toThrow(/reasoning/);
+  });
+
+  it("fillDefaultModel fills only empty MODEL steps", () => {
+    const req = chain("p > q > r", {
+      tasks: {
+        p: task.model("", "go"), // empty ⇒ filled
+        q: task.model("kx-serve:explicit", "go"), // named ⇒ untouched
+        r: task.pure(), // pure ⇒ untouched
+      },
+    }).build();
+    fillDefaultModel(req, "kx-serve:default");
+    expect(req.steps?.[0]?.modelId).toBe("kx-serve:default");
+    expect(req.steps?.[1]?.modelId).toBe("kx-serve:explicit");
+    expect(req.steps?.[2]?.modelId ?? "").toBe("");
+    // No default ⇒ no-op.
+    const req2 = chain("p", { tasks: { p: task.model("", "go") } }).build();
+    fillDefaultModel(req2, "");
+    expect(req2.steps?.[0]?.modelId ?? "").toBe("");
   });
 });

--- a/crates/kx-cli/src/verbs/blueprint.rs
+++ b/crates/kx-cli/src/verbs/blueprint.rs
@@ -19,7 +19,10 @@
 //! }
 //! ```
 //! `params` values are UTF-8 strings (their bytes land in the step's config).
-//! `kind` ∈ {`pure`, `model`, `tool`} (`exec` is reserved); `edge` ∈ {`data`,
+//! `kind` ∈ {`pure`, `model`, `tool`} (`exec` is reserved) and is now **OPTIONAL**
+//! (Batch A): omit it and the kind is inferred from field presence (`model_id`/`prompt`
+//! ⇒ `model`, a `tool_contract` with no model fields ⇒ `tool`, else ⇒ `pure`); an
+//! explicit kind must agree with the fields (fail-closed). `edge` ∈ {`data`,
 //! `control`}. `context_bundles` (PR-7, optional) attaches named context bundles to
 //! the run — the server injects them into every entry Mote at bind (SN-8).
 //!
@@ -81,8 +84,16 @@ const REACT_MAX_TOOL_CALLS_KEY: &str = "max_tool_calls";
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct StepSpec {
-    /// `pure` | `model` | `exec` (reserved) | `tool` (PR-6b-2).
-    pub(crate) kind: String,
+    /// `pure` | `model` | `tool` (PR-6b-2); `exec` is reserved (rejected client-side).
+    /// OPTIONAL (Batch A authoring veneer): when omitted the kind is INFERRED from
+    /// field presence — a non-empty `model_id`/`prompt` ⇒ `model` (a `model` step that
+    /// also carries a `tool_contract` is the deterministic-agentic step — still
+    /// `model`), a non-empty `tool_contract` with no model fields ⇒ `tool`, else ⇒
+    /// `pure`. An explicit kind is an override that MUST agree with the present fields
+    /// (fail-closed on conflict, e.g. `kind:"pure"` + a `model_id`). The SDK factories
+    /// (`pure()`/`model()`/`tool()`) always set it; this only eases the JSON surface.
+    #[serde(default)]
+    pub(crate) kind: Option<String>,
     #[serde(default)]
     pub(crate) model_id: String,
     #[serde(default)]
@@ -109,6 +120,71 @@ pub(crate) struct StepSpec {
     pub(crate) max_turns: Option<u32>,
     #[serde(default)]
     pub(crate) max_tool_calls: Option<u32>,
+}
+
+impl StepSpec {
+    /// Resolve the step's wire kind (Batch A authoring veneer). When `kind` is omitted
+    /// it is INFERRED from field presence; when present it is an override that must
+    /// AGREE with the fields (fail-closed). `exec` is rejected client-side (the binder
+    /// reserves it — fail at authoring with a clear message rather than a server
+    /// round-trip). Pure derivation of `&self` — `to_request` and the chain `@`-grant
+    /// check both call it, and it is idempotent under grant injection (model fields are
+    /// checked before `tool_contract`, so injecting tags never re-classifies a step).
+    pub(crate) fn resolve_kind(&self) -> Result<proto::WorkflowStepKind, CliError> {
+        let has_model = !self.model_id.is_empty() || !self.prompt.is_empty();
+        let has_tool = !self.tool_contract.is_empty();
+        let has_args = !self.args.is_empty();
+        // Inference (kind omitted): model fields win (an agentic model step carries a
+        // tool_contract too — it is STILL a model step), then a tool contract, else pure.
+        let inferred = if has_model {
+            proto::WorkflowStepKind::Model
+        } else if has_tool {
+            proto::WorkflowStepKind::Tool
+        } else {
+            proto::WorkflowStepKind::Pure
+        };
+        let Some(explicit) = self.kind.as_deref() else {
+            return Ok(inferred);
+        };
+        let kind = match explicit {
+            "pure" => proto::WorkflowStepKind::Pure,
+            "model" => proto::WorkflowStepKind::Model,
+            "tool" => proto::WorkflowStepKind::Tool,
+            "exec" => {
+                return Err(CliError::Usage(
+                    "step kind `exec` is reserved (a registered body is not yet runnable); \
+                     use pure|model|tool"
+                        .into(),
+                ));
+            }
+            other => {
+                return Err(CliError::Usage(format!(
+                    "step kind must be pure|model|tool, got {other:?}"
+                )));
+            }
+        };
+        // Agreement: an explicit kind must not CONTRADICT the present fields (so a typo
+        // like `kind:"pure"` next to a `model_id` fails loudly instead of silently
+        // dropping the model identity).
+        let conflict = match kind {
+            proto::WorkflowStepKind::Pure if has_model || has_tool || has_args => Some(
+                "a `pure` step carries only params (no model_id / prompt / tool_contract / args)",
+            ),
+            proto::WorkflowStepKind::Model if has_args => Some(
+                "`args` are tool-only; a `model` step uses `prompt` + an optional `tool_contract`",
+            ),
+            proto::WorkflowStepKind::Tool if has_model => {
+                Some("a `tool` step has no model_id / prompt; name the tool in `tool_contract`")
+            }
+            _ => None,
+        };
+        if let Some(why) = conflict {
+            return Err(CliError::Usage(format!(
+                "step kind {explicit:?} conflicts with its fields ({why})"
+            )));
+        }
+        Ok(kind)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -191,17 +267,9 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<BlueprintArgs, Cl
 pub(crate) fn to_request(spec: DagSpec) -> Result<proto::SubmitWorkflowRequest, CliError> {
     let mut steps = Vec::with_capacity(spec.steps.len());
     for s in spec.steps {
-        let kind = match s.kind.as_str() {
-            "pure" => proto::WorkflowStepKind::Pure,
-            "model" => proto::WorkflowStepKind::Model,
-            "exec" => proto::WorkflowStepKind::Exec,
-            "tool" => proto::WorkflowStepKind::Tool,
-            other => {
-                return Err(CliError::Usage(format!(
-                    "step kind must be pure|model|exec|tool, got {other:?}"
-                )));
-            }
-        };
+        // Batch A: the kind is resolved (inferred when omitted, validated when explicit;
+        // `exec` reserved) — see [`StepSpec::resolve_kind`].
+        let kind = s.resolve_kind()?;
         let body_signature_id = match s.body_signature_id {
             Some(h) => hex::decode_fixed::<32>(&h)
                 .map_err(|e| CliError::Usage(format!("body_signature_id: {e}")))?
@@ -366,5 +434,132 @@ mod tests {
         let spec: DagSpec =
             serde_json::from_str(r#"{ "steps": [ {"kind":"frobnicate"} ] }"#).unwrap();
         assert!(to_request(spec).is_err());
+    }
+
+    // ---- Batch A: kind inference + agreement (the JSON authoring veneer) ----
+
+    fn step(json: serde_json::Value) -> StepSpec {
+        serde_json::from_value(json).expect("a StepSpec")
+    }
+
+    #[test]
+    fn omitted_kind_is_inferred_from_field_presence() {
+        use proto::WorkflowStepKind::{Model, Pure, Tool};
+        // no fields ⇒ pure
+        assert_eq!(step(serde_json::json!({})).resolve_kind().unwrap(), Pure);
+        assert_eq!(
+            step(serde_json::json!({ "params": { "topic": "hi" } }))
+                .resolve_kind()
+                .unwrap(),
+            Pure
+        );
+        // model_id OR prompt ⇒ model
+        assert_eq!(
+            step(serde_json::json!({ "model_id": "m" }))
+                .resolve_kind()
+                .unwrap(),
+            Model
+        );
+        assert_eq!(
+            step(serde_json::json!({ "prompt": "go" }))
+                .resolve_kind()
+                .unwrap(),
+            Model
+        );
+        // tool_contract with no model fields ⇒ tool
+        assert_eq!(
+            step(serde_json::json!({ "tool_contract": { "echo": "1" } }))
+                .resolve_kind()
+                .unwrap(),
+            Tool
+        );
+        // an agentic model step (model fields + tool_contract) is STILL model, not tool
+        assert_eq!(
+            step(serde_json::json!({ "prompt": "go", "tool_contract": { "echo": "1" } }))
+                .resolve_kind()
+                .unwrap(),
+            Model
+        );
+    }
+
+    #[test]
+    fn omitted_kind_lowers_byte_identically_to_the_explicit_form() {
+        // The whole point of the veneer: an omitted kind must produce the SAME wire
+        // step as the explicit kind. Compare the lowered WorkflowStep for both.
+        for (omitted, explicit) in [
+            (
+                serde_json::json!({ "params": { "topic": "hi" } }),
+                serde_json::json!({ "kind": "pure", "params": { "topic": "hi" } }),
+            ),
+            (
+                serde_json::json!({ "model_id": "m", "prompt": "go" }),
+                serde_json::json!({ "kind": "model", "model_id": "m", "prompt": "go" }),
+            ),
+            (
+                serde_json::json!({ "tool_contract": { "echo": "1" }, "args": { "n": 3 } }),
+                serde_json::json!({ "kind": "tool", "tool_contract": { "echo": "1" }, "args": { "n": 3 } }),
+            ),
+        ] {
+            let lower = |s: serde_json::Value| {
+                to_request(DagSpec {
+                    seed: 0,
+                    steps: vec![step(s)],
+                    edges: vec![],
+                    execution_mode: None,
+                    context_bundles: vec![],
+                })
+                .unwrap()
+                .steps
+                .remove(0)
+            };
+            assert_eq!(lower(omitted.clone()), lower(explicit.clone()), "{omitted}");
+        }
+    }
+
+    #[test]
+    fn explicit_kind_conflicting_with_fields_is_rejected() {
+        // pure + a model field / tool_contract / args
+        assert!(step(serde_json::json!({ "kind": "pure", "model_id": "m" }))
+            .resolve_kind()
+            .is_err());
+        assert!(
+            step(serde_json::json!({ "kind": "pure", "tool_contract": { "echo": "1" } }))
+                .resolve_kind()
+                .is_err()
+        );
+        // model + tool-only args
+        assert!(
+            step(serde_json::json!({ "kind": "model", "args": { "n": 3 } }))
+                .resolve_kind()
+                .is_err()
+        );
+        // tool + a model field
+        assert!(step(
+            serde_json::json!({ "kind": "tool", "tool_contract": { "e": "1" }, "model_id": "m" })
+        )
+        .resolve_kind()
+        .is_err());
+    }
+
+    #[test]
+    fn exec_kind_is_reserved_and_rejected_client_side() {
+        let err = step(serde_json::json!({ "kind": "exec", "body_signature_id": null }))
+            .resolve_kind()
+            .expect_err("exec is reserved")
+            .to_string()
+            .to_lowercase();
+        assert!(err.contains("reserved"), "got: {err}");
+    }
+
+    #[test]
+    fn omitted_kind_round_trips_through_to_request() {
+        let spec: DagSpec = serde_json::from_str(
+            r#"{ "steps": [ {"params":{"topic":"hi"}}, {"model_id":"m","prompt":"go"} ],
+                 "edges": [ {"parent":0,"child":1} ] }"#,
+        )
+        .unwrap();
+        let req = to_request(spec).unwrap();
+        assert_eq!(req.steps[0].kind, proto::WorkflowStepKind::Pure as i32);
+        assert_eq!(req.steps[1].kind, proto::WorkflowStepKind::Model as i32);
     }
 }

--- a/crates/kx-cli/src/verbs/chain.rs
+++ b/crates/kx-cli/src/verbs/chain.rs
@@ -21,7 +21,7 @@
 //! Tasks come from a `--tasks <file>`, an inline `--tasks-json '{…}'`, and/or repeated
 //! `--task name='{…}'` (Batch A) — merged into one handle → [`StepSpec`](crate::verbs::blueprint)
 //! map (fail-closed on a handle defined twice). Each step's `kind` is OPTIONAL (inferred
-//! from field presence; see [`StepSpec`]). A handle that appears more than once is the
+//! from field presence; see the `StepSpec` shape). A handle that appears more than once is the
 //! SAME node (reuse builds DAGs); tasks defined but unused are ignored (lenient).
 //! Palette: `pure` / `model` /
 //! `tool` (PR-6b-2 — fire a registered tool; `args` lower to the canonical

--- a/crates/kx-cli/src/verbs/chain.rs
+++ b/crates/kx-cli/src/verbs/chain.rs
@@ -14,11 +14,16 @@
 //!
 //! ```text
 //! kx chain run "a > [b & c]" --tasks tasks.json --context team/ctx/spec --wait
+//! # …or fully inline (Batch A — no file needed):
+//! kx chain run "a > b" --task a='{"prompt":"go"}' --task b='{}' --wait
+//! kx chain run "a > b" --tasks-json '{"a":{"prompt":"go"},"b":{}}' --wait
 //! ```
-//! `--tasks` is a JSON object map `{ "a": {"kind":"pure", ...}, ... }` — each value
-//! is a [`StepSpec`](crate::verbs::blueprint) (the same shape as a `blueprint`
-//! step). A handle that appears more than once is the SAME node (reuse builds DAGs);
-//! tasks defined but unused are ignored (lenient). Palette: `pure` / `model` /
+//! Tasks come from a `--tasks <file>`, an inline `--tasks-json '{…}'`, and/or repeated
+//! `--task name='{…}'` (Batch A) — merged into one handle → [`StepSpec`](crate::verbs::blueprint)
+//! map (fail-closed on a handle defined twice). Each step's `kind` is OPTIONAL (inferred
+//! from field presence; see [`StepSpec`]). A handle that appears more than once is the
+//! SAME node (reuse builds DAGs); tasks defined but unused are ignored (lenient).
+//! Palette: `pure` / `model` /
 //! `tool` (PR-6b-2 — fire a registered tool; `args` lower to the canonical
 //! `kx.tool.args` blob). `--context <handle>` (PR-7, repeatable) attaches named
 //! context bundles to the run — the server injects them into every entry Mote at
@@ -54,8 +59,15 @@ struct TasksFile(BTreeMap<String, StepSpec>);
 pub struct ChainArgs {
     /// The chain DSL expression (the positional argument).
     pub dsl: String,
-    /// The `--tasks <tasks.json>` handle → step map.
-    pub tasks: PathBuf,
+    /// The `--tasks <tasks.json>` handle → step map FILE (optional — Batch A: a chain
+    /// can be authored entirely inline via `--task`/`--tasks-json` with no file).
+    pub tasks: Option<PathBuf>,
+    /// Batch A: `--tasks-json '{ "a": {…}, … }'` — the whole handle → step map as one
+    /// inline JSON string.
+    pub tasks_json: Option<String>,
+    /// Batch A: `--task name='{ … }'` (repeatable) — one handle → step at a time, so a
+    /// small chain needs no file. Each entry is `(handle, step-json)`.
+    pub inline_tasks: Vec<(String, String)>,
     /// The chain seed (`--seed`, default 0; folds into entrypoint identity).
     pub seed: u32,
     /// PR-7: context-bundle handles to attach (`--context <handle>`, repeatable).
@@ -84,6 +96,8 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
     }
     let mut dsl: Option<String> = None;
     let mut tasks: Option<PathBuf> = None;
+    let mut tasks_json: Option<String> = None;
+    let mut inline_tasks: Vec<(String, String)> = Vec::new();
     let mut seed: u32 = 0;
     let mut context: Vec<String> = Vec::new();
     let mut wait = false;
@@ -97,6 +111,23 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
         }
         match flag.as_str() {
             "--tasks" => tasks = Some(PathBuf::from(next_value(&mut args, "--tasks")?)),
+            "--tasks-json" => tasks_json = Some(next_value(&mut args, "--tasks-json")?),
+            "--task" => {
+                // `--task name={…}` — split on the FIRST `=` so the JSON value (which
+                // contains no bare `=` outside strings, but may inside) is preserved.
+                let kv = next_value(&mut args, "--task")?;
+                let (name, json) = kv.split_once('=').ok_or_else(|| {
+                    CliError::Usage(format!(
+                        "--task expects name=<step-json>, got {kv:?} (e.g. --task a='{{\"prompt\":\"go\"}}')"
+                    ))
+                })?;
+                if name.is_empty() {
+                    return Err(CliError::Usage(
+                        "--task handle name must be non-empty (name=<step-json>)".into(),
+                    ));
+                }
+                inline_tasks.push((name.to_string(), json.to_string()));
+            }
             "--seed" => {
                 let v = next_value(&mut args, "--seed")?;
                 seed = v.parse().map_err(|_| {
@@ -132,11 +163,15 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
     let dsl = dsl.ok_or_else(|| {
         CliError::Usage("chain run requires a DSL expression, e.g. \"a > [b & c]\"".into())
     })?;
-    let tasks =
-        tasks.ok_or_else(|| CliError::Usage("chain run requires --tasks <tasks.json>".into()))?;
+    // Batch A: tasks may come from a `--tasks` file, an inline `--tasks-json`, and/or
+    // repeated `--task name=…` — at least one source must define the DSL's handles, but
+    // the unknown-handle check (against the resolved map) is the authoritative gate, so
+    // parsing no longer REQUIRES `--tasks`.
     Ok(ChainArgs {
         dsl,
         tasks,
+        tasks_json,
+        inline_tasks,
         seed,
         context,
         wait,
@@ -144,6 +179,44 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
         out,
         common,
     })
+}
+
+/// Batch A: merge the task map from every source (`--tasks` file, `--tasks-json`,
+/// repeated `--task name=…`) into ONE handle → [`StepSpec`] map, fail-closed on a
+/// handle defined by more than one source (no silent last-wins).
+fn collect_tasks(args: &ChainArgs) -> Result<BTreeMap<String, StepSpec>, CliError> {
+    let mut tasks: BTreeMap<String, StepSpec> = BTreeMap::new();
+    let mut insert = |handle: String, spec: StepSpec| -> Result<(), CliError> {
+        if tasks.insert(handle.clone(), spec).is_some() {
+            return Err(CliError::Usage(format!(
+                "task handle {handle:?} is defined by more than one source \
+                 (--tasks / --tasks-json / --task)"
+            )));
+        }
+        Ok(())
+    };
+    if let Some(path) = &args.tasks {
+        let raw = std::fs::read(path)
+            .map_err(|e| CliError::Usage(format!("cannot read {}: {e}", path.display())))?;
+        let TasksFile(map) = serde_json::from_slice(&raw)
+            .map_err(|e| CliError::Usage(format!("invalid --tasks JSON: {e}")))?;
+        for (h, s) in map {
+            insert(h, s)?;
+        }
+    }
+    if let Some(json) = &args.tasks_json {
+        let TasksFile(map) = serde_json::from_str(json)
+            .map_err(|e| CliError::Usage(format!("invalid --tasks-json: {e}")))?;
+        for (h, s) in map {
+            insert(h, s)?;
+        }
+    }
+    for (name, json) in &args.inline_tasks {
+        let spec: StepSpec = serde_json::from_str(json)
+            .map_err(|e| CliError::Usage(format!("invalid --task {name:?} JSON: {e}")))?;
+        insert(name.clone(), spec)?;
+    }
+    Ok(tasks)
 }
 
 /// The deterministic lowering of a parsed chain: the node list in first-appearance
@@ -491,11 +564,14 @@ fn build_request(
         // tool_contract (version "1"), turning it into a deterministic-agentic step.
         // `@` tags on a non-model step are a fail-closed authoring error.
         if let Some(tags) = lowered.grants.get(&u32::try_from(idx).unwrap_or(u32::MAX)) {
-            if step.kind != "model" {
+            // Batch A: the kind is resolved (inferred/validated) — a `model` step that
+            // already carries a `tool_contract` is still `model`, so injecting the `@`
+            // tags below never re-classifies it ([`StepSpec::resolve_kind`] checks model
+            // fields before the tool contract). `@` on a non-model step is fail-closed.
+            if step.resolve_kind()? != kx_proto::proto::WorkflowStepKind::Model {
                 return Err(CliError::Usage(format!(
-                    "`@` tool grants on a non-model step {handle:?} (kind {:?}); \
-                     `@tool` tags require a model step (the deterministic-agentic step)",
-                    step.kind
+                    "`@` tool grants on a non-model step {handle:?}; \
+                     `@tool` tags require a model step (the deterministic-agentic step)"
                 )));
             }
             for tag in tags {
@@ -530,11 +606,7 @@ fn build_request(
 
 /// Execute `chain run`.
 pub async fn execute(args: ChainArgs) -> Result<(), CliError> {
-    let raw = std::fs::read(&args.tasks)
-        .map_err(|e| CliError::Usage(format!("cannot read {}: {e}", args.tasks.display())))?;
-    let TasksFile(tasks) = serde_json::from_slice(&raw)
-        .map_err(|e| CliError::Usage(format!("invalid --tasks JSON: {e}")))?;
-
+    let tasks = collect_tasks(&args)?;
     let lowered = lower(&args.dsl)?;
     let req = build_request(lowered, tasks, args.seed, args.context)?;
 
@@ -574,13 +646,15 @@ mod tests {
     // ---- arg parsing (the runs.rs / blueprint.rs precedent) ----
 
     #[test]
-    fn requires_run_subcommand_dsl_and_tasks() {
+    fn requires_run_subcommand_and_dsl() {
         assert!(p(&[]).is_err(), "no subcommand is a usage error");
         assert!(p(&["nope"]).is_err(), "unknown subcommand is a usage error");
         assert!(p(&["run"]).is_err(), "run without a DSL is a usage error");
+        // Batch A: `--tasks` is no longer required at PARSE time — tasks may be inline,
+        // and the unknown-handle check (at execute) is the authoritative gate.
         assert!(
-            p(&["run", "a > b"]).is_err(),
-            "run without --tasks is a usage error"
+            p(&["run", "a > b"]).is_ok(),
+            "run without --tasks now parses (tasks may be inline)"
         );
     }
 
@@ -604,7 +678,7 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(a.dsl, "a > [b & c]");
-        assert_eq!(a.tasks, PathBuf::from("tasks.json"));
+        assert_eq!(a.tasks, Some(PathBuf::from("tasks.json")));
         assert_eq!(a.seed, 7);
         // PR-7: --context is repeatable, captured verbatim in order.
         assert_eq!(a.context, vec!["team/ctx/spec", "team/ctx/notes"]);
@@ -649,6 +723,70 @@ mod tests {
         assert!(p(&["run", "a", "--tasks", "t.json", "--bogus"]).is_err());
         assert!(p(&["run", "a", "--tasks", "t.json", "--seed", "many"]).is_err());
         assert!(p(&["run", "a", "--tasks", "t.json", "--timeout-secs", "soon"]).is_err());
+    }
+
+    // ---- Batch A: inline tasks (--task / --tasks-json) ----
+
+    #[test]
+    fn inline_task_flags_collect_into_the_task_map() {
+        // A 2-step chain authored entirely inline (no file), with omitted kinds.
+        let a = p(&[
+            "run",
+            "a > b",
+            "--task",
+            r#"a={"prompt":"go"}"#,
+            "--task",
+            "b={}",
+        ])
+        .unwrap();
+        let tasks = collect_tasks(&a).unwrap();
+        assert_eq!(tasks.len(), 2);
+        // `a` has a prompt ⇒ inferred model; `b` is empty ⇒ inferred pure.
+        assert_eq!(
+            tasks["a"].resolve_kind().unwrap(),
+            proto::WorkflowStepKind::Model
+        );
+        assert_eq!(
+            tasks["b"].resolve_kind().unwrap(),
+            proto::WorkflowStepKind::Pure
+        );
+        // It lowers end-to-end (build_request resolves the handles).
+        let req = build_request(lower(&a.dsl).unwrap(), tasks, a.seed, a.context).unwrap();
+        assert_eq!(req.steps.len(), 2);
+        assert_eq!(req.edges.len(), 1);
+    }
+
+    #[test]
+    fn tasks_json_flag_collects_the_whole_map() {
+        let a = p(&[
+            "run",
+            "a > b",
+            "--tasks-json",
+            r#"{"a":{"prompt":"go"},"b":{}}"#,
+        ])
+        .unwrap();
+        let tasks = collect_tasks(&a).unwrap();
+        assert_eq!(tasks.len(), 2);
+        assert!(tasks.contains_key("a") && tasks.contains_key("b"));
+    }
+
+    #[test]
+    fn a_handle_defined_by_two_sources_is_fail_closed() {
+        let a = p(&["run", "a", "--tasks-json", r#"{"a":{}}"#, "--task", "a={}"]).unwrap();
+        let err = collect_tasks(&a)
+            .expect_err("duplicate handle across sources")
+            .to_string()
+            .to_lowercase();
+        assert!(err.contains("more than one source"), "got: {err}");
+    }
+
+    #[test]
+    fn malformed_inline_task_is_a_usage_error() {
+        // `--task` without `name=`.
+        assert!(p(&["run", "a", "--task", "no-equals"]).is_err());
+        // valid flag, invalid JSON value → surfaced at collect time.
+        let a = p(&["run", "a", "--task", "a={not json}"]).unwrap();
+        assert!(collect_tasks(&a).is_err());
     }
 
     // ---- the golden-corpus parity gate (the tri-surface contract) ----

--- a/docs/site/docs/chains/dsl-reference.md
+++ b/docs/site/docs/chains/dsl-reference.md
@@ -186,6 +186,57 @@ step's `model_id` and `prompt` are carried into its `StepInput`; the pure step
 carries its `params`. Params values are strings in the lowering form — each SDK
 UTF-8-encodes them at `build()` time.
 
+### Fewer inputs from the JSON / CLI surface
+
+The author-side step is **terse**: the runtime infers what it can, and you only
+spell out what you actually mean.
+
+- **`kind` is optional.** Omit it and the CLI infers it from the fields present — a
+  `model_id`/`prompt` ⇒ `model`, a `tool_contract` (with no model fields) ⇒ `tool`,
+  anything else ⇒ `pure`. An explicit `kind` is an override that must *agree* with the
+  fields (a `kind:"pure"` next to a `model_id` is a fail-closed error, not a silent
+  drop). A `model` step that also carries a `tool_contract` stays a `model` step (the
+  deterministic-agentic step).
+- **`model_id` is optional.** Omit it and the server binds the served model; set a
+  client `default_model` (Python `KxClient(default_model=…)` / TS `{ defaultModel }` /
+  the `KX_DEFAULT_MODEL` env var) to fill it for every blank MODEL step at submit.
+- **`reasoning`** (`full` / `minimal` / `off` / `strip`) is a typed knob on the SDK
+  `model()` factory — absent leaves the model's own behavior (and the step identity)
+  unchanged.
+
+```bash
+# A whole chain authored inline — no tasks file, no `kind`:
+kx chain run "plan > review" \
+  --task plan='{"prompt":"Research the topic."}' \
+  --task review='{}' --wait
+```
+
+`--task name='{…}'` (repeatable) and `--tasks-json '{…}'` are inline alternatives to
+`--tasks <file>`; all three merge into one handle → step map (fail-closed on a handle
+defined twice).
+
+### The authoring ladder
+
+Reach for the lowest rung that fits — each lowers to the same `SubmitWorkflow` the
+server compiles and warrants (SN-8):
+
+1. **`kx invoke <recipe>`** — run a published recipe by handle (`--args '{…}'`). The
+   easiest front door for a ready-made capability.
+2. **The chain DSL** — `chain("a > [b & c]", …)` / `a >> (b & c)` — compose your own
+   handles into a DAG. This page.
+3. **A raw blueprint** — `kx blueprint run --file dag.json` — full control over every
+   step and edge.
+
+### Authored vs steered tool-calling
+
+There are two lanes for tool-calling, and the API names mirror the distinction:
+
+- **Authored / deterministic** — the `model@tool` step (above): a *fixed*, server-vetted
+  tool-grant SET on a frozen-DAG step. Replayable; the tool set is part of the step's
+  identity. (Execution lands in PR-9b-2; see the note above.)
+- **Steered / dynamic** — the `kx/recipes/react` recipe: the model picks tools turn by
+  turn from the granted set. Use this for open-ended agents today.
+
 ### Attaching context bundles
 
 A chain can attach [context bundles](../context.md) — named, content-addressed

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -119,6 +119,48 @@ tasks = {
 spec = chain("gen > sum", tasks=tasks)   # two steps, edge 0→1
 ```
 
+## Fewer inputs, sensible defaults
+
+Authoring asks only for what is essential — the runtime infers the rest.
+
+**Optional `model_id` + a client `default_model`.** Omit `model_id` and the server
+binds the served model (SN-8). Set a `default_model` on the client (or the
+`KX_DEFAULT_MODEL` env var) to fill it for every MODEL step that left it blank:
+
+```python
+from kortecx import KxClient
+from kortecx.chains import model
+
+with KxClient(default_model="kx-serve:qwen3-4b-q4_k_m") as kx:
+    spec = chain("plan > review", tasks={
+        "plan":   model(prompt="Research the topic."),   # no model_id
+        "review": model(prompt="Critique the findings."),
+    })
+    print(kx.run_chain(spec, wait=True).text)
+```
+
+The default fills in at submit — the canonical lowering is untouched (it carries an
+empty `model_id`, which the server binds to the served model).
+
+**`reasoning=` — the typed knob.** Steer the model's native think mode with a typed
+keyword instead of a raw param string. Omit it and the model's own behavior (and the
+step's identity) is unchanged; set it for a new, reproducible step:
+
+```python
+model(prompt="Solve it carefully.", reasoning="full")     # "full" | "minimal" | "off" | "strip"
+```
+
+:::tip Author a quick chain from the CLI with no file
+The `kx chain` CLI infers each step's `kind` (omit it — a `prompt` ⇒ a model step, a
+`tool_contract` ⇒ a tool step, else a pure step) and takes tasks inline:
+
+```bash
+kx chain run "plan > review" \
+  --task plan='{"prompt":"Research the topic."}' \
+  --task review='{"prompt":"Critique the findings."}' --wait
+```
+:::
+
 ## Attaching context bundles
 
 Ground the chain with [context bundles](../context.md) via the `context=` argument,

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -121,6 +121,50 @@ const tasks = {
 const spec = chain("gen > sum", { tasks });   // two steps, edge 0→1
 ```
 
+## Fewer inputs, sensible defaults
+
+Authoring asks only for what is essential — the runtime infers the rest.
+
+**Optional `modelId` + a client `defaultModel`.** Omit `modelId` and the server binds
+the served model (SN-8). Set a `defaultModel` on the client (or, on Node, the
+`KX_DEFAULT_MODEL` env var) to fill it for every MODEL step that left it blank:
+
+```ts
+import { KxClient, chain, task } from "@kortecx/sdk";
+
+const kx = new KxClient("http://127.0.0.1:50151", { defaultModel: "kx-serve:qwen3-4b-q4_k_m" });
+const spec = chain("plan > review", {
+  tasks: {
+    plan: task.model("", "Research the topic."),     // no modelId
+    review: task.model("", "Critique the findings."),
+  },
+});
+console.log((await kx.runChain(spec, { wait: true })).text);
+kx.close();
+```
+
+The default fills in at submit — the canonical lowering is untouched (it carries an
+empty `modelId`, which the server binds to the served model).
+
+**`reasoning` — the typed knob.** Steer the model's native think mode with a typed
+option instead of a raw param string. Omit it and the model's own behavior (and the
+step's identity) is unchanged; set it for a new, reproducible step:
+
+```ts
+task.model("", "Solve it carefully.", {}, { reasoning: "full" }); // "full"|"minimal"|"off"|"strip"
+```
+
+:::tip Author a quick chain from the CLI with no file
+The `kx chain` CLI infers each step's `kind` (omit it — a `prompt` ⇒ a model step, a
+`tool_contract` ⇒ a tool step, else a pure step) and takes tasks inline:
+
+```bash
+kx chain run "plan > review" \
+  --task plan='{"prompt":"Research the topic."}' \
+  --task review='{"prompt":"Critique the findings."}' --wait
+```
+:::
+
 ## Attaching context bundles
 
 Ground the chain with [context bundles](../context.md) via the `context` option,

--- a/tests/golden/chains/SPEC.md
+++ b/tests/golden/chains/SPEC.md
@@ -163,3 +163,11 @@ A deterministic-agentic step (PR-9b) is authored with the `@` grammar (`p@echo`)
 populated (version `"1"` for `@`-tags) and, if a budget was set, `params["max_turns"]` /
 `params["max_tool_calls"]` = the decimal strings. `agentic_dedup` pins the order-preserving tag
 dedup; `agentic_non_model` pins the non-model rejection.
+
+A `model` task MAY omit `model_id` (it lowers to `""` — the SERVER binds the served model, SN-8;
+`model_id_optional` pins this) and MAY carry a `params["reasoning"]` value (`full` / `minimal` /
+`off` / `strip`, the opt-in reasoning mode the server reads from `config_subset`; `model_reasoning`
+pins it). The SDK `model()` factories expose `model_id` as optional and `reasoning=` as a typed
+kwarg; both lower to exactly these params. (The author-side `kind` is a CLI/JSON-only convenience —
+omit it and the CLI infers it from field presence; the SDK factories always set it, so `kind` is
+not part of this cross-surface corpus.)

--- a/tests/golden/chains/corpus.json
+++ b/tests/golden/chains/corpus.json
@@ -515,5 +515,61 @@
     "seed": 0,
     "tasks": { "p": { "kind": "model", "model_id": "kx-serve:qwen3-4b-q4_k_m", "prompt": "x" } },
     "error": "parse"
+  },
+  {
+    "name": "model_id_optional",
+    "dsl": "p > q",
+    "seed": 0,
+    "tasks": {
+      "p": { "kind": "model", "prompt": "go" },
+      "q": { "kind": "pure" }
+    },
+    "expect": {
+      "steps": [
+        {
+          "kind": "model",
+          "model_id": "",
+          "prompt": "go",
+          "body_signature_id": null,
+          "tool_contract": {},
+          "params": {}
+        },
+        {
+          "kind": "pure",
+          "model_id": "",
+          "prompt": "",
+          "body_signature_id": null,
+          "tool_contract": {},
+          "params": {}
+        }
+      ],
+      "edges": [{ "parent": 0, "child": 1, "edge": "data" }]
+    }
+  },
+  {
+    "name": "model_reasoning",
+    "dsl": "p",
+    "seed": 0,
+    "tasks": {
+      "p": {
+        "kind": "model",
+        "model_id": "kx-serve:qwen3-4b-q4_k_m",
+        "prompt": "go",
+        "params": { "reasoning": "minimal" }
+      }
+    },
+    "expect": {
+      "steps": [
+        {
+          "kind": "model",
+          "model_id": "kx-serve:qwen3-4b-q4_k_m",
+          "prompt": "go",
+          "body_signature_id": null,
+          "tool_contract": {},
+          "params": { "reasoning": "minimal" }
+        }
+      ],
+      "edges": []
+    }
   }
 ]


### PR DESCRIPTION
First batch of the **SDK / CLI / Chains authoring ergonomics** overhaul (plan: minimal inputs, runtime infers defaults, optional config for control). Adoption-first conveniences shipped across **CLI + Python + TypeScript + docs** in one batch (GR14). Pure client-side / CLI sugar over the existing wire — **golden-corpus parity preserved, no proto / runtime / digest change.**

### What's in it

| # | Change | Surface |
|---|---|---|
| A#1 | **Infer `kind`** in the JSON `StepSpec` (omit it; `model_id`/`prompt`⇒model, `tool_contract`&no-model⇒tool, else⇒pure; an agentic model step stays `model`). Explicit kind must agree (fail-closed). `exec` rejected client-side. | CLI |
| A#2 | **Inline CLI tasks** — `--task name='{…}'` (repeatable) + `--tasks-json '{…}'`; `--tasks` file now optional. Sources merge fail-closed on a duplicate handle. | CLI |
| A#3 | **Optional `model_id` + client `default_model`** — `model()`/`task.model()` default `model_id` to `""`; a client `default_model` (or `KX_DEFAULT_MODEL`) fills blank MODEL steps at submit. Lowering stays `""` (server binds served, SN-8). No `"default"` wire sentinel. | Py + TS |
| A#4 | **`reasoning=` typed kwarg** — `full`/`minimal`/`off`/`strip` → `params["reasoning"]` (the key the server already reads). Absent ⇒ byte-identical; invalid ⇒ fail-closed. | Py + TS |
| A#5 | **Docs** — chains `dsl-reference`/`python`/`typescript` (the conveniences, the authoring ladder, the authored-**Frozen** vs steered-**Dynamic** lanes) + SPEC.md corpus notes. | docs |

### Tests & verification
- **+2 cross-surface corpus cases** (`model_id_optional`, `model_reasoning`) — lower **byte-identical** on Rust / Py / TS (the GR12 tri-surface parity gate).
- New Rust inference / agreement / `exec`-reject + inline-task tests (kx-cli 151 green); Py/TS `reasoning` + `default_model`-fill tests (Py chains 63, TS chains 61 green).
- **Live-verified** against a dev serve: inline-task + omitted-kind chains **COMMITTED**; `kind` conflict / `exec` / duplicate-handle **fail-closed**; an inferred `tool` step correctly reaches the server tool resolver; the Python SDK submit path **COMMITTED**.
- `cargo fmt` / `clippy -D warnings` clean; `ruff` + `mypy` clean; `biome ci` + `tsc` clean.

### Invariants
- Frozen-trio (`kx-scheduler`/`kx-executor`/`kx-inference`) `src` diff **EMPTY** · `Cargo.lock` **unchanged** · **no proto change** · product digest `7d22d4bd` **invariant by construction** (no runtime/projection/journal touched).

### Scope note
A#3/A#4 are SDK client-side veneers; the lowering is corpus-pinned + unit-tested, the `""`→served binding is the server's existing behavior (`provision.rs`). Full model-step submission rides an inference serve (the upcoming deep cross-surface test campaign). Next: **Batch V2** (the fluent builder + first-class `Agent` + zero-config + local `@kx.tool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rots6A12xboq8ZmbiiXCxf