### PR TITLE
PR-9b-2a — journal v8→v9 substrate: ReactRound.step_salt (deterministic-agentic step)

### DIFF
--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -2401,6 +2401,9 @@ fn write_react_anchor<J: Journal>(
         branch: ReactBranch::Pending,
         max_turns,
         max_tool_calls,
+        // v9 (PR-9b-2a): run-level chain. The agentic-launch anchor (PR-9b-2b)
+        // sets this to the launch step's MoteId.
+        step_salt: None,
         seq: 0,
     };
     let durable = journal.append(entry)?;
@@ -2946,6 +2949,9 @@ fn append_react_branch<J: Journal>(
         branch,
         max_turns: anchor.max_turns,
         max_tool_calls: anchor.max_tool_calls,
+        // v9 (PR-9b-2a): run-level chain. PR-9b-2b will propagate the anchor's
+        // step_salt here so a settled branch joins the right agentic chain.
+        step_salt: None,
         seq: 0,
     };
     match journal.append(entry) {

--- a/crates/kx-gateway-core/src/react.rs
+++ b/crates/kx-gateway-core/src/react.rs
@@ -133,6 +133,7 @@ mod tests {
             branch,
             max_turns: 8,
             max_tool_calls: 8,
+            step_salt: None,
             seq: 0,
         }
     }

--- a/crates/kx-gateway/src/capture.rs
+++ b/crates/kx-gateway/src/capture.rs
@@ -452,6 +452,7 @@ mod tests {
             branch,
             max_turns: 8,
             max_tool_calls: 6,
+            step_salt: None,
             seq,
         }
     }

--- a/crates/kx-journal/src/entry.rs
+++ b/crates/kx-journal/src/entry.rs
@@ -178,21 +178,39 @@ use smallvec::SmallVec;
 ///   a `react_rounds` record), never an identity input, never folded into the
 ///   run-identity product digest. Strictly additive; `MAX_ENTRY_LEN` is unchanged.
 ///
+/// **v9 (PR-9b-2a, deterministic-agentic substrate) changes** vs v8:
+/// - `ReactRound` gains a trailing `step_salt: Option<[u8; 32]>` (encoded as a
+///   presence byte + an optional 32-byte salt at the very end of the body). It is
+///   the per-step salt that disjoins a deterministic-agentic step's private
+///   reason→tool→observe chain from the run-level react chain (and from other
+///   agentic steps in the same run); `None` ⇒ a run-level chain (every chain a v8
+///   binary ever wrote). Still off-DAG metadata — never an identity input, never
+///   folded into the run-identity product digest — so the canonical digest is
+///   invariant. `blake3` is one-way, so the salt MUST be stored (recovery cannot
+///   re-derive it), which is why this is a body change (not a recomputed field).
+///   Strictly additive at the tail; `MAX_ENTRY_LEN` is unchanged (+33 bytes max,
+///   far under the cap). The compound `(instance_id, step_salt)` chain key that
+///   *reads* this field lands with the execution path (PR-9b-2b); v9 only persists
+///   it (every v9 `ReactRound` written by this PR carries `None`).
+///
 /// The strict [`crate::SqliteJournal::open`] refuses any file whose
-/// `schema_version` is not exactly v8 (the loud-refusal contract is unchanged).
+/// `schema_version` is not exactly v9 (the loud-refusal contract is unchanged: an
+/// OLD binary refuses a v9 journal rather than misreading its trailing byte).
 ///
 /// **Migration (IMP-2, M2.x-E).** As of the schema-migration work, an older
 /// still-supported version is no longer a dead end: [`crate::migrate_entry`] /
 /// [`crate::ReplayJournal`] up-convert old entries to the current shape for
 /// replay/recovery, and [`crate::migrate_to`] rewrites an old journal into a fresh
-/// v8 one for resume-and-append. v7 → v8 is a pure pass-through (kinds 0..8 are
-/// byte-identical under v8; `ReactRound` is purely additive), as is v6 → v7
-/// (`ReplanRound` purely additive); v5 → v8 appends the safe-default
-/// `idempotency_class` byte (the lone v5→v6 delta) and is then v8-valid.
+/// v9 one for resume-and-append. v8 → v9 appends the safe-default `None` presence
+/// byte to each `ReactRound` (kind 9) body — the lone v8→v9 delta, exactly the
+/// v5→v6 trailing-byte shape — and is then v9-valid; v7 → v9 and v6 → v9 are pure
+/// pass-throughs (kinds 0..8 are byte-identical and v7/v6 predate `ReactRound`, so
+/// they carry no kind-9 entry to grow); v5 → v9 appends the safe-default
+/// `idempotency_class` byte (the lone v5→v6 delta) and is then v9-valid.
 /// The product identity digest is invariant across migration; see
 /// [`crate::migrate_entry`] for the full contract and the supported version window
