### PR TITLE
Batch B — blueprint export/import (`--emit-blueprint` + portable DAG JSON; CLI + Py + TS)

### DIFF
--- a/bindings/python/src/kortecx/chains.py
+++ b/bindings/python/src/kortecx/chains.py
@@ -28,6 +28,7 @@ Both produce a :class:`Chain`; :meth:`Chain.build` runs the one canonical loweri
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, replace
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
@@ -391,6 +392,163 @@ class Chain:
             builder.add_edge(EdgeInput(parent=parent, child=child, edge="data"))
         builder.context_bundles(self._context)
         return builder.build()
+
+    # --- Batch B (D161.2): portable blueprint export / import -----------------
+    def to_blueprint(self) -> Dict[str, object]:
+        """Export this chain as a PORTABLE blueprint dict — the same shape
+        ``kx blueprint run --file`` and :meth:`from_blueprint` consume. Round-trips:
+        feeding it back to :meth:`from_blueprint` (or the CLI) re-compiles to the
+        IDENTICAL :class:`SubmitWorkflowRequest` as :meth:`build`.
+
+        ``params`` are in their FOLDED form (a tool step's args under
+        ``kx.tool.args``; an agentic MODEL step's budget under ``max_turns`` /
+        ``max_tool_calls``) — :meth:`from_blueprint` / the server import them WITHOUT
+        re-folding (fold-idempotent). ``model_id`` is left as authored (empty ⇒ the
+        server binds the served model, SN-8 — so the artifact is portable across
+        serves). Empty fields are omitted for a clean artifact; each ``kind`` is
+        explicit (self-describing)."""
+        nodes, edges = self._lower()
+        steps: List[Dict[str, object]] = []
+        for t in nodes:
+            s = t.step
+            step: Dict[str, object] = {"kind": s.kind}
+            if s.model_id:
+                step["model_id"] = s.model_id
+            if s.prompt:
+                step["prompt"] = s.prompt
+            if s.body_signature_id is not None:
+                step["body_signature_id"] = s.body_signature_id
+            if s.tool_contract:
+                step["tool_contract"] = dict(s.tool_contract)
+            params = _effective_params(s)
+            if params:
+                # params values are pre-encoding strings (the lowering form).
+                step["params"] = {k: _as_str(v) for k, v in params.items()}
+            steps.append(step)
+        bp: Dict[str, object] = {
+            "seed": self._seed,
+            "execution_mode": "frozen",
+            "steps": steps,
+        }
+        if edges:
+            bp["edges"] = [{"parent": p, "child": c, "edge": "data"} for (p, c) in edges]
+        if self._context:
+            bp["context_bundles"] = list(self._context)
+        return bp
+
+    def export(self, path: Union[str, "os.PathLike[str]"]) -> None:
+        """Write :meth:`to_blueprint` as pretty JSON to ``path`` — the portable
+        artifact (save / version / share; re-run with ``kx blueprint run --file`` or
+        :meth:`from_blueprint`)."""
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.to_blueprint(), fh, indent=2)
+            fh.write("\n")
+
+    @classmethod
+    def from_blueprint(cls, spec: Mapping[str, object]) -> "_g.SubmitWorkflowRequest":
+        """Compile a portable blueprint dict (from :meth:`to_blueprint`, the CLI
+        ``--emit-blueprint``, or a hand-authored DAG) into a
+        :class:`SubmitWorkflowRequest` ready for ``client.submit_workflow``.
+
+        Accepts BOTH artifact forms: the SDK FOLDED form (args/budget already in
+        ``params``) and the CLI ARGS-SEPARATED form (a tool step's ``args`` map + an
+        agentic step's ``max_turns`` / ``max_tool_calls`` as separate fields) — both
+        fold to the same request. The chain TOPOLOGY is not recoverable from a DAG
+        (only the request is), so this returns the request, not a :class:`Chain`."""
+        builder = BlueprintBuilder(_opt_int(spec.get("seed")) or 0)
+        raw_steps = _get(spec, "steps", [])
+        if not isinstance(raw_steps, list):
+            raise ChainError("blueprint `steps` must be a list")
+        for d in raw_steps:
+            if not isinstance(d, Mapping):
+                raise ChainError("each blueprint step must be an object")
+            step = _step_from_spec(d)
+            # Fold the budget exactly as `build()` does (a no-op when already folded).
+            builder.add_step(replace(step, params=_effective_params(step)))
+        raw_edges = _get(spec, "edges", [])
+        for e in raw_edges if isinstance(raw_edges, list) else []:
+            if not isinstance(e, Mapping):
+                raise ChainError("each blueprint edge must be an object")
+            parent = _opt_int(e.get("parent"))
+            child = _opt_int(e.get("child"))
+            if parent is None or child is None:
+                raise ChainError("a blueprint edge needs integer `parent` + `child`")
+            builder.add_edge(
+                EdgeInput(
+                    parent=parent,
+                    child=child,
+                    edge=str(e.get("edge", "data")),
+                    non_cascade=bool(e.get("non_cascade", False)),
+                )
+            )
+        ctx = _get(spec, "context_bundles", [])
+        if isinstance(ctx, list):
+            builder.context_bundles([str(h) for h in ctx])
+        if _get(spec, "execution_mode", "frozen") == "dynamic":
+            builder.mode("dynamic")
+        return builder.build()
+
+    @classmethod
+    def from_blueprint_file(
+        cls, path: "Union[str, os.PathLike[str]]"
+    ) -> "_g.SubmitWorkflowRequest":
+        """Read a portable blueprint JSON file and compile it (see
+        :meth:`from_blueprint`)."""
+        with open(path, encoding="utf-8") as fh:
+            spec = json.load(fh)
+        if not isinstance(spec, Mapping):
+            raise ChainError("a blueprint file must be a JSON object")
+        return cls.from_blueprint(spec)
+
+
+def _get(m: "Mapping[str, object]", key: str, default: object) -> object:
+    """Mapping ``.get`` with a default (a tiny helper so `from_blueprint` reads
+    cleanly over an untyped JSON dict)."""
+    return m.get(key, default)
+
+
+def _infer_kind(d: "Mapping[str, object]") -> str:
+    """Infer a step's kind from field presence when ``kind`` is omitted — mirrors the
+    CLI ``StepSpec::resolve_kind`` (model fields win; then a tool contract; else pure).
+    Our own exports always set ``kind`` explicitly; this covers hand-authored DAGs."""
+    if d.get("model_id") or d.get("prompt"):
+        return "model"
+    if d.get("tool_contract"):
+        return "tool"
+    return "pure"
+
+
+def _opt_int(v: object) -> Optional[int]:
+    """An optional integer field from an untyped JSON value (``None`` stays ``None``)."""
+    return int(v) if isinstance(v, (int, str)) else None
+
+
+def _str_map(v: object) -> Dict[str, str]:
+    """A ``{str: str}`` map from an untyped JSON value (non-maps ⇒ empty)."""
+    return {str(k): str(val) for k, val in v.items()} if isinstance(v, Mapping) else {}
+
+
+def _step_from_spec(d: "Mapping[str, object]") -> StepInput:
+    """One blueprint step dict → a :class:`StepInput`, folding the CLI args-separated
+    form (a ``args`` map ⇒ ``kx.tool.args``) so both artifact forms import identically.
+    The agentic budget rides as ``max_turns`` / ``max_tool_calls`` on the StepInput and
+    is folded by `_effective_params` at build time (matching `Chain.build`)."""
+    kind = str(d.get("kind") or _infer_kind(d))
+    params: Dict[str, Union[bytes, str]] = {k: v for k, v in _str_map(d.get("params")).items()}
+    args = d.get("args")
+    if isinstance(args, Mapping) and args:
+        params[TOOL_ARGS_KEY] = _canonical_args_json({str(k): v for k, v in args.items()})
+    body_sig = d.get("body_signature_id")
+    return StepInput(
+        kind=kind,
+        model_id=str(d.get("model_id", "")),
+        prompt=str(d.get("prompt", "")),
+        body_signature_id=str(body_sig) if body_sig is not None else None,
+        tool_contract=_str_map(d.get("tool_contract")),
+        params=params,
+        max_turns=_opt_int(d.get("max_turns")),
+        max_tool_calls=_opt_int(d.get("max_tool_calls")),
+    )
 
 
 def _as_str(v: Union[bytes, str]) -> str:

