### PR TITLE
PR-9b-2b — deterministic-agentic step EXECUTION (authored `@tool` lane)

### DIFF
--- a/bindings/python/src/kortecx/agent.py
+++ b/bindings/python/src/kortecx/agent.py
@@ -11,9 +11,12 @@ Two lanes (D161), one object — the API name mirrors the distinction:
 
 - **Default = deterministic / frozen** — a single agent step with a FIXED tool-grant
   SET (replayable; the tool set is part of the step's identity). Pure client sugar over
-  :class:`~kortecx.flow.Flow`. The frozen tool-EXECUTION lights up with PR-9b-2; until
-  then a *tool-bearing* frozen agent is refused server-side at submit — use
-  ``dynamic=True`` (or a standalone ``tool()`` step) for tool-calling today.
+  :class:`~kortecx.flow.Flow`. The frozen tool-EXECUTION (the bounded reason→tool→observe
+  loop) is **LIVE as of PR-9b-2** — author it with EXPLICIT tool refs via
+  ``flow().model(prompt, tools=["mcp-echo"])`` / the ``model@tool`` chain DSL / a UI
+  builder model step. The ``Agent(tools=[fn])`` one-liner over LOCAL ``@kx.tool``
+  functions completes in the immediate follow-up (the dialed-tool grant-name match); a
+  tool-bearing frozen ``Agent`` raises a clear pre-flight hint until then.
 - ``dynamic=True`` → the **steered** ``kx/recipes/react`` recipe, where the model picks
   tools turn by turn. Works today.
 
@@ -88,10 +91,11 @@ class Agent:
     ) -> "Union[Run, Result]":
         """Run ``task``.
 
-        - **frozen lane (default)** ⇒ a single agent step. A tool-bearing frozen agent
-          runs a deterministic-agentic loop that **lands in PR-9b-2** (refused at
-          submit today) — so a clear pre-flight hint is raised; use ``dynamic=True`` or
-          ``flow().tool(fn, **args)`` to call tools today.
+        - **frozen lane (default)** ⇒ a single agent step. The tool-bearing frozen
+          loop EXECUTION is LIVE (PR-9b-2) via EXPLICIT tool refs
+          (``flow().model(prompt, tools=["mcp-echo"])`` / ``model@tool`` / a UI builder
+          model step); the ``Agent(tools=[fn])`` one-liner over LOCAL functions raises a
+          pre-flight hint until the immediate follow-up wires its dialed-tool grant name.
         - ``dynamic=True`` ⇒ the steered react lane. With tools it routes to
           ``kx/recipes/react-auto`` (the only lane that fires registered/dialed tools;
           needs ``KX_SERVE_AUTOGRANT=1``); without tools, plain ``kx/recipes/react``.
@@ -128,10 +132,12 @@ class Agent:
             from .tools import ToolError
 
             raise ToolError(
-                "a frozen Agent with a tool set runs a deterministic-agentic loop that "
-                "lands in PR-9b-2 and is refused at submit today; use "
-                "Agent(..., dynamic=True) for the steered react lane, or "
-                "flow().tool(fn, **args) to fire one tool deterministically"
+                "the deterministic-agentic loop is LIVE (PR-9b-2), but the Agent(tools=) "
+                "one-liner over local @kx.tool functions completes in the immediate "
+                "follow-up (the dialed-tool grant-name match); author it today with "
+                "EXPLICIT refs via flow().model(prompt, tools=['mcp-echo']) or the "
+                "`model@tool` chain DSL, use Agent(..., dynamic=True) for the steered "
+                "react lane, or flow().tool(fn, **args) to fire one tool deterministically"
             )
         return self.as_flow(task).run(wait=wait, timeout=timeout, client=kx)
 

--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -85,7 +85,7 @@ class Flow:
         """Append an agent (MODEL) step. ``model`` defaults to the served model (the
         client's ``default_model`` fills a blank one at submit, SN-8); pass ``tools``
         to make it a deterministic-agentic step — a bounded reason→tool→observe loop
-        over the granted SET (PR-9b; the execution lane lights up with PR-9b-2)."""
+        over the granted SET (PR-9b; the execution lane is LIVE as of PR-9b-2)."""
         return self._seq_append(
             _model(
                 model,

--- a/bindings/python/src/kortecx/tools.py
+++ b/bindings/python/src/kortecx/tools.py
@@ -35,9 +35,11 @@ adds no new attack surface. Cloud governs the bridge.
 - **steered / dynamic** — ``Agent(tools=[fn], dynamic=True)`` runs the
   ``kx/recipes/react-auto`` loop where the model picks tools (needs a served model
   + ``KX_SERVE_AUTOGRANT=1``).
-- **frozen / deterministic-agentic** — ``Agent(tools=[fn])`` (the default lane) is a
-  MODEL step with a fixed tool set; its bounded loop **lands in PR-9b-2** and is
-  refused at submit today, so the Agent raises a clear pre-flight hint until then.
+- **frozen / deterministic-agentic** — a MODEL step with a fixed tool set; its bounded
+  loop EXECUTION is LIVE as of PR-9b-2 via EXPLICIT refs (``flow().model(prompt,
+  tools=["mcp-echo"])`` / the ``model@tool`` DSL). The ``Agent(tools=[fn])`` one-liner
+  over LOCAL functions completes in the immediate follow-up (the dialed-tool grant-name
+  match), so a tool-bearing frozen ``Agent`` raises a clear pre-flight hint until then.
 
 **Re-import contract.** The runtime spawns ``python -m kortecx._toolserver`` which
 re-loads your module to recover the functions. Decorate at MODULE level and guard

--- a/bindings/typescript/src/agent.ts
+++ b/bindings/typescript/src/agent.ts
@@ -9,7 +9,8 @@
  *
  * Default lane = deterministic/frozen (a single agent step — replayable, the tool set
  * is part of identity); `dynamic: true` routes to the steered `kx/recipes/react`
- * recipe. The frozen tool-EXECUTION lights up with PR-9b-2. SN-8: intent only.
+ * recipe. The frozen tool-EXECUTION is LIVE as of PR-9b-2 (author with explicit tool
+ * refs via `flow().model(prompt, { tools })`). SN-8: intent only.
  */
 
 import type { ReasoningMode } from "./chains.js";
@@ -101,9 +102,11 @@ export class Agent {
   /**
    * Run `task`.
    *
-   * - **frozen lane (default)** ⇒ a single agent step. A tool-bearing frozen agent runs
-   *   a deterministic-agentic loop that **lands in PR-9b-2** (refused at submit today),
-   *   so a clear pre-flight hint is thrown; use `dynamic: true` or `flow().tool(fn, args)`.
+   * - **frozen lane (default)** ⇒ a single agent step. The tool-bearing frozen loop
+   *   EXECUTION is LIVE (PR-9b-2) via EXPLICIT tool refs (`flow().model(prompt, { tools:
+   *   ["mcp-echo"] })` / the `model@tool` chain DSL / a UI builder model step); the
+   *   `Agent({ tools: [fn] })` one-liner over LOCAL functions throws a pre-flight hint
+   *   until the immediate follow-up wires its dialed-tool grant name.
    * - `dynamic: true` ⇒ the steered react lane. With tools it routes to
    *   `kx/recipes/react-auto` (the only lane that fires registered/dialed tools; needs
    *   `KX_SERVE_AUTOGRANT=1`); without tools, plain `kx/recipes/react`.
@@ -142,9 +145,11 @@ export class Agent {
     }
     if (hasTools(tools)) {
       throw new KxToolError(
-        "a frozen Agent with a tool set runs a deterministic-agentic loop that lands in " +
-          "PR-9b-2 and is refused at submit today; use { dynamic: true } for the steered react " +
-          "lane, or flow().tool(fn, args) to fire one tool deterministically",
+        "the deterministic-agentic loop is LIVE (PR-9b-2), but the Agent({ tools }) " +
+          "one-liner over local tool functions completes in the immediate follow-up (the " +
+          "dialed-tool grant-name match); author it today with EXPLICIT refs via " +
+          "flow().model(prompt, { tools: ['mcp-echo'] }) or the `model@tool` chain DSL, use " +
+          "{ dynamic: true } for the steered react lane, or flow().tool(fn, args) to fire one tool",
       );
     }
     return this.asFlow(task).run({

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -98,7 +98,7 @@ export class Flow {
 
   /** Append an agent (MODEL) step. `model` defaults to the served model (the client's
    * `defaultModel` fills a blank one at submit, SN-8); `tools` makes it a
-   * deterministic-agentic step (PR-9b; execution lights up with PR-9b-2). */
+   * deterministic-agentic step (PR-9b; execution is LIVE as of PR-9b-2). */
   agent(prompt: string, opts: AgentStepOptions = {}): this {
     return this.append(
       task.model(

--- a/crates/kx-coordinator/src/react_shape.rs
+++ b/crates/kx-coordinator/src/react_shape.rs
@@ -196,6 +196,149 @@ pub(crate) fn build_react_tool(
     )
 }
 
+// ===========================================================================
+// PR-9b-2b — the SALT-2 builders for a DETERMINISTIC-AGENTIC STEP.
+//
+// A deterministic-agentic step is a frozen-DAG MODEL step that becomes ready
+// MID-RUN and runs its OWN bounded reason→tool→observe loop (vs the run-level
+// react chain swapped in at submit). Its turn/observation Motes are salted by an
+// ADDITIONAL 32-byte `step_salt` (= the launch step's `MoteId`) on top of the run
+// `instance_id`, so multiple agentic steps in one run — and the run-level react
+// chain — never collide on `(instance_id, turn)`. The domain tags are DISTINCT
+// from the salt-1 namespaces (`b"kx-agentic-*"` vs `b"kx-react-*"`), and the
+// byte-frozen salt-1 builders above are deliberately UNTOUCHED (their cross-impl
+// goldens stay pinned). A NEW golden pins the salt-2 derivation below.
+// ===========================================================================
+
+/// The salt-2 identity material for an agentic-step turn:
+/// `blake3(b"kx-agentic-turn" ‖ instance_id ‖ step_salt ‖ turn.to_le_bytes())`.
+/// Deterministic + distinct per `(run, step, turn)` and cryptographically
+/// distinct from EVERY salt-1 namespace (different domain tag) — so an agentic
+/// step's chain can never dedup-collide with the run-level react chain.
+#[must_use]
+pub(crate) fn react_turn_id_material2(
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    step_salt: &[u8; 32],
+    turn: u32,
+) -> [u8; 32] {
+    let mut material = b"kx-agentic-turn".to_vec();
+    material.extend_from_slice(instance_id);
+    material.extend_from_slice(step_salt);
+    material.extend_from_slice(&turn.to_le_bytes());
+    *ContentRef::of(&material).as_bytes()
+}
+
+/// Re-derive an agentic-step turn `Mote` — the salt-2 twin of [`build_react_turn`].
+/// Identical SHAPE (ROND, edge-free, instruction in `config_subset[PROMPT_KEY]`,
+/// greedy at `max_output_tokens`) EXCEPT: (a) the id is salt-2 derived, and
+/// (b) the [`REACT_TURN_KEY`] routing marker carries `instance_id ‖ step_salt`
+/// (48 bytes) so the coordinator's `resolve_parent_context` reconstructs the
+/// compound `(instance_id, step_salt)` chain key (a 16-byte marker = run-level).
+#[must_use]
+pub(crate) fn build_agentic_turn(
+    model_id: &ModelId,
+    instruction: &str,
+    turn: u32,
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    step_salt: &[u8; 32],
+    max_output_tokens: u32,
+) -> Mote {
+    let id_bytes = react_turn_id_material2(instance_id, step_salt, turn);
+
+    let mut marker = instance_id.to_vec();
+    marker.extend_from_slice(step_salt);
+
+    let mut config_subset = BTreeMap::new();
+    config_subset.insert(
+        ConfigKey(PROMPT_KEY.to_string()),
+        ConfigVal(instruction.as_bytes().to_vec()),
+    );
+    config_subset.insert(ConfigKey(REACT_TURN_KEY.to_string()), ConfigVal(marker));
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes(id_bytes),
+        model_id: model_id.clone(),
+        prompt_template_hash: PromptTemplateHash::from_bytes(id_bytes),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams {
+            max_output_tokens,
+            ..InferenceParams::default()
+        },
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes(id_bytes),
+        GraphPosition(id_bytes.to_vec()),
+        SmallVec::new(),
+    )
+}
+
+/// The salt-2 identity material for an agentic-step OBSERVATION:
+/// `blake3(b"kx-agentic-tool" ‖ instance_id ‖ step_salt ‖ turn.to_le_bytes())`.
+#[must_use]
+pub(crate) fn react_tool_id_material2(
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    step_salt: &[u8; 32],
+    turn: u32,
+) -> [u8; 32] {
+    let mut material = b"kx-agentic-tool".to_vec();
+    material.extend_from_slice(instance_id);
+    material.extend_from_slice(step_salt);
+    material.extend_from_slice(&turn.to_le_bytes());
+    *ContentRef::of(&material).as_bytes()
+}
+
+/// Re-derive an agentic-step OBSERVATION `Mote` — the salt-2 twin of
+/// [`build_react_tool`]. Identical SHAPE (WM `StageThenCommit`, one Data edge to
+/// its proposing turn, EMPTY config = the out-of-band args contract, declared
+/// `(tool_id, tool_version)` in `tool_contract`) EXCEPT the id is salt-2 derived
+/// and the parent is the agentic turn.
+#[must_use]
+pub(crate) fn build_agentic_tool(
+    model_id: &ModelId,
+    tool_id: &ToolName,
+    tool_version: &ToolVersion,
+    turn: u32,
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    step_salt: &[u8; 32],
+    turn_mote_id: MoteId,
+) -> Mote {
+    let id_bytes = react_tool_id_material2(instance_id, step_salt, turn);
+
+    let mut tool_contract = BTreeMap::new();
+    tool_contract.insert(tool_id.clone(), tool_version.clone());
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes(id_bytes),
+        model_id: model_id.clone(),
+        prompt_template_hash: PromptTemplateHash::from_bytes(id_bytes),
+        tool_contract,
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes(id_bytes),
+        GraphPosition(id_bytes.to_vec()),
+        std::iter::once(ParentRef {
+            parent_id: turn_mote_id,
+            edge: EdgeMeta::data(),
+        })
+        .collect::<SmallVec<[ParentRef; 4]>>(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,5 +445,99 @@ mod tests {
         assert_ne!(build_react_turn(&model, "p2", 1, &[1; 16], 64).id, x.id);
         assert_ne!(build_react_turn(&model, "p", 2, &[1; 16], 64).id, x.id);
         assert_ne!(build_react_turn(&model, "p", 1, &[1; 16], 65).id, x.id);
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-9b-2b — salt-2 (deterministic-agentic step) builder goldens.
+    // -----------------------------------------------------------------------
+
+    /// The frozen golden for the salt-2 turn-0 `MoteId`. Inputs: model
+    /// `kx-test:q8:deadbeef`, instruction "list the files", turn 0, salt
+    /// `[0x4d; 16]`, step_salt `[0x9a; 32]`, max_output_tokens 64. Coordinator-
+    /// local (no harness twin — agentic steps are a serve-only construct); pins
+    /// the salt-2 derivation so a drift in the domain tag / material order fails
+    /// CI. MUST differ from `SALTED_TURN0_GOLDEN` (distinct domain namespaces).
+    const AGENTIC_TURN0_GOLDEN: &str =
+        "8bed4369abcfd6da5f334ea1e2e28358773a83596d58d2e16ea12a84b0312dc2";
+
+    #[test]
+    fn agentic_turn_matches_its_golden_and_is_namespace_distinct() {
+        let model = ModelId("kx-test:q8:deadbeef".to_string());
+        let salt = [0x4d_u8; 16];
+        let step_salt = [0x9a_u8; 32];
+        let turn = build_agentic_turn(&model, "list the files", 0, &salt, &step_salt, 64);
+        // Property contract (the golden hex is bootstrapped by `just`-running this
+        // once; pinned below). Shape mirrors a salt-1 react turn.
+        assert!(turn.parents.is_empty(), "an agentic turn MUST be edge-free");
+        assert!(!turn.def.is_topology_shaper);
+        assert_eq!(turn.def.nd_class, NdClass::ReadOnlyNondet);
+        // The marker carries instance_id ‖ step_salt (48 bytes).
+        let marker = turn
+            .def
+            .config_subset
+            .get(&ConfigKey(REACT_TURN_KEY.to_string()))
+            .map(|v| v.0.clone())
+            .expect("marker present");
+        assert_eq!(marker.len(), INSTANCE_ID_LEN + 32);
+        assert_eq!(&marker[..INSTANCE_ID_LEN], &salt[..]);
+        assert_eq!(&marker[INSTANCE_ID_LEN..], &step_salt[..]);
+        // CRYPTOGRAPHICALLY distinct from the salt-1 react turn at the same coords.
+        let react = build_react_turn(&model, "list the files", 0, &salt, 64);
+        assert_ne!(turn.id, react.id, "salt-2 must not collide with salt-1");
+        assert_eq!(hex(turn.id.as_bytes()), AGENTIC_TURN0_GOLDEN);
+    }
+
+    /// The frozen golden for the salt-2 observation-0 `MoteId`. Same inputs +
+    /// tool `mcp-echo@1`, parent = the salt-2 turn-0.
+    const AGENTIC_TOOL0_GOLDEN: &str =
+        "95b763ae1384952b004b5e16d0ee47ce02c08b403b18ebc0a629e65db91b8b98";
+
+    #[test]
+    fn agentic_tool_matches_its_golden_and_is_namespace_distinct() {
+        let model = ModelId("kx-test:q8:deadbeef".to_string());
+        let salt = [0x4d_u8; 16];
+        let step_salt = [0x9a_u8; 32];
+        let turn = build_agentic_turn(&model, "list the files", 0, &salt, &step_salt, 64);
+        let obs = build_agentic_tool(
+            &model,
+            &ToolName("mcp-echo".to_string()),
+            &ToolVersion("1".to_string()),
+            0,
+            &salt,
+            &step_salt,
+            turn.id,
+        );
+        // Shape: one Data edge to the turn, empty config (out-of-band args), WM +
+        // StageThenCommit, the declared tool contract.
+        assert_eq!(obs.parents.len(), 1);
+        assert_eq!(obs.parents[0].parent_id, turn.id);
+        assert!(obs.def.config_subset.is_empty());
+        assert_eq!(obs.def.nd_class, NdClass::WorldMutating);
+        assert_eq!(obs.def.effect_pattern, EffectPattern::StageThenCommit);
+        // Distinct from the salt-1 observation at the same coords.
+        let react_obs = build_react_tool(
+            &model,
+            &ToolName("mcp-echo".to_string()),
+            &ToolVersion("1".to_string()),
+            0,
+            &salt,
+            turn.id,
+        );
+        assert_ne!(obs.id, react_obs.id);
+        assert_eq!(hex(obs.id.as_bytes()), AGENTIC_TOOL0_GOLDEN);
+    }
+
+    #[test]
+    fn agentic_ids_are_deterministic_and_step_isolated() {
+        let a = react_turn_id_material2(&[1; 16], &[2; 32], 0);
+        assert_eq!(a, react_turn_id_material2(&[1; 16], &[2; 32], 0));
+        assert_ne!(a, react_turn_id_material2(&[1; 16], &[2; 32], 1)); // per turn
+        assert_ne!(a, react_turn_id_material2(&[1; 16], &[3; 32], 0)); // per step
+        assert_ne!(a, react_turn_id_material2(&[9; 16], &[2; 32], 0)); // per run
+        // Distinct from the agentic-tool namespace at the same coords.
+        assert_ne!(a, react_tool_id_material2(&[1; 16], &[2; 32], 0));
+        // Distinct from BOTH salt-1 namespaces.
+        assert_ne!(a, react_turn_id_material(&[1; 16], 0));
+        assert_ne!(a, react_tool_id_material(&[1; 16], 0));
     }
 }

--- a/crates/kx-coordinator/src/react_shape.rs
+++ b/crates/kx-coordinator/src/react_shape.rs
@@ -339,6 +339,67 @@ pub(crate) fn build_agentic_tool(
     )
 }
 
+/// Re-derive a chain TURN `Mote` keyed by the chain's `step_salt` (PR-9b-2b): the
+/// run-level react chain (`None`) uses the salt-1 [`build_react_turn`]; an agentic
+/// step's private chain (`Some(launch MoteId)`) uses the salt-2 [`build_agentic_turn`].
+/// One dispatch point so the coordinator's settle/recover/advance code is chain-shape
+/// agnostic and the two namespaces can never be confused.
+#[must_use]
+pub(crate) fn build_chain_turn(
+    model_id: &ModelId,
+    instruction: &str,
+    turn: u32,
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    step_salt: Option<[u8; 32]>,
+    max_output_tokens: u32,
+) -> Mote {
+    match step_salt {
+        Some(salt) => build_agentic_turn(
+            model_id,
+            instruction,
+            turn,
+            instance_id,
+            &salt,
+            max_output_tokens,
+        ),
+        None => build_react_turn(model_id, instruction, turn, instance_id, max_output_tokens),
+    }
+}
+
+/// Re-derive a chain OBSERVATION `Mote` keyed by the chain's `step_salt` (PR-9b-2b):
+/// the salt-1 [`build_react_tool`] for the run-level chain, the salt-2
+/// [`build_agentic_tool`] for an agentic step's chain. The twin of [`build_chain_turn`].
+#[must_use]
+pub(crate) fn build_chain_tool(
+    model_id: &ModelId,
+    tool_id: &ToolName,
+    tool_version: &ToolVersion,
+    turn: u32,
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    step_salt: Option<[u8; 32]>,
+    turn_mote_id: MoteId,
+) -> Mote {
+    match step_salt {
+        Some(salt) => build_agentic_tool(
+            model_id,
+            tool_id,
+            tool_version,
+            turn,
+            instance_id,
+            &salt,
+            turn_mote_id,
+        ),
+        None => build_react_tool(
+            model_id,
+            tool_id,
+            tool_version,
+            turn,
+            instance_id,
+            turn_mote_id,
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -534,7 +595,7 @@ mod tests {
         assert_ne!(a, react_turn_id_material2(&[1; 16], &[2; 32], 1)); // per turn
         assert_ne!(a, react_turn_id_material2(&[1; 16], &[3; 32], 0)); // per step
         assert_ne!(a, react_turn_id_material2(&[9; 16], &[2; 32], 0)); // per run
-        // Distinct from the agentic-tool namespace at the same coords.
+                                                                       // Distinct from the agentic-tool namespace at the same coords.
         assert_ne!(a, react_tool_id_material2(&[1; 16], &[2; 32], 0));
         // Distinct from BOTH salt-1 namespaces.
         assert_ne!(a, react_turn_id_material(&[1; 16], 0));

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -627,7 +627,18 @@ fn lease_ready(
         if projection.state_of(&mote_id) == MoteState::Committed {
             continue;
         }
-        if let Some((_mote, warrant)) = submitted_defs.get(&mote_id) {
+        if let Some((mote, warrant)) = submitted_defs.get(&mote_id) {
+            // PR-9b-2b: a deterministic-AGENTIC launch step is NEVER dispatched as a
+            // plain model mote — the coordinator drives its bounded reason→tool→observe
+            // loop on a private chain (`settle_agentic_launches`) and COMMITS the launch
+            // mote with the loop's final answer to advance the frozen DAG. PARK it here
+            // (skip candidate selection) BEFORE `.take(max)` so a launch — uniquely
+            // long-lived in the ready-set (it stays `Pending` for its whole loop) — never
+            // consumes a per-poll lease slot from genuinely-dispatchable motes. The
+            // shape is disjoint from the observation/authored-tool arms (B1 tests).
+            if is_agentic_launch(mote) {
+                continue;
+            }
             if warrant.executor_class == executor_class {
                 if placement.place(&mote_id) == worker {
                     preferred.push(mote_id);
@@ -643,17 +654,6 @@ fn lease_ready(
         .take(max)
         .filter_map(|id| {
             submitted_defs.get(&id).and_then(|(mote, warrant)| {
-                // PR-9b-2b: a deterministic-AGENTIC launch step is NEVER dispatched
-                // as a plain model mote — PARK it (return None). The coordinator
-                // drives its bounded reason→tool→observe loop on a private chain
-                // (`settle_agentic_launches`) and COMMITS the launch mote with the
-                // loop's final answer to advance the frozen DAG. Parked on every poll
-                // (it stays `Pending` until that commit); the readiness scan keys on
-                // the same shape. Placed FIRST so a launch can never fall into the
-                // observation/authored-tool arms (defensive; the shapes are disjoint).
-                if is_agentic_launch(mote) {
-                    return None;
-                }
                 let parent_results = resolve_parent_context(mote, projection, submitted_defs);
                 // PR-2d-2: a ReAct OBSERVATION leases WITH its coordinator-
                 // validated args or NOT AT ALL — a transient resolution fault
@@ -3382,6 +3382,17 @@ fn dead_letter_agentic_launch<J: Journal>(
 /// so a worker leases it — `settle_react_rounds` then drives the loop. Idempotent:
 /// `write_react_anchor` no-ops on an existing turn-0 (a recovery re-submit re-parks).
 /// Gated O(1) on the parked set being non-empty (zero cost for a launch-free run).
+///
+/// **KNOWN LIMITATION (turn-0 reasons over the static prompt only).** turn-0 is built
+/// from the launch's `PROMPT_KEY` instruction (via `react_seed_params`) + the chain's
+/// own tool observations; the launch's committed DAG-PARENT results are carried into
+/// the terminal launch-commit (`commit_agentic_launch`) so the launch's CONSUMERS
+/// release, but they are NOT injected into the launch's own model context (turn-0 is
+/// edge-free; `resolve_parent_context` serves only the chain trajectory). So an agentic
+/// step wired DOWNSTREAM of producers (`producer > plan@tool`) reasons only over its
+/// prompt — the headline use is the agentic step as a generator/root, which is correct.
+/// Wiring upstream context into the agentic loop is the PR-9d context-carry follow-up
+/// (it re-baselines the salt-2 golden + must keep recovery's rebuild byte-identical).
 fn settle_agentic_launches<J: Journal>(
     journal: &J,
     store: Option<&LocalFsContentStore>,
@@ -3410,11 +3421,35 @@ fn settle_agentic_launches<J: Journal>(
             dispatch.parked_launches.remove(&launch_id);
             continue;
         }
-        let ready = launch_mote
-            .parents
-            .iter()
-            .all(|p| projection.state_of(&p.parent_id) == MoteState::Committed);
-        if !ready {
+        // A launch becomes ready when EVERY declared DAG parent commits. Distinguish
+        // "still pending" (re-check next drain) from "permanently unsatisfiable" (a
+        // parent TERMINALLY failed): a `Failed` parent never cascades the launch to a
+        // terminal state (the standing ready-set semantic — a `Failed` parent is not
+        // `Committed`), so without this the launch would sit `Pending` forever and its
+        // `parked_launches` + `dispatch.defs` entries would never be reclaimed — a slow
+        // in-memory leak in a long-lived serve. Fail-closed: dead-letter the launch (it
+        // can never run) and reclaim the park, mirroring "a Failed parent strands its
+        // consumers" while bounding the in-memory set.
+        let mut all_committed = true;
+        let mut parent_terminally_failed = false;
+        for p in &launch_mote.parents {
+            match projection.state_of(&p.parent_id) {
+                MoteState::Committed => {}
+                MoteState::Failed | MoteState::Inconsistent | MoteState::Repudiated => {
+                    parent_terminally_failed = true;
+                    all_committed = false;
+                    break;
+                }
+                _ => all_committed = false,
+            }
+        }
+        if parent_terminally_failed {
+            tracing::warn!(launch = ?launch_id, "agentic launch parent terminally failed — dead-lettering (can never become ready)");
+            dead_letter_agentic_launch(journal, projection, folded_through, dispatch, launch_id);
+            dispatch.parked_launches.remove(&launch_id);
+            continue;
+        }
+        if !all_committed {
             continue; // parents still pending — re-check next drain
         }
         let step_salt = *launch_id.as_bytes();

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -643,6 +643,17 @@ fn lease_ready(
         .take(max)
         .filter_map(|id| {
             submitted_defs.get(&id).and_then(|(mote, warrant)| {
+                // PR-9b-2b: a deterministic-AGENTIC launch step is NEVER dispatched
+                // as a plain model mote — PARK it (return None). The coordinator
+                // drives its bounded reason→tool→observe loop on a private chain
+                // (`settle_agentic_launches`) and COMMITS the launch mote with the
+                // loop's final answer to advance the frozen DAG. Parked on every poll
+                // (it stays `Pending` until that commit); the readiness scan keys on
+                // the same shape. Placed FIRST so a launch can never fall into the
+                // observation/authored-tool arms (defensive; the shapes are disjoint).
+                if is_agentic_launch(mote) {
+                    return None;
+                }
                 let parent_results = resolve_parent_context(mote, projection, submitted_defs);
                 // PR-2d-2: a ReAct OBSERVATION leases WITH its coordinator-
                 // validated args or NOT AT ALL — a transient resolution fault
@@ -878,6 +889,37 @@ fn is_authored_tool(mote: &Mote, projection: &Projection) -> bool {
         && !is_react_observation(mote, projection)
 }
 
+/// PR-9b-2b: `true` iff `mote` is a deterministic-AGENTIC launch step — a frozen-DAG
+/// MODEL step carrying an author-declared tool-grant SET that the coordinator must
+/// run as a BOUNDED reason→tool→observe loop (never dispatch as a plain model mote).
+/// The discriminant MIRRORS the gateway binder's own Model arm (`provision.rs`): a
+/// non-empty `tool_contract` + `PROMPT_KEY` (the model directive) + NO `TOOL_ARGS_KEY`
+/// (the loop GENERATES its own tool calls — vs an authored `tool()` node) +
+/// ReadOnlyNondet + StageThenCommit (a `generator`). Provably DISJOINT from every
+/// other tool-contract shape, so the lease-time park can never mis-fire on an
+/// ordinary mote (the `is_react_observation` / `is_authored_tool` tightness contract):
+/// - a react OBSERVATION ([`is_react_observation`]) carries an EMPTY `config_subset`
+///   (no `PROMPT_KEY`) and a folded react-turn Data parent;
+/// - an authored `tool()` node ([`is_authored_tool`]) carries `TOOL_ARGS_KEY` and is
+///   WorldMutating (not ReadOnlyNondet);
+/// - a react TURN has an EMPTY `tool_contract`.
+///
+/// PURE (no projection arg): the mote SHAPE alone is decisive, so a launch is parked
+/// + the readiness scan keyed on the same shape BEFORE any chain fact exists.
+fn is_agentic_launch(mote: &Mote) -> bool {
+    !mote.def.tool_contract.is_empty()
+        && mote.nd_class() == NdClass::ReadOnlyNondet
+        && mote.effect_pattern() == EffectPattern::StageThenCommit
+        && mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(PROMPT_KEY.to_string()))
+        && !mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(TOOL_ARGS_KEY.to_string()))
+}
+
 /// PR-6b-2: derive a standalone authored `tool()` node's `(args_bytes, net_scope,
 /// fs_scope)` — a PURE function of the Mote's OWN identity-bearing `config_subset`
 /// (NO parent, NO store I/O), run on the sole-writer thread at every (re-)lease:
@@ -995,66 +1037,87 @@ fn resolve_parent_context(
         .config_subset
         .contains_key(&ConfigKey(REACT_TURN_KEY.to_string()))
     {
-        // The marker VALUE is the run-salt (= the registered `instance_id`),
-        // so the chain is addressed DIRECTLY off the per-instance index
-        // (PR-2d-2) — never a scan across every chain's facts.
-        let instance: Option<[u8; INSTANCE_ID_LEN]> = mote
+        // The marker VALUE addresses the CHAIN directly (PR-2d-2 / PR-9b-2b) off
+        // the derived index — never a scan across every chain's facts. 16 bytes =
+        // `instance_id` (the run-level react chain, `step_salt = None`); 48 bytes =
+        // `instance_id ‖ step_salt` (an agentic step's PRIVATE chain). Decoding
+        // BOTH lengths is LOAD-BEARING: an agentic turn's 48-byte marker decoded as
+        // a 16-byte `instance_id` (the PR-2d-1 shape) would `try_into`-fail → no
+        // chain → an EMPTY trajectory, so every agentic turn past turn 0 would
+        // reason with no memory of its own tool observations (a silent loop break).
+        let chain: Option<([u8; INSTANCE_ID_LEN], Option<[u8; 32]>)> = mote
             .def
             .config_subset
             .get(&ConfigKey(REACT_TURN_KEY.to_string()))
-            .and_then(|v| v.0.as_slice().try_into().ok());
-        if let Some(this) = instance.as_ref().and_then(|i| {
-            projection
-                .react_rounds_of(i)
+            .and_then(|v| {
+                let bytes = v.0.as_slice();
+                if bytes.len() == INSTANCE_ID_LEN {
+                    bytes.try_into().ok().map(|i| (i, None))
+                } else if bytes.len() == INSTANCE_ID_LEN + 32 {
+                    let instance_id: [u8; INSTANCE_ID_LEN] =
+                        bytes[..INSTANCE_ID_LEN].try_into().ok()?;
+                    let step_salt: [u8; 32] = bytes[INSTANCE_ID_LEN..].try_into().ok()?;
+                    Some((instance_id, Some(step_salt)))
+                } else {
+                    None // malformed marker — fail-closed (no context)
+                }
+            });
+        if let Some((instance_id, step_salt)) = chain {
+            if let Some(this) = projection
+                .react_rounds_of(&instance_id, &step_salt)
                 .find(|r| r.turn_mote_id == mote.id)
-        }) {
-            // One entry per prior turn: its Mote id + its SETTLED branch (the
-            // highest-seq fact — a turn's facts are `Pending` then a frozen
-            // branch). PR-2d-2: a `Tool` turn ALSO contributes its OBSERVATION
-            // immediately after it — the harness transcript shape
-            // `[turn0, obs0, turn1, …]` (`react.rs` pushes turn + obs pairs), so
-            // the model reads tool results in time order. The observation's Mote
-            // is re-derived from the frozen fact (pure — `build_react_tool`); an
-            // uncommitted/absent observation (a PR-2d-1 substrate-only journal,
-            // or one still in flight) contributes nothing (fail-safe filter).
-            let mut turns: Vec<&ReactRoundRecord> = Vec::new();
-            for r in projection
-                .react_rounds_of(&this.instance_id)
-                .filter(|r| r.turn < this.turn)
             {
-                match turns.iter_mut().find(|t| t.turn == r.turn) {
-                    Some(slot) if r.seq > slot.seq => *slot = r,
-                    Some(_) => {}
-                    None => turns.push(r),
-                }
-            }
-            turns.sort_unstable_by_key(|r| r.turn);
-            let mut out: Vec<(MoteId, ContentRef)> = Vec::new();
-            for r in turns {
-                if let Some(turn_ref) = projection.result_ref_of(&r.turn_mote_id) {
-                    out.push((r.turn_mote_id, turn_ref));
-                }
-                if let ReactBranch::Tool {
-                    tool_id,
-                    tool_version,
-                } = &r.branch
+                // One entry per prior turn: its Mote id + its SETTLED branch (the
+                // highest-seq fact — a turn's facts are `Pending` then a frozen
+                // branch). PR-2d-2: a `Tool` turn ALSO contributes its OBSERVATION
+                // immediately after it — the harness transcript shape
+                // `[turn0, obs0, turn1, …]` (`react.rs` pushes turn + obs pairs), so
+                // the model reads tool results in time order. The observation's Mote
+                // is re-derived from the frozen fact (pure — `build_react_tool`); an
+                // uncommitted/absent observation (a PR-2d-1 substrate-only journal,
+                // or one still in flight) contributes nothing (fail-safe filter).
+                let this_turn = this.turn;
+                let mut turns: Vec<&ReactRoundRecord> = Vec::new();
+                for r in projection
+                    .react_rounds_of(&instance_id, &step_salt)
+                    .filter(|r| r.turn < this_turn)
                 {
-                    let obs = crate::react_shape::build_react_tool(
-                        &ModelId(r.model_id.clone()),
-                        &ToolName(tool_id.clone()),
-                        &ToolVersion(tool_version.clone()),
-                        r.turn,
-                        &this.instance_id,
-                        r.turn_mote_id,
-                    );
-                    if let Some(obs_ref) = projection.result_ref_of(&obs.id) {
-                        out.push((obs.id, obs_ref));
+                    match turns.iter_mut().find(|t| t.turn == r.turn) {
+                        Some(slot) if r.seq > slot.seq => *slot = r,
+                        Some(_) => {}
+                        None => turns.push(r),
                     }
                 }
+                turns.sort_unstable_by_key(|r| r.turn);
+                let mut out: Vec<(MoteId, ContentRef)> = Vec::new();
+                for r in turns {
+                    if let Some(turn_ref) = projection.result_ref_of(&r.turn_mote_id) {
+                        out.push((r.turn_mote_id, turn_ref));
+                    }
+                    if let ReactBranch::Tool {
+                        tool_id,
+                        tool_version,
+                    } = &r.branch
+                    {
+                        let obs = crate::react_shape::build_chain_tool(
+                            &ModelId(r.model_id.clone()),
+                            &ToolName(tool_id.clone()),
+                            &ToolVersion(tool_version.clone()),
+                            r.turn,
+                            &instance_id,
+                            step_salt,
+                            r.turn_mote_id,
+                        );
+                        if let Some(obs_ref) = projection.result_ref_of(&obs.id) {
+                            out.push((obs.id, obs_ref));
+                        }
+                    }
+                }
+                return out;
             }
-            return out;
+            return Vec::new(); // a chain marker with no matching turn fact (fail-closed)
         }
-        return Vec::new(); // a marker without folded facts: no context (fail-closed)
+        return Vec::new(); // a malformed / absent marker: no context (fail-closed)
     }
     let mut out: Vec<(MoteId, ContentRef)> = Vec::new();
     for parent in &mote.parents {
@@ -1377,6 +1440,16 @@ struct Dispatch {
     submitted: BTreeSet<MoteId>,
     defs: BTreeMap<MoteId, (Mote, WarrantSpec)>,
     tracker: LeaseTracker,
+    /// PR-9b-2b — the admitted-but-PARKED deterministic-agentic launch steps
+    /// (`is_agentic_launch`), mapped to their run's `instance_id` (the chain
+    /// salt-1 component, captured at submit where it is known — serve's journal
+    /// is SHARED across runs, so it cannot be re-derived globally at anchor time).
+    /// O(1) populated at submit (`submit_and_capture`) so `settle_agentic_launches`
+    /// need not scan all `defs` every drain; an id is dropped once its turn-0
+    /// anchor is written (the durable anchor is then the marker). In-memory only —
+    /// repopulated on a recovery re-submit (the `defs`/`tracker` precedent); the
+    /// skip-if-already-anchored guard prevents a double anchor.
+    parked_launches: BTreeMap<MoteId, [u8; INSTANCE_ID_LEN]>,
 }
 
 /// The owner-thread loop. Recovers the projection from the journal, then services
@@ -1400,6 +1473,7 @@ fn core_loop<J: Journal>(
         submitted,
         defs: BTreeMap::new(),
         tracker: LeaseTracker::default(),
+        parked_launches: BTreeMap::new(),
     };
     // PR-2c-2: re-derive the live re-plan chain from committed facts (re-materialize
     // committed round shapers' children, re-insert the in-flight round shaper, and
@@ -1487,22 +1561,10 @@ fn core_loop<J: Journal>(
             &mut dispatch,
             &mut pending,
         );
-        // PR-2c-2: after this drain's commits + dead-letters fold, drive any re-plan
-        // round that just settled (a shaper's children all reached a terminal state
-        // with ≥1 failure). Idempotent + O(rounds≤4); a no-op without a round-0 anchor.
-        settle_replan_rounds(
-            journal,
-            store,
-            &mut projection,
-            &mut folded_through,
-            &mut dispatch,
-        );
-        // PR-2d-1: after this drain's commits + dead-letters fold, settle any ReAct
-        // turn that just reached a terminal state (decode → freeze the branch →
-        // advance under budget). Idempotent; a one-bool no-op without react facts;
-        // proportional to the ACTIVE chains only (the settle cache — settled
-        // chains are skipped, the fact log is re-scanned only when it grows).
-        settle_react_rounds(
+        // After this drain's commits + dead-letters fold, run the idempotent settle
+        // passes (re-plan rounds · agentic-launch anchoring · react/agentic chain
+        // settle). Each is gated to zero cost when its feature is unused.
+        run_settle_passes(
             journal,
             store,
             &mut projection,
@@ -1824,6 +1886,13 @@ fn submit_and_capture<J: Journal>(
     let shaper_def = mote.def.is_topology_shaper.then(|| mote.def.clone());
     let shaper_mote_id = mote.id;
     let shaper_warrant = warrant.clone();
+    // PR-9b-2b: a deterministic-AGENTIC launch step is admitted (its def lands in
+    // `dispatch.defs` for the eventual terminal launch-commit) but the coordinator
+    // PARKS it here, keyed to THIS run's `instance_id` — `settle_agentic_launches`
+    // anchors + drives its bounded loop once its DAG parents commit. Captured BEFORE
+    // `handle_submit` consumes `mote`. The react seed-swap path is never a launch
+    // (the swapped turn-0 carries an empty `tool_contract`).
+    let launch_park = (!react_seed && is_agentic_launch(&mote)).then_some(mote.id);
 
     // Admit through the hosted scheduler (verbatim — the P2 thesis test).
     let warrant_for_capture = warrant.clone();
@@ -1839,6 +1908,11 @@ fn submit_and_capture<J: Journal>(
     // never reaches here — refused at Gate 2; a PURE/ROND Unresolved submit reaches
     // here and skips capture, the M1.2 behavior.)
     outcome.instance_id = Some(instance_id);
+    // PR-9b-2b: park a freshly-admitted agentic launch keyed to its run (a duplicate
+    // re-submit is already parked / anchored — the idempotency guard handles it).
+    if let (Some(launch_id), false) = (launch_park, outcome.duplicate) {
+        dispatch.parked_launches.insert(launch_id, instance_id);
+    }
     if !outcome.duplicate {
         if let ToolResolution::Resolved(_) = resolution {
             capture_run_versions(
@@ -1876,6 +1950,7 @@ fn submit_and_capture<J: Journal>(
                 projection,
                 folded_through,
                 instance_id,
+                None, // run-level react chain (the seed-swap path); agentic chains anchor via settle
                 turn0,
                 &shaper_warrant,
                 max_turns,
@@ -2360,17 +2435,17 @@ fn write_react_anchor<J: Journal>(
     projection: &mut Projection,
     folded_through: &mut u64,
     instance_id: [u8; INSTANCE_ID_LEN],
+    step_salt: Option<[u8; 32]>,
     turn0: &Mote,
     warrant: &WarrantSpec,
     max_turns: u32,
     max_tool_calls: u32,
 ) -> Result<(), CoordinatorError> {
     if projection
-        .react_rounds()
-        .iter()
-        .any(|r| r.instance_id == instance_id && r.turn == 0)
+        .react_rounds_of(&instance_id, &step_salt)
+        .any(|r| r.turn == 0)
     {
-        return Ok(()); // already anchored (idempotent re-submit / replay)
+        return Ok(()); // already anchored (idempotent re-submit / replay / re-park)
     }
     let Some(instruction) = turn0
         .def
@@ -2401,9 +2476,9 @@ fn write_react_anchor<J: Journal>(
         branch: ReactBranch::Pending,
         max_turns,
         max_tool_calls,
-        // v9 (PR-9b-2a): run-level chain. The agentic-launch anchor (PR-9b-2b)
-        // sets this to the launch step's MoteId.
-        step_salt: None,
+        // v9 (PR-9b-2b): `None` for the run-level react chain; `Some(launch
+        // MoteId)` for a deterministic-agentic step's private chain.
+        step_salt,
         seq: 0,
     };
     let durable = journal.append(entry)?;
@@ -2475,6 +2550,42 @@ fn materialize_react_tool(
     dispatch.defs.insert(obs.id, (obs.clone(), warrant));
 }
 
+/// PR-9b-2b: the post-drain settle passes — re-plan rounds (PR-2c-2), then
+/// agentic-launch anchoring (turn-0 anchor + materialize for any parked launch whose
+/// DAG parents committed), then the react/agentic chain settle (decode → freeze the
+/// branch → advance under budget; an agentic chain's terminal Answer COMMITS its launch
+/// mote, advancing the frozen DAG). Agentic anchoring runs BEFORE the react settle so a
+/// freshly-anchored chain drives in the same drain. Each pass is idempotent + gated to
+/// zero cost when its feature is unused. Extracted so `core_loop` stays under the line
+/// budget (a pure refactor — same call order as the inline block it replaced).
+#[allow(clippy::too_many_arguments)]
+fn run_settle_passes<J: Journal>(
+    journal: &J,
+    store: Option<&LocalFsContentStore>,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+    react_cache: &mut ReactSettleCache,
+    tool_registry: &dyn ToolRegistry,
+) {
+    settle_replan_rounds(journal, store, projection, folded_through, dispatch);
+    settle_agentic_launches(journal, store, projection, folded_through, dispatch);
+    settle_react_rounds(
+        journal,
+        store,
+        projection,
+        folded_through,
+        dispatch,
+        react_cache,
+        tool_registry,
+    );
+}
+
+/// PR-9b-2b: the settle/cache CHAIN key — `(instance_id, step_salt)`, not just the
+/// run — so a run carrying BOTH a run-level react chain (`step_salt = None`) and one or
+/// more agentic-step chains (`Some(launch MoteId)`) tracks each independently.
+type ChainKey = ([u8; INSTANCE_ID_LEN], Option<[u8; 32]>);
+
 /// The settle pass's incremental working set (adversarial-review finding,
 /// PR-2d-1): `react_rounds` only ever GROWS in serve's shared journal, so a
 /// naive per-drain pass over every fact of every chain is O(total-runs²) at the
@@ -2486,14 +2597,14 @@ fn materialize_react_tool(
 ///   FROZEN at append and a settled chain accepts no new facts, so membership is
 ///   monotonic — skipping is always sound. Purely in-memory: recovery starts
 ///   empty and the first pass re-derives it from the durable facts.
-/// - `active` — the distinct unsettled instances, REBUILT only when the folded
+/// - `active` — the distinct unsettled chains, REBUILT only when the folded
 ///   fact count changes (`seen_facts`); between fact-appends the pass iterates
 ///   this (usually tiny) list and touches nothing else.
 #[derive(Default)]
 struct ReactSettleCache {
     seen_facts: usize,
-    active: Vec<[u8; INSTANCE_ID_LEN]>,
-    settled: BTreeSet<[u8; INSTANCE_ID_LEN]>,
+    active: Vec<ChainKey>,
+    settled: BTreeSet<ChainKey>,
 }
 
 /// Whether one settle pass left a chain able to settle again ([`ReactChainStatus::Active`])
@@ -2538,14 +2649,13 @@ fn settle_react_rounds<J: Journal>(
     // the (usually tiny) active list — never the full accumulated fact log.
     if projection.react_rounds().len() != cache.seen_facts {
         cache.active = projection
-            .react_instances()
-            .filter(|i| !cache.settled.contains(*i))
-            .copied()
+            .react_chains()
+            .filter(|chain| !cache.settled.contains(chain))
             .collect();
         cache.seen_facts = projection.react_rounds().len();
     }
-    let mut still_active: Vec<[u8; INSTANCE_ID_LEN]> = Vec::with_capacity(cache.active.len());
-    for instance_id in std::mem::take(&mut cache.active) {
+    let mut still_active: Vec<ChainKey> = Vec::with_capacity(cache.active.len());
+    for (instance_id, step_salt) in std::mem::take(&mut cache.active) {
         let status = settle_react_chain(
             journal,
             store,
@@ -2553,12 +2663,13 @@ fn settle_react_rounds<J: Journal>(
             folded_through,
             dispatch,
             instance_id,
+            step_salt,
             tool_registry,
         );
         if status == ReactChainStatus::Settled {
-            cache.settled.insert(instance_id);
+            cache.settled.insert((instance_id, step_salt));
         } else {
-            still_active.push(instance_id);
+            still_active.push((instance_id, step_salt));
         }
     }
     cache.active = still_active;
@@ -2567,10 +2678,13 @@ fn settle_react_rounds<J: Journal>(
     cache.seen_facts = projection.react_rounds().len();
 }
 
-/// Settle ONE run's chain (see [`settle_react_rounds`]). Bounded: at most one
-/// branch fact + one advance per pass per chain (the next pass continues).
-/// Returns whether the chain can ever settle again (the cache classification).
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+/// Settle ONE chain — the `(instance_id, step_salt)` pair (see
+/// [`settle_react_rounds`]). For an AGENTIC chain (`step_salt.is_some()`) this
+/// wraps the run-level [`drive_react_chain`] with the terminal launch disposition
+/// ([`finalize_agentic_launch`]): a terminal `Answer` COMMITS the launch mote (so
+/// the frozen DAG advances), a budget-exhausted / dead-lettered chain fail-closed
+/// dead-letters it. The run-level chain (`None`) is byte-unchanged (driver only).
+#[allow(clippy::too_many_arguments)]
 fn settle_react_chain<J: Journal>(
     journal: &J,
     store: &LocalFsContentStore,
@@ -2578,9 +2692,60 @@ fn settle_react_chain<J: Journal>(
     folded_through: &mut u64,
     dispatch: &mut Dispatch,
     instance_id: [u8; INSTANCE_ID_LEN],
+    step_salt: Option<[u8; 32]>,
     tool_registry: &dyn ToolRegistry,
 ) -> ReactChainStatus {
-    let rounds: Vec<ReactRoundRecord> = projection.react_rounds_of(&instance_id).cloned().collect();
+    let status = drive_react_chain(
+        journal,
+        store,
+        projection,
+        folded_through,
+        dispatch,
+        instance_id,
+        step_salt,
+        tool_registry,
+    );
+    // PR-9b-2b: an AGENTIC chain that reached a permanent state must dispose of its
+    // LAUNCH mote (commit on Answer / dead-letter otherwise) before it is truly
+    // settled — the launch-commit is drain-driven + idempotent, so the chain stays
+    // ACTIVE until the launch reaches a terminal state (RISK 4: the launch def is
+    // lost on a crash and only repopulated by re-submit). The run-level chain
+    // (`None`) terminates the run via the seed-swap and needs no launch disposition.
+    match step_salt {
+        Some(salt) if status == ReactChainStatus::Settled => finalize_agentic_launch(
+            journal,
+            store,
+            projection,
+            folded_through,
+            dispatch,
+            instance_id,
+            salt,
+        ),
+        _ => status,
+    }
+}
+
+/// Drive ONE chain's reason→tool→observe loop one pass (the PR-2d-1/2d-2 logic,
+/// now chain-keyed by `(instance_id, step_salt)`). Bounded: at most one branch fact
+/// plus one advance per pass (the next pass continues). Returns whether the chain can
+/// ever settle again (the cache classification). The chain's `step_salt` selects
+/// the salt-1 (run-level) vs salt-2 (agentic) identity builders via the `anchor`'s
+/// own `step_salt` field, so the drive helpers stay chain-shape agnostic.
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+fn drive_react_chain<J: Journal>(
+    journal: &J,
+    store: &LocalFsContentStore,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+    instance_id: [u8; INSTANCE_ID_LEN],
+    step_salt: Option<[u8; 32]>,
+    tool_registry: &dyn ToolRegistry,
+) -> ReactChainStatus {
+    let rounds: Vec<ReactRoundRecord> = projection
+        .react_rounds_of(&instance_id, &step_salt)
+        .cloned()
+        .collect();
     // The run-fixed anchor (turn 0) carries base_prompt_ref / warrant_ref /
     // model_id / the durable budget caps.
     let Some(anchor) = rounds.iter().find(|r| r.turn == 0) else {
@@ -2744,8 +2909,10 @@ fn settle_react_chain<J: Journal>(
                 // start the tool round in the same pass (no wasted drain) —
                 // materializes the observation; the advance to the next turn
                 // happens on a later pass, once the observation commits.
-                let rounds: Vec<ReactRoundRecord> =
-                    projection.react_rounds_of(&instance_id).cloned().collect();
+                let rounds: Vec<ReactRoundRecord> = projection
+                    .react_rounds_of(&instance_id, &step_salt)
+                    .cloned()
+                    .collect();
                 progress_tool_round(
                     journal,
                     store,
@@ -2815,12 +2982,13 @@ fn progress_tool_round<J: Journal>(
     round: &ToolRound,
     tool_registry: &dyn ToolRegistry,
 ) -> ReactChainStatus {
-    let obs = crate::react_shape::build_react_tool(
+    let obs = crate::react_shape::build_chain_tool(
         &ModelId(anchor.model_id.clone()),
         &ToolName(round.tool_id.clone()),
         &ToolVersion(round.tool_version.clone()),
         turn,
         &anchor.instance_id,
+        anchor.step_salt,
         round.turn_mote_id,
     );
     let obs_state = projection.state_of(&obs.id);
@@ -2934,7 +3102,7 @@ fn append_react_branch<J: Journal>(
     branch: ReactBranch,
 ) {
     if projection
-        .react_rounds_of(&anchor.instance_id)
+        .react_rounds_of(&anchor.instance_id, &anchor.step_salt)
         .any(|r| r.turn == turn && r.branch == branch)
     {
         return; // already recorded (recovery re-drive)
@@ -2949,9 +3117,9 @@ fn append_react_branch<J: Journal>(
         branch,
         max_turns: anchor.max_turns,
         max_tool_calls: anchor.max_tool_calls,
-        // v9 (PR-9b-2a): run-level chain. PR-9b-2b will propagate the anchor's
-        // step_salt here so a settled branch joins the right agentic chain.
-        step_salt: None,
+        // v9 (PR-9b-2b): a settled branch joins the SAME chain as its anchor —
+        // `None` for the run-level chain, `Some(launch MoteId)` for an agentic step.
+        step_salt: anchor.step_salt,
         seq: 0,
     };
     match journal.append(entry) {
@@ -3022,11 +3190,12 @@ fn advance_react_chain<J: Journal>(
     };
     let next_turn = turn + 1;
     let model_id = ModelId(anchor.model_id.clone());
-    let next = crate::react_shape::build_react_turn(
+    let next = crate::react_shape::build_chain_turn(
         &model_id,
         instruction,
         next_turn,
         &anchor.instance_id,
+        anchor.step_salt,
         warrant.model_route.max_output_tokens,
     );
     // Fact BEFORE materialize (crash-safety order, the replan precedent).
@@ -3049,6 +3218,265 @@ fn advance_react_chain<J: Journal>(
     );
     tracing::info!(turn = next_turn, mote = ?next.id, "react turn materialized");
     ReactChainStatus::Active
+}
+
+/// PR-9b-2b: dispose of an AGENTIC chain's LAUNCH mote once the bounded loop has
+/// permanently settled — the contrast with the run-level chain (which terminates
+/// the run on its final Answer). A terminal `Answer` ⇒ COMMIT the launch mote with
+/// the answer turn's `result_ref` + the launch's DECLARED DAG parents (advancing the
+/// frozen DAG so its consumers become ready); any other terminal shape (a
+/// budget-exhausted `Tool` tail, a `DeadLettered` branch) ⇒ fail-closed dead-letter
+/// (the step fails honestly — never fabricate an answer, GR15).
+///
+/// **Drain-driven + idempotent** (RISK 4): the launch's def (declared parents /
+/// `mote_def_hash` / warrant) lives only in the in-memory `dispatch.defs`, lost on a
+/// coordinator restart and repopulated by the run's re-submit (the shaper-recovery
+/// precedent). When absent (the recovery PROLOGUE, before re-submit) this returns
+/// `Active` (dormant) so the FIRST drain after re-submit completes the commit; once
+/// the launch is terminal it is a no-op `Settled`.
+#[allow(clippy::too_many_arguments)]
+fn finalize_agentic_launch<J: Journal>(
+    journal: &J,
+    store: &LocalFsContentStore,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+    instance_id: [u8; INSTANCE_ID_LEN],
+    step_salt: [u8; 32],
+) -> ReactChainStatus {
+    let launch_id = MoteId::from_bytes(step_salt);
+    // Idempotent: the launch already committed (Answer) or dead-lettered on a prior
+    // pass / a recovery re-derive.
+    if is_terminal(projection.state_of(&launch_id)) {
+        return ReactChainStatus::Settled;
+    }
+    let Some((launch_mote, launch_warrant)) = dispatch.defs.get(&launch_id).cloned() else {
+        // Recovery prologue (def lost, not yet re-submitted): stay dormant.
+        return ReactChainStatus::Active;
+    };
+    // The chain's terminal decision: a frozen `Answer` ⇒ commit; otherwise (budget
+    // exhausted without an answer, or a dead-lettered branch) ⇒ dead-letter.
+    let answer_turn = projection
+        .react_rounds_of(&instance_id, &Some(step_salt))
+        .filter(|r| r.branch == ReactBranch::Answer)
+        .max_by_key(|r| r.turn)
+        .map(|r| r.turn_mote_id);
+    let Some(turn_mote_id) = answer_turn else {
+        // No frozen Answer — budget exhausted / dead-lettered. Fail-closed.
+        dead_letter_agentic_launch(journal, projection, folded_through, dispatch, launch_id);
+        return ReactChainStatus::Settled;
+    };
+    let Some(result_ref) = projection.result_ref_of(&turn_mote_id) else {
+        return ReactChainStatus::Active; // committed turn, result_ref not folded yet
+    };
+    // RISK 3: this commit is a DIRECT append (it bypasses `flush_commits`' admission
+    // + phantom-ref guards), so re-verify the answer payload is present in the store
+    // before committing — a store fault retries next pass.
+    if store.get(&result_ref).is_err() {
+        return ReactChainStatus::Active;
+    }
+    commit_agentic_launch(
+        journal,
+        projection,
+        folded_through,
+        dispatch,
+        &launch_mote,
+        &launch_warrant,
+        result_ref,
+    );
+    ReactChainStatus::Settled
+}
+
+/// PR-9b-2b: COMMIT the launch mote of an agentic step with its loop's final answer.
+/// A coordinator-SYNTHESIZED `Committed` (the launch never ran on a worker — the
+/// chain did), so the `idempotency_key` is the launch `MoteId` itself
+/// (`idempotency.md`: key == derived `MoteId`, the `failed_worker_crashed_entry`
+/// precedent). Carries the launch's DECLARED DAG parents so the projection's
+/// children-index releases the launch's consumers on the next ready-set pass. Guarded
+/// BEFORE the append by the caller's `state_of==terminal` check; the fold's
+/// `DuplicateCommitted` is the backstop. Frees the def (a committed mote never re-leases).
+fn commit_agentic_launch<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+    launch_mote: &Mote,
+    launch_warrant: &WarrantSpec,
+    result_ref: ContentRef,
+) {
+    let parents: SmallVec<[kx_journal::ParentEntry; 4]> = launch_mote
+        .parents
+        .iter()
+        .map(kx_journal::ParentEntry::from_parent_ref)
+        .collect();
+    let entry = JournalEntry::Committed {
+        mote_id: launch_mote.id,
+        idempotency_key: *launch_mote.id.as_bytes(),
+        seq: 0,
+        nondeterminism: launch_mote.def.nd_class,
+        result_ref,
+        parents,
+        warrant_ref: warrant_ref_of(launch_warrant),
+        mote_def_hash: launch_mote.def.hash(),
+    };
+    match journal.append(entry) {
+        Ok(durable) => {
+            let seq = durable.seq();
+            if seq > *folded_through && projection.fold(&durable).is_ok() {
+                *folded_through = seq;
+            }
+            dispatch.submitted.remove(&launch_mote.id);
+            dispatch.defs.remove(&launch_mote.id);
+            dispatch.parked_launches.remove(&launch_mote.id);
+            dispatch.tracker.resolve_committed(launch_mote.id);
+            tracing::info!(launch = ?launch_mote.id, "agentic launch step committed — frozen DAG advanced");
+        }
+        Err(error) => tracing::error!(%error, "failed to append agentic launch Committed"),
+    }
+}
+
+/// PR-9b-2b: fail-closed dead-letter an agentic launch whose bounded loop exhausted
+/// its budget (or dead-lettered) without a terminal answer — the step FAILS honestly
+/// rather than fabricate one (GR15). A terminal coordinator-reported
+/// `FailureReason::DeadLettered` (classified terminal by `is_pre_commit_crash` ⇒
+/// `terminal_failure_observed` ⇒ `state_of == Failed`, never re-dispatched). The
+/// launch leaves the ready-set; its DAG consumers stay `Pending` exactly as for ANY
+/// terminally-failed DAG mote (the standing ready-set semantic — a `Failed` parent is
+/// not `Committed`). Visible via the alerts inbox + `ListReactTurns`. Idempotent (the
+/// caller's `state_of==terminal` guard).
+fn dead_letter_agentic_launch<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+    launch_id: MoteId,
+) {
+    let entry = JournalEntry::Failed {
+        mote_id: launch_id,
+        idempotency_key: *launch_id.as_bytes(),
+        seq: 0,
+        reason_class: FailureReason::DeadLettered,
+        reporter_id: COORDINATOR_REPORTER_ID,
+    };
+    match journal.append(entry) {
+        Ok(durable) => {
+            let seq = durable.seq();
+            if seq > *folded_through && projection.fold(&durable).is_ok() {
+                *folded_through = seq;
+            }
+            dispatch.submitted.remove(&launch_id);
+            dispatch.defs.remove(&launch_id);
+            dispatch.parked_launches.remove(&launch_id);
+            dispatch.tracker.resolve_committed(launch_id);
+            tracing::warn!(launch = ?launch_id, "agentic launch step dead-lettered (budget exhausted without an answer)");
+        }
+        Err(error) => tracing::error!(%error, "failed to append agentic launch Failed"),
+    }
+}
+
+/// PR-9b-2b: anchor every PARKED agentic launch whose DAG parents have all committed
+/// (the launch became "ready" but `lease_ready` parked it). For each: validate the
+/// declared budget + prompt (`react_seed_params`, the `0 < tc < turns ≤ 8` gate),
+/// build the salt-2 turn-0 (`build_agentic_turn` keyed by `step_salt = launch MoteId`),
+/// write the durable turn-0 `ReactRound` anchor, and materialize turn-0 into dispatch
+/// so a worker leases it — `settle_react_rounds` then drives the loop. Idempotent:
+/// `write_react_anchor` no-ops on an existing turn-0 (a recovery re-submit re-parks).
+/// Gated O(1) on the parked set being non-empty (zero cost for a launch-free run).
+fn settle_agentic_launches<J: Journal>(
+    journal: &J,
+    store: Option<&LocalFsContentStore>,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+) {
+    if dispatch.parked_launches.is_empty() {
+        return;
+    }
+    let Some(store) = store else {
+        return; // an agentic chain needs a store for its durable anchor
+    };
+    let parked: Vec<(MoteId, [u8; INSTANCE_ID_LEN])> = dispatch
+        .parked_launches
+        .iter()
+        .map(|(id, instance)| (*id, *instance))
+        .collect();
+    for (launch_id, instance_id) in parked {
+        let Some((launch_mote, launch_warrant)) = dispatch.defs.get(&launch_id).cloned() else {
+            dispatch.parked_launches.remove(&launch_id); // def gone — drop the stale park
+            continue;
+        };
+        // Not ready until still-Pending AND every declared DAG parent committed.
+        if projection.state_of(&launch_id) != MoteState::Pending {
+            dispatch.parked_launches.remove(&launch_id);
+            continue;
+        }
+        let ready = launch_mote
+            .parents
+            .iter()
+            .all(|p| projection.state_of(&p.parent_id) == MoteState::Committed);
+        if !ready {
+            continue; // parents still pending — re-check next drain
+        }
+        let step_salt = *launch_id.as_bytes();
+        // Already anchored (recovery re-submit / a prior drain): idempotent — unpark.
+        if projection
+            .react_rounds_of(&instance_id, &Some(step_salt))
+            .any(|r| r.turn == 0)
+        {
+            dispatch.parked_launches.remove(&launch_id);
+            continue;
+        }
+        // Validate the declared budget + prompt (server-vetted at authoring; a
+        // defensive failure here dead-letters rather than wedge).
+        let (instruction, (max_turns, max_tool_calls)) = match react_seed_params(&launch_mote) {
+            Ok(decoded) => decoded,
+            Err(reason) => {
+                tracing::error!(launch = ?launch_id, %reason, "agentic launch budget/prompt invalid — dead-lettering");
+                dead_letter_agentic_launch(
+                    journal,
+                    projection,
+                    folded_through,
+                    dispatch,
+                    launch_id,
+                );
+                dispatch.parked_launches.remove(&launch_id);
+                continue;
+            }
+        };
+        let turn0 = crate::react_shape::build_agentic_turn(
+            &launch_mote.def.model_id,
+            &instruction,
+            0,
+            &instance_id,
+            &step_salt,
+            launch_warrant.model_route.max_output_tokens,
+        );
+        if let Err(error) = write_react_anchor(
+            journal,
+            store,
+            projection,
+            folded_through,
+            instance_id,
+            Some(step_salt),
+            &turn0,
+            &launch_warrant,
+            max_turns,
+            max_tool_calls,
+        ) {
+            tracing::error!(launch = ?launch_id, %error, "failed to anchor agentic launch chain");
+            continue; // transient — retry next drain (still parked)
+        }
+        materialize_react_turn(
+            projection,
+            dispatch,
+            Some(store),
+            &turn0,
+            warrant_ref_of(&launch_warrant),
+            launch_warrant.clone(),
+        );
+        dispatch.parked_launches.remove(&launch_id);
+        tracing::info!(launch = ?launch_id, turn0 = ?turn0.id, "agentic launch chain anchored");
+    }
 }
 
 /// Recover the live ReAct chains from committed facts after a restart (PR-2d-1).
@@ -3074,16 +3502,21 @@ fn recover_react_chain<J: Journal>(
     let Some(store) = store else {
         return;
     };
-    // Phase B — re-insert each chain's in-flight turn (its fact is Pending and its
-    // Mote is not yet terminal) so a worker can re-lease it. Per-chain reads off
-    // the projection's derived index (PR-2d-2).
-    let instances: Vec<[u8; INSTANCE_ID_LEN]> = projection.react_instances().copied().collect();
-    for instance_id in instances {
-        let Some(latest) = projection.latest_react_round(&instance_id).cloned() else {
+    // Phase B — re-insert each CHAIN's in-flight turn (its fact is Pending and its
+    // Mote is not yet terminal) so a worker can re-lease it. Per-chain reads off the
+    // projection's derived nested index (PR-2d-2 / PR-9b-2b): a run may carry the
+    // run-level chain (`step_salt = None`) AND agentic-step chains (`Some(..)`); the
+    // builder is selected by the chain's `step_salt` (`build_chain_turn`).
+    let chains: Vec<ChainKey> = projection.react_chains().collect();
+    for (instance_id, step_salt) in chains {
+        let Some(latest) = projection
+            .latest_react_round(&instance_id, &step_salt)
+            .cloned()
+        else {
             continue;
         };
         if !matches!(latest.branch, ReactBranch::Pending) {
-            continue; // settled tail — Phase C re-drives it
+            continue; // settled tail — Phase C re-drives it (incl. an agentic launch-commit)
         }
         if is_terminal(projection.state_of(&latest.turn_mote_id)) {
             continue; // committed/failed — Phase C decodes/settles it
@@ -3101,11 +3534,12 @@ fn recover_react_chain<J: Journal>(
             continue;
         };
         let model_id = ModelId(latest.model_id.clone());
-        let rebuilt = crate::react_shape::build_react_turn(
+        let rebuilt = crate::react_shape::build_chain_turn(
             &model_id,
             instruction,
             latest.turn,
             &instance_id,
+            step_salt,
             warrant.model_route.max_output_tokens,
         );
         if rebuilt.id != latest.turn_mote_id {
@@ -3610,5 +4044,162 @@ mod authored_tool_tests {
             .into_resolved()
             .expect("passes through");
         assert_eq!(got.0, br#"{"anything":true}"#.to_vec());
+    }
+}
+
+#[cfg(test)]
+mod agentic_launch_disjointness_tests {
+    //! PR-9b-2b: `is_agentic_launch` is provably DISJOINT from every other
+    //! tool-contract Mote shape, so the lease-time PARK (and the parked-set
+    //! population) can never mis-fire on an ordinary mote. The four shapes
+    //! partition by `(nd_class, config keys, parent shape)`:
+    //! - agentic launch — ROND + StageThenCommit + non-empty contract + `PROMPT_KEY`
+    //!   + NO `TOOL_ARGS_KEY` (a generator that emits its own tool calls);
+    //! - react turn — EMPTY contract;
+    //! - react observation — non-empty contract + EMPTY config (no `PROMPT_KEY`) +
+    //!   a react-turn Data parent;
+    //! - authored tool — non-empty contract + `TOOL_ARGS_KEY` + WorldMutating.
+    use super::*;
+    use kx_mote::{
+        ConfigVal, EdgeMeta, GraphPosition, InferenceParams, InputDataId, LogicRef, ParentRef,
+        PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION,
+    };
+
+    const INSTANCE: [u8; INSTANCE_ID_LEN] = [9u8; INSTANCE_ID_LEN];
+    const STEP_SALT: [u8; 32] = [3u8; 32];
+
+    fn served() -> ModelId {
+        ModelId("served".into())
+    }
+
+    /// The B3-binder shape: a generator MODEL step carrying an author-declared
+    /// tool-grant set + the model directive, with a declared DAG parent.
+    fn launch_mote(config: BTreeMap<ConfigKey, ConfigVal>, nd: NdClass) -> Mote {
+        let mut tool_contract = BTreeMap::new();
+        tool_contract.insert(ToolName("mcp-echo".into()), ToolVersion("1".into()));
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([1u8; 32]),
+            model_id: served(),
+            prompt_template_hash: PromptTemplateHash::from_bytes([1u8; 32]),
+            tool_contract,
+            nd_class: nd,
+            config_subset: config,
+            effect_pattern: EffectPattern::StageThenCommit,
+            critic_for: None,
+            is_topology_shaper: false,
+            inference_params: InferenceParams::default(),
+            critic_check: None,
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([1u8; 32]),
+            GraphPosition(vec![2]),
+            std::iter::once(ParentRef {
+                parent_id: MoteId::from_bytes([8u8; 32]),
+                edge: EdgeMeta::data(),
+            })
+            .collect(),
+        )
+    }
+
+    fn prompt_only() -> BTreeMap<ConfigKey, ConfigVal> {
+        let mut c = BTreeMap::new();
+        c.insert(
+            ConfigKey(PROMPT_KEY.to_string()),
+            ConfigVal(b"do it".to_vec()),
+        );
+        c
+    }
+
+    #[test]
+    fn launch_shape_is_an_agentic_launch() {
+        assert!(is_agentic_launch(&launch_mote(
+            prompt_only(),
+            NdClass::ReadOnlyNondet
+        )));
+    }
+
+    #[test]
+    fn launch_is_neither_authored_tool_nor_observation() {
+        let p = kx_projection::Projection::new();
+        let launch = launch_mote(prompt_only(), NdClass::ReadOnlyNondet);
+        assert!(
+            !is_authored_tool(&launch, &p),
+            "no TOOL_ARGS_KEY ⇒ not authored tool"
+        );
+        assert!(
+            !is_react_observation(&launch, &p),
+            "a DAG parent (not a folded react turn) ⇒ not an observation"
+        );
+    }
+
+    #[test]
+    fn react_turns_are_not_launches() {
+        // build_react_turn / build_agentic_turn ⇒ EMPTY tool_contract.
+        let run = crate::react_shape::build_react_turn(&served(), "go", 0, &INSTANCE, 256);
+        let agentic =
+            crate::react_shape::build_agentic_turn(&served(), "go", 0, &INSTANCE, &STEP_SALT, 256);
+        assert!(!is_agentic_launch(&run));
+        assert!(!is_agentic_launch(&agentic));
+    }
+
+    #[test]
+    fn react_observations_are_not_launches() {
+        // build_react_tool / build_agentic_tool ⇒ EMPTY config (no PROMPT_KEY).
+        let parent = MoteId::from_bytes([5u8; 32]);
+        let run = crate::react_shape::build_react_tool(
+            &served(),
+            &ToolName("mcp-echo".into()),
+            &ToolVersion("1".into()),
+            0,
+            &INSTANCE,
+            parent,
+        );
+        let agentic = crate::react_shape::build_agentic_tool(
+            &served(),
+            &ToolName("mcp-echo".into()),
+            &ToolVersion("1".into()),
+            0,
+            &INSTANCE,
+            &STEP_SALT,
+            parent,
+        );
+        assert!(!is_agentic_launch(&run));
+        assert!(!is_agentic_launch(&agentic));
+    }
+
+    #[test]
+    fn world_mutating_with_tool_args_is_authored_tool_not_launch() {
+        // The authored-tool shape: WorldMutating + TOOL_ARGS_KEY ⇒ NOT a launch
+        // (fails both the ReadOnlyNondet AND the no-TOOL_ARGS_KEY clauses).
+        let mut config = prompt_only();
+        config.insert(
+            ConfigKey(TOOL_ARGS_KEY.to_string()),
+            ConfigVal(b"{}".to_vec()),
+        );
+        assert!(!is_agentic_launch(&launch_mote(
+            config,
+            NdClass::WorldMutating
+        )));
+    }
+
+    #[test]
+    fn launch_needs_prompt_and_no_tool_args() {
+        // No PROMPT_KEY ⇒ not a runnable launch (cannot reason).
+        assert!(!is_agentic_launch(&launch_mote(
+            BTreeMap::new(),
+            NdClass::ReadOnlyNondet
+        )));
+        // PROMPT_KEY + TOOL_ARGS_KEY ⇒ the authored-tool discriminant wins, not a launch.
+        let mut config = prompt_only();
+        config.insert(
+            ConfigKey(TOOL_ARGS_KEY.to_string()),
+            ConfigVal(b"{}".to_vec()),
+        );
+        assert!(!is_agentic_launch(&launch_mote(
+            config,
+            NdClass::ReadOnlyNondet
+        )));
     }
 }

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -26,8 +26,9 @@ use kx_coordinator::proto::{CommitOutcome, ExecutorClass as ProtoExecutorClass};
 use kx_coordinator::{CoordinatorService, InMemoryWorkerRegistry, MoteState, WorkerRegistry};
 use kx_journal::{Journal, JournalEntry, ReactBranch, SqliteJournal};
 use kx_mote::{
-    ConfigKey, ConfigVal, EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId, Mote,
-    MoteDef, NdClass, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION, PROMPT_KEY, REACT_TURN_KEY,
+    ConfigKey, ConfigVal, EdgeMeta, EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId,
+    Mote, MoteDef, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION, PROMPT_KEY,
+    REACT_TURN_KEY,
 };
 use kx_warrant::{
     warrant_ref_of, ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling,
@@ -1386,5 +1387,255 @@ async fn worker_crash_does_not_dead_letter_and_a_late_commit_still_settles() {
             }
         ),
         "the committed answer settles the chain — never discarded"
+    );
+}
+
+// ============================================================================
+// PR-9b-2b — the deterministic-AGENTIC launch step (the `@tool` execution lane).
+// ============================================================================
+
+/// A deterministic-agentic LAUNCH step: a frozen-DAG MODEL mote (ROND +
+/// StageThenCommit) carrying an author-declared tool-grant SET + the instruction +
+/// the per-step budget. `budget = Some((turns, calls))` writes the caps into the
+/// config (`react_seed_params` reads them); `None` defaults to 8/6.
+fn launch_mote(parents: SmallVec<[ParentRef; 4]>, budget: Option<(u32, u32)>) -> Mote {
+    let mut config_subset = BTreeMap::new();
+    config_subset.insert(
+        ConfigKey(PROMPT_KEY.to_string()),
+        ConfigVal(INSTRUCTION.as_bytes().to_vec()),
+    );
+    if let Some((turns, calls)) = budget {
+        config_subset.insert(
+            ConfigKey(kx_mote::REACT_MAX_TURNS_KEY.to_string()),
+            ConfigVal(serde_json::to_vec(&turns).unwrap()),
+        );
+        config_subset.insert(
+            ConfigKey(kx_mote::REACT_MAX_TOOL_CALLS_KEY.to_string()),
+            ConfigVal(serde_json::to_vec(&calls).unwrap()),
+        );
+    }
+    let mut tool_contract = BTreeMap::new();
+    tool_contract.insert(
+        kx_mote::ToolName("mcp-echo".into()),
+        kx_mote::ToolVersion("1".into()),
+    );
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef([0x9b; 32]),
+        model_id: ModelId(MODEL.into()),
+        prompt_template_hash: PromptTemplateHash([0x9b; 32]),
+        tool_contract,
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset,
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0x9b; 32]),
+        GraphPosition(vec![0x9b]),
+        parents,
+    )
+}
+
+/// A plain PURE `> review` consumer of the launch step (its lone DAG parent),
+/// leasable only AFTER the launch commits.
+fn review_child(launch: &Mote) -> Mote {
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef([0x5c; 32]),
+        model_id: ModelId(MODEL.into()),
+        prompt_template_hash: PromptTemplateHash([0x5c; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::Pure,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0x5c; 32]),
+        GraphPosition(vec![0x5c]),
+        std::iter::once(ParentRef {
+            parent_id: launch.id,
+            edge: EdgeMeta::data(),
+        })
+        .collect(),
+    )
+}
+
+/// Submit `mote` plainly (`react_seed = false`) under the ALREADY-registered run —
+/// the SubmitWorkflow-mote path (vs `common::submit`, which registers a fresh run).
+async fn submit_plain(svc: &CoordinatorService, mote: &Mote, w: &WarrantSpec) {
+    let resp = svc
+        .submit_mote(Request::new(kx_coordinator::proto::SubmitMoteRequest {
+            mote: Some(mote.clone().into()),
+            warrant: Some(w.clone().into()),
+            accept_at_least_once: false,
+            react_seed: false,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        resp.status,
+        kx_coordinator::proto::SubmitStatus::Accepted as i32
+    );
+}
+
+/// Flagship: a deterministic-agentic launch step is PARKED at lease (never dispatched
+/// as a plain model mote), its bounded reason→tool→observe loop is driven on a private
+/// `step_salt`-keyed chain (a WORLD-MUTATING observation COMMITS — the PR-9a
+/// effect-asserting pattern), and on the terminal Answer the LAUNCH mote COMMITS,
+/// advancing the frozen DAG so its `> review` consumer becomes ready.
+#[tokio::test]
+async fn agentic_launch_drives_loop_commits_and_advances_dag() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true); // ROND + mcp-echo grant + the served route
+
+    let _ = common::register_run(&svc, [0x5a; 32]).await;
+    let launch = launch_mote(SmallVec::new(), None);
+    let review = review_child(&launch);
+    submit_plain(&svc, &launch, &w).await;
+    submit_plain(&svc, &review, &w).await;
+
+    // The launch is PARKED + the review child is Pending (parent uncommitted), so
+    // `settle_agentic_launches` anchored the launch + materialized its salt-2 turn 0
+    // — the ONLY leasable item.
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    assert_eq!(
+        leased.len(),
+        1,
+        "only the agentic turn 0 leases (launch parked, child pending)"
+    );
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    assert_ne!(
+        turn0.id, launch.id,
+        "the launch is NEVER dispatched; a server-derived salt-2 turn drives the loop"
+    );
+    let marker = turn0
+        .def
+        .config_subset
+        .get(&ConfigKey(REACT_TURN_KEY.to_string()))
+        .unwrap()
+        .0
+        .clone();
+    assert_eq!(
+        marker.len(),
+        16 + 32,
+        "the agentic marker is instance_id‖step_salt"
+    );
+    assert_eq!(
+        &marker[16..],
+        launch.id.as_bytes(),
+        "step_salt = the launch MoteId"
+    );
+
+    // turn 0 proposes a tool call → settle freezes `Tool` + materializes the observation.
+    commit_raw(&svc, &store, &turn0, &w, TOOL_ENVELOPE, worker).await;
+    let (obs, args) = lease_observation(&svc, worker, &turn0).await;
+    assert_eq!(
+        args,
+        br#"{"q":"x"}"#.to_vec(),
+        "the observation leases WITH re-derived args"
+    );
+    // ★ the WORLD-MUTATING observation COMMITS (effect-asserting, not just "settled").
+    commit_raw(&svc, &store, &obs, &w, b"echo: x", worker).await;
+    assert_eq!(
+        svc.state_of(obs.id).await.unwrap(),
+        MoteState::Committed,
+        "the tool observation committed (a real tool round fired)"
+    );
+
+    // turn 1 answers → settle freezes `Answer` → the LAUNCH mote commits.
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    assert_eq!(
+        leased.len(),
+        1,
+        "turn 1 leases after the observation commits"
+    );
+    let turn1: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    assert_ne!(turn1.id, turn0.id);
+    // ★ the F-7 trajectory is NON-EMPTY — turn 1's 48-byte agentic marker decoded to
+    // the right `(instance_id, step_salt)` chain + the observation was rebuilt via
+    // `build_agentic_tool` (a 16-byte-only decode would yield an EMPTY transcript — the
+    // silent loop-break this guards). Interleaved `[turn0, obs0]`, transcript order.
+    let traj = &leased[0].parent_results;
+    assert_eq!(traj.len(), 2, "turn 1 sees [turn0, obs0] (the agentic marker decoded)");
+    assert_eq!(traj[0].parent_mote_id, turn0.id.as_bytes().to_vec());
+    assert_eq!(traj[1].parent_mote_id, obs.id.as_bytes().to_vec());
+    commit_raw(&svc, &store, &turn1, &w, b"All done.", worker).await;
+
+    // The launch COMMITTED (carrying the answer turn's result) ⇒ the frozen DAG
+    // advanced ⇒ the `> review` consumer is now leasable.
+    assert_eq!(
+        svc.state_of(launch.id).await.unwrap(),
+        MoteState::Committed,
+        "the agentic launch step committed — the DAG advanced"
+    );
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    assert_eq!(leased.len(), 1, "the `> review` child is now ready");
+    let child: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(
+        child.id, review.id,
+        "the launch's DAG consumer leased only after the launch committed"
+    );
+
+    // Every fact of this chain is an AGENTIC fact (keyed by the launch's step_salt) —
+    // disjoint from any run-level react chain in the shared journal.
+    let facts = react_facts(&svc, &dir).await;
+    assert!(
+        facts.iter().all(|f| matches!(
+            f,
+            JournalEntry::ReactRound { step_salt: Some(s), .. } if s == launch.id.as_bytes()
+        )),
+        "every agentic ReactRound fact carries step_salt = the launch MoteId"
+    );
+}
+
+/// Budget-exhaust: a launch whose loop only ever tool-calls (never answers) within its
+/// declared budget fails CLOSED — the launch mote dead-letters (terminal `Failed`),
+/// never fabricating an answer (GR15) and never wedging its DAG consumer in `Scheduled`.
+#[tokio::test]
+async fn agentic_launch_budget_exhaust_dead_letters() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true);
+
+    let _ = common::register_run(&svc, [0x5b; 32]).await;
+    // A 2-turn / 1-tool-call budget: after the first tool round commits, the chain is
+    // budget-exhausted with no Answer.
+    let launch = launch_mote(SmallVec::new(), Some((2, 1)));
+    submit_plain(&svc, &launch, &w).await;
+
+    let worker = common::register(&svc, "w").await;
+    let turn0: Mote = common::lease_work(&svc, worker, MAC, 16).await[0]
+        .mote
+        .clone()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    commit_raw(&svc, &store, &turn0, &w, TOOL_ENVELOPE, worker).await;
+    let (obs, _) = lease_observation(&svc, worker, &turn0).await;
+    commit_raw(&svc, &store, &obs, &w, b"echo: x", worker).await;
+
+    // The tool budget (1) is now exhausted with no Answer ⇒ the launch dead-letters.
+    assert_eq!(
+        svc.state_of(launch.id).await.unwrap(),
+        MoteState::Failed,
+        "a budget-exhausted agentic launch fails closed (no fabricated answer)"
+    );
+    // No further work leases (the chain is terminal; nothing wedged in Scheduled).
+    assert!(
+        common::lease_work(&svc, worker, MAC, 16).await.is_empty(),
+        "a dead-lettered launch leaves no leasable work"
     );
 }

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -1569,7 +1569,11 @@ async fn agentic_launch_drives_loop_commits_and_advances_dag() {
     // `build_agentic_tool` (a 16-byte-only decode would yield an EMPTY transcript — the
     // silent loop-break this guards). Interleaved `[turn0, obs0]`, transcript order.
     let traj = &leased[0].parent_results;
-    assert_eq!(traj.len(), 2, "turn 1 sees [turn0, obs0] (the agentic marker decoded)");
+    assert_eq!(
+        traj.len(),
+        2,
+        "turn 1 sees [turn0, obs0] (the agentic marker decoded)"
+    );
     assert_eq!(traj[0].parent_mote_id, turn0.id.as_bytes().to_vec());
     assert_eq!(traj[1].parent_mote_id, obs.id.as_bytes().to_vec());
     commit_raw(&svc, &store, &turn1, &w, b"All done.", worker).await;
@@ -1637,5 +1641,60 @@ async fn agentic_launch_budget_exhaust_dead_letters() {
     assert!(
         common::lease_work(&svc, worker, MAC, 16).await.is_empty(),
         "a dead-lettered launch leaves no leasable work"
+    );
+}
+
+/// A parked agentic launch whose DAG parent TERMINALLY fails is dead-lettered + its
+/// in-memory park reclaimed — a `Failed` parent never makes the launch ready (it is not
+/// `Committed`), so without fail-closing the launch would sit `Pending` forever and its
+/// `parked_launches`/`dispatch.defs` entries would leak for the life of a long-lived serve.
+#[tokio::test]
+async fn agentic_launch_with_failed_parent_is_dead_lettered() {
+    let dir = TempDir::new().unwrap();
+    let (svc, _store) = coordinator(&dir);
+    let w = warrant(true);
+
+    let _ = common::register_run(&svc, [0x5d; 32]).await;
+    // A plain producer P (root model mote, empty tool_contract ⇒ not a launch) + the
+    // agentic launch wired downstream of it.
+    let parent = seed_mote();
+    let launch = launch_mote(
+        std::iter::once(ParentRef {
+            parent_id: parent.id,
+            edge: EdgeMeta::data(),
+        })
+        .collect(),
+        None,
+    );
+    submit_plain(&svc, &parent, &w).await;
+    submit_plain(&svc, &launch, &w).await;
+
+    // Only P leases (the launch is parked, its parent uncommitted). Lease P, then
+    // TERMINALLY fail it.
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    assert_eq!(leased.len(), 1, "only the producer leases (launch parked)");
+    let p: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(p.id, parent.id);
+    common::report_failure(
+        &svc,
+        &p,
+        worker,
+        kx_coordinator::proto::FailureReason::DeadLettered,
+    )
+    .await
+    .unwrap();
+
+    // The next drain's settle sees the launch's parent terminally failed ⇒ dead-letters
+    // the launch (it can NEVER become ready) + reclaims the park — no leaked entry.
+    let _ = svc.committed_count().await; // ordering barrier (a later drain runs the settle)
+    assert_eq!(
+        svc.state_of(launch.id).await.unwrap(),
+        MoteState::Failed,
+        "the launch dead-lettered — its parent can never satisfy it (no Pending-forever leak)"
+    );
+    assert!(
+        common::lease_work(&svc, worker, MAC, 16).await.is_empty(),
+        "nothing leasable — the park + def were reclaimed, not leaked"
     );
 }

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -35,7 +35,7 @@ use kx_warrant::{
     intersect, ExecutorClass, FsMode, FsScope, Host, ModelRoute, MoteClass, NetScope,
     ResourceCeiling, Role, ToolGrant, WarrantSpec,
 };
-use kx_workflow::{compile, tool_step, transform, StepDef, WorkflowDef};
+use kx_workflow::{compile, generator, tool_step, transform, StepDef, WorkflowDef};
 
 use crate::error::GatewayError;
 
@@ -1516,39 +1516,58 @@ impl HostWorkflowAuthor {
                         served.0
                     )));
                 }
-                // PR-9b (D161.1): a MODEL step carrying a non-empty tool_contract is a
-                // DETERMINISTIC-AGENTIC step (`model@tool` in the chains DSL). The
-                // AUTHORING contract — the `@` grammar, the SDK `tools=` factory, the
-                // golden corpus, the server-vetted per-step union warrant — ships in
-                // PR-9b-1, but the bounded reason→tool→observe LOOP execution (a new
-                // launch/park/terminal-commit hook in the sole-writer coordinator + a
-                // journal v8→v9 bump + the compound react-chain key + recovery) lands
-                // in PR-9b-2. Until then the server FAILS CLOSED rather than silently
-                // run the step greedy + drop the grant set (GR15): a clear refusal at
-                // authoring, before any Mote is created.
-                if !s.tool_contract.is_empty() {
-                    return Err(BinderError::InvalidArgs(
-                        "the deterministic-agentic step (a MODEL step with `@tool` grants) is \
-                         authored across the chains DSL/SDK/CLI/UI, but its bounded \
-                         reason→tool→observe loop is not yet runnable on this server (lands in \
-                         PR-9b-2); use a standalone tool() step or the `react`/`react-auto` \
-                         recipe for tool-calling today"
-                            .into(),
-                    ));
+                // PR-9b-2b (D161.1): a MODEL step carrying a non-empty tool_contract is
+                // a DETERMINISTIC-AGENTIC step (`model@tool` in the chains DSL). Build a
+                // GENERATOR StepDef (ReadOnlyNondet + StageThenCommit) + the SERVER-built
+                // UNION warrant over the AUTHOR-DECLARED tool set (`agentic_step_warrant`,
+                // resolved fail-closed). The non-empty `tool_grants` make `author()` admit
+                // the warrant DIRECTLY (SN-8: client `tool_grants` are NEVER accepted —
+                // BLOCKER-#5). The coordinator PARKS the launch at lease, drives its
+                // bounded reason→tool→observe loop on a private `step_salt`-keyed chain,
+                // and COMMITS the launch mote with the loop's final answer to advance the
+                // frozen DAG (kx-coordinator `state.rs`). Budget validated here (fail fast).
+                if s.tool_contract.is_empty() {
+                    // P1.1: the step warrant is `base` — and `blueprint_base` now carries
+                    // the SERVED model in its `model_route` (see `seed`), so the dispatch
+                    // id (served) == the warrant route id (served) and the dispatcher's
+                    // strict check passes (it used to be the demo PLACEHOLDER route ≠
+                    // served → the MODEL step dead-lettered). Using `base` verbatim keeps
+                    // the step warrant == the authoring grant ⇒ a guaranteed no-op
+                    // narrowing at admission (no `AttemptedWiden` on the model_route ceilings).
+                    transform(
+                        LogicRef::from_bytes(MODEL_LOGIC_REF),
+                        served.clone(),
+                        base.clone(),
+                        cap,
+                    )
+                } else {
+                    // A DETERMINISTIC-AGENTIC step: build the GENERATOR StepDef + the
+                    // server-built union warrant over the AUTHOR-DECLARED set (resolved
+                    // fail-closed). The non-empty `tool_grants` make `author()` admit it
+                    // DIRECTLY (SN-8: client `tool_grants` NEVER accepted — BLOCKER-#5);
+                    // the coordinator parks + drives the bounded loop + commits the launch.
+                    let tools = self.tools.as_ref().ok_or_else(|| {
+                        BinderError::InvalidArgs(
+                            "this serve has no tool registry; deterministic-agentic \
+                             (`@tool`) steps are unavailable"
+                                .into(),
+                        )
+                    })?;
+                    validate_agentic_budget(s)?;
+                    let warrant = agentic_step_warrant(base, &s.tool_contract, tools.as_ref())?;
+                    let mut sd = generator(
+                        LogicRef::from_bytes(MODEL_LOGIC_REF),
+                        served.clone(),
+                        warrant,
+                        cap.clone(),
+                    );
+                    let mut tc = std::collections::BTreeMap::new();
+                    for (name, version) in &s.tool_contract {
+                        tc.insert(ToolName(name.clone()), ToolVersion(version.clone()));
+                    }
+                    sd.tool_contract = tc;
+                    sd
                 }
-                // P1.1: the step warrant is `base` — and `blueprint_base` now carries
-                // the SERVED model in its `model_route` (see `seed`), so the dispatch
-                // id (served) == the warrant route id (served) and the dispatcher's
-                // strict check passes (it used to be the demo PLACEHOLDER route ≠
-                // served → the MODEL step dead-lettered). Using `base` verbatim keeps
-                // the step warrant == the authoring grant ⇒ a guaranteed no-op
-                // narrowing at admission (no `AttemptedWiden` on the model_route ceilings).
-                transform(
-                    LogicRef::from_bytes(MODEL_LOGIC_REF),
-                    served.clone(),
-                    base.clone(),
-                    cap,
-                )
             }
             // EXEC: references a registered body — reserved for a follow-up (Tier-1
             // PR-1 ships PURE + MODEL; EXEC needs the body-registry lookup wiring).
@@ -2509,6 +2528,103 @@ pub(crate) fn tool_union_warrant(
         executor_class: base.executor_class,
         ..Default::default()
     }
+}
+
+/// PR-9b-2b: the SERVER-built UNION warrant for a deterministic-AGENTIC step — a
+/// MODEL step carrying an AUTHOR-DECLARED `@tool` set. Mirrors [`tool_union_warrant`]
+/// (the react-auto auto-grant) but over the DECLARED contract resolved FAIL-CLOSED:
+/// every declared `(tool, version)` MUST be registered, carry the empty syscall
+/// profile (BUG-24 — a sandboxed-body tool cannot share the union warrant), and have
+/// an fs scope that unions (LUB-or-refuse); ANY miss REFUSES the whole step at
+/// authoring rather than silently drop a grant (GR15). `tool_grants` = the full
+/// declared set; `net_scope` / `fs_scope` = the LUB of their declared requirements;
+/// `syscall_profile_ref` = the empty sentinel (so the resolver's per-tool EQUALITY
+/// gate passes for every granted tool); `model_route` / `resource_ceiling` /
+/// `executor_class` from `base` (the served blueprint base) so the chain leases on
+/// the served worker. ReadOnlyNondet — a generator. Admitted DIRECTLY by `author()`
+/// (non-empty `tool_grants`, SN-8: client warrants NEVER accepted — BLOCKER-#5); the
+/// broker precheck + the coordinator's D66 re-verify every axis at each fire.
+fn agentic_step_warrant(
+    base: &WarrantSpec,
+    tool_contract: &std::collections::BTreeMap<String, String>,
+    tools: &dyn ToolRegistry,
+) -> Result<WarrantSpec, BinderError> {
+    if tool_contract.is_empty() {
+        return Err(BinderError::InvalidArgs(
+            "a deterministic-agentic step must declare at least one tool".into(),
+        ));
+    }
+    let mut grants: BTreeSet<ToolGrant> = BTreeSet::new();
+    let mut net_scope = NetScope::None;
+    let mut fs_scope = FsScope::empty();
+    for (name, version) in tool_contract {
+        let tool_name = ToolName(name.clone());
+        let tool_version = ToolVersion(version.clone());
+        let tdef = tools.lookup(&tool_name, &tool_version).ok_or_else(|| {
+            BinderError::InvalidArgs(format!(
+                "agentic step references unregistered tool {name}@{version}"
+            ))
+        })?;
+        let cap = &tdef.required_capability;
+        if cap.syscall_profile_ref != ContentRef::from_bytes(EMPTY_SYSCALL_PROFILE) {
+            return Err(BinderError::InvalidArgs(format!(
+                "tool {name}@{version} requires a sandboxed syscall profile and cannot be \
+                 granted to a deterministic-agentic step (BUG-24)"
+            )));
+        }
+        let Some(merged_fs) = fs_scope_union(&fs_scope, &cap.fs_scope_required) else {
+            return Err(BinderError::InvalidArgs(format!(
+                "tool {name}@{version} has an fs scope incompatible with the agentic step's \
+                 other tools"
+            )));
+        };
+        fs_scope = merged_fs;
+        net_scope = net_scope_union(&net_scope, &cap.net_scope_required);
+        grants.insert(ToolGrant {
+            tool_id: tool_name,
+            tool_version,
+        });
+    }
+    Ok(WarrantSpec {
+        mote_class: MoteClass::ReadOnlyNondet,
+        nd_class: MoteClass::ReadOnlyNondet,
+        fs_scope,
+        net_scope,
+        syscall_profile_ref: ContentRef::from_bytes(EMPTY_SYSCALL_PROFILE),
+        tool_grants: grants,
+        model_route: base.model_route.clone(),
+        resource_ceiling: base.resource_ceiling,
+        environment_ref: None,
+        executor_class: base.executor_class,
+        ..Default::default()
+    })
+}
+
+/// PR-9b-2b: validate a deterministic-agentic step's declared budget AT AUTHORING
+/// (fail fast) — the same `0 < max_tool_calls < max_turns ≤ 8` gate the coordinator
+/// enforces durably at anchor (`react_seed_params`) + the SDK enforces at lowering.
+/// The caps ride `params` as canonical-JSON `u32` under the react budget keys; an
+/// absent cap defaults (8 turns / 6 tool-calls — the coordinator `react_shape`
+/// constants), an explicit malformed/out-of-range cap is refused.
+fn validate_agentic_budget(s: &AuthorStep) -> Result<(), BinderError> {
+    let parse = |key: &str, default: u32| -> Result<u32, BinderError> {
+        match s.params.get(key) {
+            None => Ok(default),
+            Some(bytes) => serde_json::from_slice::<u32>(bytes).map_err(|_| {
+                BinderError::InvalidArgs(format!(
+                    "agentic budget `{key}` must be a canonical-JSON unsigned integer"
+                ))
+            }),
+        }
+    };
+    let max_turns = parse(kx_mote::REACT_MAX_TURNS_KEY, 8)?;
+    let max_tool_calls = parse(kx_mote::REACT_MAX_TOOL_CALLS_KEY, 6)?;
+    if max_tool_calls == 0 || max_tool_calls >= max_turns || max_turns > 8 {
+        return Err(BinderError::InvalidArgs(
+            "agentic budget must satisfy 0 < max_tool_calls < max_turns <= 8".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// PR-6b-4: the seed-time PLACEHOLDER warrant for `kx/recipes/react-auto`. Mirrors

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -804,6 +804,8 @@ fn derive_react_index(state: &mut State) {
             .react_index
             .entry(record.instance_id)
             .or_default()
+            .entry(record.step_salt)
+            .or_default()
             .push(idx);
         state.react_turn_motes.insert(record.turn_mote_id);
     }
@@ -1085,10 +1087,20 @@ mod tests {
             escalation_reason_ref: None,
             seq: 4,
         });
-        // PR-2d-1 (v4) + PR-9b-2 (v5): react-turn records covering a run-level
-        // anchor (step_salt None) + an AGENTIC Tool settle (step_salt Some), so the
-        // round-trip proves both the v4 payload field (the enum branch with payload)
-        // AND the v5 `step_salt` Option are preserved — the bumps' point.
+        push_sample_react_rounds(&mut s);
+        // PR-2d-2: a real State's derived react index/turn-set is ALWAYS
+        // consistent with `react_rounds` (the fold maintains it; the load path
+        // re-derives it) — the fixture must uphold the same invariant or the
+        // lossless-roundtrip assert would compare an unindexed source against
+        // a re-derived decode.
+        derive_react_index(&mut s);
+        s
+    }
+
+    /// PR-2d-1 (v4) + PR-9b-2b (v5): the fixture's react-turn records — a RUN-LEVEL
+    /// anchor (`step_salt None`) + an AGENTIC `Tool` settle (`step_salt Some`) — so the
+    /// round-trip proves BOTH the v4 payload branch AND the v5 `step_salt` Option survive.
+    fn push_sample_react_rounds(s: &mut State) {
         s.react_rounds.push(ReactRoundRecord {
             turn: 0,
             turn_mote_id: mid(40),
@@ -1118,13 +1130,6 @@ mod tests {
             step_salt: Some([0x77; 32]),
             seq: 4,
         });
-        // PR-2d-2: a real State's derived react index/turn-set is ALWAYS
-        // consistent with `react_rounds` (the fold maintains it; the load path
-        // re-derives it) — the fixture must uphold the same invariant or the
-        // lossless-roundtrip assert would compare an unindexed source against
-        // a re-derived decode.
-        derive_react_index(&mut s);
-        s
     }
 
     /// PR-9b-2b: pin the checkpoint format version so the v4→v5 bump (the

--- a/crates/kx-projection/src/checkpoint.rs
+++ b/crates/kx-projection/src/checkpoint.rs
@@ -77,7 +77,18 @@ use crate::state::{
 /// payload AND `state_digest()` move for every state, a stale v3 sidecar is
 /// rejected, recovery full-folds and re-seals (self-healing). Only the PRODUCT
 /// run-identity digest is invariant.
-pub const CURRENT_FORMAT_VERSION: u16 = 4;
+///
+/// `5` (PR-9b-2b, deterministic-agentic step): `ReactRoundRecordDto` gained
+/// `step_salt` (the per-step salt disjoining an agentic step's private chain) so a
+/// checkpoint-seeded recovery preserves which chain each turn belongs to. Same
+/// deliberate-break contract: the per-record payload grows by the `Option` tag,
+/// shifting the bincoded bytes + `state_digest()` of any state THAT HAS react
+/// records; a state with NO react rounds (the demo / a non-react run) encodes a
+/// length-0 `react_rounds` Vec either way, so its `encode_state` /
+/// `state_content_digest` are BYTE-UNCHANGED and the canonical PRODUCT digest
+/// `7d22d4bd` is invariant. A stale v4 sidecar is rejected; recovery full-folds
+/// from the v9 journal (which carries `step_salt`) and re-seals (self-healing).
+pub const CURRENT_FORMAT_VERSION: u16 = 5;
 
 /// Payload codec tag. `0` = canonical-bincode (LE + fixed-int, the house
 /// [`kx_mote::canonical_config`]). Reserved for a future rkyv zero-copy payload
@@ -523,6 +534,9 @@ struct ReactRoundRecordDto {
     branch: kx_journal::ReactBranch,
     max_turns: u32,
     max_tool_calls: u32,
+    /// PR-9b-2 — the per-step salt (`None` ⇒ run-level). The format-version bump
+    /// (v4→v5) covers this added field; absent in v4 sidecars (rejected → full-fold).
+    step_salt: Option<[u8; 32]>,
     seq: u64,
 }
 
@@ -710,6 +724,7 @@ impl From<&ReactRoundRecord> for ReactRoundRecordDto {
             branch,
             max_turns,
             max_tool_calls,
+            step_salt,
             seq,
         } = r;
         Self {
@@ -722,6 +737,7 @@ impl From<&ReactRoundRecord> for ReactRoundRecordDto {
             branch: branch.clone(),
             max_turns: *max_turns,
             max_tool_calls: *max_tool_calls,
+            step_salt: *step_salt,
             seq: *seq,
         }
     }
@@ -954,6 +970,7 @@ impl From<ReactRoundRecordDto> for ReactRoundRecord {
             branch,
             max_turns,
             max_tool_calls,
+            step_salt,
             seq,
         } = dto;
         ReactRoundRecord {
@@ -966,6 +983,7 @@ impl From<ReactRoundRecordDto> for ReactRoundRecord {
             branch,
             max_turns,
             max_tool_calls,
+            step_salt,
             seq,
         }
     }
@@ -1067,9 +1085,10 @@ mod tests {
             escalation_reason_ref: None,
             seq: 4,
         });
-        // PR-2d-1 (v4): react-turn records covering an anchor + a Tool settle, so
-        // the round-trip proves the v4 payload field (incl. the enum branch with
-        // payload) is preserved — the v4 bump's point.
+        // PR-2d-1 (v4) + PR-9b-2 (v5): react-turn records covering a run-level
+        // anchor (step_salt None) + an AGENTIC Tool settle (step_salt Some), so the
+        // round-trip proves both the v4 payload field (the enum branch with payload)
+        // AND the v5 `step_salt` Option are preserved — the bumps' point.
         s.react_rounds.push(ReactRoundRecord {
             turn: 0,
             turn_mote_id: mid(40),
@@ -1080,6 +1099,7 @@ mod tests {
             branch: kx_journal::ReactBranch::Pending,
             max_turns: 8,
             max_tool_calls: 8,
+            step_salt: None,
             seq: 4,
         });
         s.react_rounds.push(ReactRoundRecord {
@@ -1095,6 +1115,7 @@ mod tests {
             },
             max_turns: 8,
             max_tool_calls: 8,
+            step_salt: Some([0x77; 32]),
             seq: 4,
         });
         // PR-2d-2: a real State's derived react index/turn-set is ALWAYS
@@ -1106,22 +1127,22 @@ mod tests {
         s
     }
 
-    /// PR-2d-1: pin the checkpoint format version so the v3→v4 bump (the
-    /// additive `react_rounds` payload field) is an intentional, reviewable
-    /// change — and so a v3 sidecar written by the previous binary is REFUSED
-    /// (decode error → full-fold self-heal), never misread.
+    /// PR-9b-2b: pin the checkpoint format version so the v4→v5 bump (the
+    /// additive `ReactRoundRecordDto.step_salt` field) is an intentional,
+    /// reviewable change — and so a v4 sidecar written by the previous binary is
+    /// REFUSED (decode error → full-fold self-heal), never misread.
     #[test]
-    fn format_version_is_v4_and_v3_blobs_are_refused() {
-        assert_eq!(CURRENT_FORMAT_VERSION, 4);
+    fn format_version_is_v5_and_v4_blobs_are_refused() {
+        assert_eq!(CURRENT_FORMAT_VERSION, 5);
         let mut bytes = FoldCheckpoint::from_state(&sample_state()).to_bytes();
-        // Stamp the envelope version back to v3 (bytes 0..2, LE u16).
-        bytes[0..2].copy_from_slice(&3u16.to_le_bytes());
+        // Stamp the envelope version back to v4 (bytes 0..2, LE u16).
+        bytes[0..2].copy_from_slice(&4u16.to_le_bytes());
         assert!(matches!(
             FoldCheckpoint::from_bytes(&bytes),
-            // The version is part of the digest preimage, so a re-stamped v3
+            // The version is part of the digest preimage, so a re-stamped v4
             // envelope fails as UnsupportedVersion or DigestMismatch — both are
             // fail-safe discards (full fold).
-            Err(CheckpointError::UnsupportedVersion { got: 3 } | CheckpointError::DigestMismatch)
+            Err(CheckpointError::UnsupportedVersion { got: 4 } | CheckpointError::DigestMismatch)
         ));
     }
 

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -1090,27 +1090,50 @@ impl Projection {
         &self.state.react_rounds
     }
 
-    /// The `ReactRound` records of ONE chain (`instance_id`), in journal (seq)
-    /// order — served off the DERIVED per-instance index (PR-2d-2), so a
-    /// per-chain read costs O(that chain's facts), never a scan over every
-    /// chain in serve's shared journal (the PR-2d-1 O(runs²) finding).
+    /// The `ReactRound` records of ONE chain — the `(instance_id, step_salt)`
+    /// pair — in journal (seq) order, served off the DERIVED nested per-chain
+    /// index (PR-2d-2 / PR-9b-2b), so a per-chain read costs O(that chain's
+    /// facts), never a scan over every chain in serve's shared journal (the
+    /// PR-2d-1 O(runs²) finding). `step_salt` is `None` for the run-level react
+    /// chain (every chain v8 wrote) and `Some(launch MoteId)` for an agentic
+    /// step's private chain (PR-9b-2b) — so the two never alias within one run.
     pub fn react_rounds_of(
         &self,
         instance_id: &[u8; kx_journal::INSTANCE_ID_LEN],
+        step_salt: &Option<[u8; 32]>,
     ) -> impl Iterator<Item = &crate::state::ReactRoundRecord> + '_ {
         self.state
             .react_index
             .get(instance_id)
+            .and_then(|chains| chains.get(step_salt))
             .into_iter()
             .flatten()
             .map(|&idx| &self.state.react_rounds[idx])
     }
 
-    /// The distinct `instance_id`s with folded react facts, ascending — each an
-    /// independent chain in serve's SHARED journal. Served off the index keys
-    /// (PR-2d-2): O(chains), not O(total facts).
+    /// The distinct `instance_id`s with folded react facts, ascending — each run
+    /// in serve's SHARED journal. Served off the index keys (PR-2d-2): O(runs).
     pub fn react_instances(&self) -> impl Iterator<Item = &[u8; kx_journal::INSTANCE_ID_LEN]> + '_ {
         self.state.react_index.keys()
+    }
+
+    /// Every distinct CHAIN — the `(instance_id, step_salt)` pairs — with folded
+    /// react facts (PR-9b-2b). The unit the coordinator settles/recovers: a run
+    /// may carry the run-level chain (`step_salt = None`) AND one or more agentic
+    /// step chains (`Some(launch MoteId)`). Served off the nested index keys:
+    /// O(chains), not O(total facts).
+    pub fn react_chains(
+        &self,
+    ) -> impl Iterator<Item = ([u8; kx_journal::INSTANCE_ID_LEN], Option<[u8; 32]>)> + '_ {
+        self.state
+            .react_index
+            .iter()
+            .flat_map(|(instance_id, chains)| {
+                let instance_id = *instance_id;
+                chains
+                    .keys()
+                    .map(move |step_salt| (instance_id, *step_salt))
+            })
     }
 
     /// `true` iff `id` is a react TURN's `MoteId` (some folded `ReactRound`
@@ -1121,18 +1144,20 @@ impl Projection {
         self.state.react_turn_motes.contains(id)
     }
 
-    /// The highest-`turn` `ReactRound` record for `instance_id` folded so far, or
-    /// `None` if that run has anchored no ReAct chain. Scoped by `instance_id`
-    /// (the run-salt) because serve's journal is SHARED across runs. On a turn
-    /// tie the highest-`seq` record wins — the LATEST fact for a turn is its
-    /// settled branch (anchor `Pending` then a resolution), so recovery reads
-    /// the freshest decision deterministically.
+    /// The highest-`turn` `ReactRound` record for ONE chain — the
+    /// `(instance_id, step_salt)` pair — folded so far, or `None` if that chain
+    /// has anchored no ReAct turn. Scoped by the chain key because serve's
+    /// journal is SHARED across runs AND a run may carry both a run-level and
+    /// agentic-step chain (PR-9b-2b). On a turn tie the highest-`seq` record
+    /// wins — the LATEST fact for a turn is its settled branch (anchor `Pending`
+    /// then a resolution), so recovery reads the freshest decision deterministically.
     #[must_use]
     pub fn latest_react_round(
         &self,
         instance_id: &[u8; kx_journal::INSTANCE_ID_LEN],
+        step_salt: &Option<[u8; 32]>,
     ) -> Option<&crate::state::ReactRoundRecord> {
-        self.react_rounds_of(instance_id)
+        self.react_rounds_of(instance_id, step_salt)
             .max_by(|a, b| a.turn.cmp(&b.turn).then(a.seq.cmp(&b.seq)))
     }
 

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -646,11 +646,7 @@ impl Projection {
                 branch,
                 max_turns,
                 max_tool_calls,
-                // v9 (PR-9b-2a): the compound `(instance_id, step_salt)` chain key
-                // that READS this lands with the execution path (PR-9b-2b); the
-                // run-level fold here ignores it (every v9 record this PR writes
-                // carries None), keeping the run-level query path byte-unchanged.
-                step_salt: _,
+                step_salt,
                 seq,
             } => {
                 // v8 (PR-2d-1). Append-many: a run accrues one record per turn
@@ -671,6 +667,7 @@ impl Projection {
                         branch: branch.clone(),
                         max_turns: *max_turns,
                         max_tool_calls: *max_tool_calls,
+                        step_salt: *step_salt,
                         seq: *seq,
                     });
                 // PR-2d-2: maintain the DERIVED per-instance index + turn-Mote

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -209,6 +209,14 @@ pub struct ReactRoundRecord {
     pub seq: u64,
 }
 
+/// PR-9b-2b: the DERIVED nested per-CHAIN react index — `instance_id → step_salt →
+/// indices into `react_rounds``. The inner `Option<[u8;32]>` disjoins an agentic
+/// step's private chain (`Some(launch MoteId)`) from the run-level chain (`None`)
+/// within one run. A named alias (vs the inline literal) keeps the `State` field
+/// readable + satisfies `clippy::type_complexity`.
+type ReactChainIndex =
+    BTreeMap<[u8; kx_journal::INSTANCE_ID_LEN], BTreeMap<Option<[u8; 32]>, Vec<usize>>>;
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct State {
     /// Per-MoteId info — declared, committed, and any in-flight state.
@@ -235,16 +243,23 @@ pub(crate) struct State {
     /// identity/scheduling/digest input. Emptiness is the `has_react_turn`
     /// sentinel that keeps react-free runs (and the demo) zero-cost.
     pub(crate) react_rounds: Vec<ReactRoundRecord>,
-    /// PR-2d-2 — DERIVED per-instance index over `react_rounds`: `instance_id`
-    /// → indices into the Vec, in append (= seq) order. `react_rounds` only
-    /// ever GROWS in serve's shared journal, so without this every per-chain
-    /// settle/recover/trajectory query is a scan over EVERY chain's facts
-    /// forever (the PR-2d-1 O(runs²) adversarial finding — the coordinator's
-    /// `ReactSettleCache` bounds the settle; this bounds the per-chain reads).
+    /// PR-2d-2 / PR-9b-2b — DERIVED per-CHAIN index over `react_rounds`,
+    /// NESTED `instance_id → step_salt → indices` into the Vec, in append (=
+    /// seq) order. The inner `Option<[u8;32]>` step_salt key disjoins an
+    /// agentic step's PRIVATE chain (`Some(launch MoteId)`, PR-9b-2b) from the
+    /// run-level react chain (`None`, every chain v8 wrote) within one
+    /// `instance_id` — so two chains sharing a run never alias (budget counts,
+    /// trajectory context). `react_rounds` only ever GROWS in serve's shared
+    /// journal, so without this every per-chain settle/recover/trajectory query
+    /// is a scan over EVERY chain's facts forever (the PR-2d-1 O(runs²)
+    /// adversarial finding — the coordinator's `ReactSettleCache` bounds the
+    /// settle; this bounds the per-chain reads). NESTED (not a flat compound
+    /// key) so [`crate::Projection::react_instances`] keeps returning
+    /// `instance_id`s and [`crate::Projection::is_react_turn_mote`] is untouched.
     /// Maintained by the fold; RE-DERIVED on checkpoint load — NEVER serialized
     /// (it is not in `CheckpointState`), so `encode_state`, the
-    /// `state_content_digest`, and the v4 checkpoint format are byte-unchanged.
-    pub(crate) react_index: BTreeMap<[u8; kx_journal::INSTANCE_ID_LEN], Vec<usize>>,
+    /// `state_content_digest`, and the checkpoint format are byte-unchanged.
+    pub(crate) react_index: ReactChainIndex,
     /// PR-2d-2 — DERIVED set of every react TURN's `MoteId` (each
     /// `ReactRound.turn_mote_id`). O(log n) membership for the coordinator's
     /// lease-time "is this Mote's parent a react turn?" check (the observation
@@ -269,6 +284,8 @@ impl State {
         let record = &self.react_rounds[idx];
         self.react_index
             .entry(record.instance_id)
+            .or_default()
+            .entry(record.step_salt)
             .or_default()
             .push(idx);
         self.react_turn_motes.insert(record.turn_mote_id);

--- a/crates/kx-projection/src/state.rs
+++ b/crates/kx-projection/src/state.rs
@@ -198,6 +198,13 @@ pub struct ReactRoundRecord {
     pub max_turns: u32,
     /// The run's durable tool-call cap (recorded on the anchor).
     pub max_tool_calls: u32,
+    /// PR-9b-2 (deterministic-agentic step): the per-step salt (= the launch
+    /// step's `MoteId`) that disjoins an agentic step's PRIVATE chain from the
+    /// run-level react chain. `None` ⇒ a run-level chain (every chain v8 wrote;
+    /// the v8→v9 up-convert default). The compound `(instance_id, step_salt)`
+    /// chain key that READS this lands with the execution path (PR-9b-2b); B0
+    /// only persists it across the fold + checkpoint round-trip.
+    pub step_salt: Option<[u8; 32]>,
     /// The entry's journal seq (audit/order).
     pub seq: u64,
 }

--- a/ui/src/components/builder/StepConfigDrawer.tsx
+++ b/ui/src/components/builder/StepConfigDrawer.tsx
@@ -163,6 +163,90 @@ export function StepConfigDrawer({
                 behavior (and the step's identity) unchanged.
               </span>
             </div>
+
+            <div className="builder-field">
+              <span className="builder-field__label">Tools (agentic loop)</span>
+              {toolsNotWired || tools.length === 0 ? (
+                <p className="muted" data-testid="step-config-no-agent-tools">
+                  No tools are registered. Register one in <strong>Tools → Registry</strong> or dial
+                  an external MCP server in <strong>Tools → Connections</strong> to grant a set
+                  here.
+                </p>
+              ) : (
+                <div className="builder-chips" data-testid="step-config-agent-tools">
+                  {tools.map((t) => {
+                    const granted = step.toolContract[t.toolName] === t.toolVersion;
+                    return (
+                      <button
+                        key={`grant-${t.toolName}@${t.toolVersion}`}
+                        type="button"
+                        className={`chip${granted ? " chip--active" : ""}`}
+                        title={t.description}
+                        aria-pressed={granted}
+                        onClick={() => {
+                          const next = { ...step.toolContract };
+                          if (next[t.toolName] === t.toolVersion) {
+                            delete next[t.toolName];
+                          } else {
+                            next[t.toolName] = t.toolVersion;
+                          }
+                          onChange({ ...step, toolContract: next });
+                        }}
+                      >
+                        {t.toolName}@{t.toolVersion}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              <span className="builder-field__hint">
+                Grant a FIXED tool set to run a bounded reason→tool→observe loop (the set is part of
+                the step's identity). The SERVER builds the union warrant + drives the loop (SN-8).
+              </span>
+            </div>
+
+            {Object.keys(step.toolContract).length > 0 ? (
+              <>
+                <label className="builder-field">
+                  <span className="builder-field__label">Max turns</span>
+                  <input
+                    className="builder-input"
+                    type="number"
+                    min={2}
+                    max={8}
+                    data-testid="step-config-max-turns"
+                    value={step.maxTurns ?? 8}
+                    onChange={(e) =>
+                      onChange({
+                        ...step,
+                        maxTurns: Number.parseInt(e.target.value, 10) || undefined,
+                      })
+                    }
+                  />
+                </label>
+                <label className="builder-field">
+                  <span className="builder-field__label">Max tool calls</span>
+                  <input
+                    className="builder-input"
+                    type="number"
+                    min={1}
+                    max={7}
+                    data-testid="step-config-max-tool-calls"
+                    value={step.maxToolCalls ?? 6}
+                    onChange={(e) =>
+                      onChange({
+                        ...step,
+                        maxToolCalls: Number.parseInt(e.target.value, 10) || undefined,
+                      })
+                    }
+                  />
+                  <span className="builder-field__hint">
+                    Bounded loop: <code>0 &lt; tool-calls &lt; turns ≤ 8</code> (a turn is left to
+                    read the last observation and answer). Defaults 8 / 6.
+                  </span>
+                </label>
+              </>
+            ) : null}
           </>
         ) : null}
 

--- a/ui/src/components/builder/builder-graph.ts
+++ b/ui/src/components/builder/builder-graph.ts
@@ -42,6 +42,16 @@ export interface BuilderStep {
   readonly toolId: string;
   /** TOOL: the registered tool version (defaults to "1" when blank). */
   readonly toolVersion: string;
+  /** MODEL (PR-9b-2b): the author-declared tool-grant SET `{tool_id: version}` that
+   *  makes this a DETERMINISTIC-AGENTIC step — a bounded reason→tool→observe loop over
+   *  the FIXED set (the set is part of the step's identity). Empty ⇒ a plain model step
+   *  (byte-identical to before). The SERVER builds the union warrant + drives the loop
+   *  (SN-8: client tool_grants stay refused). */
+  readonly toolContract: Readonly<Record<string, string>>;
+  /** MODEL agentic: the per-step turn budget (default 8; `0 < maxToolCalls < maxTurns ≤ 8`). */
+  readonly maxTurns?: number;
+  /** MODEL agentic: the per-step tool-call budget (default 6). */
+  readonly maxToolCalls?: number;
 }
 
 /** One authored edge (by client-local node id). `instruction` (D141.5) is the
@@ -130,6 +140,16 @@ export function validationError(graph: BuilderGraph): string | null {
     if (s.kind === "tool" && s.toolId.trim() === "") {
       return `Tool step "${s.label}" needs a registered tool.`;
     }
+    // PR-9b-2b: a deterministic-agentic step's budget must satisfy the loop invariant
+    // (mirrors the server's `react_seed_params` + the SDK lowering gate). Defaults
+    // (8 / 6) are valid; an explicit out-of-range pair is refused at authoring.
+    if (s.kind === "model" && Object.keys(s.toolContract).length > 0) {
+      const turns = s.maxTurns ?? 8;
+      const calls = s.maxToolCalls ?? 6;
+      if (calls < 1 || calls >= turns || turns > 8) {
+        return `Agent step "${s.label}" tool budget must satisfy 0 < tool-calls < turns ≤ 8.`;
+      }
+    }
     if (s.paramsText.trim() !== "" && !isJsonObject(s.paramsText)) {
       return `Step "${s.label}" ${s.kind === "tool" ? "args" : "params"} must be a JSON object.`;
     }
@@ -184,6 +204,23 @@ export function toRequest(graph: BuilderGraph, seed = 0) {
       // is byte-identical to the Py/TS/CLI surfaces (the golden-corpus contract).
       step = task
         .tool(s.toolId, s.toolVersion.trim() === "" ? "1" : s.toolVersion, toolArgs(s))
+        .toStepInput();
+    } else if (s.kind === "model" && Object.keys(s.toolContract).length > 0) {
+      // PR-9b-2b: a DETERMINISTIC-AGENTIC step — reuse the SDK `task.model(tools=,
+      // maxTurns=, maxToolCalls=)` factory so the tool_contract + budget→params
+      // lowering is BYTE-IDENTICAL to the chains DSL / CLI (the golden corpus). The
+      // server builds the union warrant + parks/drives the bounded loop.
+      let prompt = s.prompt;
+      const instr = inbound.get(s.id);
+      if (instr && instr.length > 0) {
+        prompt = `${instr.join("\n\n")}\n\n${s.prompt}`.trim();
+      }
+      step = task
+        .model(s.modelId, prompt, paramsRecord(s), {
+          tools: s.toolContract,
+          maxTurns: s.maxTurns,
+          maxToolCalls: s.maxToolCalls,
+        })
         .toStepInput();
     } else {
       const params = paramsRecord(s);
@@ -270,5 +307,6 @@ export function newStep(kind: BuilderStepKind, id: string): BuilderStep {
     reasoning: "",
     toolId: "",
     toolVersion: "",
+    toolContract: {},
   };
 }

--- a/ui/src/kx/use-clone-graph.ts
+++ b/ui/src/kx/use-clone-graph.ts
@@ -95,6 +95,10 @@ export function useCloneGraph(instanceId: string | null): UseCloneGraph {
           // TOOL step (the projection's stepKind is model|pure), so empty is correct.
           toolId: "",
           toolVersion: "",
+          // A cloned MODEL step's tool-grant set is re-authored in the builder (the
+          // projection exposes stepKind, not the agentic tool_contract); empty ⇒ a
+          // plain model step until the user grants a set.
+          toolContract: {},
         };
       });
       const edges: BuilderEdge[] = [];


### PR DESCRIPTION
Completes PR-9b-2 (after 9b-2a journal substrate `#235`): the **authored / frozen tool-calling lane**. A MODEL step carrying an author-declared `@tool` set (`plan@mcp-echo > review`) now **PARKS** at lease and the coordinator drives its **bounded reason→tool→observe loop** on a private `step_salt`-keyed chain, committing the launch mote (with the loop's final answer) to **advance the frozen DAG**. Two commits: `f047ff4` (B0 substrate — salt-2 builders + `ReactRound.step_salt` projection/checkpoint plumbing) + `cd02a81` (B1–B5 execution).

## What changed
- **B1** `is_agentic_launch` predicate (ROND + StageThenCommit + `PROMPT_KEY` + no `TOOL_ARGS_KEY`) + **6 reciprocal disjointness tests** (vs react-observation / authored-tool / react-turn).
- **B2** sole-writer deep core (`kx-coordinator/state.rs`): park in `lease_ready`; `Dispatch.parked_launches` (launch→instance_id, captured at submit); `settle_agentic_launches` anchors turn-0 (salt-2 `build_agentic_turn`, budget via `react_seed_params`); `drive_react_chain` (the chain-keyed PR-2d driver) + `settle_react_chain` wrapper + `finalize_agentic_launch` (terminal Answer → `commit_agentic_launch`; budget-exhaust/dead-letter → `dead_letter_agentic_launch`, fail-closed `FailureReason::DeadLettered`); `recover_react_chain` iterates `react_chains()`; `run_settle_passes`. Projection: **nested** `react_index` (`instance_id → step_salt → idx`) + `react_chains()` + compound `react_rounds_of`/`latest_react_round` (run-level `None` byte-unchanged; `is_react_turn_mote` untouched). `react_shape::build_chain_turn`/`build_chain_tool`.
- **B3** gateway `agentic_step_warrant` (fail-closed UNION over the declared set — each tool resolved, BUG-24 empty-syscall filter, net/fs LUB-or-refuse, ROND + served route) + `validate_agentic_budget` + **flip the binder refusal** to a generator StepDef admitted-direct (SN-8: client `tool_grants` ignored — BLOCKER-#5).
- **B5** UI per-step tool-grant chip editor + budget inputs (`StepConfigDrawer`/`builder-graph`, reuses the SDK `model(tools=,…)` lowering for golden parity) + **2 live e2e** in `react_live.rs` (headline park→drive→obs-COMMITS→launch-commits→DAG-advances, incl. the 48-byte-marker trajectory assertion; budget-exhaust → dead-letter). SDK Agent docstrings/messages corrected to honest (the loop is LIVE via explicit refs; the `Agent(tools=[local_fn])` one-liner = the BUG-32 follow-up).

## 5 adversarial corrections folded (from a plan-mode Plan-agent pass)
1. `resolve_parent_context` 16B/48B marker branch — the empty-transcript trap (an agentic turn's 48-byte marker decoded as 16B → empty trajectory → silent loop-break). Now directly asserted in the e2e.
2. **B4 = fail-closed dead-letter** matching the standing DAG-failure semantic — a `Failed` launch hangs its child exactly as ANY failed mote does (`helpers.rs`). Runtime-wide terminal-failure DAG-propagation is a **GR16 follow-up**, NOT an agentic-only cascade.
3. Guard the launch-commit BEFORE append (it bypasses `flush_commits`' guards).
4. Drain-driven + idempotent finalize (`step_salt.is_none()`; the launch def is lost on crash → re-submit-driven).
5. NESTED `react_index` (not a flat compound key) — keeps `react_instances()`/`is_react_turn_mote` untouched.

## Invariants (GR8 / GR9)
- Canonical digest **`7d22d4bd` INVARIANT** (a0_guard / audit_trail / checkpoint_recovery) — off-DAG `ReactRound`/`step_salt` + the derived nested index never enter the digest.
- **Frozen trio** (`kx-scheduler`/`kx-executor`/`kx-inference` src) **EMPTY** — the thesis test holds.
- **`Cargo.lock` + proto UNCHANGED** (no new deps, no wire change — `tool_contract`/`params` already carry everything).
- fwd/back-compat: an opt-in agentic run commits a real new launch mote ⇒ that *workflow's* digest is honestly different (not a canonical-demo regression).

## Gate (full local `just ci`-equivalent — all green)
clippy `-D warnings` (workspace) · fmt · doc · **workspace test 347/347** · **check-reproducible (I1.c) PASS** · scale-smoke (fold stays linear) · smoke-test-with-model · GR10 profile (no regression: submit→committed p50 29.6ms / warmup 14.6ms) · UI biome/tsc/vitest 593 · SDK pytest/mypy/biome/tsc/vitest.

## Live Gemma-4-12B witness (GR15-honest)
Served Gemma-4-12b + authored `plan@mcp-echo > review`: the serve log shows **`agentic launch chain anchored`** → Gemma drove turn-0 → **fail-closed dead-letter** when it proposed `mcp-echo:echo` ≠ grant `mcp-echo` → run FAILED honestly (no fabricated answer; `kx react list` shows the durable `dead_lettered` chain). The runtime mechanism is end-to-end proven on a real model; live tool-*firing* is gated by **BUG-32** (dialed-tool name reconciliation), the explicitly-sequenced next PR — now confirmed to affect the authored lane too. The model-free e2e covers the fire-commits/DAG-advance happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Np7vauKDt9Rmx2oNXfDN3i