-/// ([`crate::MIN_SUPPORTED_SCHEMA_VERSION`]..=v8).
-pub const JOURNAL_SCHEMA_VERSION: u16 = 8;
+/// ([`crate::MIN_SUPPORTED_SCHEMA_VERSION`]..=v9).
+pub const JOURNAL_SCHEMA_VERSION: u16 = 9;
 
 /// Fixed entry-header length in bytes (`journal-entry.md` §3).
 pub const HEADER_LEN: usize = 74;
@@ -1056,6 +1074,14 @@ pub enum JournalEntry {
         max_turns: u32,
         /// The run's durable tool-call cap (see `max_turns`).
         max_tool_calls: u32,
+        /// v9 (PR-9b-2a): the per-step salt that disjoins a deterministic-agentic
+        /// step's PRIVATE reason→tool→observe chain from the run-level react chain
+        /// (and from other agentic steps in the same run). `None` ⇒ a run-level
+        /// chain (every chain v8 ever wrote up-converts to `None`). The execution
+        /// path (PR-9b-2b) sets it to the launch step's `MoteId` and keys the
+        /// chain by `(instance_id, step_salt)`. Off-DAG metadata — never an
+        /// identity input, never folded into the run-identity product digest.
+        step_salt: Option<[u8; 32]>,
         /// Journal-assigned sequence (0 until appended).
         seq: u64,
     },
@@ -1290,6 +1316,10 @@ pub enum DecodeError {
     /// [`ReactBranch`] tags (v8, PR-2d-1).
     #[error("unknown ReactRound branch tag: {0}")]
     UnknownReactBranch(u8),
+    /// A `ReactRound` entry's trailing `step_salt` presence tag byte is not `0`
+    /// (absent) or `1` (present) (v9, PR-9b-2a).
+    #[error("unknown ReactRound step_salt presence tag: {0}")]
+    UnknownReactStepSaltTag(u8),
     /// Trailing bytes after a complete entry (§2 no-trailing-data rule).
     #[error("trailing bytes after entry: {0} extra")]
     TrailingBytes(usize),
@@ -1621,12 +1651,16 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             branch,
             max_turns,
             max_tool_calls,
+            step_salt,
             ..
         } => {
-            // v8 (PR-2d-1): body = turn(u32 LE) ‖ instance_id(16) ‖
+            // v9 (PR-9b-2a): body = turn(u32 LE) ‖ instance_id(16) ‖
             // base_prompt_ref(32) ‖ warrant_ref(32) ‖ u16-prefixed model_id ‖
             // branch_tag(u8) ‖ [if Tool: u16-prefixed tool_id ‖ u16-prefixed
-            // tool_version] ‖ max_turns(u32 LE) ‖ max_tool_calls(u32 LE).
+            // tool_version] ‖ max_turns(u32 LE) ‖ max_tool_calls(u32 LE) ‖
+            // step_salt_present(u8: 0|1) ‖ [if 1: step_salt(32)]. The step_salt
+            // presence byte is the lone v8→v9 delta (a trailing additive byte,
+            // exactly the v5→v6 shape); v8 bodies up-convert by appending `0`.
             out.extend_from_slice(&turn.to_le_bytes());
             out.extend_from_slice(instance_id);
             out.extend_from_slice(base_prompt_ref.as_bytes());
@@ -1643,6 +1677,13 @@ pub fn encode_entry(entry: &JournalEntry) -> Result<Vec<u8>, EncodeError> {
             }
             out.extend_from_slice(&max_turns.to_le_bytes());
             out.extend_from_slice(&max_tool_calls.to_le_bytes());
+            match step_salt {
+                None => out.push(0u8),
+                Some(salt) => {
+                    out.push(1u8);
+                    out.extend_from_slice(salt);
+                }
+            }
             // Pathological-id guard (mirrors ReplanRound) — refuse rather than
             // over-cap a single oversize entry.
             if out.len() > MAX_ENTRY_LEN {
@@ -2062,6 +2103,14 @@ pub fn decode_entry_with_def_hash(
             };
             let max_turns = read_u32(body, &mut cursor, kind)?;
             let max_tool_calls = read_u32(body, &mut cursor, kind)?;
+            // v9 (PR-9b-2a): the trailing step_salt presence byte (a v8 body
+            // up-converts by appending `0`). Strict: an unknown presence tag is a
+            // decode error; the trailing-bytes check below still fences the end.
+            let step_salt = match read_u8(body, &mut cursor, kind)? {
+                0 => None,
+                1 => Some(read_array32(body, &mut cursor, kind)?),
+                other => return Err(DecodeError::UnknownReactStepSaltTag(other)),
+            };
             if cursor != body.len() {
                 return Err(DecodeError::TrailingBytes(body.len() - cursor));
             }
@@ -2075,6 +2124,7 @@ pub fn decode_entry_with_def_hash(
                 branch,
                 max_turns,
                 max_tool_calls,
+                step_salt,
                 seq,
             })
         }
