### PR TITLE
PR-2 — BUG-33: bundled tool <server>/<remote> id so a live model's bare remote name resolves (deep cross-surface campaign)

### DIFF
--- a/crates/kx-gateway/src/mcp_tool.rs
+++ b/crates/kx-gateway/src/mcp_tool.rs
@@ -23,11 +23,20 @@ use kx_tool_registry::{
 };
 use kx_warrant::{FsScope, NetScope, ResourceCeiling, ToolRequirement};
 
-/// The bundled tool's identity — `mcp-echo@1` (the vocabulary the PR-2d-1
-/// substrate tests froze).
+/// The bundled tool's identity — `mcp-echo/echo@1`. The id follows the
+/// `<server>/<remote>` convention every other MCP tool uses (a dialed/local tool
+/// registers `<server>/<remote>`, e.g. `kxlocal-a1b2c3d4/multiply` or a dialed
+/// `pr2echo/echo`), so the BUG-32 name-resolution leaf rule
+/// (`kx_toolcall::resolve_granted_name`) resolves the short remote leaf `echo`
+/// the model naturally emits. BEFORE this fix the bundled tool was a flat
+/// `mcp-echo` (server+remote conflated into one hyphenated token with no `/`),
+/// so a capable model that proposed the bare `echo` was refused `UngrantedTool`
+/// and the live ReAct chain dead-lettered with no answer (PR-2 deep-test campaign
+/// finding A1 / BUG-33). The remote method name passed to the MCP server stays
+/// `echo` (see [`register_echo_capability`]), so firing is unchanged.
 #[must_use]
 pub(crate) fn echo_tool() -> (ToolName, ToolVersion) {
-    (ToolName("mcp-echo".into()), ToolVersion("1".into()))
+    (ToolName("mcp-echo/echo".into()), ToolVersion("1".into()))
 }
 
 /// The bundled tool's [`ToolDef`]: an MCP stdio tool with NO egress requirement
@@ -252,4 +261,34 @@ fn echo_binary_path() -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// BUG-33 (PR-2 deep-test campaign finding A1) regression guard: the bundled
+    /// echo MUST be granted as `<server>/<remote>` (a `/`-bearing id) whose last
+    /// segment equals the MCP remote method name — so `kx_toolcall`'s leaf rule
+    /// resolves the bare remote name (`echo`) a capable model naturally emits. A
+    /// flat id (no `/`, the pre-fix shape) reintroduces the `UngrantedTool`
+    /// dead-letter that left the live ReAct chain with no answer.
+    #[test]
+    fn bundled_tool_id_is_server_slash_remote_so_the_model_leaf_resolves() {
+        let (name, _ver) = echo_tool();
+        assert!(
+            name.0.contains('/'),
+            "bundled tool id must be <server>/<remote>, got {:?}",
+            name.0
+        );
+        let leaf = name.0.rsplit('/').next().unwrap();
+        match &echo_tool_def().kind {
+            ToolKind::Mcp { remote_name, .. } => assert_eq!(
+                leaf, remote_name,
+                "the id leaf must equal the MCP remote name so the model's bare \
+                 remote name resolves to the grant"
+            ),
+            _ => panic!("bundled echo must be an MCP tool"),
+        }
+    }
 }

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -461,6 +461,46 @@ mod tests {
     }
 
     #[test]
