### PR TITLE
PR-1 — BUG-32: live tool-firing (lane-agnostic name resolution) across runtime + SDK + docs

### DIFF
--- a/bindings/python/src/kortecx/agent.py
+++ b/bindings/python/src/kortecx/agent.py
@@ -12,11 +12,12 @@ Two lanes (D161), one object — the API name mirrors the distinction:
 - **Default = deterministic / frozen** — a single agent step with a FIXED tool-grant
   SET (replayable; the tool set is part of the step's identity). Pure client sugar over
   :class:`~kortecx.flow.Flow`. The frozen tool-EXECUTION (the bounded reason→tool→observe
-  loop) is **LIVE as of PR-9b-2** — author it with EXPLICIT tool refs via
-  ``flow().model(prompt, tools=["mcp-echo"])`` / the ``model@tool`` chain DSL / a UI
-  builder model step. The ``Agent(tools=[fn])`` one-liner over LOCAL ``@kx.tool``
-  functions completes in the immediate follow-up (the dialed-tool grant-name match); a
-  tool-bearing frozen ``Agent`` raises a clear pre-flight hint until then.
+  loop) is **LIVE** — the ``Agent(tools=[fn])`` one-liner over LOCAL ``@kx.tool``
+  functions now fires: ``run`` registers each function as a stdio MCP tool and grants its
+  namespaced ``<server>/<name>`` to the step, and the served model dials it (a bare/leaf
+  name resolves to the grant). No ``KX_SERVE_AUTOGRANT`` needed (the step grants its own
+  tools). EXPLICIT refs (``flow().model(prompt, tools=["mcp-echo"])`` / the ``model@tool``
+  chain DSL / a UI builder model step) work the same way.
 - ``dynamic=True`` → the **steered** ``kx/recipes/react`` recipe, where the model picks
   tools turn by turn. Works today.
 
@@ -91,11 +92,11 @@ class Agent:
     ) -> "Union[Run, Result]":
         """Run ``task``.
 
-        - **frozen lane (default)** ⇒ a single agent step. The tool-bearing frozen
-          loop EXECUTION is LIVE (PR-9b-2) via EXPLICIT tool refs
-          (``flow().model(prompt, tools=["mcp-echo"])`` / ``model@tool`` / a UI builder
-          model step); the ``Agent(tools=[fn])`` one-liner over LOCAL functions raises a
-          pre-flight hint until the immediate follow-up wires its dialed-tool grant name.
+        - **frozen lane (default)** ⇒ a single agent step. The tool-bearing frozen loop
+          EXECUTION is LIVE — the ``Agent(tools=[fn])`` one-liner over LOCAL functions
+          fires (``run`` resolves each ``@kx.tool`` to its namespaced grant on the step),
+          as do EXPLICIT refs (``flow().model(prompt, tools=["mcp-echo"])`` / ``model@tool``
+          / a UI builder model step). No ``KX_SERVE_AUTOGRANT`` needed.
         - ``dynamic=True`` ⇒ the steered react lane. With tools it routes to
           ``kx/recipes/react-auto`` (the only lane that fires registered/dialed tools;
           needs ``KX_SERVE_AUTOGRANT=1``); without tools, plain ``kx/recipes/react``.
@@ -128,17 +129,13 @@ class Agent:
                     "serve with KX_SERVE_AUTOGRANT=1 to enable it (it auto-grants the "
                     "registered tool set to the loop)"
                 ) from exc
-        if has_tools:
-            from .tools import ToolError
-
-            raise ToolError(
-                "the deterministic-agentic loop is LIVE (PR-9b-2), but the Agent(tools=) "
-                "one-liner over local @kx.tool functions completes in the immediate "
-                "follow-up (the dialed-tool grant-name match); author it today with "
-                "EXPLICIT refs via flow().model(prompt, tools=['mcp-echo']) or the "
-                "`model@tool` chain DSL, use Agent(..., dynamic=True) for the steered "
-                "react lane, or flow().tool(fn, **args) to fire one tool deterministically"
-            )
+        # Frozen lane (with OR without tools): a single agent step whose tool-grant
+        # SET is part of the step's identity (replayable). `as_flow` → `run_chain`
+        # resolves any local `@kx.tool` functions to their namespaced `<server>/<name>`
+        # and writes them into the step's tool_contract; the served model fires them in
+        # a bounded reason→tool→observe loop (a model's bare/leaf name resolves to the
+        # grant — the BUG-32 fix). No `KX_SERVE_AUTOGRANT` needed: the step grants its
+        # OWN exact tools (SN-8 — the server still compiles + warrants every step).
         return self.as_flow(task).run(wait=wait, timeout=timeout, client=kx)
 
     def stream(self, task: str, *, client: "Optional[KxClient]" = None) -> "Run":

--- a/bindings/python/src/kortecx/tools.py
+++ b/bindings/python/src/kortecx/tools.py
@@ -36,10 +36,11 @@ adds no new attack surface. Cloud governs the bridge.
   ``kx/recipes/react-auto`` loop where the model picks tools (needs a served model
   + ``KX_SERVE_AUTOGRANT=1``).
 - **frozen / deterministic-agentic** — a MODEL step with a fixed tool set; its bounded
-  loop EXECUTION is LIVE as of PR-9b-2 via EXPLICIT refs (``flow().model(prompt,
-  tools=["mcp-echo"])`` / the ``model@tool`` DSL). The ``Agent(tools=[fn])`` one-liner
-  over LOCAL functions completes in the immediate follow-up (the dialed-tool grant-name
-  match), so a tool-bearing frozen ``Agent`` raises a clear pre-flight hint until then.
+  loop EXECUTION is LIVE. The ``Agent(tools=[fn])`` one-liner over LOCAL functions fires
+  (``run`` registers each function as a stdio MCP tool and grants its namespaced
+  ``<server>/<name>`` to the step; a model's bare/leaf call resolves to that grant), as do
+  EXPLICIT refs (``flow().model(prompt, tools=["mcp-echo"])`` / the ``model@tool`` DSL).
+  No ``KX_SERVE_AUTOGRANT`` needed — the frozen step grants its OWN exact tools.
 
 **Re-import contract.** The runtime spawns ``python -m kortecx._toolserver`` which
 re-loads your module to recover the functions. Decorate at MODULE level and guard

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -2,8 +2,8 @@
 
 Covers the decorator + type-hint→inputSchema mapping, the ``tool`` overload
 (decorator vs the back-compat node factory), tool-set splitting, the run-terminal
-resolution against a mock client, the Agent routing (frozen pre-flight hint +
-dynamic→react-auto), and the hand-rolled stdio MCP server round-trip.
+resolution against a mock client, the Agent routing (frozen one-liner resolves +
+fires via run_chain; dynamic→react-auto), and the hand-rolled stdio MCP server round-trip.
 """
 
 from __future__ import annotations
@@ -143,6 +143,7 @@ class _FakeClient:
     def __init__(self) -> None:
         self.registered: List[tuple] = []
         self.invoked: List[tuple] = []
+        self.ran_chains: List[object] = []
 
     def register_mcp_server(self, *, name, transport, endpoint, args):  # noqa: ANN001
         self.registered.append((name, transport, endpoint, tuple(args)))
@@ -176,6 +177,14 @@ class _FakeClient:
     def invoke(self, handle, args, *, wait=True, timeout=120.0):  # noqa: ANN001
         self.invoked.append((handle, args, wait))
         return "INVOKED"