@@ -2532,7 +2582,9 @@ mod tests {
             anchor
         );
 
-        // v8 (PR-2d-1): ReactRound — every branch shape round-trips.
+        // v9 (PR-9b-2a): ReactRound — every branch shape round-trips, under both
+        // step_salt absent (None, the run-level chain) and present (Some, an
+        // agentic step's private chain).
         for (branch, seq) in [
             (ReactBranch::Pending, 500u64),
             (ReactBranch::Answer, 501),
@@ -2545,20 +2597,68 @@ mod tests {
             ),
             (ReactBranch::DeadLettered, 503),
         ] {
-            let rt = JournalEntry::ReactRound {
-                turn: 2,
-                turn_mote_id: MoteId::from_bytes([0x8e; 32]),
-                instance_id: [0x4d; INSTANCE_ID_LEN],
-                base_prompt_ref: ContentRef::from_bytes([0x12; 32]),
-                warrant_ref: ContentRef::from_bytes([0x34; 32]),
-                model_id: "kx-serve:qwen3-4b".to_string(),
-                branch,
-                max_turns: 8,
-                max_tool_calls: 8,
-                seq,
-            };
-            assert_eq!(decode_entry(&encode_entry(&rt).unwrap()).unwrap(), rt);
+            for step_salt in [None, Some([0x5a_u8; 32])] {
+                let rt = JournalEntry::ReactRound {
+                    turn: 2,
+                    turn_mote_id: MoteId::from_bytes([0x8e; 32]),
+                    instance_id: [0x4d; INSTANCE_ID_LEN],
+                    base_prompt_ref: ContentRef::from_bytes([0x12; 32]),
+                    warrant_ref: ContentRef::from_bytes([0x34; 32]),
+                    model_id: "kx-serve:qwen3-4b".to_string(),
+                    branch: branch.clone(),
+                    max_turns: 8,
+                    max_tool_calls: 8,
+                    step_salt,
+                    seq,
+                };
+                assert_eq!(decode_entry(&encode_entry(&rt).unwrap()).unwrap(), rt);
+            }
         }
+    }
+
+    /// v9 (PR-9b-2a): the step_salt presence byte is the lone v8→v9 delta — a v8
+    /// `ReactRound` body is EXACTLY a v9 `step_salt: None` body minus its final
+    /// `0` byte (the migration's append-`0` rule). Pin that byte relationship so a
+    /// drift in either the encode tail or the migration up-converter fails CI.
+    #[test]
+    fn react_round_v8_body_is_v9_none_minus_trailing_zero() {
+        let none = JournalEntry::ReactRound {
+            turn: 3,
+            turn_mote_id: MoteId::from_bytes([0x8e; 32]),
+            instance_id: [0x4d; INSTANCE_ID_LEN],
+            base_prompt_ref: ContentRef::from_bytes([0x12; 32]),
+            warrant_ref: ContentRef::from_bytes([0x34; 32]),
+            model_id: "m".to_string(),
+            branch: ReactBranch::Answer,
+            max_turns: 8,
+            max_tool_calls: 6,
+            step_salt: None,
+            seq: 600,
+        };
+        let v9_none = encode_entry(&none).unwrap();
+        // The final body byte is the `None` presence tag (`0`); dropping it yields
+        // the v8 byte shape, and appending `0` back recovers the v9 None encoding.
+        assert_eq!(*v9_none.last().unwrap(), 0u8);
+        let v8_shape = &v9_none[..v9_none.len() - 1];
+        let mut reappended = v8_shape.to_vec();
+        reappended.push(0u8);
+        assert_eq!(reappended, v9_none);
+        // A v9 Some(..) body is the v8 shape + presence(1) + 32 salt bytes.
+        let some = JournalEntry::ReactRound {
+            turn: 3,
+            turn_mote_id: MoteId::from_bytes([0x8e; 32]),
+            instance_id: [0x4d; INSTANCE_ID_LEN],
+            base_prompt_ref: ContentRef::from_bytes([0x12; 32]),
+            warrant_ref: ContentRef::from_bytes([0x34; 32]),
+            model_id: "m".to_string(),
+            branch: ReactBranch::Answer,
+            max_turns: 8,
+            max_tool_calls: 6,
+            step_salt: Some([0x5a; 32]),
+            seq: 600,
+        };
+        let v9_some = encode_entry(&some).unwrap();
+        assert_eq!(v9_some.len(), v9_none.len() + 32);
     }
 
     #[test]
@@ -2576,6 +2676,7 @@ mod tests {
             branch: ReactBranch::Pending,
             max_turns: 8,
             max_tool_calls: 8,
+            step_salt: None,
             seq: 11,
         };
         assert_eq!(e.kind(), KIND_REACT_ROUND);
