### PR TITLE
SDK Batch V2a — fluent flow() builder + first-class Agent + zero-config (Py + TS)

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -22,8 +22,17 @@ from .branch import (
     SnapshotResult,
 )
 from .capture import CaptureRecord, CaptureRecordPage
+from .agent import Agent
 from .chains import Chain, Task, chain, model, pure, tool
 from .client import DEFAULT_ENDPOINT, AsyncKxClient, KxClient
+from .defaults import (
+    default_client,
+    invoke,
+    make_client,
+    run,
+    set_default_client,
+)
+from .flow import Flow, flow
 from .content import ContentItem, PutResult
 from .context import ContextBundle, ContextBundleItem, PutContextBundleResult
 from .datasets import DatasetHit, DatasetSummary, FuzzyHit, IngestDocument, IngestResult
@@ -145,6 +154,15 @@ __all__ = [
     "pure",
     "model",
     "tool",
+    # Batch V2 — the fluent builder + first-class Agent + zero-config helpers.
+    "Flow",
+    "flow",
+    "Agent",
+    "run",
+    "invoke",
+    "make_client",
+    "default_client",
+    "set_default_client",
     "TeamSummary",
     "TeamMember",
     "TeamMembers",

--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -12,6 +12,7 @@ go::
 
 from __future__ import annotations
 
+from .agent import Agent
 from .alerts import AlertsPage, AlertSummary
 from .blueprints import BlueprintBuilder, EdgeInput, StepInput
 from .branch import (
@@ -22,9 +23,11 @@ from .branch import (
     SnapshotResult,
 )
 from .capture import CaptureRecord, CaptureRecordPage
-from .agent import Agent
 from .chains import Chain, Task, chain, model, pure, tool
 from .client import DEFAULT_ENDPOINT, AsyncKxClient, KxClient
+from .content import ContentItem, PutResult
+from .context import ContextBundle, ContextBundleItem, PutContextBundleResult
+from .datasets import DatasetHit, DatasetSummary, FuzzyHit, IngestDocument, IngestResult
 from .defaults import (
     default_client,
     invoke,
@@ -32,10 +35,6 @@ from .defaults import (
     run,
     set_default_client,
 )
-from .flow import Flow, flow
-from .content import ContentItem, PutResult
-from .context import ContextBundle, ContextBundleItem, PutContextBundleResult
-from .datasets import DatasetHit, DatasetSummary, FuzzyHit, IngestDocument, IngestResult
 from .errors import (
     ErrorCode,
     KxCatchupRequired,
@@ -54,6 +53,7 @@ from .errors import (
     KxWaitTimeout,
 )
 from .feedback import FeedbackPage, FeedbackRow, rating_from_proto, rating_to_proto
+from .flow import Flow, flow
 from .grants import AssetGrants, GrantView
 from .models import ModelSummary
 from .motes import MoteConfigItem, MoteDetail, effect_pattern_name, nd_class_name

--- a/bindings/python/src/kortecx/agent.py
+++ b/bindings/python/src/kortecx/agent.py
@@ -1,0 +1,95 @@
+"""A first-class Agent (Batch V2).
+
+```python
+import kortecx as kx
+
+analyst = kx.Agent("You are a research analyst.", tools=["web-search", "fs-list"])
+print(analyst.run("Summarize the kortecx README").text)
+```
+
+Two lanes (D161), one object — the API name mirrors the distinction:
+
+- **Default = deterministic / frozen** — a single agent step with a FIXED tool-grant
+  SET (replayable; the tool set is part of the step's identity). Pure client sugar over
+  :class:`~kortecx.flow.Flow`. The frozen tool-EXECUTION lights up with PR-9b-2; until
+  then a *tool-bearing* frozen agent is refused server-side at submit — use
+  ``dynamic=True`` (or a standalone ``tool()`` step) for tool-calling today.
+- ``dynamic=True`` → the **steered** ``kx/recipes/react`` recipe, where the model picks
+  tools turn by turn. Works today.
+
+SN-8: an Agent describes intent only — the server compiles + warrants every step.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Union
+
+from .flow import flow as _flow
+
+if TYPE_CHECKING:
+    from .client import KxClient
+    from .flow import Flow
+    from .run import Result, Run
+    from .v1 import gateway_pb2 as _g
+
+#: The steered, dynamic-tool recipe (the model chooses tools turn by turn).
+REACT_RECIPE_HANDLE = "kx/recipes/react"
+
+
+class Agent:
+    """A reusable agent: instructions + an optional tool set + model/loop config.
+    Call :meth:`run` with a task. Frozen (default) or ``dynamic=True`` (the react lane)."""
+
+    def __init__(
+        self,
+        instructions: str = "",
+        *,
+        tools: "Optional[Union[Sequence[str], Mapping[str, str]]]" = None,
+        model: str = "",
+        max_turns: Optional[int] = None,
+        max_tool_calls: Optional[int] = None,
+        reasoning: Optional[str] = None,
+        dynamic: bool = False,
+    ) -> None:
+        self.instructions = instructions
+        self.tools = tools
+        self.model = model
+        self.max_turns = max_turns
+        self.max_tool_calls = max_tool_calls
+        self.reasoning = reasoning
+        self.dynamic = dynamic
+
+    def _prompt(self, task: str) -> str:
+        """Compose the per-call instruction = the standing instructions + the task."""
+        return f"{self.instructions}\n\n{task}".strip() if self.instructions else task
+
+    def as_flow(self, task: str) -> "Flow":
+        """The FROZEN-lane :class:`~kortecx.flow.Flow` for ``task`` — a single agent
+        step carrying this agent's config. (The dynamic lane runs a recipe, not a flow.)"""
+        return _flow().agent(
+            self._prompt(task),
+            tools=self.tools,
+            model=self.model,
+            max_turns=self.max_turns,
+            max_tool_calls=self.max_tool_calls,
+            reasoning=self.reasoning,
+        )
+
+    def run(
+        self,
+        task: str,
+        *,
+        wait: bool = True,
+        timeout: float = 120.0,
+        client: "Optional[KxClient]" = None,
+    ) -> "Union[_g.RunHandle, Run, Result]":
+        """Run ``task``. Frozen lane (default) ⇒ a single agent step; ``dynamic=True``
+        ⇒ the steered ``kx/recipes/react`` recipe. Waits for the committed
+        :class:`~kortecx.run.Result` unless ``wait=False``."""
+        from .defaults import default_client
+
+        kx = client if client is not None else default_client()
+        if self.dynamic:
+            args = {"instruction": self._prompt(task)}
+            return kx.invoke(REACT_RECIPE_HANDLE, args, wait=wait, timeout=timeout)
+        return self.as_flow(task).run(wait=wait, timeout=timeout, client=kx)

--- a/bindings/python/src/kortecx/defaults.py
+++ b/bindings/python/src/kortecx/defaults.py
@@ -1,0 +1,121 @@
+"""Zero-config client resolution (Batch V2).
+
+``import kortecx as kx; kx.run(...)`` uses a lazily-built, process-wide default client
+so the simplest path needs no constructor. Config order (first wins):
+
+1. explicit kwargs,
+2. environment — ``KX_ENDPOINT`` / ``KX_TOKEN`` / ``KX_DEFAULT_MODEL``,
+3. ``~/.kortecx/config.toml`` (a ``[client]`` table),
+4. the conventional defaults (loopback endpoint, no token, server-bound model).
+
+The explicit :class:`~kortecx.client.KxClient` / :class:`~kortecx.client.AsyncKxClient`
+stay available for full control; this module is the convenience layer on top.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+from .client import DEFAULT_ENDPOINT, KxClient
+
+#: What the gateway accepts as recipe args (mirrors the client's ``ArgsType``).
+ArgsType = Union[dict, bytes, bytearray, str]
+
+#: The process-wide default client (lazily built on first use).
+_DEFAULT_CLIENT: Optional[KxClient] = None
+_CONFIG_PATH = Path.home() / ".kortecx" / "config.toml"
+
+
+def _load_config() -> dict:
+    """Best-effort read of the ``[client]`` table from ``~/.kortecx/config.toml``.
+    A missing file / no ``tomllib`` (Python < 3.11) / a parse error ⇒ ``{}`` (env +
+    defaults still apply). Never raises."""
+    try:
+        import tomllib  # type: ignore[import-not-found]  # Python 3.11+
+    except ModuleNotFoundError:
+        return {}
+    try:
+        with _CONFIG_PATH.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, ValueError):
+        return {}
+    section = data.get("client")
+    return section if isinstance(section, dict) else {}
+
+
+def resolve_endpoint(explicit: Optional[str] = None) -> str:
+    """The gateway endpoint: explicit → ``KX_ENDPOINT`` → config → the loopback default."""
+    cfg = _load_config()
+    return explicit or os.environ.get("KX_ENDPOINT") or cfg.get("endpoint") or DEFAULT_ENDPOINT
+
+
+def resolve_default_model(explicit: str = "") -> str:
+    """The default model id: explicit → ``KX_DEFAULT_MODEL`` → config → ``""`` (the
+    server binds the served model, SN-8)."""
+    cfg = _load_config()
+    return explicit or os.environ.get("KX_DEFAULT_MODEL") or cfg.get("default_model") or ""
+
+
+def make_client(
+    endpoint: Optional[str] = None,
+    *,
+    token: Optional[str] = None,
+    default_model: str = "",
+) -> KxClient:
+    """Build a :class:`~kortecx.client.KxClient` from explicit args + env +
+    ``~/.kortecx/config.toml`` + the defaults."""
+    cfg = _load_config()
+    tok = token or os.environ.get("KX_TOKEN") or cfg.get("token")
+    return KxClient(
+        resolve_endpoint(endpoint),
+        token=tok,
+        default_model=resolve_default_model(default_model),
+    )
+
+
+def default_client() -> KxClient:
+    """The lazily-built, process-wide default client used by the module-level
+    ``kx.run`` / ``kx.invoke`` and the :class:`~kortecx.flow.Flow` /
+    :class:`~kortecx.agent.Agent` terminals.
+
+    NOTE (async / threads): this is a SINGLE shared client (one gRPC channel) — fine
+    for scripts and sync use; for concurrent or async work, construct explicit
+    :class:`~kortecx.client.KxClient` / :class:`~kortecx.client.AsyncKxClient`
+    instances rather than relying on this singleton."""
+    global _DEFAULT_CLIENT
+    if _DEFAULT_CLIENT is None:
+        _DEFAULT_CLIENT = make_client()
+    return _DEFAULT_CLIENT
+
+
+def set_default_client(client: Optional[KxClient]) -> None:
+    """Override (or clear, with ``None``) the process-wide default client — for tests
+    or a custom endpoint/token without threading a client through every call."""
+    global _DEFAULT_CLIENT
+    _DEFAULT_CLIENT = client
+
+
+def run(target: object, *, wait: bool = True, timeout: float = 120.0, **agent_kwargs):
+    """Module-level convenience — run a :class:`~kortecx.flow.Flow`, a
+    :class:`~kortecx.chains.Chain`, or a bare prompt (a one-line agent) via the default
+    client. ``agent_kwargs`` (``tools=`` / ``reasoning=`` / …) apply only to the prompt
+    form."""
+    from .chains import Chain
+    from .flow import Flow
+    from .flow import flow as _flow
+
+    kx = default_client()
+    if isinstance(target, Flow):
+        return target.run(wait=wait, timeout=timeout, client=kx)
+    if isinstance(target, Chain):
+        return kx.run_chain(target, wait=wait, timeout=timeout)
+    if isinstance(target, str):
+        return _flow().agent(target, **agent_kwargs).run(wait=wait, timeout=timeout, client=kx)
+    raise TypeError(f"kx.run() accepts a Flow, Chain, or prompt str, got {type(target).__name__}")
+
+
+def invoke(handle: str, args: "ArgsType", **kwargs):
+    """Module-level convenience — invoke a published recipe via the default client."""
+    return default_client().invoke(handle, args, **kwargs)

--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -1,0 +1,174 @@
+"""The fluent Flow builder — the headline authoring surface (Batch V2).
+
+```python
+import kortecx as kx
+
+out = (kx.flow()
+       .agent("Research the topic", tools=["web-search"])
+       .then("Critique the findings")
+       .run())
+print(out.text)
+```
+
+A thin, discoverable veneer over the operator AST in :mod:`kortecx.chains`: every
+method appends to the SAME ``_Seq`` / ``_Par`` node graph the ``>>`` / ``&`` / ``|``
+operators build, so a :class:`Flow` lowers **byte-identically** to the equivalent
+chain (the golden-corpus tri-surface contract holds by construction — a Flow is sugar,
+never a new wire shape). Defaults are filled in (served model, budget 8/6, wait) so the
+common case is one line; every knob stays optional. SN-8: a Flow describes TOPOLOGY
+only — the server compiles + warrants every step.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from .chains import (
+    Chain,
+    ChainError,
+    Task,
+    _as_node,
+    _Node,
+    _Par,
+    _Seq,
+)
+from .chains import model as _model
+from .chains import pure as _pure
+from .chains import tool as _tool
+
+if TYPE_CHECKING:
+    from .run import Result
+    from .v1 import gateway_pb2 as _g
+
+#: Anything a builder method can fold into the graph: a prompt (⇒ an agent step), a
+#: :class:`~kortecx.chains.Task`, another :class:`Flow`, or a raw operator node.
+FlowItem = Union[str, Task, "Flow", _Seq, _Par]
+
+
+def _to_node(item: "FlowItem") -> "_Node":
+    """Resolve a flow item to an operator AST node. A bare ``str`` is an agent
+    (MODEL) step with all-default config — the most common case."""
+    if isinstance(item, Flow):
+        return item._require_node()
+    if isinstance(item, str):
+        return _model(prompt=item)
+    return _as_node(item)
+
+
+class Flow:
+    """A fluent chain builder. Each builder method APPENDS to the graph and returns
+    ``self`` (chain the calls); terminate with :meth:`run` / :meth:`submit` /
+    :meth:`to_chain`. The string DSL (:func:`~kortecx.chains.chain`) and operator
+    sugar (``a >> b``) remain available as power forms — all three lower identically.
+    """
+
+    def __init__(self, *, seed: int = 0) -> None:
+        self._node: Optional[_Node] = None
+        self._seed = seed
+        self._context: List[str] = []
+
+    # -- builders (each appends SEQUENTIALLY after the current tail) --
+
+    def _seq_append(self, node: "_Node") -> "Flow":
+        self._node = node if self._node is None else _Seq([_as_node(self._node), node])
+        return self
+
+    def agent(
+        self,
+        prompt: str,
+        *,
+        tools=None,
+        model: str = "",
+        max_turns: Optional[int] = None,
+        max_tool_calls: Optional[int] = None,
+        reasoning: Optional[str] = None,
+    ) -> "Flow":
+        """Append an agent (MODEL) step. ``model`` defaults to the served model (the
+        client's ``default_model`` fills a blank one at submit, SN-8); pass ``tools``
+        to make it a deterministic-agentic step — a bounded reason→tool→observe loop
+        over the granted SET (PR-9b; the execution lane lights up with PR-9b-2)."""
+        return self._seq_append(
+            _model(
+                model,
+                prompt,
+                tools=tools,
+                max_turns=max_turns,
+                max_tool_calls=max_tool_calls,
+                reasoning=reasoning,
+            )
+        )
+
+    def step(self, **params: Union[bytes, str]) -> "Flow":
+        """Append a PURE step (deterministic, no model/egress)."""
+        return self._seq_append(_pure(**params))
+
+    def tool(self, tool_id: str, tool_version: str = "1", **args: object) -> "Flow":
+        """Append a standalone TOOL step — fire ONE registered tool (PR-6b-2). The
+        server resolves it in its live registry + builds the warrant (SN-8)."""
+        return self._seq_append(_tool(tool_id, tool_version, **args))
+
+    def then(self, item: "FlowItem", **agent_kwargs: object) -> "Flow":
+        """Append ``item`` sequentially. A bare string is an agent step (with the
+        optional ``agent_kwargs``, e.g. ``tools=`` / ``reasoning=``); a Task or Flow
+        is appended as-is. Reads as the natural follow-on after :meth:`agent`."""
+        if isinstance(item, str):
+            return self.agent(item, **agent_kwargs)  # type: ignore[arg-type]
+        return self._seq_append(_to_node(item))
+
+    def parallel(self, *items: "FlowItem") -> "Flow":
+        """Append a PARALLEL fan of ``items`` (each a prompt / Task / Flow) as one
+        merge node, sequential after the current tail — a fan-out when something
+        precedes it, a fan-in when something follows (``a > [b & c]`` / ``[a & b] > c``)."""
+        if not items:
+            raise ChainError("parallel() needs at least one branch")
+        return self._seq_append(_Par([_to_node(i) for i in items]))
+
+    def context(self, *handles: str) -> "Flow":
+        """Attach context-bundle handles to the run (PR-7, chain-level grounding the
+        server injects into every entry Mote at bind, SN-8). Appends in order."""
+        self._context.extend(handles)
+        return self
+
+    # -- terminals --
+
+    def _require_node(self) -> "_Node":
+        if self._node is None:
+            raise ChainError("empty flow — add a step (.agent / .step / .tool) first")
+        return self._node
+
+    def to_chain(self) -> Chain:
+        """Lower this flow to a :class:`~kortecx.chains.Chain` (the operator/DSL form)."""
+        return Chain(self._require_node(), seed=self._seed, context_bundles=self._context)
+
+    def build(self):
+        """Lower to a ``SubmitWorkflowRequest`` (via :meth:`to_chain`)."""
+        return self.to_chain().build()
+
+    def lowering(self):
+        """The canonical pre-encoding lowering (the corpus-parity dict)."""
+        return self.to_chain().lowering()
+
+    def run(
+        self, *, wait: bool = True, timeout: float = 120.0, client=None
+    ) -> "Union[_g.RunHandle, Result]":
+        """Submit and (by default) WAIT for the committed :class:`~kortecx.run.Result`,
+        over the given ``client`` or the zero-config default client. ``wait=False``
+        returns a run handle."""
+        from .defaults import default_client
+
+        kx = client if client is not None else default_client()
+        return kx.run_chain(self.to_chain(), wait=wait, timeout=timeout)
+
+    def submit(self, *, client=None) -> "_g.RunHandle":
+        """Submit without waiting — return the run handle."""
+        from .defaults import default_client
+
+        kx = client if client is not None else default_client()
+        handle = kx.run_chain(self.to_chain(), wait=False)
+        return handle  # type: ignore[return-value]
+
+
+def flow(*, seed: int = 0) -> Flow:
+    """Start a fluent chain: ``kx.flow().agent(...).then(...).run()``. The headline
+    authoring surface — reads top-to-bottom, IDE-discoverable, defaults filled in."""
+    return Flow(seed=seed)

--- a/bindings/python/tests/test_flow.py
+++ b/bindings/python/tests/test_flow.py
@@ -1,0 +1,108 @@
+"""The fluent Flow builder + first-class Agent — pure unit tests (no server).
+
+A Flow is sugar over the operator AST, so the core assertion is PARITY: a fluent
+chain lowers byte-identically to the equivalent operator/DSL chain. Plus Agent
+frozen/dynamic-lane shape + zero-config resolution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kortecx.agent import Agent
+from kortecx.chains import Chain, ChainError, model, pure
+from kortecx.flow import Flow, flow
+
+
+def test_flow_sequence_matches_operator_sugar() -> None:
+    # .agent(...).then(...) == model() >> model()
+    fluent = flow().agent("research", tools=["web-search"]).then("review").lowering()
+    sugar = Chain.from_node(
+        model(prompt="research", tools=["web-search"]) >> model(prompt="review")
+    ).lowering()
+    assert fluent == sugar
+    # two model steps, one data edge, default (empty) model_id
+    assert [s["kind"] for s in fluent["steps"]] == ["model", "model"]
+    assert fluent["steps"][0]["model_id"] == ""
+    assert fluent["steps"][0]["tool_contract"] == {"web-search": "1"}
+    assert fluent["edges"] == [{"parent": 0, "child": 1, "edge": "data"}]
+
+
+def test_flow_parallel_fans_out_and_in() -> None:
+    # fan-out: a > [b & c]
+    fan_out = flow().agent("a").parallel("b", "c").lowering()
+    assert len(fan_out["steps"]) == 3
+    assert sorted((e["parent"], e["child"]) for e in fan_out["edges"]) == [(0, 1), (0, 2)]
+    # fan-in: [a & b] > c
+    fan_in = flow().parallel("a", "b").then("c").lowering()
+    assert sorted((e["parent"], e["child"]) for e in fan_in["edges"]) == [(0, 2), (1, 2)]
+
+
+def test_flow_step_and_tool() -> None:
+    lowered = flow().step(topic="hi").tool("echo", "1", n=3).lowering()
+    assert lowered["steps"][0]["kind"] == "pure"
+    assert lowered["steps"][0]["params"] == {"topic": "hi"}
+    assert lowered["steps"][1]["kind"] == "tool"
+    assert lowered["steps"][1]["tool_contract"] == {"echo": "1"}
+    assert lowered["steps"][1]["params"] == {"kx.tool.args": '{"n":3}'}
+
+
+def test_flow_then_accepts_a_task_and_subflow() -> None:
+    sub = flow().agent("inner")
+    chained = flow().agent("outer").then(pure(label="x")).then(sub).lowering()
+    assert [s["kind"] for s in chained["steps"]] == ["model", "pure", "model"]
+    assert chained["edges"] == [
+        {"parent": 0, "child": 1, "edge": "data"},
+        {"parent": 1, "child": 2, "edge": "data"},
+    ]
+
+
+def test_flow_context_and_seed() -> None:
+    lowered = flow(seed=7).agent("a").context("team/ctx/spec").lowering()
+    assert lowered["context_bundles"] == ["team/ctx/spec"]
+    assert flow(seed=7).agent("a").to_chain()._seed == 7  # type: ignore[attr-defined]
+
+
+def test_empty_flow_is_fail_closed() -> None:
+    with pytest.raises(ChainError):
+        flow().to_chain()
+    with pytest.raises(ChainError):
+        flow().parallel().agent("a")  # parallel with no branch
+
+
+def test_agent_frozen_lane_is_a_single_agent_step() -> None:
+    a = Agent("You are helpful.", tools=["echo"], reasoning="minimal")
+    lowered = a.as_flow("do it").lowering()
+    assert len(lowered["steps"]) == 1
+    step = lowered["steps"][0]
+    assert step["kind"] == "model"
+    assert step["tool_contract"] == {"echo": "1"}
+    assert step["params"] == {"reasoning": "minimal"}
+    # the instruction is prepended to the task
+    assert step["prompt"] == "You are helpful.\n\ndo it"
+
+
+def test_agent_default_lane_is_frozen() -> None:
+    assert Agent("x").dynamic is False
+    assert Agent("x", dynamic=True).dynamic is True
+
+
+def test_zero_config_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kortecx import defaults
+
+    # env wins over the default; config is best-effort (skip the real file).
+    monkeypatch.setattr(defaults, "_load_config", lambda: {})
+    monkeypatch.setenv("KX_ENDPOINT", "http://example:1234")
+    monkeypatch.setenv("KX_DEFAULT_MODEL", "kx-serve:envmodel")
+    assert defaults.resolve_endpoint() == "http://example:1234"
+    assert defaults.resolve_default_model() == "kx-serve:envmodel"
+    # explicit beats env
+    assert defaults.resolve_endpoint("http://explicit:9") == "http://explicit:9"
+    # config provides a fallback when env is absent
+    monkeypatch.delenv("KX_DEFAULT_MODEL")
+    monkeypatch.setattr(defaults, "_load_config", lambda: {"default_model": "kx-serve:cfg"})
+    assert defaults.resolve_default_model() == "kx-serve:cfg"
+
+
+def test_flow_is_a_flow_instance() -> None:
+    assert isinstance(flow(), Flow)

--- a/bindings/typescript/src/agent.ts
+++ b/bindings/typescript/src/agent.ts
@@ -1,0 +1,81 @@
+/**
+ * A first-class Agent (Batch V2) — the TS mirror of the Python `kx.Agent`.
+ *
+ * ```ts
+ * const analyst = new Agent("You are a research analyst.", { tools: ["web-search"] });
+ * const out = await analyst.run("Summarize the README", { client: kx });
+ * console.log(out.text);
+ * ```
+ *
+ * Default lane = deterministic/frozen (a single agent step — replayable, the tool set
+ * is part of identity); `dynamic: true` routes to the steered `kx/recipes/react`
+ * recipe. The frozen tool-EXECUTION lights up with PR-9b-2. SN-8: intent only.
+ */
+
+import type { ReasoningMode } from "./chains.js";
+import { type FlowClient, flow } from "./flow.js";
+
+/** The steered, dynamic-tool recipe (the model chooses tools turn by turn). */
+export const REACT_RECIPE_HANDLE = "kx/recipes/react";
+
+export interface AgentOptions {
+  tools?: readonly string[] | Readonly<Record<string, string>>;
+  model?: string;
+  maxTurns?: number;
+  maxToolCalls?: number;
+  reasoning?: ReasoningMode;
+  /** `false` (default) = the deterministic/frozen lane; `true` = the steered react recipe. */
+  dynamic?: boolean;
+}
+
+/** The client surface {@link Agent.run} needs: `runChain` (frozen) + `invoke` (dynamic). */
+export interface AgentClient extends FlowClient {
+  invoke(
+    handle: string,
+    args: unknown,
+    opts?: { wait?: boolean; timeoutMs?: number },
+  ): Promise<unknown>;
+}
+
+/** A reusable agent: instructions + an optional tool set + model/loop config. */
+export class Agent {
+  constructor(
+    readonly instructions = "",
+    readonly opts: AgentOptions = {},
+  ) {}
+
+  private prompt(task: string): string {
+    return this.instructions ? `${this.instructions}\n\n${task}`.trim() : task;
+  }
+
+  /** The FROZEN-lane {@link import("./flow.js").Flow} for `task` — one agent step. */
+  asFlow(task: string) {
+    return flow().agent(this.prompt(task), {
+      tools: this.opts.tools,
+      model: this.opts.model,
+      maxTurns: this.opts.maxTurns,
+      maxToolCalls: this.opts.maxToolCalls,
+      reasoning: this.opts.reasoning,
+    });
+  }
+
+  /** Run `task`. Frozen lane (default) ⇒ a single agent step; `dynamic` ⇒ the steered
+   * `kx/recipes/react` recipe. Waits for the committed result unless `wait: false`. */
+  async run(
+    task: string,
+    opts: { wait?: boolean; timeoutMs?: number; client: AgentClient },
+  ): Promise<unknown> {
+    if (this.opts.dynamic) {
+      return opts.client.invoke(
+        REACT_RECIPE_HANDLE,
+        { instruction: this.prompt(task) },
+        { wait: opts.wait ?? true, timeoutMs: opts.timeoutMs },
+      );
+    }
+    return this.asFlow(task).run({
+      wait: opts.wait,
+      timeoutMs: opts.timeoutMs,
+      client: opts.client,
+    });
+  }
+}

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -102,6 +102,11 @@ export {
   ChainCycleError,
 } from "./chains.js";
 export type { Frag, ChainOptions, Lowered, LoweredStep, LoweredEdge } from "./chains.js";
+// Batch V2 — the fluent builder + first-class Agent (the headline authoring surface).
+export { Flow, flow } from "./flow.js";
+export type { FlowItem, AgentStepOptions, FlowClient } from "./flow.js";
+export { Agent, REACT_RECIPE_HANDLE } from "./agent.js";
+export type { AgentOptions, AgentClient } from "./agent.js";
 
 export { TeamSummary, TeamMember, TeamMembers, WarrantView, teamsFromProto } from "./teams.js";
 export { GrantView, AssetGrants } from "./grants.js";

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -1,0 +1,160 @@
+/**
+ * The fluent Flow builder — the headline authoring surface (Batch V2).
+ *
+ * ```ts
+ * import { flow } from "@kortecx/sdk";
+ *
+ * const out = await flow()
+ *   .agent("Research the topic", { tools: ["web-search"] })
+ *   .then("Critique the findings")
+ *   .run({ client: kx });
+ * console.log(out.text);
+ * ```
+ *
+ * A thin, discoverable veneer over the combinator API in `chains.ts`: every method
+ * folds into the SAME `seq` / `par` fragment graph the string DSL lowers from, so a
+ * `Flow` lowers BYTE-IDENTICALLY to the equivalent chain (a Flow is sugar, never a new
+ * wire shape). SN-8: a Flow describes TOPOLOGY only — the server compiles + warrants.
+ */
+
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import {
+  type Chain,
+  ChainParseError,
+  type Frag,
+  type ReasoningMode,
+  chainFrom,
+  par,
+  seq,
+  task,
+} from "./chains.js";
+import type { SubmitWorkflowRequestSchema } from "./gen/kortecx/v1/gateway_pb.js";
+
+/** A thing a builder method can fold in: a prompt (⇒ an agent step) or a `Frag`. */
+export type FlowItem = string | Frag;
+
+/** Options for {@link Flow.agent} (and the `then(string, …)` form). */
+export interface AgentStepOptions {
+  tools?: readonly string[] | Readonly<Record<string, string>>;
+  model?: string;
+  maxTurns?: number;
+  maxToolCalls?: number;
+  reasoning?: ReasoningMode;
+}
+
+function toFrag(item: FlowItem): Frag {
+  // A bare string is an agent (MODEL) step with all-default config (the common case).
+  return typeof item === "string" ? task.model("", item) : item;
+}
+
+/** A minimal client surface the Flow terminals need (avoids a node/web import cycle). */
+export interface FlowClient {
+  runChain(chain: Chain, opts?: { wait?: boolean; timeoutMs?: number }): Promise<unknown>;
+}
+
+/**
+ * A fluent chain builder. Each method APPENDS to the graph and returns `this`;
+ * terminate with {@link Flow.run} / {@link Flow.toChain}. The string DSL (`chain(...)`)
+ * and the combinators (`seq`/`par`/`chainFrom`) remain available as power forms — all
+ * lower identically.
+ */
+export class Flow {
+  private node: Frag | undefined;
+  private readonly seed: number;
+  private readonly ctx: string[] = [];
+
+  constructor(opts: { seed?: number } = {}) {
+    this.seed = opts.seed ?? 0;
+  }
+
+  private append(frag: Frag): this {
+    this.node = this.node === undefined ? frag : seq(this.node, frag);
+    return this;
+  }
+
+  /** Append an agent (MODEL) step. `model` defaults to the served model (the client's
+   * `defaultModel` fills a blank one at submit, SN-8); `tools` makes it a
+   * deterministic-agentic step (PR-9b; execution lights up with PR-9b-2). */
+  agent(prompt: string, opts: AgentStepOptions = {}): this {
+    return this.append(
+      task.model(
+        opts.model ?? "",
+        prompt,
+        {},
+        {
+          tools: opts.tools,
+          maxTurns: opts.maxTurns,
+          maxToolCalls: opts.maxToolCalls,
+          reasoning: opts.reasoning,
+        },
+      ),
+    );
+  }
+
+  /** Append a PURE step. */
+  step(params: Readonly<Record<string, string>> = {}): this {
+    return this.append(task.pure(params));
+  }
+
+  /** Append a standalone TOOL step — fire ONE registered tool (PR-6b-2). */
+  tool(
+    toolId: string,
+    version = "1",
+    args: Readonly<Record<string, string | number | boolean>> = {},
+  ): this {
+    return this.append(task.tool(toolId, version, args));
+  }
+
+  /** Append `item` sequentially. A bare string is an agent step (with `opts`); a `Frag`
+   * is appended as-is. Reads as the natural follow-on after {@link Flow.agent}. */
+  // biome-ignore lint/suspicious/noThenProperty: Flow is a builder, not a thenable — terminate with `.run()` (the awaited Promise); a Flow is never awaited directly, and `.then(item)` mirrors the Python fluent API (cross-surface vocab).
+  then(item: FlowItem, opts: AgentStepOptions = {}): this {
+    if (typeof item === "string") return this.agent(item, opts);
+    return this.append(item);
+  }
+
+  /** Append a PARALLEL fan of `items` as one merge node, sequential after the tail —
+   * a fan-out when something precedes it, a fan-in when something follows. */
+  parallel(...items: FlowItem[]): this {
+    if (items.length === 0) throw new ChainParseError("parallel() needs at least one branch");
+    return this.append(par(...items.map(toFrag)));
+  }
+
+  /** Attach context-bundle handles to the run (PR-7, chain-level grounding). */
+  context(...handles: string[]): this {
+    this.ctx.push(...handles);
+    return this;
+  }
+
+  /** Lower this flow to a {@link Chain}. */
+  toChain(): Chain {
+    if (this.node === undefined) {
+      throw new ChainParseError("empty flow — add a step (.agent / .step / .tool) first");
+    }
+    return chainFrom(this.node, { seed: this.seed, context: this.ctx });
+  }
+
+  /** Lower to a `SubmitWorkflow` request. */
+  build(): MessageInitShape<typeof SubmitWorkflowRequestSchema> {
+    return this.toChain().build();
+  }
+
+  /** The canonical pre-encoding lowering (the corpus-parity shape). */
+  lower(): ReturnType<Chain["lower"]> {
+    return this.toChain().lower();
+  }
+
+  /** Submit and (by default) WAIT for the committed result, over `opts.client`. */
+  async run(opts: { wait?: boolean; timeoutMs?: number; client: FlowClient }): Promise<unknown> {
+    return opts.client.runChain(this.toChain(), {
+      wait: opts.wait ?? true,
+      timeoutMs: opts.timeoutMs,
+    });
+  }
+}
+
+/** Start a fluent chain: `flow().agent(...).then(...).run({ client })`. The headline
+ * authoring surface — reads top-to-bottom, IDE-discoverable, defaults filled in. */
+export function flow(opts: { seed?: number } = {}): Flow {
+  return new Flow(opts);
+}

--- a/bindings/typescript/test/flow.test.ts
+++ b/bindings/typescript/test/flow.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The fluent Flow builder + first-class Agent — pure unit tests (no server).
+ *
+ * A Flow is sugar over the combinator API, so the core assertion is PARITY: a fluent
+ * chain lowers byte-identically to the equivalent combinator/DSL chain.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Agent } from "../src/agent.js";
+import { ChainParseError, chain, chainFrom, par, seq, task } from "../src/chains.js";
+import { Flow, flow } from "../src/flow.js";
+
+describe("Flow — fluent builder", () => {
+  it("a sequence matches the combinator form", () => {
+    const fluent = flow()
+      .agent("research", { tools: ["web-search"] })
+      .then("review")
+      .lower();
+    const combinator = chainFrom(
+      seq(task.model("", "research", {}, { tools: ["web-search"] }), task.model("", "review")),
+    ).lower();
+    expect(fluent).toEqual(combinator);
+    expect(fluent.steps.map((s) => s.kind)).toEqual(["model", "model"]);
+    expect(fluent.steps[0]?.model_id).toBe("");
+    expect(fluent.steps[0]?.tool_contract).toEqual({ "web-search": "1" });
+    expect(fluent.edges).toEqual([{ parent: 0, child: 1, edge: "data" }]);
+  });
+
+  it("parallel fans out and in", () => {
+    const fanOut = flow().agent("a").parallel("b", "c").lower();
+    expect(fanOut.steps).toHaveLength(3);
+    expect(fanOut.edges.map((e) => [e.parent, e.child]).sort()).toEqual([
+      [0, 1],
+      [0, 2],
+    ]);
+    const fanIn = flow().parallel("a", "b").then("c").lower();
+    expect(fanIn.edges.map((e) => [e.parent, e.child]).sort()).toEqual([
+      [0, 2],
+      [1, 2],
+    ]);
+  });
+
+  it("step and tool", () => {
+    const lowered = flow().step({ topic: "hi" }).tool("echo", "1", { n: 3 }).lower();
+    expect(lowered.steps[0]?.kind).toBe("pure");
+    expect(lowered.steps[0]?.params).toEqual({ topic: "hi" });
+    expect(lowered.steps[1]?.kind).toBe("tool");
+    expect(lowered.steps[1]?.tool_contract).toEqual({ echo: "1" });
+    expect(lowered.steps[1]?.params).toEqual({ "kx.tool.args": '{"n":3}' });
+  });
+
+  it("matches the string DSL for the same topology", () => {
+    const viaFlow = flow().agent("p").then("q").lower();
+    const viaString = chain("p > q", {
+      tasks: { p: task.model("", "p"), q: task.model("", "q") },
+    }).lower();
+    expect(viaFlow).toEqual(viaString);
+  });
+
+  it("context and seed flow through", () => {
+    const lowered = flow({ seed: 7 }).agent("a").context("team/ctx/spec").lower();
+    expect(lowered.context_bundles).toEqual(["team/ctx/spec"]);
+  });
+
+  it("an empty flow is fail-closed", () => {
+    expect(() => flow().toChain()).toThrow(ChainParseError);
+    expect(() => flow().parallel()).toThrow(ChainParseError);
+  });
+
+  it("flow() returns a Flow", () => {
+    expect(flow()).toBeInstanceOf(Flow);
+  });
+});
+
+describe("Agent", () => {
+  it("the frozen lane is a single agent step", () => {
+    const a = new Agent("You are helpful.", { tools: ["echo"], reasoning: "minimal" });
+    const lowered = a.asFlow("do it").lower();
+    expect(lowered.steps).toHaveLength(1);
+    const step = lowered.steps[0];
+    expect(step?.kind).toBe("model");
+    expect(step?.tool_contract).toEqual({ echo: "1" });
+    expect(step?.params).toEqual({ reasoning: "minimal" });
+    expect(step?.prompt).toBe("You are helpful.\n\ndo it");
+  });
+
+  it("defaults to the frozen lane", () => {
+    expect(new Agent("x").opts.dynamic ?? false).toBe(false);
+    expect(new Agent("x", { dynamic: true }).opts.dynamic).toBe(true);
+  });
+
+  it("a bare task (no instructions) is the prompt verbatim", () => {
+    const lowered = new Agent().asFlow("just do it").lower();
+    expect(lowered.steps[0]?.prompt).toBe("just do it");
+  });
+});

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -19,7 +19,59 @@ pip install kortecx            # core client (grpcio + protobuf)
 pip install 'kortecx[ws]'      # + the optional WebSocket live-tail
 ```
 
+## The fluent builder (recommended)
+
+The friendliest way to author a chain reads top-to-bottom and fills in defaults — no
+`tasks` map, no `kind`, no `model_id`:
+
+```python
+import kortecx as kx
+
+out = (kx.flow()
+       .agent("Research the topic", tools=["web-search"])   # an agent (MODEL) step
+       .then("Critique the findings")                       # a follow-on agent
+       .run())                                              # default client + wait
+print(out.text)
+```
+
+`kx.flow()` builds the SAME `(steps, edges)` as the operator/DSL forms (it lowers
+byte-identically — a Flow is sugar, never a new wire shape). Builders:
+`.agent(prompt, tools=…, reasoning=…)` · `.step(**params)` (pure) · `.tool(id, ver, **args)` ·
+`.then(item)` (sequential — a string is an agent) · `.parallel(*items)` (fan-out / fan-in) ·
+`.context(*handles)`. Terminate with `.run()` (waits for the `Result`), `.submit()` (a
+handle), or `.to_chain()` / `.build()` to inspect.
+
+### A reusable Agent
+
+```python
+import kortecx as kx
+
+analyst = kx.Agent("You are a research analyst.", tools=["web-search", "fs-list"])
+print(analyst.run("Summarize the kortecx README").text)
+```
+
+`kx.Agent` carries instructions + an optional tool set + model/loop config. The **default
+lane is deterministic/frozen** — a single agent step with a FIXED tool-grant SET
+(replayable; the tools are part of the step's identity; execution lands with PR-9b-2).
+`dynamic=True` routes to the **steered** `kx/recipes/react` recipe, where the model picks
+tools turn by turn (works today).
+
+### Zero-config
+
+`import kortecx as kx; kx.run(...)` uses a lazily-built default client. Config order:
+explicit → env (`KX_ENDPOINT` / `KX_TOKEN` / `KX_DEFAULT_MODEL`) → `~/.kortecx/config.toml`
+→ the loopback default. Pass an explicit `KxClient` (the `client=` kwarg, or
+`kx.set_default_client(...)`) for full control — the singleton is a script convenience
+(construct explicit clients for concurrent/async work).
+
+```python
+kx.run("Summarize this design doc.", reasoning="minimal")   # a one-line agent
+```
+
 ## The string DSL
+
+The operator sugar (`a >> b`), the string DSL, and the raw blueprint JSON remain as
+power forms — all lower identically to the fluent builder above.
 
 Compose published task handles into a DAG with a single expression. The `tasks`
 map resolves each handle to a typed step.

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -19,7 +19,50 @@ npm install @kortecx/sdk       # node + browser entry points
 npm install ws                 # optional: node live-tail
 ```
 
+## The fluent builder (recommended)
+
+The friendliest way to author a chain reads top-to-bottom and fills in defaults — no
+`tasks` map, no `kind`, no `modelId`:
+
+```ts
+import { KxClient, flow } from "@kortecx/sdk";
+
+const kx = new KxClient("http://127.0.0.1:50151", { defaultModel: "kx-serve:qwen3-4b-q4_k_m" });
+
+const out = await flow()
+  .agent("Research the topic", { tools: ["web-search"] })   // an agent (MODEL) step
+  .then("Critique the findings")                            // a follow-on agent
+  .run({ client: kx });                                     // waits for the Result
+console.log(out.text);
+```
+
+`flow()` builds the SAME `(steps, edges)` as the combinator/DSL forms (it lowers
+byte-identically — a Flow is sugar, never a new wire shape). Builders:
+`.agent(prompt, { tools, reasoning })` · `.step(params)` (pure) · `.tool(id, ver, args)` ·
+`.then(item)` (sequential — a string is an agent) · `.parallel(...items)` (fan-out / fan-in) ·
+`.context(...handles)`. Terminate with `.run({ client })`, or `.toChain()` / `.lower()` to inspect.
+
+### A reusable Agent
+
+```ts
+import { Agent } from "@kortecx/sdk";
+
+const analyst = new Agent("You are a research analyst.", { tools: ["web-search", "fs-list"] });
+const out = await analyst.run("Summarize the README", { client: kx });
+console.log(out.text);
+```
+
+`Agent` carries instructions + an optional tool set + config. The **default lane is
+deterministic/frozen** — a single agent step with a FIXED tool-grant SET (replayable;
+execution lands with PR-9b-2). `{ dynamic: true }` routes to the **steered**
+`kx/recipes/react` recipe (the model picks tools turn by turn; works today). The TS
+`run` takes an explicit `{ client }` (browser-safe); the Python SDK adds a zero-config
+default client.
+
 ## The string DSL
+
+The combinators (`seq`/`par`/`chainFrom`), the string DSL, and the raw blueprint JSON
+remain as power forms — all lower identically to the fluent builder above.
 
 Compose published task handles into a DAG with a single expression. The `tasks`
 map resolves each handle to a typed step.


### PR DESCRIPTION
The headline of the **SDK ergonomics overhaul** (Batch V2) — the adoption-first paradigm you chose. Pure client-side sugar over the existing operator/combinator AST: a `Flow` lowers **byte-identically** to the equivalent chain (parity-tested), so **no proto / runtime / digest change**.

### What's in it
- **Fluent builder** (`flow.py` / `flow.ts`): `kx.flow().agent(prompt, tools=…).step().tool().then().parallel().context().run()`. Reads top-to-bottom, IDE-discoverable, defaults filled (served model, budget, wait). Builds the same `_Seq`/`_Par` (Py) / `seq`/`par` (TS) graph the operators do.
- **First-class `Agent`** (`agent.py` / `agent.ts`): `kx.Agent(instructions, tools=[], dynamic=False).run(task)`. **Default lane = deterministic/frozen** (one agent step, replayable); `dynamic=True` → the steered `kx/recipes/react` recipe.
- **Zero-config** (`defaults.py`, Python): `import kortecx as kx; kx.run(...)` — a lazy default client; config order explicit → env (`KX_ENDPOINT`/`KX_TOKEN`/`KX_DEFAULT_MODEL`) → `~/.kortecx/config.toml`. (TS `run()` takes an explicit `{ client }`, browser-safe; the node zero-config default is a small follow-on.)
- **Docs**: chains `python.md` + `typescript.md` gain a prominent "fluent builder (recommended)" section.

### Tests & verification
- `test_flow.py` (10) + `test/flow.test.ts` (10): fluent ↔ operator/combinator ↔ string-DSL **lowering parity**, fan-out/in, Agent frozen shape, zero-config resolution. Python chains 63 + flow 10; TS chains 61 + flow 10. mypy + ruff clean; tsc + biome ci clean.
- **Live-verified**: `kx.flow().step().then().run()` and `kx.run(flow)` (with `.parallel`) both **COMMITTED** end-to-end via the zero-config default client.

### Invariants
- No proto/runtime change; frozen-trio untouched; product digest `7d22d4bd` unaffected (pure client sugar; the Flow lowers to the same wire the corpus already pins).

Part of the overhaul: Batch A ✅ (#230) → **V2a (this)** → V2b (local `@kx.tool` MCP bridge) → Batch B (export) → Batch C (inference params). PR-9b-2 (the `@tool` bounded-loop execution) is the parallel deferred deep-core; the frozen-tool lane of `Agent` lights up when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rots6A12xboq8ZmbiiXCxf