--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -158,6 +158,14 @@ class Flow:
         """The canonical pre-encoding lowering (the corpus-parity dict)."""
         return self.to_chain().lowering()
 
+    def to_blueprint(self):
+        """Export this flow as a portable blueprint dict (Batch B; via :meth:`to_chain`)."""
+        return self.to_chain().to_blueprint()
+
+    def export(self, path) -> None:
+        """Write the portable blueprint JSON to ``path`` (Batch B; via :meth:`to_chain`)."""
+        self.to_chain().export(path)
+
     def run(
         self, *, wait: bool = True, timeout: float = 120.0, client=None
     ) -> "Union[Run, Result]":

--- a/bindings/python/tests/test_chains.py
+++ b/bindings/python/tests/test_chains.py
@@ -100,6 +100,27 @@ def test_corpus_parity(case: Dict[str, object]) -> None:
     assert lowered == expected
 
 
+@pytest.mark.parametrize(
+    "case",
+    [c for c in _CORPUS if "expect" in c],
+    ids=[c["name"] for c in _CORPUS if "expect" in c],
+)
+def test_corpus_export_import_round_trip(case: Dict[str, object]) -> None:
+    """Batch B (D161.2): every corpus SUCCESS case round-trips through the portable
+    blueprint artifact — ``to_blueprint()`` → JSON → ``from_blueprint()`` re-compiles
+    to the IDENTICAL ``SubmitWorkflowRequest`` as ``build()`` (the cross-surface
+    export/import guarantee), with no new corpus cases needed."""
+    tasks = _tasks_from_spec(case["tasks"])
+    seed = case.get("seed", 0)
+    context = case.get("context_bundles")
+    c = chain(case["dsl"], tasks, seed=seed, context=context)
+
+    bp = c.to_blueprint()
+    # The artifact must survive a JSON round-trip (a real file write/read).
+    reparsed = json.loads(json.dumps(bp))
+    assert Chain.from_blueprint(reparsed) == c.build(), case["name"]
+
+
 def test_seed_flows_to_the_request() -> None:
     """``seed`` is opaque to the lowering inspector but reaches the built request."""
     tasks = {"a": pure(), "b": pure()}

--- a/bindings/python/tests/test_flow.py
+++ b/bindings/python/tests/test_flow.py
@@ -108,6 +108,30 @@ def test_flow_is_a_flow_instance() -> None:
     assert isinstance(flow(), Flow)
 
 
+# --- Batch B: portable blueprint export/import (Flow delegates to Chain) ----------
+
+
+def test_flow_to_blueprint_round_trips_to_build() -> None:
+    from kortecx.chains import Chain
+
+    f = flow(seed=3).step(topic="hi").then("write about it")
+    bp = f.to_blueprint()
+    assert bp["seed"] == 3
+    assert bp["execution_mode"] == "frozen"
+    assert [s["kind"] for s in bp["steps"]] == ["pure", "model"]
+    # The exported artifact re-compiles to the IDENTICAL request as the flow's build().
+    assert Chain.from_blueprint(bp) == f.build()
+
+
+def test_flow_export_writes_a_reimportable_file(tmp_path) -> None:
+    from kortecx.chains import Chain
+
+    f = flow(seed=1).agent("a").then("b")
+    path = tmp_path / "bp.json"
+    f.export(path)
+    assert Chain.from_blueprint_file(path) == f.build()
+
+
 # --- V2a g2/g4: Run-from-handle, await-any wait, Agent.stream, Result.json --------
 
 

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -19,7 +19,7 @@
  */
 
 import type { MessageInitShape } from "@bufbuild/protobuf";
-import { BlueprintBuilder, type EdgeInput, type StepInput } from "./blueprints.js";
+import { BlueprintBuilder, type EdgeInput, type StepInput, type StepKind } from "./blueprints.js";
 import type { SubmitWorkflowRequestSchema } from "./gen/kortecx/v1/gateway_pb.js";
 // V2b: a `@kx.localTool` function-as-tool def — type-only here (the runtime dep is
 // one-way tools.ts → chains.ts; this never creates an import cycle).
@@ -911,6 +911,141 @@ export class Chain {
     builder.contextBundles(this.contextBundles);
     return builder.build();
   }
+
+  // --- Batch B (D161.2): portable blueprint export / import -----------------
+
+  /**
+   * Export this chain as a PORTABLE blueprint object — the same shape
+   * `kx blueprint run --file` and {@link Chain.fromBlueprint} consume. Round-trips:
+   * feeding it back to {@link Chain.fromBlueprint} (or the CLI) re-compiles to the
+   * IDENTICAL `SubmitWorkflowRequest` as {@link Chain.build}. `params` are in their
+   * FOLDED form (a tool step's args under `kx.tool.args`; an agentic MODEL step's
+   * budget under `max_turns`/`max_tool_calls`) — import is fold-idempotent. `model_id`
+   * stays as authored (empty ⇒ the server binds the served model, SN-8) so the
+   * artifact is portable across serves. Each `kind` is explicit (self-describing).
+   */
+  toBlueprint(): DagSpecJson {
+    const low = this.lower();
+    const steps: DagSpecStep[] = low.steps.map((s) => {
+      const step: DagSpecStep = { kind: s.kind };
+      if (s.model_id) step.model_id = s.model_id;
+      if (s.prompt) step.prompt = s.prompt;
+      if (Object.keys(s.tool_contract).length > 0) step.tool_contract = s.tool_contract;
+      if (Object.keys(s.params).length > 0) step.params = s.params;
+      return step;
+    });
+    const bp: DagSpecJson = { seed: this.seed, execution_mode: "frozen", steps };
+    if (low.edges.length > 0) {
+      bp.edges = low.edges.map((e) => ({ parent: e.parent, child: e.child, edge: "data" }));
+    }
+    if (this.contextBundles.length > 0) bp.context_bundles = [...this.contextBundles];
+    return bp;
+  }
+
+  /**
+   * Write {@link Chain.toBlueprint} as pretty JSON to `path` — the portable artifact
+   * (save / version / share; re-run with `kx blueprint run --file` or
+   * {@link Chain.fromBlueprint}). NODE-ONLY: the dynamic `node:fs/promises` import
+   * keeps it out of the `web`/`chains` static bundle graph (a browser cannot write a
+   * file — author there, export from Node).
+   */
+  async export(path: string): Promise<void> {
+    const fs = await import("node:fs/promises");
+    await fs.writeFile(path, `${JSON.stringify(this.toBlueprint(), null, 2)}\n`);
+  }
+
+  /**
+   * Compile a portable blueprint object (from {@link Chain.toBlueprint}, the CLI
+   * `--emit-blueprint`, or a hand-authored DAG) into a `SubmitWorkflowRequest` init
+   * shape ready for `client.submitWorkflow`. Accepts BOTH artifact forms: the SDK
+   * FOLDED form (args/budget already in `params`) and the CLI ARGS-SEPARATED form (a
+   * tool step's `args` map + an agentic step's `max_turns`/`max_tool_calls` fields) —
+   * both fold to the same request. The chain TOPOLOGY is not recoverable from a DAG
+   * (only the request is), so this returns the request, not a {@link Chain}.
+   */
+  static fromBlueprint(spec: DagSpecJson): MessageInitShape<typeof SubmitWorkflowRequestSchema> {
+    const builder = new BlueprintBuilder(spec.seed ?? 0);
+    for (const d of spec.steps ?? []) {
+      builder.addStep(stepFromSpec(d));
+    }
+    for (const e of spec.edges ?? []) {
+      builder.addEdge({
+        parent: e.parent,
+        child: e.child,
+        edge: e.edge === "control" ? "control" : "data",
+        nonCascade: e.non_cascade ?? false,
+      });
+    }
+    builder.contextBundles(spec.context_bundles ?? []);
+    if (spec.execution_mode === "dynamic") builder.mode("dynamic");
+    return builder.build();
+  }
+
+  /** Read a portable blueprint JSON file (Node) and compile it (see
+   * {@link Chain.fromBlueprint}). */
+  static async fromBlueprintFile(
+    path: string,
+  ): Promise<MessageInitShape<typeof SubmitWorkflowRequestSchema>> {
+    const fs = await import("node:fs/promises");
+    const raw = await fs.readFile(path, "utf-8");
+    return Chain.fromBlueprint(JSON.parse(raw) as DagSpecJson);
+  }
+}
+
+/** One step in a portable blueprint (the `kx blueprint run --file` JSON shape). `kind`
+ * is optional on IMPORT (inferred from fields, like the CLI); {@link Chain.toBlueprint}
+ * always sets it. `args` / `max_turns` / `max_tool_calls` are the CLI ARGS-SEPARATED
+ * form; the SDK export folds them into `params` instead (both import-equivalent). */
+export interface DagSpecStep {
+  kind?: StepKind;
+  model_id?: string;
+  prompt?: string;
+  body_signature_id?: string | null;
+  tool_contract?: Record<string, string>;
+  params?: Record<string, string>;
+  args?: Record<string, string | number | boolean>;
+  max_turns?: number;
+  max_tool_calls?: number;
+}
+
+/** A portable blueprint (the `kx blueprint run --file` JSON shape). */
+export interface DagSpecJson {
+  seed: number;
+  execution_mode?: string;
+  steps: DagSpecStep[];
+  edges?: Array<{ parent: number; child: number; edge?: string; non_cascade?: boolean }>;
+  context_bundles?: string[];
+}
+
+/** Infer a step's kind from field presence when `kind` is omitted — mirrors the CLI
+ * `StepSpec::resolve_kind` (model fields win; then a tool contract; else pure). */
+function inferKind(d: DagSpecStep): StepKind {
+  if (d.model_id || d.prompt) return "model";
+  if (d.tool_contract && Object.keys(d.tool_contract).length > 0) return "tool";
+  return "pure";
+}
+
+/** One blueprint step object → a {@link StepInput}, folding the CLI args-separated form
+ * (a `args` map ⇒ `kx.tool.args`; `max_turns`/`max_tool_calls` ⇒ the budget keys) so
+ * both artifact forms import to the same request. */
+function stepFromSpec(d: DagSpecStep): StepInput {
+  const kind = d.kind ?? inferKind(d);
+  const params: Record<string, Uint8Array | string> = { ...(d.params ?? {}) };
+  if (d.args && Object.keys(d.args).length > 0) {
+    params[TOOL_ARGS_KEY] = canonicalArgsJson(d.args);
+  }
+  if (kind === "model" && d.tool_contract && Object.keys(d.tool_contract).length > 0) {
+    if (d.max_turns !== undefined) params[REACT_MAX_TURNS_KEY] = String(d.max_turns);
+    if (d.max_tool_calls !== undefined) params[REACT_MAX_TOOL_CALLS_KEY] = String(d.max_tool_calls);
+  }
+  return {
+    kind,
+    modelId: d.model_id ?? "",
+    prompt: d.prompt ?? "",
+    bodySignatureId: d.body_signature_id ?? undefined,
+    toolContract: d.tool_contract ?? {},
+    params,
+  };
 }
 
 /** Assemble a {@link Chain} from resolved node-ordered tasks + canonical edges + seed. */

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -101,7 +101,17 @@ export {
   ChainUnknownHandleError,
   ChainCycleError,
 } from "./chains.js";
