### PR TITLE
UI foundation: console on :8888, monochrome+orange theme, in-development nav + A2 cold-fold pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ world-touching step twice.
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Kortecx/kortecx/main/scripts/install.sh | sh
 kx serve --journal /tmp/kx.db --content /tmp/kx-content --dev-allow-local
-# → gRPC 127.0.0.1:50151 · events ws://127.0.0.1:50152 · web console http://127.0.0.1:50180
+# → gRPC 127.0.0.1:50151 · events ws://127.0.0.1:50152 · web console http://127.0.0.1:8888
 ```
 
 ---
@@ -54,7 +54,7 @@ kx serve --journal /tmp/kx.db --content /tmp/kx-content --dev-allow-local
 | **Run capture (Morphic)** | Every serve-path run's actions are captured to a durable sidecar — your agents' exhaust becomes queryable data | SDKs (`ListCaptureRecords`) |
 | **Teams & grants** | Durable membership + asset grants with resolved-warrant views | console Systems · SDKs |
 | **Audit trail** | An off-the-truth-path JSONL record of the run lifecycle | `kx run --audit-log` |
-| **The web console** | All of the above in a browser — served by `kx` itself, zero extra setup | `http://127.0.0.1:50180` |
+| **The web console** | All of the above in a browser — served by `kx` itself, zero extra setup | `http://127.0.0.1:8888` |
 
 Every capability is reachable from the **CLI**, the **Python and TypeScript
 SDKs**, and the **web console** — same wire, same guarantees.
@@ -128,7 +128,7 @@ bridge, and (prebuilt binaries) the web console:
 ```bash
 kx serve --journal /tmp/kx.db --content /tmp/kx-content --dev-allow-local
 #    gRPC on 127.0.0.1:50151 · events on ws://127.0.0.1:50152
-#    web console at http://127.0.0.1:50180  ← open this in your browser
+#    web console at http://127.0.0.1:8888  ← open this in your browser
 ```
 
 **2. Run your first blueprints** (another terminal):
@@ -186,7 +186,7 @@ turns — that's the whole point.
 ## The web console
 
 `kx serve` (prebuilt binaries) hosts the full console at
-**`http://127.0.0.1:50180`** — no node, no separate install. Connect to your
+**`http://127.0.0.1:8888`** — no node, no separate install. Connect to your
 gateway endpoint (pre-filled: `http://127.0.0.1:50151`; the bearer token, if you
 use one, stays in browser memory and is never stored).
 
@@ -240,7 +240,7 @@ kx serve --journal <path> --content <dir> [flags]
 |---|---|---|
 | `--listen <addr:port>` | `127.0.0.1:50151` | the gRPC + gRPC-web endpoint |
 | `--ws-listen <addr:port>` | `127.0.0.1:50152` | the live-event WebSocket bridge |
-| `--console-listen <addr:port>` | `127.0.0.1:50180` | the embedded web console (loopback only) |
+| `--console-listen <addr:port>` | `127.0.0.1:8888` | the embedded web console (loopback only) |
 | `--no-console` | — | disable the web console |
 | `--dev-allow-local` | off | dev auth: allow loopback callers (loopback binds only) |
 | `--auth-token <token>=<party>` | — | accept a bearer token as a party (repeatable) |

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -108,7 +108,7 @@ def _spawn(kx_bin: str, tmp: pathlib.Path, extra: List[str]) -> Server:
         f"127.0.0.1:{port}",
         "--ws-listen",
         f"127.0.0.1:{ws_port}",
-        # A console-enabled binary would otherwise bind the DEFAULT :50180 and
+        # A console-enabled binary would otherwise bind the DEFAULT :8888 and
         # concurrent test servers collide (no-op flag on console-less builds).
         "--no-console",
         *extra,