+
+    def run_chain(self, chain, *, wait=False, timeout=120.0):  # noqa: ANN001
+        # Mirror the real KxClient.run_chain: resolve local tools (register +
+        # rewrite each step's tool_contract to the namespaced name) then record the
+        # resolved chain for inspection. The frozen lane reaches here (NOT invoke).
+        resolve_local_tools(self, chain)
+        self.ran_chains.append(chain)
+        return "RAN"
 
 
 def _add_tool():  # noqa: ANN202
@@ -231,10 +240,19 @@ def test_resolve_noop_without_local_tools() -> None:
 # --- Agent routing ------------------------------------------------------------
 
 
-def test_agent_frozen_with_tools_raises_preflight_hint() -> None:
+def test_agent_frozen_with_tools_fires_via_resolved_contract() -> None:
+    # BUG-32 fix: the frozen `Agent(tools=[fn])` one-liner now RESOLVES the local
+    # tool onto its model step (no pre-flight raise) and runs it via run_chain —
+    # NOT through the dynamic react-auto invoke path.
     add = _add_tool()
-    with pytest.raises(ToolError, match="PR-9b-2"):
-        Agent("do math", tools=[add]).run("2+2", client=_FakeClient())
+    fc = _FakeClient()
+    Agent("do math", tools=[add]).run("2+2", client=fc)
+    assert fc.registered, "the frozen lane registers the local tool's stdio server"
+    assert not fc.invoked, "the frozen lane does NOT route through invoke / react-auto"
+    sname = _server_name_for(local_tool_def(add).script_path)
+    step = fc.ran_chains[0]._iter_steps()[0]
+    assert step.kind == "model"
+    assert step.tool_contract == {f"{sname}/add": "1"}
 
 
 def test_agent_dynamic_with_local_tools_routes_to_react_auto() -> None:

--- a/bindings/typescript/src/agent.ts
+++ b/bindings/typescript/src/agent.ts
@@ -9,8 +9,10 @@
  *
  * Default lane = deterministic/frozen (a single agent step — replayable, the tool set
  * is part of identity); `dynamic: true` routes to the steered `kx/recipes/react`
- * recipe. The frozen tool-EXECUTION is LIVE as of PR-9b-2 (author with explicit tool
- * refs via `flow().model(prompt, { tools })`). SN-8: intent only.
+ * recipe. The frozen tool-EXECUTION is LIVE — the `Agent({ tools: [fn] })` one-liner over
+ * local `localTool(...)` defs now fires (`run` registers each as a stdio MCP tool and
+ * grants its namespaced `<server>/<name>` to the step; a model's bare/leaf call resolves
+ * to that grant). No `KX_SERVE_AUTOGRANT` needed. SN-8: intent only.
  */
 
 import type { ReasoningMode } from "./chains.js";
@@ -103,10 +105,10 @@ export class Agent {
    * Run `task`.
    *
    * - **frozen lane (default)** ⇒ a single agent step. The tool-bearing frozen loop
-   *   EXECUTION is LIVE (PR-9b-2) via EXPLICIT tool refs (`flow().model(prompt, { tools:
-   *   ["mcp-echo"] })` / the `model@tool` chain DSL / a UI builder model step); the
-   *   `Agent({ tools: [fn] })` one-liner over LOCAL functions throws a pre-flight hint
-   *   until the immediate follow-up wires its dialed-tool grant name.
+   *   EXECUTION is LIVE — the `Agent({ tools: [fn] })` one-liner over LOCAL functions
+   *   fires (`run` resolves each `localTool(...)` to its namespaced grant on the step),
+   *   as do EXPLICIT refs (`flow().model(prompt, { tools: ["mcp-echo"] })` / the
+   *   `model@tool` chain DSL / a UI builder model step). No `KX_SERVE_AUTOGRANT` needed.
    * - `dynamic: true` ⇒ the steered react lane. With tools it routes to
    *   `kx/recipes/react-auto` (the only lane that fires registered/dialed tools; needs
    *   `KX_SERVE_AUTOGRANT=1`); without tools, plain `kx/recipes/react`.
@@ -143,15 +145,13 @@ export class Agent {
         throw e;
       }
     }