+    fn bundled_server_slash_remote_resolves_the_bare_remote_leaf() {
+        // BUG-33 (PR-2 deep-test campaign finding A1): the bundled echo is now granted
+        // as `mcp-echo/echo` (the <server>/<remote> convention every MCP tool uses — a
+        // dialed/local tool registers `<server>/<remote>`). A capable model
+        // (Gemma-4-12B) prompted to "use the echo tool" naturally proposes the bare
+        // remote leaf `echo`; it MUST resolve to the grant via the leaf rule. Before
+        // the fix the bundled tool was a flat `mcp-echo` (no `/`), so the bare `echo`
+        // was refused `UngrantedTool` and the live ReAct chain dead-lettered with no
+        // answer. SN-8: the leaf is EXACT segment equality, never prefix/substring.
+        let w = warrant_granting(Some(("mcp-echo/echo", "1")));
+
+        // (a) the bare remote leaf, version-less (JSON envelope) ⇒ resolves to the grant.
+        let env = br#"{"tool_call":{"name":"echo","version":"","args":{"q":"x"}}}"#;
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("the bare remote leaf resolves to the <server>/<remote> grant");
+        assert_eq!(call.name, ToolName("mcp-echo/echo".into()));
+        assert_eq!(call.version, ToolVersion("1".into())); // the GRANT's version, not the model's
+
+        // (b) the Gemma-4 NATIVE shape with the bare leaf ⇒ resolves too.
+        let native = b"<|tool_call>call:echo{\"q\":\"x\"}<tool_call|>";
+        let nc = parse_tool_call(native, &w, 4096)
+            .unwrap()
+            .expect("native bare leaf resolves");
+        assert_eq!(nc.name, ToolName("mcp-echo/echo".into()));
+
+        // (c) the full id still resolves (exact match path).
+        let env_full = br#"{"tool_call":{"name":"mcp-echo/echo","version":"1","args":{"q":"x"}}}"#;
+        assert!(parse_tool_call(env_full, &w, 4096).unwrap().is_some());
+
+        // (d) SN-8 boundary: the server PREFIX alone (`mcp-echo` — neither the full id
+        //     nor the leaf segment) does NOT resolve. No prefix/substring widening.
+        let env_prefix = br#"{"tool_call":{"name":"mcp-echo","version":"","args":{"q":"x"}}}"#;
+        assert!(matches!(
+            parse_tool_call(env_prefix, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
     fn think_only_no_json_is_normal_completion() {
         let w = warrant_granting(Some(("mcp-echo", "1")));
         // Reasoning then prose (no JSON) ⇒ not a tool call.


### PR DESCRIPTION
## What

Deep cross-surface test campaign (open model, **Gemma-4-12B**, 5 capabilities × 4 surfaces) found and fixed a **critical live tool-calling bug (A1 / BUG-33)**.

**Symptom:** a capable model told to "use the echo tool" emits the bare remote name `echo`; the runtime refused it `UngrantedTool` and the live ReAct chain **dead-lettered with no answer**.

**Root cause:** the bundled echo was granted as a flat `mcp-echo` (server+remote conflated, no `/`). PR-1's `resolve_granted_name` leaf rule resolves `<server>/<remote>` ids by their leaf (e.g. dialed `pr2echo/echo`, local `kxlocal-…/multiply`) — but `mcp-echo` has no `/`, so the bare `echo` matched neither the full id nor a leaf (SN-8-correct: no substring/fuzzy).

**Fix:** give the bundled tool the `<server>/<remote>` id every other MCP tool uses — `echo_tool()` → `mcp-echo/echo`. Resolver unchanged; firing unchanged (MCP remote method stays `echo`). Validated live: Gemma's bare `echo` now resolves (no `UngrantedTool`).

## Regression guards
- `kx-toolcall/parse.rs`: bare remote leaf + Gemma-native shape resolve to the grant; the server prefix alone is still refused (SN-8, no widening).
- `kx-gateway/mcp_tool.rs`: the bundled id must be `<server>/<remote>` with leaf == the MCP remote name (prevents reverting to a flat id).

## Invariants
Frozen trio diff-empty · canonical projection digest `7d22d4bd` invariant (pure 8-mote demo has no tools) · no proto/journal/Cargo.lock change · **2 files, +82/-3**.

## Campaign verdict (other cells PASS cross-surface, real data, GR15)
CAS, datasets/RAG, branching, and chat-reasoning orchestration all verified **byte-identical across CLI/Py/TS** on the live Gemma serve, plus a UI chat round-trip + both-theme Playwright smoke. Remaining tool-calling reliability gaps (A2 dead-letter brittleness, A3 model-arg quality) + lower-severity findings are ticketed for the next focused PR (detail in the private corpus, SN-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)