@@ -2596,6 +2697,7 @@ mod tests {
             branch: ReactBranch::Answer,
             max_turns: 8,
             max_tool_calls: 8,
+            step_salt: None,
             seq: 12,
         };
         let bytes = encode_entry(&e).unwrap();
@@ -2607,6 +2709,14 @@ mod tests {
         assert!(matches!(
             decode_entry(&corrupt),
             Err(DecodeError::UnknownReactBranch(0xee))
+        ));
+        // v9 (PR-9b-2a): the trailing step_salt presence byte (the final body byte
+        // for a None entry) must be 0 or 1; an unknown tag is fail-closed.
+        let mut bad_salt_tag = bytes.clone();
+        *bad_salt_tag.last_mut().unwrap() = 0xee;
+        assert!(matches!(
+            decode_entry(&bad_salt_tag),
+            Err(DecodeError::UnknownReactStepSaltTag(0xee))
         ));
         // Trailing garbage after a complete entry is fail-closed (§2).
         let mut trailing = bytes;

--- a/crates/kx-journal/src/migration.rs
+++ b/crates/kx-journal/src/migration.rs
@@ -47,7 +47,7 @@ use kx_mote::MoteDefHash;
 
 use crate::entry::{
     decode_entry_with_def_hash, IdempotencyClassTag, JournalEntry, HEADER_LEN, INSTANCE_ID_LEN,
-    JOURNAL_SCHEMA_VERSION, KIND_RUN_VERSIONS_RESOLVED,
+    JOURNAL_SCHEMA_VERSION, KIND_REACT_ROUND, KIND_RUN_VERSIONS_RESOLVED,
 };
 use crate::JournalError;
 
@@ -97,24 +97,49 @@ pub fn migrate_entry(
     // double-append its `idempotency_class` byte). `from_version` is guaranteed in
     // [MIN_SUPPORTED, CURRENT] by the guard above.
     match from_version {
-        // v8 (current): no transform, the single source of truth for decode.
+        // v9 (current): no transform, the single source of truth for decode.
         JOURNAL_SCHEMA_VERSION => Ok(decode_entry_with_def_hash(bytes, def_hash)?),
-        // v7 → v8: a PURE pass-through. Kinds 0..8 are byte-identical under v8 and
-        // `ReactRound` (kind 9) is purely additive, so a v7 journal's existing
-        // bytes already decode correctly under v8 — no transform.
+        // v8 → v9: append the safe-default `None` step_salt presence byte to each
+        // `ReactRound` (kind 9) body (the lone v8→v9 delta — a trailing additive
+        // byte, exactly the v5→v6 shape); every other kind is byte-identical and
+        // passes through. The result is v9-shaped.
+        8 => upconvert_v8_to_current(bytes, def_hash),
+        // v7 → v9: a PURE pass-through. Kinds 0..8 are byte-identical and v7
+        // predates `ReactRound` (kind 9, added v8), so a v7 journal carries no
+        // kind-9 body to grow — its existing bytes decode correctly under v9.
         7 => Ok(decode_entry_with_def_hash(bytes, def_hash)?),
-        // v6 → v8: a PURE pass-through. Kinds 0..7 are byte-identical and
-        // `ReplanRound` (kind 8) / `ReactRound` (kind 9) are purely additive, so a
-        // v6 journal's existing bytes already decode correctly — no transform.
+        // v6 → v9: a PURE pass-through. Kinds 0..7 are byte-identical and v6
+        // predates both `ReplanRound` (kind 8) and `ReactRound` (kind 9) — no
+        // kind-8/9 body to grow.
         6 => Ok(decode_entry_with_def_hash(bytes, def_hash)?),
-        // v5 → v8: append the safe-default `idempotency_class` byte (the lone v5→v6
-        // delta); the result is v6-shaped, which decodes identically under v8.
+        // v5 → v9: append the safe-default `idempotency_class` byte (the lone v5→v6
+        // delta); v5 predates `ReactRound`, so no step_salt byte is needed. The
+        // result is v6-shaped, which decodes identically under v9.
         5 => upconvert_v5_to_current(bytes, def_hash),
         // Unreachable (guarded above); kept total + fail-closed.
         other => Err(JournalError::SchemaVersionMismatch {
             expected: JOURNAL_SCHEMA_VERSION,
             found: other,
         }),
+    }
+}
+
+/// v8 → current up-converter. The lone transform is appending the safe-default
+/// `None` step_salt presence byte (`0`) to a `ReactRound` (kind 9) body; all other
+/// v8 bytes are already valid current-version bytes and pass through. A v8
+/// `ReactRound` body ends at `max_tool_calls` (no trailing byte), so appending `0`
+/// produces a valid v9 `step_salt: None` body that the canonical decoder accepts.
+fn upconvert_v8_to_current(
+    bytes: &[u8],
+    def_hash: MoteDefHash,
+) -> Result<JournalEntry, JournalError> {
+    if bytes.first() == Some(&KIND_REACT_ROUND) {
+        let mut upconverted = Vec::with_capacity(bytes.len() + 1);
+        upconverted.extend_from_slice(bytes);
+        upconverted.push(0u8); // step_salt present == false (None)
+        Ok(decode_entry_with_def_hash(&upconverted, def_hash)?)
+    } else {
+        Ok(decode_entry_with_def_hash(bytes, def_hash)?)
     }
 }
 

--- a/crates/kx-journal/src/sqlite.rs
+++ b/crates/kx-journal/src/sqlite.rs
@@ -787,17 +787,21 @@ fn migrate_into_temp(
         let head = replay.current_seq()?;
         for entry in replay.read_entries_by_seq(0..head + 1)? {
             let src_seq = entry.seq();
-            // Only the v5 arm TRANSFORMS bytes (appends the idempotency_class
-            // byte to a capability-present record); v6/v7 → current are pure
-            // pass-throughs (additive kinds only), so nothing "up-converts".
-            let upconverted = from_version < 6
+            // Two arms TRANSFORM bytes (everything else is a pure pass-through —
+            // additive kinds only): v5→ appends the idempotency_class byte to a
+            // capability-present record; v8→v9 appends the `None` step_salt
+            // presence byte to every `ReactRound` (kind 9, the only pre-v9 version
+            // carrying one is v8). Mirror `migrate_entry`'s transform predicate so
+            // the report's `entries_upconverted` is accurate.
+            let upconverted = (from_version < 6
                 && matches!(
                     &entry,
                     JournalEntry::RunVersionsResolved {
                         capability: Some(_),
                         ..
                     }
-                );
+                ))
+                || (from_version == 8 && matches!(&entry, JournalEntry::ReactRound { .. }));
             let durable = append_one(&txn, entry)?;
             if durable.seq() != src_seq {
                 return Err(JournalError::Invariant(

--- a/crates/kx-journal/tests/dod.rs
+++ b/crates/kx-journal/tests/dod.rs
@@ -303,16 +303,16 @@ fn obligation_13_schema_version_mismatch_loud_refusal() {
     }
 }
 
-/// PR-2d-1 (react-substrate): pin the schema version so the v7→v8 bump (the
-/// additive `ReactRound` entry kind) is an intentional, reviewable change — a
-/// future edit that touches the entry encoding must bump this in lock-step.
-/// (Prior bumps: v3→v4 added `RunVersionsResolved`, M1.2/D79; v4→v5 added
-/// `DigestSealed`, M2.2c/D104; v5→v6 added
-/// `ResolvedCapabilityRecord.idempotency_class`, M2.3b/D105.4; v6→v7 added
-/// `ReplanRound`, PR-2c-2.)
+/// PR-9b-2a (deterministic-agentic substrate): pin the schema version so a bump
+/// is an intentional, reviewable change — a future edit that touches the entry
+/// encoding must bump this in lock-step. (Prior bumps: v3→v4 added
+/// `RunVersionsResolved`, M1.2/D79; v4→v5 added `DigestSealed`, M2.2c/D104; v5→v6
+/// added `ResolvedCapabilityRecord.idempotency_class`, M2.3b/D105.4; v6→v7 added
+/// `ReplanRound`, PR-2c-2; v7→v8 added the `ReactRound` kind, PR-2d-1; v8→v9 added
+/// the trailing `ReactRound.step_salt`, PR-9b-2a.)
 #[test]
-fn schema_version_is_v8() {
-    assert_eq!(JOURNAL_SCHEMA_VERSION, 8);
+fn schema_version_is_v9() {
+    assert_eq!(JOURNAL_SCHEMA_VERSION, 9);
 }
 
 /// IMP-2 (M2.x-E): pin the migration floor. The schema-migration ladder

--- a/crates/kx-journal/tests/schema_evolution.rs
+++ b/crates/kx-journal/tests/schema_evolution.rs
@@ -350,10 +350,10 @@ fn replay_reads_v7_as_pure_passthrough() {
 }
 
 #[test]
-fn migrate_v7_to_v8_upconverts_nothing_and_preserves_committed_facts() {
+fn migrate_v7_to_current_upconverts_nothing_and_preserves_committed_facts() {
     let tmp = tempfile::tempdir().unwrap();
     let src = build_v7_journal(tmp.path());
-    let dst = tmp.path().join("migrated_v8.kxjournal");
+    let dst = tmp.path().join("migrated_from_v7.kxjournal");
 
     let report = migrate_to(&src, &dst).unwrap();
     assert_eq!(report.from_version, 7);
@@ -378,12 +378,204 @@ fn migrate_v7_to_v8_upconverts_nothing_and_preserves_committed_facts() {
     assert_eq!(committed_bytes(&src), committed_bytes(&dst));
 }
 
+// ---------------------------------------------------------------------------
+// The frozen v8 representation (PR-9b-2a): v8 = v9 minus the trailing ReactRound
+// step_salt presence byte. Kinds 0..8 are byte-identical under v9; the lone v8→v9
+// delta is a `0` (None) byte appended to each kind-9 `ReactRound` body.
+// ---------------------------------------------------------------------------
+
+/// Build the v8 fixture journal: the curated entry set PLUS a `ReplanRound`
+/// (kind 8) AND two `ReactRound` facts (kind 9, the v8 addition — an anchor +
+/// settle), then DOWNGRADE the kind-9 bodies to the v8 byte shape (strip the
+/// trailing `0` step_salt presence byte the v9 encoder now writes) and stamp
+/// `metadata.schema_version = 8`.
+fn build_v8_journal(dir: &Path) -> PathBuf {
+    let path = dir.join("sample_v8.kxjournal");
+    {
+        let j = SqliteJournal::open(&path).unwrap();
+        let mut entries = curated_v6_entries();
+        entries.push(JournalEntry::ReplanRound {
+            round: 1,
+            shaper_mote_id: MoteId::from_bytes([0x7c; 32]),
+            base_prompt_ref: ContentRef::from_bytes([0x11; 32]),
+            corrected_prompt_ref: ContentRef::from_bytes([0x22; 32]),
+            warrant_ref: ContentRef::from_bytes([0xaa; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            failed_steps: SmallVec::new(),
+            escalation_reason_ref: None,
+            seq: 0,
+        });
+        entries.push(JournalEntry::ReactRound {
+            turn: 0,
+            turn_mote_id: MoteId::from_bytes([0x8e; 32]),
+            instance_id: [0x4d; INSTANCE_ID_LEN],
+            base_prompt_ref: ContentRef::from_bytes([0x12; 32]),
+            warrant_ref: ContentRef::from_bytes([0x34; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            branch: ReactBranch::Pending,
+            max_turns: 8,
+            max_tool_calls: 6,
+            step_salt: None,
+            seq: 0,
+        });
+        entries.push(JournalEntry::ReactRound {
+            turn: 0,
+            turn_mote_id: MoteId::from_bytes([0x8e; 32]),
+            instance_id: [0x4d; INSTANCE_ID_LEN],
+            base_prompt_ref: ContentRef::from_bytes([0x12; 32]),
+            warrant_ref: ContentRef::from_bytes([0x34; 32]),
+            model_id: "qwen2-0_5b".to_string(),
+            branch: ReactBranch::Answer,
+            max_turns: 8,
+            max_tool_calls: 6,
+            step_salt: None,
+            seq: 0,
+        });
+        j.append_batch(entries).unwrap();
+    }
+    downgrade_to_v8(&path);
+    path
+}
+
+/// Raw-SQL downgrade of a v9 journal file to the v8 byte shape: strip the trailing
+/// `0` (None) step_salt presence byte from each `ReactRound` (kind 9), and stamp
+/// `metadata.schema_version = 8`. Wrapped in one transaction.
+fn downgrade_to_v8(path: &Path) {
+    let mut conn = Connection::open(path).unwrap();
+    let kind9: Vec<(i64, Vec<u8>)> = {
+        let mut stmt = conn
+            .prepare("SELECT seq, entry_bytes FROM entries WHERE kind = 9")
+            .unwrap();
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    };
+    let txn = conn.transaction().unwrap();
+    for (seq, bytes) in kind9 {
+        // The fixture only writes step_salt: None, so the v9 tail byte is `0`;
+        // dropping it yields the exact v8 shape.
+        assert_eq!(
+            *bytes.last().unwrap(),
+            0u8,
+            "fixture ReactRound must be None"
+        );
+        let v8 = &bytes[..bytes.len() - 1];
+        txn.execute(
+            "UPDATE entries SET entry_bytes = ?1 WHERE seq = ?2",
+            params![v8, seq],
+        )
+        .unwrap();
+    }
+    let v8_ver: [u8; 2] = 8u16.to_le_bytes();
+    txn.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
+        params![&v8_ver[..]],
+    )
+    .unwrap();
+    txn.commit().unwrap();
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .unwrap();
+}
+
 #[test]
-fn v8_react_round_persists_and_resumes() {
-    // A fresh (v8) journal carrying ReactRound facts round-trips the strict
-    // open + resume path: the anchor and a settled branch read back verbatim.
+fn open_still_refuses_v8_loudly() {
+    // The strict open() contract is unchanged by the v9 bump: a v8 journal is
+    // refused loudly (migration is the separate, additive path) — the same
+    // contract that makes an OLD binary refuse a v9 journal rather than misread
+    // its trailing step_salt byte (forward-compat = refusal, never corruption).
     let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().join("react_v8.kxjournal");
+    let path = build_v8_journal(tmp.path());
+    let err = SqliteJournal::open(&path).unwrap_err();
+    assert!(matches!(
+        err,
+        JournalError::SchemaVersionMismatch { found: 8, expected } if expected == JOURNAL_SCHEMA_VERSION
+    ));
+}
+
+#[test]
+fn replay_reads_v8_and_upconverts_react_step_salt() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = build_v8_journal(tmp.path());
+
+    let replay = ReplayJournal::open(&path).unwrap();
+    assert_eq!(replay.from_version(), 8);
+    assert_eq!(replay.count_entries().unwrap(), 10);
+
+    // The two v8 ReactRound facts up-convert to step_salt: None (the run-level
+    // chain — every chain a v8 binary ever wrote); capability classes from the
+    // curated set are PRESERVED (not defaulted — that is the v5 path).
+    let entries = read_all(&replay);
+    let react: Vec<_> = entries
+        .iter()
+        .filter_map(|e| match e {
+            JournalEntry::ReactRound { step_salt, .. } => Some(*step_salt),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(react, vec![None, None]);
+    let cap = entries
+        .iter()
+        .find_map(|e| match e {
+            JournalEntry::RunVersionsResolved {
+                capability: Some(c),
+                ..
+            } => Some(c),
+            _ => None,
+        })
+        .expect("a capability-present RunVersionsResolved");
+    assert_eq!(cap.idempotency_class, IdempotencyClassTag::Token);
+}
+
+#[test]
+fn migrate_v8_to_v9_upconverts_react_and_preserves_committed_facts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = build_v8_journal(tmp.path());
+    let dst = tmp.path().join("migrated_v9.kxjournal");
+
+    let report = migrate_to(&src, &dst).unwrap();
+    assert_eq!(report.from_version, 8);
+    assert_eq!(report.to_version, JOURNAL_SCHEMA_VERSION);
+    assert_eq!(report.entries_migrated, 10);
+    assert_eq!(report.entries_upconverted, 2); // exactly the two ReactRound facts
+
+    // Strict open accepts the result; committed facts are byte-identical (product
+    // identity invariant — the durability law; only kind-9 bodies grow by 1 byte).
+    let j = SqliteJournal::open(&dst).unwrap();
+    assert_eq!(j.count_entries().unwrap(), 10);
+    let committed_bytes = |p: &Path| -> Vec<Vec<u8>> {
+        let conn = Connection::open(p).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT entry_bytes FROM entries WHERE kind = 1 ORDER BY seq")
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, Vec<u8>>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    };
+    assert_eq!(committed_bytes(&src), committed_bytes(&dst));
+
+    // The migrated ReactRound facts now carry the explicit None step_salt.
+    let via_migrate = read_all(&j);
+    assert!(via_migrate
+        .iter()
+        .filter(|e| matches!(e, JournalEntry::ReactRound { .. }))
+        .all(|e| matches!(
+            e,
+            JournalEntry::ReactRound {
+                step_salt: None,
+                ..
+            }
+        )));
+}
+
+#[test]
+fn v9_react_round_persists_and_resumes() {
+    // A fresh (v9) journal carrying ReactRound facts round-trips the strict
+    // open + resume path: the anchor (run-level, step_salt None) and a settled
+    // branch carrying a step_salt (the agentic-step shape) read back verbatim.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("react_v9.kxjournal");
     let anchor = JournalEntry::ReactRound {
         turn: 0,
         turn_mote_id: MoteId::from_bytes([0x8e; 32]),
@@ -394,6 +586,7 @@ fn v8_react_round_persists_and_resumes() {
         branch: ReactBranch::Pending,
         max_turns: 8,
         max_tool_calls: 8,
+        step_salt: None,
         seq: 0,
     };
     let settle = JournalEntry::ReactRound {
@@ -406,6 +599,7 @@ fn v8_react_round_persists_and_resumes() {
         branch: ReactBranch::Answer,
         max_turns: 8,
         max_tool_calls: 8,
+        step_salt: Some([0x5a; 32]),
         seq: 0,
     };
     {
@@ -421,6 +615,7 @@ fn v8_react_round_persists_and_resumes() {
             turn: 0,
             branch: ReactBranch::Pending,
             max_turns: 8,
+            step_salt: None,
             ..
         }
     ));
@@ -428,8 +623,9 @@ fn v8_react_round_persists_and_resumes() {
         &entries[1],
         JournalEntry::ReactRound {
             branch: ReactBranch::Answer,
+            step_salt: Some(salt),
             ..
-        }
+        } if *salt == [0x5a; 32]
     ));
 }
 

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -646,6 +646,11 @@ impl Projection {
                 branch,
                 max_turns,
                 max_tool_calls,
+                // v9 (PR-9b-2a): the compound `(instance_id, step_salt)` chain key
+                // that READS this lands with the execution path (PR-9b-2b); the
+                // run-level fold here ignores it (every v9 record this PR writes
+                // carries None), keeping the run-level query path byte-unchanged.
+                step_salt: _,
                 seq,
             } => {
                 // v8 (PR-2d-1). Append-many: a run accrues one record per turn

--- a/crates/kx-runtime/tests/schema_evolution.rs
+++ b/crates/kx-runtime/tests/schema_evolution.rs
@@ -141,12 +141,13 @@ fn migrate_and_verify_preserves_product_identity() {
 
     let report = migrate_and_verify(&src, &dst).unwrap();
     assert_eq!(report.from_version, 5);
-    // The migration target tracks the current schema (v8 as of PR-2d-1's additive
-    // `ReactRound`; v7 was PR-2c-2's `ReplanRound`); the v5→current up-conversion
-    // still appends exactly the lone `idempotency_class` byte. Pinned as a
-    // reviewable change — the PRODUCT identity digest below is the real invariant
-    // (unchanged across the bump).
-    assert_eq!(report.to_version, 8);
+    // The migration target tracks the current schema (v9 as of PR-9b-2a's additive
+    // `ReactRound.step_salt`; v8 was PR-2d-1's `ReactRound`; v7 was PR-2c-2's
+    // `ReplanRound`); the v5→current up-conversion still appends exactly the lone
+    // `idempotency_class` byte (this v5 fixture has no kind-9 ReactRound, so no
+    // step_salt byte is added). Pinned as a reviewable change — the PRODUCT
+    // identity digest below is the real invariant (unchanged across the bump).
+    assert_eq!(report.to_version, 9);
     assert_eq!(report.entries_upconverted, 1);
 
     // The up-converted source and the migrated destination fold to the same


### PR DESCRIPTION
## PR-9b-2a — journal v8→v9 substrate: `ReactRound.step_salt`

The **durable-schema half** of PR-9b-2 (the deterministic-agentic `@tool` step), split out per GR8/GR12 so the **forward/back-compat blast radius lands in isolation**, fully migration-tested, with the canonical product digest proven **invariant before any execution path can fire**. **No behavior change.**

### What & why
`ReactRound` (kind 9) gains a trailing `step_salt: Option<[u8; 32]>` — the per-step salt that (in PR-9b-2b) disjoins a deterministic-agentic step's *private* reason→tool→observe chain from the run-level react chain. `None` ⇒ a run-level chain (every chain v8 ever wrote). `blake3` is one-way, so the salt **must be stored** (recovery cannot re-derive it) — hence a body change + version bump, not a recomputed field. The v8 body is exactly a v9 `None` body minus its final `0` byte — the **v5→v6 trailing-byte precedent**.

### Changes
- **`entry.rs`**: `JOURNAL_SCHEMA_VERSION` 8→9; `ReactRound.step_salt`; encode appends a presence byte + optional 32 bytes at the body tail; decode reads it before the strict trailing-bytes fence; new `UnknownReactStepSaltTag` error; v9 doc-ladder.
- **`migration.rs`**: v8→v9 up-converter appends the `None` byte to each kind-9 body; v7/v6 stay pure pass-throughs (predate `ReactRound`); window `5..=9`.
- **`sqlite.rs`**: `entries_upconverted` accounting extended to count the `ReactRound` transforms (mirrors `migrate_entry`'s predicate).
- **projection** fold ignores `step_salt` (the compound `(instance_id, step_salt)` key reads it in 9b-2b); run-level query path byte-unchanged.
- **coordinator** anchor + branch writers pass `step_salt: None` (run-level).

### Forward/back-compat (GR8)
- Old binary reads v9 → loud refusal at strict `open` (forward-compat = refusal, never corruption).
- New binary reads v8 → `ReplayJournal`/`migrate_to` up-convert `absent ⇒ None ⇒ run-level`.
- **Canonical product digest `7d22d4bd` INVARIANT** (off-DAG metadata; a0_guard + audit_trail + runtime `schema_evolution` product-identity `6bf5b52d` preserved across v5→v9).

### Invariants
Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference`) diff-**EMPTY**; `Cargo.lock` + proto **UNCHANGED**.

### Gates (full `just ci` green)
fmt · clippy `-D warnings` · test `--workspace` (356 suites) · deny · doc · ffi-link · build-no-inference · features-guard · **check-reproducible (I1.c byte-determinism PASS)** · scale-smoke (`migrate_25k` linear ratio 0.57) · verify-quickstart (`7d22d4bd` 8/8).

### Tests added
v9 round-trip (None + Some) · v8-fixture → v9 migration (committed facts byte-identical) · the v8/v9 byte-relationship pin · unknown-tag rejection · `schema_version_is_v9`.

Next: **PR-9b-2b** (the bounded reason→tool→observe execution) builds on this substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