-export type { Frag, ChainOptions, Lowered, LoweredStep, LoweredEdge, ToolRef } from "./chains.js";
+export type {
+  Frag,
+  ChainOptions,
+  Lowered,
+  LoweredStep,
+  LoweredEdge,
+  ToolRef,
+  // Batch B (D161.2): the portable blueprint export/import shapes.
+  DagSpecJson,
+  DagSpecStep,
+} from "./chains.js";
 // Batch V2 — the fluent builder + first-class Agent (the headline authoring surface).
 export { Flow, flow } from "./flow.js";
 export type { FlowItem, AgentStepOptions, FlowClient } from "./flow.js";

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -180,6 +180,16 @@ export class Flow {
     return this.toChain().lower();
   }
 
+  /** Export this flow as a portable blueprint object (Batch B; via {@link Flow.toChain}). */
+  toBlueprint(): ReturnType<Chain["toBlueprint"]> {
+    return this.toChain().toBlueprint();
+  }
+
+  /** Write the portable blueprint JSON to `path` (Batch B; NODE-only via {@link Flow.toChain}). */
+  export(path: string): Promise<void> {
+    return this.toChain().export(path);
+  }
+
   /** Submit and (by default) WAIT for the committed result, over `opts.client` or the
    * zero-config Node default client. `wait: false` returns a {@link Run} handle. */
   async run(

--- a/bindings/typescript/test/chains.test.ts
+++ b/bindings/typescript/test/chains.test.ts
@@ -23,7 +23,7 @@ import {
   seq,
   task,
 } from "../src/chains.js";
-import type { Lowered, Task } from "../src/chains.js";
+import type { DagSpecJson, Lowered, Task } from "../src/chains.js";
 import { fillDefaultModel } from "../src/client.js";
 
 // The golden corpus lives at the repo root; this test file is bindings/typescript/test.
@@ -122,6 +122,61 @@ describe("Chains DSL — golden corpus parity", () => {
       });
     }
   }
+});
+
+describe("Chains DSL — Batch B portable blueprint export/import round-trip", () => {
+  // Every corpus SUCCESS case: toBlueprint() → JSON → fromBlueprint() re-compiles to
+  // the IDENTICAL request as build() (the cross-surface export/import guarantee).
+  for (const c of corpus.filter((x) => x.expect !== undefined)) {
+    it(`${c.name}: export→import == build`, () => {
+      const chn = chain(c.dsl, {
+        tasks: tasksFromCorpus(c.tasks),
+        seed: c.seed,
+        context: c.context_bundles,
+      });
+      const bp = chn.toBlueprint();
+      // The artifact must survive a JSON round-trip (a real file write/read).
+      const reparsed = JSON.parse(JSON.stringify(bp));
+      expect(Chain.fromBlueprint(reparsed)).toEqual(chn.build());
+    });
+  }
+
+  it("imports the CLI args-separated form identical to the SDK folded form", () => {
+    // A CLI-exported artifact keeps `args` + `max_turns` SEPARATE (not folded); it
+    // must import to the same request as the equivalent SDK-authored chain.
+    const cliArtifact: DagSpecJson = {
+      seed: 2,
+      execution_mode: "frozen",
+      steps: [
+        { kind: "tool", tool_contract: { echo: "1" }, args: { n: 3, msg: "x" } },
+        {
+          kind: "model",
+          prompt: "res",
+          tool_contract: { "web-search": "1" },
+          max_turns: 4,
+          max_tool_calls: 3,
+        },
+      ],
+      edges: [{ parent: 0, child: 1, edge: "data" }],
+    };
+    const equiv = chain("t > p", {
+      tasks: {
+        t: task.tool("echo", "1", { n: 3, msg: "x" }),
+        p: task.model("", "res", {}, { tools: ["web-search"], maxTurns: 4, maxToolCalls: 3 }),
+      },
+      seed: 2,
+    }).build();
+    expect(Chain.fromBlueprint(cliArtifact)).toEqual(equiv);
+  });
+
+  it("infers kind when omitted (a hand-authored DAG) == explicit kind", () => {
+    const inferred = Chain.fromBlueprint({ seed: 0, steps: [{ model_id: "", prompt: "go" }] });
+    const explicit = Chain.fromBlueprint({
+      seed: 0,
+      steps: [{ kind: "model", model_id: "", prompt: "go" }],
+    });
+    expect(inferred).toEqual(explicit);
+  });
 });
 
 describe("Chains DSL — combinator API parity with the string form", () => {

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -45,8 +45,9 @@ usage: kx <command> [args]
 
   client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --tls-ca <path> --json):
     kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--stream] [--timeout-secs N] [--out <file>] [--context <handle>]...
