### PR TITLE
PR-9c-2a — opt-in LLM-judge critic (T-AGENT2) across runtime + CLI/Py/TS/UI + docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
 name = "kx-cli"
 version = "0.1.1"
 dependencies = [
+ "kx-critic-types",
  "kx-gateway",
  "kx-proto",
  "kx-runtime",
@@ -1946,6 +1947,7 @@ name = "kx-refusal"
 version = "0.1.1"
 dependencies = [
  "kx-content",
+ "kx-critic-types",
  "kx-mote",
  "kx-tool-registry",
  "kx-warrant",

--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -28,6 +28,7 @@ from .chains import Chain, Task, chain, model, pure
 from .client import DEFAULT_ENDPOINT, AsyncKxClient, KxClient
 from .content import ContentItem, PutResult
 from .context import ContextBundle, ContextBundleItem, PutContextBundleResult
+from .critic import decode_critic_verdict
 from .datasets import DatasetHit, DatasetSummary, FuzzyHit, IngestDocument, IngestResult
 from .defaults import (
     default_client,
@@ -166,6 +167,8 @@ __all__ = [
     "run_agent_async",
     "AgentResult",
     "AuditedAction",
+    # T-AGENT2 — decode a committed CriticVerdict (the kx/recipes/judge terminal).
+    "decode_critic_verdict",
     # V2b — local function tools (@kx.tool → a governed stdio MCP tool).
     "LocalToolDef",
     "ToolError",

--- a/bindings/python/src/kortecx/agent_result.py
+++ b/bindings/python/src/kortecx/agent_result.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from .critic import decode_critic_verdict
 from .react import ReactTurn
 
 
@@ -46,6 +47,15 @@ class AgentResult:
         """True iff the agent produced a committed answer."""
         return self.answer_bytes is not None
 
+    @property
+    def verdict(self) -> Optional[str]:
+        """T-AGENT2: if this run's terminal is an LLM-judge (``kx/recipes/judge``),
+        the decoded ``"valid"`` / ``"invalid: <reason>"`` summary; ``None`` for a
+        plain answer. Display-only (SN-8)."""
+        if self.answer_bytes is None:
+            return None
+        return decode_critic_verdict(self.answer_bytes)
+
     def to_dict(self) -> dict:
         """A JSON-able view (the ``kx agent run --json`` shape)."""
         out: dict = {
@@ -58,6 +68,9 @@ class AgentResult:
         }
         if self.answer is not None:
             out["answer"] = self.answer
+        verdict = self.verdict
+        if verdict is not None:
+            out["verdict"] = verdict
         return out
 
     def json(self) -> dict:

--- a/bindings/python/src/kortecx/critic.py
+++ b/bindings/python/src/kortecx/critic.py
@@ -1,0 +1,57 @@
+"""Decode a committed ``CriticVerdict`` to a readable summary (T-AGENT2).
+
+The opt-in LLM-judge gate (``kx/recipes/judge``) commits a ``CriticVerdict`` as its
+terminal result. Its canonical wire encoding is a tiny, stable byte layout — a
+2-byte little-endian ``CRITIC_SCHEMA_VERSION`` prefix followed by fixed-int bincode
+of the verdict enum — so the SDK decodes the VALID/INVALID summary directly,
+without a bincode dependency. Display-only (SN-8): the summary never authorizes
+anything; the runtime's promotion gate reads the committed fact, not this string.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Must match ``kx_critic_types::CRITIC_SCHEMA_VERSION``.
+_CRITIC_SCHEMA_VERSION = 1
+
+# ``CriticReason`` variant discriminants (the enum's declaration order; JudgeRejected
+# is the trailing T-AGENT2 addition). Only used for a human-readable summary.
+_REASONS = {
+    0: "schema mismatch",
+    1: "duplicate detected",
+    2: "stat out of bounds",
+    3: "PII leak",
+    4: "unparseable input",
+    5: "judge rejected",
+}
+_JUDGE_CODES = {
+    0: "judge: answer did not satisfy the rubric",
+    1: "judge: response was unparseable (fail-closed)",
+}
+
+
+def decode_critic_verdict(payload: bytes) -> Optional[str]:
+    """Decode ``payload`` as a ``CriticVerdict`` → ``"valid"`` / ``"invalid: <reason>"``.
+
+    Returns ``None`` for any payload that is not a well-formed verdict (a model
+    answer, a tool observation, an empty/short buffer, an unknown schema version),
+    so callers fall back to the raw bytes. Total + panic-free over arbitrary input.
+    """
+    if len(payload) < 6:
+        return None
+    if int.from_bytes(payload[0:2], "little") != _CRITIC_SCHEMA_VERSION:
+        return None
+    variant = int.from_bytes(payload[2:6], "little")
+    if variant == 0:  # CriticVerdict::Valid
+        return "valid"
+    if variant != 1:  # not Invalid either ⇒ not a verdict
+        return None
+    if len(payload) < 10:
+        return "invalid"
+    reason = int.from_bytes(payload[6:10], "little")
+    detail = _REASONS.get(reason, "rejected")
+    if reason == 5 and len(payload) >= 12:  # JudgeRejected { reason_code: u16 }
+        code = int.from_bytes(payload[10:12], "little")
+        detail = _JUDGE_CODES.get(code, f"judge: rejected (code {code})")
+    return f"invalid: {detail}"

--- a/bindings/python/src/kortecx/run.py
+++ b/bindings/python/src/kortecx/run.py
@@ -64,6 +64,17 @@ class Result:
         except UnicodeDecodeError:
             return None
 
+    @property
+    def verdict(self) -> Optional[str]:
+        """T-AGENT2: if this run's terminal is an LLM-judge (``kx/recipes/judge``),
+        the decoded ``"valid"`` / ``"invalid: <reason>"`` summary; ``None`` otherwise.
+        Display-only (SN-8)."""
+        from .critic import decode_critic_verdict
+
+        if self.payload is None:
+            return None
+        return decode_critic_verdict(self.payload)
+
     def to_dict(self, include_payload: bool = True) -> dict:
         """The CLI ``--wait --json`` shape (parity with ``render_wait``)."""
         out: dict = {
@@ -77,6 +88,9 @@ class Result:
             out["timed_out"] = True
         if self.payload is not None:
             out["result_len"] = len(self.payload)
+            verdict = self.verdict
+            if verdict is not None:
+                out["verdict"] = verdict
             if include_payload:
                 text = self.text
                 if text is not None:

--- a/bindings/python/tests/test_critic_verdict.py
+++ b/bindings/python/tests/test_critic_verdict.py
@@ -1,0 +1,35 @@
+"""T-AGENT2: decode a committed ``CriticVerdict`` (the ``kx/recipes/judge`` terminal).
+
+Pins the SDK decoder against the EXACT ``kx_critic_types::CriticVerdict::encode``
+byte layout (2-byte LE schema version ‖ fixed-int bincode) — a pure unit test, no
+serve. Mirrors the CLI ``critic_verdict_summary`` + the TS ``decodeCriticVerdict``.
+"""
+
+from kortecx import decode_critic_verdict
+
+# Canonical encodings (must match the Rust `CriticVerdict::encode` bytes the
+# kx-critic-types `trailing_judge_variants_are_byte_neutral` test pins).
+_VALID = bytes([1, 0, 0, 0, 0, 0])  # version 1 ‖ enum variant 0 (Valid)
+# version 1 ‖ Invalid (variant 1) ‖ CriticReason JudgeRejected (variant 5) ‖ code u16
+_INVALID_JUDGE_0 = bytes([1, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0])
+_INVALID_JUDGE_1 = bytes([1, 0, 1, 0, 0, 0, 5, 0, 0, 0, 1, 0])
+
+
+def test_decode_valid() -> None:
+    assert decode_critic_verdict(_VALID) == "valid"
+
+
+def test_decode_invalid_judge_reasons() -> None:
+    assert decode_critic_verdict(_INVALID_JUDGE_0) == (
+        "invalid: judge: answer did not satisfy the rubric"
+    )
+    assert decode_critic_verdict(_INVALID_JUDGE_1) == (
+        "invalid: judge: response was unparseable (fail-closed)"
+    )
+
+
+def test_non_verdict_payload_is_none() -> None:
+    # A plain model answer / short / wrong-version buffer is left alone.
+    assert decode_critic_verdict(b"Paris") is None
+    assert decode_critic_verdict(b"") is None
+    assert decode_critic_verdict(bytes([2, 0, 0, 0, 0, 0])) is None  # wrong version

--- a/bindings/typescript/src/agent-result.ts
+++ b/bindings/typescript/src/agent-result.ts
@@ -9,6 +9,7 @@
  * and web entries via `common`. SN-8: every id + action is server-derived.
  */
 
+import { decodeCriticVerdict } from "./critic.js";
 import type { ReactTurn } from "./react.js";
 
 /** One tool action the agent took — a settled ReAct `tool` turn. The `toolId` /
@@ -50,6 +51,13 @@ export class AgentResult {
     return this.answerBytes !== null;
   }
 
+  /** T-AGENT2: if this run's terminal is an LLM-judge (`kx/recipes/judge`), the
+   *  decoded `"valid"` / `"invalid: <reason>"` summary; `null` for a plain answer.
+   *  Display-only (SN-8). */
+  get verdict(): string | null {
+    return this.answerBytes === null ? null : decodeCriticVerdict(this.answerBytes);
+  }
+
   /** A JSON-able view (the `kx agent run --json` shape; parity with the Python SDK). */
   toJSON(): Record<string, unknown> {
     const out: Record<string, unknown> = {
@@ -58,6 +66,8 @@ export class AgentResult {
       actions: this.actions.map((a) => a.toJSON()),
     };
     if (this.answer !== null) out.answer = this.answer;
+    const verdict = this.verdict;
+    if (verdict !== null) out.verdict = verdict;
     return out;
   }
 

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -50,6 +50,8 @@ export type { ReactTurnPage } from "./react.js";
 // data (no Node imports) — safe in both the node and web bundles. `runAgent` itself
 // (the zero-config entry) is node-only and exported from the root `index`.
 export { AgentResult, AuditedAction, assembleActions } from "./agent-result.js";
+// T-AGENT2: decode a committed CriticVerdict (the kx/recipes/judge terminal).
+export { decodeCriticVerdict } from "./critic.js";
 
 export { TokenChunk } from "./tokens.js";
 

--- a/bindings/typescript/src/critic.ts
+++ b/bindings/typescript/src/critic.ts
@@ -1,0 +1,69 @@
+/**
+ * Decode a committed `CriticVerdict` to a readable summary (T-AGENT2).
+ *
+ * The opt-in LLM-judge gate (`kx/recipes/judge`) commits a `CriticVerdict` as its
+ * terminal result. Its canonical wire encoding is a tiny, stable byte layout — a
+ * 2-byte little-endian `CRITIC_SCHEMA_VERSION` prefix followed by fixed-int bincode
+ * of the verdict enum — so the SDK decodes the VALID/INVALID summary directly,
+ * without a bincode dependency. Platform-neutral (no Node imports): re-exported by
+ * both the node and web entries via `common`. Display-only (SN-8): the summary
+ * never authorizes anything; the runtime's promotion gate reads the committed fact.
+ */
+
+/** Must match `kx_critic_types::CRITIC_SCHEMA_VERSION`. */
+const CRITIC_SCHEMA_VERSION = 1;
+
+/** `CriticReason` variant discriminants (declaration order; `JudgeRejected` is the
+ *  trailing T-AGENT2 addition). Used only for a human-readable summary. */
+const REASONS: Record<number, string> = {
+  0: "schema mismatch",
+  1: "duplicate detected",
+  2: "stat out of bounds",
+  3: "PII leak",
+  4: "unparseable input",
+  5: "judge rejected",
+};
+const JUDGE_CODES: Record<number, string> = {
+  0: "judge: answer did not satisfy the rubric",
+  1: "judge: response was unparseable (fail-closed)",
+};
+
+// Callers length-guard before reading; `?? 0` satisfies `noUncheckedIndexedAccess`
+// without changing behavior (the fallback is never reached in-bounds).
+function u16le(b: Uint8Array, off: number): number {
+  return (b[off] ?? 0) | ((b[off + 1] ?? 0) << 8);
+}
+function u32le(b: Uint8Array, off: number): number {
+  // `>>> 0` keeps it an unsigned 32-bit value.
+  return (
+    ((b[off] ?? 0) |
+      ((b[off + 1] ?? 0) << 8) |
+      ((b[off + 2] ?? 0) << 16) |
+      ((b[off + 3] ?? 0) << 24)) >>>
+    0
+  );
+}
+
+/**
+ * Decode `payload` as a `CriticVerdict` → `"valid"` / `"invalid: <reason>"`.
+ *
+ * Returns `null` for any payload that is not a well-formed verdict (a model answer,
+ * a tool observation, an empty/short buffer, an unknown schema version), so callers
+ * fall back to the raw bytes. Total + never throws over arbitrary input.
+ */
+export function decodeCriticVerdict(payload: Uint8Array): string | null {
+  if (payload.length < 6) return null;
+  if (u16le(payload, 0) !== CRITIC_SCHEMA_VERSION) return null;
+  const variant = u32le(payload, 2);
+  if (variant === 0) return "valid"; // CriticVerdict::Valid
+  if (variant !== 1) return null; // not Invalid either ⇒ not a verdict
+  if (payload.length < 10) return "invalid";
+  const reason = u32le(payload, 6);
+  let detail = REASONS[reason] ?? "rejected";
+  if (reason === 5 && payload.length >= 12) {
+    // JudgeRejected { reason_code: u16 }
+    const code = u16le(payload, 10);
+    detail = JUDGE_CODES[code] ?? `judge: rejected (code ${code})`;
+  }
+  return `invalid: ${detail}`;
+}

--- a/bindings/typescript/src/run.ts
+++ b/bindings/typescript/src/run.ts
@@ -8,6 +8,7 @@
  */
 
 import type { KxClientBase } from "./client.js";
+import { decodeCriticVerdict } from "./critic.js";
 import { encode } from "./hexids.js";
 import type { TokenChunk } from "./tokens.js";
 import type { Delta, Projection } from "./types.js";
@@ -65,6 +66,13 @@ export class Result {
     }
   }
 
+  /** T-AGENT2: if this run's terminal is an LLM-judge (`kx/recipes/judge`), the
+   *  decoded `"valid"` / `"invalid: <reason>"` summary; `null` otherwise.
+   *  Display-only (SN-8). */
+  get verdict(): string | null {
+    return this.payload === null ? null : decodeCriticVerdict(this.payload);
+  }
+
   /** The CLI `--wait --json` shape (parity with `render_wait` / the Python SDK). */
   toJSON(includePayload = true): Record<string, unknown> {
     const out: Record<string, unknown> = {
@@ -76,6 +84,8 @@ export class Result {
     if (this.timedOut) out.timed_out = true;
     if (this.payload !== null) {
       out.result_len = this.payload.length;
+      const verdict = this.verdict;
+      if (verdict !== null) out.verdict = verdict;
       if (includePayload) {
         const t = this.text;
         if (t !== null) out.result_utf8 = t;

--- a/bindings/typescript/test/critic-verdict.test.ts
+++ b/bindings/typescript/test/critic-verdict.test.ts
@@ -1,0 +1,39 @@
+/**
+ * T-AGENT2: decode a committed `CriticVerdict` (the `kx/recipes/judge` terminal).
+ *
+ * Pins the SDK decoder against the EXACT `kx_critic_types::CriticVerdict::encode`
+ * byte layout (2-byte LE schema version ‖ fixed-int bincode). Pure unit test, no
+ * serve. Mirrors the Python `decode_critic_verdict` + the CLI `critic_verdict_summary`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { decodeCriticVerdict } from "../src/critic.js";
+
+// Canonical encodings (must match the Rust `CriticVerdict::encode` bytes the
+// kx-critic-types `trailing_judge_variants_are_byte_neutral` test pins).
+const VALID = new Uint8Array([1, 0, 0, 0, 0, 0]); // version 1 ‖ enum variant 0 (Valid)
+// version 1 ‖ Invalid (variant 1) ‖ CriticReason JudgeRejected (variant 5) ‖ code u16
+const INVALID_JUDGE_0 = new Uint8Array([1, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0]);
+const INVALID_JUDGE_1 = new Uint8Array([1, 0, 1, 0, 0, 0, 5, 0, 0, 0, 1, 0]);
+
+describe("decodeCriticVerdict", () => {
+  it("decodes a VALID verdict", () => {
+    expect(decodeCriticVerdict(VALID)).toBe("valid");
+  });
+
+  it("decodes INVALID judge reasons", () => {
+    expect(decodeCriticVerdict(INVALID_JUDGE_0)).toBe(
+      "invalid: judge: answer did not satisfy the rubric",
+    );
+    expect(decodeCriticVerdict(INVALID_JUDGE_1)).toBe(
+      "invalid: judge: response was unparseable (fail-closed)",
+    );
+  });
+
+  it("returns null for a non-verdict payload", () => {
+    expect(decodeCriticVerdict(new TextEncoder().encode("Paris"))).toBeNull();
+    expect(decodeCriticVerdict(new Uint8Array([]))).toBeNull();
+    // wrong schema version
+    expect(decodeCriticVerdict(new Uint8Array([2, 0, 0, 0, 0, 0]))).toBeNull();
+  });
+});

--- a/crates/kx-cli/Cargo.toml
+++ b/crates/kx-cli/Cargo.toml
@@ -24,6 +24,9 @@ kx-runtime = { workspace = true }
 kx-gateway = { workspace = true }
 # The FROZEN KxGateway client stubs + request/response messages.
 kx-proto   = { workspace = true }
+# T-AGENT2: decode a committed `CriticVerdict` (the judge recipe's terminal) to a
+# readable VALID/INVALID summary for `kx invoke`/`kx mote show` (tiny FFI-free leaf).
+kx-critic-types = { workspace = true }
 # gRPC transport + Request/Status/Code for the client verbs. `tls` lets the client
 # dial an `https://` gateway (A1); `tls-native-roots` trusts the OS trust store for
 # a public CA (Apache/MIT — `tls-webpki-roots` is MPL-2.0, which deny.toml forbids).

--- a/crates/kx-cli/src/format.rs
+++ b/crates/kx-cli/src/format.rs
@@ -332,6 +332,39 @@ pub fn render_global_delta(delta: &proto::GlobalEventDelta, json: bool) -> Strin
     }
 }
 
+/// T-AGENT2: decode a committed payload as a [`kx_critic_types::CriticVerdict`]
+/// (the `kx/recipes/judge` terminal, or any critic mote's result) to a readable
+/// `"valid"` / `"invalid: <reason>"` summary. Returns `None` for any payload that
+/// is not a well-formed verdict (a model answer, a tool observation, …), so the
+/// caller falls back to the raw UTF-8/hex display. Display-only (SN-8): the
+/// summary never authorizes anything.
+#[must_use]
+pub fn critic_verdict_summary(payload: &[u8]) -> Option<String> {
+    use kx_critic_types::{CriticReason, CriticVerdict};
+    match CriticVerdict::decode(payload).ok()? {
+        CriticVerdict::Valid => Some("valid".to_string()),
+        CriticVerdict::Invalid { reason } => {
+            let detail = match reason {
+                CriticReason::JudgeRejected { reason_code: 0 } => {
+                    "judge: answer did not satisfy the rubric".to_string()
+                }
+                CriticReason::JudgeRejected { reason_code: 1 } => {
+                    "judge: response was unparseable (fail-closed)".to_string()
+                }
+                CriticReason::JudgeRejected { reason_code } => {
+                    format!("judge: rejected (code {reason_code})")
+                }
+                CriticReason::SchemaMismatch { .. } => "schema mismatch".to_string(),
+                CriticReason::DuplicateDetected { .. } => "duplicate detected".to_string(),
+                CriticReason::StatOutOfBounds { .. } => "stat out of bounds".to_string(),
+                CriticReason::PiiLeak { .. } => "PII leak".to_string(),
+                CriticReason::Unparseable { .. } => "unparseable input".to_string(),
+            };
+            Some(format!("invalid: {detail}"))
+        }
+    }
+}
+
 /// Render the result of a `--wait` run. `include_payload` is `false` when the
 /// caller wrote the payload to `--out` (then only metadata is emitted).
 #[must_use]
@@ -362,6 +395,11 @@ pub fn render_wait(outcome: &WaitOutcome, json: bool, include_payload: bool) -> 
         }
         if let Some(payload) = &outcome.payload {
             map.insert("result_len".into(), json!(payload.len()));
+            // T-AGENT2: a judge/critic terminal commits a `CriticVerdict` — surface
+            // the decoded VALID/INVALID summary alongside the raw bytes.
+            if let Some(verdict) = critic_verdict_summary(payload) {
+                map.insert("verdict".into(), json!(verdict));
+            }
             if include_payload {
                 if let Ok(text) = std::str::from_utf8(payload) {
                     map.insert("result_utf8".into(), json!(text));
@@ -381,11 +419,20 @@ pub fn render_wait(outcome: &WaitOutcome, json: bool, include_payload: bool) -> 
         }
         if let Some(payload) = &outcome.payload {
             let _ = write!(out, "\nresult_len       {}", payload.len());
+            // T-AGENT2: a judge/critic terminal commits a `CriticVerdict` — show the
+            // decoded VALID/INVALID summary (the raw bytes follow as result/hex).
+            let verdict = critic_verdict_summary(payload);
+            if let Some(ref v) = verdict {
+                let _ = write!(out, "\nverdict          {v}");
+            }
             if include_payload {
                 match std::str::from_utf8(payload) {
+                    // A judge verdict is non-UTF-8 bincode; the `verdict` line above
+                    // is the readable form, so suppress the redundant raw hex for it.
                     Ok(text) => {
                         let _ = write!(out, "\nresult           {text}");
                     }
+                    Err(_) if verdict.is_some() => {}
                     Err(_) => {
                         let _ = write!(out, "\nresult_hex       {}", hex::encode(payload));
                     }
@@ -2044,6 +2091,43 @@ pub fn render_capture_records(resp: &proto::ListCaptureRecordsResponse, json: bo
 mod tests {
     use super::*;
     use crate::wait::{WaitOutcome, WaitState};
+
+    #[test]
+    fn critic_verdict_summary_decodes_judge_and_ignores_prose() {
+        use kx_critic_types::{CriticReason, CriticVerdict};
+        // A committed judge verdict decodes to a readable summary.
+        assert_eq!(
+            critic_verdict_summary(&CriticVerdict::Valid.encode()).as_deref(),
+            Some("valid")
+        );
+        let invalid = CriticVerdict::Invalid {
+            reason: CriticReason::JudgeRejected { reason_code: 0 },
+        }
+        .encode();
+        assert_eq!(
+            critic_verdict_summary(&invalid).as_deref(),
+            Some("invalid: judge: answer did not satisfy the rubric")
+        );
+        // A plain model answer (not a verdict) is left alone (raw display).
+        assert_eq!(critic_verdict_summary(b"Paris"), None);
+        assert_eq!(critic_verdict_summary(b""), None);
+    }
+
+    #[test]
+    fn render_wait_shows_decoded_verdict_for_a_judge_terminal() {
+        use kx_critic_types::CriticVerdict;
+        let outcome = WaitOutcome {
+            instance_id: vec![1; 16],
+            terminal_mote_id: vec![2; 32],
+            state: WaitState::Committed,
+            result_ref: Some(vec![3; 32]),
+            payload: Some(CriticVerdict::Valid.encode()),
+        };
+        let text = render_wait(&outcome, false, true);
+        assert!(text.contains("verdict          valid"), "got: {text}");
+        // The non-UTF-8 bincode is NOT dumped as redundant hex when decoded.
+        assert!(!text.contains("result_hex"), "got: {text}");
+    }
 
     #[test]
     fn state_names_cover_range_and_unknown() {

--- a/crates/kx-critic-types/src/lib.rs
+++ b/crates/kx-critic-types/src/lib.rs
@@ -62,8 +62,8 @@ mod verdict;
 mod tests;
 
 pub use spec::{
-    CheckSpec, DedupSpec, PiiSpec, RecordFraming, SchemaSpec, SchemaTag, StatBoundsSpec,
-    TensorDTypeTag,
+    CheckSpec, DedupSpec, LlmJudgeSpec, PiiSpec, RecordFraming, SchemaSpec, SchemaTag,
+    StatBoundsSpec, TensorDTypeTag,
 };
 pub use verdict::{
     canonical_config, CheckKind, CriticReason, CriticVerdict, PiiClass, SchemaFault, StatKind,

--- a/crates/kx-critic-types/src/spec.rs
+++ b/crates/kx-critic-types/src/spec.rs
@@ -13,8 +13,16 @@ use smallvec::SmallVec;
 
 use crate::verdict::{CheckKind, PiiClass, StatKind};
 
-/// One deterministic check. The runtime evaluates exactly one of these against a
-/// producer's committed output bytes (see `kx_critic::evaluate`).
+/// One check the runtime evaluates against a producer's committed output bytes.
+///
+/// The first four kinds are **deterministic** in-process checks (see
+/// `kx_critic::evaluate`) committed `Pure`. [`CheckSpec::LlmJudge`] is the
+/// opt-in **model-graded** kind (T-AGENT2): a `ReadOnlyNondet` gate dispatched
+/// by the live serve executor (NOT in-process — `kx_critic::evaluate` fails it
+/// closed to `Invalid`). It is a **trailing variant**: the four deterministic
+/// variants keep their canonical discriminants, so a `critic_check: None` (the
+/// canonical demo) and every existing native critic fold byte-identically —
+/// the projection digest is unaffected (no `CRITIC_SCHEMA_VERSION` bump).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CheckSpec {
     /// Validate that the output conforms to a declared [`SchemaTag`].
@@ -25,6 +33,11 @@ pub enum CheckSpec {
     StatBounds(StatBoundsSpec),
     /// Reject when a forbidden PII pattern class matches.
     PiiLeak(PiiSpec),
+    /// Opt-in **LLM-judge** gate (T-AGENT2): grade the producer output against a
+    /// content-addressed rubric using the served model. A `ReadOnlyNondet` gate
+    /// — sampled once, committed, replayed (never re-queried). SN-8: the judge
+    /// returns a discrete Valid/Invalid decision, **never a similarity score**.
+    LlmJudge(LlmJudgeSpec),
 }
 
 /// The element type of a tensor payload. Self-contained mirror of
@@ -219,6 +232,27 @@ pub struct PiiSpec {
     pub forbidden: BTreeSet<PiiClass>,
 }
 
+/// Spec for the opt-in LLM-judge gate (T-AGENT2).
+///
+/// The judge dispatches the **served model** (not a spec-named model — for the
+/// OSS single-served-model RC the served model IS the judge; a future PR can add
+/// a per-spec model selector) over a rubric + the producer's committed bytes,
+/// and parses the completion into a discrete `Valid`/`Invalid` verdict.
+///
+/// The rubric (the grading instruction) is delivered via the judge Mote's
+/// `config_subset[JUDGE_RUBRIC_KEY]` (identity-bearing, like a model step's
+/// prompt) — NOT carried here — so two judges with different rubrics are distinct
+/// Motes by construction without a content-store read on the hot path. This spec
+/// carries only the integer output-token bound (the verdict is a short discrete
+/// decision). Integer-only — **no floats** on the identity path.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmJudgeSpec {
+    /// Authored fail-closed cap on the judge model's output tokens. Folds into the
+    /// critic Mote's `MoteId`; the recipe also mirrors it into the step warrant's
+    /// `model_route.max_output_tokens`, which `inference_params_from_mote` enforces.
+    pub max_output_tokens: u32,
+}
+
 impl CheckSpec {
     /// Which check kind this is.
     #[must_use]
@@ -228,7 +262,19 @@ impl CheckSpec {
             CheckSpec::Dedup(_) => CheckKind::Dedup,
             CheckSpec::StatBounds(_) => CheckKind::StatBounds,
             CheckSpec::PiiLeak(_) => CheckKind::PiiLeak,
+            CheckSpec::LlmJudge(_) => CheckKind::LlmJudge,
         }
+    }
+
+    /// `true` iff this is the opt-in model-graded [`CheckSpec::LlmJudge`] gate
+    /// (T-AGENT2) — a `ReadOnlyNondet` critic dispatched by the live serve
+    /// executor — as opposed to one of the four deterministic, `Pure`,
+    /// in-process checks. An inherent helper so downstream crates that hold a
+    /// `CheckSpec` (the refusal gate, the worker dispatch) can branch the judge
+    /// vs native path WITHOUT importing the type or matching its variants.
+    #[must_use]
+    pub const fn is_llm_judge(&self) -> bool {
+        matches!(self, CheckSpec::LlmJudge(_))
     }
 
     /// Fold this spec into a hasher canonically. Stable per-variant u8 tag,
@@ -266,6 +312,10 @@ impl CheckSpec {
                 for class in &s.forbidden {
                     h.update(&[pii_tag(*class)]);
                 }
+            }
+            CheckSpec::LlmJudge(s) => {
+                h.update(&[4]);
+                h.update(&s.max_output_tokens.to_le_bytes());
             }
         }
     }

--- a/crates/kx-critic-types/src/tests.rs
+++ b/crates/kx-critic-types/src/tests.rs
@@ -56,6 +56,8 @@ fn all_reason_samples() -> Vec<CriticReason> {
             check: crate::CheckKind::Dedup,
             at_offset: 11,
         },
+        CriticReason::JudgeRejected { reason_code: 0 },
+        CriticReason::JudgeRejected { reason_code: 1 },
     ]
 }
 
@@ -63,6 +65,49 @@ fn all_reason_samples() -> Vec<CriticReason> {
 fn verdict_encode_carries_version_prefix() {
     let bytes = CriticVerdict::Valid.encode();
     assert_eq!(&bytes[0..2], &CRITIC_SCHEMA_VERSION.to_le_bytes());
+}
+
+#[test]
+fn trailing_judge_variants_are_byte_neutral() {
+    // T-AGENT2 digest-neutrality pin: adding the trailing `LlmJudge` /
+    // `JudgeRejected` / `CheckKind::LlmJudge` variants must NOT change the
+    // canonical bytes of any EXISTING value (else every committed native verdict
+    // / critic Mote would re-address and the projection digest would move).
+    // `Valid` = version 1 LE (`[1,0]`) ‖ bincode-fixint enum index 0 (`[0,0,0,0]`).
+    assert_eq!(CriticVerdict::Valid.encode(), vec![1, 0, 0, 0, 0, 0]);
+    // A native critic spec folds byte-identically (Schema is discriminant 0).
+    let schema = CheckSpec::Schema(SchemaSpec {
+        expected: SchemaTag::Json,
+    });
+    let mut h = blake3::Hasher::new();
+    schema.hash_into(&mut h);
+    // Discriminant tag `0` then the `Json` tag `2` — fixed regardless of how many
+    // trailing variants the enum gains.
+    let mut expected = blake3::Hasher::new();
+    expected.update(&[0, 2]);
+    assert_eq!(h.finalize(), expected.finalize());
+}
+
+#[test]
+fn llmjudge_spec_round_trips_and_discriminates() {
+    use crate::LlmJudgeSpec;
+    let spec = CheckSpec::LlmJudge(LlmJudgeSpec {
+        max_output_tokens: 64,
+    });
+    // Folds deterministically (reproducible-by-construction identity).
+    assert_eq!(digest(&spec), digest(&spec));
+    // Distinct output bound ⇒ distinct fold (the rubric, delivered via
+    // config_subset, discriminates identity at the MoteDef level).
+    let other = CheckSpec::LlmJudge(LlmJudgeSpec {
+        max_output_tokens: 128,
+    });
+    assert_ne!(digest(&spec), digest(&other));
+    // Distinct from every native kind.
+    let native = CheckSpec::Schema(SchemaSpec {
+        expected: SchemaTag::Blob,
+    });
+    assert_ne!(digest(&spec), digest(&native));
+    assert_eq!(spec.kind(), crate::CheckKind::LlmJudge);
 }
 
 #[test]

--- a/crates/kx-critic-types/src/verdict.rs
+++ b/crates/kx-critic-types/src/verdict.rs
@@ -8,9 +8,18 @@ use thiserror::Error;
 use crate::spec::SchemaTag;
 
 /// Schema version of the [`CriticVerdict`] / `CheckSpec` wire encodings. Bumped
-/// on ANY change to the canonical bytes of either (the verdict bytes are a
-/// committed content-addressed fact; the spec bytes fold into a critic Mote's
-/// `MoteId`). Encoded as the first two bytes of [`CriticVerdict::encode`].
+/// on ANY change to the canonical bytes of an EXISTING value (the verdict bytes
+/// are a committed content-addressed fact; the spec bytes fold into a critic
+/// Mote's `MoteId`). Encoded as the first two bytes of [`CriticVerdict::encode`].
+///
+/// **Not bumped for a *trailing* enum variant** (T-AGENT2's `LlmJudge` /
+/// `JudgeRejected` / `CheckKind::LlmJudge`): a trailing variant leaves every
+/// existing variant's discriminant — and therefore every previously-encoded
+/// verdict/spec's bytes and content ref — byte-identical. Bumping would instead
+/// re-prefix EVERY verdict (native included) and break decode of version-`1`
+/// verdicts already committed in a user's journal (a back-compat regression);
+/// staying at `1` keeps recovery/replay of existing native-critic runs intact
+/// while a forward judge verdict simply fails closed on an old binary.
 pub const CRITIC_SCHEMA_VERSION: u16 = 1;
 
 /// A critic's committed verdict — the value a critic Mote's `result_ref` payload
@@ -86,6 +95,18 @@ pub enum CriticReason {
         /// Byte offset where parsing failed.
         at_offset: u64,
     },
+    /// The opt-in LLM-judge gate ([`crate::CheckSpec::LlmJudge`]) rejected the
+    /// output. **Trailing variant** — existing reasons keep their discriminants,
+    /// so native verdicts fold byte-identically (no `CRITIC_SCHEMA_VERSION` bump).
+    /// `reason_code` is a small, deterministic, integer-only classification of the
+    /// judge's discrete decision (see `kx_gateway`'s judge reason codes); it carries
+    /// no free-text / host-derived data, preserving the no-float identity rule.
+    JudgeRejected {
+        /// Integer classification of the rejection (`0` = the judge graded the
+        /// output invalid against the rubric; `1` = the judge completion was
+        /// unparseable/ambiguous and the gate failed closed to `Invalid`).
+        reason_code: u16,
+    },
 }
 
 /// Stable, u8-tagged discriminant naming a deterministic check kind. Carried by
@@ -100,6 +121,9 @@ pub enum CheckKind {
     StatBounds,
     /// The PII-leakage check.
     PiiLeak,
+    /// The opt-in LLM-judge gate (T-AGENT2). **Trailing variant** — the four
+    /// deterministic kinds keep their discriminants (digest-neutral).
+    LlmJudge,
 }
 
 /// The first structural fact that failed a schema check.

--- a/crates/kx-critic/src/evaluate.rs
+++ b/crates/kx-critic/src/evaluate.rs
@@ -1,14 +1,25 @@
 //! [`evaluate`] — the single entry point dispatching a [`CheckSpec`] to its check.
 
-use kx_critic_types::{CheckSpec, CriticVerdict};
+use kx_critic_types::{CheckSpec, CriticReason, CriticVerdict};
 
 use crate::checks;
+
+/// Reason code for an [`CheckSpec::LlmJudge`] reaching the in-process evaluator:
+/// the model-graded gate is dispatched by the live serve executor, NEVER
+/// in-process, so this path is unreachable in the live loop and fails closed.
+const JUDGE_UNPARSEABLE_CODE: u16 = 1;
 
 /// Evaluate one deterministic check against a producer's committed output bytes.
 ///
 /// **Pure, total, deterministic** (see the crate-level contract): returns a
 /// [`CriticVerdict`] for every input, never panics, and yields byte-identical
 /// verdicts for identical `(spec, input)` across runs / processes / machines.
+///
+/// [`CheckSpec::LlmJudge`] (T-AGENT2) is **not** a deterministic in-process
+/// check: the live serve executor dispatches the served model for it (see
+/// `kx_gateway`'s `run_judge`). Reaching the in-process evaluator with a judge
+/// spec is a misroute — it **fails closed to `Invalid`** (withhold), never
+/// `Valid`, so a misconfiguration can never silently promote unverified output.
 #[must_use]
 pub fn evaluate(spec: &CheckSpec, input: &[u8]) -> CriticVerdict {
     match spec {
@@ -16,5 +27,10 @@ pub fn evaluate(spec: &CheckSpec, input: &[u8]) -> CriticVerdict {
         CheckSpec::Dedup(s) => checks::dedup::eval(s, input),
         CheckSpec::StatBounds(s) => checks::stat_bounds::eval(s, input),
         CheckSpec::PiiLeak(s) => checks::pii::eval(s, input),
+        CheckSpec::LlmJudge(_) => CriticVerdict::Invalid {
+            reason: CriticReason::JudgeRejected {
+                reason_code: JUDGE_UNPARSEABLE_CODE,
+            },
+        },
     }
 }

--- a/crates/kx-critic/src/lib.rs
+++ b/crates/kx-critic/src/lib.rs
@@ -62,7 +62,7 @@ pub use evaluate::evaluate;
 
 // Re-export the full vocabulary so downstream crates depend on `kx-critic` alone.
 pub use kx_critic_types::{
-    canonical_config, CheckKind, CheckSpec, CriticReason, CriticVerdict, DedupSpec, PiiClass,
-    PiiSpec, RecordFraming, SchemaFault, SchemaSpec, SchemaTag, StatBoundsSpec, StatKind,
+    canonical_config, CheckKind, CheckSpec, CriticReason, CriticVerdict, DedupSpec, LlmJudgeSpec,
+    PiiClass, PiiSpec, RecordFraming, SchemaFault, SchemaSpec, SchemaTag, StatBoundsSpec, StatKind,
     TensorDTypeTag, VerdictDecodeError, CRITIC_SCHEMA_VERSION,
 };

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -182,8 +182,9 @@ pub use error::GatewayError;
 pub use live_tail::{GlobalLiveTailer, LiveTailer};
 pub use provision::{
     DemoLibrary, HostRecipeBinder, HostRecipeCatalog, HostSignatureCatalog, HostWorkflowAuthor,
-    DEMO_RECIPE_HANDLE, MODEL_RECIPE_HANDLE, PASSTHROUGH_DAG_HANDLE, REACT_AUTO_RECIPE_HANDLE,
-    REACT_EDIT_RECIPE_HANDLE, REACT_FS_RECIPE_HANDLE, REACT_RECIPE_HANDLE, VISION_RECIPE_HANDLE,
+    DEMO_RECIPE_HANDLE, JUDGE_RECIPE_HANDLE, MODEL_RECIPE_HANDLE, PASSTHROUGH_DAG_HANDLE,
+    REACT_AUTO_RECIPE_HANDLE, REACT_EDIT_RECIPE_HANDLE, REACT_FS_RECIPE_HANDLE,
+    REACT_RECIPE_HANDLE, VISION_RECIPE_HANDLE,
 };
 pub use server::{serve, start, RunningGateway};
 pub use teams::{seed_workspace_team, HostGrantView, HostMembershipView, WORKSPACE_TEAM_HANDLE};

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -194,6 +194,86 @@ fn chatml(prompt: &str) -> String {
     )
 }
 
+/// The fixed system instruction for the opt-in LLM-JUDGE gate (T-AGENT2). It
+/// constrains the judge to a single discrete decision token — SN-8: the runtime
+/// parses a Valid/Invalid VERDICT, never a similarity score; the model proposes,
+/// the runtime decides promotion.
+const JUDGE_SYSTEM: &str = "You are a strict output evaluator. Decide whether the OUTPUT \
+satisfies the RUBRIC. Reply with exactly one word: VALID if it fully satisfies the rubric, \
+otherwise INVALID. Do not explain.";
+
+/// ChatML fallback for the judge turn (used only when the backend cannot render
+/// the served model's own chat template — the deterministic test stub). Mirrors
+/// [`chatml`] but with the judge system instruction; kept separate so the
+/// byte-sensitive model path's `chatml` is untouched.
+#[must_use]
+fn judge_chatml(prompt: &str) -> String {
+    format!(
+        "<|im_start|>system\n{JUDGE_SYSTEM}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+    )
+}
+
+/// Build the judge USER turn: the original QUESTION (so the judge can grade
+/// whether the answer addresses it — without it a rubric like "addresses the
+/// prompt" is ungradeable), the RUBRIC, then the producer's ANSWER to grade. A
+/// pure, deterministic framing — the model's only input besides `JUDGE_SYSTEM`.
+/// An empty `question` (a workflow-authored judge that didn't bind one) omits the
+/// QUESTION section rather than emitting a blank one.
+#[must_use]
+fn render_judge_user(question: &str, rubric: &str, output: &str) -> String {
+    let q = question.trim();
+    let head = if q.is_empty() {
+        String::new()
+    } else {
+        format!("QUESTION:\n{q}\n\n")
+    };
+    format!("{head}RUBRIC:\n{rubric}\n\nANSWER:\n{output}\n\nVerdict (VALID or INVALID):")
+}
+
+/// Reason code: the judge model graded the output INVALID against the rubric.
+const JUDGE_INVALID_CODE: u16 = 0;
+/// Reason code: the judge completion was unparseable/ambiguous → fail closed to
+/// `Invalid` (withhold). Mirrors `kx_critic::evaluate`'s in-process fail-closed.
+const JUDGE_UNPARSEABLE_CODE: u16 = 1;
+
+/// Parse a judge model completion into a discrete [`kx_critic::CriticVerdict`].
+///
+/// **Total + fail-closed** (SN-8 / GR15). The decision is the **LAST standalone
+/// `VALID` / `INVALID` token** in the completion: a reasoning model (Gemma-4's
+/// `<|think|>`, Qwen's `<think>`, …) concludes with its verdict, so an earlier
+/// reasoning mention ("is this *invalid*? no") does NOT override the final
+/// answer. Matching on word boundaries (not a substring) also kills the trap
+/// where `INVALID` contains `VALID`. No decision token at all ⇒ `Invalid`
+/// (withhold) — NEVER a silent `Valid` on unparseable / reasoning-only output.
+#[must_use]
+fn parse_judge_verdict(bytes: &[u8]) -> kx_critic::CriticVerdict {
+    use kx_critic::{CriticReason, CriticVerdict};
+    let invalid = |code| CriticVerdict::Invalid {
+        reason: CriticReason::JudgeRejected { reason_code: code },
+    };
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return invalid(JUDGE_UNPARSEABLE_CODE);
+    };
+    // The last alphabetic token equal to VALID/INVALID is the verdict. Tokenizing
+    // on non-alphabetic boundaries makes `INVALID` its own token (never `VALID`).
+    let mut decision: Option<bool> = None;
+    for tok in text
+        .to_ascii_uppercase()
+        .split(|c: char| !c.is_ascii_alphabetic())
+    {
+        match tok {
+            "INVALID" => decision = Some(false),
+            "VALID" => decision = Some(true),
+            _ => {}
+        }
+    }
+    match decision {
+        Some(true) => CriticVerdict::Valid,
+        Some(false) => invalid(JUDGE_INVALID_CODE),
+        None => invalid(JUDGE_UNPARSEABLE_CODE),
+    }
+}
+
 /// Resolve the serve model GGUF: the `KX_SERVE_MODEL_GGUF` env path, iff it
 /// exists. `None` ⇒ no model serving (the model recipe is not provisioned), so
 /// `kx serve --features inference` still runs the durable spine + demo recipes.
@@ -813,6 +893,127 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             finished_at_epoch_ms: 0,
         })
     }
+
+    /// Run an opt-in **LLM-JUDGE** critic Mote (T-AGENT2) — the model-graded
+    /// sibling of [`Self::run_critic`]. Where the native critic evaluates a
+    /// deterministic check in-process (`Pure`), the judge dispatches the SERVED
+    /// model under the step warrant to grade the producer's committed output
+    /// against a content-addressed rubric, and commits a discrete
+    /// [`kx_critic::CriticVerdict`]. The Mote is `ReadOnlyNondet`
+    /// (StageThenCommit): sampled once, committed, and served-not-re-queried on
+    /// replay (a committed verdict is never re-dispatched — the digest of an
+    /// opt-in workflow is replay-stable).
+    ///
+    /// **SN-8 / GR15 — fail-closed on EVERY path** (never promote unverified
+    /// output): an ill-formed judge shape (R-15), an unserved model, a missing
+    /// producer, an oversized input, or an unparseable judge completion all
+    /// withhold (`Invalid`), never `Valid`. The judge cannot escalate authority —
+    /// `backend.dispatch` enforces the warrant's `model_route`/ceilings (D35); the
+    /// model PROPOSES a verdict, the runtime PARSES it to a discrete decision.
+    fn run_judge(
+        &self,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        // (1) Judge SHAPE gate (R-15: ReadOnlyNondet + critic_for + !shaper). Terminal.
+        kx_refusal::native_judge_shape(mote)
+            .map_err(|e| internal(&format!("LLM-judge shape (R-15): {e}")))?;
+        if !matches!(
+            mote.def.critic_check.as_ref(),
+            Some(kx_critic::CheckSpec::LlmJudge(_))
+        ) {
+            return Err(internal(
+                "run_judge reached without an LlmJudge critic_check",
+            ));
+        }
+        let producer_id = mote
+            .def
+            .critic_for
+            .ok_or_else(|| internal("judge critic_for vanished after shape gate"))?;
+        // The rubric (grading instruction) rides config_subset (identity-bearing,
+        // like a model step's prompt); absent ⇒ fail closed (a judge with no
+        // rubric cannot grade — never a silent VALID).
+        let rubric = rubric_from_config(mote)
+            .ok_or_else(|| internal("LLM-judge Mote carries no rubric (config_subset)"))?;
+        // The original QUESTION (the recipe binds the same `prompt` free-param to the
+        // judge step) — so the judge can grade whether the answer ADDRESSES it. Empty
+        // for a workflow-authored judge that bound none (graded on the rubric alone).
+        let question = prompt_from_config(mote).unwrap_or_default();
+
+        // (2) The judge dispatches the SERVED model — fail closed on an unserved
+        // model (never fall through to a placeholder verdict).
+        if !self.backend.supports(&mote.def.model_id) {
+            return Err(internal(&format!(
+                "LLM-judge Mote {:?} routes to an unserved model {:?} (fail-closed)",
+                mote.id, mote.def.model_id
+            )));
+        }
+
+        // (3) The producer's committed bytes via the F-7 seam (EXACTLY `critic_for`),
+        // bounded fail-closed (never truncate — that would corrupt the gate).
+        let parents = self.take_parent_context(mote.id).unwrap_or_default();
+        let producer_ref = parents
+            .iter()
+            .find(|(id, _)| *id == producer_id)
+            .map(|(_, r)| *r)
+            .ok_or_else(|| {
+                internal(&format!(
+                    "judge producer {producer_id:?} bytes not delivered via F-7 \
+                     (scheduling/D55 invariant) — withholding fail-closed"
+                ))
+            })?;
+        let producer_bytes = self
+            .store
+            .get(&producer_ref)
+            .map_err(|e| internal(&format!("read judge producer bytes: {e}")))?;
+        if producer_bytes.len() > CRITIC_MAX_INPUT_BYTES {
+            return Err(internal(&format!(
+                "judge producer output {} bytes exceeds max {CRITIC_MAX_INPUT_BYTES}",
+                producer_bytes.len()
+            )));
+        }
+
+        // (4) Build the judge prompt + dispatch under the warrant (the warrant's
+        // `model_route` bounds output tokens — set by the recipe from the spec's
+        // `max_output_tokens`; `inference_params_from_mote` refuses a widening, D35).
+        let user = render_judge_user(
+            &question,
+            &rubric,
+            &String::from_utf8_lossy(&producer_bytes),
+        );
+        let rendered = self
+            .backend
+            .render_chat(&mote.def.model_id, JUDGE_SYSTEM, &user)
+            .unwrap_or_else(|| judge_chatml(&user));
+        let input = InferenceInput::text(rendered);
+        let params = inference_params_from_mote(mote, warrant)
+            .map_err(|e| internal(&format!("judge inference params: {e}")))?;
+        let out = self
+            .backend
+            .dispatch(&mote.def.model_id, &input, &params, warrant)
+            .map_err(|e| internal(&format!("judge dispatch: {e}")))?;
+        if let Some(usage) = &self.usage {
+            usage.record_usage(
+                *mote.id.as_bytes(),
+                &out.model_id.0,
+                u64::from(out.output_tokens),
+            );
+        }
+
+        // (6) Parse the completion → a discrete verdict (fail-closed to Invalid),
+        // commit its canonical bytes. The committed Mote's `nd_class`
+        // (ReadOnlyNondet) is what the projection folds into the digest.
+        let verdict = parse_judge_verdict(&out.bytes);
+        let result_ref = self
+            .store
+            .put(&verdict.encode())
+            .map_err(|e| internal(&format!("content store put (judge verdict): {e}")))?;
+        Ok(MoteExecutionResult {
+            result_ref,
+            started_at_epoch_ms: 0,
+            finished_at_epoch_ms: 0,
+        })
+    }
 }
 
 impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
@@ -822,12 +1023,18 @@ impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
         warrant: &WarrantSpec,
         env: Option<Rootfs>,
     ) -> Result<MoteExecutionResult, MoteExecutorError> {
-        // Native deterministic CRITIC FIRST (PR-2c-3 critic-live): a critic carries no
+        // CRITIC FIRST (PR-2c-3 critic-live; T-AGENT2 judge): a critic carries no
         // prompt (so `has_prompt` is false) and would otherwise fall to the inner
-        // echo/real-body router, committing the wrong bytes instead of a verdict. Route
-        // it to the in-process check (mirrors the FROZEN `run_native_critic_mote`).
-        if mote.def.critic_check.is_some() {
-            return self.run_critic(mote);
+        // echo/real-body router, committing the wrong bytes instead of a verdict.
+        // The opt-in LLM-JUDGE gate routes to the model-graded `run_judge` (which
+        // needs the warrant for dispatch); every native check routes to the
+        // in-process `run_critic` (mirrors the FROZEN `run_native_critic_mote`).
+        if let Some(check) = mote.def.critic_check.as_ref() {
+            return if check.is_llm_judge() {
+                self.run_judge(mote, warrant)
+            } else {
+                self.run_critic(mote)
+            };
         }
         // A prompt-bearing Mote is a MODEL step. If the backend does NOT serve its
         // model_id, FAIL CLOSED — never delegate to the inner demo/echo executor.
@@ -893,6 +1100,22 @@ fn prompt_from_config(mote: &Mote) -> Option<String> {
         .def
         .config_subset
         .get(&ConfigKey(PROMPT_KEY.to_string()))?
+        .0;
+    Some(
+        serde_json::from_slice::<String>(raw)
+            .unwrap_or_else(|_| String::from_utf8_lossy(raw).into_owned()),
+    )
+}
+
+/// The T-AGENT2 judge's RUBRIC from `config_subset[JUDGE_RUBRIC_KEY]` (the
+/// grading instruction), decoded JSON-quoted-or-raw exactly like
+/// [`prompt_from_config`]. `None` ⇒ the judge mote carries no rubric (run_judge
+/// fails closed — a judge with no rubric cannot grade).
+fn rubric_from_config(mote: &Mote) -> Option<String> {
+    let raw = &mote
+        .def
+        .config_subset
+        .get(&ConfigKey(kx_mote::JUDGE_RUBRIC_KEY.to_string()))?
         .0;
     Some(
         serde_json::from_slice::<String>(raw)
@@ -1869,6 +2092,131 @@ mod tests {
         assert_eq!(out.result_ref, ContentRef::of(b"The answer is blue."));
     }
 
+    // --- T-AGENT2: the opt-in LLM-judge gate (run_judge) ---------------------
+
+    /// A judge critic Mote: `ReadOnlyNondet` (samples the model), `critic_for` the
+    /// producer, `critic_check = LlmJudge`, rubric in `config_subset` — the exact
+    /// shape the recipe + `compile.rs` (`DeterministicCritic` role + ROND) produce.
+    fn judge_mote(producer: MoteId) -> Mote {
+        let mut cfg = BTreeMap::new();
+        cfg.insert(
+            ConfigKey(kx_mote::JUDGE_RUBRIC_KEY.to_string()),
+            ConfigVal(b"The answer must be a single capital city.".to_vec()),
+        );
+        let def = MoteDef {
+            logic_ref: LogicRef::from_bytes([0x56u8; 32]),
+            model_id: model_id(),
+            prompt_template_hash: PromptTemplateHash::from_bytes([4u8; 32]),
+            tool_contract: BTreeMap::new(),
+            nd_class: NdClass::ReadOnlyNondet,
+            config_subset: cfg,
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: Some(producer),
+            is_topology_shaper: false,
+            inference_params: InferenceParams::default(),
+            critic_check: Some(kx_critic::CheckSpec::LlmJudge(kx_critic::LlmJudgeSpec {
+                max_output_tokens: 8,
+            })),
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([21u8; 32]),
+            GraphPosition(b"/judge".to_vec()),
+            SmallVec::new(),
+        )
+    }
+
+    #[test]
+    fn judge_dispatches_once_and_grades_valid_then_invalid() {
+        use kx_critic::{CriticReason, CriticVerdict};
+        let producer = MoteId::from_bytes([0x70u8; 32]);
+        let judge = judge_mote(producer);
+
+        // VALID reply ⇒ a `Valid` verdict, the model dispatched EXACTLY once.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let producer_ref = store.put(b"Paris").unwrap();
+        let (exec, backend) = executor(&store, b"VALID", None);
+        let out =
+            run_critic_with_context(&exec, &judge, vec![(producer, producer_ref)]).expect("judge");
+        assert_eq!(
+            backend.calls.load(Ordering::SeqCst),
+            1,
+            "the judge dispatches the served model exactly once"
+        );
+        let verdict = CriticVerdict::decode(store.get(&out.result_ref).unwrap().as_ref()).unwrap();
+        assert!(matches!(verdict, CriticVerdict::Valid));
+        // Determinism-after-commit: the verdict's content ref is `blake3(encode)`,
+        // so re-deriving the SAME verdict yields the SAME ref (replay dedups it —
+        // the projection never re-queries the judge).
+        assert_eq!(
+            out.result_ref,
+            ContentRef::of(&CriticVerdict::Valid.encode())
+        );
+
+        // INVALID reply ⇒ the judge actually grades (not a rubber-stamp).
+        let dir2 = tempfile::tempdir().unwrap();
+        let store2 = LocalFsContentStore::open(dir2.path()).unwrap();
+        let producer_ref2 = store2.put(b"a long rambling non-answer").unwrap();
+        let (exec2, _) = executor(&store2, b"INVALID", None);
+        let out2 = run_critic_with_context(&exec2, &judge, vec![(producer, producer_ref2)])
+            .expect("judge");
+        let verdict2 =
+            CriticVerdict::decode(store2.get(&out2.result_ref).unwrap().as_ref()).unwrap();
+        assert!(matches!(
+            verdict2,
+            CriticVerdict::Invalid {
+                reason: CriticReason::JudgeRejected { reason_code: 0 }
+            }
+        ));
+        // The two honest verdicts are DISTINCT facts (distinct content refs) — the
+        // gate is data-dependent, the basis of the opt-in workflow's own digest.
+        assert_ne!(out.result_ref, out2.result_ref);
+    }
+
+    #[test]
+    fn judge_fails_closed_on_unparseable_completion_and_missing_rubric() {
+        use kx_critic::{CriticReason, CriticVerdict};
+        let producer = MoteId::from_bytes([0x70u8; 32]);
+        let judge = judge_mote(producer);
+
+        // Ambiguous completion ⇒ withhold (Invalid/unparseable), never silent Valid.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let producer_ref = store.put(b"Paris").unwrap();
+        let (exec, _) = executor(&store, b"hmm, hard to say", None);
+        let out =
+            run_critic_with_context(&exec, &judge, vec![(producer, producer_ref)]).expect("judge");
+        let verdict = CriticVerdict::decode(store.get(&out.result_ref).unwrap().as_ref()).unwrap();
+        assert!(matches!(
+            verdict,
+            CriticVerdict::Invalid {
+                reason: CriticReason::JudgeRejected { reason_code: 1 }
+            }
+        ));
+
+        // A judge with NO rubric fails closed (terminal) — never grades blind.
+        let mut no_rubric = judge.def.clone();
+        no_rubric
+            .config_subset
+            .remove(&ConfigKey(kx_mote::JUDGE_RUBRIC_KEY.to_string()));
+        let no_rubric = Mote::new(
+            no_rubric,
+            InputDataId::from_bytes([21u8; 32]),
+            GraphPosition(b"/judge".to_vec()),
+            SmallVec::new(),
+        );
+        let dir2 = tempfile::tempdir().unwrap();
+        let store2 = LocalFsContentStore::open(dir2.path()).unwrap();
+        let producer_ref2 = store2.put(b"Paris").unwrap();
+        let (exec2, _) = executor(&store2, b"VALID", None);
+        assert!(
+            run_critic_with_context(&exec2, &no_rubric, vec![(producer, producer_ref2)]).is_err(),
+            "a rubric-less judge is terminal (fail-closed), never a silent VALID"
+        );
+    }
+
     #[test]
     fn react_arm_commits_a_granted_tool_proposal_raw() {
         // PR-2d-2 (the live tool round): a well-formed, warrant-GRANTED proposal
@@ -1951,5 +2299,53 @@ mod tests {
             .run(&leaf, &granted_warrant(), None)
             .expect("a leaf model Mote has no fence");
         assert_eq!(store.get(&out.result_ref).unwrap().as_ref(), env.as_slice());
+    }
+
+    // --- T-AGENT2: judge verdict parsing (total + fail-closed) ---------------
+
+    #[test]
+    fn parse_judge_verdict_total_and_fail_closed() {
+        use kx_critic::{CriticReason, CriticVerdict};
+        let is_invalid = |b: &[u8], code: u16| {
+            matches!(parse_judge_verdict(b), CriticVerdict::Invalid { reason }
+                if reason == CriticReason::JudgeRejected { reason_code: code })
+        };
+        // A clear VALID ⇒ Valid (case-insensitive; trailing prose ignored).
+        assert!(matches!(
+            parse_judge_verdict(b"VALID"),
+            CriticVerdict::Valid
+        ));
+        assert!(matches!(
+            parse_judge_verdict(b"valid, it satisfies the rubric"),
+            CriticVerdict::Valid
+        ));
+        // A clear INVALID ⇒ Invalid (the word-boundary token, not a substring).
+        assert!(is_invalid(b"INVALID", 0));
+        // ★ The live-Gemma fix (GR20): a reasoning block that MENTIONS "invalid"
+        // while concluding VALID must read as VALID — the LAST decision token wins.
+        assert!(matches!(
+            parse_judge_verdict(
+                b"<|think|>Is the answer invalid? No, Paris is correct.</|think|>\nVALID"
+            ),
+            CriticVerdict::Valid
+        ));
+        assert!(matches!(
+            parse_judge_verdict(b"<think>checking... not invalid</think> valid"),
+            CriticVerdict::Valid
+        ));
+        // A reasoning block concluding INVALID stays INVALID.
+        assert!(is_invalid(b"<think>the answer is wrong</think> INVALID", 0));
+        // Ambiguous / neither token / non-UTF-8 / reasoning-only ⇒ fail-closed.
+        for bad in [
+            &b"maybe"[..],
+            &b""[..],
+            &[0xFF, 0xFE][..],
+            &b"hmm, hard to say"[..],
+        ] {
+            assert!(
+                is_invalid(bad, 1),
+                "expected unparseable-Invalid for {bad:?}"
+            );
+        }
     }
 }

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -220,6 +220,31 @@ pub const REACT_EDIT_RECIPE_HANDLE: &str = "kx/recipes/react-edit";
 /// `0x55` is the next free sentinel after react-fs (`0x54`).
 const REACT_EDIT_LOGIC_REF: [u8; 32] = [0x55; 32];
 
+/// T-AGENT2: the opt-in self-checking model recipe — a single greedy model
+/// PRODUCER step (a `prompt` free-param) gated by an LLM-JUDGE critic that grades
+/// the answer against a fixed rubric using the served model. The terminal is the
+/// judge, so `Invoke` returns the discrete `CriticVerdict` (`VALID`/`INVALID`); the
+/// graded answer is the producer Mote's committed output (shown in the run DAG and
+/// the mote inspector). A SEPARATE recipe (the react-fs/react-edit precedent) keeps
+/// the canonical recipes and the projection digest byte-unchanged; inference-gated
+/// (default-OFF without a served model, so the digest is unaffected).
+pub const JUDGE_RECIPE_HANDLE: &str = "kx/recipes/judge";
+
+/// Distinct `logic_ref` sentinels for the judge recipe's two steps (BUG-25 — a
+/// shared ref collides at seed). `0x56`/`0x57` are the next free after react-edit
+/// (`0x55`); the storing executor ignores `logic_ref`, so these give the producer
+/// and judge steps distinct identities.
+const JUDGE_PRODUCER_LOGIC_REF: [u8; 32] = [0x56; 32];
+const JUDGE_CRITIC_LOGIC_REF: [u8; 32] = [0x57; 32];
+
+/// The default grading rubric the judge evaluates the producer's answer against
+/// (delivered via the judge step's `config_subset[JUDGE_RUBRIC_KEY]`). Advisory
+/// prompt bytes only — never an authority/identity input beyond the judge Mote's
+/// own `MoteId` (SN-8).
+const JUDGE_DEFAULT_RUBRIC: &str =
+    "The answer must directly and correctly address the user's prompt, be free of \
+hedging or refusals, and contain no obvious factual error.";
+
 /// Schema-refs of the react recipe's typed free-params.
 const REACT_INSTRUCTION_SCHEMA_REF: [u8; 32] = [0x4f; 32];
 /// See [`REACT_INSTRUCTION_SCHEMA_REF`].
@@ -664,6 +689,37 @@ impl DemoLibrary {
             ));
         }
 
+        // (judge) T-AGENT2: a SEPARATE opt-in self-checking recipe — a greedy model
+        // PRODUCER (a `prompt` free-param) gated by an LLM-JUDGE critic (ReadOnlyNondet)
+        // that grades the answer against a fixed rubric using the served model. Seeded
+        // only when a model is served (default-OFF without ⇒ the canonical recipes +
+        // the projection digest are byte-unchanged). The judge warrant is the
+        // text-model warrant (model_route bounds the judge's output tokens; the
+        // executor's `inference_params_from_mote` refuses a widening, D35). OWN logic
+        // refs (BUG-25). The verdict commits ReadOnlyNondet ⇒ an opt-in run gets its
+        // OWN honest digest; the canonical demo never invokes it (digest-SCOPE).
+        if let Some(model_id) = serve_model {
+            let judge_w = model_warrant(exec_class, model_id);
+            let judge_h = judge_handle()?;
+            seed_recipe(
+                &versions,
+                &bodies,
+                &grants,
+                &owner,
+                parties,
+                &judge_h,
+                judge_body(&judge_w)?,
+                &judge_w,
+            )?;
+            recipes.push((
+                judge_h,
+                RecipeMeta {
+                    owner_root: judge_w,
+                    free_params: judge_contract(),
+                },
+            ));
+        }
+
         // (blueprints/author) the Tier-1 DAG-authoring asset — granted Use to each
         // party so `SubmitWorkflow` resolves the party's authority from this same
         // ledger (no body/version; authoring submits one-off DAGs). Always seeded.
@@ -928,6 +984,10 @@ fn recipe_advisory(handle: &str) -> (&'static str, &'static [&'static str]) {
         VISION_RECIPE_HANDLE => (
             "Vision — a multimodal completion over an attached image.",
             &["model", "vision", "image", "multimodal", "agent"],
+        ),
+        JUDGE_RECIPE_HANDLE => (
+            "Judge — a self-checking completion: the served model answers the prompt, then an LLM-judge grades the answer against a rubric (VALID / INVALID). Opt-in model-graded verification (T-AGENT2).",
+            &["agent", "judge", "critic", "verify", "llm-judge", "reasoning"],
         ),
         _ => ("", &[]),
     }
@@ -2363,6 +2423,78 @@ pub(crate) fn react_edit_warrant(exec_class: ExecutorClass, model_id: &ModelId) 
 fn react_edit_handle() -> Result<AssetPath, GatewayError> {
     parse_handle(REACT_EDIT_RECIPE_HANDLE)
         .ok_or_else(|| GatewayError::Catalog("invalid react-edit recipe handle".into()))
+}
+
+fn judge_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(JUDGE_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid judge recipe handle".into()))
+}
+
+/// The judge recipe's free-param contract: one `prompt` slot (the producer's
+/// question) — the rubric is FIXED (not a free-param) so the judge's grading
+/// criterion is stable + server-controlled. Same shape as [`prompt_contract`].
+fn judge_contract() -> FreeParamContract {
+    FreeParamContract::new().with_slot(
+        PROMPT_KEY,
+        FreeParamSlot::variable(Some(MODEL_PROMPT_SCHEMA_REF)),
+    )
+}
+
+/// The T-AGENT2 judge recipe body (producer → judge): a greedy model PRODUCER
+/// (a `prompt` free-param) and an LLM-JUDGE critic on it (`ReadOnlyNondet`, the
+/// fixed rubric in `config_subset[JUDGE_RUBRIC_KEY]`). A DATA edge wires
+/// producer → judge so the producer precedes the judge (compile resolves the
+/// judge's `critic_for` to the producer's MoteId) and the coordinator delivers
+/// the producer's committed bytes to `run_judge` via the F-7 critic special-case.
+/// The judge is added last ⇒ the run's terminal (Invoke returns the verdict).
+fn judge_body(warrant: &WarrantSpec) -> Result<WorkflowDef, GatewayError> {
+    let edge_err = |e: kx_workflow::CompileError| GatewayError::Catalog(format!("judge edge: {e}"));
+    let b = JUDGE_PRODUCER_LOGIC_REF;
+    let seed = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+    let mut wf = WorkflowDef::new(seed);
+    let model = warrant.model_route.model_id.clone();
+
+    // The PRODUCER: a greedy model step answering the bound `prompt` (the model
+    // recipe shape — routed by config_subset[PROMPT_KEY] + the served model_id).
+    let mut producer = transform(
+        LogicRef::from_bytes(JUDGE_PRODUCER_LOGIC_REF),
+        model.clone(),
+        warrant.clone(),
+        ToolName("demo".into()),
+    );
+    producer
+        .config_subset
+        .insert(ConfigKey(PROMPT_KEY.into()), ConfigVal(Vec::new()));
+    let producer_ref = wf.add_step(producer);
+
+    // The JUDGE: a ReadOnlyNondet LLM-judge critic on the producer, carrying the
+    // fixed rubric. The output bound mirrors the warrant's model_route ceiling.
+    let mut judge_step = kx_workflow::judge(
+        producer_ref,
+        kx_workflow::CheckSpec::LlmJudge(kx_workflow::LlmJudgeSpec {
+            max_output_tokens: warrant.model_route.max_output_tokens,
+        }),
+        LogicRef::from_bytes(JUDGE_CRITIC_LOGIC_REF),
+        model,
+        warrant.clone(),
+        ToolName("demo".into()),
+    );
+    judge_step.config_subset.insert(
+        ConfigKey(kx_mote::JUDGE_RUBRIC_KEY.into()),
+        ConfigVal(JUDGE_DEFAULT_RUBRIC.as_bytes().to_vec()),
+    );
+    // The judge ALSO carries the `prompt` free-param slot (empty here): `bind_param`
+    // fills EVERY step with the slot, so the bound question reaches the judge too —
+    // it grades whether the producer's answer ADDRESSES the question (the rubric
+    // references "the user's prompt"). Identity-bearing, like the producer's slot.
+    judge_step
+        .config_subset
+        .insert(ConfigKey(PROMPT_KEY.into()), ConfigVal(Vec::new()));
+    let judge_ref = wf.add_step(judge_step);
+
+    wf.add_edge(producer_ref, judge_ref, EdgeMeta::data())
+        .map_err(edge_err)?;
+    Ok(wf)
 }
 
 /// The model-executor config key for the opt-in reasoning mode (mirrors

--- a/crates/kx-gateway/tests/react_auto_serve.rs
+++ b/crates/kx-gateway/tests/react_auto_serve.rs
@@ -125,6 +125,7 @@ async fn autogrant_serve_provisions_react_auto_and_drives_a_live_chain() {
             .list_react_turns(proto::ListReactTurnsRequest {
                 limit: None,
                 instance_id: Some(resp.instance_id.clone()),
+                step_salt: None,
             })
             .await
             .unwrap()
@@ -216,6 +217,7 @@ async fn react_auto_dialed_tool_resolves_and_the_chain_settles() {
             .list_react_turns(proto::ListReactTurnsRequest {
                 limit: None,
                 instance_id: Some(resp.instance_id.clone()),
+                step_salt: None,
             })
             .await
             .unwrap()

--- a/crates/kx-gateway/tests/react_serve.rs
+++ b/crates/kx-gateway/tests/react_serve.rs
@@ -132,6 +132,7 @@ async fn invoke_react_recipe_drives_a_live_chain_to_answer() {
             .list_react_turns(proto::ListReactTurnsRequest {
                 limit: None,
                 instance_id: Some(resp.instance_id.clone()),
+                step_salt: None,
             })
             .await
             .unwrap()

--- a/crates/kx-mote/src/lib.rs
+++ b/crates/kx-mote/src/lib.rs
@@ -92,8 +92,8 @@ pub use mote::Mote;
 pub use ndclass::NdClass;
 pub use strings::{
     ConfigKey, ConfigVal, GraphPosition, ModelId, ToolName, ToolVersion, CONTEXT_ITEMS_KEY,
-    PROMPT_KEY, REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY, REACT_MAX_TURNS_KEY,
-    REACT_TURN_KEY, TOOL_ARGS_KEY,
+    JUDGE_RUBRIC_KEY, PROMPT_KEY, REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY,
+    REACT_MAX_TURNS_KEY, REACT_TURN_KEY, TOOL_ARGS_KEY,
 };
 pub use topology::{ChildDescriptor, RoleId, TopologyDecision};
 

--- a/crates/kx-mote/src/strings.rs
+++ b/crates/kx-mote/src/strings.rs
@@ -60,6 +60,17 @@ pub struct ConfigVal(pub Vec<u8>);
 /// or referencing it cannot move any digest.
 pub const PROMPT_KEY: &str = "prompt";
 
+/// The [`ConfigKey`] *name* under which an opt-in LLM-JUDGE critic Mote
+/// (T-AGENT2) carries its RUBRIC — the grading instruction the judge model
+/// evaluates the producer's output against. Delivered like [`PROMPT_KEY`]
+/// (identity-bearing in `config_subset` ⇒ folds into `MoteId`), so two judges
+/// with different rubrics are distinct Motes without a content-store read; the
+/// `CheckSpec::LlmJudge` spec itself carries only the integer output bound.
+///
+/// Only the *string value* participates in identity; adding or referencing the
+/// constant cannot move any digest (the canonical demo declares no judge).
+pub const JUDGE_RUBRIC_KEY: &str = "kx.judge.rubric";
+
 /// The single canonical [`ConfigKey`] *name* marking a Mote as a live ReAct
 /// TURN (PR-2d-1, react-substrate). The value is the run-salt (the registered
 /// `instance_id`) — the same bytes salted into the turn's identity material.

--- a/crates/kx-refusal/Cargo.toml
+++ b/crates/kx-refusal/Cargo.toml
@@ -27,6 +27,8 @@ kx-content = { workspace = true }
 smallvec   = { workspace = true }
 # Property tests: validate_mote_submission is pure/total over arbitrary inputs.
 proptest   = { workspace = true }
+# T-AGENT2: construct an `LlmJudge` CheckSpec to exercise `native_judge_shape`.
+kx-critic-types = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kx-refusal/src/lib.rs
+++ b/crates/kx-refusal/src/lib.rs
@@ -37,6 +37,7 @@
 mod refusal;
 
 pub use refusal::{
-    native_critic_shape, refusal_from_narrowing, validate_mote_submission, validate_submission,
-    validate_submission_with_idempotency, SubmissionRefusal, ToolResolution, WorkflowSubmission,
+    native_critic_shape, native_judge_shape, refusal_from_narrowing, validate_mote_submission,
+    validate_submission, validate_submission_with_idempotency, SubmissionRefusal, ToolResolution,
+    WorkflowSubmission,
 };

--- a/crates/kx-refusal/src/refusal.rs
+++ b/crates/kx-refusal/src/refusal.rs
@@ -200,15 +200,16 @@ pub enum SubmissionRefusal {
         mote_id: MoteId,
     },
 
-    /// **R-15** (D60 / P4.2-2). A `MoteDef` carrying a `critic_check` (a native
-    /// deterministic-critic Mote) whose shape is illegal: a native check is
-    /// evaluated in-process against a producer's committed bytes, so the Mote
-    /// MUST be `Pure` (no nondet/world-mutation), MUST declare `critic_for`
-    /// (the producer it gates), and MUST NOT be a topology shaper. Refusing
-    /// these at submission keeps the executor's native-check path
-    /// (`run_native_critic_mote`) total and the deterministic gate decorrelated
-    /// from the model that produced the output (D60).
-    #[error("R-15: Mote {mote_id:?} carries a critic_check but is not a well-formed native critic (must be Pure + critic_for=Some + !is_topology_shaper) (D60 / P4.2-2)")]
+    /// **R-15** (D60 / P4.2-2; T-AGENT2 extends it to the judge gate). A `MoteDef`
+    /// carrying a `critic_check` whose shape is illegal. A *native* check is
+    /// evaluated in-process against a producer's committed bytes, so the Mote MUST
+    /// be `Pure`; the opt-in *LLM-judge* gate samples the served model, so it MUST
+    /// be `ReadOnlyNondet`. EITHER kind MUST declare `critic_for` (the producer it
+    /// gates) and MUST NOT be a topology shaper. Refusing these at submission keeps
+    /// the executor's critic path total and the gate decorrelated from the model
+    /// that produced the output (D60). The closed refusal vocabulary reuses this
+    /// one R-15 code for both shapes (a new code would need its own D-number).
+    #[error("R-15: Mote {mote_id:?} carries a critic_check but is not a well-formed critic (native ⇒ Pure, LLM-judge ⇒ ReadOnlyNondet; either ⇒ critic_for=Some + !is_topology_shaper) (D60 / P4.2-2 / T-AGENT2)")]
     R15NativeCheckShape {
         /// The offending Mote.
         mote_id: MoteId,
@@ -670,8 +671,16 @@ fn check_r14(mote: &Mote) -> Result<(), SubmissionRefusal> {
 /// `critic_check` but is not a well-formed native critic (not `Pure`, missing
 /// `critic_for`, or a topology shaper).
 pub fn native_critic_shape(mote: &Mote) -> Result<(), SubmissionRefusal> {
-    if mote.def.critic_check.is_none() {
-        return Ok(());
+    match &mote.def.critic_check {
+        // Not a critic, or the opt-in LLM-judge gate — neither is enforced by THIS
+        // (frozen-mirror, Pure-only) predicate. A judge is gated by
+        // [`native_judge_shape`]; routing it here would mis-refuse a legal
+        // `ReadOnlyNondet` judge AND drift this byte-mirror from the frozen
+        // executor's Pure-only R-15 guard. The judge never reaches the frozen
+        // executor (the serve `run` arm routes it to `run_judge`).
+        None => return Ok(()),
+        Some(c) if c.is_llm_judge() => return Ok(()),
+        Some(_) => {}
     }
     if mote.def.nd_class != NdClass::Pure
         || mote.def.critic_for.is_none()
@@ -682,10 +691,47 @@ pub fn native_critic_shape(mote: &Mote) -> Result<(), SubmissionRefusal> {
     Ok(())
 }
 
-/// **R-15** (D60 / P4.2-2). Refuse a `critic_check`-bearing Mote that is not a
-/// well-formed native critic. Delegates to the shared [`native_critic_shape`] gate.
+/// **R-15** (T-AGENT2) — the SHAPE gate for the opt-in model-graded judge gate
+/// (`CheckSpec::LlmJudge`). The judge
+/// samples the served model, so it MUST be [`NdClass::ReadOnlyNondet`] (NOT
+/// `Pure` — that is the native-check requirement), MUST declare `critic_for`, and
+/// MUST NOT be a topology shaper. A non-judge (`!is_llm_judge`) trivially passes.
+///
+/// Distinct from [`native_critic_shape`] (the Pure-only frozen-executor mirror):
+/// the judge is dispatched by `kx-gateway`'s `ModelRouterExecutor::run_judge`, an
+/// arm the FROZEN `kx_executor::run_native_critic_mote` never reaches, so the two
+/// shapes stay structurally disjoint (a Mote is a native critic XOR a judge).
+/// Reuses the closed R-15 refusal code (see [`SubmissionRefusal::R15NativeCheckShape`]).
+///
+/// # Errors
+///
+/// [`SubmissionRefusal::R15NativeCheckShape`] iff `mote` carries an `LlmJudge`
+/// `critic_check` but is not `ReadOnlyNondet` + `critic_for=Some` + non-shaper.
+pub fn native_judge_shape(mote: &Mote) -> Result<(), SubmissionRefusal> {
+    match &mote.def.critic_check {
+        Some(c) if c.is_llm_judge() => {}
+        _ => return Ok(()),
+    }
+    if mote.def.nd_class != NdClass::ReadOnlyNondet
+        || mote.def.critic_for.is_none()
+        || mote.def.is_topology_shaper
+    {
+        return Err(SubmissionRefusal::R15NativeCheckShape { mote_id: mote.id });
+    }
+    Ok(())
+}
+
+/// **R-15** (D60 / P4.2-2 / T-AGENT2). Refuse a `critic_check`-bearing Mote that
+/// is not a well-formed critic — routing the opt-in LLM-judge to
+/// [`native_judge_shape`] (`ReadOnlyNondet`) and every native check to
+/// [`native_critic_shape`] (`Pure`). Both ill-formed shapes trip the same R-15 code.
 fn check_r15(mote: &Mote) -> Result<(), SubmissionRefusal> {
-    native_critic_shape(mote)
+    let is_judge = matches!(&mote.def.critic_check, Some(c) if c.is_llm_judge());
+    if is_judge {
+        native_judge_shape(mote)
+    } else {
+        native_critic_shape(mote)
+    }
 }
 
 fn check_r9(mote: &Mote, motes: &BTreeMap<MoteId, Mote>) -> Result<(), SubmissionRefusal> {

--- a/crates/kx-refusal/tests/mote_submission.rs
+++ b/crates/kx-refusal/tests/mote_submission.rs
@@ -13,8 +13,8 @@ use kx_mote::{
     PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
 };
 use kx_refusal::{
-    validate_mote_submission, validate_submission, SubmissionRefusal, ToolResolution,
-    WorkflowSubmission,
+    native_critic_shape, native_judge_shape, validate_mote_submission, validate_submission,
+    SubmissionRefusal, ToolResolution, WorkflowSubmission,
 };
 use kx_tool_registry::IdempotencyClass;
 use smallvec::SmallVec;
@@ -342,4 +342,115 @@ fn refusal_code_matches_display_prefix_for_every_variant() {
             refusal.code(),
         );
     }
+}
+
+// ===================== T-AGENT2 — the LLM-judge SHAPE gate =====================
+
+/// Build a critic Mote carrying the given `critic_check` spec + nd_class + producer.
+fn build_critic(
+    nd_class: NdClass,
+    critic_for: Option<MoteId>,
+    is_topology_shaper: bool,
+    spec: Option<kx_critic_types::CheckSpec>,
+) -> Mote {
+    let def = MoteDef {
+        critic_check: spec,
+        logic_ref: LogicRef::from_bytes([1; 32]),
+        model_id: ModelId("local".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([2; 32]),
+        tool_contract: BTreeMap::new(),
+        nd_class,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for,
+        is_topology_shaper,
+        inference_params: kx_mote::InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([0; 32]),
+        GraphPosition(vec![0xAA]),
+        SmallVec::new(),
+    )
+}
+
+fn llm_judge_spec() -> kx_critic_types::CheckSpec {
+    kx_critic_types::CheckSpec::LlmJudge(kx_critic_types::LlmJudgeSpec {
+        max_output_tokens: 64,
+    })
+}
+
+#[test]
+fn judge_shape_accepts_read_only_nondet_judge() {
+    let producer = MoteId::from_bytes([5; 32]);
+    let judge = build_critic(
+        NdClass::ReadOnlyNondet,
+        Some(producer),
+        false,
+        Some(llm_judge_spec()),
+    );
+    // The judge gate accepts a well-formed ReadOnlyNondet judge.
+    assert!(native_judge_shape(&judge).is_ok());
+    // The Pure-only native gate SKIPS a judge (so it can never mis-refuse it AND
+    // stays a byte-mirror of the frozen executor's native-only R-15).
+    assert!(native_critic_shape(&judge).is_ok());
+    // The submission dispatch routes the judge to the judge gate ⇒ accepted.
+    assert!(
+        validate_mote_submission(&judge, false, &ToolResolution::Unresolved).is_ok(),
+        "a well-formed ReadOnlyNondet LLM-judge must be admitted"
+    );
+}
+
+#[test]
+fn judge_shape_refuses_pure_judge() {
+    // A judge that is Pure (the native-critic class) is ill-formed — a judge
+    // samples the model, so it MUST be ReadOnlyNondet. Fail-closed under R-15.
+    let producer = MoteId::from_bytes([5; 32]);
+    let bad = build_critic(NdClass::Pure, Some(producer), false, Some(llm_judge_spec()));
+    assert!(matches!(
+        native_judge_shape(&bad),
+        Err(SubmissionRefusal::R15NativeCheckShape { .. })
+    ));
+    assert!(matches!(
+        validate_mote_submission(&bad, false, &ToolResolution::Unresolved),
+        Err(SubmissionRefusal::R15NativeCheckShape { .. })
+    ));
+}
+
+#[test]
+fn judge_shape_refuses_judge_without_producer_or_as_shaper() {
+    // No producer ⇒ R-15.
+    let orphan = build_critic(NdClass::ReadOnlyNondet, None, false, Some(llm_judge_spec()));
+    assert!(native_judge_shape(&orphan).is_err());
+    // A topology shaper that is also a judge ⇒ refused by the judge gate.
+    let producer = MoteId::from_bytes([5; 32]);
+    let shaper_judge = build_critic(
+        NdClass::ReadOnlyNondet,
+        Some(producer),
+        true,
+        Some(llm_judge_spec()),
+    );
+    assert!(native_judge_shape(&shaper_judge).is_err());
+}
+
+#[test]
+fn native_gate_still_refuses_read_only_nondet_native_critic() {
+    // A NATIVE check (not a judge) that is ReadOnlyNondet stays refused — the
+    // judge relaxation must NOT leak into the deterministic-check class.
+    let producer = MoteId::from_bytes([5; 32]);
+    let native_spec = kx_critic_types::CheckSpec::Schema(kx_critic_types::SchemaSpec {
+        expected: kx_critic_types::SchemaTag::Json,
+    });
+    let bad = build_critic(
+        NdClass::ReadOnlyNondet,
+        Some(producer),
+        false,
+        Some(native_spec),
+    );
+    assert!(matches!(
+        native_critic_shape(&bad),
+        Err(SubmissionRefusal::R15NativeCheckShape { .. })
+    ));
+    assert!(validate_mote_submission(&bad, false, &ToolResolution::Unresolved).is_err());
 }

--- a/crates/kx-worker/src/run.rs
+++ b/crates/kx-worker/src/run.rs
@@ -48,6 +48,11 @@ where
 /// decode is serve-once via the coordinator's first-wins commit dedup, R49) and
 /// propose the staged `result_ref`. Warrant ceilings are enforced INSIDE the
 /// model dispatch (`inference_params_from_mote` refuses a widening, D35).
+///
+/// **Also serves the T-AGENT2 LLM-JUDGE critic** (any ReadOnlyNondet model Mote
+/// dispatched directly through the executor, never the broker): the executor's
+/// `run_judge` arm grades the producer + commits a `CriticVerdict`. The function
+/// is intentionally generic — it is `executor.run` plus the result-ref extraction.
 pub(crate) fn run_react_turn<E>(
     mote: &Mote,
     warrant: &WarrantSpec,

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -223,13 +223,20 @@ impl Worker {
             // next item. Transport/RPC errors on the lease/commit calls stay batch-level.
             let exec = if mote.nd_class() == NdClass::Pure {
                 run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)
-            } else if is_react_turn(&mote) {
+            } else if is_react_turn(&mote) || mote.def.critic_check.is_some() {
                 // PR-2d-2: a coordinator-materialized ReAct TURN (the identity-
                 // bearing marker, NO tool_contract) is a prompt-carrying ROND
                 // model Mote — it dispatches through the hosted EXECUTOR (whose
                 // react arm decodes + fences pre-commit), never the capability
                 // broker (it proposes; the observation Mote fires). Direct
                 // dispatch matches the IdempotentByConstruction pattern.
+                //
+                // T-AGENT2: the opt-in LLM-JUDGE critic is the SAME shape — a ROND
+                // model Mote the executor's `run_judge` arm grades + commits as a
+                // verdict (no broker effect). A *native* critic is `Pure` (caught by
+                // the first arm ⇒ `run_pure`), so `critic_check.is_some()` HERE
+                // uniquely identifies the ReadOnlyNondet judge; the executor routes
+                // both react turns and judges through this direct dispatch.
                 run::run_react_turn(&mote, &warrant, &*self.executor)
             } else {
                 // PR-2d-2: the coordinator-validated args + egress for a ReAct

--- a/crates/kx-workflow/src/lib.rs
+++ b/crates/kx-workflow/src/lib.rs
@@ -69,9 +69,13 @@ pub use recipes::{
 pub use retrieval::{encode_retrieval_fact, retrieval, retrieval_result_ref};
 pub use share::{Manifest, ManifestId};
 pub use synthesis::{
-    critic, deterministic_critic, generator, permissive_warrant, synthesis_pipeline, tool_step,
-    topology_shaper, transform,
+    critic, deterministic_critic, generator, judge, permissive_warrant, synthesis_pipeline,
+    tool_step, topology_shaper, transform,
 };
+// Re-export the check vocabulary so a workflow author building a critic / judge
+// step depends on `kx-workflow` alone (the `deterministic_critic` / `judge`
+// builders take a `CheckSpec`).
+pub use kx_critic_types::{CheckSpec, LlmJudgeSpec};
 
 #[cfg(test)]
 mod tests;

--- a/crates/kx-workflow/src/synthesis.rs
+++ b/crates/kx-workflow/src/synthesis.rs
@@ -203,6 +203,45 @@ pub fn deterministic_critic(
     )
 }
 
+/// An opt-in **LLM-JUDGE** critic validating `producer` (T-AGENT2): the
+/// model-graded sibling of [`deterministic_critic`]. Same `DeterministicCritic`
+/// role carrying a [`CheckSpec::LlmJudge`] check, but **READ-ONLY-NONDET** (it
+/// samples the served model) — so it compiles to a judge Mote the gateway's
+/// `run_judge` arm grades + commits as a `CriticVerdict` (`ReadOnlyNondet` ⇒
+/// sampled once, committed, replayed). The grading RUBRIC is delivered via the
+/// step's `config_subset[kx_mote::JUDGE_RUBRIC_KEY]` (set by the caller), exactly
+/// like a model step's prompt. The compiled `MoteDef` satisfies R-15's judge
+/// shape by construction (`ReadOnlyNondet` + `critic_for=Some` + `!is_topology_shaper`).
+/// Declare a dependency edge from `producer` to this step so it precedes the judge.
+///
+/// # Panics
+///
+/// Debug-asserts `check` is a [`CheckSpec::LlmJudge`] — a native check here would
+/// compile to a `ReadOnlyNondet` *native* critic, which the executor refuses (R-15).
+#[must_use]
+pub fn judge(
+    producer: StepRef,
+    check: CheckSpec,
+    logic_ref: LogicRef,
+    model_id: ModelId,
+    warrant: WarrantSpec,
+    capability: ToolName,
+) -> StepDef {
+    debug_assert!(
+        check.is_llm_judge(),
+        "judge() requires a CheckSpec::LlmJudge (a native check must use deterministic_critic)"
+    );
+    step(
+        logic_ref,
+        model_id,
+        NdClass::ReadOnlyNondet,
+        EffectPattern::IdempotentByConstruction,
+        StepRole::DeterministicCritic { producer, check },
+        warrant,
+        capability,
+    )
+}
+
 /// A topology shaper (READ-ONLY-NONDET; R-14 forbids WORLD-MUTATING shapers).
 /// At runtime it commits a `TopologyDecision` from which the projection
 /// materializes children deterministically — its dynamic fan-out is not static

--- a/docs/site/docs/agent-runner.md
+++ b/docs/site/docs/agent-runner.md
@@ -207,3 +207,51 @@ kx react list --instance <id>        # turn 1  branch rejected  reason <why> …
 
 The reason is also on `ReactTurn.rejection_reason` (Python / TypeScript SDK) and
 expands inline on the rejected chip in the console's agent-loop strip.
+
+## Self-checking with an LLM judge (opt-in)
+
+Reasoning loops can be wrong. The **LLM-judge** is an *opt-in* verification gate
+(T-AGENT2): the served model answers your prompt, then grades its own answer
+against a rubric and commits a discrete **VALID** / **INVALID** verdict. It is a
+durable, replayed fact — sampled once, committed, and reused on recovery (never
+re-queried), so a run's outcome is stable.
+
+Run the bundled `kx/recipes/judge` recipe (available when `kx serve` runs with a
+model, `--features inference`):
+
+```bash
+kx invoke kx/recipes/judge --args '{"prompt":"What is the capital of France?"}' --wait
+# state            COMMITTED
+# verdict          valid
+```
+
+```python
+import kortecx as kx
+r = kx.invoke("kx/recipes/judge", {"prompt": "What is the capital of France?"}, wait=True)
+print(r.verdict)        # "valid" | "invalid: judge: answer did not satisfy the rubric"
+```
+
+```typescript
+const r = await kx.invoke(
+  "kx/recipes/judge",
+  { prompt: "What is the capital of France?" },
+  { wait: true },
+);
+console.log(r.verdict); // "valid" | "invalid: …"
+```
+
+The graded answer itself is the producer step's committed output (visible in the
+run's DAG and the mote inspector); the judge node carries the verdict.
+
+**How it stays honest and reproducible:**
+
+- **Server-derived authority (SN-8).** The judge runs under a server-built warrant
+  — it dispatches the model but **cannot escalate authority** (no tools, no network
+  unless explicitly granted). The model *proposes* a verdict; the runtime *parses*
+  it to a discrete decision. There is **no similarity score** — only `VALID` /
+  `INVALID`. An unparseable or ambiguous judge response **fails closed to invalid**
+  (it never silently passes unverified output).
+- **Opt-in, digest-scoped.** The default deterministic critics (schema / dedup /
+  PII / stat-bounds) and the canonical demo are unchanged. A workflow that opts the
+  judge **in** commits a `ReadOnlyNondet` verdict and so gets its *own* honest,
+  replay-stable digest; a workflow that doesn't is byte-for-byte unaffected.

--- a/ui/src/components/ResultPreview.tsx
+++ b/ui/src/components/ResultPreview.tsx
@@ -76,6 +76,29 @@ export function ResultPreview({
       </span>
     );
   }
+  // T-AGENT2: a committed LLM-judge / critic verdict — render the decoded VALID /
+  // INVALID summary as a badge (the durable fact, display-only). `valid` reads as
+  // a positive accent; any `invalid: …` as a caution. Both themes via tokens.
+  if (content.kind === "verdict") {
+    const ok = content.text === "valid";
+    return (
+      <span
+        className="result-preview"
+        data-testid="result-preview"
+        data-state="verdict"
+        data-verdict={ok ? "valid" : "invalid"}
+      >
+        <span
+          className="result-verdict"
+          data-verdict={ok ? "valid" : "invalid"}
+          title={content.text}
+        >
+          {ok ? "✓ valid" : `✗ ${content.text}`}
+        </span>{" "}
+        {chipEl}
+      </span>
+    );
+  }
   // text | json: the resolved text IS the headline; the digest is the pointer.
   return (
     <span className="result-preview" data-testid="result-preview" data-state="text">

--- a/ui/src/lib/artifact-kind.ts
+++ b/ui/src/lib/artifact-kind.ts
@@ -21,6 +21,7 @@ const VISUALS: Record<DecodedKind, ArtifactKindVisual> = {
   text: { label: "Text", glyph: "¶" },
   markdown: { label: "Markdown", glyph: "M↓" },
   binary: { label: "Binary", glyph: "⬚" },
+  verdict: { label: "Verdict", glyph: "✓" },
   empty: { label: "Empty", glyph: "∅" },
   image: { label: "Image", glyph: "🖼" },
   video: { label: "Video", glyph: "▶" },

--- a/ui/src/lib/content-decode.ts
+++ b/ui/src/lib/content-decode.ts
@@ -13,10 +13,12 @@
  * fuzzy content heuristic, so a plain-text artifact never silently re-renders.
  */
 
+import { decodeCriticVerdict } from "@kortecx/sdk/web";
+
 /** A media MIME sniffed from magic bytes (or supplied as an advisory hint). */
 type MediaKind = "image" | "video" | "audio";
 
-export type DecodedKind = "empty" | "json" | "text" | "markdown" | "binary" | MediaKind;
+export type DecodedKind = "empty" | "json" | "text" | "markdown" | "binary" | "verdict" | MediaKind;
 
 export interface DecodedContent {
   readonly kind: DecodedKind;
@@ -131,6 +133,16 @@ function isMarkdownHint(hints: DecodeHints): boolean {
 export function decodeContent(bytes: Uint8Array, hints: DecodeHints = {}): DecodedContent {
   if (bytes.length === 0) {
     return { kind: "empty", text: "", byteLength: 0, truncated: false };
+  }
+
+  // T-AGENT2: a committed LLM-judge / critic verdict has a specific binary header
+  // (2-byte schema version ‖ fixed-int variant) — recognize it BEFORE the text /
+  // media classification, since its low control bytes decode as valid UTF-8. The
+  // decoder is exact + conservative (version + variant must match), so a real text
+  // / JSON payload is never mis-read as a verdict. Display-only (SN-8).
+  const verdict = decodeCriticVerdict(bytes);
+  if (verdict !== null) {
+    return { kind: "verdict", text: verdict, byteLength: bytes.length, truncated: false };
   }
 
   // Media first: a magic-byte sniff, then an advisory image/video/audio hint. The

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -465,6 +465,19 @@ button:disabled {
   flex: 1 1 auto;
 }
 
+/* T-AGENT2: the LLM-judge / critic verdict badge (token-driven, both themes; the
+ * tone follows the durable VALID/INVALID fact — display-only, never authority). */
+.result-verdict {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.result-verdict[data-verdict="valid"] {
+  color: var(--success);
+}
+.result-verdict[data-verdict="invalid"] {
+  color: var(--error);
+}
+
 /* ---- view toggle (DAG / table) ---- */
 .view-toggle {
   display: inline-flex;

--- a/ui/test/unit/content-decode.test.ts
+++ b/ui/test/unit/content-decode.test.ts
@@ -10,12 +10,29 @@ const withMagic = (magic: number[], len = 32) => {
   return b;
 };
 
+// T-AGENT2: canonical `CriticVerdict::encode` bytes (2-byte LE schema version ‖
+// fixed-int bincode) — must match the Rust/SDK byte layout.
+const VERDICT_VALID = new Uint8Array([1, 0, 0, 0, 0, 0]);
+const VERDICT_INVALID_JUDGE = new Uint8Array([1, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0]);
+
 describe("decodeContent", () => {
   it("empty bytes → empty", () => {
     const d = decodeContent(new Uint8Array());
     expect(d.kind).toBe("empty");
     expect(d.byteLength).toBe(0);
     expect(d.text).toBe("");
+  });
+
+  it("a committed VALID judge verdict → verdict kind", () => {
+    const d = decodeContent(VERDICT_VALID);
+    expect(d.kind).toBe("verdict");
+    expect(d.text).toBe("valid");
+  });
+
+  it("a committed INVALID judge verdict → verdict kind with the reason", () => {
+    const d = decodeContent(VERDICT_INVALID_JUDGE);
+    expect(d.kind).toBe("verdict");
+    expect(d.text).toBe("invalid: judge: answer did not satisfy the rubric");
   });
 
   it("plain UTF-8 text → text", () => {

--- a/ui/test/unit/result-preview.test.tsx
+++ b/ui/test/unit/result-preview.test.tsx
@@ -48,6 +48,25 @@ describe("ResultPreview", () => {
     expect(el).toHaveTextContent("(empty)");
   });
 
+  it("a committed judge verdict renders a VALID badge (not a hex dump)", () => {
+    // canonical CriticVerdict::Valid bytes (version 1 ‖ enum variant 0)
+    const valid = new Uint8Array([1, 0, 0, 0, 0, 0]);
+    render(<ResultPreview resultRef={REF} content={decodeContent(valid)} />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-state", "verdict");
+    expect(el).toHaveAttribute("data-verdict", "valid");
+    expect(el).toHaveTextContent("valid");
+    expect(screen.getByTestId("digest-chip")).toBeInTheDocument();
+  });
+
+  it("a committed INVALID verdict renders the reason badge", () => {
+    const invalid = new Uint8Array([1, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0]);
+    render(<ResultPreview resultRef={REF} content={decodeContent(invalid)} />);
+    const el = screen.getByTestId("result-preview");
+    expect(el).toHaveAttribute("data-verdict", "invalid");
+    expect(el).toHaveTextContent("invalid: judge: answer did not satisfy the rubric");
+  });
+
   it("text result shows the resolved TEXT as the headline (not the hash)", () => {
     render(<ResultPreview resultRef={REF} content={decodeContent(enc("the model said hello"))} />);
     const el = screen.getByTestId("result-preview");


### PR DESCRIPTION
## Summary

The opt-in **LLM-judge critic** (T-AGENT2) from the PR-9 B-spec — a model-graded verification gate, split from the `CLIENT_LOCAL` sandbox half (deferred to its own security PR with a D-number; the proto twice gates client-body execution behind one). **Digest-NEUTRAL (no re-baseline), frozen trio diff-empty.**

A judge is a `ReadOnlyNondet` critic the live serve executor grades via the served model (never in-process). Opt in by invoking the new `kx/recipes/judge` recipe; the served model answers, then grades its own answer against a rubric and commits a discrete **VALID/INVALID** verdict (sampled once, committed, replayed — never re-queried).

## Design (digest-neutral)

- **`kx-critic-types`** — `CheckSpec::LlmJudge` / `CriticReason::JudgeRejected` / `CheckKind::LlmJudge` as **trailing** enum variants ⇒ existing variants keep their canonical discriminants, so `critic_check: None` (the canonical 8-mote demo) folds byte-identically and **`7d22d4bd` is invariant** (`a0_guard` green). **No `CRITIC_SCHEMA_VERSION` bump** — a trailing variant is byte-additive, and bumping would break decode of version-1 native verdicts in an existing journal (back-compat). Rubric rides `config_subset[JUDGE_RUBRIC_KEY]` (identity-bearing, like a model prompt).
- **`kx-refusal`** — `native_judge_shape` (ReadOnlyNondet) alongside the unchanged Pure-only `native_critic_shape` (kept a byte-mirror of the frozen executor); reuses the closed R-15 code (no new D-number).
- **`kx-gateway` `ModelRouterExecutor::run_judge`** — fail-closed on every path; dispatches the served model under the **server-derived** warrant (cannot escalate authority, SN-8); parses to a discrete Valid/Invalid (**no score**). `kx-worker` routes the ROND judge through the executor-dispatch arm. `kx/recipes/judge` = a producer→judge `WorkflowDef` recipe (inference-gated).

## Cross-surface verdict decode (GR14)

CLI `render_wait` · Py/TS SDK `Result`/`AgentResult.verdict` + `decode_critic_verdict`/`decodeCriticVerdict` · UI `verdict` content kind + `ResultPreview` badge (both themes, D142) · `docs/site/agent-runner.md`. The `CriticVerdict` wire shape (2-byte version + fixint) is decoded server-free in each surface.

## GR20 — two real bugs found via the LIVE Gemma-4-12B witness + fixed

1. A **correct** answer graded INVALID because the verdict parse did `contains("INVALID")` over Gemma's `<|think|>` reasoning → now the **last word-boundary VALID/INVALID token wins** (reasoning-format-agnostic; also kills the `INVALID`⊃`VALID` substring trap).
2. The judge couldn't grade "addresses the prompt" because it never received the **question** → the recipe now binds the prompt to the judge step too (`bind_param` fills every slot) and `run_judge` renders QUESTION + RUBRIC + ANSWER.

**Live witnesses (Gemma-4-12B, Gemma-only per the standing rule):** "capital of France" → Paris → **VALID** · "2+2" → 4 → **VALID** · a forced refusal → **INVALID** (the gate discriminates). Verdict decodes readably in the CLI + crosses the wire via `--json`.

## Invariants

- Frozen trio (`kx-scheduler`/`kx-executor`/`kx-inference` src) **diff-empty**.
- Default-path digest **`7d22d4bd` invariant** (`a0_guard`).
- **No proto change** (codegen-fresh clean); `Cargo.lock` edge-only (`kx-critic-types` into `kx-cli`/`kx-refusal`).
- Also fixed a pre-existing PR-R1 breakage: the inference `--ignored` tests missed `step_salt` on `ListReactTurnsRequest`.

## Tests

`kx-critic-types` byte-neutrality pin + LlmJudge round-trip · `kx-refusal` judge-shape table · `kx-gateway` `run_judge` (dispatch-once, grades, deterministic verdict ref, fail-closed) + `parse_judge_verdict` (reasoning-block) · CLI/Py/TS/UI verdict-decode units. Local gate green: fmt · clippy `-D warnings` (workspace + inference) · workspace tests · doc `-D warnings` · deny · build-no-inference · dep-wall · Py(ruff/mypy/pytest) · TS(biome/tsc/vitest) · UI(biome/tsc/vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)