--- a/bindings/typescript/test/fixtures/serve.ts
+++ b/bindings/typescript/test/fixtures/serve.ts
@@ -128,7 +128,7 @@ export async function spawnServer(...extra: string[]): Promise<Server> {
       `127.0.0.1:${port}`,
       "--ws-listen",
       `127.0.0.1:${wsPort}`,
-      // A console-enabled binary would otherwise bind the DEFAULT :50180 —
+      // A console-enabled binary would otherwise bind the DEFAULT :8888 —
       // concurrent test servers then collide (a console-less binary accepts
       // the flag as a no-op). Every test spawn disables the console.
       "--no-console",

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -477,7 +477,7 @@ kx serve --dev-allow-local [--journal <path>] [--content <dir>] [--catalog-dir <
   every store path + the gRPC/WebSocket/console endpoints print as a startup banner for reference.
   --listen (gRPC) defaults to 127.0.0.1:50151; --ws-listen (the R5 live-event WebSocket bridge) to
   127.0.0.1:50152. Web console: a console-build kx (the prebuilt release) also serves the embedded
-  browser console at http://127.0.0.1:50180 — override with --console-listen <addr:port> (loopback
+  browser console at http://127.0.0.1:8888 — override with --console-listen <addr:port> (loopback
   only) or disable with --no-console.
   Deny-all by default: an auth posture is REQUIRED — pass --dev-allow-local (alias --allow-local-dev,
   loopback only) or --auth-token(-file); a bare `kx serve` with neither errors with a hint.

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -249,7 +249,7 @@ inference = [
 # requests return FAILED_PRECONDITION. Independent of `inference` — they compose.
 hnsw = ["dep:kx-dataset-hnsw"]
 # D139: `kx serve` hosts the embedded web console (the built React SPA) on a third
-# loopback listener (default 127.0.0.1:50180). OFF by default: the dist is embedded
+# loopback listener (default 127.0.0.1:8888). OFF by default: the dist is embedded
 # at COMPILE time by build.rs, so a console build needs `ui/dist` (a repo checkout
 # with node, or the prebuilt release which ships it) — plain `cargo build/install`
 # stays node-free and byte-identical. FFI-free (hyper stack only); composes with

--- a/crates/kx-gateway/src/config.rs
+++ b/crates/kx-gateway/src/config.rs
@@ -30,7 +30,7 @@ pub const DEFAULT_CONTENT_MAX_BYTES: u64 = 32 * 1024 * 1024;
 /// CORS self-grant derives from this origin, and remote browsers have the
 /// supported static-host + explicit `--cors-origin` path instead).
 pub const DEFAULT_CONSOLE_LISTEN: SocketAddr =
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50180);
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8888);
 
 /// How the embedded web console should run (D139). Parsed feature-free so the
 /// SAME flags are accepted by every build: on a console-less binary `Default`
@@ -849,8 +849,8 @@ mod tests {
             ConsoleMode::Listen("127.0.0.1:0".parse().unwrap())
         );
         // D139.3: non-loopback console binds are refused outright.
-        assert!(base(&["--console-listen", "0.0.0.0:50180"]).is_err());
-        assert!(base(&["--console-listen", "192.168.1.10:50180"]).is_err());
+        assert!(base(&["--console-listen", "0.0.0.0:8888"]).is_err());
+        assert!(base(&["--console-listen", "192.168.1.10:8888"]).is_err());
         // The two console flags are mutually exclusive, in either order.
         assert!(base(&["--no-console", "--console-listen", "127.0.0.1:0"]).is_err());
         assert!(base(&["--console-listen", "127.0.0.1:0", "--no-console"]).is_err());