-    kx chain run \"<dsl>\" --tasks <tasks.json> [--seed N] [--wait] [--timeout-secs N] [--out <file>]
-                                                 (string-DSL DAG: a > [b & c]; see `kx help chain`)
+    kx chain run \"<dsl>\" --tasks <tasks.json> [--seed N] [--wait] [--out <file>] [--emit-blueprint <file>] [--dry-run]
+                                                 (string-DSL DAG: a > [b & c]; --emit-blueprint = a portable blueprint; see `kx help chain`)
+    kx blueprint run|import --file <dag.json> [--wait]    (run a portable DAG, or import = validate+summarize offline; `kx help blueprint`)
     kx projection --instance <hex16> [--at-seq N]
     kx runs list [--limit N] [--before-seq N]    (durable run history, newest-first)
     kx runs rerun <instance-hex16> [--set k=v]   (re-run a prior run with edited args)
@@ -475,16 +476,22 @@ kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--stream] [--tim
   the committed result stays the authority), then resolve — handy for chat/vision recipes."
             .into(),
         "blueprint" => "\
-kx blueprint run --file <dag.json> [--wait] [--timeout-secs N] [--out <file>] [client flags]
-  Author a Tier-1 DAG (a vetted palette of PURE / MODEL steps + DATA/CONTROL edges)
-  and run it via SubmitWorkflow. The server COMPILES the DAG, derives all identity,
-  and builds every warrant from the party's grants (SN-8) — the client sends only the
-  topology + params. The authored run is then viewable in the console (Runs, Monitoring).
-  JSON: { \"seed\": N, \"steps\": [{\"kind\":\"pure\"|\"model\", \"prompt\":..., \"params\":{..}}],
+kx blueprint run    --file <dag.json> [--wait] [--timeout-secs N] [--out <file>] [client flags]
+kx blueprint import --file <dag.json> [--json]
+  run    Author a Tier-1 DAG (a vetted palette of PURE / MODEL / TOOL steps + DATA/CONTROL
+         edges) and run it via SubmitWorkflow. The server COMPILES the DAG, derives all
+         identity, and builds every warrant from the party's grants (SN-8) — the client
+         sends only the topology + params. Viewable in the console (Runs, Monitoring).
+  import Validate + summarize a portable blueprint JSON OFFLINE (no gateway) — the
+         counterpart of `chain run --emit-blueprint`. Compiles the DAG client-side (kinds /
+         edges / tool args / reserved `exec` all fail closed), prints the resolved shape,
+         and does NOT submit. Then run it with `blueprint run --file`.
+  JSON: { \"seed\": N, \"steps\": [{\"kind\":\"pure\"|\"model\"|\"tool\", \"prompt\":..., \"params\":{..}}],
           \"edges\": [{\"parent\":i, \"child\":j, \"edge\":\"data\"|\"control\"}], \"execution_mode\":\"frozen\" }"
             .into(),
         "chain" => "\
-kx chain run \"<dsl>\" --tasks <tasks.json> [--seed N] [--wait] [--timeout-secs N] [--out <file>] [client flags]
+kx chain run \"<dsl>\" --tasks <tasks.json> [--seed N] [--wait] [--timeout-secs N] [--out <file>]
+              [--emit-blueprint <file>] [--dry-run] [client flags]
   Author a Tier-1 DAG from the kortecx Chains STRING-DSL and run it via SubmitWorkflow
   (the same compile + warrant path `blueprint run` uses — a chain only changes how the
   topology is AUTHORED). The positional <dsl> composes task handles with operators:
@@ -496,8 +503,11 @@ kx chain run \"<dsl>\" --tasks <tasks.json> [--seed N] [--wait] [--timeout-secs 
   A handle that appears more than once is the SAME node (reuse builds DAGs). Examples:
     \"a > [b & c]\" fans out (a->b, a->c); \"[a & b] > c\" fans in (a->c, b->c).
   --tasks is a JSON object map { \"a\": {\"kind\":\"pure\"|\"model\", \"prompt\":..., \"params\":{..}}, ... };
-  each value is a step definition (P1 palette: pure | model). Tasks defined but unused are
-  ignored. Errors fail closed: empty/empty-group -> parse; an unknown handle; a cycle."
+  each value is a step definition (palette: pure | model | tool). Tasks defined but unused are
+  ignored. Errors fail closed: empty/empty-group -> parse; an unknown handle; a cycle.
+  --emit-blueprint <file> also writes the lowered chain as a PORTABLE blueprint JSON (the
+  exact `blueprint run --file` input — save / share / re-run it). --dry-run lowers +
+  validates (+ emits) WITHOUT submitting (needs no gateway), the offline export path."
             .into(),
         "projection" => "\
 kx projection --instance <hex16> [--at-seq N] [client flags]

--- a/crates/kx-cli/src/verbs/blueprint.rs
+++ b/crates/kx-cli/src/verbs/blueprint.rs
@@ -5,6 +5,13 @@
 //! topology + params. The authored run is then viewable in the console (Runs → the
 //! live DAG, Monitoring).
 //!
+//! `kx blueprint import --file <dag.json>` (Batch B / D161.2) — validate + summarize a
+//! portable blueprint JSON WITHOUT contacting a gateway (the symmetric counterpart of
+//! `kx chain run --emit-blueprint <file>`): the same `to_request` compile validates the
+//! DAG client-side (kinds / edges / tool args / reserved `exec` all fail-closed) and
+//! prints the resolved shape; then run it with `blueprint run --file`. A portable DAG
+//! JSON is the share/round-trip artifact; cross-party sharing/marketplace = Cloud.
+//!
 //! The `<dag.json>` shape:
 //! ```json
 //! {
@@ -39,7 +46,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use kx_proto::proto;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::client::{next_value, ClientCommon};
 use crate::error::CliError;
@@ -53,19 +60,23 @@ const DEFAULT_TIMEOUT_SECS: u64 = 120;
 /// the one canonical proto assembly ([`to_request`]) instead of re-deriving the
 /// `SubmitWorkflowRequest` — a chain only changes *how* the `(steps, edges)` are
 /// authored, never how they lower to the wire.
-#[derive(Debug, Deserialize)]
+/// `Serialize` (Batch B / D161.2): a parsed/lowered `DagSpec` re-serializes to a
+/// portable blueprint JSON (`kx chain run --emit-blueprint`). The `skip_serializing_if`
+/// guards keep the artifact clean — each skipped field's `#[serde(default)]` exactly
+/// reproduces the omitted value on re-read, so export→import is byte-stable.
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct DagSpec {
     #[serde(default)]
     pub(crate) seed: u32,
     pub(crate) steps: Vec<StepSpec>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) edges: Vec<EdgeSpec>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) execution_mode: Option<String>,
     /// PR-7: context-bundle handles to attach to the run (chain-level grounding the
     /// SERVER resolves + injects into every entry Mote at bind, SN-8). Verbatim
     /// order; empty ⇒ byte-identical to pre-PR-7.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) context_bundles: Vec<String>,
 }
 
@@ -82,7 +93,7 @@ const TOOL_ARGS_KEY: &str = "kx.tool.args";
 const REACT_MAX_TURNS_KEY: &str = "max_turns";
 const REACT_MAX_TOOL_CALLS_KEY: &str = "max_tool_calls";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct StepSpec {
     /// `pure` | `model` | `tool` (PR-6b-2); `exec` is reserved (rejected client-side).
     /// OPTIONAL (Batch A authoring veneer): when omitted the kind is INFERRED from
@@ -92,33 +103,35 @@ pub(crate) struct StepSpec {
     /// `pure`. An explicit kind is an override that MUST agree with the present fields
     /// (fail-closed on conflict, e.g. `kind:"pure"` + a `model_id`). The SDK factories
     /// (`pure()`/`model()`/`tool()`) always set it; this only eases the JSON surface.
-    #[serde(default)]
+    /// Export (Batch B) sets it EXPLICITLY (the self-describing portable form); omitted
+    /// ⇒ inferred on re-read, so the round-trip is stable either way.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) kind: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub(crate) model_id: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub(crate) prompt: String,
     /// EXEC only: the registered body's content/signature id as 64-char hex.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) body_signature_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) tool_contract: BTreeMap<String, String>,
     /// Free config entries; values are UTF-8 strings.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) params: BTreeMap<String, String>,
     /// TOOL only (PR-6b-2): the tool-call arguments, serialized at lowering to ONE
     /// canonical-JSON object under [`TOOL_ARGS_KEY`] (sorted keys, compact) —
     /// byte-identical to the Py/TS `tool()` factories. No floats (SN-8).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) args: BTreeMap<String, serde_json::Value>,
     /// Agentic MODEL step only (PR-9b, D161.1): the bounded reason→tool→observe
     /// loop budget. Lowered to canonical-JSON `u32` bytes under
     /// [`REACT_MAX_TURNS_KEY`] / [`REACT_MAX_TOOL_CALLS_KEY`] in `params` when the
     /// step is a MODEL step with a non-empty `tool_contract`; ignored otherwise.
     /// Absent ⇒ the coordinator default (8 turns / 6 tool calls).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) max_turns: Option<u32>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) max_tool_calls: Option<u32>,
 }
 
@@ -187,14 +200,14 @@ impl StepSpec {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct EdgeSpec {
     pub(crate) parent: u32,
     pub(crate) child: u32,
-    /// `data` (default) | `control`.
-    #[serde(default = "default_edge")]
+    /// `data` (default) | `control`. Omitted on export when it is the `data` default.
+    #[serde(default = "default_edge", skip_serializing_if = "is_default_edge")]
     pub(crate) edge: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub(crate) non_cascade: bool,
 }
 
@@ -202,9 +215,36 @@ fn default_edge() -> String {
     "data".to_string()
 }
 
+/// Export guard: a `data` edge is the default, so omit it from the emitted JSON
+/// (re-read restores it via [`default_edge`]) — keeps exported blueprints clean.
+fn is_default_edge(edge: &str) -> bool {
+    edge == "data"
+}
+
+/// Export guard for a plain `bool` default (serde's `skip_serializing_if` needs a
+/// `fn(&T) -> bool`, so the `&bool` is required by the trait, not a choice).
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// `blueprint run` (submit + optionally wait) vs `blueprint import` (validate +
+/// summarize a portable blueprint JSON WITHOUT contacting a gateway — the symmetric
+/// counterpart of `kx chain run --emit-blueprint`, Batch B / D161.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlueprintMode {
+    /// `blueprint run` — compile + submit (and optionally `--wait`) via the gateway.
+    Run,
+    /// `blueprint import` — compile + validate + summarize a portable blueprint JSON
+    /// offline (no gateway); the counterpart of `chain run --emit-blueprint`.
+    Import,
+}
+
 /// Parsed `blueprint` arguments.
 #[derive(Debug)]
 pub struct BlueprintArgs {
+    /// `run` (submit) or `import` (validate + summarize, no gateway).
+    pub mode: BlueprintMode,
     /// The author-side DAG JSON file to compile + run.
     pub file: PathBuf,
     /// Run to completion and print the committed result (`--wait`).
@@ -217,16 +257,21 @@ pub struct BlueprintArgs {
     pub common: ClientCommon,
 }
 
-/// Parse `blueprint run --file <p> [--wait] ...` (the verb already consumed `run`).
+/// Parse `blueprint run|import --file <p> [--wait] ...` (the verb already consumed the
+/// leading `blueprint`).
 pub fn parse(mut args: impl Iterator<Item = String>) -> Result<BlueprintArgs, CliError> {
     let sub = args
         .next()
-        .ok_or_else(|| CliError::Usage("blueprint expects a subcommand (run)".into()))?;
-    if sub != "run" {
-        return Err(CliError::Usage(format!(
-            "unknown blueprint subcommand {sub:?} (only `run`)"
-        )));
-    }
+        .ok_or_else(|| CliError::Usage("blueprint expects a subcommand (run|import)".into()))?;
+    let mode = match sub.as_str() {
+        "run" => BlueprintMode::Run,
+        "import" => BlueprintMode::Import,
+        other => {
+            return Err(CliError::Usage(format!(
+                "unknown blueprint subcommand {other:?} (run|import)"
+            )));
+        }
+    };
     let mut file: Option<PathBuf> = None;
     let mut wait = false;
     let mut timeout_secs = DEFAULT_TIMEOUT_SECS;
@@ -251,9 +296,10 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<BlueprintArgs, Cl
         }
     }
 
-    let file =
-        file.ok_or_else(|| CliError::Usage("blueprint run requires --file <dag.json>".into()))?;
+    let file = file
+        .ok_or_else(|| CliError::Usage("blueprint run|import requires --file <dag.json>".into()))?;
     Ok(BlueprintArgs {
+        mode,
         file,
         wait,
         timeout_secs,
@@ -345,13 +391,23 @@ pub(crate) fn to_request(spec: DagSpec) -> Result<proto::SubmitWorkflowRequest, 
     })
 }
 
-/// Execute `blueprint run`.
+/// Execute `blueprint run` / `blueprint import`.
 pub async fn execute(args: BlueprintArgs) -> Result<(), CliError> {
     let raw = std::fs::read(&args.file)
         .map_err(|e| CliError::Usage(format!("cannot read {}: {e}", args.file.display())))?;
     let spec: DagSpec = serde_json::from_slice(&raw)
         .map_err(|e| CliError::Usage(format!("invalid blueprint JSON: {e}")))?;
+    // `to_request` is the canonical compile + client-side validation (kinds / edges /
+    // tool args / reserved `exec` all fail-closed here, BEFORE any gateway contact).
     let req = to_request(spec)?;
+
+    // `import` = validate + summarize the portable blueprint WITHOUT a gateway (the
+    // counterpart of `chain run --emit-blueprint`): the compile above already validated
+    // it; print the resolved DAG shape and stop. No submit, no connection.
+    if args.mode == BlueprintMode::Import {
+        print_import_summary(&req, &args.file, args.common.json);
+        return Ok(());
+    }
 
     let resolved = args.common.resolve()?;
     let mut client = resolved.connect().await?;
@@ -373,6 +429,82 @@ pub async fn execute(args: BlueprintArgs) -> Result<(), CliError> {
     } else {
         println!("{}", format::render_submit(&handle, args.common.json));
         Ok(())
+    }
+}
+
+/// Map a proto `WorkflowStepKind` back to its DSL string (display helper).
+fn step_kind_name(k: i32) -> &'static str {
+    match proto::WorkflowStepKind::try_from(k) {
+        Ok(proto::WorkflowStepKind::Pure) => "pure",
+        Ok(proto::WorkflowStepKind::Model) => "model",
+        Ok(proto::WorkflowStepKind::Tool) => "tool",
+        Ok(proto::WorkflowStepKind::Exec) => "exec",
+        _ => "unspecified",
+    }
+}
+
+/// Print a human / JSON summary of an imported blueprint (`blueprint import`) — the
+/// resolved DAG shape, display-only, no run. The `to_request` compile already
+/// validated it (kinds / edges / args / reserved `exec`), so reaching here means valid.
+fn print_import_summary(req: &proto::SubmitWorkflowRequest, file: &std::path::Path, json: bool) {
+    let mode = if req.execution_mode == proto::WorkflowExecutionMode::Dynamic as i32 {
+        "dynamic"
+    } else {
+        "frozen"
+    };
+    let sorted_tools = |s: &proto::WorkflowStep| {
+        let mut t: Vec<String> = s.tool_contract.keys().cloned().collect();
+        t.sort();
+        t
+    };
+    if json {
+        let steps: Vec<serde_json::Value> = req
+            .steps
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "kind": step_kind_name(s.kind),
+                    "model_id": s.model_id,
+                    "tools": sorted_tools(s),
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "file": file.display().to_string(),
+            "valid": true,
+            "seed": req.seed,
+            "execution_mode": mode,
+            "steps": steps,
+            "edges": req.edges.len(),
+            "context_bundles": req.context_bundles,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+    } else {
+        println!("blueprint {} is valid", file.display());
+        println!(
+            "  seed={}  mode={}  steps={}  edges={}  context_bundles={}",
+            req.seed,
+            mode,
+            req.steps.len(),
+            req.edges.len(),
+            req.context_bundles.len()
+        );
+        for (i, s) in req.steps.iter().enumerate() {
+            let tools = sorted_tools(s);
+            let model = if s.model_id.is_empty() {
+                "<served>".to_string()
+            } else {
+                s.model_id.clone()
+            };
+            let detail = match step_kind_name(s.kind) {
+                "model" if !tools.is_empty() => format!("model {model} @{tools:?}"),
+                "model" => format!("model {model}"),
+                "tool" => format!("tool {tools:?}"),
+                k => k.to_string(),
+            };
+            println!("  [{i}] {detail}");
+        }
+        println!("run it with: kx blueprint run --file {}", file.display());
     }
 }
 