-    if (hasTools(tools)) {
-      throw new KxToolError(
-        "the deterministic-agentic loop is LIVE (PR-9b-2), but the Agent({ tools }) " +
-          "one-liner over local tool functions completes in the immediate follow-up (the " +
-          "dialed-tool grant-name match); author it today with EXPLICIT refs via " +
-          "flow().model(prompt, { tools: ['mcp-echo'] }) or the `model@tool` chain DSL, use " +
-          "{ dynamic: true } for the steered react lane, or flow().tool(fn, args) to fire one tool",
-      );
-    }
+    // Frozen lane (with OR without tools): a single agent step whose tool-grant SET is
+    // part of the step's identity (replayable). `asFlow` → `runChain` resolves any local
+    // `localTool(...)` defs to their namespaced `<server>/<name>` and writes them into the
+    // step's toolContract; the served model fires them in a bounded reason→tool→observe
+    // loop (a model's bare/leaf name resolves to the grant — the BUG-32 fix). No
+    // `KX_SERVE_AUTOGRANT` needed: the step grants its OWN exact tools (SN-8 — the server
+    // still compiles + warrants every step).
     return this.asFlow(task).run({
       wait: opts.wait,
       timeoutMs: opts.timeoutMs,

--- a/bindings/typescript/src/tools.ts
+++ b/bindings/typescript/src/tools.ts
@@ -26,7 +26,9 @@
  *
  * **Firing lanes (GR15-honest):** deterministic `flow().tool(fn, args)` (today) ·
  * steered `new Agent({ tools:[fn], dynamic:true })` → `kx/recipes/react-auto` (today,
- * needs `KX_SERVE_AUTOGRANT=1`) · frozen agentic loop → PR-9b-2 (a clear pre-flight hint).
+ * needs `KX_SERVE_AUTOGRANT=1`) · frozen agentic loop → `new Agent({ tools:[fn] })`
+ * fires the bounded reason→tool→observe loop (the step grants its OWN resolved tools;
+ * no `KX_SERVE_AUTOGRANT` needed).
  */
 
 import { type Chain, type Task, task } from "./chains.js";

--- a/bindings/typescript/test/tools.test.ts
+++ b/bindings/typescript/test/tools.test.ts
@@ -10,9 +10,9 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 import { Agent, REACT_AUTO_RECIPE_HANDLE, REACT_RECIPE_HANDLE } from "../src/agent.js";
+import type { Chain } from "../src/chains.js";
 import { flow } from "../src/flow.js";
 import {
-  KxToolError,
   type LocalToolDef,
   isLocalTool,
   localTool,
@@ -95,6 +95,7 @@ describe("tools=[...] splitting", () => {
 class FakeClient {
   registered: Array<{ name: string; transport: string; endpoint: string; args: string[] }> = [];
   invoked: Array<{ handle: string }> = [];
+  ranChains: Array<{ resolved: ReadonlyMap<LocalToolDef, string> | undefined }> = [];
 
   async registerMcpServer(input: {
     name: string;
@@ -115,8 +116,11 @@ class FakeClient {
     return "INVOKED";
   }
 
-  // The frozen-tools Agent lane throws before this is reached (it satisfies AgentClient).
-  async runChain(): Promise<unknown> {
+  // Mirror KxClientBase.runChain: resolve any local tools (register + build the
+  // namespaced map) and record it. The frozen `Agent(tools=[fn])` lane reaches here.
+  async runChain(chain: Chain, _opts?: { wait?: boolean; timeoutMs?: number }): Promise<unknown> {
+    const resolved = await resolveLocalTools(this, chain);
+    this.ranChains.push({ resolved });
     return "RAN";
   }
 }
@@ -152,10 +156,15 @@ describe("resolveLocalTools", () => {
 describe("Agent routing", () => {
   const add = localTool({ name: "add", params: { a: "integer" }, run: ({ a }) => a });
 
-  it("frozen + tools throws a pre-flight hint", async () => {
-    await expect(
-      new Agent("go", { tools: [add] }).run("2+2", { client: new FakeClient() }),
-    ).rejects.toThrow(KxToolError);
+  it("frozen + tools resolves the local tool + fires via runChain", async () => {
+    // BUG-32 fix: the frozen one-liner now RESOLVES the local tool onto its step and
+    // runs it via runChain — no pre-flight throw, NOT the dynamic react-auto invoke.
+    const fc = new FakeClient();
+    await new Agent("go", { tools: [add] }).run("2+2", { client: fc });
+    expect(fc.registered.length).toBeGreaterThan(0);
+    expect(fc.invoked.length).toBe(0);
+    const serverName = serverNameFor(add.module);
+    expect(fc.ranChains[0]?.resolved?.get(add)).toBe(`${serverName}/add`);
   });
 
   it("dynamic + local tools registers + routes to react-auto", async () => {

--- a/crates/kx-context-assembler/src/assemble.rs
+++ b/crates/kx-context-assembler/src/assemble.rs
@@ -12,18 +12,23 @@ use kx_warrant::WarrantSpec;
 use crate::errors::AssemblyError;
 use crate::types::{AssembledContext, AssembledItem};
 
-/// PR-6a: render the tool-menu text the model sees for a granted tool — its
-/// description PLUS, when the tool declares a typed `inputSchema`, a deterministic
+/// PR-6a/PR-1: render the tool-menu text the model sees for a granted tool — the
+/// EXACT callable name (`grant_id`, PR-1/BUG-32 name-steering), then its description
+/// PLUS, when the tool declares a typed `inputSchema`, a deterministic
 /// one-line-per-parameter block (name · type · required/optional). This is the
-/// "suggest better tools/steps" lever: the model proposes well-formed calls
-/// instead of guessing argument shapes; the runtime still validates the proposed
-/// args fail-closed against the SAME schema (SN-8 — advisory in, exact enforced).
-/// A tool with NO schema yields its description verbatim (legacy-byte-identical).
-fn tool_menu_text(def: &ToolDef) -> String {
+/// "suggest better tools/steps" lever: the model proposes well-formed calls with
+/// the granted name (a dialed/local tool is registered NAMESPACED `<server>/<remote>`
+/// — leading with `name:` steers the model to emit it verbatim) instead of guessing.
+/// The runtime still validates the proposed name+args fail-closed against the grant
+/// set and the SAME schema (SN-8 — advisory in, exact enforced). The `name:` line is
+/// advisory prompt bytes only: it lands in `AssembledItem.bytes` (read by the model),
+/// never in `source_ref`/the journal/`MoteId`, so it moves no committed-fact digest.
+fn tool_menu_text(grant_id: &str, def: &ToolDef) -> String {
+    let head = format!("name: {grant_id}\n");
     let Some(schema) = &def.input_schema else {
-        return def.description.clone();
+        return format!("{head}{}", def.description);
     };
-    let mut text = def.description.clone();
+    let mut text = format!("{head}{}", def.description);
     text.push_str("\nInputs:");
     for p in &schema.params {
         let ty = match &p.ty {
@@ -172,7 +177,8 @@ pub fn assemble<S: ContentStore>(
         // tool calls (the runtime still validates args fail-closed against the
         // same `inputSchema`, SN-8). A tool with NO schema is byte-unchanged (the
         // description alone), so legacy menus are identical.
-        let desc_bytes = Bytes::copy_from_slice(tool_menu_text(&resolved.def).as_bytes());
+        let desc_bytes =
+            Bytes::copy_from_slice(tool_menu_text(&grant.tool_id.0, &resolved.def).as_bytes());
         let label = format!("tool.{}@{}", grant.tool_id.0, grant.tool_version.0);
         items.push(AssembledItem {
             label,
@@ -244,9 +250,23 @@ mod tool_menu_tests {
     }
 
     #[test]
-    fn no_schema_is_description_verbatim() {
-        // Legacy-byte-identical: a tool with no schema yields its description.
-        assert_eq!(tool_menu_text(&def(None)), "List a directory.");
+    fn no_schema_is_name_then_description() {
+        // PR-1/BUG-32 name-steering: the menu leads with the EXACT granted name so a
+        // model emits it verbatim, then the description.
+        assert_eq!(
+            tool_menu_text("fs-list", &def(None)),
+            "name: fs-list\nList a directory."
+        );
+    }
+
+    #[test]
+    fn namespaced_grant_id_steers_the_model() {
+        // A dialed/local tool is granted NAMESPACED; the `name:` line carries the
+        // full callable id (the grant id, not the def's bare name).
+        assert_eq!(
+            tool_menu_text("kxlocal-a1b2c3d4/multiply", &def(None)),
+            "name: kxlocal-a1b2c3d4/multiply\nList a directory."
+        );
     }
 
     #[test]
@@ -260,8 +280,8 @@ mod tool_menu_tests {
             deny_unknown: true,
         };
         assert_eq!(
-            tool_menu_text(&def(Some(schema))),
-            "List a directory.\nInputs:\n  - path (string, optional)"
+            tool_menu_text("fs-list", &def(Some(schema))),
+            "name: fs-list\nList a directory.\nInputs:\n  - path (string, optional)"
         );
     }
 }

--- a/crates/kx-context-assembler/src/tests.rs
+++ b/crates/kx-context-assembler/src/tests.rs
@@ -205,8 +205,9 @@ fn assemble_two_parents_one_tool() {
     // Parent bytes are resolved content (NEVER hashes).
     assert_eq!(&ctx.items[0].bytes[..], parent_a_bytes);
     assert_eq!(&ctx.items[1].bytes[..], parent_b_bytes);
-    // Tool item carries the description.
-    assert_eq!(&ctx.items[2].bytes[..], b"reads files");
+    // Tool item leads with the granted name (PR-1/BUG-32 steering), then the
+    // description (this byte change is prompt-only — see `source_ref` below).
+    assert_eq!(&ctx.items[2].bytes[..], b"name: fs-read\nreads files");
 }
 
 // -----------------------------------------------------------------

--- a/crates/kx-context-assembler/tests/proptest_assembler.rs
+++ b/crates/kx-context-assembler/tests/proptest_assembler.rs
@@ -23,8 +23,9 @@
 //!    `source_ref == ContentRef::of(bytes)` for the parent path; this property
 //!    proves the negative invariant ("bytes is never the hash") across BOTH
 //!    code paths in `assemble`.
-//! 7. **Tool-path shape (H-2)**: tool items carry `description.as_bytes()` as
-//!    `bytes` and `blake3(canonical_bincode(ToolDef))` as `source_ref`. The
+//! 7. **Tool-path shape (H-2)**: tool items carry the menu text
+//!    (`"name: <grant_id>\n<description>"`, PR-1/BUG-32 name-steering) as `bytes`
+//!    and `blake3(canonical_bincode(ToolDef))` as `source_ref`. The
 //!    `event.resolved_def_hash` MUST match the freshly-computed hash —
 //!    deviation would mean the registry handed out a wrong content-address.
 //! 8. **Control edges contribute no content (H-2)**: a parent on a Control
@@ -431,7 +432,7 @@ proptest! {
     /// **Why this is necessary**: property 3 only proved
     /// `source_ref == ContentRef::of(bytes)` for the parent path. The tool
     /// path has `source_ref = blake3(canonical_bincode(ToolDef))` and
-    /// `bytes = description.as_bytes()` — the two are NOT related by the
+    /// `bytes = "name: <grant_id>\n<description>"` — the two are NOT related by the
     /// `ContentRef::of` equation. The negative invariant ("bytes is never
     /// equal to the 32-byte hash") needs its own proof.
     #[test]
@@ -498,7 +499,7 @@ proptest! {
     /// Property 7 (tool-path shape):
     ///
     /// When tools are granted in the warrant, each emitted tool item has:
-    ///   - `bytes = description.as_bytes()` (literal description, not the def)
+    ///   - `bytes = "name: <grant_id>\n<description>"` (menu text, not the def)
     ///   - `source_ref = blake3(canonical_bincode(ToolDef))` (the def hash)
     /// Combined with property 6, this proves the tool path doesn't leak the
     /// def hash bytes into `bytes`. The registry's resolution event's
@@ -526,10 +527,12 @@ proptest! {
             "exactly one tool item should be emitted"
         );
         let item = &ctx.items[0];
+        // PR-1/BUG-32: the menu leads with the granted name, then the description.
+        let expected_menu = format!("name: {tool_name_seed}-only\n{description}");
         prop_assert_eq!(
             item.bytes.as_ref(),
-            description.as_bytes(),
-            "tool item bytes MUST equal the literal description bytes"
+            expected_menu.as_bytes(),
+            "tool item bytes MUST be the `name:` steering line then the description"
         );
         // source_ref MUST be the canonical def hash. We can't recompute the
         // def hash here without rebuilding the ToolDef; but we CAN assert
@@ -684,7 +687,7 @@ fn mixed_parents_and_tools_emit_independent_items_with_correct_shapes() {
         .expect("tool item present");
     assert_eq!(
         &tool_item.bytes[..],
-        b"describes a tool whose description bytes go to the model"
+        b"name: h2-mixed-tool\ndescribes a tool whose description bytes go to the model"
     );
     assert_ne!(
         tool_item.source_ref,

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -621,6 +621,143 @@ async fn tool_branch_fires_and_commits_via_gemma_native_shape() {
     );
 }
 
+/// The PR-9b-2b LIVE Gemma-4-12B shape that BUG-32 made fail-closed: the model
+/// proposed `mcp-echo:echo` (the `<id>:<remote>` join) with an EMPTY version against
+/// the `mcp-echo@1` grant. Before the fix the JSON-envelope arm's exact
+/// `(name, version)` membership refused it ⇒ `UngrantedTool` ⇒ the chain
+/// dead-lettered (honest, no fabricated answer). After the fix the `:remote` tail is
+/// dropped, the head resolves to the unique grant, the GRANT's version is taken, and
+/// the tool FIRES + commits — driven through the REAL coordinator settle here.
+#[tokio::test]
+async fn bug32_envelope_versionless_drift_fires_and_commits() {
+    const TOOL_ENVELOPE_DRIFT: &[u8] =
+        br#"{"tool_call":{"name":"mcp-echo:echo","version":"","args":{"q":"x"}}}"#;
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true); // mcp-echo@1 GRANTED
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    commit_raw(&svc, &store, &turn0, &w, TOOL_ENVELOPE_DRIFT, worker).await;
+
+    // (a) the settle resolved the drifted name to `mcp-echo@1` and froze a Tool fact.
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(
+        facts.len(),
+        2,
+        "anchor + the Tool settle (the drift shape FIRED)"
+    );
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Tool { tool_id, tool_version },
+                ..
+            } if tool_id == "mcp-echo" && tool_version == "1"
+        ),
+        "`mcp-echo:echo`+empty-version resolves to the granted `mcp-echo@1`"
+    );
+
+    // (b) + (c) the observation leases with the args and COMMITS (the tool fired).
+    let (obs, args) = lease_observation(&svc, worker, &turn0).await;
+    assert_eq!(args, br#"{"q":"x"}"#.to_vec());
+    commit_raw(&svc, &store, &obs, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
+    assert_eq!(
+        svc.state_of(obs.id).await.unwrap(),
+        MoteState::Committed,
+        "the world-mutating observation COMMITTED — a drifted-name tool genuinely fired"
+    );
+}
+
+/// The headline BUG-32 shape (V2b): a dialed/local tool is granted NAMESPACED
+/// (`kxlocal-<hash>/echo`) but the model proposes the BARE LEAF (`echo`). The
+/// leaf must resolve to the namespaced grant (unambiguously) and the tool must
+/// fire + commit. Uses a registry + warrant whose ONLY echo tool is namespaced.
+#[tokio::test]
+async fn bug32_native_bare_leaf_against_namespaced_grant_fires_and_commits() {
+    const NS_TOOL: &str = "kxlocal-a1b2c3d4/echo";
+    const BARE_LEAF_NATIVE: &[u8] = br#"<|tool_call>call:echo{"q":"x"}<tool_call|>"#;
+
+    let namespaced_def = {
+        let mut d = echo_tool_def();
+        d.tool_id = kx_mote::ToolName(NS_TOOL.into());
+        d
+    };
+    let registry: Arc<dyn kx_tool_registry::ToolRegistry> = {
+        use kx_tool_registry::{InMemoryToolRegistry, ToolProvenance, ToolRegistry};
+        let mut reg = InMemoryToolRegistry::with_builtins();
+        let _ = reg.register(
+            namespaced_def,
+            ToolProvenance::HumanAuthored {
+                author: "test".into(),
+            },
+        );
+        Arc::new(reg)
+    };
+    let mut w = warrant(false);
+    w.tool_grants.insert(ToolGrant {
+        tool_id: kx_mote::ToolName(NS_TOOL.into()),
+        tool_version: kx_mote::ToolVersion("1".into()),
+    });
+
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator_with(&dir, registry);
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    commit_raw(&svc, &store, &turn0, &w, BARE_LEAF_NATIVE, worker).await;
+
+    // (a) the bare leaf resolved to the NAMESPACED grant and froze a Tool fact.
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(
+        facts.len(),
+        2,
+        "anchor + the Tool settle (the bare leaf FIRED)"
+    );
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Tool { tool_id, tool_version },
+                ..
+            } if tool_id == NS_TOOL && tool_version == "1"
+        ),
+        "the bare `echo` resolves to the namespaced grant `{NS_TOOL}@1`"
+    );
+
+    // (b) the observation leases (declaring the namespaced tool) WITH its args, and
+    // (c) commits — a bare-leaf model call against a namespaced grant genuinely fired.
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    assert_eq!(leased.len(), 1, "the observation is leasable");
+    let item = &leased[0];
+    let obs: Mote = item.mote.clone().unwrap().try_into().unwrap();
+    assert_eq!(
+        obs.def
+            .tool_contract
+            .get(&kx_mote::ToolName(NS_TOOL.into()))
+            .map(|v| v.0.clone()),
+        Some("1".to_string()),
+        "the observation declares the resolved NAMESPACED tool"
+    );
+    let args = item
+        .tool_args
+        .as_ref()
+        .expect("the observation leases WITH its validated args");
+    assert_eq!(args.args_bytes, br#"{"q":"x"}"#.to_vec());
+    commit_raw(&svc, &store, &obs, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
+    assert_eq!(
+        svc.state_of(obs.id).await.unwrap(),
+        MoteState::Committed,
+        "the world-mutating observation COMMITTED — a bare-leaf dialed tool fired"
+    );
+}
+
 /// PR-9a (the format-drift fail-closed invariant): an UNRECOGNIZED tool-shaped
 /// completion under a GRANTING warrant commits as an ANSWER and fires NOTHING —
 /// the SN-8 default. This is the durable invariant a format guard can hold: a

--- a/crates/kx-gateway/tests/react_auto_serve.rs
+++ b/crates/kx-gateway/tests/react_auto_serve.rs
@@ -143,3 +143,103 @@ async fn autogrant_serve_provisions_react_auto_and_drives_a_live_chain() {
     running.shutdown().await.unwrap();
     std::env::remove_var("KX_SERVE_AUTOGRANT");
 }
+
+/// PR-1/BUG-32 (real-model integration witness, LOCAL / `--ignored`): drive a served
+/// Gemma-4 model on a tool-forcing instruction against the bundled `mcp-echo`
+/// (namespaced/dialed) tool and assert the chain reaches a **terminal answer** — i.e.
+/// when the model dials the tool by the (bare/decorated) name it reads from the menu,
+/// the authority gate RESOLVES it to the namespaced grant and the tool FIRES, instead
+/// of refusing it `UngrantedTool` (the BUG-32 symptom: a refused dial dead-letters the
+/// chain with no answer). The assertion is the non-flaky invariant (the chain settles,
+/// never dead-letters on a dialed tool); whether a `tool` round actually fired is
+/// model-nondeterministic (the model may answer a trivial echo directly), so it is
+/// LOGGED for the operator, not asserted. CI keeps the DETERMINISTIC model-free
+/// fire-commits proof (`kx-coordinator/tests/react_live.rs`, which stage Gemma's EXACT
+/// byte shapes — `mcp-echo:echo` + bare leaf). Run with `KX_SERVE_MODEL_GGUF=<gemma>`.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real in-process LLM inference; needs a GGUF; opt in with --ignored"]
+async fn react_auto_dialed_tool_resolves_and_the_chain_settles() {
+    let Some(gguf) = serve_model() else {
+        eprintln!("skipping: no serve model — set KX_SERVE_MODEL_GGUF (a real GGUF)");
+        return;
+    };
+    std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+    std::env::set_var("KX_SERVE_AUTOGRANT", "1");
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_AUTO_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: react-auto not provisioned — bundled kx-mcp-echo missing");
+        running.shutdown().await.unwrap();
+        std::env::remove_var("KX_SERVE_AUTOGRANT");
+        return;
+    }
+
+    // A tool-forcing instruction. `mcp-echo` is a dialed/namespaced tool — the model
+    // proposes whatever short name it reads from the menu, and the BUG-32 gate resolves
+    // that to the grant (a refused dial would dead-letter the chain ⇒ no answer below).
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_AUTO_RECIPE_HANDLE.to_string(),
+            args: br#"{"instruction":"You MUST use the echo tool to echo the exact text 'pong'. Call the tool first, then report what it returned.","max_turns":6,"max_tool_calls":3}"#
+                .to_vec(),
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke kx/recipes/react-auto")
+        .into_inner();
+
+    let mut fired = false;
+    let mut settled = false;
+    let mut last = String::new();
+    // ~120s: ample for the fast default agent model (`just fetch-agent-model` ⇒
+    // Qwen3-0.6B settles in ~3s). A large opt-in model (e.g. Gemma-4-12B via
+    // KX_SERVE_MODEL_GGUF) running a multi-turn tool loop can exceed this — that is
+    // model slowness, not a failure; raise the bound when driving a big model.
+    for _ in 0..1200 {
+        let turns = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        let branches: Vec<&str> = turns.turns.iter().map(|t| t.branch.as_str()).collect();
+        let snap = format!("{branches:?}");
+        if snap != last {
+            eprintln!("BUG-32 witness — trajectory so far: {snap}");
+            last = snap;
+        }
+        fired |= turns.turns.iter().any(|t| t.branch == "tool");
+        if turns.turns.iter().any(|t| t.branch == "answer") {
+            settled = true;
+            eprintln!("BUG-32 witness — SETTLED. tool fired: {fired}");
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        settled,
+        "the chain settled a terminal Answer — a dialed tool RESOLVED + fired (or the \
+         model answered directly); it did NOT dead-letter on an UngrantedTool refusal \
+         (the BUG-32 regression). tool fired this run: {fired}"
+    );
+
+    running.shutdown().await.unwrap();
+    std::env::remove_var("KX_SERVE_AUTOGRANT");
+}

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -161,24 +161,61 @@ fn balanced_object(s: &str) -> Option<&str> {
     None
 }
 
-/// Resolve a model-emitted (often separator-variant, version-less) tool name to a
-/// GRANTED `(ToolName, ToolVersion)`, SN-8-safe. Normalization is SEPARATOR-ONLY
-/// (`_`→`-`, matching how Gemma renders `fs-list` as `fs_list`) — never an
-/// arbitrary remap. Resolution = the UNIQUE granted tool whose name, after the
-/// SAME separator-normalization on BOTH sides, equals the model's. Ambiguity (two
-/// granted tools collapsing to one normalized name) ⇒ `None` (fail-closed — no
-/// guessing). The returned version is whatever the grant pins, so the downstream
-/// `tool_grants.contains` check is exact by construction.
-fn resolve_granted_name(raw_name: &str, warrant: &WarrantSpec) -> Option<ToolGrant> {
-    fn norm(s: &str) -> String {
-        s.replace('_', "-")
+/// Separator-canonicalize a single name segment: `_`→`-` (matching how Gemma
+/// renders `fs-list` as `fs_list`), trimmed. This is the EXISTING gate
+/// normalization, factored out — NEVER a fuzzy/similarity/edit-distance remap
+/// (SN-8: no similarity on any identity path).
+fn canon(s: &str) -> String {
+    s.trim().replace('_', "-")
+}
+
+/// Reduce a model-emitted name to its identity core: drop an `@version` tail, then
+/// a `:remote` tail — decorations a grant's `tool_id` never carries (the model
+/// reconstructs `<id>:<remote>` from the menu, or copies the `tool.<id>@<ver>`
+/// label), then `canon`. The version is authoritatively the grant's (taken by the
+/// caller) and the remote-name is the tool's internal wiring, never an identity the
+/// warrant grants on — so dropping them cannot reach a tool outside the grant set.
+/// Total + panic-free (`split` always yields at least one element).
+fn model_name_core(raw_name: &str) -> String {
+    let no_ver = raw_name.split('@').next().unwrap_or(raw_name);
+    let no_remote = no_ver.split(':').next().unwrap_or(no_ver);
+    canon(no_remote)
+}
+
+/// True iff `target` (an already-`canon`'d model name core) addresses `tool_id` by
+/// one of its canonical aliases: the FULL id (today's behavior) OR the leaf segment
+/// after the last `/` (the namespace strip — a dialed/local MCP tool is registered
+/// `<server>/<remote>`, but a model proposes the short leaf `<remote>`). EXACT
+/// segment equality only — never a prefix/substring/fuzzy match (SN-8).
+fn id_matches(target: &str, tool_id: &str) -> bool {
+    let full = canon(tool_id);
+    if full == target {
+        return true;
     }
-    let target = norm(raw_name);
+    match full.rsplit_once('/') {
+        Some((_, leaf)) => !leaf.is_empty() && leaf == target,
+        None => false,
+    }
+}
+
+/// Resolve a model-emitted (often separator-variant, version-less, or
+/// namespace-stripped) tool name to a GRANTED `(ToolName, ToolVersion)`, SN-8-safe.
+/// Resolution = the UNIQUE granted tool addressed by the model's name core (its
+/// full id OR the leaf after the last `/`, both `canon`-normalized). ANY ambiguity
+/// (two distinct grants addressed by the same core) ⇒ `None` (fail-closed — no
+/// guessing). The returned version is whatever the grant pins, so the downstream
+/// `tool_grants` membership is exact by construction. NEVER widens the grant set:
+/// the result is always an element of `warrant.tool_grants` (cloned) or `None`.
+fn resolve_granted_name(raw_name: &str, warrant: &WarrantSpec) -> Option<ToolGrant> {
+    let target = model_name_core(raw_name);
+    if target.is_empty() {
+        return None; // a name that canonicalizes to nothing addresses no grant
+    }
     let mut hit: Option<&ToolGrant> = None;
     for g in &warrant.tool_grants {
-        if norm(&g.tool_id.0) == target {
+        if id_matches(&target, &g.tool_id.0) {
             if hit.is_some() {
-                return None; // ambiguous ⇒ fail-closed
+                return None; // ambiguous ⇒ fail-closed (SN-8)
             }
             hit = Some(g);
         }
@@ -270,17 +307,31 @@ pub fn parse_tool_call(
         return Ok(None);
     };
 
-    // (3) The model committed to a tool call. Enforce tool ∈ warrant.tool_grants
-    //     by EXACT (name, version) crypto-equality — never fuzzy (SN-8 / D70).
+    // (3) The model committed to a tool call. Enforce tool ∈ warrant.tool_grants.
+    //     EXACT (name, version) crypto-equality is tried FIRST — byte-identical to
+    //     every prior row (SN-8 / D70). Only on an exact MISS *with an empty
+    //     version* (the `mcp-echo:echo` separator/version-drift shape a model emits
+    //     when it copies the menu label) do we resolve the name to a UNIQUE grant
+    //     and take the GRANT's version — never the model's. A NON-empty wrong
+    //     version stays `UngrantedTool` (the model pinned a different tool — SN-8;
+    //     keeps `ungranted_tool_is_refused` valid). The returned call is an element
+    //     of `tool_grants` by construction (never widens the set).
     let name = ToolName(raw.name);
     let version = ToolVersion(raw.version);
-    let grant = ToolGrant {
+    let exact = ToolGrant {
         tool_id: name.clone(),
         tool_version: version.clone(),
     };
-    if !warrant.tool_grants.contains(&grant) {
+    let grant = if warrant.tool_grants.contains(&exact) {
+        exact
+    } else if version.0.trim().is_empty() {
+        match resolve_granted_name(&name.0, warrant) {
+            Some(g) => g,
+            None => return Err(DecodeError::UngrantedTool { name, version }),
+        }
+    } else {
         return Err(DecodeError::UngrantedTool { name, version });
-    }
+    };
 
     // (4) Carry the args verbatim, size-capped (IMP-16).
     let args_bytes = raw.args.get().as_bytes().to_vec();
@@ -292,8 +343,8 @@ pub fn parse_tool_call(
     }
 
     Ok(Some(ToolCall {
-        name,
-        version,
+        name: grant.tool_id,
+        version: grant.tool_version,
         args_bytes,
     }))
 }
@@ -600,5 +651,141 @@ mod tests {
         // Open delim but no `{` ⇒ not extractable ⇒ falls through ⇒ Ok(None).
         let env = b"<|tool_call>call:fs_list no args here";
         assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    // ---- BUG-32: namespace-strip + version-drift resolution (lane-agnostic) ----
+
+    /// Grant several tools at once (the namespaced dialed-tool case the single-grant
+    /// `warrant_granting` cannot express).
+    fn warrant_granting_many(tools: &[(&str, &str)]) -> WarrantSpec {
+        let mut w = warrant_granting(None);
+        for (id, ver) in tools {
+            w.tool_grants.insert(ToolGrant {
+                tool_id: ToolName((*id).into()),
+                tool_version: ToolVersion((*ver).into()),
+            });
+        }
+        w
+    }
+
+    #[test]
+    fn bug32_native_bare_leaf_resolves_namespaced_grant() {
+        // The headline BUG-32 shape: a dialed/local tool is granted NAMESPACED, the
+        // model proposes the bare leaf. The leaf must resolve to the namespaced grant.
+        let w = warrant_granting_many(&[("kxlocal-a1b2c3d4/multiply", "1")]);
+        let env = br#"<|tool_call>call:multiply{"a":2,"b":3}<tool_call|>"#;
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a native call");
+        assert_eq!(call.name, ToolName("kxlocal-a1b2c3d4/multiply".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+        assert_eq!(call.args_bytes, br#"{"a":2,"b":3}"#.to_vec());
+    }
+
+    #[test]
+    fn bug32_envelope_bare_leaf_versionless_resolves_namespaced_grant() {
+        // Same shape via the JSON envelope, with the empty version a model emits when
+        // it copied the leaf rather than the full `tool.<id>@<ver>` label.
+        let w = warrant_granting_many(&[("kxlocal-a1b2c3d4/multiply", "1")]);
+        let env = br#"{"tool_call":{"name":"multiply","version":"","args":{"a":2}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("kxlocal-a1b2c3d4/multiply".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+    }
+
+    #[test]
+    fn bug32_envelope_separator_version_drift_resolves() {
+        // The LIVE Gemma-4-12B shape from PR-9b-2b: the model emitted `mcp-echo:echo`
+        // (the `<id>:<remote>` join) with an empty version against the `mcp-echo@1`
+        // grant. The `:remote` tail is dropped, the head resolves, the grant's
+        // version is taken. (Leaf-on-`/` alone would MISS this — there is no `/`.)
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":"mcp-echo:echo","version":"","args":{"q":"x"}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn bug32_ambiguous_leaf_is_fail_closed() {
+        // Two distinct grants sharing the leaf `run` ⇒ the bare `run` is ambiguous ⇒
+        // refused (SN-8: never guess which tool the model meant).
+        let w = warrant_granting_many(&[("svc-a/run", "1"), ("svc-b/run", "1")]);
+        let env = b"<|tool_call>call:run{}<tool_call|>";
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn bug32_exact_full_id_still_wins_byte_identical() {
+        // An exact full-id call against a namespaced grant resolves to itself — the
+        // exact branch is preserved even though the leaf alias also exists.
+        let w = warrant_granting_many(&[("kxlocal-a1b2c3d4/multiply", "1")]);
+        let env = br#"{"tool_call":{"name":"kxlocal-a1b2c3d4/multiply","version":"1","args":{}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("kxlocal-a1b2c3d4/multiply".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+    }
+
+    #[test]
+    fn bug32_nonempty_wrong_version_still_refused() {
+        // A NON-empty mismatching version is the model pinning a DIFFERENT tool —
+        // stays refused (no version-recovery for non-empty versions; SN-8). Pins the
+        // tightening that keeps `ungranted_tool_is_refused`'s @2 assertion valid.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":"mcp-echo","version":"2","args":{}}}"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn bug32_leaf_of_non_granted_tool_is_refused() {
+        // A leaf that addresses NO grant ⇒ refused — the candidate set is exactly
+        // `tool_grants`; a model cannot conjure a tool by naming a plausible leaf.
+        let w = warrant_granting_many(&[("safe/list", "1")]);
+        let env = b"<|tool_call>call:delete{}<tool_call|>";
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn bug32_colon_injection_resolves_to_head_only_no_escalation() {
+        // `mcp-echo:rm-rf` drops the `:rm-rf` tail and resolves to the granted
+        // `mcp-echo` — the injected segment never reaches a tool (the remote-name is
+        // fixed by the registry, not selectable by the model).
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":"mcp-echo:rm-rf","version":"","args":{}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+    }
+
+    #[test]
+    fn bug32_at_in_name_field_cannot_override_grant_version() {
+        // An `@version` baked into the NAME field (version field empty) drops to the
+        // grant's version — the model cannot force a version it was not granted.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":"mcp-echo@999","version":"","args":{}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.version, ToolVersion("1".into()));
+    }
+
+    #[test]
+    fn bug32_empty_core_name_is_refused() {
+        // A name that canonicalizes to nothing (just a `:` decoration) addresses no
+        // grant ⇒ refused, never a silent match.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_call":{"name":":echo","version":"","args":{}}}"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
     }
 }

--- a/docs/site/docs/agent-runner.md
+++ b/docs/site/docs/agent-runner.md
@@ -80,6 +80,9 @@ When an agent is granted tools, the loop **plans** topology, **re-plans** on fai
 passes **critic** gates, and runs **ReAct turns** against real MCP tools — every turn
 a durable fact, bounded by `max_turns` / `max_tool_calls`. Crash the server mid-loop
 and it resumes from its committed turns. Inspect a run's turns with `ListReactTurns`
-(`kx react list`). See the
+(`kx react list`). The same loop powers the `Agent(tools=[fn])` one-liner (Python / TS)
+and the `model@tool` chain step — the granted tool set is part of the step's identity,
+so the loop replays deterministically (and a model's bare/leaf tool name resolves to the
+granted `&lt;server&gt;/&lt;name&gt;`). See the
 [Quickstart agent loop](./quickstart.md#run-the-agent-loop) and
 [Concepts → ReAct chain](./concepts.md#react-chain--reactround).

--- a/docs/site/docs/chains/python.md
+++ b/docs/site/docs/chains/python.md
@@ -77,10 +77,12 @@ print(analyst.run("Summarize the kortecx README").text)
 
 `kx.Agent` carries instructions + an optional tool set + model/loop config. The **default
 lane is deterministic/frozen** — a single agent step with a FIXED tool-grant SET
-(replayable; the tools are part of the step's identity; execution lands with PR-9b-2).
-`dynamic=True` routes to the **steered** `kx/recipes/react` recipe, where the model picks
-tools turn by turn (works today). `analyst.stream(task)` submits without blocking and
-returns a `Run` (consume `.events()` / `.tokens(mote)`).
+(replayable; the tools are part of the step's identity). Execution is **live**: a
+tool-bearing `Agent(tools=[fn])` fires the granted set in a bounded reason→tool→observe
+loop (no `KX_SERVE_AUTOGRANT` needed — the step grants its own tools). `dynamic=True`
+routes to the **steered** `kx/recipes/react` recipe, where the model picks tools turn by
+turn. `analyst.stream(task)` submits without blocking and returns a `Run` (consume
+`.events()` / `.tokens(mote)`).
 
 The tool set may include your own functions — decorate one with `@kx.tool` and pass it in
 `tools=[...]`; the SDK registers it as a local stdio MCP server the runtime dials. See
@@ -177,11 +179,12 @@ plan = model("kx-serve:my-model", "Research the topic.",
 budget (`max_turns` / `max_tool_calls`) defaults to 8 / 6 when omitted. The server
 vets every tagged tool and builds the per-step warrant (SN-8).
 
-:::info Authoring now, execution in PR-9b-2
-Authoring is available across every surface in PR-9b-1; the bounded-loop
-**execution** lands in PR-9b-2 — until then the server fails closed on a submitted
-`model@tool` step. For tool-calling today, use a standalone `tool()` step or the
-`react` / `react-auto` recipe.
+:::info Live
+The bounded-loop **execution** is live: a `model@tool` step (and the
+`Agent(tools=[fn])` one-liner) runs a reason→tool→observe loop, firing its granted
+tools and committing each observation. The tool set is part of the step's identity, so
+the run replays deterministically. A standalone `tool()` step and the `react` /
+`react-auto` recipes remain available for one-shot and steered tool-calling.
 :::
 
 ## A model step

--- a/docs/site/docs/chains/typescript.md
+++ b/docs/site/docs/chains/typescript.md
@@ -106,10 +106,12 @@ console.log((out as Result).text);
 ```
 
 `Agent` carries instructions + an optional tool set + config. The **default lane is
-deterministic/frozen** — a single agent step with a FIXED tool-grant SET (replayable;
-execution lands with PR-9b-2). `{ dynamic: true }` routes to the **steered**
-`kx/recipes/react` recipe (the model picks tools turn by turn; works today). `agent.stream(task)`
-submits without blocking and returns a `Run` (consume `.events()` / `.tokens(mote)`).
+deterministic/frozen** — a single agent step with a FIXED tool-grant SET (replayable).
+Execution is **live**: a tool-bearing `new Agent({ tools: [fn] })` fires the granted set
+in a bounded reason→tool→observe loop (no `KX_SERVE_AUTOGRANT` needed). `{ dynamic: true }`
+routes to the **steered** `kx/recipes/react` recipe (the model picks tools turn by turn).
+`agent.stream(task)` submits without blocking and returns a `Run` (consume `.events()` /
+`.tokens(mote)`).
 
 The tool set may include your own functions — wrap one with `localTool({ name, params, run })`
 and pass it in `tools: [...]`; the SDK registers it as a local stdio MCP server the runtime
@@ -197,11 +199,12 @@ const plan = task.model("kx-serve:my-model", "Research the topic.", {}, {
 the budget (`maxTurns` / `maxToolCalls`) defaults to 8 / 6 when omitted. The server
 vets every tagged tool and builds the per-step warrant (SN-8).
 
-:::info Authoring now, execution in PR-9b-2
-Authoring is available across every surface in PR-9b-1; the bounded-loop
-**execution** lands in PR-9b-2 — until then the server fails closed on a submitted
-`model@tool` step. For tool-calling today, use a standalone `tool()` step or the
-`react` / `react-auto` recipe.
+:::info Live
+The bounded-loop **execution** is live: a `model@tool` step (and the
+`new Agent({ tools: [fn] })` one-liner) runs a reason→tool→observe loop, firing its
+granted tools and committing each observation. The tool set is part of the step's
+identity, so the run replays deterministically. A standalone `tool()` step and the
+`react` / `react-auto` recipes remain available for one-shot and steered tool-calling.
 :::
 
 ## A model step

--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -208,11 +208,11 @@ string.
 
 | Lane | How | Status |
 | --- | --- | --- |
-| **Deterministic** | `flow().tool(fn, **args)` — one tool, fixed args | ✅ today (even model-free) — the reliable path for local tools |
-| **Steered / dynamic** | `Agent(tools=[fn], dynamic=True)` → `kx/recipes/react-auto` (the model chooses) | ⚠ the loop runs + the model proposes the call (needs a served model + `KX_SERVE_AUTOGRANT=1`), but a *dialed* tool is namespaced `&lt;server&gt;/&lt;name&gt;` and the autonomous authority gate doesn't yet match a model's bare-name call — a runtime improvement is tracked; use the deterministic lane for local tools today |
-| **Frozen / deterministic-agentic** | `Agent(tools=[fn])` — a fixed tool set, replayable bounded loop | ⏳ lands in PR-9b-2 (a clear pre-flight hint until then) |
+| **Deterministic** | `flow().tool(fn, **args)` — one tool, fixed args | ✅ today (even model-free) — the reliable path for one fixed call |
+| **Steered / dynamic** | `Agent(tools=[fn], dynamic=True)` → `kx/recipes/react-auto` (the model chooses) | ✅ the model picks tools turn by turn and fires them (needs a served model + `KX_SERVE_AUTOGRANT=1`) — a dialed tool's namespaced `&lt;server&gt;/&lt;name&gt;` name resolves from the model's bare/leaf call |
+| **Frozen / deterministic-agentic** | `Agent(tools=[fn])` — a fixed tool set, replayable bounded loop | ✅ fires the granted SET in a bounded reason→tool→observe loop — **no** `KX_SERVE_AUTOGRANT` needed (the step grants its OWN exact tools) |
 
-For the **deterministic** lane the SDK fires the tool by its exact server-derived name, so it always works. The other two depend on a *model* choosing the call: builtins (bare names like `fs-list`) match today; namespaced dialed/local tools wait on the runtime name-match improvement (and the frozen lane on PR-9b-2).
+All three lanes fire today. The SN-8 authority gate stays exact: a model's bare/leaf or version-less name resolves to a **unique** granted tool (`&lt;server&gt;/&lt;name&gt;` → the grant), and ambiguity or an unknown name is refused fail-closed — the model never widens its grants.
 
 **Dev-scoped & co-located.** The runtime *spawns* the stdio tool-server subprocess,
 so this is the **Node / local-Python** SDK on the **same machine** as `kx serve`:


### PR DESCRIPTION
## What & why

The first RC-backbone PR (corpus `docs/plans/2026-06-21-oss-rc-master-plan-d164.md` §6: "▶ PICK UP HERE = PR-1 (BUG-32)"). It makes **live tool-firing** work across every surface — the capability gated behind a pre-flight hint until now.

**The bug.** The authority gate `resolve_granted_name` (`kx-toolcall`) exact-matched a model's proposed tool name against the warrant grant set. A dialed/local MCP tool is registered **namespaced** (`kxlocal-<hash>/multiply`, `mcp-echo@1`), but a model proposes the **bare leaf** (`multiply`) or the separator/version-drifted `mcp-echo:echo` (empty version) — so the call was refused `UngrantedTool` and the chain dead-lettered fail-closed (honest, but tools never fired). The PR-9b-2b live Gemma-4-12B e2e proved this is **lane-agnostic** (autonomous `react-auto` AND the authored deterministic-agentic lane).

## Changes

**Runtime — `kx-toolcall/src/parse.rs`** (load-bearing, SN-8):
- `resolve_granted_name` resolves a model name to the **unique** granted tool by canonical-segment **exact** equality — full id OR leaf after the last `/`, with `model_name_core` dropping a `@version` then a `:remote` tail. **Ambiguity ⇒ fail-closed.** Result is always an element of `tool_grants`; version is always the grant's. No similarity/fuzzy match, no grant-set widening.
- Both decode arms route through it; the JSON-envelope arm tries exact `(name, version)` first (byte-identical for every prior row) and only resolves on a miss **with an empty version** (a non-empty wrong version stays refused).
- +10 unit tests incl. SN-8 adversarial (ambiguous leaf, leaf-of-non-granted, `:`/`@` injection, empty-core).

**Menu steering — `kx-context-assembler/src/assemble.rs`:** `tool_menu_text` leads with `name: <grant_id>` so the model emits the granted name. Advisory prompt bytes only (`AssembledItem.bytes`) — never `source_ref`/journal/`MoteId`, digest-neutral.

**SDK one-liner (LIVE)** — Python `Agent(tools=[fn]).run()` and TS `new Agent({tools:[fn]}).run()` now resolve each local tool to its namespaced grant on the frozen agentic step and fire it (wiring already existed via `run_chain` → `resolve_local_tools`; the pre-flight raise/throw is removed). No `KX_SERVE_AUTOGRANT` needed. Honest-state docstrings flipped; SDK tests assert resolve+route.

**CLI:** no change — authors explicit refs, benefits automatically from the runtime fix.

**Docs:** `tools.md` / `agent-runner.md` / `chains/{python,typescript}.md` caveats flipped to live.

## Tests / validation
- **Deterministic (CI):** +10 `kx-toolcall` unit tests; +2 `kx-coordinator/react_live.rs` model-free e2e staging Gemma's **exact byte shapes** (`mcp-echo:echo` versionless drift + bare leaf against a namespaced grant) → resolve → Tool freeze → observation **Committed** through the real coordinator settle.
- **Real model (local `--ignored`):** `kx-gateway/react_auto_serve.rs` witness asserts the live chain settles (no dead-letter regression on a dialed tool). Validated on Qwen3-0.6B (2.66s) and the live **Gemma-4-12B** stack (the existing react-auto witness passes in 28.6s with real Metal inference).

## Invariants (GR8)
- **Frozen trio** (`kx-scheduler`/`kx-executor`/`kx-inference`) diff-empty.
- **Canonical projection digest `7d22d4bd` invariant** (`a0_guard` green — the canonical demo doesn't exercise dialed-tool resolution; the menu-text change touches no digested bytes).
- No proto / journal / `Cargo.lock` change; resolver helpers are crate-private (no public API change).
- Behavior change is intentional + documented: previously-refused tool calls now fire (a clean live-lane change, not a data-format break — no migration). A bare/leaf/version-less name now resolves to a unique grant; ambiguous/unknown/non-empty-wrong-version stays fail-closed.
- **GR10:** the resolver is parse-time, O(grants) with small constant (a couple of split/replace ops once per model turn) — negligible vs the inference forward pass; no new hot-path regression.

## Gates run
workspace clippy `-D warnings` · fmt · workspace tests (zero failures) · doc `-D warnings` · Python ruff/mypy + 212 unit tests · TS biome/tsc + tool tests. (The full `just ci` incl. `check-reproducible`/`scale-smoke` runs pre-merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)