@@ -870,7 +870,7 @@ mod tests {
             "--content",
             "/tmp/c",
             "--console-listen",
-            "127.0.0.1:50180",
+            "127.0.0.1:8888",
         ])
         .unwrap_err();
         assert!(

--- a/crates/kx-model-harness/tests/react_loop_e2e.rs
+++ b/crates/kx-model-harness/tests/react_loop_e2e.rs
@@ -32,7 +32,7 @@ use kx_model_harness::{
 use kx_mote::{ModelId, ToolName, ToolVersion};
 use kx_projection::{MoteState, Projection};
 use kx_runtime::config::Mode;
-use kx_runtime::{RuntimeConfig, RuntimeError};
+use kx_runtime::{digest_journal, RuntimeConfig, RuntimeError};
 use kx_tool_registry::{
     IdempotencyClass, InMemoryToolRegistry, McpEndpointId, ToolDef, ToolKind, ToolProvenance,
     ToolRegistry,
@@ -654,6 +654,59 @@ fn rejected_proposal_reprompts_then_answers() {
         backend.inputs()[1].contains("REJECTED") && backend.inputs()[1].contains("not granted"),
         "the re-prompt steer + reason reached the next turn: {}",
         backend.inputs()[1]
+    );
+}
+
+#[test]
+fn rejected_branch_cold_folds_identically() {
+    // GR15 / R49: a journal that CONTAINS an A2 `Rejected` branch must be
+    // replay-stable — two independent COLD re-folds of the on-disk journal
+    // reproduce the live committed-facts digest byte-for-byte (recovery re-reads
+    // the frozen rejected turn + its DETERMINISTIC re-prompt, never re-samples).
+    // This pins the harness A2 mirror's recovery determinism DETERMINISTICALLY;
+    // the `with-model` invariant test only exercises the happy path (a real model
+    // may or may not actually reject), so the rejected branch needs its own pin.
+    let script = vec![
+        envelope("mcp-danger", "1", "x"), // turn 0: ungranted → A2 `Rejected`
+        envelope("mcp-tool", "1", "q"),   // turn 1: granted → fires (observation)
+        b"Done.".to_vec(),                // turn 2: final answer
+    ];
+    let dir = tempfile::tempdir().unwrap();
+    let (outcome, _backend, journal) = drive(
+        dir.path(),
+        script,
+        vec![jsonrpc_result(r#"{"obs":"OBSERVATION"}"#)],
+        ReactBudget {
+            max_turns: 6,
+            max_tool_calls: 6,
+        },
+    );
+    let outcome = outcome.expect("loop runs");
+    assert_eq!(outcome.outcome, ReactStop::Answered);
+    assert_eq!(
+        outcome.tool_calls, 2,
+        "the rejected attempt + the good tool both count against the budget"
+    );
+    // The precondition this test pins: the journal carries a rejected branch — a
+    // refused proposal that COMMITTED (A2), never a terminal Failed fact.
+    assert_eq!(
+        failed_count(&journal),
+        0,
+        "A2: the rejected turn committed, not dead-lettered"
+    );
+
+    let live = digest_journal(&*journal).expect("digest the live journal");
+    // Two independent COLD folds from the on-disk journal (the recovery path).
+    let path = config_for(dir.path()).journal_path;
+    let cold1 = digest_journal(&SqliteJournal::open(&path).unwrap()).expect("cold fold 1");
+    let cold2 = digest_journal(&SqliteJournal::open(&path).unwrap()).expect("cold fold 2");
+    assert_eq!(
+        live, cold1,
+        "a cold re-fold reproduces the live digest with a rejected branch present (R49)"
+    );
+    assert_eq!(
+        cold1, cold2,
+        "two cold re-folds agree — deterministic A2 recovery"
     );
 }
 

--- a/docs/site/docs/intro.md
+++ b/docs/site/docs/intro.md
@@ -20,7 +20,7 @@ world-touching step twice.
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Kortecx/kortecx/main/scripts/install.sh | sh
 kx serve --journal /tmp/kx.db --content /tmp/kx-content --dev-allow-local
-# → gRPC 127.0.0.1:50151 · events ws://127.0.0.1:50152 · web console http://127.0.0.1:50180
+# → gRPC 127.0.0.1:50151 · events ws://127.0.0.1:50152 · web console http://127.0.0.1:8888
 ```
 
 ## What you get

--- a/docs/site/docs/quickstart.md
+++ b/docs/site/docs/quickstart.md
@@ -60,7 +60,7 @@ auth posture; the journal, content store, and catalog auto-resolve:
 ```bash
 kx serve --dev-allow-local
 #    gRPC on 127.0.0.1:50151 · events on ws://127.0.0.1:50152
-#    web console at http://127.0.0.1:50180  ← open this in your browser
+#    web console at http://127.0.0.1:8888  ← open this in your browser
 ```
 
 On start, the server prints a banner with every resolved path and endpoint:
@@ -69,7 +69,7 @@ On start, the server prints a banner with every resolved path and endpoint:
 kx-gateway STARTUP — resolved durable layout + endpoints
   data_dir=~/.kortecx  journal=~/.kortecx/kx.db  content_dir=~/.kortecx/content
   catalog_dir=~/.kortecx/catalog  (catalog.db · members.db · telemetry.db · capture.db · uploads.db · datasets/)
-  grpc_endpoint=http://127.0.0.1:50151  ws_endpoint=ws://127.0.0.1:50152  console_url=http://127.0.0.1:50180/
+  grpc_endpoint=http://127.0.0.1:50151  ws_endpoint=ws://127.0.0.1:50152  console_url=http://127.0.0.1:8888/
   auth_mode=dev-allow-local  connect_hint=kx runs list --endpoint http://127.0.0.1:50151
 ```
 

--- a/justfile
+++ b/justfile
@@ -221,7 +221,7 @@ fetch-gemma-model:
 
 # The ONE-COMMAND inference serve (§2.194 guardrail): fetch the stand-in model
 # if absent (idempotent, checksum-verified), then start `kx serve` with it +
-# the embedded console at :50180. Model paths are DETERMINISTIC
+# the embedded console at :8888. Model paths are DETERMINISTIC
 # (target/models/ via the fetch recipes, or the KX_AGENT_MODEL_* overrides) —
 # never hunt the filesystem for GGUFs. Journal/content are PINNED under
 # target/serve/ here for a repeatable, inspectable layout (override:
@@ -241,7 +241,7 @@ serve-inference journal="target/serve/kx.db" content="target/serve/blobs": fetch
 # sees a FRESH console + REAL (non-echo) chat — closing the three reviewer failure
 # modes (STALE BINARY · STALE UI EMBED · NO MODEL → echo). Rebuilds ui/dist
 # (console-dist) → builds kx with inference+console → frees the console port (kills
-# any stale kx on :50180) → serves WITH the fetched model → HARD-verifies: (a) the
+# any stale kx on :8888) → serves WITH the fetched model → HARD-verifies: (a) the
 # served console index byte-matches the just-built ui/dist [stale-embed catch;
 # relies on the console serving raw `include_bytes!` bytes, no Content-Encoding],
 # (b) ListModels is non-empty [a model is loaded ⇒ chat uses kx/recipes/chat, NOT
@@ -252,7 +252,7 @@ serve-inference journal="target/serve/kx.db" content="target/serve/blobs": fetch
 review-serve journal="target/serve/kx.db" content="target/serve/blobs": fetch-agent-model console-dist
     #!/usr/bin/env bash
     set -euo pipefail
-    PORT=50180; GRPC="http://127.0.0.1:50151"
+    PORT=8888; GRPC="http://127.0.0.1:50151"
     MODEL="${KX_AGENT_MODEL_DEST:-$(pwd)/target/models/qwen3-0.6b-q4_k_m.gguf}"
     test -f "$MODEL" || { echo " ✗ model GGUF missing: $MODEL" >&2; exit 1; }
     cargo build --release -p kx-cli --features inference,hnsw,console --bin kx
@@ -297,7 +297,7 @@ review-serve journal="target/serve/kx.db" content="target/serve/blobs": fetch-ag
 review-serve-gemma journal="target/serve/kx.db" content="target/serve/blobs": fetch-gemma-model console-dist
     #!/usr/bin/env bash
     set -euo pipefail
-    PORT=50180; GRPC="http://127.0.0.1:50151"
+    PORT=8888; GRPC="http://127.0.0.1:50151"
     MODEL="${KX_GEMMA_MODEL_DEST:-$(pwd)/target/models/gemma-4-12b-it-q4_k_m.gguf}"
     MMPROJ="${KX_GEMMA_MMPROJ_DEST:-$(pwd)/target/models/gemma-4-12b-it-mmproj-f16.gguf}"
     test -f "$MODEL" || { echo " ✗ model GGUF missing: $MODEL" >&2; exit 1; }

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,7 +2,7 @@
 
 > **End users don't need any of this**: the prebuilt `kx` (the `curl|sh` install)
 > ships this console **embedded** — `kx serve` hosts it at
-> `http://127.0.0.1:50180` with zero node/npm (D139; `--console-listen` /
+> `http://127.0.0.1:8888` with zero node/npm (D139; `--console-listen` /
 > `--no-console` to override). This README is the **developer** workflow (Vite
 > dev server + HMR against a local gateway).
 

--- a/ui/e2e/fixtures/serve.ts
+++ b/ui/e2e/fixtures/serve.ts
@@ -104,7 +104,7 @@ export interface SpawnOpts {
   /**
    * Serve the embedded web console (D139) on a free loopback port. Needs a
    * `--features console` kx (the CI ui job builds one); everything else passes
-   * `--no-console` so a default-on console build can never collide on 50180.
+   * `--no-console` so a default-on console build can never collide on 8888.
    */
   console?: boolean;
   /**
@@ -133,7 +133,7 @@ export async function spawnGateway(opts: SpawnOpts = {}): Promise<Gateway> {
     "--dev-allow-local",
   ];
   // `--no-console` parses as a no-op on console-less builds, so it is safe to
-  // pass unconditionally — and REQUIRED for console builds (default-on 50180
+  // pass unconditionally — and REQUIRED for console builds (default-on 8888
   // would collide across parallel spawns).
   if (opts.console) {
     args.push("--console-listen", `127.0.0.1:${consolePort}`);

--- a/ui/src/components/shell/Sidebar.tsx
+++ b/ui/src/components/shell/Sidebar.tsx
@@ -7,6 +7,8 @@ import { TokenUsageFooter } from "./TokenUsageFooter";
 import {
   CLOUD_GROUP_LABEL,
   CLOUD_PLACEHOLDERS,
+  DEV_GROUP_LABEL,
+  DEV_PLACEHOLDERS,
   NAV_GROUPS,
   NAV_SECTIONS,
   SETTINGS_SECTION,
@@ -116,6 +118,33 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
             })}
           </div>
         ))}
+        <div
+          className="sidebar__group"
+          data-color="neutral"
+          data-testid="nav-group-dev"
+          aria-label="Coming soon (in development)"
+        >
+          {collapsed ? null : <p className="sidebar__group-label">{DEV_GROUP_LABEL}</p>}
+          {DEV_PLACEHOLDERS.map((p) => (
+            <div
+              key={p.id}
+              className="navitem navitem--disabled"
+              aria-disabled="true"
+              data-testid={`dev-${p.id}`}
+              title={`${p.label} — in development (coming in the POC roadmap)`}
+            >
+              <span className="navitem__icon">
+                <Icon name={p.icon} />
+              </span>
+              {collapsed ? null : (
+                <>
+                  <span className="navitem__label">{p.label}</span>
+                  <span className="chip chip--soon">In dev</span>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
         <div
           className="sidebar__group"
           data-color="neutral"

--- a/ui/src/components/shell/nav-model.ts
+++ b/ui/src/components/shell/nav-model.ts
@@ -246,3 +246,21 @@ export const CLOUD_PLACEHOLDERS: readonly CloudPlaceholder[] = [
   { id: "federation", label: "Federation", icon: "systems" },
   { id: "experts", label: "Experts", icon: "activity" },
 ] as const;
+
+/**
+ * An HONEST in-development placeholder (GR15 don't-fake-gaps): a section on the POC
+ * roadmap (≈D166) that is NOT yet built. Structurally a {@link CloudPlaceholder} — NO
+ * `path`, NEVER navigable, rendered greyed with an "In dev" chip — so the nav previews
+ * what's coming without fabricating a working surface. These map to ACTUAL planned POC
+ * sections: Apps (the agentic-app workspace, POC-4/5 — subsumes Workflows/Blueprints)
+ * and Policies (the per-App agent-write gate, POC-5b). Promote one to a real
+ * {@link NAV_SECTIONS} entry in the PR that ships it.
+ */
+export type DevPlaceholder = CloudPlaceholder;
+
+export const DEV_GROUP_LABEL = "Coming";
+
+export const DEV_PLACEHOLDERS: readonly DevPlaceholder[] = [
+  { id: "apps", label: "Apps", icon: "artifacts" },
+  { id: "policies", label: "Policies", icon: "systems" },
+] as const;

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -27,19 +27,19 @@
   --border-strong: rgba(13, 13, 13, 0.26);
   --focus: #f04500;
 
-  /* semantic + accent palette (reference globals.css, AA on light surfaces) */
-  --success: #059669;
-  --warning: #d97706;
-  --error: #dc2626;
-  --info: #2563eb;
-  --teal: #0d9488;
-  --violet: #7c3aed;
-  --rose: #e11d48;
-  --indigo: #4f46e5;
-  --teal-dim: rgba(13, 148, 136, 0.08);
-  --violet-dim: rgba(124, 58, 237, 0.08);
-  --rose-dim: rgba(225, 29, 72, 0.08);
-  --indigo-dim: rgba(79, 70, 229, 0.08);
+  /* semantic + accent palette — monochrome (dark grays, AA on light surfaces) */
+  --success: #3f3f3f;
+  --warning: #555555;
+  --error: #444444;
+  --info: #5a5a5a;
+  --teal: #525252;
+  --violet: #4c4c4c;
+  --rose: #464646;
+  --indigo: #585858;
+  --teal-dim: rgba(128, 128, 128, 0.08);
+  --violet-dim: rgba(128, 128, 128, 0.08);
+  --rose-dim: rgba(128, 128, 128, 0.08);
+  --indigo-dim: rgba(128, 128, 128, 0.08);
 
   /* layout + shape */
   --radius: 6px;
@@ -70,29 +70,29 @@
   --backdrop-color: rgba(13, 13, 13, 0.32);
   --scrim-color: rgba(13, 13, 13, 0.04);
 
-  /* Mote state tones (re-mapped for light surfaces: each ≥4.5:1 as text on white
-   * AND under white pill text — the dark-theme hexes fail on light) */
-  --t-pending: #475569;
-  --t-scheduled: #b45309;
-  --t-committed: #047857;
-  --t-failed: #dc2626;
-  --t-repudiated: #c2410c;
-  --t-inconsistent: #7c3aed;
-  --t-unknown: #4b5563;
+  /* Mote state tones — monochrome (distinct dark-gray tiers; each ≥4.5:1 as text
+   * on white AND under white pill text) */
+  --t-pending: #5a5a5a;
+  --t-scheduled: #555555;
+  --t-committed: #3f3f3f;
+  --t-failed: #444444;
+  --t-repudiated: #525252;
+  --t-inconsistent: #4c4c4c;
+  --t-unknown: #606060;
 
-  /* nd_class tones */
-  --t-pure: #2563eb;
-  --t-read-only-nondet: #0f766e;
-  --t-world-mutating: #be123c;
+  /* nd_class tones — monochrome */
+  --t-pure: #4f4f4f;
+  --t-read-only-nondet: #484848;
+  --t-world-mutating: #414141;
 
-  /* notice tones */
-  --n-retry: #b45309;
-  --n-reauth: #2563eb;
-  --n-forbidden: #dc2626;
-  --n-bad-input: #c2410c;
-  --n-not-wired: #4b5563;
-  --n-not-found: #4b5563;
-  --n-generic: #dc2626;
+  /* notice tones — monochrome */
+  --n-retry: #555555;
+  --n-reauth: #5a5a5a;
+  --n-forbidden: #444444;
+  --n-bad-input: #525252;
+  --n-not-wired: #606060;
+  --n-not-found: #606060;
+  --n-generic: #444444;
 }
 
 /* ===========================================================================
@@ -126,18 +126,18 @@
   --border-strong: rgba(244, 244, 245, 0.3);
   --focus: #f04500;
 
-  --success: #34d399;
-  --warning: #fbbf24;
-  --error: #f87171;
-  --info: #60a5fa;
-  --teal: #2dd4bf;
-  --violet: #a78bfa;
-  --rose: #fb7185;
-  --indigo: #818cf8;
-  --teal-dim: rgba(45, 212, 191, 0.12);
-  --violet-dim: rgba(167, 139, 250, 0.12);
-  --rose-dim: rgba(251, 113, 133, 0.12);
-  --indigo-dim: rgba(129, 140, 248, 0.12);
+  --success: #ededed;
+  --warning: #d6d6d6;
+  --error: #e8e8e8;
+  --info: #bebebe;
+  --teal: #c2c2c2;
+  --violet: #cccccc;
+  --rose: #e0e0e0;
+  --indigo: #b0b0b0;
+  --teal-dim: rgba(128, 128, 128, 0.12);
+  --violet-dim: rgba(128, 128, 128, 0.12);
+  --rose-dim: rgba(128, 128, 128, 0.12);
+  --indigo-dim: rgba(128, 128, 128, 0.12);
 
   --bg-input: #141417;
   --accent-fg: #1a0a00;
@@ -146,29 +146,29 @@
   --backdrop-color: rgba(0, 0, 0, 0.55);
   --scrim-color: rgba(0, 0, 0, 0.3);
 
-  /* Mote state tones, brightened for dark surfaces: each ≥4.5:1 as text on
-   * --bg/--surface AND under the dark --pill-fg pill text. */
-  --t-pending: #94a3b8;
-  --t-scheduled: #fbbf24;
-  --t-committed: #34d399;
-  --t-failed: #f87171;
-  --t-repudiated: #fb923c;
-  --t-inconsistent: #a78bfa;
-  --t-unknown: #9ca3af;
+  /* Mote state tones — monochrome (distinct light-gray tiers; each ≥4.5:1 as text
+   * on --bg/--surface AND under the dark --pill-fg pill text). */
+  --t-pending: #aeaeae;
+  --t-scheduled: #d6d6d6;
+  --t-committed: #ededed;
+  --t-failed: #e8e8e8;
+  --t-repudiated: #c0c0c0;
+  --t-inconsistent: #cccccc;
+  --t-unknown: #9e9e9e;
 
-  /* nd_class tones */
-  --t-pure: #60a5fa;
-  --t-read-only-nondet: #2dd4bf;
-  --t-world-mutating: #fb7185;
+  /* nd_class tones — monochrome */
+  --t-pure: #cacaca;
+  --t-read-only-nondet: #b6b6b6;
+  --t-world-mutating: #e0e0e0;
 
-  /* notice tones */
-  --n-retry: #fbbf24;
-  --n-reauth: #60a5fa;
-  --n-forbidden: #f87171;
-  --n-bad-input: #fb923c;
-  --n-not-wired: #9ca3af;
-  --n-not-found: #9ca3af;
-  --n-generic: #f87171;
+  /* notice tones — monochrome */
+  --n-retry: #d6d6d6;
+  --n-reauth: #bebebe;
+  --n-forbidden: #e8e8e8;
+  --n-bad-input: #c0c0c0;
+  --n-not-wired: #9e9e9e;
+  --n-not-found: #9e9e9e;
+  --n-generic: #e8e8e8;
 }
 
 * {

--- a/ui/test/component/Sidebar.test.tsx
+++ b/ui/test/component/Sidebar.test.tsx
@@ -73,6 +73,17 @@ describe("Sidebar", () => {
     }
   });
 
+  it("renders in-development placeholders as honest-disabled (GR15/≈D166)", () => {
+    render(<Sidebar collapsed={false} onToggle={() => {}} />);
+    expect(screen.getByTestId("nav-group-dev")).toHaveTextContent("Coming");
+    for (const id of ["apps", "policies"]) {
+      const el = screen.getByTestId(`dev-${id}`);
+      expect(el).toBeInTheDocument();
+      expect(el).toHaveAttribute("aria-disabled", "true");
+      expect(el.tagName).toBe("DIV");
+    }
+  });
+
   it("hides labels, group labels and the footer (icon rail) when collapsed", () => {
     render(<Sidebar collapsed={true} onToggle={() => {}} />);
     // The items remain (icons), but the text labels are not rendered.

--- a/ui/test/contract/serve.ts
+++ b/ui/test/contract/serve.ts
@@ -120,7 +120,7 @@ export async function spawnServer(...extra: string[]): Promise<Server> {
       "--ws-listen",
       `127.0.0.1:${wsPort}`,
       // A console-feature kx defaults its web console onto the well-known
-      // 50180 — disable it here so parallel contract servers never collide
+      // 8888 — disable it here so parallel contract servers never collide
       // (a no-op on console-less builds; same as the e2e fixture).
       "--no-console",
       ...extra,

--- a/ui/test/unit/nav-model.test.ts
+++ b/ui/test/unit/nav-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CLOUD_PLACEHOLDERS,
+  DEV_PLACEHOLDERS,
   HIDDEN_SECTIONS,
   NAV_GROUPS,
   NAV_SECTIONS,
@@ -150,6 +151,30 @@ describe("CLOUD_PLACEHOLDERS (honest-disabled — GR15/D129)", () => {
     const sectionIds = new Set(NAV_SECTIONS.map((s) => s.id));
     for (const p of CLOUD_PLACEHOLDERS) {
       expect(sectionIds.has(p.id)).toBe(false);
+    }
+  });
+});
+
+describe("DEV_PLACEHOLDERS (honest in-development — GR15/≈D166)", () => {
+  it("are never navigable: NO path field on any placeholder", () => {
+    for (const p of DEV_PLACEHOLDERS) {
+      expect(p).not.toHaveProperty("path");
+      expect(p.label.length).toBeGreaterThan(0);
+      expect(p.icon.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("preview the headline coming POC sections (Apps · Policies)", () => {
+    expect(DEV_PLACEHOLDERS.map((p) => p.id)).toEqual(["apps", "policies"]);
+  });
+
+  it("do not collide with real section ids or the cloud placeholders", () => {
+    const taken = new Set([
+      ...NAV_SECTIONS.map((s) => s.id),
+      ...CLOUD_PLACEHOLDERS.map((p) => p.id),
+    ]);
+    for (const p of DEV_PLACEHOLDERS) {
+      expect(taken.has(p.id)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## What & why

The first **UI-foundation** batch for the POC roadmap (≈D166), plus a tool-calling
recovery pin. It makes the console match the target aesthetic and address, and
honestly previews the coming POC sections — without touching the runtime's
tool-calling behavior.

A deep, fact-based pass (GR22) found the "tool-calling robustness" theme is
**already shipped**: T-CONN reachability consistency is tested
(`register_and_test_agree_on_an_initialize_only_server`), the harness A2 mirror +
rejected-turn replay landed in PR-9c-2b-Part2, and cross-surface tool-calling
(CLI `kx agent run` actions · Py/TS `AgentResult.actions` · the UI live ReAct-turn
trajectory in chat + Monitoring) shipped in PR-9c-1/PR-R1. The one genuinely-new
item — **multi-element `tool_calls` firing** — is a deep `journal v12→v13` +
`ReactBranch::ToolBatch` + call-indexed observations + harness↔coordinator
`react_shape` lockstep (cross-impl golden) + digest/recovery change the corpus
itself deferred to "its own PR". It is **carried forward as the dedicated next PR**.

## Changes

- **Console port → `127.0.0.1:8888`** (`DEFAULT_CONSOLE_LISTEN`). The CORS
  self-grant derives from the new origin; `--console-listen` still overrides;
  vite dev stays `:5173`. Docs, `justfile` (verify/review serve), and tests updated.
- **Monochrome + orange theme** — retone BOTH light & dark to black/white/grays
  with a single orange accent for hovers/borders/shadows/focus. Semantic/state/
  nd_class tones collapse to grayscale brightness tiers. Token-only edit; the
  executable WCAG-AA contrast lock is green in both themes (`theme-contrast` 94/94).
- **Honest in-development nav** (GR15) — a "Coming" group with greyed,
  non-navigable **Apps** and **Policies** placeholders (the headline coming POC
  sections), mirroring the existing Cloud-placeholder pattern.
- **A2 cold-fold pin** — `rejected_branch_cold_folds_identically`: a deterministic
  test that a journal containing an A2 `Rejected` branch replays byte-identically
  across two cold re-folds (R49/GR15 — closes the "test both halves of the seam
  deterministically" gap for the rejected branch).

## Invariants

- Digest **`7d22d4bd`** invariant (`a0_guard` green); frozen trio
  (kx-scheduler/kx-executor/kx-inference) diff-EMPTY; **no** proto / journal /
  checkpoint / `Cargo.lock` change. UI/config/test/docs only.

## Verification

- `cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` ·
  `cargo test --workspace` · `a0_guard` (digest 7d22d4bd) · frozen-trio diff empty.
- UI: `vitest` 609/609 (incl. the real-`kx serve` contract test) · `biome ci .` ·
  `tsc --noEmit`.
- Live: console reachable on `127.0.0.1:8888`; both-theme review (GR12/GR13);
  tool-calling regression on Gemma-4 (no runtime change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