@@ -434,6 +566,51 @@ mod tests {
         let spec: DagSpec =
             serde_json::from_str(r#"{ "steps": [ {"kind":"frobnicate"} ] }"#).unwrap();
         assert!(to_request(spec).is_err());
+    }
+
+    #[test]
+    fn parses_import_subcommand() {
+        let a = p(&["import", "--file", "bp.json"]).unwrap();
+        assert_eq!(a.mode, BlueprintMode::Import);
+        assert_eq!(a.file, PathBuf::from("bp.json"));
+        assert_eq!(
+            p(&["run", "--file", "bp.json"]).unwrap().mode,
+            BlueprintMode::Run
+        );
+        assert!(
+            p(&["import"]).is_err(),
+            "import without --file is a usage error"
+        );
+    }
+
+    /// Batch B: a `DagSpec` survives Serialize → Deserialize and re-compiles to the
+    /// IDENTICAL proto — the export→import byte-stability invariant (covering the
+    /// `skip_serializing_if` guards: the tool `args` + the agentic budget round-trip).
+    #[test]
+    fn dagspec_serialize_round_trip_compiles_identically() {
+        let json = r#"{
+            "seed": 5,
+            "steps": [
+                {"kind":"pure","params":{"topic":"hi"}},
+                {"kind":"tool","tool_contract":{"echo":"1"},"args":{"n":3,"msg":"x"}},
+                {"kind":"model","prompt":"go","tool_contract":{"web-search":"1"},"max_turns":4,"max_tool_calls":3}
+            ],
+            "edges": [ {"parent":0,"child":1}, {"parent":1,"child":2,"non_cascade":true} ],
+            "context_bundles": ["team/ctx/spec"]
+        }"#;
+        let spec: DagSpec = serde_json::from_str(json).unwrap();
+        let req_direct = to_request(spec).unwrap();
+
+        // Re-parse the SAME source, serialize it (the export path), re-read, re-compile.
+        let spec2: DagSpec = serde_json::from_str(json).unwrap();
+        let emitted = serde_json::to_string_pretty(&spec2).unwrap();
+        let reparsed: DagSpec = serde_json::from_str(&emitted).unwrap();
+        let req_round_trip = to_request(reparsed).unwrap();
+
+        assert_eq!(
+            req_direct, req_round_trip,
+            "export→import must re-compile to a byte-identical SubmitWorkflowRequest"
+        );
     }
 
     // ---- Batch A: kind inference + agreement (the JSON authoring veneer) ----

