### PR TITLE
PR-9c-1 — embeddable agent-runner `run_agent` + dynamic multi-format tool-calling

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -13,6 +13,7 @@ go::
 from __future__ import annotations
 
 from .agent import Agent
+from .agent_result import AgentResult, AuditedAction
 from .alerts import AlertsPage, AlertSummary
 from .blueprints import BlueprintBuilder, EdgeInput, StepInput
 from .branch import (
@@ -70,6 +71,7 @@ from .recipes import (
 )
 from .replan import ReplanRound, ReplanRoundPage
 from .run import AsyncRun, Result, Run
+from .run_agent import run_agent, run_agent_async
 from .runs import RunInputs, RunPage, RunSummary
 from .teams import TeamMember, TeamMembers, TeamSummary, WarrantView
 from .telemetry import ModelTokenRollup, MoteTelemetryRow, TelemetryPage, TelemetrySummary
@@ -159,6 +161,11 @@ __all__ = [
     "Flow",
     "flow",
     "Agent",
+    # PR-9c-1 — the embeddable agent-runner (goal → answer + audited actions).
+    "run_agent",
+    "run_agent_async",
+    "AgentResult",
+    "AuditedAction",
     # V2b — local function tools (@kx.tool → a governed stdio MCP tool).
     "LocalToolDef",
     "ToolError",

--- a/bindings/python/src/kortecx/agent_result.py
+++ b/bindings/python/src/kortecx/agent_result.py
@@ -1,0 +1,75 @@
+"""The agent-runner result — the one-object answer of ``run_agent`` (PR-9c-1).
+
+``run_agent(goal) → AgentResult``: the model's final answer PLUS the audited set of
+tool actions it took (each a durable ``ReactRound`` ``tool`` fact, server-derived). A
+thin, read-only projection over the steered ``kx/recipes/react`` chain — no new wire
+surface, no proto change (assembled client-side from ``ListReactTurns`` +
+``GetContent``). SN-8: every id + action is server-derived; the SDK only shapes them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .react import ReactTurn
+
+
+@dataclass(frozen=True)
+class AuditedAction:
+    """One tool action the agent took — a settled ReAct ``tool`` turn. The
+    ``tool_id`` / ``tool_version`` are the GRANTED tool's (SN-8), never the model's
+    raw proposal."""
+
+    tool_id: str
+    tool_version: str
+    turn: int
+
+    @classmethod
+    def from_turn(cls, t: ReactTurn) -> "AuditedAction":
+        return cls(tool_id=t.tool_id, tool_version=t.tool_version, turn=t.turn)
+
+
+@dataclass(frozen=True)
+class AgentResult:
+    """The terminal answer of an agent run + its audited action set + the durable,
+    re-attachable run handle (the instance id)."""
+
+    answer: Optional[str]  # the final answer decoded UTF-8 (None if non-text/absent)
+    answer_bytes: Optional[bytes]  # the raw committed answer bytes
+    actions: List[AuditedAction] = field(default_factory=list)
+    run_handle: str = ""  # hex instance id — the durable handle to re-attach to this run
+    instance_id: str = ""  # hex instance id (== run_handle)
+
+    @property
+    def ok(self) -> bool:
+        """True iff the agent produced a committed answer."""
+        return self.answer_bytes is not None
+
+    def to_dict(self) -> dict:
+        """A JSON-able view (the ``kx agent run --json`` shape)."""
+        out: dict = {
+            "instance_id": self.instance_id,
+            "run_handle": self.run_handle,
+            "actions": [
+                {"tool_id": a.tool_id, "tool_version": a.tool_version, "turn": a.turn}
+                for a in self.actions
+            ],
+        }
+        if self.answer is not None:
+            out["answer"] = self.answer
+        return out
+
+    def json(self) -> dict:
+        """Alias of :meth:`to_dict` (mirrors :meth:`kortecx.run.Result.json` + the TS SDK)."""
+        return self.to_dict()
+
+
+def assemble_actions(turns: List[ReactTurn]) -> List[AuditedAction]:
+    """The audited action set = the chain's settled ``tool`` turns, in turn order.
+    Pure client-side derivation over the durable ``ListReactTurns`` facts."""
+    return [
+        AuditedAction.from_turn(t)
+        for t in sorted(turns, key=lambda t: t.turn)
+        if t.branch == "tool"
+    ]

--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -1287,10 +1287,18 @@ class AsyncKxClient:
         timeout: float = 120.0,
         wait_mode: str = "poll",
         out: Optional[str] = None,
+        context: Optional[Sequence[str]] = None,
+        context_refs: Optional[Sequence[str]] = None,
     ) -> Union[AsyncRun, Result]:
         resp = await self._acall(
             self._stub.Invoke(
-                _g.InvokeRequest(handle=handle, args=_encode_args(args)), metadata=self._md
+                _g.InvokeRequest(
+                    handle=handle,
+                    args=_encode_args(args),
+                    context_bundles=list(context or []),
+                    context_refs=list(context_refs or []),
+                ),
+                metadata=self._md,
             )
         )
         run = AsyncRun(self, resp.instance_id, resp.terminal_mote_id, resp.recipe_fingerprint)

--- a/bindings/python/src/kortecx/run_agent.py
+++ b/bindings/python/src/kortecx/run_agent.py
@@ -1,0 +1,113 @@
+"""The embeddable agent-runner — ``run_agent`` (PR-9c-1).
+
+The headline adoption entry (GR18/D149): give a goal (+ optional context + inputs),
+the runtime completes it AGENTICALLY — reasoning, calling permission-gated tools, and
+returning a reasoned answer PLUS the AUDITED set of actions it took. A thin wrapper
+over ``invoke("kx/recipes/react")`` — NEVER ``SubmitRun`` (BLOCKER #5); the warrant is
+always SERVER-DERIVED (SN-8), the client only parameterizes the published recipe.
+
+``inputs`` fold into the goal prompt — the ``kx/recipes/react`` contract has no
+structured input slot today (instruction / max_turns / max_tool_calls only); a
+structured-inputs slot is a later contract addition.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Union, cast
+
+from .agent_result import AgentResult, assemble_actions
+from .client import REACT_RECIPE_HANDLE
+
+if TYPE_CHECKING:
+    from .client import AsyncKxClient, KxClient
+    from .run import AsyncRun, Result, Run
+
+#: The recipe's anchored bounded-loop budget (mirrors Agent + the UI's planReactArgs).
+_DEFAULT_MAX_TURNS = 8
+_DEFAULT_MAX_TOOL_CALLS = 6
+
+
+def _fold_inputs(goal: str, inputs: Optional[Mapping[str, str]]) -> str:
+    """Fold structured ``inputs`` into the goal prompt (no structured recipe slot)."""
+    if not inputs:
+        return goal
+    lines = "\n".join(f"- {k}: {v}" for k, v in inputs.items())
+    return f"{goal}\n\nInputs:\n{lines}"
+
+
+def _args(goal: str, inputs: Optional[Mapping[str, str]]) -> dict:
+    return {
+        "instruction": _fold_inputs(goal, inputs),
+        "max_turns": _DEFAULT_MAX_TURNS,
+        "max_tool_calls": _DEFAULT_MAX_TOOL_CALLS,
+    }
+
+
+def run_agent(
+    goal: str,
+    *,
+    context: Optional[Sequence[str]] = None,
+    inputs: Optional[Mapping[str, str]] = None,
+    wait: bool = True,
+    timeout: float = 120.0,
+    client: "Optional[KxClient]" = None,
+) -> "Union[AgentResult, Run]":
+    """Complete ``goal`` agentically and return an :class:`~kortecx.agent_result.AgentResult`
+    (the final answer + the audited tool actions). ``context`` = published
+    context-bundle handles (PR-7) the server resolves + injects; ``inputs`` fold into
+    the prompt. With ``wait=False`` returns the started :class:`~kortecx.run.Run`
+    (assemble the result later via ``ListReactTurns``). Uses the process-wide default
+    client unless one is passed.
+
+    Raises :class:`~kortecx.errors.KxRunFailed` if the chain dead-letters (terminal
+    failure) and :class:`~kortecx.errors.KxWaitTimeout` if it does not settle in time —
+    same as ``invoke(wait=True)``."""
+    from .defaults import default_client
+
+    kx = client if client is not None else default_client()
+    args = _args(goal, inputs)
+    if not wait:
+        return cast("Run", kx.invoke(REACT_RECIPE_HANDLE, args, context=context, wait=False))
+    # invoke(wait=True) on a react handle always settles to a Result (never a Run).
+    result = cast(
+        "Result", kx.invoke(REACT_RECIPE_HANDLE, args, context=context, wait=True, timeout=timeout)
+    )
+    turns = kx.list_react_turns(instance_id=result.instance_id).turns
+    return AgentResult(
+        answer=result.text,
+        answer_bytes=result.payload,
+        actions=assemble_actions(turns),
+        run_handle=result.instance_id,
+        instance_id=result.instance_id,
+    )
+
+
+async def run_agent_async(
+    goal: str,
+    *,
+    client: "AsyncKxClient",
+    context: Optional[Sequence[str]] = None,
+    inputs: Optional[Mapping[str, str]] = None,
+    wait: bool = True,
+    timeout: float = 120.0,
+) -> "Union[AgentResult, AsyncRun]":
+    """Async mirror of :func:`run_agent`. Requires an explicit
+    :class:`~kortecx.client.AsyncKxClient` (there is no async default singleton)."""
+    args = _args(goal, inputs)
+    if not wait:
+        return cast(
+            "AsyncRun",
+            await client.invoke(REACT_RECIPE_HANDLE, args, context=context, wait=False),
+        )
+    result = cast(
+        "Result",
+        await client.invoke(REACT_RECIPE_HANDLE, args, context=context, wait=True, timeout=timeout),
+    )
+    page = await client.list_react_turns(instance_id=result.instance_id)
+    return AgentResult(
+        answer=result.text,
+        answer_bytes=result.payload,
+        actions=assemble_actions(page.turns),
+        run_handle=result.instance_id,
+        instance_id=result.instance_id,
+    )

--- a/bindings/python/tests/test_run_agent.py
+++ b/bindings/python/tests/test_run_agent.py
@@ -1,0 +1,143 @@
+"""run_agent — the embeddable agent-runner (PR-9c-1). Pure unit tests (no server).
+
+A thin wrapper over ``invoke("kx/recipes/react")`` + ``list_react_turns``; the tests
+stub the client and assert the assembled :class:`AgentResult` (answer + audited
+actions), the ``wait=False`` Run path, prompt-folding of ``inputs``, and the
+zero-config default-client resolution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kortecx.agent_result import AgentResult, AuditedAction, assemble_actions
+from kortecx.react import ReactTurn
+from kortecx.run import Result, Run
+from kortecx.run_agent import _args, _fold_inputs, run_agent
+
+
+def _turn(turn: int, branch: str, tool_id: str = "", tool_version: str = "") -> ReactTurn:
+    return ReactTurn(
+        turn=turn,
+        turn_mote_id="aa",
+        instance_id="bb",
+        model_id="m",
+        branch=branch,
+        tool_id=tool_id,
+        tool_version=tool_version,
+        max_turns=8,
+        max_tool_calls=6,
+        seq=turn,
+    )
+
+
+class _FakeTurnPage:
+    def __init__(self, turns: list) -> None:
+        self.turns = turns
+        self.has_more = False
+
+
+class _FakeClient:
+    """Records the invoke call + returns a canned Result + react-turn page."""
+
+    def __init__(self, *, turns: list | None = None, payload: bytes = b"the answer") -> None:
+        self.turns = turns or []
+        self.payload = payload
+        self.invoke_calls: list[dict] = []
+
+    def invoke(self, handle, args, *, context=None, wait=False, timeout=120.0):
+        self.invoke_calls.append({"handle": handle, "args": args, "context": context, "wait": wait})
+        if not wait:
+            return Run(self, b"\x01" * 16, b"\x02" * 32, b"")
+        return Result(
+            instance_id="ab" * 8,
+            terminal_mote_id="cd" * 32,
+            state="COMMITTED",
+            result_ref="ef" * 32,
+            payload=self.payload,
+        )
+
+    def list_react_turns(self, *, instance_id=None, limit=None):
+        return _FakeTurnPage(self.turns)
+
+
+def test_assemble_actions_filters_tool_turns_in_order() -> None:
+    turns = [
+        _turn(2, "tool", "fs-list", "1"),
+        _turn(0, "pending"),
+        _turn(1, "tool", "mcp-echo/echo", "1"),
+        _turn(3, "answer"),
+    ]
+    actions = assemble_actions(turns)
+    assert [a.turn for a in actions] == [1, 2]  # tool turns only, sorted by turn
+    assert actions[0] == AuditedAction("mcp-echo/echo", "1", 1)
+
+
+def test_run_agent_assembles_answer_and_actions() -> None:
+    fc = _FakeClient(
+        turns=[_turn(0, "tool", "mcp-echo/echo", "1"), _turn(1, "answer")],
+        payload=b"pong",
+    )
+    out = run_agent("echo pong", client=fc)
+    assert isinstance(out, AgentResult)
+    assert out.answer == "pong"
+    assert out.answer_bytes == b"pong"
+    assert [a.tool_id for a in out.actions] == ["mcp-echo/echo"]
+    assert out.run_handle == out.instance_id != ""
+    assert out.ok
+    # the steered react recipe was invoked with the bounded-loop budget
+    call = fc.invoke_calls[0]
+    assert call["handle"] == "kx/recipes/react"
+    assert call["args"]["max_turns"] == 8 and call["args"]["max_tool_calls"] == 6
+    assert call["args"]["instruction"] == "echo pong"
+
+
+def test_run_agent_no_wait_returns_run() -> None:
+    fc = _FakeClient()
+    out = run_agent("do it", wait=False, client=fc)
+    assert isinstance(out, Run)
+    assert fc.invoke_calls[0]["wait"] is False
+
+
+def test_run_agent_folds_inputs_into_prompt() -> None:
+    fc = _FakeClient(turns=[_turn(0, "answer")])
+    run_agent("summarize", inputs={"url": "x", "lang": "en"}, client=fc)
+    instr = fc.invoke_calls[0]["args"]["instruction"]
+    assert instr.startswith("summarize")
+    assert "- url: x" in instr and "- lang: en" in instr
+
+
+def test_run_agent_passes_context() -> None:
+    fc = _FakeClient(turns=[_turn(0, "answer")])
+    run_agent("g", context=["team/ctx/spec"], client=fc)
+    assert fc.invoke_calls[0]["context"] == ["team/ctx/spec"]
+
+
+def test_agent_result_json_shape() -> None:
+    r = AgentResult(
+        answer="hi",
+        answer_bytes=b"hi",
+        actions=[AuditedAction("mcp-echo/echo", "1", 0)],
+        run_handle="ab",
+        instance_id="ab",
+    )
+    j = r.json()
+    assert j == r.to_dict()
+    assert j["answer"] == "hi"
+    assert j["instance_id"] == "ab"
+    assert j["actions"] == [{"tool_id": "mcp-echo/echo", "tool_version": "1", "turn": 0}]
+
+
+def test_run_agent_zero_config_default_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kortecx import defaults
+
+    fc = _FakeClient(turns=[_turn(0, "answer")], payload=b"ok")
+    monkeypatch.setattr(defaults, "default_client", lambda: fc)
+    out = run_agent("g")
+    assert isinstance(out, AgentResult)
+    assert out.answer == "ok"
+
+
+def test_fold_inputs_noop_without_inputs() -> None:
+    assert _fold_inputs("g", None) == "g"
+    assert _args("g", None)["instruction"] == "g"

--- a/bindings/typescript/src/agent-result.ts
+++ b/bindings/typescript/src/agent-result.ts
@@ -1,0 +1,78 @@
+/**
+ * The agent-runner result — the one-object answer of `runAgent` (PR-9c-1).
+ *
+ * `runAgent({ goal }) → AgentResult`: the model's final answer PLUS the audited set
+ * of tool actions it took (each a durable `ReactRound` `tool` fact, server-derived).
+ * A thin, read-only projection over the steered `kx/recipes/react` chain — no new
+ * wire surface, no proto change (assembled client-side from `ListReactTurns` +
+ * `GetContent`). Platform-neutral (no Node imports): re-exported by both the node
+ * and web entries via `common`. SN-8: every id + action is server-derived.
+ */
+
+import type { ReactTurn } from "./react.js";
+
+/** One tool action the agent took — a settled ReAct `tool` turn. The `toolId` /
+ *  `toolVersion` are the GRANTED tool's (SN-8), never the model's raw proposal. */
+export class AuditedAction {
+  constructor(
+    readonly toolId: string,
+    readonly toolVersion: string,
+    readonly turn: number,
+  ) {}
+
+  static fromTurn(t: ReactTurn): AuditedAction {
+    return new AuditedAction(t.toolId, t.toolVersion, t.turn);
+  }
+
+  /** A plain snake_case object (parity with the Python SDK + the CLI `--json`). */
+  toJSON() {
+    return { tool_id: this.toolId, tool_version: this.toolVersion, turn: this.turn };
+  }
+}
+
+/** The terminal answer of an agent run + its audited action set + the durable,
+ *  re-attachable run handle (the instance id). */
+export class AgentResult {
+  constructor(
+    /** The final answer decoded UTF-8 (`null` if non-text / absent). */
+    readonly answer: string | null,
+    /** The raw committed answer bytes. */
+    readonly answerBytes: Uint8Array | null,
+    readonly actions: readonly AuditedAction[],
+    /** hex instance id — the durable handle to re-attach to this run. */
+    readonly runHandle: string,
+    /** hex instance id (=== {@link runHandle}). */
+    readonly instanceId: string,
+  ) {}
+
+  /** True iff the agent produced a committed answer. */
+  get ok(): boolean {
+    return this.answerBytes !== null;
+  }
+
+  /** A JSON-able view (the `kx agent run --json` shape; parity with the Python SDK). */
+  toJSON(): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+      instance_id: this.instanceId,
+      run_handle: this.runHandle,
+      actions: this.actions.map((a) => a.toJSON()),
+    };
+    if (this.answer !== null) out.answer = this.answer;
+    return out;
+  }
+
+  /** Alias of {@link toJSON} (mirrors the Python `AgentResult.json()`). */
+  json(): Record<string, unknown> {
+    return this.toJSON();
+  }
+}
+
+/** The audited action set = the chain's settled `tool` turns, in turn order. Pure
+ *  client-side derivation over the durable `ListReactTurns` facts (no mutation of
+ *  the input). */
+export function assembleActions(turns: readonly ReactTurn[]): AuditedAction[] {
+  return turns
+    .filter((t) => t.branch === "tool")
+    .sort((a, b) => a.turn - b.turn)
+    .map((t) => AuditedAction.fromTurn(t));
+}

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -46,6 +46,11 @@ export type { RunPage } from "./runs.js";
 export { ReactTurn } from "./react.js";
 export type { ReactTurnPage } from "./react.js";
 
+// PR-9c-1: the embeddable agent-runner's result (answer + audited actions). Pure
+// data (no Node imports) — safe in both the node and web bundles. `runAgent` itself
+// (the zero-config entry) is node-only and exported from the root `index`.
+export { AgentResult, AuditedAction, assembleActions } from "./agent-result.js";
+
 export { TokenChunk } from "./tokens.js";
 
 export { ReplanRound } from "./replan.js";

--- a/bindings/typescript/src/index.ts
+++ b/bindings/typescript/src/index.ts
@@ -27,3 +27,7 @@ export * from "./common.js";
 // setDefaultClient) — importing this entry installs the lazy default-client factory the
 // Flow/Agent terminals use. NODE-ONLY (the web/chains entries are explicit-client).
 export * from "./defaults.js";
+// PR-9c-1: the embeddable agent-runner. NODE-ONLY (uses the zero-config default
+// client); the `AgentResult`/`AuditedAction` data types ride `common` (web-safe).
+export { runAgent } from "./run-agent.js";
+export type { RunAgentOptions } from "./run-agent.js";

--- a/bindings/typescript/src/run-agent.ts
+++ b/bindings/typescript/src/run-agent.ts
@@ -1,0 +1,78 @@
+/**
+ * The embeddable agent-runner — `runAgent` (PR-9c-1). The headline adoption entry
+ * (GR18/D149): give a goal (+ optional context + inputs), the runtime completes it
+ * AGENTICALLY — reasoning, calling permission-gated tools, and returning a reasoned
+ * answer PLUS the AUDITED set of actions it took.
+ *
+ * A thin wrapper over `invoke("kx/recipes/react")` — NEVER `submitRun` (BLOCKER #5);
+ * the warrant is always SERVER-DERIVED (SN-8), the client only parameterizes the
+ * published recipe. NODE entry (uses the zero-config default client); the `web` /
+ * `chains` entrypoints are explicit-client and do NOT import this module.
+ *
+ * `inputs` fold into the goal prompt — the `kx/recipes/react` contract has no
+ * structured input slot today (instruction / max_turns / max_tool_calls only).
+ */
+
+import { AgentResult, assembleActions } from "./agent-result.js";
+import { REACT_RECIPE_HANDLE } from "./client.js";
+import { defaultClient } from "./defaults.js";
+import type { KxClient } from "./node.js";
+import type { Result, Run } from "./run.js";
+
+/** The recipe's anchored bounded-loop budget (mirrors Agent + the UI's planReactArgs). */
+const DEFAULT_MAX_TURNS = 8;
+const DEFAULT_MAX_TOOL_CALLS = 6;
+
+export interface RunAgentOptions {
+  /** What to accomplish — becomes the react recipe's instruction. */
+  goal: string;
+  /** Published context-bundle handles (PR-7) the server resolves + injects. */
+  context?: readonly string[];
+  /** Structured inputs folded into the goal prompt (no structured recipe slot yet). */
+  inputs?: Readonly<Record<string, string>>;
+  /** `true` (default) returns an {@link AgentResult}; `false` returns the started {@link Run}. */
+  wait?: boolean;
+  timeoutMs?: number;
+  /** An explicit client; defaults to the zero-config process-wide default client. */
+  client?: KxClient;
+}
+
+function foldInputs(goal: string, inputs?: Readonly<Record<string, string>>): string {
+  const lines = inputs ? Object.entries(inputs).map(([k, v]) => `- ${k}: ${v}`) : [];
+  return lines.length === 0 ? goal : `${goal}\n\nInputs:\n${lines.join("\n")}`;
+}
+
+/**
+ * Complete `opts.goal` agentically and return an {@link AgentResult} (the final
+ * answer + the audited tool actions). With `wait: false` returns the started
+ * {@link Run} (assemble the result later via `listReactTurns`). Throws
+ * `KxRunFailed` if the chain dead-letters and `KxWaitTimeout` on a timeout — same
+ * as `invoke({ wait: true })`.
+ */
+export async function runAgent(opts: RunAgentOptions): Promise<AgentResult | Run> {
+  const kx = opts.client ?? defaultClient();
+  const args = {
+    instruction: foldInputs(opts.goal, opts.inputs),
+    max_turns: DEFAULT_MAX_TURNS,
+    max_tool_calls: DEFAULT_MAX_TOOL_CALLS,
+  };
+  if (opts.wait === false) {
+    return (await kx.invoke(REACT_RECIPE_HANDLE, args, {
+      context: opts.context,
+      wait: false,
+    })) as Run;
+  }
+  const result = (await kx.invoke(REACT_RECIPE_HANDLE, args, {
+    context: opts.context,
+    wait: true,
+    timeoutMs: opts.timeoutMs,
+  })) as Result;
+  const page = await kx.listReactTurns({ instanceId: result.instanceId });
+  return new AgentResult(
+    result.text,
+    result.payload,
+    assembleActions(page.turns),
+    result.instanceId,
+    result.instanceId,
+  );
+}

--- a/bindings/typescript/test/run-agent.test.ts
+++ b/bindings/typescript/test/run-agent.test.ts
@@ -1,0 +1,153 @@
+/**
+ * runAgent — the embeddable agent-runner (PR-9c-1). Pure unit tests (no server).
+ *
+ * A thin wrapper over `invoke("kx/recipes/react")` + `listReactTurns`; the tests
+ * stub the client and assert the assembled `AgentResult` (answer + audited actions),
+ * the `wait: false` Run path, prompt-folding of `inputs`, context pass-through, and
+ * the zero-config default-client resolution.
+ */
+
+import { describe, expect, it } from "vitest";
+import { AgentResult, AuditedAction, assembleActions } from "../src/agent-result.js";
+import { setDefaultClient } from "../src/default-client.js";
+import type { KxClient } from "../src/node.js";
+import { ReactTurn } from "../src/react.js";
+import { runAgent } from "../src/run-agent.js";
+import { Result, Run } from "../src/run.js";
+
+function turn(t: number, branch: string, toolId = "", toolVersion = ""): ReactTurn {
+  return new ReactTurn(t, "aa", "bb", "m", branch, toolId, toolVersion, 8, 6, t, "");
+}
+
+interface InvokeCall {
+  handle: string;
+  args: Record<string, unknown>;
+  opts: { wait?: boolean; context?: readonly string[] };
+}
+
+/** Records the invoke call + returns a canned Result + react-turn page. */
+class FakeClient {
+  invokeCalls: InvokeCall[] = [];
+  constructor(
+    private readonly turns: ReactTurn[] = [],
+    private readonly payload: Uint8Array | null = new TextEncoder().encode("the answer"),
+  ) {}
+
+  async invoke(
+    handle: string,
+    args: Record<string, unknown>,
+    opts: { wait?: boolean; context?: readonly string[]; timeoutMs?: number } = {},
+  ): Promise<Run | Result> {
+    this.invokeCalls.push({ handle, args, opts });
+    if (!opts.wait) {
+      return new Run(
+        this as unknown as KxClient,
+        new Uint8Array(16).fill(1),
+        new Uint8Array(32).fill(2),
+        new Uint8Array(0),
+      );
+    }
+    return new Result(
+      "abababababababab",
+      "cd".repeat(32),
+      "COMMITTED",
+      "ef".repeat(32),
+      this.payload,
+    );
+  }
+
+  async listReactTurns(
+    _opts: { instanceId?: string } = {},
+  ): Promise<{ turns: ReactTurn[]; hasMore: boolean }> {
+    return { turns: this.turns, hasMore: false };
+  }
+}
+
+describe("assembleActions", () => {
+  it("keeps only tool turns, sorted by turn", () => {
+    const actions = assembleActions([
+      turn(2, "tool", "fs-list", "1"),
+      turn(0, "pending"),
+      turn(1, "tool", "mcp-echo/echo", "1"),
+      turn(3, "answer"),
+    ]);
+    expect(actions.map((a) => a.turn)).toEqual([1, 2]);
+    expect(actions[0]).toEqual(new AuditedAction("mcp-echo/echo", "1", 1));
+  });
+});
+
+describe("runAgent", () => {
+  it("assembles the answer + audited actions", async () => {
+    const fc = new FakeClient(
+      [turn(0, "tool", "mcp-echo/echo", "1"), turn(1, "answer")],
+      new TextEncoder().encode("pong"),
+    );
+    const out = (await runAgent({
+      goal: "echo pong",
+      client: fc as unknown as KxClient,
+    })) as AgentResult;
+    expect(out).toBeInstanceOf(AgentResult);
+    expect(out.answer).toBe("pong");
+    expect(out.actions.map((a) => a.toolId)).toEqual(["mcp-echo/echo"]);
+    expect(out.runHandle).toBe(out.instanceId);
+    expect(out.ok).toBe(true);
+    const call = fc.invokeCalls[0];
+    expect(call?.handle).toBe("kx/recipes/react");
+    expect(call?.args.max_turns).toBe(8);
+    expect(call?.args.max_tool_calls).toBe(6);
+    expect(call?.args.instruction).toBe("echo pong");
+  });
+
+  it("returns a Run with wait:false", async () => {
+    const fc = new FakeClient();
+    const out = await runAgent({ goal: "do it", wait: false, client: fc as unknown as KxClient });
+    expect(out).toBeInstanceOf(Run);
+    expect(fc.invokeCalls[0]?.opts.wait).toBe(false);
+  });
+
+  it("folds inputs into the prompt", async () => {
+    const fc = new FakeClient([turn(0, "answer")]);
+    await runAgent({
+      goal: "summarize",
+      inputs: { url: "x", lang: "en" },
+      client: fc as unknown as KxClient,
+    });
+    const instr = fc.invokeCalls[0]?.args.instruction as string;
+    expect(instr.startsWith("summarize")).toBe(true);
+    expect(instr).toContain("- url: x");
+    expect(instr).toContain("- lang: en");
+  });
+
+  it("passes context bundles through", async () => {
+    const fc = new FakeClient([turn(0, "answer")]);
+    await runAgent({ goal: "g", context: ["team/ctx/spec"], client: fc as unknown as KxClient });
+    expect(fc.invokeCalls[0]?.opts.context).toEqual(["team/ctx/spec"]);
+  });
+
+  it("AgentResult.json() is the snake_case shape", () => {
+    const r = new AgentResult(
+      "hi",
+      new TextEncoder().encode("hi"),
+      [new AuditedAction("mcp-echo/echo", "1", 0)],
+      "ab",
+      "ab",
+    );
+    expect(r.json()).toEqual({
+      instance_id: "ab",
+      run_handle: "ab",
+      answer: "hi",
+      actions: [{ tool_id: "mcp-echo/echo", tool_version: "1", turn: 0 }],
+    });
+  });
+
+  it("uses the registry default client when none is passed", async () => {
+    const fc = new FakeClient([turn(0, "answer")], new TextEncoder().encode("ok"));
+    setDefaultClient(fc as unknown as KxClient);
+    try {
+      const out = (await runAgent({ goal: "g" })) as AgentResult;
+      expect(out.answer).toBe("ok");
+    } finally {
+      setDefaultClient(undefined);
+    }
+  });
+});

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -44,6 +44,8 @@ usage: kx <command> [args]
               --cors-origin enables the gRPC-web browser shim for the listed origins, deny-by-default)
 
   client verbs (gRPC over the gateway; common flags: --endpoint <url> --token <t> | --token-file <p> --tls-ca <path> --json):
+    kx agent run --goal <text> [--context <handle>]... [--context-ref <hex>]... [--input k=v]... [--timeout-secs N]
+                                                 (the embeddable agent-runner: goal → answer + audited actions; see `kx help agent`)
     kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--stream] [--timeout-secs N] [--out <file>] [--context <handle>]...
     kx chain run \"<dsl>\" --tasks <tasks.json> [--seed N] [--wait] [--out <file>] [--emit-blueprint <file>] [--dry-run]
                                                  (string-DSL DAG: a > [b & c]; --emit-blueprint = a portable blueprint; see `kx help chain`)
@@ -94,6 +96,8 @@ pub enum Cli {
     },
     /// Forward to the gateway server: the `serve` args (verb stripped).
     Serve(Vec<String>),
+    /// `agent run` — the embeddable agent-runner (PR-9c-1; Invoke-of-react wrapper).
+    Agent(verbs::agent::AgentArgs),
     /// `invoke` a published blueprint by handle (wire-legacy: recipe).
     Invoke(verbs::invoke::InvokeArgs),
     /// `blueprint run` — author a Tier-1 DAG and run it (SubmitWorkflow).
@@ -172,6 +176,7 @@ impl Cli {
                 })
             }
             Some("serve") => Ok(Cli::Serve(args.collect())),
+            Some("agent") => Ok(Cli::Agent(verbs::agent::parse(args)?)),
             Some("invoke") => Ok(Cli::Invoke(verbs::invoke::parse(args)?)),
             Some("blueprint") => Ok(Cli::Blueprint(verbs::blueprint::parse(args)?)),
             Some("chain") => Ok(Cli::Chain(verbs::chain::parse(args)?)),
@@ -245,6 +250,7 @@ async fn dispatch(cli: Cli) -> Result<(), CliError> {
         }
         Cli::Runtime { argv, json } => run_engine(argv, json).await,
         Cli::Serve(rest) => serve(rest).await,
+        Cli::Agent(a) => verbs::agent::execute(a).await,
         Cli::Invoke(a) => verbs::invoke::execute(a).await,
         Cli::Blueprint(a) => verbs::blueprint::execute(a).await,
         Cli::Chain(a) => verbs::chain::execute(a).await,
@@ -466,6 +472,17 @@ kx serve --dev-allow-local [--journal <path>] [--content <dir>] [--catalog-dir <
   loopback only) or --auth-token(-file); a bare `kx serve` with neither errors with a hint.
   Browser SPAs: --cors-origin <scheme://host[:port]> (repeatable, deny-by-default) enables the
   gRPC-web shim for the listed origins (pair with --tls-cert/--tls-key for https)."
+            .into(),
+        "agent" => "\
+kx agent run --goal <text> [--context <handle>]... [--context-ref <hex>]... [--input k=v]... [--timeout-secs N] [client flags]
+  The embeddable agent-runner (PR-9c-1): give a GOAL and the runtime completes it
+  AGENTICALLY — reasoning, calling permission-gated tools in a bounded loop, and
+  returning a reasoned answer PLUS the AUDITED action set (the tools it fired).
+  A thin wrapper over Invoke of `kx/recipes/react` — NEVER SubmitRun (BLOCKER #5);
+  the warrant is always server-derived (SN-8). --context attaches published context
+  bundles; --input k=v folds into the goal prompt (the react contract has no
+  structured input slot yet). --json prints {answer, actions, run_handle, instance_id};
+  exit 0 = answered, 1 = the run failed, 3 = timed out (resume with `kx react list`)."
             .into(),
         "invoke" => "\
 kx invoke <handle> --args <json> [--args-file <path>] [--wait] [--stream] [--timeout-secs N] [--out <file>] [client flags]

--- a/crates/kx-cli/src/format.rs
+++ b/crates/kx-cli/src/format.rs
@@ -396,6 +396,73 @@ pub fn render_wait(outcome: &WaitOutcome, json: bool, include_payload: bool) -> 
     }
 }
 
+/// Render `kx agent run` (PR-9c-1) — the agent's final answer plus its AUDITED
+/// tool-action set (the chain's settled `tool` turns, in order). `--json` mirrors
+/// the SDK `AgentResult.json()` shape (`instance_id` / `run_handle` / `actions` /
+/// `answer`); a non-committed disposition is surfaced honestly via `state`.
+/// `actions` is a pre-filtered `(tool_id, tool_version, turn)` list.
+#[must_use]
+pub fn render_agent_result(
+    outcome: &WaitOutcome,
+    actions: &[(String, String, u32)],
+    json: bool,
+) -> String {
+    if json {
+        let action_vals: Vec<Value> = actions
+            .iter()
+            .map(|(id, ver, turn)| json!({ "tool_id": id, "tool_version": ver, "turn": turn }))
+            .collect();
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "instance_id".into(),
+            json!(hex::encode(&outcome.instance_id)),
+        );
+        // `run_handle` is the durable, re-attachable handle = the instance id.
+        map.insert(
+            "run_handle".into(),
+            json!(hex::encode(&outcome.instance_id)),
+        );
+        map.insert("actions".into(), json!(action_vals));
+        if let Some(payload) = &outcome.payload {
+            if let Ok(text) = std::str::from_utf8(payload) {
+                map.insert("answer".into(), json!(text));
+            }
+        }
+        if outcome.state != WaitState::Committed {
+            let st = match outcome.state {
+                WaitState::Failed => "FAILED",
+                WaitState::Running => "RUNNING",
+                WaitState::Committed => "COMMITTED",
+            };
+            map.insert("state".into(), json!(st));
+        }
+        Value::Object(map).to_string()
+    } else {
+        let mut out = String::new();
+        match &outcome.payload {
+            Some(payload) => match std::str::from_utf8(payload) {
+                Ok(text) => out.push_str(text),
+                Err(_) => {
+                    let _ = write!(out, "(binary answer, {} bytes)", payload.len());
+                }
+            },
+            None => out.push_str(match outcome.state {
+                WaitState::Failed => "(no answer — the agent run failed)",
+                WaitState::Running => {
+                    "(no answer yet — timed out; resume with `kx react list --instance <id>`)"
+                }
+                WaitState::Committed => "(no answer payload)",
+            }),
+        }
+        let _ = write!(out, "\n\nActions taken: {}", actions.len());
+        for (id, ver, turn) in actions {
+            let _ = write!(out, "\n  turn {turn}: {id}@{ver}");
+        }
+        let _ = write!(out, "\ninstance_id {}", hex::encode(&outcome.instance_id));
+        out
+    }
+}
+
 /// Render the JSON form of a fetched content blob (the human path writes raw
 /// bytes; this is only used under `--json`).
 #[must_use]

--- a/crates/kx-cli/src/verbs/agent.rs
+++ b/crates/kx-cli/src/verbs/agent.rs
@@ -1,0 +1,223 @@
+//! `kx agent run --goal <text> ...` — the embeddable agent-runner (PR-9c-1).
+//!
+//! A thin wrapper over Invoke of `kx/recipes/react`: the runtime completes the
+//! goal AGENTICALLY (reason → permission-gated tool calls → answer) and the verb
+//! prints the answer plus the AUDITED action set (the chain's settled `tool`
+//! turns). NEVER SubmitRun (BLOCKER #5); the warrant is always server-derived
+//! (SN-8). `--input k=v` folds into the goal prompt — the react contract has no
+//! structured input slot yet (instruction / max_turns / max_tool_calls only).
+
+use std::time::Duration;
+
+use kx_proto::proto;
+
+use crate::client::{next_value, ClientCommon};
+use crate::error::CliError;
+use crate::format;
+use crate::wait::{self, WaitState};
+
+/// Default `--timeout-secs` (matches `invoke`).
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+/// The steered ReAct recipe the runner invokes (Invoke-only, server-warranted).
+const REACT_RECIPE_HANDLE: &str = "kx/recipes/react";
+/// The recipe's anchored bounded-loop budget (mirrors the SDK + the UI's planReactArgs).
+const DEFAULT_MAX_TURNS: u32 = 8;
+const DEFAULT_MAX_TOOL_CALLS: u32 = 6;
+
+/// Parsed `agent run` arguments.
+#[derive(Debug)]
+pub struct AgentArgs {
+    /// What to accomplish — becomes the react recipe's instruction.
+    pub goal: String,
+    /// Published context-bundle handles to attach (`--context`, repeatable).
+    pub context_bundles: Vec<String>,
+    /// Raw 64-hex content-store refs to attach as context (`--context-ref`, repeatable).
+    pub context_refs: Vec<String>,
+    /// Structured inputs (`--input k=v`, repeatable) folded into the goal prompt.
+    pub inputs: Vec<(String, String)>,
+    /// Settle timeout in seconds.
+    pub timeout_secs: u64,
+    /// Common client flags.
+    pub common: ClientCommon,
+}
+
+/// Parse `agent` args (the verb already consumed). The first token selects the
+/// subcommand (only `run` today).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<AgentArgs, CliError> {
+    let kw = args
+        .next()
+        .ok_or_else(|| CliError::Usage("agent requires a subcommand: run".into()))?;
+    if kw != "run" {
+        return Err(CliError::Usage(format!(
+            "unknown agent subcommand {kw:?} (expected: run)"
+        )));
+    }
+    let mut goal: Option<String> = None;
+    let mut context_bundles = Vec::new();
+    let mut context_refs = Vec::new();
+    let mut inputs: Vec<(String, String)> = Vec::new();
+    let mut timeout_secs = DEFAULT_TIMEOUT_SECS;
+    let mut common = ClientCommon::default();
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--goal" => goal = Some(next_value(&mut args, "--goal")?),
+            "--context" => context_bundles.push(next_value(&mut args, "--context")?),
+            "--context-ref" => context_refs.push(next_value(&mut args, "--context-ref")?),
+            "--input" => {
+                let kv = next_value(&mut args, "--input")?;
+                let (k, v) = kv
+                    .split_once('=')
+                    .ok_or_else(|| CliError::Usage(format!("--input expects k=v, got {kv:?}")))?;
+                inputs.push((k.to_string(), v.to_string()));
+            }
+            "--timeout-secs" => {
+                let v = next_value(&mut args, "--timeout-secs")?;
+                timeout_secs = v.parse().map_err(|_| {
+                    CliError::Usage(format!("--timeout-secs expects an integer, got {v:?}"))
+                })?;
+            }
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+    let goal = goal.ok_or_else(|| CliError::Usage("agent run requires --goal <text>".into()))?;
+    Ok(AgentArgs {
+        goal,
+        context_bundles,
+        context_refs,
+        inputs,
+        timeout_secs,
+        common,
+    })
+}
+
+/// Fold `--input k=v` pairs into the goal prompt (no structured recipe slot yet).
+fn fold_inputs(goal: &str, inputs: &[(String, String)]) -> String {
+    if inputs.is_empty() {
+        return goal.to_string();
+    }
+    let lines: Vec<String> = inputs.iter().map(|(k, v)| format!("- {k}: {v}")).collect();
+    format!("{goal}\n\nInputs:\n{}", lines.join("\n"))
+}
+
+/// Execute `agent run`.
+pub async fn execute(args: AgentArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+
+    let instruction = fold_inputs(&args.goal, &args.inputs);
+    let req_args = serde_json::json!({
+        "instruction": instruction,
+        "max_turns": DEFAULT_MAX_TURNS,
+        "max_tool_calls": DEFAULT_MAX_TOOL_CALLS,
+    })
+    .to_string()
+    .into_bytes();
+
+    let resp = client
+        .invoke(resolved.request(proto::InvokeRequest {
+            handle: REACT_RECIPE_HANDLE.to_string(),
+            args: req_args,
+            context_bundles: args.context_bundles,
+            context_refs: args.context_refs,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+
+    let outcome = wait::await_react_result(
+        &mut client,
+        &resolved,
+        resp.instance_id.clone(),
+        Duration::from_secs(args.timeout_secs),
+    )
+    .await?;
+
+    // The AUDITED action set = the chain's settled `tool` turns, in turn order.
+    let turns = client
+        .list_react_turns(resolved.request(proto::ListReactTurnsRequest {
+            limit: None,
+            instance_id: Some(resp.instance_id.clone()),
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner()
+        .turns;
+    let mut actions: Vec<(String, String, u32)> = turns
+        .iter()
+        .filter(|t| t.branch == "tool")
+        .map(|t| (t.tool_id.clone(), t.tool_version.clone(), t.turn))
+        .collect();
+    actions.sort_by_key(|(_, _, turn)| *turn);
+
+    println!(
+        "{}",
+        format::render_agent_result(&outcome, &actions, args.common.json)
+    );
+
+    // The exit-code contract mirrors `finish_wait`: committed → success,
+    // failed → exit 1, timed out → exit 3 (resumable).
+    match outcome.state {
+        WaitState::Committed => Ok(()),
+        WaitState::Failed => Err(CliError::Failed),
+        WaitState::Running => Err(CliError::WaitTimeout),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<AgentArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn run_parses_goal_context_inputs_and_json() {
+        let a = p(&[
+            "run",
+            "--goal",
+            "echo pong",
+            "--context",
+            "team/ctx/spec",
+            "--input",
+            "url=http://x",
+            "--input",
+            "lang=en",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(a.goal, "echo pong");
+        assert_eq!(a.context_bundles, vec!["team/ctx/spec".to_string()]);
+        assert_eq!(
+            a.inputs,
+            vec![
+                ("url".to_string(), "http://x".to_string()),
+                ("lang".to_string(), "en".to_string()),
+            ]
+        );
+        assert!(a.common.json);
+        assert_eq!(a.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn fold_inputs_appends_pairs_else_noop() {
+        assert_eq!(fold_inputs("g", &[]), "g");
+        let folded = fold_inputs("g", &[("k".into(), "v".into())]);
+        assert!(folded.starts_with("g\n\nInputs:\n"));
+        assert!(folded.contains("- k: v"));
+    }
+
+    #[test]
+    fn bad_inputs_are_usage_errors() {
+        assert!(p(&[]).is_err(), "no subcommand");
+        assert!(p(&["list"]).is_err(), "unknown subcommand");
+        assert!(p(&["run"]).is_err(), "missing --goal");
+        assert!(p(&["run", "--goal"]).is_err(), "missing --goal value");
+        assert!(p(&["run", "--goal", "g", "--input", "novalue"]).is_err());
+        assert!(p(&["run", "--goal", "g", "--timeout-secs", "soon"]).is_err());
+        assert!(p(&["run", "--goal", "g", "--bogus"]).is_err());
+    }
+}

--- a/crates/kx-cli/src/verbs/mod.rs
+++ b/crates/kx-cli/src/verbs/mod.rs
@@ -2,6 +2,7 @@
 //! `parse(...)`, and an async `execute(...)`. Shared `--wait` finishing lives
 //! here (used by `invoke` + `chain`).
 
+pub mod agent;
 pub mod alerts;
 pub mod blueprint;
 pub mod branch;

--- a/crates/kx-cli/src/wait.rs
+++ b/crates/kx-cli/src/wait.rs
@@ -202,6 +202,66 @@ pub async fn await_any_result(
     }
 }
 
+/// The branch a settled ReAct turn freezes to (vs the live `pending` / `tool` states).
+const REACT_ANSWER: &str = "answer";
+const REACT_DEAD: &str = "dead_lettered";
+
+/// Wait for a ReAct CHAIN to settle (the `kx/recipes/react` path). A react chain
+/// has no statically-known terminal Mote — the run-salted turn-0 id the gateway
+/// returns never commits, and the settled Answer turn is unknown until the model
+/// emits it — so completion is observed via `ListReactTurns`: done when a turn
+/// settles to `answer` (resolve its committed content) or `dead_lettered` (terminal
+/// failure). Mirrors the SDK `poll_react_result` (campaign finding F13). The
+/// `agent run` verb collects the tool ACTIONS with a final `ListReactTurns`.
+pub async fn await_react_result(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    instance_id: Vec<u8>,
+    timeout: Duration,
+) -> Result<WaitOutcome, CliError> {
+    let start = tokio::time::Instant::now();
+    loop {
+        let turns = client
+            .list_react_turns(resolved.request(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(instance_id.clone()),
+            })?)
+            .await
+            .map_err(CliError::from_status)?
+            .into_inner()
+            .turns;
+        if let Some(answer) = turns.iter().find(|t| t.branch == REACT_ANSWER) {
+            // The answer turn's committed result lives at its `result_ref` in the
+            // projection (the run-salted turn id is not statically known up front).
+            let view = get_projection(client, resolved, &instance_id).await?;
+            let result_ref = view
+                .motes
+                .iter()
+                .find(|m| m.mote_id == answer.turn_mote_id)
+                .and_then(|m| m.result_ref.clone());
+            return committed_outcome(
+                client,
+                resolved,
+                instance_id,
+                answer.turn_mote_id.clone(),
+                result_ref,
+            )
+            .await;
+        }
+        if let Some(dead) = turns.iter().find(|t| t.branch == REACT_DEAD) {
+            return Ok(terminal(
+                instance_id,
+                dead.turn_mote_id.clone(),
+                WaitState::Failed,
+            ));
+        }
+        if start.elapsed() >= timeout {
+            return Ok(terminal(instance_id, Vec::new(), WaitState::Running));
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -49,6 +49,15 @@ const TOOL_ENVELOPE: &[u8] = br#"{"tool_call":{"name":"mcp-echo","version":"1","
 /// decode→Tool-freeze→observation-fire→commit path; this const lets the fire-commits
 /// test assert that invariant for BOTH the JSON envelope and the native shape.
 const GEMMA_NATIVE: &[u8] = br#"<|tool_call>call:mcp_echo{"q":"x"}<tool_call|>"#;
+/// PR-9c-1 (dynamic multi-format tool-calling): Llama-3.1/3.2's native
+/// `<|python_tag|>{"name":…,"parameters":…}` shape — drives the new accept-side arm
+/// through the SAME settle→Tool-freeze→observation-fire→commit path. `parameters`
+/// (Llama's alias) exercises the tolerant args-key resolution.
+const PYTHON_TAG_NATIVE: &[u8] = br#"<|python_tag|>{"name":"mcp-echo","parameters":{"q":"x"}}"#;
+/// PR-9c-1: Qwen3/Hermes's native `<tool_call>\n{"name":…,"arguments":…}\n</tool_call>`
+/// XML-ish shape (newline-wrapped, as Qwen3 emits) — the other new accept-side arm.
+const XML_TOOL_NATIVE: &[u8] =
+    b"<tool_call>\n{\"name\":\"mcp-echo\",\"arguments\":{\"q\":\"x\"}}\n</tool_call>";
 
 /// The client's SEED Mote: an ordinary ROND model Mote carrying the instruction.
 /// Its identity is advisory — the coordinator swaps in the run-salted turn 0.
@@ -618,6 +627,108 @@ async fn tool_branch_fires_and_commits_via_gemma_native_shape() {
         svc.state_of(obs.id).await.unwrap(),
         MoteState::Committed,
         "the world-mutating observation COMMITTED — a tool genuinely fired"
+    );
+}
+
+/// PR-9c-1: the Llama `<|python_tag|>{…}` shape FIRES + commits through the real
+/// settle — proving the new accept-side arm is wired end-to-end (not just unit
+/// tested in the parser leaf). The `parameters` alias + a non-namespaced grant.
+#[tokio::test]
+async fn tool_branch_fires_and_commits_via_python_tag_shape() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true); // mcp-echo@1 GRANTED
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    commit_raw(&svc, &store, &turn0, &w, PYTHON_TAG_NATIVE, worker).await;
+
+    // (a) the settle decoded the python_tag shape + froze a Tool fact for mcp-echo@1.
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(
+        facts.len(),
+        2,
+        "anchor + the Tool settle (python_tag FIRED)"
+    );
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Tool { tool_id, tool_version },
+                ..
+            } if tool_id == "mcp-echo" && tool_version == "1"
+        ),
+        "the Llama `<|python_tag|>{{…}}` shape decodes + freezes a Tool fact"
+    );
+
+    // (b) the observation leases WITH the args decoded from `parameters`.
+    let (obs, args) = lease_observation(&svc, worker, &turn0).await;
+    assert_eq!(
+        args,
+        br#"{"q":"x"}"#.to_vec(),
+        "args decode from `parameters`"
+    );
+
+    // (c) the observation commits (the tool FIRED) ⇒ turn 1 spawns.
+    commit_raw(&svc, &store, &obs, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
+    assert_eq!(
+        svc.state_of(obs.id).await.unwrap(),
+        MoteState::Committed,
+        "the world-mutating observation COMMITTED — a python_tag tool genuinely fired"
+    );
+}
+
+/// PR-9c-1: the Qwen3/Hermes `<tool_call>\n{…}\n</tool_call>` shape FIRES + commits
+/// through the real settle — the other new accept-side arm, end-to-end. The
+/// `arguments` alias + the newline-wrapped form Qwen3 actually emits.
+#[tokio::test]
+async fn tool_branch_fires_and_commits_via_xml_tool_call_shape() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true); // mcp-echo@1 GRANTED
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+    let leased = common::lease_work(&svc, worker, MAC, 16).await;
+    let turn0: Mote = leased[0].mote.clone().unwrap().try_into().unwrap();
+    commit_raw(&svc, &store, &turn0, &w, XML_TOOL_NATIVE, worker).await;
+
+    // (a) the settle decoded the `<tool_call>` shape + froze a Tool fact for mcp-echo@1.
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(
+        facts.len(),
+        2,
+        "anchor + the Tool settle (`<tool_call>` FIRED)"
+    );
+    assert!(
+        matches!(
+            &facts[1],
+            JournalEntry::ReactRound {
+                turn: 0,
+                branch: ReactBranch::Tool { tool_id, tool_version },
+                ..
+            } if tool_id == "mcp-echo" && tool_version == "1"
+        ),
+        "the Qwen3 `<tool_call>{{…}}</tool_call>` shape decodes + freezes a Tool fact"
+    );
+
+    // (b) the observation leases WITH the args decoded from `arguments`.
+    let (obs, args) = lease_observation(&svc, worker, &turn0).await;
+    assert_eq!(
+        args,
+        br#"{"q":"x"}"#.to_vec(),
+        "args decode from `arguments`"
+    );
+
+    // (c) the observation commits (the tool FIRED) ⇒ turn 1 spawns.
+    commit_raw(&svc, &store, &obs, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
+    assert_eq!(
+        svc.state_of(obs.id).await.unwrap(),
+        MoteState::Committed,
+        "the world-mutating observation COMMITTED — an `<tool_call>` tool genuinely fired"
     );
 }
 

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -161,6 +161,90 @@ fn balanced_object(s: &str) -> Option<&str> {
     None
 }
 
+/// Llama-3.1/3.2's native tool-call open delimiter (`<|python_tag|>{"name":…}`).
+const PYTHON_TAG_OPEN: &str = "<|python_tag|>";
+/// Qwen3/Hermes XML-ish tool-call open tag (`<tool_call>{"name":…}</tool_call>`).
+/// DISTINCT from Gemma's `<|tool_call>` (note the `|`): `strip_prefix` is exact, so
+/// the two delimiters never collide, and the Gemma arm runs first.
+const XML_TOOL_OPEN: &str = "<tool_call>";
+
+/// Strip a DEFINED open delimiter, then return the brace-balanced inner `{ … }`
+/// object that follows it (after optional whitespace) — or `None`. Shared by the
+/// `<|python_tag|>` and `<tool_call>` shapes, which both wrap a
+/// `{"name":…, "arguments"|"parameters"|"args":…}` object after a marker. NEVER a
+/// mid-string `{` search (the marker is the boundary, and `balanced_object` bounds
+/// the object so a `</tool_call>` close tag / trailing prose can never leak in) —
+/// so the SN-8 injection boundary is unchanged. Total + panic-free.
+fn marked_object<'a>(text: &'a str, open: &str) -> Option<&'a str> {
+    let after = text.trim_start().strip_prefix(open)?;
+    balanced_object(after.trim_start())
+}
+
+/// Decode an inner `{"name":…, <args-alias>:…}` object (the body of a
+/// `<|python_tag|>` / `<tool_call>` shape) into `(raw_name, args_bytes)`, or `None`
+/// if it is not a recognizable named-tool object (fail-closed → the caller falls
+/// through to a normal completion). The args bag is accepted under ANY of
+/// `args` | `arguments` | `parameters` (models differ) — EXACTLY one present (two or
+/// more ⇒ `None`, ambiguous), as either a JSON object (carried verbatim) OR a
+/// pre-serialized JSON STRING (unescaped to its inner JSON — some models emit
+/// `"arguments":"{…}"`). Requires a non-empty `name`.
+///
+/// SN-8: this widens only ENVELOPE recognition — the `name` and the args bytes are
+/// preserved and still flow through `resolve_granted_name` (exact grant membership)
+/// and the downstream schema `validate_args`. Unknown sibling keys are ignored here
+/// (tolerant envelope), but a smuggled ARG key is still rejected by the typed schema
+/// downstream, so the authority surface is unchanged. Total + panic-free.
+fn decode_named_object(obj: &str) -> Option<(String, Vec<u8>)> {
+    #[derive(Deserialize)]
+    struct Named<'a> {
+        name: Option<String>,
+        #[serde(borrow, default)]
+        args: Option<&'a RawValue>,
+        #[serde(borrow, default)]
+        arguments: Option<&'a RawValue>,
+        #[serde(borrow, default)]
+        parameters: Option<&'a RawValue>,
+    }
+    let parsed: Named = serde_json::from_str(obj).ok()?;
+    let name = parsed.name?;
+    if name.trim().is_empty() {
+        return None;
+    }
+    let mut present = [parsed.args, parsed.arguments, parsed.parameters]
+        .into_iter()
+        .flatten();
+    let args_bytes = match present.next() {
+        // No args alias ⇒ an empty args object (matches `validate_args`' empty == `{}`).
+        None => b"{}".to_vec(),
+        Some(v) => {
+            if present.next().is_some() {
+                return None; // two+ aliases ⇒ ambiguous ⇒ fail-closed
+            }
+            args_value_bytes(v)?
+        }
+    };
+    Some((name, args_bytes))
+}
+
+/// Resolve a tool-call args VALUE (a `RawValue`) to verbatim args-object bytes: a
+/// JSON object is carried byte-for-byte; a pre-serialized JSON STRING is unescaped
+/// to its inner JSON (then JSON5-repaired + schema-validated downstream); any other
+/// kind (array/scalar) ⇒ `None` (a tool's args are an object). Total + panic-free.
+fn args_value_bytes(v: &RawValue) -> Option<Vec<u8>> {
+    let raw = v.get();
+    let head = raw.trim_start();
+    if head.starts_with('{') {
+        Some(raw.as_bytes().to_vec())
+    } else if head.starts_with('"') {
+        // A pre-serialized JSON string: unescape to the inner JSON bytes.
+        serde_json::from_str::<String>(raw)
+            .ok()
+            .map(String::into_bytes)
+    } else {
+        None
+    }
+}
+
 /// Separator-canonicalize a single name segment: `_`→`-` (matching how Gemma
 /// renders `fs-list` as `fs_list`), trimmed. This is the EXISTING gate
 /// normalization, factored out — NEVER a fuzzy/similarity/edit-distance remap
@@ -293,6 +377,42 @@ pub fn parse_tool_call(
         }));
     }
 
+    // (1b) Llama-3.1 `<|python_tag|>{…}` and Qwen3/Hermes `<tool_call>{…}</tool_call>`
+    //      — two MORE DEFINED-delimiter shapes (markers required; never a `{` search),
+    //      each wrapping a `{"name":…, "arguments"|"parameters"|"args":…}` object.
+    //      The name + args flow through the SAME grant resolution + exact
+    //      `tool_grants` equality (SN-8) as every other arm; the args bag tolerates
+    //      the model's alias + a pre-serialized-string value. A marker that does not
+    //      wrap a NAMED object falls through (like a bare Gemma marker), byte-identical
+    //      for every existing row (no current input begins with these markers).
+    for open in [PYTHON_TAG_OPEN, XML_TOOL_OPEN] {
+        let Some(obj) = marked_object(trimmed, open) else {
+            continue;
+        };
+        let Some((raw_name, args_bytes)) = decode_named_object(obj) else {
+            continue; // marked but not a recognizable named call ⇒ normal completion
+        };
+        // The model COMMITTED to a named marked call ⇒ resolve or fail-closed (a bad
+        // name is a refusal, never silent prose — mirrors the Gemma-native arm).
+        let Some(grant) = resolve_granted_name(&raw_name, warrant) else {
+            return Err(DecodeError::UngrantedTool {
+                name: ToolName(raw_name),
+                version: ToolVersion(String::new()),
+            });
+        };
+        if args_bytes.len() > max_args_bytes {
+            return Err(DecodeError::Oversize {
+                got: args_bytes.len(),
+                max: max_args_bytes,
+            });
+        }
+        return Ok(Some(ToolCall {
+            name: grant.tool_id,
+            version: grant.tool_version,
+            args_bytes,
+        }));
+    }
+
     if !trimmed.starts_with('{') {
         return Ok(None);
     }
@@ -333,8 +453,13 @@ pub fn parse_tool_call(
         return Err(DecodeError::UngrantedTool { name, version });
     };
 
-    // (4) Carry the args verbatim, size-capped (IMP-16).
-    let args_bytes = raw.args.get().as_bytes().to_vec();
+    // (4) Carry the args verbatim, size-capped (IMP-16). An args OBJECT is carried
+    //     byte-for-byte (the PR-2d-1 pin); a pre-serialized JSON-STRING value (some
+    //     models emit `"args":"{…}"`) is unescaped to its inner JSON, then repaired +
+    //     schema-validated downstream — the envelope-side complement to PR-3's args
+    //     repair. A non-object/non-string value carries verbatim (refused downstream).
+    let args_bytes =
+        args_value_bytes(&raw.args).unwrap_or_else(|| raw.args.get().as_bytes().to_vec());
     if args_bytes.len() > max_args_bytes {
         return Err(DecodeError::Oversize {
             got: args_bytes.len(),
@@ -827,5 +952,186 @@ mod tests {
             parse_tool_call(env, &w, 4096),
             Err(DecodeError::UngrantedTool { .. })
         ));
+    }
+
+    // ---- PR-9c-1: dynamic multi-format envelopes (accept-side; common open set) ----
+    // Llama `<|python_tag|>{…}` · Qwen3/Hermes `<tool_call>{…}</tool_call>` · args
+    // under args|arguments|parameters · args as a pre-serialized JSON string. All
+    // are ACCEPT-side, fail-closed, and flow through the SAME grant resolution (SN-8)
+    // as every other arm — the envelope-side complement to PR-3's args-side JSON5
+    // repair. The markerless bare `{name,arguments}` object + multiple-calls-per-turn
+    // are DEFERRED (pinned to Ok(None) below).
+
+    #[test]
+    fn python_tag_call_with_parameters_alias_is_decoded() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Llama-3.1/3.2 native: `<|python_tag|>` + a `{"name","parameters"}` object.
+        let env = br#"<|python_tag|>{"name":"mcp-echo","parameters":{"q":"x"}}"#;
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("a python_tag call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
+        assert_eq!(call.version, ToolVersion("1".into())); // the GRANT's version
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn python_tag_name_normalized_and_resolved() {
+        let w = warrant_granting(Some(("fs-list", "1")));
+        let env = br#"<|python_tag|>{"name":"fs_list","arguments":{}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("fs-list".into())); // `_`→`-` normalized
+        assert_eq!(call.args_bytes, b"{}".to_vec());
+    }
+
+    #[test]
+    fn python_tag_bare_leaf_resolves_namespaced_grant() {
+        let w = warrant_granting_many(&[("kxlocal-a1b2c3d4/multiply", "1")]);
+        let env = br#"<|python_tag|>{"name":"multiply","parameters":{"a":2,"b":3}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.name, ToolName("kxlocal-a1b2c3d4/multiply".into()));
+        assert_eq!(call.args_bytes, br#"{"a":2,"b":3}"#.to_vec());
+    }
+
+    #[test]
+    fn python_tag_non_json_body_is_normal_completion() {
+        // Llama's `<|python_tag|>func.call(...)` (non-JSON) form is OUT OF SCOPE:
+        // no `{` after the marker ⇒ no balanced object ⇒ falls through ⇒ Ok(None).
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = b"<|python_tag|>echo(\"x\")";
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn python_tag_ungranted_tool_is_refused() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"<|python_tag|>{"name":"mcp-danger","arguments":{}}"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn xml_tool_call_newline_wrapped_is_decoded() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Qwen3's native: `<tool_call>\n{"name","arguments"}\n</tool_call>`.
+        let env = b"<tool_call>\n{\"name\":\"mcp-echo\",\"arguments\":{\"q\":\"x\"}}\n</tool_call>";
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("an xml call");
+        assert_eq!(call.name, ToolName("mcp-echo".into()));
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn xml_tool_call_tolerates_missing_close_tag() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Truncated close tag — `balanced_object` still bounds the object.
+        let env = br#"<tool_call>{"name":"mcp-echo","arguments":{"q":"x"}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn xml_tool_call_does_not_collide_with_gemma_native() {
+        // `<tool_call>` (no pipe) must NOT be mistaken for Gemma's `<|tool_call>`
+        // (with pipe) — the delimiters are distinct and the Gemma arm runs first.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"<tool_call>{"name":"mcp-echo","args":{"q":"x"}}</tool_call>"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn marked_object_without_name_is_normal_completion() {
+        // A marked but un-named object is not a recognizable call ⇒ falls through.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"<tool_call>{"foo":"bar"}</tool_call>"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn two_args_aliases_is_fail_closed() {
+        // Both `args` and `arguments` present ⇒ ambiguous ⇒ not a call ⇒ Ok(None).
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env =
+            br#"<tool_call>{"name":"mcp-echo","args":{"q":"x"},"arguments":{"q":"y"}}</tool_call>"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn string_args_are_reparsed_in_marked_shape() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // Some models emit the args as a pre-serialized JSON string.
+        let env = br#"<tool_call>{"name":"mcp-echo","arguments":"{\"q\":\"x\"}"}</tool_call>"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn string_args_are_reparsed_in_wrapped_envelope() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        // The Kortecx `{"tool_call":{…}}` envelope with a STRING args value.
+        let env = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":"{\"q\":\"x\"}"}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("a call");
+        assert_eq!(call.args_bytes, br#"{"q":"x"}"#.to_vec());
+    }
+
+    #[test]
+    fn python_tag_oversize_args_refused() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let big = "x".repeat(100);
+        let env = format!(r#"<|python_tag|>{{"name":"mcp-echo","parameters":{{"q":"{big}"}}}}"#);
+        assert!(matches!(
+            parse_tool_call(env.as_bytes(), &w, 8),
+            Err(DecodeError::Oversize { .. })
+        ));
+    }
+
+    #[test]
+    fn marked_shape_empty_grants_is_none() {
+        let w = warrant_granting(None); // step (0) short-circuits before any arm
+        let env = br#"<|python_tag|>{"name":"mcp-echo","parameters":{}}"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    // ---- PR-9c-1: DEFERRED shapes degrade to a normal completion (pinned) ----
+
+    #[test]
+    fn bare_function_object_is_deferred_normal_completion() {
+        // Markerless `{"name":…,"arguments":…}` (Hermes/OpenAI) is DEFERRED: no
+        // `tool_call` wrapper, no marker ⇒ the JSON path finds no `tool_call` key ⇒
+        // Ok(None). Pins the boundary for a future markerless detector.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"name":"mcp-echo","arguments":{"q":"x"}}"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn multiple_tool_calls_array_is_deferred_normal_completion() {
+        // A multi-call array is a LOOP-SEMANTICS change (one Tool fact/turn) ⇒ DEFERRED;
+        // a `[` start never passes the `{`-gate ⇒ Ok(None) (fires nothing, fail-closed).
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"[{"name":"mcp-echo","arguments":{}},{"name":"mcp-echo","arguments":{}}]"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn tool_calls_plural_wrapper_is_deferred_normal_completion() {
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let env = br#"{"tool_calls":[{"name":"mcp-echo","arguments":{}}]}"#;
+        assert_eq!(parse_tool_call(env, &w, 4096), Ok(None));
+    }
+
+    #[test]
+    fn existing_shapes_a_and_b_unchanged_smoke() {
+        // Re-assert both pre-existing shapes still decode after the widening.
+        let w = warrant_granting(Some(("mcp-echo", "1")));
+        let a = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{"q":"x"}}}"#;
+        assert!(parse_tool_call(a, &w, 4096).unwrap().is_some());
+        let wf = warrant_granting(Some(("fs-list", "1")));
+        let b = b"<|tool_call>call:fs_list{}<tool_call|>";
+        assert!(parse_tool_call(b, &wf, 4096).unwrap().is_some());
     }
 }

--- a/docs/site/docs/agent-runner.md
+++ b/docs/site/docs/agent-runner.md
@@ -12,6 +12,62 @@ agents into workflows (a **chain of agents**), control how much a model **reason
 and read that reasoning back from a run. The live tool-using loop (plan / re-plan /
 critic / ReAct turns) runs **inside `kx serve`** and is crash-safe end to end.
 
+## Run an agent (the agent-runner)
+
+The fastest way to put the loop to work: give a **goal**, get back a reasoned
+**answer** plus the **audited set of actions** the agent took. `run_agent` is a thin,
+permission-gated wrapper over the live ReAct recipe — the runtime **derives the
+warrant** (you never author one, SN-8) and runs the bounded reason → tool → observe
+loop, then returns the committed answer with the tools it fired. It never uses
+`SubmitRun` (admission is identical to `kx invoke`).
+
+**Python** — `run_agent(goal, *, context=…, inputs=…, wait=True)`:
+
+```python
+import kortecx as kx
+
+result = kx.run_agent("Use the echo tool to repeat 'pong'.")
+print(result.answer)                        # the reasoned final answer
+for a in result.actions:                    # the audited action set
+    print(f"  turn {a.turn}: {a.tool_id}@{a.tool_version}")
+# async: await kx.run_agent_async(goal, client=async_client)
+```
+
+**TypeScript** — `runAgent({ goal, context?, inputs?, wait? })`:
+
+```ts
+import { runAgent } from "@kortecx/sdk";
+
+const result = await runAgent({ goal: "Use the echo tool to repeat 'pong'." });
+console.log(result.answer);
+for (const a of result.actions) {
+  console.log(`  turn ${a.turn}: ${a.toolId}@${a.toolVersion}`);
+}
+```
+
+**CLI** — `kx agent run`:
+
+```bash
+kx agent run --goal "Use the echo tool to repeat 'pong'." --json
+# { "answer": "...", "actions": [{ "tool_id": "mcp-echo/echo", "tool_version": "1", "turn": 1 }],
+#   "run_handle": "<hex>", "instance_id": "<hex>" }
+# exit 0 = answered · 1 = the run failed · 3 = timed out (resume with `kx react list`)
+```
+
+- **`context`** attaches published [context bundles](./context.md) the server resolves
+  and injects (identity-bearing — a different context is a different run).
+- **`inputs`** (`k=v` on the CLI, a map in the SDKs) fold into the goal prompt.
+- The returned **`AgentResult`** carries `answer` (+ `answer_bytes`), `actions` (the
+  audited tool set), and the re-attachable `run_handle` / `instance_id`. With
+  `wait=False` you get the run handle back instead and assemble the result later.
+
+> **Composing in a chain.** The agent-runner is the *steered* whole-run entry (the
+> model picks tools turn by turn). To put a tool-using agent *step* inside a larger
+> DAG, use the deterministic lane — `flow().agent(prompt, tools=[…])` or the
+> `model@tool` chain step (see the [DSL reference](./chains/dsl-reference.md)) — where
+> the granted tool set is fixed and part of the step's identity. There is no separate
+> chains `agent()` node by design (it would be a second, divergent wire shape).
+
 ## Chains of agents
 
 Wire one agent's output into the next with a **data edge** — the upstream result
@@ -105,9 +161,31 @@ Two things make the model more likely to get it right the first time:
 - The tool menu the model sees includes a well-formed **`Example:`** call for
   each tool (the exact JSON keys + a typed placeholder), so it emits the right
   shape.
-- Common, unambiguous JSON malformations (a **trailing comma**) are tolerated
-  when validating arguments — the authority gate (which tool, which grant) stays
-  exact; only the argument *syntax* is forgiven.
+- Common, unambiguous JSON malformations in the **arguments** — a trailing comma,
+  an unquoted key, a single-quoted string (the JSON5-ish subset real models emit)
+  — are repaired when validating; the authority gate (which tool, which grant)
+  stays exact, only the argument *syntax* is forgiven.
+
+### Different models, different shapes
+
+Tool-calling output varies by model, so the runtime recognizes the common
+**call envelopes** — accept-side and fail-closed — and routes them all through the
+same exact grant check:
+
+| Model family | Shape recognized |
+|---|---|
+| Kortecx / generic JSON | `{"tool_call":{"name":…,"args":…}}` |
+| Gemma | `<\|tool_call>call:NAME{…}<tool_call\|>` |
+| Llama 3.x | `<\|python_tag\|>{"name":…,"parameters":…}` |
+| Qwen / Hermes | `<tool_call>{"name":…,"arguments":…}</tool_call>` |
+
+The arguments bag is accepted under `args`, `arguments`, or `parameters`, as either
+a JSON object or a pre-serialized JSON string. A reasoning preamble
+(`<think>…</think>` / Gemma `<|channel>…`) or a Markdown code fence around the call
+is stripped first. Anything the runtime doesn't recognize as a call is treated as a
+normal answer (it never mis-fires a tool). This is **acceptance** only — the tool
+name still resolves to an exact grant (SN-8); a model can never widen its own
+authority by how it phrases a call.
 
 Inspect what happened per turn:
 

--- a/ui/src/components/chat/ReactProgress.tsx
+++ b/ui/src/components/chat/ReactProgress.tsx
@@ -33,6 +33,11 @@ export function ReactProgress({ turns }: { turns: readonly ReactTurnVM[] }) {
     );
   }
   const cap = turns[0]?.maxTurns ?? 8;
+  // PR-9c-1: the AUDITED action set — the chain's settled `tool` turns. A pure
+  // derivation over the same durable facts (no new RPC/state); shown as an honest
+  // summary so the action set reads as a *set*, not only per-turn chips.
+  const actions = turns.filter((t) => t.branch === "tool");
+  const distinctTools = [...new Set(actions.map((t) => `${t.toolId}@${t.toolVersion}`))];
   return (
     <div className="react-progress" data-testid="react-progress">
       <span className="muted">
@@ -65,6 +70,11 @@ export function ReactProgress({ turns }: { turns: readonly ReactTurnVM[] }) {
             {chipLabel(t)}
           </span>
         ),
+      )}
+      {actions.length > 0 && (
+        <span className="muted react-actions" data-testid="react-actions">
+          Actions taken: {actions.length} ({distinctTools.join(", ")})
+        </span>
       )}
     </div>
   );

--- a/ui/test/unit/react-progress-actions.test.tsx
+++ b/ui/test/unit/react-progress-actions.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * ReactProgress — the PR-9c-1 "Actions taken" summary. The agent-runner surfaces
+ * the AUDITED action set (the chain's settled `tool` turns) as an honest summary
+ * derived from the same durable `ListReactTurns` facts — no new RPC/state.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReactProgress } from "../../src/components/chat/ReactProgress";
+import type { ReactTurnVM } from "../../src/kx/use-react-progress";
+
+function turn(turn: number, branch: string, toolId = "", toolVersion = ""): ReactTurnVM {
+  return { turn, branch, toolId, toolVersion, turnMoteId: "ab", maxTurns: 8, rejectionReason: "" };
+}
+
+describe("ReactProgress — actions taken summary", () => {
+  it("summarizes the fired tool turns as an audited action set", () => {
+    render(
+      <ReactProgress
+        turns={[
+          turn(0, "tool", "mcp-echo/echo", "1"),
+          turn(1, "pending"),
+          turn(2, "tool", "fs-list", "1"),
+          turn(3, "answer"),
+        ]}
+      />,
+    );
+    const summary = screen.getByTestId("react-actions");
+    expect(summary.textContent).toContain("Actions taken: 2");
+    expect(summary.textContent).toContain("mcp-echo/echo@1");
+    expect(summary.textContent).toContain("fs-list@1");
+  });
+
+  it("dedupes repeated tools but counts every action", () => {
+    render(
+      <ReactProgress
+        turns={[turn(0, "tool", "mcp-echo/echo", "1"), turn(1, "tool", "mcp-echo/echo", "1")]}
+      />,
+    );
+    const summary = screen.getByTestId("react-actions");
+    expect(summary.textContent).toContain("Actions taken: 2");
+    // one distinct tool listed
+    expect(summary.textContent).toContain("(mcp-echo/echo@1)");
+  });
+
+  it("renders no actions summary when the agent only reasons + answers", () => {
+    render(<ReactProgress turns={[turn(0, "pending"), turn(1, "answer")]} />);
+    expect(screen.queryByTestId("react-actions")).toBeNull();
+  });
+});


### PR DESCRIPTION
The next RC-backbone PR (D164) after PR-3. **Two coherent halves, both digest-neutral.**

## Part A — agent-runner `run_agent` (GR18/D149 adoption headline)

A thin, permission-gated wrapper over **Invoke of `kx/recipes/react`** — **never `SubmitRun`** (BLOCKER #5); the warrant is always **server-derived** (SN-8). `run_agent(goal) → AgentResult{answer, actions, run_handle, instance_id}`, where `actions` is the audited set of tool turns assembled client-side from `ListReactTurns` (no proto change). Shipped **same-PR across every surface** (GR14):

- **Py** `run_agent` / `run_agent_async` + `AgentResult`/`AuditedAction` (+ async `invoke` `context` parity)
- **TS** `runAgent` + `AgentResult`/`AuditedAction` (node-only entry; the data types ride `common`, so `web`/`chains` bundles stay node-free — verified)
- **CLI** `kx agent run --goal … [--context] [--context-ref] [--input k=v] [--json]` (new react-settle wait loop; exit `0`/`1`/`3` contract)
- **UI** ReactProgress **"Actions taken"** summary (pure derivation over the same durable facts, both themes, D142)
- **docs/site** agent-runner page (the page was already comprehensive — the B-spec's "0-byte stub" was stale)

`inputs` fold into the prompt (the react contract has no structured slot yet). The Chains `agent()` node is **documented N/A** (GR1 — the deterministic lane is `flow().agent(prompt, tools=[…])` / `model@tool`; a node would be a divergent wire shape).

## Part B — dynamic multi-format tool-call parsing (`kx-toolcall`, accept-side)

The **envelope-side complement** to PR-3's args-side JSON5 repair. New **fail-closed** detectors for **Llama** `<|python_tag|>{…}` and **Qwen/Hermes** `<tool_call>{…}</tool_call>`, plus tolerant args keys (`args`|`arguments`|`parameters`) and **args-as-JSON-string**. New arms slot in **before** the `{`-gate and flow through the **same exact grant resolution** (`resolve_granted_name`, SN-8) + schema validation — only envelope *recognition* widens, never authority. The markerless bare `{name,arguments}` object and multiple-calls-per-turn are **deferred** (pinned to `Ok(None)`).

## Invariants

- digest **`7d22d4bd` invariant** (a0_guard + audit_trail; the canonical demo grants no tools, so `parse_tool_call` short-circuits before any detector)
- frozen trio **diff-EMPTY** (`kx-toolcall` is outside it) · `SALTED_TURN0_GOLDEN` untouched
- **no proto / journal / `Cargo.lock` change** · additive client surface only

## Tested

- `kx-toolcall` **36 → 54** unit tests (each new shape + adversarial false-positive guards; existing shapes byte-identical)
- `react_live.rs` **python_tag / xml fire → commit** model-free e2e (the `TOOL_ENVELOPE`/`GEMMA_NATIVE` fixtures unchanged; `unrecognized_tool_shape…fires_nothing` still green)
- Py **259** pytest + **8** `run_agent` · TS **259** vitest + **7** `runAgent` · UI **599** vitest + **3** ReactProgress · fmt / clippy `-D warnings` / doc / deny green
- **Live Gemma-4-12B** witnesses: clean reasoning (17×23=391), A2 graceful recovery (bad args → answer), **live tool-fire** (6× echo with a populated action set)

## Known pre-existing limitation (NOT this PR)

A react recipe's `instance_id` is **recipe-deterministic**, so multiple agent-runner invocations on one long-lived serve share it and answer/action retrieval keys on the first chain (the documented **§2.232/§2.241 shared-instance behavior**; the runner inherits it from `poll_react_result`). Use a fresh journal per distinct run today; the fix (a per-invocation react run identity) is a runtime change for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)