### PR TITLE
SDK V2b — local `@kx.tool` / `localTool` function-as-tool (Py + TS) via the PR-6b MCP gateway

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -23,7 +23,7 @@ from .branch import (
     SnapshotResult,
 )
 from .capture import CaptureRecord, CaptureRecordPage
-from .chains import Chain, Task, chain, model, pure, tool
+from .chains import Chain, Task, chain, model, pure
 from .client import DEFAULT_ENDPOINT, AsyncKxClient, KxClient
 from .content import ContentItem, PutResult
 from .context import ContextBundle, ContextBundleItem, PutContextBundleResult
@@ -73,6 +73,7 @@ from .run import AsyncRun, Result, Run
 from .runs import RunInputs, RunPage, RunSummary
 from .teams import TeamMember, TeamMembers, TeamSummary, WarrantView
 from .telemetry import ModelTokenRollup, MoteTelemetryRow, TelemetryPage, TelemetrySummary
+from .tools import LocalToolDef, ToolError, tool
 from .toolscout import (
     BundleScore,
     BundleSpec,
@@ -158,6 +159,9 @@ __all__ = [
     "Flow",
     "flow",
     "Agent",
+    # V2b — local function tools (@kx.tool → a governed stdio MCP tool).
+    "LocalToolDef",
+    "ToolError",
     "run",
     "invoke",
     "make_client",

--- a/bindings/python/src/kortecx/_toolserver.py
+++ b/bindings/python/src/kortecx/_toolserver.py
@@ -1,0 +1,164 @@
+"""A minimal stdio MCP server for ``@kx.tool`` local functions (Batch V2b).
+
+The runtime SPAWNS this (``python -m kortecx._toolserver --script <abs> --tools
+a,b``) when it dials an SDK-registered local tool server. It re-loads the user's
+module to recover the decorated functions, then speaks newline-delimited JSON-RPC
+2.0 over stdin/stdout — the same wire the runtime's ``StdioSession`` drives
+(``initialize`` → ``tools/list`` → ``tools/call``). Hand-rolled (the SDK has no
+``mcp`` dependency); templated on the in-repo ``kx-mcp`` test stdio servers.
+
+Re-import: the module is loaded under a NON-``__main__`` run name, so a user's
+``if __name__ == "__main__":`` block (e.g. their ``.run()`` calls) never re-runs;
+only the top-level ``@kx.tool`` decorations register. The ``KX_TOOLSERVE`` env is
+set first so the lazy default client refuses to start a run in this context.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import runpy
+import sys
+from typing import Any, Dict, List, Optional
+
+from .tools import TOOLSERVE_ENV, LocalToolDef
+
+#: The MCP revision we advertise; the runtime negotiates and never hard-gates.
+_PROTOCOL_VERSION = "2026-07-28"
+
+
+def _load_tools(
+    script: Optional[str], module: Optional[str], names: List[str]
+) -> Dict[str, LocalToolDef]:
+    """Re-import the user's module (registering its ``@kx.tool`` decorations) and
+    return the requested tools by name."""
+    os.environ[TOOLSERVE_ENV] = "1"
+    # Importing here (not at module top) so the env sentinel is set first.
+    from . import tools as _tools
+
+    if script:
+        # Run the script's top level under a non-__main__ name so a guarded main
+        # block is skipped; the decorators populate `_tools._LOCAL_TOOLS`.
+        runpy.run_path(script, run_name="__kx_tools__")
+    elif module:
+        import importlib
+
+        importlib.import_module(module)
+    selected: Dict[str, LocalToolDef] = {}
+    for name in names:
+        tdef = _tools._LOCAL_TOOLS.get(name)
+        if tdef is not None:
+            selected[name] = tdef
+    return selected
+
+
+def _ok(req_id: Any, result: Any) -> str:
+    return json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}, ensure_ascii=False)
+
+
+def _err(req_id: Any, code: int, message: str) -> str:
+    return json.dumps(
+        {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}},
+        ensure_ascii=False,
+    )
+
+
+def _tools_list_result(tools: Dict[str, LocalToolDef]) -> Dict[str, Any]:
+    return {
+        "tools": [
+            {"name": t.name, "description": t.description, "inputSchema": t.schema}
+            for t in tools.values()
+        ]
+    }
+
+
+def _handle(req: Dict[str, Any], tools: Dict[str, LocalToolDef]) -> Optional[str]:
+    """Answer ONE JSON-RPC request, or ``None`` for a notification (no ``id``)."""
+    method = req.get("method")
+    if "id" not in req:
+        return None  # a notification (e.g. notifications/initialized) — no reply
+    req_id = req.get("id")
+    if method == "initialize":
+        return _ok(
+            req_id,
+            {
+                "protocolVersion": _PROTOCOL_VERSION,
+                "capabilities": {},
+                "serverInfo": {"name": "kortecx-local-tools", "version": "1"},
+            },
+        )
+    if method == "tools/list":
+        return _ok(req_id, _tools_list_result(tools))
+    if method == "tools/call":
+        params = req.get("params") or {}
+        name = params.get("name")
+        tdef = tools.get(name) if isinstance(name, str) else None
+        if tdef is None:
+            return _err(req_id, -32602, f"no such tool: {name}")
+        args = params.get("arguments") or {}
+        if not isinstance(args, dict):
+            return _err(req_id, -32602, "arguments must be a JSON object")
+        try:
+            result = tdef.fn(**args)
+        except Exception as exc:  # the tool body failed — surface it as a tool error
+            return _err(req_id, -32000, f"{type(exc).__name__}: {exc}")
+        try:
+            # The runtime extracts the JSON-RPC `result` field verbatim as the
+            # tool's committed output.
+            json.dumps(result)
+        except (TypeError, ValueError):
+            return _err(req_id, -32000, "tool returned a non-JSON-serializable value")
+        return _ok(req_id, result)
+    return _err(req_id, -32601, f"no such method: {method}")
+
+
+def _parse_args(argv: List[str]) -> Dict[str, Any]:
+    script: Optional[str] = None
+    module: Optional[str] = None
+    names: List[str] = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--script" and i + 1 < len(argv):
+            script = argv[i + 1]
+            i += 2
+        elif a == "--module" and i + 1 < len(argv):
+            module = argv[i + 1]
+            i += 2
+        elif a == "--tools" and i + 1 < len(argv):
+            names = [n for n in argv[i + 1].split(",") if n]
+            i += 2
+        else:
+            i += 1
+    return {"script": script, "module": module, "names": names}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    opts = _parse_args(sys.argv[1:] if argv is None else argv)
+    tools = _load_tools(opts["script"], opts["module"], opts["names"])
+
+    stdin = sys.stdin
+    out = sys.stdout
+    for line in stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except (TypeError, ValueError):
+            out.write(_err(0, -32700, "parse error") + "\n")
+            out.flush()
+            continue
+        if not isinstance(req, dict):
+            out.write(_err(0, -32600, "invalid request") + "\n")
+            out.flush()
+            continue
+        reply = _handle(req, tools)
+        if reply is not None:
+            out.write(reply + "\n")
+            out.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bindings/python/src/kortecx/agent.py
+++ b/bindings/python/src/kortecx/agent.py
@@ -34,6 +34,10 @@ if TYPE_CHECKING:
 
 #: The steered, dynamic-tool recipe (the model chooses tools turn by turn).
 REACT_RECIPE_HANDLE = "kx/recipes/react"
+#: The steered lane that AUTO-GRANTS the live registered tool set (PR-6b-4) — the
+#: dynamic lane routes here when the agent carries tools (only react-auto can fire a
+#: dialed/registered tool). Requires the serve to run with ``KX_SERVE_AUTOGRANT=1``.
+REACT_AUTO_RECIPE_HANDLE = "kx/recipes/react-auto"
 
 
 class Agent:
@@ -44,7 +48,7 @@ class Agent:
         self,
         instructions: str = "",
         *,
-        tools: "Optional[Union[Sequence[str], Mapping[str, str]]]" = None,
+        tools: "Optional[Union[Sequence[object], Mapping[str, str]]]" = None,
         model: str = "",
         max_turns: Optional[int] = None,
         max_tool_calls: Optional[int] = None,
@@ -83,13 +87,51 @@ class Agent:
         timeout: float = 120.0,
         client: "Optional[KxClient]" = None,
     ) -> "Union[_g.RunHandle, Run, Result]":
-        """Run ``task``. Frozen lane (default) ⇒ a single agent step; ``dynamic=True``
-        ⇒ the steered ``kx/recipes/react`` recipe. Waits for the committed
-        :class:`~kortecx.run.Result` unless ``wait=False``."""
+        """Run ``task``.
+
+        - **frozen lane (default)** ⇒ a single agent step. A tool-bearing frozen agent
+          runs a deterministic-agentic loop that **lands in PR-9b-2** (refused at
+          submit today) — so a clear pre-flight hint is raised; use ``dynamic=True`` or
+          ``flow().tool(fn, **args)`` to call tools today.
+        - ``dynamic=True`` ⇒ the steered react lane. With tools it routes to
+          ``kx/recipes/react-auto`` (the only lane that fires registered/dialed tools;
+          needs ``KX_SERVE_AUTOGRANT=1``); without tools, plain ``kx/recipes/react``.
+
+        Waits for the committed :class:`~kortecx.run.Result` unless ``wait=False``."""
         from .defaults import default_client
 
         kx = client if client is not None else default_client()
+        has_tools = bool(self.tools)
         if self.dynamic:
-            args = {"instruction": self._prompt(task)}
-            return kx.invoke(REACT_RECIPE_HANDLE, args, wait=wait, timeout=timeout)
+            # The react / react-auto recipes REQUIRE the bounded-loop budget (the
+            # `react_contract` slots; the UI's planReactArgs mirrors this) — default
+            # to the recipe's anchored 8 / 6 when the agent didn't set them.
+            args = {
+                "instruction": self._prompt(task),
+                "max_turns": self.max_turns if self.max_turns is not None else 8,
+                "max_tool_calls": self.max_tool_calls if self.max_tool_calls is not None else 6,
+            }
+            if not has_tools:
+                return kx.invoke(REACT_RECIPE_HANDLE, args, wait=wait, timeout=timeout)
+            from .errors import KxNotFound
+            from .tools import ToolError, register_tools
+
+            register_tools(kx, self.tools)
+            try:
+                return kx.invoke(REACT_AUTO_RECIPE_HANDLE, args, wait=wait, timeout=timeout)
+            except KxNotFound as exc:
+                raise ToolError(
+                    "the dynamic tool lane needs the 'kx/recipes/react-auto' recipe — "
+                    "serve with KX_SERVE_AUTOGRANT=1 to enable it (it auto-grants the "
+                    "registered tool set to the loop)"
+                ) from exc
+        if has_tools:
+            from .tools import ToolError
+
+            raise ToolError(
+                "a frozen Agent with a tool set runs a deterministic-agentic loop that "
+                "lands in PR-9b-2 and is refused at submit today; use "
+                "Agent(..., dynamic=True) for the steered react lane, or "
+                "flow().tool(fn, **args) to fire one tool deterministically"
+            )
         return self.as_flow(task).run(wait=wait, timeout=timeout, client=kx)

--- a/bindings/python/src/kortecx/blueprints.py
+++ b/bindings/python/src/kortecx/blueprints.py
@@ -11,11 +11,14 @@ only changes what is PROPOSED, never what identity it gets.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Union
 
 from . import hexids
 from .v1 import coordinator_pb2 as _c
 from .v1 import gateway_pb2 as _g
+
+if TYPE_CHECKING:
+    from .tools import LocalToolDef
 
 _KIND = {
     "pure": _g.WorkflowStepKind.WORKFLOW_STEP_KIND_PURE,
@@ -61,6 +64,11 @@ class StepInput:
     #: otherwise. Absent ⇒ the coordinator default (8 turns / 6 tool calls).
     max_turns: Optional[int] = None
     max_tool_calls: Optional[int] = None
+    #: V2b (local tools): ``@kx.tool``-decorated functions referenced by this step.
+    #: Off the wire + the lowering — resolved at the run terminal (the SDK registers
+    #: each as a stdio MCP server, then fills the server-derived names into
+    #: ``tool_contract``). Empty ⇒ byte-identical to a string-only tool set.
+    local_tools: Tuple["LocalToolDef", ...] = ()
 
 
 @dataclass

--- a/bindings/python/src/kortecx/chains.py
+++ b/bindings/python/src/kortecx/chains.py
@@ -175,7 +175,7 @@ def model(
     model_id: str = "",
     prompt: str = "",
     *,
-    tools: "Optional[Union[Sequence[str], Mapping[str, str]]]" = None,
+    tools: "Optional[Union[Sequence[object], Mapping[str, str]]]" = None,
     max_turns: Optional[int] = None,
     max_tool_calls: Optional[int] = None,
     reasoning: Optional[str] = None,
@@ -194,7 +194,14 @@ def model(
     ``{name: version}`` map) to make this a **deterministic-agentic step** — the
     model runs a bounded reason→tool→observe loop over the granted tool SET (the
     same step the string DSL authors as ``handle@tool@tool``). ``max_turns`` /
-    ``max_tool_calls`` bound the loop (default 8 / 6; ignored when no tools)."""
+    ``max_tool_calls`` bound the loop (default 8 / 6; ignored when no tools).
+
+    V2b: ``tools`` may also include ``@kx.tool``-decorated LOCAL functions — the SDK
+    registers each as a stdio MCP server at the run terminal and fills the
+    server-derived name into the contract (off the lowering until then)."""
+    from .tools import split_tools
+
+    str_tools, local_tools = split_tools(tools)
     step_params: Dict[str, Union[bytes, str]] = dict(params)
     if reasoning is not None:
         step_params[REASONING_KEY] = _validate_reasoning(reasoning)
@@ -203,10 +210,11 @@ def model(
             kind="model",
             model_id=model_id,
             prompt=prompt,
-            tool_contract=_grants_to_contract(tools),
+            tool_contract=_grants_to_contract(str_tools),
             params=step_params,
             max_turns=max_turns,
             max_tool_calls=max_tool_calls,
+            local_tools=local_tools,
         )
     )
 
@@ -362,6 +370,13 @@ class Chain:
         # PR-7b: the chain-level context attachment, emitted verbatim (the corpus
         # pins its byte-identity across surfaces; absent ⇒ []).
         return {"steps": steps, "edges": edge_rows, "context_bundles": list(self._context)}
+
+    def _iter_steps(self) -> List[StepInput]:
+        """The lowered steps (in first-appearance order) — the live ``StepInput``
+        objects, so the V2b local-tool resolver can fill resolved names into their
+        ``tool_contract`` in place before :meth:`build` reads them."""
+        nodes, _ = self._lower()
+        return [t.step for t in nodes]
 
     def build(self) -> "_g.SubmitWorkflowRequest":
         """Lower → :class:`~kortecx.blueprints.BlueprintBuilder` → the request. Nodes

--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -318,7 +318,14 @@ class KxClient:
         and run it. A thin convenience over :meth:`submit_workflow` — the server
         still COMPILES the DAG + builds every warrant from the party's grants
         (SN-8). Returns the ``RunHandle``, or — with ``wait=True`` — the first
-        committed :class:`Result`."""
+        committed :class:`Result`.
+
+        V2b: any ``@kx.tool`` local functions referenced by the chain are registered
+        (as stdio MCP servers the runtime dials) + resolved into their steps' tool
+        contracts first; a chain with no local tools is unaffected."""
+        from .tools import resolve_local_tools
+
+        resolve_local_tools(self, chain)
         return self.submit_workflow(chain.build(), wait=wait, timeout=timeout)
 
     def get_projection(
@@ -1320,7 +1327,11 @@ class AsyncKxClient:
         self, chain: "_chains.Chain", *, wait: bool = False, timeout: float = 120.0
     ) -> Union["_g.RunHandle", Result]:
         """As :meth:`KxClient.run_chain` — lower a :class:`~kortecx.chains.Chain` and
-        run it over :meth:`submit_workflow`."""
+        run it over :meth:`submit_workflow`. V2b local tools (if any) are registered
+        + resolved first."""
+        from .tools import aresolve_local_tools
+
+        await aresolve_local_tools(self, chain)
         return await self.submit_workflow(chain.build(), wait=wait, timeout=timeout)
 
     async def get_projection(

--- a/bindings/python/src/kortecx/defaults.py
+++ b/bindings/python/src/kortecx/defaults.py
@@ -84,6 +84,15 @@ def default_client() -> KxClient:
     for scripts and sync use; for concurrent or async work, construct explicit
     :class:`~kortecx.client.KxClient` / :class:`~kortecx.client.AsyncKxClient`
     instances rather than relying on this singleton."""
+    # V2b guard: when re-imported inside `kortecx._toolserver` (the local-tool stdio
+    # server), an un-guarded top-level `.run()` would try to start a NEW run + recurse.
+    # Fail loudly with the fix (guard run calls under `if __name__ == "__main__":`).
+    if os.environ.get("KX_TOOLSERVE"):
+        raise RuntimeError(
+            "cannot start a run while serving @kx.tool local tools (the toolserver "
+            "re-import context) — put your .run()/.invoke() calls under "
+            '`if __name__ == "__main__":` so they do not re-execute.'
+        )
     global _DEFAULT_CLIENT
     if _DEFAULT_CLIENT is None:
         _DEFAULT_CLIENT = make_client()

--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -102,10 +102,21 @@ class Flow:
         """Append a PURE step (deterministic, no model/egress)."""
         return self._seq_append(_pure(**params))
 
-    def tool(self, tool_id: str, tool_version: str = "1", **args: object) -> "Flow":
-        """Append a standalone TOOL step — fire ONE registered tool (PR-6b-2). The
-        server resolves it in its live registry + builds the warrant (SN-8)."""
-        return self._seq_append(_tool(tool_id, tool_version, **args))
+    def tool(
+        self, tool_id: "Union[str, object]", tool_version: str = "1", **args: object
+    ) -> "Flow":
+        """Append a standalone TOOL step — fire ONE tool (PR-6b-2). The server
+        resolves it in its live registry + builds the warrant (SN-8).
+
+        ``tool_id`` is either a registered tool's name OR a ``@kx.tool``-decorated
+        LOCAL function (V2b) — the SDK registers the function as a stdio MCP server
+        at the run terminal and fires the resolved tool deterministically."""
+        from .tools import local_tool_def, local_tool_node
+
+        tdef = local_tool_def(tool_id)
+        if tdef is not None:
+            return self._seq_append(local_tool_node(tdef, args))
+        return self._seq_append(_tool(tool_id, tool_version, **args))  # type: ignore[arg-type]
 
     def then(self, item: "FlowItem", **agent_kwargs: object) -> "Flow":
         """Append ``item`` sequentially. A bare string is an agent step (with the

--- a/bindings/python/src/kortecx/tools.py
+++ b/bindings/python/src/kortecx/tools.py
@@ -1,0 +1,460 @@
+"""Local function tools — the ``@kx.tool`` decorator (Batch V2b).
+
+```python
+import kortecx as kx
+
+@kx.tool
+def add(a: int, b: int) -> int:
+    "Add two integers."
+    return a + b
+
+# fire it deterministically (works today):
+print(kx.flow().tool(add, a=2, b=2).run().text)
+
+# or let a model decide (the steered react-auto lane; needs KX_SERVE_AUTOGRANT=1):
+print(kx.Agent("Do the math.", tools=[add], dynamic=True).run("what is 2+2?").text)
+```
+
+Decorating a Python function turns it into a real, governed, fireable tool with
+**zero new runtime substrate**: the SDK exposes the decorated functions as a local
+**stdio MCP server** (:mod:`kortecx._toolserver`) and the runtime DIALS it through
+the existing PR-6b MCP gateway (``RegisterMcpServer`` / ``DiscoverServerTools``).
+A local tool is just another external MCP tool the runtime fires under a
+server-built warrant (SN-8 — the client never supplies a warrant).
+
+**Dev-scoped by design.** The runtime spawns the stdio server subprocess, so the
+runtime, this interpreter, and the tool module must be co-located (the SDK user is
+the operator on their own machine). Registering a stdio MCP server is the same
+host-trusted operation as ``kx connections add --command`` (PR-6b/D81/GR19); V2b
+adds no new attack surface. Cloud governs the bridge.
+
+**Three firing lanes (D161, GR15-honest):**
+
+- **deterministic** — ``flow().tool(fn, **args)`` fires ONE tool as a standalone
+  node (works today, even model-free).
+- **steered / dynamic** — ``Agent(tools=[fn], dynamic=True)`` runs the
+  ``kx/recipes/react-auto`` loop where the model picks tools (needs a served model
+  + ``KX_SERVE_AUTOGRANT=1``).
+- **frozen / deterministic-agentic** — ``Agent(tools=[fn])`` (the default lane) is a
+  MODEL step with a fixed tool set; its bounded loop **lands in PR-9b-2** and is
+  refused at submit today, so the Agent raises a clear pre-flight hint until then.
+
+**Re-import contract.** The runtime spawns ``python -m kortecx._toolserver`` which
+re-loads your module to recover the functions. Decorate at MODULE level and guard
+any ``.run()`` calls under ``if __name__ == "__main__":`` (the toolserver loads the
+module under a non-``__main__`` name, so a guarded main block never re-runs).
+"""
+
+from __future__ import annotations
+
+import enum
+import inspect
+import os
+import sys
+import typing
+import warnings
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from .blueprints import TOOL_ARGS_KEY, StepInput
+
+if TYPE_CHECKING:
+    from .chains import Chain, Task
+
+#: Env sentinel set by :mod:`kortecx._toolserver` while it re-imports the user's
+#: module. The lazy default client refuses to run a flow/agent in this context
+#: (a guard against an un-guarded top-level ``.run()`` re-executing + recursing).
+TOOLSERVE_ENV = "KX_TOOLSERVE"
+
+#: The stable server-name prefix for an SDK-registered local stdio MCP server.
+_LOCAL_SERVER_PREFIX = "kxlocal-"
+
+
+@dataclass(eq=False)
+class LocalToolDef:
+    """A function exposed as a local MCP tool (identity = the object). ``fn`` runs
+    IN the toolserver subprocess; ``schema`` is the derived MCP ``inputSchema``."""
+
+    name: str
+    version: str
+    description: str
+    schema: Dict[str, Any]
+    fn: Callable[..., Any]
+    module: str
+    qualname: str
+    script_path: str
+
+
+#: Process-global registry the toolserver subprocess reads after re-importing a
+#: module (name → def). In the authoring process it simply accumulates decorations.
+_LOCAL_TOOLS: Dict[str, LocalToolDef] = {}
+
+
+# --- type-hint → MCP inputSchema (the gateway's mapper gates str/int/bool/enum) ---
+
+
+def _type_to_jsonschema(name: str, ann: Any) -> Dict[str, Any]:
+    """Map ONE parameter annotation to a JSON-Schema property. Mirrors what the
+    gateway's ``json_schema_to_input_schema`` actually type-gates: ``str`` /
+    ``int`` / ``bool`` / string-enum. ``float`` maps to ``number`` (the runtime
+    does NOT gate floats — a warn mirrors the ``tool()`` no-floats rule); any
+    other / missing annotation falls back to ``string`` (the arg passes verbatim)."""
+    origin = typing.get_origin(ann)
+    if origin is typing.Literal:
+        vals = list(typing.get_args(ann))
+        if vals and all(isinstance(v, str) for v in vals):
+            return {"enum": vals}
+        return {"type": "string"}
+    if isinstance(ann, type) and issubclass(ann, enum.Enum):
+        members = [m.value for m in ann]
+        if members and all(isinstance(v, str) for v in members):
+            return {"enum": members}
+        return {"type": "string"}
+    # NOTE: bool is a subclass of int — check it first.
+    if ann is bool:
+        return {"type": "boolean"}
+    if ann is int:
+        return {"type": "integer"}
+    if ann is str:
+        return {"type": "string"}
+    if ann is float:
+        warnings.warn(
+            f"@kx.tool: parameter {name!r} is typed float; the runtime does not "
+            "type-gate numbers — it is passed verbatim. Prefer int where possible.",
+            stacklevel=4,
+        )
+        return {"type": "number"}
+    # Unknown/complex (list/dict/typed object) — no client gate; document that the
+    # function receives the decoded JSON value verbatim.
+    return {"type": "string"}
+
+
+def _schema_from_signature(fn: Callable[..., Any]) -> Dict[str, Any]:
+    """Derive an MCP ``inputSchema`` (``{type:object, properties, required}``) from
+    ``fn``'s signature + type hints. Params without a default are ``required``;
+    ``*args`` / ``**kwargs`` are skipped (un-mappable — documented)."""
+    sig = inspect.signature(fn)
+    try:
+        hints = typing.get_type_hints(fn)
+    except Exception:  # pragma: no cover - exotic annotations
+        hints = {}
+    props: Dict[str, Any] = {}
+    required: List[str] = []
+    for pname, param in sig.parameters.items():
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        ann = hints.get(pname, param.annotation)
+        props[pname] = _type_to_jsonschema(pname, ann)
+        if param.default is inspect.Parameter.empty:
+            required.append(pname)
+    schema: Dict[str, Any] = {"type": "object", "properties": props}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _script_path_of(fn: Callable[..., Any]) -> str:
+    """The abs path of the file defining ``fn`` (the toolserver re-loads it). Raise
+    a clear error for a function with no source file (a REPL/notebook closure)."""
+    src = inspect.getsourcefile(fn) or inspect.getfile(fn)
+    if not src:
+        raise ToolError(
+            f"@kx.tool: cannot locate the source file for {getattr(fn, '__name__', fn)!r}; "
+            "a local tool must be a function defined in a .py file (not a REPL closure)."
+        )
+    return os.path.abspath(src)
+
+
+class ToolError(ValueError):
+    """A local-tool authoring/registration error."""
+
+
+def _make_local_tool(
+    fn: Callable[..., Any],
+    *,
+    name: Optional[str] = None,
+    version: str = "1",
+    description: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Tag ``fn`` with a :class:`LocalToolDef` and register it. Returns ``fn``
+    unchanged (still directly callable)."""
+    if not callable(fn):
+        raise ToolError("@kx.tool must decorate a callable")
+    tool_name = name or fn.__name__.replace("_", "-")
+    desc = description if description is not None else (inspect.getdoc(fn) or "")
+    tdef = LocalToolDef(
+        name=tool_name,
+        version=str(version),
+        description=desc.strip(),
+        schema=_schema_from_signature(fn),
+        fn=fn,
+        module=getattr(fn, "__module__", ""),
+        qualname=getattr(fn, "__qualname__", tool_name),
+        script_path=_script_path_of(fn),
+    )
+    _LOCAL_TOOLS[tool_name] = tdef
+    fn.__kx_tool__ = tdef  # type: ignore[attr-defined]
+    return fn
+
+
+def local_tool_def(fn: Any) -> Optional[LocalToolDef]:
+    """Return the :class:`LocalToolDef` a ``@kx.tool``-decorated ``fn`` carries, or
+    ``None`` (not a local tool)."""
+    return getattr(fn, "__kx_tool__", None)
+
+
+# --- the public `tool` symbol: a decorator AND the back-compat node factory -------
+
+
+@typing.overload
+def tool(fn: Callable[..., Any]) -> Callable[..., Any]: ...
+
+
+@typing.overload
+def tool(
+    *, name: Optional[str] = ..., version: str = ..., description: Optional[str] = ...
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
+
+
+@typing.overload
+def tool(tool_id: str, tool_version: str, **args: object) -> "Task": ...
+
+
+def tool(*args: Any, **kwargs: Any) -> Any:
+    """``@kx.tool`` — expose a local function as a governed tool (V2b); OR
+    ``tool("id", "version", **args)`` — a standalone TOOL node firing a REGISTERED
+    tool (PR-6b-2, the back-compat factory).
+
+    Decorator forms::
+
+        @kx.tool
+        def add(a: int, b: int) -> int: ...
+
+        @kx.tool(name="adder", version="2")
+        def add(a: int, b: int) -> int: ...
+
+    The function's type hints become the tool's MCP ``inputSchema`` (str / int /
+    bool / string-enum are type-gated by the runtime; floats pass verbatim).
+    """
+    # Bare decorator: @kx.tool
+    if len(args) == 1 and callable(args[0]) and not kwargs:
+        return _make_local_tool(args[0])
+    # Node factory (back-compat): tool("id", "version", **args)
+    if args and isinstance(args[0], str):
+        from .chains import tool as _node_tool
+
+        return _node_tool(*args, **kwargs)
+    # Parametrized decorator: @kx.tool(name=..., version=..., description=...)
+    if not args:
+        name = kwargs.pop("name", None)
+        version = kwargs.pop("version", "1")
+        description = kwargs.pop("description", None)
+        if kwargs:
+            raise ToolError(f"@kx.tool got unexpected keyword(s): {sorted(kwargs)}")
+
+        def _decorate(fn: Callable[..., Any]) -> Callable[..., Any]:
+            return _make_local_tool(fn, name=name, version=version, description=description)
+
+        return _decorate
+    raise ToolError(
+        "tool(...) takes either @kx.tool on a function, @kx.tool(name=..., version=...), "
+        'or the node factory tool("id", "version", **args)'
+    )
+
+
+# --- run-terminal resolution: register the stdio server(s) + name the tools -------
+
+ToolsArg = Optional[Union[Sequence[Any], Mapping[str, str]]]
+
+
+def split_tools(tools: ToolsArg) -> Tuple[ToolsArg, Tuple[LocalToolDef, ...]]:
+    """Split a ``tools=`` value into (string/mapping grants, local-tool defs). A bare
+    function must be ``@kx.tool``-decorated; a plain lambda is a fail-closed error."""
+    if tools is None or isinstance(tools, Mapping):
+        return tools, ()
+    names: List[Any] = []
+    locals_: List[LocalToolDef] = []
+    for t in tools:
+        tdef = local_tool_def(t)
+        if tdef is not None:
+            locals_.append(tdef)
+        elif callable(t):
+            raise ToolError(
+                "a plain function in tools=[...] must be decorated with @kx.tool "
+                f"(got {getattr(t, '__name__', t)!r})"
+            )
+        else:
+            names.append(t)
+    return (names if names else None), tuple(locals_)
+
+
+def local_tool_node(tdef: LocalToolDef, args: Mapping[str, object]) -> "Task":
+    """A standalone TOOL node for a local function — the tool_contract is filled at
+    resolution (the namespaced ``<server>/<name>`` is server-derived)."""
+    from .chains import Task, _canonical_args_json
+
+    return Task(
+        StepInput(
+            kind="tool",
+            tool_contract={},
+            params={TOOL_ARGS_KEY: _canonical_args_json(dict(args))},
+            local_tools=(tdef,),
+        )
+    )
+
+
+def _server_name_for(script_path: str) -> str:
+    """A stable, deterministic server name per defining script (so re-runs upsert
+    the same connection — ``connection_id_of(name)`` is deterministic, SN-8)."""
+    import hashlib
+
+    digest = hashlib.blake2b(script_path.encode("utf-8"), digest_size=8).hexdigest()
+    return f"{_LOCAL_SERVER_PREFIX}{digest}"
+
+
+def _server_args(script_path: str, names: Sequence[str]) -> List[str]:
+    return [
+        "-m",
+        "kortecx._toolserver",
+        "--script",
+        script_path,
+        "--tools",
+        ",".join(sorted(set(names))),
+    ]
+
+
+def _plan_registrations(
+    defs: Sequence[LocalToolDef],
+) -> List[Tuple[str, str, List[str]]]:
+    """Group defs by defining script → one stdio server each. Returns
+    ``(server_name, script_path, [tool_names])`` per server, deterministically."""
+    by_script: Dict[str, List[LocalToolDef]] = {}
+    for d in defs:
+        by_script.setdefault(d.script_path, []).append(d)
+    plan: List[Tuple[str, str, List[str]]] = []
+    for script in sorted(by_script):
+        names = [d.name for d in by_script[script]]
+        plan.append((_server_name_for(script), script, names))
+    return plan
+
+
+def _resolved_name(server_name: str, tool_name: str, registered: Sequence[Any]) -> str:
+    """Find the namespaced ``<server>/<name>`` for ``tool_name`` among a server's
+    discovered tools (read back — never guess the namespacing rule)."""
+    want = f"{server_name}/{tool_name}"
+    for rt in registered:
+        if getattr(rt, "tool_name", None) == want:
+            return rt.tool_name
+    # Fall back to a remote-segment match (defensive against any normalization).
+    for rt in registered:
+        full = getattr(rt, "tool_name", "")
+        if "/" in full and full.split("/", 1)[1] == tool_name:
+            return full
+    raise ToolError(
+        f"local tool {tool_name!r} was not discovered on server {server_name!r} "
+        "(registration/discovery mismatch)"
+    )
+
+
+def _apply_contract(chain: "Chain", name_map: Dict[int, str]) -> None:
+    """Augment each step's ``tool_contract`` with its resolved local-tool names
+    (idempotent ``setdefault`` — safe to re-run)."""
+    for step in chain._iter_steps():
+        for tdef in step.local_tools:
+            resolved = name_map.get(id(tdef))
+            if resolved is not None:
+                step.tool_contract.setdefault(resolved, tdef.version)
+
+
+def resolve_local_tools(client: Any, chain: "Chain") -> None:
+    """Register every local tool referenced by ``chain`` (sync) + rewrite each
+    step's ``tool_contract`` to the server-derived names. No-op when there are none."""
+    defs = _collect_defs(chain)
+    if not defs:
+        return
+    by_def: Dict[str, List[LocalToolDef]] = {}
+    for d in defs:
+        by_def.setdefault(d.script_path, []).append(d)
+    name_map: Dict[int, str] = {}
+    for server_name, script, names in _plan_registrations(defs):
+        client.register_mcp_server(
+            name=server_name,
+            transport="stdio",
+            endpoint=sys.executable,
+            args=_server_args(script, names),
+        )
+        page = client.discover_server_tools(name=server_name)
+        for tdef in by_def[script]:
+            name_map[id(tdef)] = _resolved_name(server_name, tdef.name, page.tools)
+    _apply_contract(chain, name_map)
+
+
+async def aresolve_local_tools(client: Any, chain: "Chain") -> None:
+    """As :func:`resolve_local_tools`, over an async client."""
+    defs = _collect_defs(chain)
+    if not defs:
+        return
+    by_def: Dict[str, List[LocalToolDef]] = {}
+    for d in defs:
+        by_def.setdefault(d.script_path, []).append(d)
+    name_map: Dict[int, str] = {}
+    for server_name, script, names in _plan_registrations(defs):
+        await client.register_mcp_server(
+            name=server_name,
+            transport="stdio",
+            endpoint=sys.executable,
+            args=_server_args(script, names),
+        )
+        page = await client.discover_server_tools(name=server_name)
+        for tdef in by_def[script]:
+            name_map[id(tdef)] = _resolved_name(server_name, tdef.name, page.tools)
+    _apply_contract(chain, name_map)
+
+
+def _collect_defs(chain: "Chain") -> List[LocalToolDef]:
+    seen: Dict[int, LocalToolDef] = {}
+    for step in chain._iter_steps():
+        for tdef in step.local_tools:
+            seen.setdefault(id(tdef), tdef)
+    return list(seen.values())
+
+
+def register_tools(client: Any, tools: ToolsArg) -> None:
+    """Register the local tools in a ``tools=`` set (sync) WITHOUT rewriting a
+    contract — used by the dynamic react-auto lane, which auto-grants the live
+    registry. No-op when there are no local tools."""
+    _, defs = split_tools(tools)
+    if not defs:
+        return
+    for server_name, script, names in _plan_registrations(defs):
+        client.register_mcp_server(
+            name=server_name,
+            transport="stdio",
+            endpoint=sys.executable,
+            args=_server_args(script, names),
+        )
+
+
+async def aregister_tools(client: Any, tools: ToolsArg) -> None:
+    """As :func:`register_tools`, over an async client."""
+    _, defs = split_tools(tools)
+    if not defs:
+        return
+    for server_name, script, names in _plan_registrations(defs):
+        await client.register_mcp_server(
+            name=server_name,
+            transport="stdio",
+            endpoint=sys.executable,
+            args=_server_args(script, names),
+        )

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -1,0 +1,343 @@
+"""Local function tools (``@kx.tool``, Batch V2b) — unit tests (no server).
+
+Covers the decorator + type-hint→inputSchema mapping, the ``tool`` overload
+(decorator vs the back-compat node factory), tool-set splitting, the run-terminal
+resolution against a mock client, the Agent routing (frozen pre-flight hint +
+dynamic→react-auto), and the hand-rolled stdio MCP server round-trip.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict, List, Literal
+
+import pytest
+
+import kortecx as kx
+from kortecx.agent import REACT_AUTO_RECIPE_HANDLE, REACT_RECIPE_HANDLE, Agent
+from kortecx.chains import Task
+from kortecx.tools import (
+    ToolError,
+    _server_name_for,
+    local_tool_def,
+    resolve_local_tools,
+    split_tools,
+    tool,
+)
+from kortecx.toolscout import RegisteredTool, RegisteredToolsPage
+
+# --- decorator + schema mapping ----------------------------------------------
+
+
+def test_decorator_maps_basic_types_and_required() -> None:
+    @tool
+    def f(a: int, b: str, c: bool, d: int = 7) -> int:
+        "A tool."
+        return a
+
+    td = local_tool_def(f)
+    assert td is not None
+    assert td.name == "f" and td.version == "1" and td.description == "A tool."
+    assert td.schema == {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer"},
+            "b": {"type": "string"},
+            "c": {"type": "boolean"},
+            "d": {"type": "integer"},
+        },
+        "required": ["a", "b", "c"],  # d has a default → not required
+    }
+    assert f(1, "x", True) == 1  # still directly callable
+
+
+def test_decorator_underscore_to_hyphen_name() -> None:
+    @tool
+    def my_cool_tool(x: int) -> int:
+        return x
+
+    assert local_tool_def(my_cool_tool).name == "my-cool-tool"
+
+
+class _Color(str, enum.Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+@tool
+def _pick(mode: Literal["fast", "slow"], color: _Color) -> str:
+    return mode
+
+
+def test_decorator_enum_and_literal_map_to_string_enum() -> None:
+    # NOTE: module-level imports + def — the real @kx.tool usage where
+    # ``get_type_hints`` can resolve the names (a nested def under
+    # ``from __future__ import annotations`` cannot resolve locally-imported names).
+    schema = local_tool_def(_pick).schema["properties"]
+    assert schema["mode"] == {"enum": ["fast", "slow"]}
+    assert schema["color"] == {"enum": ["red", "blue"]}
+
+
+def test_decorator_float_warns_and_maps_to_number() -> None:
+    with pytest.warns(UserWarning, match="float"):
+
+        @tool
+        def f(x: float) -> float:
+            return x
+
+    assert local_tool_def(f).schema["properties"]["x"] == {"type": "number"}
+
+
+def test_parametrized_decorator() -> None:
+    @tool(name="adder", version="3", description="custom")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    td = local_tool_def(add)
+    assert td.name == "adder" and td.version == "3" and td.description == "custom"
+
+
+def test_tool_overload_node_factory_still_works() -> None:
+    node = tool("srv/echo", "1", q="hi")
+    assert isinstance(node, Task)
+    assert node.step.kind == "tool"
+    assert node.step.tool_contract == {"srv/echo": "1"}
+
+
+def test_tool_overload_rejects_bad_kwargs() -> None:
+    with pytest.raises(ToolError):
+        tool(bogus="x")  # type: ignore[call-overload]
+
+
+# --- tool-set splitting -------------------------------------------------------
+
+
+def test_split_tools_mixes_strings_and_locals() -> None:
+    @tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    strs, locals_ = split_tools(["web-search", add])
+    assert strs == ["web-search"]
+    assert [d.name for d in locals_] == ["add"]
+
+
+def test_split_tools_plain_function_is_fail_closed() -> None:
+    with pytest.raises(ToolError, match="@kx.tool"):
+        split_tools([lambda a: a])  # type: ignore[list-item]
+
+
+def test_split_tools_mapping_passthrough() -> None:
+    strs, locals_ = split_tools({"x": "2"})
+    assert strs == {"x": "2"} and locals_ == ()
+
+
+# --- run-terminal resolution (mock client) ------------------------------------
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.registered: List[tuple] = []
+        self.invoked: List[tuple] = []
+
+    def register_mcp_server(self, *, name, transport, endpoint, args):  # noqa: ANN001
+        self.registered.append((name, transport, endpoint, tuple(args)))
+
+        class _R:
+            connection_id = "00" * 16
+            discovered = 1
+            health = "connected"
+
+        return _R()
+
+    def discover_server_tools(self, *, name):  # noqa: ANN001
+        # Mimic the gateway: a discovered tool is namespaced <server>/<remote>.
+        tools = [
+            RegisteredTool(
+                tool_id="ab" * 16,
+                tool_name=f"{name}/add",
+                tool_version="1",
+                kind="Mcp",
+                description="Add.",
+                idempotency_class="i",
+                provenance="HumanAuthored",
+                registration_status="Approved",
+                server_host="",
+                net_scope="none",
+                is_builtin=False,
+            )
+        ]
+        return RegisteredToolsPage(tools=tools, has_more=False)
+
+    def invoke(self, handle, args, *, wait=True, timeout=120.0):  # noqa: ANN001
+        self.invoked.append((handle, args, wait))
+        return "INVOKED"
+
+
+def _add_tool():  # noqa: ANN202
+    @tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    return add
+
+
+def test_resolve_fills_tool_node_contract() -> None:
+    add = _add_tool()
+    fc = _FakeClient()
+    chain = kx.flow().tool(add, a=2, b=2).to_chain()
+    resolve_local_tools(fc, chain)
+    sname = _server_name_for(local_tool_def(add).script_path)
+    step = chain._iter_steps()[0]
+    assert step.kind == "tool"
+    assert step.tool_contract == {f"{sname}/add": "1"}
+    assert fc.registered[0][0] == sname and fc.registered[0][1] == "stdio"
+    assert fc.registered[0][2] == sys.executable
+    assert "kortecx._toolserver" in fc.registered[0][3]
+
+
+def test_resolve_is_idempotent() -> None:
+    add = _add_tool()
+    fc = _FakeClient()
+    chain = kx.flow().tool(add, a=1, b=1).to_chain()
+    resolve_local_tools(fc, chain)
+    resolve_local_tools(fc, chain)  # second pass: no duplicate, no error
+    sname = _server_name_for(local_tool_def(add).script_path)
+    assert chain._iter_steps()[0].tool_contract == {f"{sname}/add": "1"}
+
+
+def test_resolve_agentic_model_step() -> None:
+    add = _add_tool()
+    fc = _FakeClient()
+    chain = kx.flow().agent("do math", tools=[add]).to_chain()
+    resolve_local_tools(fc, chain)
+    sname = _server_name_for(local_tool_def(add).script_path)
+    step = chain._iter_steps()[0]
+    assert step.kind == "model" and step.tool_contract == {f"{sname}/add": "1"}
+
+
+def test_resolve_noop_without_local_tools() -> None:
+    fc = _FakeClient()
+    chain = kx.flow().agent("hi", tools=["web-search"]).to_chain()
+    resolve_local_tools(fc, chain)
+    assert fc.registered == []
+    assert chain._iter_steps()[0].tool_contract == {"web-search": "1"}
+
+
+# --- Agent routing ------------------------------------------------------------
+
+
+def test_agent_frozen_with_tools_raises_preflight_hint() -> None:
+    add = _add_tool()
+    with pytest.raises(ToolError, match="PR-9b-2"):
+        Agent("do math", tools=[add]).run("2+2", client=_FakeClient())
+
+
+def test_agent_dynamic_with_local_tools_routes_to_react_auto() -> None:
+    add = _add_tool()
+    fc = _FakeClient()
+    Agent("do math", tools=[add], dynamic=True).run("2+2", client=fc)
+    # registered the local tool's stdio server + invoked react-AUTO (not plain react)
+    assert fc.registered, "local tool should be registered for the dynamic lane"
+    assert fc.invoked[0][0] == REACT_AUTO_RECIPE_HANDLE
+
+
+def test_agent_dynamic_without_tools_uses_plain_react() -> None:
+    fc = _FakeClient()
+    Agent("just chat", dynamic=True).run("hello", client=fc)
+    assert fc.registered == []
+    assert fc.invoked[0][0] == REACT_RECIPE_HANDLE
+
+
+# --- the stdio MCP server round-trip -----------------------------------------
+
+
+def _toolserver_env() -> Dict[str, str]:
+    # Make `python -m kortecx._toolserver` importable from the test's interpreter.
+    src_dir = os.path.dirname(os.path.dirname(kx.__file__))
+    env = dict(os.environ)
+    env["PYTHONPATH"] = src_dir + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+def test_toolserver_roundtrip_and_skips_main_block(tmp_path: Any) -> None:
+    script = tmp_path / "mytools.py"
+    script.write_text(
+        "import kortecx as kx\n"
+        "@kx.tool\n"
+        "def add(a: int, b: int) -> int:\n"
+        '    "Add."\n'
+        "    return a + b\n"
+        'if __name__ == "__main__":\n'
+        '    print("MAIN_RAN")\n'
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "kortecx._toolserver", "--script", str(script), "--tools", "add"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_toolserver_env(),
+    )
+    reqs = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},  # no id ⇒ no reply
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "add", "arguments": {"a": 2, "b": 40}},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "nope", "arguments": {}},
+        },
+    ]
+    out, err = proc.communicate("\n".join(json.dumps(r) for r in reqs) + "\n", timeout=30)
+    assert "MAIN_RAN" not in out, "the __main__ guard must be skipped on re-import"
+    resps = {json.loads(line)["id"]: json.loads(line) for line in out.splitlines() if line.strip()}
+    assert set(resps) == {1, 2, 3, 4}, f"a notification must not get a reply: {err}"
+    assert resps[1]["result"]["protocolVersion"]
+    assert resps[2]["result"]["tools"][0]["name"] == "add"
+    assert resps[2]["result"]["tools"][0]["inputSchema"]["required"] == ["a", "b"]
+    assert resps[3]["result"] == 42  # the runtime extracts `result` verbatim
+    assert resps[4]["error"]["code"] == -32602  # unknown tool
+
+
+def test_toolserver_surfaces_tool_exception() -> None:
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write(
+            "import kortecx as kx\n"
+            "@kx.tool\n"
+            "def boom(x: int) -> int:\n"
+            "    raise ValueError('nope')\n"
+        )
+        path = fh.name
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "kortecx._toolserver", "--script", path, "--tools", "boom"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_toolserver_env(),
+    )
+    req = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "boom", "arguments": {"x": 1}},
+    }
+    out, _ = proc.communicate(json.dumps(req) + "\n", timeout=30)
+    resp = json.loads(out.splitlines()[0])
+    assert resp["error"]["code"] == -32000
+    assert "ValueError" in resp["error"]["message"]
+    os.unlink(path)

--- a/bindings/typescript/src/_toolserver.ts
+++ b/bindings/typescript/src/_toolserver.ts
@@ -1,0 +1,143 @@
+/**
+ * A minimal stdio MCP server for `localTool(...)` functions (Batch V2b, Node-only).
+ *
+ * The runtime SPAWNS this (`node _toolserver.js --module <url> --tools a,b`) when it
+ * dials an SDK-registered local tool server. It re-imports the user's module to
+ * recover the `localTool(...)` registrations, then speaks newline-delimited JSON-RPC
+ * 2.0 over stdin/stdout — the wire the runtime's `StdioSession` drives (`initialize`
+ * → `tools/list` → `tools/call`). Hand-rolled (no `mcp` dependency).
+ *
+ * Re-import: top-level `localTool(...)` calls register into the process registry;
+ * guard any `.run()` calls under an entry check (`import.meta.url === ...` / a main
+ * guard) so they do not re-execute (`KX_TOOLSERVE` is set, so a stray run is refused).
+ */
+
+import { createInterface } from "node:readline";
+import { LOCAL_TOOLS, type LocalToolDef } from "./tools.js";
+
+const PROTOCOL_VERSION = "2026-07-28";
+
+interface JsonRpcReq {
+  id?: unknown;
+  method?: string;
+  params?: { name?: unknown; arguments?: unknown };
+}
+
+function parseArgs(argv: string[]): { module?: string; names: string[] } {
+  let module: string | undefined;
+  let names: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--module" && i + 1 < argv.length) {
+      module = argv[++i];
+    } else if (argv[i] === "--tools" && i + 1 < argv.length) {
+      names = (argv[++i] ?? "").split(",").filter((n) => n.length > 0);
+    }
+  }
+  return { module, names };
+}
+
+async function loadTools(
+  moduleUrl: string | undefined,
+  names: string[],
+): Promise<Map<string, LocalToolDef>> {
+  process.env.KX_TOOLSERVE = "1"; // a stray top-level run() is refused (see resolveLocalTools)
+  if (moduleUrl !== undefined) {
+    await import(moduleUrl); // registers via localTool()
+  }
+  const selected = new Map<string, LocalToolDef>();
+  for (const n of names) {
+    const d = LOCAL_TOOLS.get(n);
+    if (d !== undefined) {
+      selected.set(n, d);
+    }
+  }
+  return selected;
+}
+
+function ok(id: unknown, result: unknown): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function err(id: unknown, code: number, message: string): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+async function handle(req: JsonRpcReq, tools: Map<string, LocalToolDef>): Promise<string | null> {
+  if (!("id" in req)) {
+    return null; // a notification (e.g. notifications/initialized) — no reply
+  }
+  const id = req.id;
+  if (req.method === "initialize") {
+    return ok(id, {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      serverInfo: { name: "kortecx-local-tools", version: "1" },
+    });
+  }
+  if (req.method === "tools/list") {
+    return ok(id, {
+      tools: [...tools.values()].map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.schema,
+      })),
+    });
+  }
+  if (req.method === "tools/call") {
+    const name = req.params?.name;
+    const def = typeof name === "string" ? tools.get(name) : undefined;
+    if (def === undefined) {
+      return err(id, -32602, `no such tool: ${String(name)}`);
+    }
+    const args = req.params?.arguments;
+    if (typeof args !== "object" || args === null) {
+      return err(id, -32602, "arguments must be a JSON object");
+    }
+    let result: unknown;
+    try {
+      result = await def.run(args as Record<string, unknown>);
+    } catch (e) {
+      return err(id, -32000, `${(e as Error)?.name ?? "Error"}: ${(e as Error)?.message ?? e}`);
+    }
+    try {
+      JSON.stringify(result); // the runtime extracts `result` verbatim
+    } catch {
+      return err(id, -32000, "tool returned a non-JSON-serializable value");
+    }
+    return ok(id, result);
+  }
+  return err(id, -32601, `no such method: ${req.method}`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const { module, names } = parseArgs(argv);
+  const tools = await loadTools(module, names);
+  const rl = createInterface({ input: process.stdin });
+  for await (const line of rl) {
+    const t = line.trim();
+    if (t.length === 0) {
+      continue;
+    }
+    let req: unknown;
+    try {
+      req = JSON.parse(t);
+    } catch {
+      process.stdout.write(`${err(0, -32700, "parse error")}\n`);
+      continue;
+    }
+    if (typeof req !== "object" || req === null) {
+      process.stdout.write(`${err(0, -32600, "invalid request")}\n`);
+      continue;
+    }
+    const reply = await handle(req as JsonRpcReq, tools);
+    if (reply !== null) {
+      process.stdout.write(`${reply}\n`);
+    }
+  }
+}
+
+// Run when invoked directly (`node _toolserver.js ...`).
+main().catch((e) => {
+  process.stderr.write(`${String(e)}\n`);
+  process.exit(1);
+});

--- a/bindings/typescript/src/agent.ts
+++ b/bindings/typescript/src/agent.ts
@@ -13,13 +13,20 @@
  */
 
 import type { ReasoningMode } from "./chains.js";
+import { KxNotFound } from "./errors.js";
 import { type FlowClient, flow } from "./flow.js";
+import { KxToolError, type LocalToolDef, registerLocalTools } from "./tools.js";
 
 /** The steered, dynamic-tool recipe (the model chooses tools turn by turn). */
 export const REACT_RECIPE_HANDLE = "kx/recipes/react";
+/** The steered lane that AUTO-GRANTS the live registered tool set (PR-6b-4) — the
+ *  dynamic lane routes here when the agent carries tools (only react-auto fires a
+ *  dialed/registered tool). Requires the serve to run with `KX_SERVE_AUTOGRANT=1`. */
+export const REACT_AUTO_RECIPE_HANDLE = "kx/recipes/react-auto";
 
 export interface AgentOptions {
-  tools?: readonly string[] | Readonly<Record<string, string>>;
+  /** Tool grants — registered tool names and/or `localTool(...)` defs (V2b). */
+  tools?: readonly (string | LocalToolDef)[] | Readonly<Record<string, string>>;
   model?: string;
   maxTurns?: number;
   maxToolCalls?: number;
@@ -28,13 +35,28 @@ export interface AgentOptions {
   dynamic?: boolean;
 }
 
-/** The client surface {@link Agent.run} needs: `runChain` (frozen) + `invoke` (dynamic). */
+/** The client surface {@link Agent.run} needs: `runChain` (frozen) + `invoke` (dynamic)
+ *  + the MCP-gateway methods (V2b local-tool registration for the dynamic lane). */
 export interface AgentClient extends FlowClient {
   invoke(
     handle: string,
     args: unknown,
     opts?: { wait?: boolean; timeoutMs?: number },
   ): Promise<unknown>;
+  registerMcpServer(input: {
+    name: string;
+    transport: string;
+    endpoint: string;
+    args: string[];
+  }): Promise<unknown>;
+  discoverServerTools(name: string): Promise<{ tools: ReadonlyArray<{ toolName: string }> }>;
+}
+
+function hasTools(tools: AgentOptions["tools"]): boolean {
+  if (tools === undefined) {
+    return false;
+  }
+  return Array.isArray(tools) ? tools.length > 0 : Object.keys(tools).length > 0;
 }
 
 /** A reusable agent: instructions + an optional tool set + model/loop config. */
@@ -59,17 +81,52 @@ export class Agent {
     });
   }
 
-  /** Run `task`. Frozen lane (default) ⇒ a single agent step; `dynamic` ⇒ the steered
-   * `kx/recipes/react` recipe. Waits for the committed result unless `wait: false`. */
+  /**
+   * Run `task`.
+   *
+   * - **frozen lane (default)** ⇒ a single agent step. A tool-bearing frozen agent runs
+   *   a deterministic-agentic loop that **lands in PR-9b-2** (refused at submit today),
+   *   so a clear pre-flight hint is thrown; use `dynamic: true` or `flow().tool(fn, args)`.
+   * - `dynamic: true` ⇒ the steered react lane. With tools it routes to
+   *   `kx/recipes/react-auto` (the only lane that fires registered/dialed tools; needs
+   *   `KX_SERVE_AUTOGRANT=1`); without tools, plain `kx/recipes/react`.
+   */
   async run(
     task: string,
     opts: { wait?: boolean; timeoutMs?: number; client: AgentClient },
   ): Promise<unknown> {
+    const tools = this.opts.tools;
     if (this.opts.dynamic) {
-      return opts.client.invoke(
-        REACT_RECIPE_HANDLE,
-        { instruction: this.prompt(task) },
-        { wait: opts.wait ?? true, timeoutMs: opts.timeoutMs },
+      // The react / react-auto recipes REQUIRE the bounded-loop budget (the
+      // `react_contract` slots; the UI's planReactArgs mirrors this) — default to
+      // the recipe's anchored 8 / 6 when the agent didn't set them.
+      const args = {
+        instruction: this.prompt(task),
+        max_turns: this.opts.maxTurns ?? 8,
+        max_tool_calls: this.opts.maxToolCalls ?? 6,
+      };
+      const runOpts = { wait: opts.wait ?? true, timeoutMs: opts.timeoutMs };
+      if (!hasTools(tools)) {
+        return opts.client.invoke(REACT_RECIPE_HANDLE, args, runOpts);
+      }
+      await registerLocalTools(opts.client, tools);
+      try {
+        return await opts.client.invoke(REACT_AUTO_RECIPE_HANDLE, args, runOpts);
+      } catch (e) {
+        if (e instanceof KxNotFound) {
+          throw new KxToolError(
+            "the dynamic tool lane needs the 'kx/recipes/react-auto' recipe — serve with " +
+              "KX_SERVE_AUTOGRANT=1 to enable it (it auto-grants the registered tool set to the loop)",
+          );
+        }
+        throw e;
+      }
+    }
+    if (hasTools(tools)) {
+      throw new KxToolError(
+        "a frozen Agent with a tool set runs a deterministic-agentic loop that lands in " +
+          "PR-9b-2 and is refused at submit today; use { dynamic: true } for the steered react " +
+          "lane, or flow().tool(fn, args) to fire one tool deterministically",
       );
     }
     return this.asFlow(task).run({

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -21,6 +21,9 @@
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { BlueprintBuilder, type EdgeInput, type StepInput } from "./blueprints.js";
 import type { SubmitWorkflowRequestSchema } from "./gen/kortecx/v1/gateway_pb.js";
+// V2b: a `@kx.localTool` function-as-tool def — type-only here (the runtime dep is
+// one-way tools.ts → chains.ts; this never creates an import cycle).
+import type { LocalToolDef } from "./tools.js";
 
 /** Error class for a malformed expression / empty group (the `parse` corpus class). */
 export class ChainParseError extends Error {
@@ -85,6 +88,12 @@ export class Task {
     /** Agentic MODEL step only (PR-9b): the bounded-loop budget (default 8 / 6). */
     readonly maxTurns?: number,
     readonly maxToolCalls?: number,
+    /**
+     * V2b (local tools): `localTool(...)` defs referenced by this step. Off the wire
+     * + the lowering — the SDK registers each as a stdio MCP server at the run
+     * terminal and folds the server-derived name into `toolContract` ({@link Chain.build}).
+     */
+    readonly localTools: readonly LocalToolDef[] = [],
   ) {}
 
   /** The {@link StepInput} this task lowers to (the builder encodes params). */
@@ -169,6 +178,32 @@ function grantsToContract(
   return { ...(tools as Record<string, string>) };
 }
 
+/** V2b: anything accepted in `tools: [...]` — a registered tool NAME or a `localTool(...)`. */
+export type ToolRef = string | LocalToolDef;
+
+/** Split a `tools=` value into (string/record grants, local-tool defs). A non-string,
+ * non-`localTool` array item is a fail-closed authoring error. */
+function splitTools(tools?: readonly ToolRef[] | Readonly<Record<string, string>>): {
+  strings?: readonly string[] | Readonly<Record<string, string>>;
+  locals: LocalToolDef[];
+} {
+  if (tools === undefined || !Array.isArray(tools)) {
+    return { strings: tools as Readonly<Record<string, string>> | undefined, locals: [] };
+  }
+  const strings: string[] = [];
+  const locals: LocalToolDef[] = [];
+  for (const t of tools) {
+    if (t && typeof t === "object" && (t as { __kxLocalTool?: boolean }).__kxLocalTool === true) {
+      locals.push(t as LocalToolDef);
+    } else if (typeof t === "string") {
+      strings.push(t);
+    } else {
+      throw new ChainParseError("a tool must be a registered name (string) or a localTool(...)");
+    }
+  }
+  return { strings: strings.length > 0 ? strings : undefined, locals };
+}
+
 /**
  * PR-6b-2: the single canonical `config_subset` key a `tool()` step's authored
  * args ride under. MUST equal the Rust `kx_mote::TOOL_ARGS_KEY` + the Python
@@ -211,7 +246,7 @@ export const task = {
     prompt = "",
     params: Readonly<Record<string, string>> = {},
     opts: {
-      tools?: readonly string[] | Readonly<Record<string, string>>;
+      tools?: readonly ToolRef[] | Readonly<Record<string, string>>;
       maxTurns?: number;
       maxToolCalls?: number;
       reasoning?: ReasoningMode;
@@ -221,14 +256,18 @@ export const task = {
     if (opts.reasoning !== undefined) {
       stepParams[REASONING_KEY] = validateReasoning(opts.reasoning);
     }
+    // V2b: `localTool(...)` defs ride off the contract (resolved at the run terminal);
+    // string/record grants lower as before (golden-corpus byte-identical).
+    const { strings, locals } = splitTools(opts.tools);
     return new Task(
       "model",
       modelId,
       prompt,
       stepParams,
-      grantsToContract(opts.tools),
+      grantsToContract(strings),
       opts.maxTurns,
       opts.maxToolCalls,
+      locals,
     );
   },
   /**
@@ -249,6 +288,25 @@ export const task = {
       {
         [toolId]: version,
       },
+    );
+  },
+  /**
+   * V2b: a standalone TOOL node firing a LOCAL `localTool(...)` function — the
+   * contract is filled at the run terminal (the server-derived `<server>/<name>`).
+   */
+  localTool(
+    def: LocalToolDef,
+    args: Readonly<Record<string, string | number | boolean>> = {},
+  ): Task {
+    return new Task(
+      "tool",
+      "",
+      "",
+      { [TOOL_ARGS_KEY]: canonicalArgsJson(args) },
+      {},
+      undefined,
+      undefined,
+      [def],
     );
   },
 };
@@ -679,6 +737,7 @@ function withGrants(base: Task, handle: string, tags: string[]): Task {
     contract,
     base.maxTurns,
     base.maxToolCalls,
+    base.localTools,
   );
 }
 
@@ -805,16 +864,45 @@ export class Chain {
     };
   }
 
+  /** The distinct {@link LocalToolDef}s referenced across this chain's steps (V2b) —
+   * what the run terminal registers + resolves. */
+  collectLocalTools(): LocalToolDef[] {
+    const seen = new Set<LocalToolDef>();
+    for (const t of this.nodes) {
+      for (const lt of t.localTools) {
+        seen.add(lt);
+      }
+    }
+    return [...seen];
+  }
+
   /**
    * The `SubmitWorkflowRequest` init shape, assembled via the EXISTING
    * {@link BlueprintBuilder} (kinds → enum, strings → UTF-8, mode → FROZEN).
    * The DSL only feeds the builder `StepInput`/`EdgeInput` lists — it never
    * reassembles the wire request itself.
+   *
+   * V2b: `resolved` maps each local-tool def → its server-derived `<server>/<name>`;
+   * those names are folded into the owning step's `tool_contract` at build time
+   * (absent ⇒ a chain with no local tools, byte-identical to before).
    */
-  build(): MessageInitShape<typeof SubmitWorkflowRequestSchema> {
+  build(
+    resolved?: ReadonlyMap<LocalToolDef, string>,
+  ): MessageInitShape<typeof SubmitWorkflowRequestSchema> {
     const builder = new BlueprintBuilder(this.seed);
     for (const t of this.nodes) {
-      builder.addStep(t.toStepInput());
+      const step = t.toStepInput();
+      if (resolved !== undefined && t.localTools.length > 0) {
+        const contract: Record<string, string> = { ...step.toolContract };
+        for (const lt of t.localTools) {
+          const name = resolved.get(lt);
+          if (name !== undefined && !(name in contract)) {
+            contract[name] = lt.version;
+          }
+        }
+        step.toolContract = contract;
+      }
+      builder.addStep(step);
     }
     for (const e of this.edgePairs) {
       const edge: EdgeInput = { parent: e.parent, child: e.child, edge: "data" };

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -253,7 +253,11 @@ export abstract class KxClientBase {
     chain: Chain,
     opts: { wait?: boolean; timeoutMs?: number } = {},
   ): Promise<{ instanceId: Uint8Array; recipeFingerprint: Uint8Array } | Result> {
-    return this.submitWorkflow(chain.build(), opts);
+    // V2b: register + resolve any `localTool(...)` functions the chain references
+    // (a chain with none is unaffected — `resolved` is undefined ⇒ build() byte-identical).
+    const { resolveLocalTools } = await import("./tools.js");
+    const resolved = await resolveLocalTools(this, chain);
+    return this.submitWorkflow(chain.build(resolved), opts);
   }
 
   async getProjection(instanceId: Id, opts: { atSeq?: bigint } = {}): Promise<Projection> {

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -101,12 +101,15 @@ export {
   ChainUnknownHandleError,
   ChainCycleError,
 } from "./chains.js";
-export type { Frag, ChainOptions, Lowered, LoweredStep, LoweredEdge } from "./chains.js";
+export type { Frag, ChainOptions, Lowered, LoweredStep, LoweredEdge, ToolRef } from "./chains.js";
 // Batch V2 — the fluent builder + first-class Agent (the headline authoring surface).
 export { Flow, flow } from "./flow.js";
 export type { FlowItem, AgentStepOptions, FlowClient } from "./flow.js";
-export { Agent, REACT_RECIPE_HANDLE } from "./agent.js";
+export { Agent, REACT_RECIPE_HANDLE, REACT_AUTO_RECIPE_HANDLE } from "./agent.js";
 export type { AgentOptions, AgentClient } from "./agent.js";
+// V2b — local function tools (localTool → a governed stdio MCP tool the runtime dials).
+export { localTool, isLocalTool, KxToolError } from "./tools.js";
+export type { LocalToolDef, LocalToolSpec, LocalParamType, LocalParamSpec } from "./tools.js";
 
 export { TeamSummary, TeamMember, TeamMembers, WarrantView, teamsFromProto } from "./teams.js";
 export { GrantView, AssetGrants } from "./grants.js";

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -29,13 +29,15 @@ import {
   task,
 } from "./chains.js";
 import type { SubmitWorkflowRequestSchema } from "./gen/kortecx/v1/gateway_pb.js";
+import { type LocalToolDef, isLocalTool, localToolNode } from "./tools.js";
 
 /** A thing a builder method can fold in: a prompt (⇒ an agent step) or a `Frag`. */
 export type FlowItem = string | Frag;
 
 /** Options for {@link Flow.agent} (and the `then(string, …)` form). */
 export interface AgentStepOptions {
-  tools?: readonly string[] | Readonly<Record<string, string>>;
+  /** Tool grants — registered tool names and/or `localTool(...)` defs (V2b). */
+  tools?: readonly (string | LocalToolDef)[] | Readonly<Record<string, string>>;
   model?: string;
   maxTurns?: number;
   maxToolCalls?: number;
@@ -96,13 +98,25 @@ export class Flow {
     return this.append(task.pure(params));
   }
 
-  /** Append a standalone TOOL step — fire ONE registered tool (PR-6b-2). */
+  /** Append a standalone TOOL step — fire ONE tool (PR-6b-2). `toolId` is either a
+   * registered tool name OR a `localTool(...)` def (V2b — then the 2nd arg is its
+   * args object, registered at the run terminal + fired deterministically). */
   tool(
     toolId: string,
-    version = "1",
+    version?: string,
+    args?: Readonly<Record<string, string | number | boolean>>,
+  ): this;
+  tool(toolId: LocalToolDef, args?: Readonly<Record<string, string | number | boolean>>): this;
+  tool(
+    toolId: string | LocalToolDef,
+    versionOrArgs?: string | Readonly<Record<string, string | number | boolean>>,
     args: Readonly<Record<string, string | number | boolean>> = {},
   ): this {
-    return this.append(task.tool(toolId, version, args));
+    if (isLocalTool(toolId)) {
+      const a = (versionOrArgs as Readonly<Record<string, string | number | boolean>>) ?? {};
+      return this.append(localToolNode(toolId, a));
+    }
+    return this.append(task.tool(toolId, (versionOrArgs as string) ?? "1", args));
   }
 
   /** Append `item` sequentially. A bare string is an agent step (with `opts`); a `Frag`

--- a/bindings/typescript/src/tools.ts
+++ b/bindings/typescript/src/tools.ts
@@ -1,0 +1,362 @@
+/**
+ * Local function tools — `localTool(...)` (Batch V2b), the TS mirror of Python's
+ * `@kx.tool`.
+ *
+ * ```ts
+ * import { localTool, flow } from "@kortecx/sdk";
+ *
+ * const add = localTool({
+ *   name: "add",
+ *   params: { a: "integer", b: "integer" }, // explicit — TS types are erased at runtime
+ *   run: ({ a, b }) => a + b,
+ * });
+ *
+ * await flow().tool(add, { a: 2, b: 2 }).run({ client: kx }); // deterministic, today
+ * ```
+ *
+ * `localTool` exposes a JS function as a real, governed tool: the SDK runs it as a
+ * local **stdio MCP server** (`_toolserver`) the runtime DIALS through the existing
+ * PR-6b MCP gateway — zero new runtime substrate; the runtime fires it under a
+ * server-built warrant (SN-8).
+ *
+ * **Node + dev-scoped.** The runtime spawns the stdio server subprocess, so this is
+ * the Node SDK only (a browser cannot spawn a subprocess) and the tool MODULE must
+ * be Node-importable (compiled JS / `.mjs`) and co-located with the serve. Unlike
+ * Python (type hints → schema), TS types are erased, so the param schema is explicit.
+ *
+ * **Firing lanes (GR15-honest):** deterministic `flow().tool(fn, args)` (today) ·
+ * steered `new Agent({ tools:[fn], dynamic:true })` → `kx/recipes/react-auto` (today,
+ * needs `KX_SERVE_AUTOGRANT=1`) · frozen agentic loop → PR-9b-2 (a clear pre-flight hint).
+ */
+
+import { type Chain, type Task, task } from "./chains.js";
+
+/** A local-tool authoring/registration error. */
+export class KxToolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "KxToolError";
+  }
+}
+
+/** A param's declared type — `"string"` / `"integer"` / `"boolean"`, or a string
+ *  array (an exact-match enum). Floats are intentionally absent (the runtime does
+ *  not type-gate numbers; pass an int). */
+export type LocalParamType = "string" | "integer" | "boolean" | readonly string[];
+
+/** A param spec: a bare type (required) or `{ type, required? }`. */
+export type LocalParamSpec = LocalParamType | { type: LocalParamType; required?: boolean };
+
+/** The spec passed to {@link localTool}. */
+export interface LocalToolSpec {
+  /** The tool name (the model + `flow().tool` reference it). */
+  name: string;
+  /** The argument schema (explicit — TS types are erased at runtime). */
+  params?: Readonly<Record<string, LocalParamSpec>>;
+  /** The implementation — receives the decoded args, returns a JSON-able value. */
+  run: (args: Record<string, unknown>) => unknown;
+  version?: string;
+  description?: string;
+  /** The defining module's `import.meta.url` (auto-captured from the call site if
+   *  omitted; pass it explicitly if capture fails, e.g. under a bundler). */
+  module?: string;
+}
+
+/** A function exposed as a local MCP tool (the value put in `tools: [...]`). */
+export interface LocalToolDef {
+  readonly __kxLocalTool: true;
+  readonly name: string;
+  readonly version: string;
+  readonly description: string;
+  /** The derived MCP `inputSchema`. */
+  readonly schema: Record<string, unknown>;
+  /** The implementation (run IN the toolserver subprocess). */
+  readonly run: (args: Record<string, unknown>) => unknown;
+  /** The defining module (file URL / path), used to re-import in the toolserver. */
+  readonly module: string;
+}
+
+/** Process-global registry the toolserver subprocess reads after re-importing a
+ *  module (name → def). Backed by `globalThis` so it is ONE Map even when `tools.ts`
+ *  is inlined into multiple bundles (tsup `splitting: false`) — the user registers via
+ *  the SDK bundle, the toolserver reads via its own; both must see the same registry. */
+export const LOCAL_TOOLS: Map<string, LocalToolDef> = (() => {
+  const key = "__kx_local_tools__";
+  const g = globalThis as Record<string, unknown>;
+  const existing = g[key];
+  if (existing instanceof Map) {
+    return existing as Map<string, LocalToolDef>;
+  }
+  const m = new Map<string, LocalToolDef>();
+  g[key] = m;
+  return m;
+})();
+
+function jsonProp(t: LocalParamType): Record<string, unknown> {
+  if (Array.isArray(t)) {
+    return { enum: [...t] };
+  }
+  if (t === "integer") {
+    return { type: "integer" };
+  }
+  if (t === "boolean") {
+    return { type: "boolean" };
+  }
+  return { type: "string" };
+}
+
+function buildSchema(params?: Readonly<Record<string, LocalParamSpec>>): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  for (const [name, spec] of Object.entries(params ?? {})) {
+    if (typeof spec === "string" || Array.isArray(spec)) {
+      properties[name] = jsonProp(spec); // a bare type or a string-enum array
+      required.push(name);
+    } else if (typeof spec === "object" && "type" in spec) {
+      properties[name] = jsonProp(spec.type);
+      if (spec.required !== false) {
+        required.push(name);
+      }
+    }
+  }
+  const schema: Record<string, unknown> = { type: "object", properties };
+  if (required.length > 0) {
+    schema.required = required;
+  }
+  return schema;
+}
+
+/** Best-effort caller-module capture from the stack (no Node import — browser-safe).
+ *  The first stack frame is THIS file (the SDK bundle — `dist/node.js` etc. once
+ *  bundled, not literally `tools.ts`), so we skip every frame sharing that file and
+ *  return the first user frame. Robust to bundling (tsup inlines `tools.ts` into each
+ *  entry, so a filename-based skip would miss it). */
+function callerModule(): string {
+  const stack = new Error().stack ?? "";
+  let selfFile: string | undefined;
+  for (const line of stack.split("\n").slice(1)) {
+    const m = line.match(/(file:\/\/\/\S+?|[/\\]\S+?):\d+:\d+/);
+    if (m === null || m[1] === undefined) {
+      continue;
+    }
+    const p: string = m[1];
+    if (selfFile === undefined) {
+      // The frame of `callerModule` itself — the SDK bundle to skip past.
+      selfFile = p;
+      continue;
+    }
+    if (p === selfFile || p.includes("/node_modules/")) {
+      continue;
+    }
+    return p;
+  }
+  throw new KxToolError(
+    "could not determine the calling module for localTool(); pass { module: import.meta.url }",
+  );
+}
+
+/** Expose a JS function as a governed local tool (V2b). Returns a {@link LocalToolDef}
+ *  to put in `tools: [...]` or `flow().tool(def, args)`; also registers it (so the
+ *  toolserver subprocess recovers it after re-importing the module). */
+export function localTool(spec: LocalToolSpec): LocalToolDef {
+  if (typeof spec.run !== "function") {
+    throw new KxToolError("localTool({ run }) must be a function");
+  }
+  const def: LocalToolDef = {
+    __kxLocalTool: true,
+    name: spec.name,
+    version: spec.version ?? "1",
+    description: spec.description ?? "",
+    schema: buildSchema(spec.params),
+    run: spec.run,
+    module: spec.module ?? callerModule(),
+  };
+  LOCAL_TOOLS.set(def.name, def);
+  return def;
+}
+
+/** Is `t` a {@link LocalToolDef}? */
+export function isLocalTool(t: unknown): t is LocalToolDef {
+  return (
+    typeof t === "object" && t !== null && (t as { __kxLocalTool?: boolean }).__kxLocalTool === true
+  );
+}
+
+/** The local-tool defs in a `tools` value (for the dynamic react-auto lane). */
+export function localToolsOf(
+  tools?: readonly (string | LocalToolDef)[] | Readonly<Record<string, string>>,
+): LocalToolDef[] {
+  if (tools === undefined || !Array.isArray(tools)) {
+    return [];
+  }
+  return tools.filter(isLocalTool);
+}
+
+/** A deterministic dependency-free server name per defining module (so re-runs
+ *  upsert the same connection — `connection_id_of(name)` is deterministic, SN-8). */
+export function serverNameFor(module: string): string {
+  // FNV-1a 32-bit — stable + dependency-free (no cryptographic strength needed).
+  let h = 0x811c9dc5;
+  for (let i = 0; i < module.length; i++) {
+    h ^= module.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return `kxlocal-${(h >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+/** A minimal client surface the resolver needs. */
+export interface ToolGatewayClient {
+  registerMcpServer(input: {
+    name: string;
+    transport: string;
+    endpoint: string;
+    args: string[];
+  }): Promise<unknown>;
+  discoverServerTools(name: string): Promise<{ tools: ReadonlyArray<{ toolName: string }> }>;
+}
+
+/** Resolve a local tool's namespaced `<server>/<name>` from a server's discovered set. */
+function resolvedName(
+  serverName: string,
+  toolName: string,
+  registered: ReadonlyArray<{ toolName: string }>,
+): string {
+  const want = `${serverName}/${toolName}`;
+  for (const rt of registered) {
+    if (rt.toolName === want) {
+      return rt.toolName;
+    }
+  }
+  for (const rt of registered) {
+    const full = rt.toolName;
+    if (full.includes("/") && full.slice(full.indexOf("/") + 1) === toolName) {
+      return full;
+    }
+  }
+  throw new KxToolError(
+    `local tool '${toolName}' was not discovered on server '${serverName}' (registration mismatch)`,
+  );
+}
+
+/** Guard: refuse to (re)register while the toolserver is re-importing a module — a
+ *  stray un-guarded top-level `.run()` would recurse. */
+function assertNotReentrant(): void {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    ?.env;
+  if (env?.KX_TOOLSERVE !== undefined) {
+    throw new KxToolError(
+      "cannot start a run while serving localTool() tools (the toolserver re-import context) — " +
+        "guard your .run() calls (e.g. behind a main/entry check) so they do not re-execute.",
+    );
+  }
+}
+
+/** The Node binary + the built `_toolserver.js` entry (Node-only; throws in a browser).
+ *  The toolserver sits beside the running bundle in `dist/`; we resolve its directory
+ *  from `import.meta.url` (the ESM build) or `__dirname` (the CJS build — esbuild emits
+ *  one or the other depending on the consumed format). */
+async function spawnTarget(): Promise<{ node: string; entry: string }> {
+  assertNotReentrant();
+  const proc = (globalThis as { process?: { execPath?: string } }).process;
+  if (proc?.execPath === undefined) {
+    throw new KxToolError(
+      "local tools require the Node SDK (@kortecx/sdk/node) — a browser cannot spawn a tool server",
+    );
+  }
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, join } = await import("node:path");
+  const metaUrl = (import.meta as { url?: string }).url;
+  const baseDir =
+    typeof metaUrl === "string" && metaUrl.length > 0
+      ? dirname(fileURLToPath(metaUrl))
+      : ((globalThis as { __dirname?: string }).__dirname ?? __dirname);
+  return { node: proc.execPath, entry: join(baseDir, "_toolserver.js") };
+}
+
+async function toFileUrl(module: string): Promise<string> {
+  if (module.startsWith("file:")) {
+    return module;
+  }
+  const { pathToFileURL } = await import("node:url");
+  return pathToFileURL(module).href;
+}
+
+/** Register every local tool a chain references (Node), returning the def → server-derived
+ *  `<server>/<name>` map (or `undefined` when there are none). */
+export async function resolveLocalTools(
+  client: ToolGatewayClient,
+  chain: Chain,
+): Promise<ReadonlyMap<LocalToolDef, string> | undefined> {
+  assertNotReentrant();
+  const defs = chain.collectLocalTools();
+  if (defs.length === 0) {
+    return undefined;
+  }
+  const { node, entry } = await spawnTarget();
+  const byModule = new Map<string, LocalToolDef[]>();
+  for (const d of defs) {
+    const list = byModule.get(d.module);
+    if (list === undefined) {
+      byModule.set(d.module, [d]);
+    } else {
+      list.push(d);
+    }
+  }
+  const resolved = new Map<LocalToolDef, string>();
+  for (const [module, group] of byModule) {
+    const serverName = serverNameFor(module);
+    const url = await toFileUrl(module);
+    const names = [...new Set(group.map((d) => d.name))].sort();
+    await client.registerMcpServer({
+      name: serverName,
+      transport: "stdio",
+      endpoint: node,
+      args: [entry, "--module", url, "--tools", names.join(",")],
+    });
+    const page = await client.discoverServerTools(serverName);
+    for (const d of group) {
+      resolved.set(d, resolvedName(serverName, d.name, page.tools));
+    }
+  }
+  return resolved;
+}
+
+/** Register the local tools in a `tools=` set WITHOUT rewriting a contract — used by
+ *  the dynamic react-auto lane (which auto-grants the live registry). */
+export async function registerLocalTools(
+  client: ToolGatewayClient,
+  tools?: readonly (string | LocalToolDef)[] | Readonly<Record<string, string>>,
+): Promise<void> {
+  const defs = localToolsOf(tools);
+  if (defs.length === 0) {
+    return;
+  }
+  const { node, entry } = await spawnTarget();
+  const byModule = new Map<string, LocalToolDef[]>();
+  for (const d of defs) {
+    const list = byModule.get(d.module);
+    if (list === undefined) {
+      byModule.set(d.module, [d]);
+    } else {
+      list.push(d);
+    }
+  }
+  for (const [module, group] of byModule) {
+    const url = await toFileUrl(module);
+    const names = [...new Set(group.map((d) => d.name))].sort();
+    await client.registerMcpServer({
+      name: serverNameFor(module),
+      transport: "stdio",
+      endpoint: node,
+      args: [entry, "--module", url, "--tools", names.join(",")],
+    });
+  }
+}
+
+/** A standalone TOOL node firing a local function deterministically (V2b). */
+export function localToolNode(
+  def: LocalToolDef,
+  args: Readonly<Record<string, string | number | boolean>> = {},
+): Task {
+  return task.localTool(def, args);
+}

--- a/bindings/typescript/test/tools.test.ts
+++ b/bindings/typescript/test/tools.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Local function tools — `localTool(...)` (Batch V2b) — unit tests (no server, plus a
+ * spawned stdio MCP server round-trip against the built `dist/_toolserver.js`).
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { Agent, REACT_AUTO_RECIPE_HANDLE, REACT_RECIPE_HANDLE } from "../src/agent.js";
+import { flow } from "../src/flow.js";
+import {
+  KxToolError,
+  type LocalToolDef,
+  isLocalTool,
+  localTool,
+  localToolsOf,
+  registerLocalTools,
+  resolveLocalTools,
+  serverNameFor,
+} from "../src/tools.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distIndex = resolve(here, "../dist/index.js");
+
+// --- localTool + schema mapping ----------------------------------------------
+
+describe("localTool — schema mapping", () => {
+  it("maps explicit params + required", () => {
+    const add = localTool({
+      name: "add",
+      description: "Add two ints.",
+      params: { a: "integer", b: "string", c: "boolean", d: { type: "integer", required: false } },
+      run: () => 0,
+    });
+    expect(isLocalTool(add)).toBe(true);
+    expect(add.name).toBe("add");
+    expect(add.version).toBe("1");
+    expect(add.schema).toEqual({
+      type: "object",
+      properties: {
+        a: { type: "integer" },
+        b: { type: "string" },
+        c: { type: "boolean" },
+        d: { type: "integer" },
+      },
+      required: ["a", "b", "c"],
+    });
+  });
+
+  it("maps a string array to an enum", () => {
+    const t = localTool({ name: "pick", params: { mode: ["fast", "slow"] }, run: () => "" });
+    expect(t.schema.properties).toEqual({ mode: { enum: ["fast", "slow"] } });
+  });
+
+  it("captures the calling module", () => {
+    const t = localTool({ name: "x", run: () => 0 });
+    expect(t.module).toContain("tools.test");
+  });
+});
+
+// --- tool-set splitting + flow wiring -----------------------------------------
+
+describe("tools=[...] splitting", () => {
+  const add = localTool({ name: "add", params: { a: "integer" }, run: ({ a }) => a });
+
+  it("a model step splits strings from local defs", () => {
+    const lowered = flow()
+      .agent("go", { tools: ["web-search", add] })
+      .lower();
+    // the string grant lowers as before; the local def rides off the lowering
+    expect(lowered.steps[0]?.tool_contract).toEqual({ "web-search": "1" });
+  });
+
+  it("localToolsOf extracts the local defs", () => {
+    expect(localToolsOf(["web-search", add]).map((d) => d.name)).toEqual(["add"]);
+    expect(localToolsOf(["web-search"]).length).toBe(0);
+  });
+
+  it("flow().tool(def, args) builds a deferred local tool node", () => {
+    const chainObj = flow().tool(add, { a: 7 }).toChain();
+    const tools = chainObj.collectLocalTools();
+    expect(tools.map((t) => t.name)).toEqual(["add"]);
+    const lowered = chainObj.lower();
+    expect(lowered.steps[0]?.kind).toBe("tool");
+    expect(lowered.steps[0]?.tool_contract).toEqual({}); // filled at resolution
+    expect(lowered.steps[0]?.params["kx.tool.args"]).toBe('{"a":7}');
+  });
+});
+
+// --- run-terminal resolution (mock client) ------------------------------------
+
+class FakeClient {
+  registered: Array<{ name: string; transport: string; endpoint: string; args: string[] }> = [];
+  invoked: Array<{ handle: string }> = [];
+
+  async registerMcpServer(input: {
+    name: string;
+    transport: string;
+    endpoint: string;
+    args: string[];
+  }): Promise<unknown> {
+    this.registered.push(input);
+    return { connectionId: "00", discovered: 1, health: "connected" };
+  }
+
+  async discoverServerTools(name: string): Promise<{ tools: ReadonlyArray<{ toolName: string }> }> {
+    return { tools: [{ toolName: `${name}/add` }] };
+  }
+
+  async invoke(handle: string): Promise<unknown> {
+    this.invoked.push({ handle });
+    return "INVOKED";
+  }
+
+  // The frozen-tools Agent lane throws before this is reached (it satisfies AgentClient).
+  async runChain(): Promise<unknown> {
+    return "RAN";
+  }
+}
+
+describe("resolveLocalTools", () => {
+  const add = localTool({ name: "add", params: { a: "integer" }, run: ({ a }) => a });
+
+  it("registers a stdio server + resolves the namespaced name", async () => {
+    const fc = new FakeClient();
+    const chainObj = flow().tool(add, { a: 2 }).toChain();
+    const resolved = await resolveLocalTools(fc, chainObj);
+    const serverName = serverNameFor(add.module);
+    expect(resolved?.get(add)).toBe(`${serverName}/add`);
+    expect(fc.registered[0]?.transport).toBe("stdio");
+    expect(fc.registered[0]?.name).toBe(serverName);
+    expect(fc.registered[0]?.args).toContain("--module");
+    expect(fc.registered[0]?.args[0]).toContain("_toolserver");
+  });
+
+  it("is a no-op without local tools", async () => {
+    const fc = new FakeClient();
+    const chainObj = flow()
+      .agent("hi", { tools: ["web-search"] })
+      .toChain();
+    const resolved = await resolveLocalTools(fc, chainObj);
+    expect(resolved).toBeUndefined();
+    expect(fc.registered.length).toBe(0);
+  });
+});
+
+// --- Agent routing ------------------------------------------------------------
+
+describe("Agent routing", () => {
+  const add = localTool({ name: "add", params: { a: "integer" }, run: ({ a }) => a });
+
+  it("frozen + tools throws a pre-flight hint", async () => {
+    await expect(
+      new Agent("go", { tools: [add] }).run("2+2", { client: new FakeClient() }),
+    ).rejects.toThrow(KxToolError);
+  });
+
+  it("dynamic + local tools registers + routes to react-auto", async () => {
+    const fc = new FakeClient();
+    await new Agent("go", { tools: [add], dynamic: true }).run("2+2", { client: fc });
+    expect(fc.registered.length).toBeGreaterThan(0);
+    expect(fc.invoked[0]?.handle).toBe(REACT_AUTO_RECIPE_HANDLE);
+  });
+
+  it("dynamic without tools uses plain react", async () => {
+    const fc = new FakeClient();
+    await new Agent("chat", { dynamic: true }).run("hi", { client: fc });
+    expect(fc.registered.length).toBe(0);
+    expect(fc.invoked[0]?.handle).toBe(REACT_RECIPE_HANDLE);
+  });
+});
+
+// --- the stdio MCP server round-trip (spawns dist/_toolserver.js) --------------
+
+function roundTrip(moduleUrl: string, reqs: object[]): Promise<Record<number, any>> {
+  const entry = resolve(here, "../dist/_toolserver.js");
+  return new Promise((resolveP, rejectP) => {
+    const proc = spawn(process.execPath, [entry, "--module", moduleUrl, "--tools", "add"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let out = "";
+    let err = "";
+    proc.stdout.on("data", (d) => {
+      out += d;
+    });
+    proc.stderr.on("data", (d) => {
+      err += d;
+    });
+    proc.on("error", rejectP);
+    proc.on("close", () => {
+      try {
+        const byId: Record<number, any> = {};
+        for (const line of out.split("\n")) {
+          if (line.trim()) {
+            const r = JSON.parse(line);
+            byId[r.id] = r;
+          }
+        }
+        resolveP(byId);
+      } catch (e) {
+        rejectP(new Error(`bad toolserver output: ${out}\nstderr: ${err}\n${e}`));
+      }
+    });
+    proc.stdin.write(`${reqs.map((r) => JSON.stringify(r)).join("\n")}\n`);
+    proc.stdin.end();
+  });
+}
+
+describe("the stdio toolserver", () => {
+  it("serves initialize / tools/list / tools/call and skips a main guard", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kxtool-"));
+    const mod = join(dir, "mytools.mjs");
+    writeFileSync(
+      mod,
+      `import { localTool } from ${JSON.stringify(pathToFileURL(distIndex).href)};\n` +
+        `localTool({ name: "add", description: "Add.", params: { a: "integer", b: "integer" }, run: ({ a, b }) => a + b });\n` +
+        `globalThis.__MAIN_RAN = true; // not a guard; the toolserver must still answer\n`,
+    );
+    const byId = await roundTrip(pathToFileURL(mod).href, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", method: "notifications/initialized" }, // no id ⇒ no reply
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "add", arguments: { a: 2, b: 40 } },
+      },
+      { jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "nope", arguments: {} } },
+    ]);
+    expect(Object.keys(byId).sort()).toEqual(["1", "2", "3", "4"]); // a notification gets no reply
+    expect(byId[1].result.protocolVersion).toBeTruthy();
+    expect(byId[2].result.tools[0].name).toBe("add");
+    expect(byId[2].result.tools[0].inputSchema.required).toEqual(["a", "b"]);
+    expect(byId[3].result).toBe(42); // the runtime extracts `result` verbatim
+    expect(byId[4].error.code).toBe(-32602);
+  });
+});

--- a/bindings/typescript/test/tools.test.ts
+++ b/bindings/typescript/test/tools.test.ts
@@ -3,12 +3,12 @@
  * spawned stdio MCP server round-trip against the built `dist/_toolserver.js`).
  */
 
-import { spawn } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { Agent, REACT_AUTO_RECIPE_HANDLE, REACT_RECIPE_HANDLE } from "../src/agent.js";
 import { flow } from "../src/flow.js";
 import {
@@ -210,14 +210,25 @@ function roundTrip(moduleUrl: string, reqs: object[]): Promise<Record<number, an
 }
 
 describe("the stdio toolserver", () => {
+  // The round-trip spawns the BUILT `dist/_toolserver.js` and imports the built
+  // `dist/index.js` — the CI `sdk-typescript` job runs vitest without a prior build,
+  // so build the bundle once here (idempotent; skipped if already present).
+  beforeAll(() => {
+    const pkgRoot = resolve(here, "..");
+    if (!existsSync(resolve(pkgRoot, "dist/_toolserver.js")) || !existsSync(distIndex)) {
+      execFileSync("npx", ["tsup"], { cwd: pkgRoot, stdio: "ignore" });
+    }
+  }, 120_000);
+
   it("serves initialize / tools/list / tools/call and skips a main guard", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kxtool-"));
     const mod = join(dir, "mytools.mjs");
     writeFileSync(
       mod,
-      `import { localTool } from ${JSON.stringify(pathToFileURL(distIndex).href)};\n` +
-        `localTool({ name: "add", description: "Add.", params: { a: "integer", b: "integer" }, run: ({ a, b }) => a + b });\n` +
-        `globalThis.__MAIN_RAN = true; // not a guard; the toolserver must still answer\n`,
+      `import { localTool } from ${JSON.stringify(pathToFileURL(distIndex).href)};
+localTool({ name: "add", description: "Add.", params: { a: "integer", b: "integer" }, run: ({ a, b }) => a + b });
+globalThis.__MAIN_RAN = true; // not a guard; the toolserver must still answer
+`,
     );
     const byId = await roundTrip(pathToFileURL(mod).href, [
       { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },

--- a/bindings/typescript/tsup.config.ts
+++ b/bindings/typescript/tsup.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     node: "src/node.ts",
     web: "src/web.ts",
     chains: "src/chains.ts",
+    // V2b: the stdio MCP server the runtime spawns for local `localTool(...)` functions.
+    _toolserver: "src/_toolserver.ts",
   },
   format: ["esm", "cjs"],
   dts: true,

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -56,6 +56,10 @@ lane is deterministic/frozen** — a single agent step with a FIXED tool-grant S
 `dynamic=True` routes to the **steered** `kx/recipes/react` recipe, where the model picks
 tools turn by turn (works today).
 
+The tool set may include your own functions — decorate one with `@kx.tool` and pass it in
+`tools=[...]`; the SDK registers it as a local stdio MCP server the runtime dials. See
+[Local function tools](../tools.md#local-function-tools-kxtool--localtool).
+
 ### Zero-config
 
 `import kortecx as kx; kx.run(...)` uses a lazily-built default client. Config order:

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -59,6 +59,11 @@ execution lands with PR-9b-2). `{ dynamic: true }` routes to the **steered**
 `run` takes an explicit `{ client }` (browser-safe); the Python SDK adds a zero-config
 default client.
 
+The tool set may include your own functions — wrap one with `localTool({ name, params, run })`
+and pass it in `tools: [...]`; the SDK registers it as a local stdio MCP server the runtime
+dials (Node only). See
+[Local function tools](../tools.md#local-function-tools-kxtool--localtool).
+
 ## The string DSL
 
 The combinators (`seq`/`par`/`chainFrom`), the string DSL, and the raw blueprint JSON

--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -160,6 +160,73 @@ edit its **Args (JSON)** — the server resolves + warrants it on submit. The
 `q="…"`-style args lower **byte-identically across Python, TypeScript, Rust (CLI),
 and the UI** (the `tests/golden/chains` parity gate).
 
+## Local function tools (`@kx.tool` / `localTool`)
+
+Turn a plain function into a real, governed tool. The SDK exposes your decorated
+functions as a **local stdio MCP server**, and the runtime **dials it through the
+same external-MCP gateway** above — so a local function is just another dialed MCP
+tool the runtime fires under a server-built warrant (SN-8). **No new runtime
+substrate**, no proto change.
+
+```python
+import kortecx as kx
+
+@kx.tool
+def add(a: int, b: int) -> int:
+    "Add two integers."
+    return a + b
+
+# Deterministic — fire it as one node (works today, even model-free):
+print(kx.flow().tool(add, a=2, b=2).run().text)
+
+# Steered — let a model decide (the react-auto loop; needs KX_SERVE_AUTOGRANT=1):
+print(kx.Agent("Do the math.", tools=[add], dynamic=True).run("what is 2+2?").text)
+```
+
+```typescript
+import { localTool, flow, Agent } from "@kortecx/sdk/node";
+
+// TS types are erased at runtime, so the param schema is explicit:
+const add = localTool({
+  name: "add",
+  params: { a: "integer", b: "integer" },
+  run: ({ a, b }) => (a as number) + (b as number),
+});
+
+await flow().tool(add, { a: 2, b: 2 }).run({ client: kx });
+await new Agent("Do the math.", { tools: [add], dynamic: true }).run("2+2", { client: kx });
+```
+
+**Schema from the signature.** Python derives the MCP `inputSchema` from your type
+hints — `int` → integer, `str` → string, `bool` → boolean, `Literal[...]` / a
+string `Enum` → an exact-match enum; a parameter with no default is required.
+TypeScript declares the schema explicitly (`params`). **Floats are not type-gated**
+by the runtime (pass an `int` where you can); nested objects fall back to a JSON
+string.
+
+**Three firing lanes (be honest about what runs today):**
+
+| Lane | How | Status |
+| --- | --- | --- |
+| **Deterministic** | `flow().tool(fn, **args)` — one tool, fixed args | ✅ today (even model-free) — the reliable path for local tools |
+| **Steered / dynamic** | `Agent(tools=[fn], dynamic=True)` → `kx/recipes/react-auto` (the model chooses) | ⚠ the loop runs + the model proposes the call (needs a served model + `KX_SERVE_AUTOGRANT=1`), but a *dialed* tool is namespaced `&lt;server&gt;/&lt;name&gt;` and the autonomous authority gate doesn't yet match a model's bare-name call — a runtime improvement is tracked; use the deterministic lane for local tools today |
+| **Frozen / deterministic-agentic** | `Agent(tools=[fn])` — a fixed tool set, replayable bounded loop | ⏳ lands in PR-9b-2 (a clear pre-flight hint until then) |
+
+For the **deterministic** lane the SDK fires the tool by its exact server-derived name, so it always works. The other two depend on a *model* choosing the call: builtins (bare names like `fs-list`) match today; namespaced dialed/local tools wait on the runtime name-match improvement (and the frozen lane on PR-9b-2).
+
+**Dev-scoped & co-located.** The runtime *spawns* the stdio tool-server subprocess,
+so this is the **Node / local-Python** SDK on the **same machine** as `kx serve`:
+the interpreter, your tool module, and the runtime are co-located. Registering a
+local tool is the same host-trusted operation as `kx connections add --command`
+(see [Connections](#connections--the-external-mcp-gateway)) — V2b adds no new
+attack surface. In Cloud the bridge is governed.
+
+**Re-import contract.** The runtime spawns `python -m kortecx._toolserver`
+(Node: `node _toolserver.js`) which re-loads your module to recover the functions.
+Define your tools at **module level** and guard any `.run()` calls under
+`if __name__ == "__main__":` (the loader runs the module under a non-`__main__`
+name, so a guarded main block never re-executes).
+
 ## OSS / Cloud line
 
 Kortecx OSS is the **secure gateway to external MCP** — the runtime is the


### PR DESCRIPTION
## What

Decorate a Python function (`@kx.tool`) or wrap a TS function (`localTool`) and the SDK exposes it as a **local stdio MCP server** the runtime dials through the **existing PR-6b external-MCP gateway** — a user's own function becomes a real, governed, fireable tool with **zero new runtime substrate, no proto change, no digest move**. This is the V2b batch of the SDK authoring-ergonomics overhaul (after V2a #231).

```python
import kortecx as kx

@kx.tool
def add(a: int, b: int) -> int:
    "Add two integers."
    return a + b

print(kx.flow().tool(add, a=2, b=2).run().text)   # deterministic, fires today
```

```typescript
import { localTool, flow } from "@kortecx/sdk/node";
const add = localTool({ name: "add", params: { a: "integer", b: "integer" }, run: ({a,b}) => a+b });
await flow().tool(add, { a: 2, b: 2 }).run({ client: kx });
```

## How

- **Python** — `@kx.tool` decorator (overloads the existing `tool()` node factory on a callable first arg) + type-hint→`inputSchema` mapping (str/int/bool/enum; no floats) + a hand-rolled stdio MCP server (`kortecx._toolserver`; `runpy` re-import skips the `__main__` guard) + run-terminal resolution (register stdio server → discover → fill the server-derived `<server>/<name>` into `tool_contract`).
- **TypeScript** — `localTool({name, params, run})` (explicit schema — TS types are erased) + a **Node-only** `_toolserver` + the same resolution; the registry is `globalThis`-backed so the toolserver + SDK bundles (tsup `splitting:false`) share one Map.
- `flow().tool(fn, **args)` fires a local function **deterministically** (works today, even model-free); `Agent(tools=[fn], dynamic=True)` routes to `kx/recipes/react-auto` (+ registers the local tools); the **frozen** `Agent(tools=[fn])` lane raises a clear pre-flight hint (lands in PR-9b-2).
- **Bug fix (latent in V2a):** the Agent dynamic lane never passed the required `max_turns`/`max_tool_calls` (both `react` and `react-auto` require them) → `MissingRequired`. Now defaulted to 8/6 (mirrors the UI's `planReactArgs`).
- **Docs:** `tools.md` "Local function tools" section + chains python/typescript cross-links.

## Invariants

Pure client-side: **no Rust / proto / `Cargo.lock` / golden-corpus change** ⇒ canonical digest `7d22d4bd` **invariant by construction**, frozen-trio empty, golden-corpus parity preserved (string-tool lowering byte-identical).

## Tests + live verification

- Python `test_tools` (19) + TS `tools.test` (12); ruff/format/mypy + tsc/biome clean.
- **Live-verified through the real runtime** (it spawns the toolserver, negotiates MCP `2026-07-28`, fires the function): Python `add(2,40)→42`, `shout→"KORTECX"`; TS `tsadd(5,37)→42`; the plain-react dynamic lane commits (budget-fix confirmed).
- A TS bug was found + fixed by live testing: `callerModule` returned the SDK bundle path once bundled (`tools.ts`→`node.js`), re-importing the wrong file — fixed to skip frames sharing `callerModule`'s own file.

## Known runtime limitation (separate ticket — not this PR)

The autonomous `react-auto` authority gate **exact-matches** grants, so a model that calls a *namespaced dialed* tool by its **bare** name (e.g. `multiply` vs the grant `kxlocal-…/multiply`) is refused. This affects **any** dialed tool in the autonomous loop — §2.230 only fired dialed tools via authored `tool()` nodes. The **deterministic** `flow().tool()` lane is the reliable path for local tools today; docs say so honestly. A runtime name-match improvement is tracked for the agent-runner track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)