--- a/crates/kx-cli/src/verbs/chain.rs
+++ b/crates/kx-cli/src/verbs/chain.rs
@@ -79,6 +79,13 @@ pub struct ChainArgs {
     pub timeout_secs: u64,
     /// Write the committed result bytes to this file instead of inlining them.
     pub out: Option<PathBuf>,
+    /// Batch B (D161.2): `--emit-blueprint <file>` — also write the lowered chain as a
+    /// portable blueprint JSON (the exact `kx blueprint run --file` input). Pairs with
+    /// `--dry-run` to export without contacting a gateway.
+    pub emit_blueprint: Option<PathBuf>,
+    /// Batch B: `--dry-run` — lower + validate (+ `--emit-blueprint` if set) but do NOT
+    /// submit (needs no gateway). Useful to produce/lint a portable blueprint offline.
+    pub dry_run: bool,
     /// Common client flags.
     pub common: ClientCommon,
 }
@@ -103,6 +110,8 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
     let mut wait = false;
     let mut timeout_secs = DEFAULT_TIMEOUT_SECS;
     let mut out: Option<PathBuf> = None;
+    let mut emit_blueprint: Option<PathBuf> = None;
+    let mut dry_run = false;
     let mut common = ClientCommon::default();
 
     while let Some(flag) = args.next() {
@@ -143,6 +152,10 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
                 })?;
             }
             "--out" => out = Some(PathBuf::from(next_value(&mut args, "--out")?)),
+            "--emit-blueprint" => {
+                emit_blueprint = Some(PathBuf::from(next_value(&mut args, "--emit-blueprint")?));
+            }
+            "--dry-run" => dry_run = true,
             other if other.starts_with("--") => {
                 return Err(CliError::Usage(format!("unknown flag {other:?}")));
             }
@@ -177,6 +190,8 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ChainArgs, CliErr
         wait,
         timeout_secs,
         out,
+        emit_blueprint,
+        dry_run,
         common,
     })
 }
@@ -546,15 +561,17 @@ fn detect_cycle(node_count: usize, edges: &[(u32, u32)]) -> Result<(), CliError>
     }
 }
 
-/// Resolve the lowered topology against the `--tasks` map and build the SAME
-/// `DagSpec` the visual `blueprint` authors, so the one canonical proto assembly
-/// (`blueprint::to_request`) is reused verbatim.
-fn build_request(
+/// Resolve the lowered topology against the `--tasks` map into the canonical
+/// [`DagSpec`] — the exact `kx blueprint run --file` shape, the single in-memory
+/// blueprint both the run path and the Batch-B `--emit-blueprint` export share. Each
+/// step's `kind` is set EXPLICITLY (the expanded/portable form) so the emitted JSON is
+/// self-describing and re-import re-compiles identically.
+fn build_dagspec(
     lowered: Lowered,
     mut tasks: BTreeMap<String, StepSpec>,
     seed: u32,
     context_bundles: Vec<String>,
-) -> Result<kx_proto::proto::SubmitWorkflowRequest, CliError> {
+) -> Result<DagSpec, CliError> {
     let mut steps = Vec::with_capacity(lowered.nodes.len());
     for (idx, handle) in lowered.nodes.iter().enumerate() {
         let mut step = tasks.remove(handle).ok_or_else(|| {
@@ -580,6 +597,16 @@ fn build_request(
                     .or_insert_with(|| "1".to_string());
             }
         }
+        // Batch B: pin the kind explicitly (the expanded/portable export form).
+        // Idempotent — `resolve_kind` already validated it; setting `Some(resolved)`
+        // re-resolves to the same kind, so the run path's proto is byte-unchanged.
+        let resolved = match step.resolve_kind()? {
+            kx_proto::proto::WorkflowStepKind::Model => "model",
+            kx_proto::proto::WorkflowStepKind::Tool => "tool",
+            // resolve_kind only ever yields Pure/Model/Tool (exec/unspecified are errors).
+            _ => "pure",
+        };
+        step.kind = Some(resolved.to_string());
         steps.push(step);
     }
     let edges = lowered
@@ -592,7 +619,7 @@ fn build_request(
             non_cascade: false,
         })
         .collect();
-    let spec = DagSpec {
+    Ok(DagSpec {
         seed,
         steps,
         edges,
@@ -600,7 +627,23 @@ fn build_request(
         execution_mode: Some("frozen".to_string()),
         // PR-7: chain-level context attachment, verbatim (the server canonicalizes).
         context_bundles,
-    };
+    })
+}
+
+/// Build the `SubmitWorkflowRequest` from a lowered chain — `build_dagspec` then the
+/// SAME canonical proto assembly (`blueprint::to_request`) the visual `blueprint`
+/// authors use, so a chain only changes *how* the `(steps, edges)` are authored.
+/// Test-only since Batch B: `execute` now goes through `build_dagspec` directly (so it
+/// can `--emit-blueprint` the pre-fold spec before `to_request` consumes it); the
+/// corpus parity tests still drive the full lower→request path through this helper.
+#[cfg(test)]
+fn build_request(
+    lowered: Lowered,
+    tasks: BTreeMap<String, StepSpec>,
+    seed: u32,
+    context_bundles: Vec<String>,
+) -> Result<kx_proto::proto::SubmitWorkflowRequest, CliError> {
+    let spec = build_dagspec(lowered, tasks, seed, context_bundles)?;
     crate::verbs::blueprint::to_request(spec)
 }
 
@@ -608,7 +651,26 @@ fn build_request(
 pub async fn execute(args: ChainArgs) -> Result<(), CliError> {
     let tasks = collect_tasks(&args)?;
     let lowered = lower(&args.dsl)?;
-    let req = build_request(lowered, tasks, args.seed, args.context)?;
+    let spec = build_dagspec(lowered, tasks, args.seed, args.context)?;
+
+    // Batch B (D161.2): also write the lowered chain as a portable blueprint JSON — the
+    // exact `kx blueprint run --file` input. Emit BEFORE `to_request` consumes the spec.
+    if let Some(path) = &args.emit_blueprint {
+        let json = serde_json::to_string_pretty(&spec)
+            .map_err(|e| CliError::Usage(format!("serialize blueprint: {e}")))?;
+        std::fs::write(path, json)
+            .map_err(|e| CliError::Usage(format!("write {}: {e}", path.display())))?;
+        eprintln!("wrote blueprint to {}", path.display());
+    }
+
+    // The canonical compile + client-side validation (kinds / edges / args fail-closed).
+    let req = crate::verbs::blueprint::to_request(spec)?;
+
+    // `--dry-run`: lowered + validated (+ emitted if requested) but NOT submitted — needs
+    // no gateway. The pairing with `--emit-blueprint` is the offline export path.
+    if args.dry_run {
+        return Ok(());
+    }
 
     let resolved = args.common.resolve()?;
     let mut client = resolved.connect().await?;
@@ -690,6 +752,25 @@ mod tests {
     fn no_context_flag_yields_an_empty_attachment() {
         let a = p(&["run", "a > b", "--tasks", "t.json"]).unwrap();
         assert!(a.context.is_empty());
+    }
+
+    #[test]
+    fn parses_emit_blueprint_and_dry_run() {
+        let a = p(&[
+            "run",
+            "a > b",
+            "--tasks",
+            "t.json",
+            "--emit-blueprint",
+            "bp.json",
+            "--dry-run",
+        ])
+        .unwrap();
+        assert_eq!(a.emit_blueprint, Some(PathBuf::from("bp.json")));
+        assert!(a.dry_run);
+        // absent ⇒ neither set (the default run path is unaffected).
+        let b = p(&["run", "a > b", "--tasks", "t.json"]).unwrap();
+        assert!(b.emit_blueprint.is_none() && !b.dry_run);
     }
 
     #[test]
@@ -949,6 +1030,41 @@ mod tests {
                 })
                 .collect();
             assert_eq!(got_edges, want_edges, "[{}] edges", case.name);
+        }
+    }
+
+    /// Batch B (D161.2): EVERY corpus success case must round-trip through the portable
+    /// blueprint artifact — `chain run --emit-blueprint` serializes the pre-fold
+    /// `DagSpec`; `blueprint run --file` re-reads + re-compiles it. The invariant: the
+    /// re-imported proto is byte-identical to the directly-compiled one. This is the
+    /// cross-surface export/import guarantee, pinned per case (no new corpus cases — the
+    /// existing tri-surface contract IS the fixture set).
+    #[test]
+    fn corpus_success_cases_export_import_round_trip_identically() {
+        use crate::verbs::blueprint::to_request;
+        for case in load_corpus().into_iter().filter(|c| c.expect.is_some()) {
+            let lowered =
+                lower(&case.dsl).unwrap_or_else(|e| panic!("[{}] lower failed: {e}", case.name));
+            // The export surface: the pre-`to_request` DagSpec the CLI emits.
+            let spec = build_dagspec(lowered, case.tasks, case.seed, case.context_bundles)
+                .unwrap_or_else(|e| panic!("[{}] build_dagspec failed: {e}", case.name));
+
+            // Serialize (export) → re-read (import) → a SECOND DagSpec from the artifact.
+            let json = serde_json::to_string(&spec)
+                .unwrap_or_else(|e| panic!("[{}] serialize: {e}", case.name));
+            let reparsed: crate::verbs::blueprint::DagSpec = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("[{}] re-parse: {e}\n{json}", case.name));
+
+            // Both compile through the SAME canonical assembly; the protos must match.
+            let direct = to_request(spec)
+                .unwrap_or_else(|e| panic!("[{}] direct to_request: {e}", case.name));
+            let round_trip = to_request(reparsed)
+                .unwrap_or_else(|e| panic!("[{}] round-trip to_request: {e}", case.name));
+            assert_eq!(
+                direct, round_trip,
+                "[{}] export→import must re-compile to a byte-identical request",
+                case.name
+            );
         }
     }
 

--- a/docs/site/docs/blueprint-builder.md
+++ b/docs/site/docs/blueprint-builder.md
@@ -109,6 +109,50 @@ b.add_edge(EdgeInput(parent=draft, child=critique, edge="data"))
 handle = client.submit_workflow(b.build())
 ```
 
+## Portable blueprints — export & import
+
+A lowered chain can be saved as a **portable blueprint JSON** — the exact shape
+`kx blueprint run --file` consumes. Save it, version it in git, share it, and re-run
+it on any serve. (Cross-party sharing / a marketplace is a Cloud capability.)
+
+**Export from the CLI** — `--emit-blueprint` writes the blueprint alongside the run;
+pair with `--dry-run` to export offline (no gateway):
+
+```bash
+kx chain run "research > review" \
+  --task research='{"kind":"model","prompt":"Research the topic."}' \
+  --task review='{"kind":"model","prompt":"Critique the findings."}' \
+  --emit-blueprint plan.json --dry-run        # lower + validate + write, no submit
+
+kx blueprint run --file plan.json --wait      # run it (here, or anywhere)
+kx blueprint import --file plan.json          # validate + summarize offline (no run)
+```
+
+**Export from the SDKs** — `to_blueprint()` returns the dict; `export(path)` writes JSON:
+
+```python
+import kortecx as kx
+flow = kx.flow().agent("Research the topic").then("Critique the findings")
+flow.export("plan.json")                       # portable artifact
+req = kx.Chain.from_blueprint_file("plan.json")  # → a SubmitWorkflowRequest
+client.submit_workflow(req, wait=True)
+```
+
+```typescript
+import { flow, Chain } from "@kortecx/sdk";
+await flow().agent("Research the topic").then("Critique the findings").export("plan.json");
+const req = await Chain.fromBlueprintFile("plan.json");   // → a SubmitWorkflowRequest
+await client.submitWorkflow(req, { wait: true });
+```
+
+The artifact is **self-describing** (each step's `kind` is explicit) and **portable**:
+`model_id` is left as authored — empty binds the **serve's** model at submit (SN-8), so
+the same blueprint runs against whatever model a target serve hosts unless you pin a
+specific `model_id`. Export → import re-compiles to a **byte-identical**
+`SubmitWorkflowRequest` (and, on a fixed model, the identical committed result). The CLI
+emits the args-separated form and the SDKs the params-folded form; both import
+equivalently.
+
 ## Finding a blueprint
 
 The console's Blueprints section has a **search box** backed by `SearchRecipes` —

--- a/docs/site/docs/chains/dsl-reference.md
+++ b/docs/site/docs/chains/dsl-reference.md
@@ -263,6 +263,23 @@ chain with no attached context lowers byte-identically to pre-context-bundle, an
 the attachment's byte-identity across Python, TypeScript, and the CLI is pinned by
 the golden corpus alongside the topology.
 
+## Portable blueprints (export / import)
+
+A lowered chain can be saved as a **portable blueprint JSON** — the exact shape
+`kx blueprint run --file` consumes — and re-run anywhere:
+
+```bash
+kx chain run "a > b" --tasks tasks.json --emit-blueprint plan.json --dry-run
+kx blueprint run    --file plan.json --wait     # run it
+kx blueprint import --file plan.json            # validate + summarize offline
+```
+
+The SDKs mirror this: `flow.export(path)` / `Chain.to_blueprint()` and
+`Chain.from_blueprint(_file)`. Export → import re-compiles to a **byte-identical**
+request. The artifact pins explicit `kind` but leaves `model_id` as authored (empty binds
+the serve's model, SN-8), so a blueprint is portable across serves. See
+[Blueprint builder → Portable blueprints](../blueprint-builder.md#portable-blueprints--export--import).
+
 ## Per-language authoring
 
 - **[Chains in Python](./python.md)** — the `chain()` string DSL plus the

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -39,12 +39,32 @@ byte-identically — a Flow is sugar, never a new wire shape). Builders:
 `.agent(prompt, tools=…, reasoning=…)` · `.step(**params)` (pure) · `.tool(id, ver, **args)` ·
 `.then(item)` (sequential — a string is an agent) · `.parallel(*items)` (fan-out / fan-in) ·
 `.context(*handles)`. Terminate with `.run()` (waits for the `Result`), `.submit()` (a
-non-blocking `Run` handle), or `.to_chain()` / `.build()` to inspect.
+non-blocking `Run` handle), `.to_chain()` / `.build()` to inspect, or `.export(path)` to
+save a **portable blueprint** (see [Export / import](#export--import-a-portable-blueprint)).
 
 A `Run` (from `.submit()` or `.run(wait=False)`) drives the run without blocking:
 `run.events()` (live projection deltas), `run.wait()` (the first committed Mote — the
 await-any path), `run.tokens(mote)` (one model mote's advisory token chunks). The
 `Result` exposes `.text` / `.bytes` and `.json()` (the `kx … --wait --json` shape).
+
+### Export / import a portable blueprint
+
+`.export(path)` writes the lowered chain as a portable blueprint JSON (the exact
+`kx blueprint run --file` input — save / version / share / re-run it); `to_blueprint()`
+returns the dict. `Chain.from_blueprint(spec)` / `Chain.from_blueprint_file(path)`
+compile one back into a `SubmitWorkflowRequest`:
+
+```python
+import kortecx as kx
+
+kx.flow().agent("Research the topic").then("Critique it").export("plan.json")
+req = kx.Chain.from_blueprint_file("plan.json")   # → a SubmitWorkflowRequest
+client.submit_workflow(req, wait=True)
+```
+
+The artifact is self-describing (explicit `kind`) and portable — `model_id` stays as
+authored (empty binds the serve's model at submit, SN-8). Export → import re-compiles to
+the IDENTICAL request as `.build()`. See [Blueprint builder → Portable blueprints](../blueprint-builder.md#portable-blueprints--export--import).
 
 ### A reusable Agent
 

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -74,6 +74,27 @@ console.log(result.json());               // the `kx … --wait --json` shape
 // run.tokens(moteId) streams ONE model mote's advisory token chunks.
 ```
 
+### Export / import a portable blueprint
+
+`.export(path)` writes the lowered chain as a portable blueprint JSON (the exact
+`kx blueprint run --file` input — save / version / share / re-run it; `toBlueprint()`
+returns the object). `Chain.fromBlueprint(spec)` / `Chain.fromBlueprintFile(path)` compile
+one back into a `SubmitWorkflowRequest`:
+
+```ts
+import { flow, Chain } from "@kortecx/sdk";
+
+await flow().agent("Research the topic").then("Critique it").export("plan.json");
+const req = await Chain.fromBlueprintFile("plan.json");   // → a SubmitWorkflowRequest
+await client.submitWorkflow(req, { wait: true });
+```
+
+The artifact is self-describing (explicit `kind`) and portable — `model_id` stays as
+authored (empty binds the serve's model at submit, SN-8). Export → import re-compiles to
+the IDENTICAL request as `.build()`. `export` / `fromBlueprintFile` are Node-only (file
+I/O); `toBlueprint` / `fromBlueprint` (in-memory) work everywhere. See
+[Blueprint builder → Portable blueprints](../blueprint-builder.md#portable-blueprints--export--import).
+
 ### A reusable Agent
 
 ```ts

--- a/tests/golden/chains/corpus.json
+++ b/tests/golden/chains/corpus.json
@@ -571,5 +571,45 @@
       ],
       "edges": []
     }
+  },
+  {
+    "name": "tool_args_and_agentic_budget_in_one_dag",
+    "dsl": "t > p@web-search",
+    "seed": 5,
+    "tasks": {
+      "t": {
+        "kind": "tool",
+        "tool_contract": { "echo": "1" },
+        "args": { "n": 3, "msg": "x" }
+      },
+      "p": {
+        "kind": "model",
+        "model_id": "kx-serve:qwen3-4b-q4_k_m",
+        "prompt": "summarize",
+        "max_turns": 4,
+        "max_tool_calls": 3
+      }
+    },
+    "expect": {
+      "steps": [
+        {
+          "kind": "tool",
+          "model_id": "",
+          "prompt": "",
+          "body_signature_id": null,
+          "tool_contract": { "echo": "1" },
+          "params": { "kx.tool.args": "{\"msg\":\"x\",\"n\":3}" }
+        },
+        {
+          "kind": "model",
+          "model_id": "kx-serve:qwen3-4b-q4_k_m",
+          "prompt": "summarize",
+          "body_signature_id": null,
+          "tool_contract": { "web-search": "1" },
+          "params": { "max_turns": "4", "max_tool_calls": "3" }
+        }
+      ],
+      "edges": [{ "parent": 0, "child": 1, "edge": "data" }]
+    }
   }
 ]


### PR DESCRIPTION
**D161.2** — the next ergonomics batch after the V2a gap-closure (#233). A lowered chain can now be saved as a **portable blueprint JSON** (the exact `kx blueprint run --file` input), then versioned, shared, and re-run anywhere. Cross-party sharing/marketplace stays **Cloud** (GR19). One GR14 batch across **CLI + Python + TypeScript + docs**.

**Pure client-side ⇒ product digest `7d22d4bd` invariant by construction** (kx-cli is a client; no runtime/projection/journal/proto touched), frozen-trio diff-EMPTY, `Cargo.lock` + proto UNCHANGED, golden chains corpus byte-stable (one additive case).

### CLI
- `kx chain run --emit-blueprint <file> [--dry-run]` — serialize the lowered chain to a portable DagSpec JSON (`--dry-run` exports **offline**, no gateway). `build_request` split into `build_dagspec` (explicit `kind`, `model_id` left as-authored for portability) + `to_request`.
- `kx blueprint import --file <file>` — compile + validate + **summarize a blueprint offline** (no gateway), the symmetric counterpart of `--emit-blueprint`.
- `Serialize` derives + `skip_serializing_if` guards on `DagSpec`/`StepSpec`/`EdgeSpec` (each skipped field's serde default reproduces it on re-read ⇒ byte-stable; pinned by a unit test).

### SDK (Python + TypeScript, at parity)
- `Chain.to_blueprint()` / `Chain.export(path)` (+ `Flow` delegation); `Chain.from_blueprint(spec)` / `from_blueprint_file(path)` → a `SubmitWorkflowRequest`.
- TS `export`/`fromBlueprintFile` are **Node-only** (dynamic `node:fs/promises` — verified to stay out of the `web`/`chains` static bundle graph).
- `from_blueprint` accepts **both** the SDK folded form and the CLI args-separated form (fold-idempotent) ⇒ **cross-tool artifact interop**.

### Round-trip invariant
Export → import re-compiles to a **byte-identical request**. Proven by reusing **every** golden corpus success case as a round-trip fixture (Rust/Py/TS) + a new combined corpus case (tool args + agentic budget in one DAG) + a `DagSpec` serialize→deserialize→compile unit test.

### Verification (deep, on real Gemma-4-12B)
- CLI export → re-import → **identical `result_ref`** (single MODEL step + multi-step pure→model DAG).
- The import path **genuinely drives the model**: a planet blueprint run via `blueprint run --file` → **"Jupiter"** (read from its specific committed mote, bypassing the await-any-on-shared-instance behavior).
- `blueprint import` offline-validates + summarizes.
- **Cross-surface**: a Python-authored `.export()` artifact runs via the **CLI** on Gemma → **"Au"** (gold).
- Gates: Rust clippy `-D warnings` + fmt + kx-cli tests; Python ruff/format/mypy + **250** pytest; TS biome/tsc + vitest.

> **Note (pre-existing, not this PR):** during e2e I confirmed the documented §2.232 await-any-on-shared-`instance_id` behavior — `--wait` on a journal with multiple committed runs can surface a sibling run's terminal. I initially suspected a MODEL-step identity collision but **rigorous fresh-journal mote enumeration disproved it** (model steps differentiate by prompt correctly: distinct `def_hash`/`mote_id`). No new bug; recorded for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsPb3czFCgZEzD4ZMLEzRX