### PR TITLE
POC-2 — context-edit: view/edit/import/export bundle items across CLI/SDK/UI + docs

### DIFF
--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -26,7 +26,7 @@ from .alerts import AlertsPage, AlertSummary
 from .branch import AdvanceResult, Branch, CreateBranchResult, SnapshotResult
 from .capture import CaptureRecord, CaptureRecordPage
 from .content import ContentItem, PutResult
-from .context import ContextBundle, PutContextBundleResult
+from .context import ContextBundle, ContextBundleItem, PutContextBundleResult
 from .datasets import (
     DatasetHit,
     DatasetSummary,
@@ -35,7 +35,7 @@ from .datasets import (
     IngestResult,
     _to_documents,
 )
-from .errors import KxError, KxUsage, from_rpc_error
+from .errors import KxError, KxFailedPrecondition, KxUsage, from_rpc_error
 from .feedback import FeedbackPage, FeedbackRow, rating_to_proto
 from .grants import AssetGrants
 from .models import ModelSummary
@@ -503,6 +503,125 @@ class KxClient:
             )
         )
         return resp.removed
+
+    @staticmethod
+    def _resolve_context_item(
+        manifest: ContextBundle, item: "Union[str, int]"
+    ) -> "tuple[int, ContextBundleItem]":
+        """Resolve a context-item selector to ``(index, item)`` against ``manifest``.
+
+        ``item`` is the advisory item NAME (a ``str``) or a 0-based INDEX (an
+        ``int``). A name with more than one match is AMBIGUOUS — pass the index.
+        Raises :class:`KxUsage` (a client-side selection error) on an out-of-range
+        index, an unknown name, or an ambiguous name. ``bool`` is rejected (it is an
+        ``int`` subtype, so ``True``/``False`` would silently mean index 1/0)."""
+        items = manifest.items
+        if isinstance(item, bool):
+            raise KxUsage("item selector must be a name (str) or an index (int), not a bool")
+        if isinstance(item, int):
+            if item < 0 or item >= len(items):
+                raise KxUsage(
+                    f"item index {item} is out of range for bundle {manifest.handle!r} "
+                    f"({len(items)} item{'s' if len(items) != 1 else ''})"
+                )
+            return item, items[item]
+        matches = [(i, it) for i, it in enumerate(items) if it.name == item]
+        if not matches:
+            raise KxUsage(f"no item named {item!r} in bundle {manifest.handle!r}")
+        if len(matches) > 1:
+            raise KxUsage(
+                f"item name {item!r} is ambiguous in bundle {manifest.handle!r} "
+                f"({len(matches)} matches) — pass the integer index instead"
+            )
+        return matches[0]
+
+    def _read_context_bundle_or_raise(
+        self, handle: str, expect_bundle_ref: Optional[str]
+    ) -> ContextBundle:
+        """Re-read ``handle`` as the freshest edit base + run the optimistic-
+        concurrency guard. With ``expect_bundle_ref`` set, a mismatch means the
+        bundle changed under the caller ⇒ :class:`KxFailedPrecondition` (fail-closed,
+        never a silent last-writer-wins clobber). The content-addressed
+        ``bundle_ref`` is a free compare-and-swap token (any item/description change
+        moves it)."""
+        manifest = self.get_context_bundle(handle)
+        if manifest is None:
+            raise KxError(f"context bundle {handle!r} not found")
+        if expect_bundle_ref is not None and manifest.bundle_ref != expect_bundle_ref:
+            raise KxFailedPrecondition(
+                f"context bundle {handle!r} changed since you read it "
+                f"(expected bundle_ref {expect_bundle_ref}, now {manifest.bundle_ref}); "
+                "re-read it and re-apply your change"
+            )
+        return manifest
+
+    def edit_context_item(
+        self,
+        handle: str,
+        item: "Union[str, int]",
+        new_body: bytes,
+        *,
+        media_type: Optional[str] = None,
+        expect_bundle_ref: Optional[str] = None,
+    ) -> PutContextBundleResult:
+        """Replace one context-item's body IN PLACE (POC-2 context-edit).
+
+        The content store is IMMUTABLE, so this uploads ``new_body`` (a NEW
+        server-derived ref via :meth:`put_content`) and re-upserts the bundle with
+        that item re-pointed at the new ref — the item's advisory ``name`` and
+        ``media_type`` are preserved unless ``media_type`` overrides. ``item``
+        selects by name or index (see :meth:`_resolve_context_item`). Set
+        ``expect_bundle_ref`` (the ``bundle_ref`` you viewed) to fail-closed on a
+        concurrent change (:class:`KxFailedPrecondition`) instead of a silent
+        overwrite. Editing to byte-identical content re-reports ``deduplicated``.
+        Raises :class:`KxUsage` for an unknown/ambiguous item and :class:`KxError`
+        if the bundle is gone."""
+        manifest = self._read_context_bundle_or_raise(handle, expect_bundle_ref)
+        idx, target = self._resolve_context_item(manifest, item)
+        media = media_type if media_type is not None else target.media_type
+        new_ref = self.put_content(new_body, media_type=media, filename=target.name).content_ref
+        items = [(it.name, it.content_ref, it.media_type) for it in manifest.items]
+        items[idx] = (target.name, new_ref, media)
+        return self.put_context_bundle(handle, items, description=manifest.description)
+
+    def remove_context_item(
+        self,
+        handle: str,
+        item: "Union[str, int]",
+        *,
+        expect_bundle_ref: Optional[str] = None,
+    ) -> PutContextBundleResult:
+        """Drop one item from a bundle (POC-2) and re-upsert the remainder.
+
+        Refuses (:class:`KxUsage`) if it would empty the bundle — the server rejects
+        an empty manifest; use :meth:`delete_context_bundle` to unbind the whole
+        handle. ``expect_bundle_ref`` makes it fail-closed on a concurrent change."""
+        manifest = self._read_context_bundle_or_raise(handle, expect_bundle_ref)
+        idx, _ = self._resolve_context_item(manifest, item)
+        if len(manifest.items) <= 1:
+            raise KxUsage(
+                f"removing the last item would empty bundle {handle!r}; "
+                "use delete_context_bundle to unbind the whole handle"
+            )
+        items = [
+            (it.name, it.content_ref, it.media_type)
+            for i, it in enumerate(manifest.items)
+            if i != idx
+        ]
+        return self.put_context_bundle(handle, items, description=manifest.description)
+
+    def export_context_item(self, handle: str, item: "Union[str, int]") -> bytes:
+        """Fetch one context-item's FULL body bytes (POC-2) from the uploads scope.
+
+        Returns the whole payload (the single :meth:`get_content` read is uncapped,
+        unlike a preview-clamped batch fetch). Raises :class:`KxUsage` for an
+        unknown/ambiguous item, :class:`KxError` if the bundle is gone, and the RPC's
+        :class:`KxPermissionDenied` if the ref is not in this party's scope."""
+        manifest = self.get_context_bundle(handle)
+        if manifest is None:
+            raise KxError(f"context bundle {handle!r} not found")
+        _, target = self._resolve_context_item(manifest, item)
+        return self.get_content(target.content_ref)
 
     def create_branch(
         self, handle: str, *, parent: str = "", description: str = ""

--- a/bindings/python/tests/test_context_edit.py
+++ b/bindings/python/tests/test_context_edit.py
@@ -1,0 +1,122 @@
+"""POC-2 context-edit SDK helpers — pure-unit selector tests + a server-backed
+edit/remove/export round trip over a real ``kx serve``.
+
+The edit family is pure CLIENT composition over existing RPCs (GetContextBundle →
+PutContent → PutContextBundle re-upsert): no proto/journal change, digest-invariant
+by construction. These tests pin the selector semantics + the stale-base guard +
+the empty-bundle refusal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kortecx import KxClient
+from kortecx.context import ContextBundle, ContextBundleItem
+from kortecx.errors import KxFailedPrecondition, KxUsage
+
+
+def _bundle(*names: str) -> ContextBundle:
+    items = [
+        ContextBundleItem(name=n, content_ref=f"{i:02x}" * 32, media_type="text/plain")
+        for i, n in enumerate(names)
+    ]
+    return ContextBundle(
+        bundle_ref="ab" * 16, handle="t/ctx/b", description="", items=items, item_count=len(items)
+    )
+
+
+# ---- pure-unit selector semantics (no server) -------------------------------
+
+
+def test_resolve_item_by_name_and_index():
+    b = _bundle("intro", "body")
+    assert KxClient._resolve_context_item(b, "body")[0] == 1
+    assert KxClient._resolve_context_item(b, 0)[1].name == "intro"
+
+
+def test_resolve_item_unknown_name_is_usage_error():
+    with pytest.raises(KxUsage):
+        KxClient._resolve_context_item(_bundle("intro"), "missing")
+
+
+def test_resolve_item_ambiguous_name_requires_index():
+    b = _bundle("dup", "dup")
+    with pytest.raises(KxUsage, match="ambiguous"):
+        KxClient._resolve_context_item(b, "dup")
+    # The index disambiguates.
+    assert KxClient._resolve_context_item(b, 1)[0] == 1
+
+
+def test_resolve_item_out_of_range_index_is_usage_error():
+    with pytest.raises(KxUsage, match="out of range"):
+        KxClient._resolve_context_item(_bundle("intro"), 5)
+    with pytest.raises(KxUsage):
+        KxClient._resolve_context_item(_bundle("intro"), -1)
+
+
+def test_resolve_item_rejects_bool_selector():
+    # bool is an int subtype — True/False must NOT silently mean index 1/0.
+    with pytest.raises(KxUsage):
+        KxClient._resolve_context_item(_bundle("intro", "body"), True)
+
+
+# ---- server-backed round trip ------------------------------------------------
+
+
+def test_edit_remove_export_round_trip(dev_server):
+    with KxClient(dev_server.endpoint) as kx:
+        a = kx.put_content(b"alpha", media_type="text/plain", filename="a.txt").content_ref
+        b = kx.put_content(b"beta", media_type="text/plain", filename="b.txt").content_ref
+        put = kx.put_context_bundle(
+            "t/ctx/docs", [("a", a, "text/plain"), ("b", b, "text/plain")], description="d"
+        )
+
+        # export returns the FULL body (uploads scope, uncapped).
+        assert kx.export_context_item("t/ctx/docs", "a") == b"alpha"
+        assert kx.export_context_item("t/ctx/docs", 1) == b"beta"
+
+        # edit re-points item "a" at NEW bytes; name + media preserved; description kept.
+        res = kx.edit_context_item("t/ctx/docs", "a", b"ALPHA-v2")
+        assert res.bundle_ref != put.bundle_ref  # the manifest changed
+        assert kx.export_context_item("t/ctx/docs", "a") == b"ALPHA-v2"
+        bundle = kx.get_context_bundle("t/ctx/docs")
+        assert bundle is not None and bundle.description == "d"
+        assert {it.name for it in bundle.items} == {"a", "b"}
+
+        # editing back to identical bytes re-reports deduplicated at the content layer
+        # (the manifest still re-upserts; the put is a dedup hit).
+        again = kx.edit_context_item("t/ctx/docs", "a", b"ALPHA-v2")
+        assert again.deduplicated is True
+
+        # remove drops item "b" (re-upsert); export of "b" now errors as unknown.
+        kx.remove_context_item("t/ctx/docs", "b")
+        left = kx.get_context_bundle("t/ctx/docs")
+        assert left is not None and [it.name for it in left.items] == ["a"]
+        with pytest.raises(KxUsage):
+            kx.export_context_item("t/ctx/docs", "b")
+
+        # removing the last item is refused (use delete_context_bundle instead).
+        with pytest.raises(KxUsage, match="empty"):
+            kx.remove_context_item("t/ctx/docs", "a")
+
+
+def test_stale_base_guard_fails_closed(dev_server):
+    with KxClient(dev_server.endpoint) as kx:
+        a = kx.put_content(b"v1", media_type="text/plain", filename="a.txt").content_ref
+        put = kx.put_context_bundle("t/ctx/race", [("a", a, "text/plain")])
+        stale = put.bundle_ref
+
+        # A concurrent writer changes the bundle (a second item ⇒ a new bundle_ref).
+        b = kx.put_content(b"added", media_type="text/plain", filename="b.txt").content_ref
+        kx.put_context_bundle("t/ctx/race", [("a", a, "text/plain"), ("b", b, "text/plain")])
+
+        # An edit holding the STALE bundle_ref is refused (no silent clobber).
+        with pytest.raises(KxFailedPrecondition, match="changed since"):
+            kx.edit_context_item("t/ctx/race", "a", b"v2", expect_bundle_ref=stale)
+
+        # The same edit with the CURRENT ref (or none) succeeds.
+        current = kx.get_context_bundle("t/ctx/race")
+        assert current is not None
+        kx.edit_context_item("t/ctx/race", "a", b"v2", expect_bundle_ref=current.bundle_ref)
+        assert kx.export_context_item("t/ctx/race", "a") == b"v2"

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -17,9 +17,23 @@ import { AdvanceResult, Branch, CreateBranchResult, SnapshotResult } from "./bra
 import { CaptureRecord, type CaptureRecordPage } from "./capture.js";
 import type { Chain } from "./chains.js";
 import { ContentItem, PutResult } from "./content.js";
-import { ContextBundle, type ContextItemInput, PutContextBundleResult } from "./context.js";
+import {
+  ContextBundle,
+  type ContextBundleItem,
+  type ContextItemInput,
+  PutContextBundleResult,
+} from "./context.js";
 import { DatasetHit, DatasetSummary, type IngestDoc, IngestResult } from "./datasets.js";
-import { KxConnectError, KxRunFailed, KxUnimplemented, KxWaitTimeout, rpc } from "./errors.js";
+import {
+  KxConnectError,
+  KxError,
+  KxFailedPrecondition,
+  KxRunFailed,
+  KxUnimplemented,
+  KxUsage,
+  KxWaitTimeout,
+  rpc,
+} from "./errors.js";
 import {
   streamAllDeltas,
   streamDeltas,
@@ -410,6 +424,130 @@ export abstract class KxClientBase {
   async deleteContextBundle(handle: string): Promise<boolean> {
     const resp = await rpc(this.grpc.deleteContextBundle({ handle }));
     return resp.removed;
+  }
+
+  /**
+   * Resolve a context-item selector to `[index, item]` against `manifest`. `item`
+   * is the advisory item NAME (a `string`) or a 0-based INDEX (a `number`); a name
+   * with more than one match is AMBIGUOUS — pass the index. Throws {@link KxUsage}
+   * (a client-side selection error) on an out-of-range index, an unknown name, or
+   * an ambiguous name.
+   */
+  private resolveContextItem(
+    manifest: ContextBundle,
+    item: string | number,
+  ): [number, ContextBundleItem] {
+    const items = manifest.items;
+    if (typeof item === "number") {
+      const found = Number.isInteger(item) ? items[item] : undefined;
+      if (found === undefined) {
+        throw new KxUsage(
+          `item index ${item} is out of range for bundle '${manifest.handle}' (${items.length} item${items.length === 1 ? "" : "s"})`,
+        );
+      }
+      return [item, found];
+    }
+    const matches = items
+      .map((it, i): [number, ContextBundleItem] => [i, it])
+      .filter(([, it]) => it.name === item);
+    if (matches.length > 1) {
+      throw new KxUsage(
+        `item name '${item}' is ambiguous in bundle '${manifest.handle}' (${matches.length} matches) — pass the integer index instead`,
+      );
+    }
+    const sole = matches[0];
+    if (sole === undefined) {
+      throw new KxUsage(`no item named '${item}' in bundle '${manifest.handle}'`);
+    }
+    return sole;
+  }
+
+  /**
+   * Re-read `handle` as the freshest edit base + run the optimistic-concurrency
+   * guard. With `expectBundleRef` set, a mismatch means the bundle changed under
+   * the caller ⇒ {@link KxFailedPrecondition} (fail-closed, never a silent
+   * last-writer-wins clobber). The content-addressed `bundleRef` is a free
+   * compare-and-swap token (any item/description change moves it).
+   */
+  private async readContextBundleOrThrow(
+    handle: string,
+    expectBundleRef: string | undefined,
+  ): Promise<ContextBundle> {
+    const manifest = await this.getContextBundle(handle);
+    if (manifest === null) throw new KxError(`context bundle '${handle}' not found`);
+    if (expectBundleRef !== undefined && manifest.bundleRef !== expectBundleRef) {
+      throw new KxFailedPrecondition(
+        `context bundle '${handle}' changed since you read it (expected bundle_ref ${expectBundleRef}, now ${manifest.bundleRef}); re-read it and re-apply your change`,
+      );
+    }
+    return manifest;
+  }
+
+  /**
+   * Replace one context-item's body IN PLACE (POC-2 context-edit). The content
+   * store is IMMUTABLE, so this uploads `newBody` (a NEW server-derived ref via
+   * {@link putContent}) and re-upserts the bundle with that item re-pointed at the
+   * new ref — the item's advisory `name` and `mediaType` are preserved unless
+   * `opts.mediaType` overrides. `item` selects by name or index. Set
+   * `opts.expectBundleRef` (the `bundleRef` you viewed) to fail-closed on a
+   * concurrent change ({@link KxFailedPrecondition}) instead of a silent overwrite.
+   * Editing to byte-identical content re-reports `deduplicated`.
+   */
+  async editContextItem(
+    handle: string,
+    item: string | number,
+    newBody: Uint8Array,
+    opts: { mediaType?: string; expectBundleRef?: string } = {},
+  ): Promise<PutContextBundleResult> {
+    const manifest = await this.readContextBundleOrThrow(handle, opts.expectBundleRef);
+    const [idx, target] = this.resolveContextItem(manifest, item);
+    const media = opts.mediaType ?? target.mediaType;
+    const put = await this.putContent(newBody, { mediaType: media, filename: target.name });
+    const items: ContextItemInput[] = manifest.items.map((it) => ({
+      name: it.name,
+      contentRef: it.contentRef,
+      mediaType: it.mediaType,
+    }));
+    items[idx] = { name: target.name, contentRef: put.contentRef, mediaType: media };
+    return this.putContextBundle(handle, items, { description: manifest.description });
+  }
+
+  /**
+   * Drop one item from a bundle (POC-2) and re-upsert the remainder. Refuses
+   * ({@link KxUsage}) if it would empty the bundle — the server rejects an empty
+   * manifest; use {@link deleteContextBundle} to unbind the whole handle.
+   * `opts.expectBundleRef` makes it fail-closed on a concurrent change.
+   */
+  async removeContextItem(
+    handle: string,
+    item: string | number,
+    opts: { expectBundleRef?: string } = {},
+  ): Promise<PutContextBundleResult> {
+    const manifest = await this.readContextBundleOrThrow(handle, opts.expectBundleRef);
+    const [idx] = this.resolveContextItem(manifest, item);
+    if (manifest.items.length <= 1) {
+      throw new KxUsage(
+        `removing the last item would empty bundle '${handle}'; use deleteContextBundle to unbind the whole handle`,
+      );
+    }
+    const items: ContextItemInput[] = manifest.items
+      .filter((_, i) => i !== idx)
+      .map((it) => ({ name: it.name, contentRef: it.contentRef, mediaType: it.mediaType }));
+    return this.putContextBundle(handle, items, { description: manifest.description });
+  }
+
+  /**
+   * Fetch one context-item's FULL body bytes (POC-2) from the uploads scope.
+   * Returns the whole payload (the single {@link getContent} read is uncapped,
+   * unlike a preview-clamped batch fetch). Throws {@link KxUsage} for an
+   * unknown/ambiguous item, {@link KxError} if the bundle is gone, and the RPC's
+   * {@link KxPermissionDenied} if the ref is not in this party's scope.
+   */
+  async exportContextItem(handle: string, item: string | number): Promise<Uint8Array> {
+    const manifest = await this.getContextBundle(handle);
+    if (manifest === null) throw new KxError(`context bundle '${handle}' not found`);
+    const [, target] = this.resolveContextItem(manifest, item);
+    return this.getContent(target.contentRef);
   }
 
   /**

--- a/bindings/typescript/test/context-edit.test.ts
+++ b/bindings/typescript/test/context-edit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * POC-2 context-edit SDK helpers over a real `kx serve`. The edit family is pure
+ * CLIENT composition over existing RPCs (GetContextBundle → PutContent →
+ * PutContextBundle re-upsert): no proto/journal change, digest-invariant by
+ * construction. Mirrors the Python `test_context_edit.py`: round-trip
+ * edit/remove/export, the stale-base optimistic-concurrency guard, the
+ * empty-bundle refusal, and the selector error cases (driven through the public
+ * methods, since `resolveContextItem` is private).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { KxClient, KxFailedPrecondition, KxUsage } from "../src/node.js";
+import { devServer, stopAllServers } from "./fixtures/serve.js";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+afterEach(async () => {
+  await stopAllServers();
+});
+
+describe("context-edit helpers", () => {
+  it("round-trips edit / export / remove and preserves name + media + description", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    try {
+      const a = (await kx.putContent(enc.encode("alpha"), { mediaType: "text/plain" })).contentRef;
+      const b = (await kx.putContent(enc.encode("beta"), { mediaType: "text/plain" })).contentRef;
+      const put = await kx.putContextBundle(
+        "t/ctx/docs",
+        [
+          { name: "a", contentRef: a, mediaType: "text/plain" },
+          { name: "b", contentRef: b, mediaType: "text/plain" },
+        ],
+        { description: "d" },
+      );
+
+      expect(dec.decode(await kx.exportContextItem("t/ctx/docs", "a"))).toBe("alpha");
+      expect(dec.decode(await kx.exportContextItem("t/ctx/docs", 1))).toBe("beta");
+
+      const res = await kx.editContextItem("t/ctx/docs", "a", enc.encode("ALPHA-v2"));
+      expect(res.bundleRef).not.toBe(put.bundleRef);
+      expect(dec.decode(await kx.exportContextItem("t/ctx/docs", "a"))).toBe("ALPHA-v2");
+      const bundle = await kx.getContextBundle("t/ctx/docs");
+      expect(bundle?.description).toBe("d");
+      expect(bundle?.items.map((i) => i.name).sort()).toEqual(["a", "b"]);
+
+      // Editing back to identical bytes is a content-layer dedup hit.
+      const again = await kx.editContextItem("t/ctx/docs", "a", enc.encode("ALPHA-v2"));
+      expect(again.deduplicated).toBe(true);
+
+      await kx.removeContextItem("t/ctx/docs", "b");
+      const left = await kx.getContextBundle("t/ctx/docs");
+      expect(left?.items.map((i) => i.name)).toEqual(["a"]);
+      await expect(kx.exportContextItem("t/ctx/docs", "b")).rejects.toBeInstanceOf(KxUsage);
+
+      // Removing the last item is refused (use deleteContextBundle instead).
+      await expect(kx.removeContextItem("t/ctx/docs", "a")).rejects.toThrow(/empty/);
+    } finally {
+      kx.close();
+    }
+  });
+
+  it("the stale-base guard fails closed on a concurrent change", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    try {
+      const a = (await kx.putContent(enc.encode("v1"), { mediaType: "text/plain" })).contentRef;
+      const put = await kx.putContextBundle("t/ctx/race", [
+        { name: "a", contentRef: a, mediaType: "text/plain" },
+      ]);
+      const stale = put.bundleRef;
+
+      // A concurrent writer changes the bundle (a second item ⇒ a new bundleRef).
+      const b = (await kx.putContent(enc.encode("added"), { mediaType: "text/plain" })).contentRef;
+      await kx.putContextBundle("t/ctx/race", [
+        { name: "a", contentRef: a, mediaType: "text/plain" },
+        { name: "b", contentRef: b, mediaType: "text/plain" },
+      ]);
+
+      await expect(
+        kx.editContextItem("t/ctx/race", "a", enc.encode("v2"), { expectBundleRef: stale }),
+      ).rejects.toBeInstanceOf(KxFailedPrecondition);
+
+      const current = await kx.getContextBundle("t/ctx/race");
+      await kx.editContextItem("t/ctx/race", "a", enc.encode("v2"), {
+        expectBundleRef: current?.bundleRef,
+      });
+      expect(dec.decode(await kx.exportContextItem("t/ctx/race", "a"))).toBe("v2");
+    } finally {
+      kx.close();
+    }
+  });
+
+  it("rejects unknown, ambiguous, and out-of-range item selectors", async () => {
+    const s = await devServer();
+    const kx = new KxClient(s.endpoint);
+    try {
+      const r = (await kx.putContent(enc.encode("x"), { mediaType: "text/plain" })).contentRef;
+      await kx.putContextBundle("t/ctx/sel", [
+        { name: "dup", contentRef: r, mediaType: "text/plain" },
+        { name: "dup", contentRef: r, mediaType: "text/plain" },
+      ]);
+      await expect(kx.exportContextItem("t/ctx/sel", "missing")).rejects.toBeInstanceOf(KxUsage);
+      await expect(kx.exportContextItem("t/ctx/sel", "dup")).rejects.toThrow(/ambiguous/);
+      await expect(kx.exportContextItem("t/ctx/sel", 9)).rejects.toThrow(/out of range/);
+      // The index disambiguates a duplicate name.
+      expect(dec.decode(await kx.exportContextItem("t/ctx/sel", 1))).toBe("x");
+    } finally {
+      kx.close();
+    }
+  });
+});

--- a/crates/kx-cli/src/verbs/context.rs
+++ b/crates/kx-cli/src/verbs/context.rs
@@ -1,18 +1,29 @@
-//! `kx context add | list | get | remove` — author + govern PR-7 context bundles
-//! (named, content-addressed collections a caller attaches to a run via
-//! `kx invoke --context <handle>`). Tri-surface parity with the SDK + UI.
+//! `kx context add | list | get | edit | remove-item | describe | remove` —
+//! author + govern + EDIT PR-7 context bundles (named, content-addressed
+//! collections a caller attaches to a run via `kx invoke --context <handle>`).
+//! Tri-surface parity with the SDK + UI.
 //!
 //! The bundle manifest lives in an off-journal `bundles.db` sidecar; the server
 //! derives `bundle_ref` (SN-8) and scopes every bundle to the authoring party.
 //! `--item <name>=<hex32>` attaches an existing content-store ref; `--file
 //! <name>=<path>` uploads the file first (`PutContent`) then attaches its
 //! server-derived ref.
+//!
+//! POC-2 context-edit: because the content store is IMMUTABLE, an item edit is a
+//! pure CLIENT compose over existing RPCs — `GetContextBundle` → `PutContent`
+//! (new bytes ⇒ a NEW ref) → `PutContextBundle` re-upsert with that item
+//! re-pointed. `get --output` exports each item body; `edit` replaces/renames one
+//! item; `remove-item` drops one; `describe` re-sets the description. All
+//! off-journal ⇒ digest-invariant by construction.
 
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
 
-use crate::client::{next_value, ClientCommon};
+use crate::client::{next_value, ClientCommon, Resolved};
 use crate::error::CliError;
 use crate::format;
 
@@ -23,10 +34,29 @@ pub enum ContextSub {
     Add(AddSpec),
     /// List the caller's bundles.
     List,
-    /// Show one bundle's manifest.
+    /// Show one bundle's manifest, or `--output <dir>` to export each item body.
     Get {
         /// The bundle handle.
         handle: String,
+        /// Export each item's body to this directory (+ a `manifest.json`).
+        output: Option<PathBuf>,
+    },
+    /// Replace one item's body (POC-2) — upload `--file` and re-point the item,
+    /// optionally renaming it with `--name`.
+    Edit(EditSpec),
+    /// Drop one item from a bundle (re-upsert the remainder).
+    RemoveItem {
+        /// The bundle handle.
+        handle: String,
+        /// Which item to drop.
+        selector: ItemSelector,
+    },
+    /// Re-set a bundle's advisory description (re-upsert, items unchanged).
+    Describe {
+        /// The bundle handle.
+        handle: String,
+        /// The new description.
+        description: String,
     },
     /// Unbind a bundle (its CAS blobs stay).
     Remove {
@@ -48,6 +78,29 @@ pub struct AddSpec {
     pub files: Vec<(String, PathBuf)>,
 }
 
+/// A `context edit` request (replace one item's body, optionally rename it).
+#[derive(Debug)]
+pub struct EditSpec {
+    /// The bundle handle.
+    pub handle: String,
+    /// Which item to replace.
+    pub selector: ItemSelector,
+    /// The file whose bytes become the item's new body.
+    pub file: PathBuf,
+    /// An optional new advisory name for the edited item.
+    pub new_name: Option<String>,
+}
+
+/// How a per-item verb selects its target: by advisory NAME or by 0-based INDEX.
+/// A name with more than one match is ambiguous — pass `--index`.
+#[derive(Debug, Clone)]
+pub enum ItemSelector {
+    /// The advisory item name.
+    Name(String),
+    /// The 0-based item index.
+    Index(usize),
+}
+
 /// Parsed `context` arguments.
 #[derive(Debug)]
 pub struct ContextArgs {
@@ -57,7 +110,7 @@ pub struct ContextArgs {
     pub common: ClientCommon,
 }
 
-/// Split a `name=value` flag value (the shape of `--item` / `--file`).
+/// Split a `name=value` flag value (the shape of `add`'s `--item` / `--file`).
 fn split_named(value: &str, flag: &str) -> Result<(String, String), CliError> {
     let (name, rest) = value
         .split_once('=')
@@ -71,16 +124,28 @@ fn split_named(value: &str, flag: &str) -> Result<(String, String), CliError> {
 }
 
 /// Parse `context` args (the verb already consumed). The first token selects the
-/// subcommand (`add` / `list` / `get` / `remove`).
+/// subcommand (`add` / `list` / `get` / `edit` / `remove-item` / `describe` /
+/// `remove`). The overloaded `--item` / `--file` flags are interpreted by verb:
+/// `add` uses `<name>=<value>` pairs; the per-item edit verbs use a bare selector
+/// name (`--item`) and a single path (`--file`).
 pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ContextArgs, CliError> {
     let kw = args.next().ok_or_else(|| {
-        CliError::Usage("context requires a subcommand: add | list | get | remove".into())
+        CliError::Usage(
+            "context requires a subcommand: add | list | get | edit | remove-item | describe | remove"
+                .into(),
+        )
     })?;
+    let is_add = kw == "add";
 
     let mut handle: Option<String> = None;
-    let mut description = String::new();
+    let mut description: Option<String> = None;
     let mut refs: Vec<(String, [u8; 32])> = Vec::new();
     let mut files: Vec<(String, PathBuf)> = Vec::new();
+    let mut output: Option<PathBuf> = None;
+    let mut item_name: Option<String> = None;
+    let mut index: Option<usize> = None;
+    let mut edit_file: Option<PathBuf> = None;
+    let mut new_name: Option<String> = None;
     let mut common = ClientCommon::default();
 
     while let Some(flag) = args.next() {
@@ -88,16 +153,26 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ContextArgs, CliE
             continue;
         }
         match flag.as_str() {
-            "--description" => description = next_value(&mut args, "--description")?,
-            "--item" => {
+            "--description" => description = Some(next_value(&mut args, "--description")?),
+            "--output" => output = Some(PathBuf::from(next_value(&mut args, "--output")?)),
+            "--name" => new_name = Some(next_value(&mut args, "--name")?),
+            "--index" => {
+                let raw = next_value(&mut args, "--index")?;
+                index = Some(raw.parse::<usize>().map_err(|_| {
+                    CliError::Usage(format!("--index expects an integer, got {raw:?}"))
+                })?);
+            }
+            "--item" if is_add => {
                 let (name, hexref) = split_named(&next_value(&mut args, "--item")?, "--item")?;
                 let r = crate::hex::decode_fixed::<32>(&hexref)?;
                 refs.push((name, r));
             }
-            "--file" => {
+            "--item" => item_name = Some(next_value(&mut args, "--item")?),
+            "--file" if is_add => {
                 let (name, path) = split_named(&next_value(&mut args, "--file")?, "--file")?;
                 files.push((name, PathBuf::from(path)));
             }
+            "--file" => edit_file = Some(PathBuf::from(next_value(&mut args, "--file")?)),
             other if other.starts_with("--") => {
                 return Err(CliError::Usage(format!("unknown flag {other:?}")))
             }
@@ -106,6 +181,49 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ContextArgs, CliE
         }
     }
 
+    let sub = assemble_sub(
+        &kw,
+        Flags {
+            handle,
+            description,
+            refs,
+            files,
+            output,
+            item_name,
+            index,
+            edit_file,
+            new_name,
+        },
+    )?;
+    Ok(ContextArgs { sub, common })
+}
+
+/// The accumulated `context` flags, dispatched to a subcommand by [`assemble_sub`].
+struct Flags {
+    handle: Option<String>,
+    description: Option<String>,
+    refs: Vec<(String, [u8; 32])>,
+    files: Vec<(String, PathBuf)>,
+    output: Option<PathBuf>,
+    item_name: Option<String>,
+    index: Option<usize>,
+    edit_file: Option<PathBuf>,
+    new_name: Option<String>,
+}
+
+/// Validate the accumulated flags against the verb and build the subcommand.
+fn assemble_sub(kw: &str, f: Flags) -> Result<ContextSub, CliError> {
+    let Flags {
+        handle,
+        description,
+        refs,
+        files,
+        output,
+        item_name,
+        index,
+        edit_file,
+        new_name,
+    } = f;
     let require_handle = |h: Option<String>, verb: &str| -> Result<String, CliError> {
         h.filter(|s| !s.is_empty()).ok_or_else(|| {
             CliError::Usage(format!(
@@ -113,15 +231,58 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ContextArgs, CliE
             ))
         })
     };
+    // A per-item verb needs exactly one of `--item <name>` / `--index <n>`.
+    let require_selector = |verb: &str| -> Result<ItemSelector, CliError> {
+        match (&item_name, index) {
+            (Some(_), Some(_)) => Err(CliError::Usage(format!(
+                "context {verb}: pass either --item <name> OR --index <n>, not both"
+            ))),
+            (Some(name), None) => Ok(ItemSelector::Name(name.clone())),
+            (None, Some(i)) => Ok(ItemSelector::Index(i)),
+            (None, None) => Err(CliError::Usage(format!(
+                "context {verb} requires --item <name> or --index <n>"
+            ))),
+        }
+    };
 
-    let sub = match kw.as_str() {
-        "list" => ContextSub::List,
-        "get" => ContextSub::Get {
+    match kw {
+        "list" => Ok(ContextSub::List),
+        "get" => Ok(ContextSub::Get {
             handle: require_handle(handle, "get")?,
-        },
-        "remove" => ContextSub::Remove {
+            output,
+        }),
+        "remove" => Ok(ContextSub::Remove {
             handle: require_handle(handle, "remove")?,
-        },
+        }),
+        "describe" => {
+            let handle = require_handle(handle, "describe")?;
+            Ok(ContextSub::Describe {
+                handle,
+                description: description.ok_or_else(|| {
+                    CliError::Usage("context describe requires --description <text>".into())
+                })?,
+            })
+        }
+        "remove-item" => {
+            let handle = require_handle(handle, "remove-item")?;
+            Ok(ContextSub::RemoveItem {
+                handle,
+                selector: require_selector("remove-item")?,
+            })
+        }
+        "edit" => {
+            let handle = require_handle(handle, "edit")?;
+            let selector = require_selector("edit")?;
+            let file = edit_file.ok_or_else(|| {
+                CliError::Usage("context edit requires --file <path> (the new body)".into())
+            })?;
+            Ok(ContextSub::Edit(EditSpec {
+                handle,
+                selector,
+                file,
+                new_name,
+            }))
+        }
         "add" => {
             let handle = require_handle(handle, "add")?;
             if refs.is_empty() && files.is_empty() {
@@ -129,20 +290,142 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ContextArgs, CliE
                     "context add requires at least one --item <name>=<hex32> or --file <name>=<path>".into(),
                 ));
             }
-            ContextSub::Add(AddSpec {
+            Ok(ContextSub::Add(AddSpec {
                 handle,
-                description,
+                description: description.unwrap_or_default(),
                 refs,
                 files,
-            })
+            }))
         }
-        other => {
-            return Err(CliError::Usage(format!(
-                "unknown context subcommand {other:?} (expected add | list | get | remove)"
-            )))
+        other => Err(CliError::Usage(format!(
+            "unknown context subcommand {other:?} (expected add | list | get | edit | remove-item | describe | remove)"
+        ))),
+    }
+}
+
+/// Resolve a selector against a fetched bundle's items → `(index, item)`.
+/// A name with more than one match is AMBIGUOUS (pass `--index`); an unknown
+/// name or an out-of-range index is a usage error.
+fn resolve_item<'a>(
+    items: &'a [proto::ContextItem],
+    selector: &ItemSelector,
+    handle: &str,
+) -> Result<(usize, &'a proto::ContextItem), CliError> {
+    match selector {
+        ItemSelector::Index(i) => items.get(*i).map(|it| (*i, it)).ok_or_else(|| {
+            CliError::Usage(format!("item index {i} is out of range for {handle:?}"))
+        }),
+        ItemSelector::Name(name) => {
+            let matches: Vec<usize> = items
+                .iter()
+                .enumerate()
+                .filter(|(_, it)| &it.name == name)
+                .map(|(i, _)| i)
+                .collect();
+            match matches.as_slice() {
+                [] => Err(CliError::Usage(format!(
+                    "no item named {name:?} in {handle:?}"
+                ))),
+                [i] => Ok((*i, &items[*i])),
+                _ => Err(CliError::Usage(format!(
+                    "item name {name:?} is ambiguous in {handle:?} ({} matches) — pass --index",
+                    matches.len()
+                ))),
+            }
         }
-    };
-    Ok(ContextArgs { sub, common })
+    }
+}
+
+/// Fetch a bundle's manifest or fail with a usage error (uniform not-found).
+async fn fetch_bundle(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    handle: &str,
+) -> Result<proto::ContextBundle, CliError> {
+    let resp = client
+        .get_context_bundle(resolved.request(proto::GetContextBundleRequest {
+            handle: handle.to_string(),
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+    resp.bundle
+        .filter(|_| resp.found)
+        .ok_or_else(|| CliError::Usage(format!("context bundle {handle:?} not found")))
+}
+
+/// Sanitise an advisory item name into a safe, relative export filename: keep
+/// only the basename, strip path separators / `..` / leading dots, fall back to
+/// `item-<n>`. (Item names are advisory and attacker-influenceable in a shared
+/// store — never trust them as a path.)
+fn safe_filename(name: &str, idx: usize) -> String {
+    let base = name.rsplit(['/', '\\']).next().unwrap_or(name);
+    let cleaned: String = base
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, '.' | '-' | '_' | ' ') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let cleaned = cleaned.trim_start_matches('.').trim();
+    if cleaned.is_empty() || cleaned == ".." {
+        format!("item-{idx}")
+    } else {
+        cleaned.to_string()
+    }
+}
+
+/// `context add`: author/upsert a bundle from `--item`/`--file` flags.
+async fn execute_add(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    spec: AddSpec,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut items: Vec<proto::ContextItem> = Vec::new();
+    for (name, r) in spec.refs {
+        items.push(proto::ContextItem {
+            name,
+            content_ref: r.to_vec(),
+            media_type: String::new(),
+        });
+    }
+    for (name, path) in spec.files {
+        let content_ref = upload_file(client, resolved, &path).await?;
+        items.push(proto::ContextItem {
+            name,
+            content_ref,
+            media_type: String::new(),
+        });
+    }
+    let resp = reupsert(client, resolved, &spec.handle, spec.description, items).await?;
+    println!("{}", format::render_put_context_bundle(&resp, json));
+    Ok(())
+}
+
+/// `context edit`: replace one item's body (POC-2) — `GetContextBundle` →
+/// `PutContent` (new ref) → `PutContextBundle` re-upsert, preserving the item's
+/// media (and name unless `--name` renames it).
+async fn execute_edit(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    spec: EditSpec,
+    json: bool,
+) -> Result<(), CliError> {
+    let bundle = fetch_bundle(client, resolved, &spec.handle).await?;
+    let (idx, _) = resolve_item(&bundle.items, &spec.selector, &spec.handle)?;
+    let new_ref = upload_file(client, resolved, &spec.file).await?;
+    let mut items = bundle.items;
+    items[idx].content_ref = new_ref;
+    if let Some(name) = spec.new_name {
+        items[idx].name = name;
+    }
+    let resp = reupsert(client, resolved, &spec.handle, bundle.description, items).await?;
+    println!("{}", format::render_put_context_bundle(&resp, json));
+    Ok(())
 }
 
 /// Execute `context`.
@@ -152,50 +435,8 @@ pub async fn execute(args: ContextArgs) -> Result<(), CliError> {
     let json = args.common.json;
 
     match args.sub {
-        ContextSub::Add(spec) => {
-            let mut items: Vec<proto::ContextItem> = Vec::new();
-            // Existing content-store refs.
-            for (name, r) in spec.refs {
-                items.push(proto::ContextItem {
-                    name,
-                    content_ref: r.to_vec(),
-                    media_type: String::new(),
-                });
-            }
-            // Files: upload each first (PutContent), then attach its server-derived ref.
-            for (name, path) in spec.files {
-                let payload = std::fs::read(&path)
-                    .map_err(|e| CliError::Io(format!("read {}: {e}", path.display())))?;
-                let filename = path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_default();
-                let put = client
-                    .put_content(resolved.request(proto::PutContentRequest {
-                        payload,
-                        media_type: String::new(),
-                        filename,
-                    })?)
-                    .await
-                    .map_err(CliError::from_status)?
-                    .into_inner();
-                items.push(proto::ContextItem {
-                    name,
-                    content_ref: put.content_ref,
-                    media_type: String::new(),
-                });
-            }
-            let resp = client
-                .put_context_bundle(resolved.request(proto::PutContextBundleRequest {
-                    handle: spec.handle,
-                    description: spec.description,
-                    items,
-                })?)
-                .await
-                .map_err(CliError::from_status)?
-                .into_inner();
-            println!("{}", format::render_put_context_bundle(&resp, json));
-        }
+        ContextSub::Add(spec) => execute_add(&mut client, &resolved, spec, json).await?,
+        ContextSub::Edit(spec) => execute_edit(&mut client, &resolved, spec, json).await?,
         ContextSub::List => {
             let resp = client
                 .list_context_bundles(resolved.request(proto::ListContextBundlesRequest {
@@ -207,13 +448,40 @@ pub async fn execute(args: ContextArgs) -> Result<(), CliError> {
                 .into_inner();
             println!("{}", format::render_context_bundles_list(&resp, json));
         }
-        ContextSub::Get { handle } => {
-            let resp = client
-                .get_context_bundle(resolved.request(proto::GetContextBundleRequest { handle })?)
-                .await
-                .map_err(CliError::from_status)?
-                .into_inner();
-            println!("{}", format::render_get_context_bundle(&resp, json));
+        ContextSub::Get { handle, output } => {
+            if let Some(dir) = output {
+                export_bundle(&mut client, &resolved, &handle, &dir, json).await?;
+            } else {
+                let resp = client
+                    .get_context_bundle(
+                        resolved.request(proto::GetContextBundleRequest { handle })?,
+                    )
+                    .await
+                    .map_err(CliError::from_status)?
+                    .into_inner();
+                println!("{}", format::render_get_context_bundle(&resp, json));
+            }
+        }
+        ContextSub::RemoveItem { handle, selector } => {
+            let bundle = fetch_bundle(&mut client, &resolved, &handle).await?;
+            let (idx, _) = resolve_item(&bundle.items, &selector, &handle)?;
+            if bundle.items.len() <= 1 {
+                return Err(CliError::Usage(format!(
+                    "removing the last item would empty {handle:?}; use `context remove {handle}` to unbind the whole handle"
+                )));
+            }
+            let mut items = bundle.items;
+            items.remove(idx);
+            let resp = reupsert(&mut client, &resolved, &handle, bundle.description, items).await?;
+            println!("{}", format::render_put_context_bundle(&resp, json));
+        }
+        ContextSub::Describe {
+            handle,
+            description,
+        } => {
+            let bundle = fetch_bundle(&mut client, &resolved, &handle).await?;
+            let resp = reupsert(&mut client, &resolved, &handle, description, bundle.items).await?;
+            println!("{}", format::render_put_context_bundle(&resp, json));
         }
         ContextSub::Remove { handle } => {
             let resp = client
@@ -225,6 +493,113 @@ pub async fn execute(args: ContextArgs) -> Result<(), CliError> {
                 .into_inner();
             println!("{}", format::render_delete_context_bundle(&resp, json));
         }
+    }
+    Ok(())
+}
+
+/// `PutContent` a file's bytes, returning the server-derived ref.
+async fn upload_file(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    path: &Path,
+) -> Result<Vec<u8>, CliError> {
+    let payload =
+        std::fs::read(path).map_err(|e| CliError::Io(format!("read {}: {e}", path.display())))?;
+    let filename = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let put = client
+        .put_content(resolved.request(proto::PutContentRequest {
+            payload,
+            media_type: String::new(),
+            filename,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+    Ok(put.content_ref)
+}
+
+/// Re-upsert a bundle's manifest (the POC-2 edit primitive — off-journal).
+async fn reupsert(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    handle: &str,
+    description: String,
+    items: Vec<proto::ContextItem>,
+) -> Result<proto::PutContextBundleResponse, CliError> {
+    Ok(client
+        .put_context_bundle(resolved.request(proto::PutContextBundleRequest {
+            handle: handle.to_string(),
+            description,
+            items,
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner())
+}
+
+/// `context get --output <dir>`: write each item body (uploads scope, FULL bytes)
+/// to a safe filename under `dir`, plus a `manifest.json` mapping names → refs.
+async fn export_bundle(
+    client: &mut KxGatewayClient<Channel>,
+    resolved: &Resolved,
+    handle: &str,
+    dir: &Path,
+    json: bool,
+) -> Result<(), CliError> {
+    let bundle = fetch_bundle(client, resolved, handle).await?;
+    std::fs::create_dir_all(dir)
+        .map_err(|e| CliError::Io(format!("--output {}: {e}", dir.display())))?;
+    let mut used: HashSet<String> = HashSet::new();
+    let mut manifest_rows: Vec<serde_json::Value> = Vec::new();
+    for (idx, item) in bundle.items.iter().enumerate() {
+        let blob = client
+            .get_content(resolved.request(proto::GetContentRequest {
+                content_ref: item.content_ref.clone(),
+                instance_id: Vec::new(), // uploads scope (FULL bytes, uncapped)
+            })?)
+            .await
+            .map_err(CliError::from_status)?
+            .into_inner();
+        // De-collide sanitised filenames (`name`, `name-2`, `name-3`, …).
+        let stem = safe_filename(&item.name, idx);
+        let mut fname = stem.clone();
+        let mut n = 2;
+        while !used.insert(fname.clone()) {
+            fname = format!("{stem}-{n}");
+            n += 1;
+        }
+        let path = dir.join(&fname);
+        std::fs::write(&path, &blob.payload)
+            .map_err(|e| CliError::Io(format!("write {}: {e}", path.display())))?;
+        manifest_rows.push(serde_json::json!({
+            "name": item.name,
+            "file": fname,
+            "content_ref": crate::hex::encode(&item.content_ref),
+            "media_type": item.media_type,
+            "bytes": blob.payload.len(),
+        }));
+    }
+    let manifest = serde_json::json!({
+        "handle": bundle.handle,
+        "bundle_ref": crate::hex::encode(&bundle.bundle_ref),
+        "description": bundle.description,
+        "items": manifest_rows,
+    });
+    let manifest_path = dir.join("manifest.json");
+    std::fs::write(&manifest_path, format!("{manifest:#}\n"))
+        .map_err(|e| CliError::Io(format!("write {}: {e}", manifest_path.display())))?;
+    if json {
+        println!("{manifest}");
+    } else {
+        println!(
+            "exported {} item(s) of {} to {}",
+            bundle.items.len(),
+            handle,
+            dir.display()
+        );
     }
     Ok(())
 }
@@ -274,12 +649,60 @@ mod tests {
         assert!(matches!(p(&["list"]).unwrap().sub, ContextSub::List));
         assert!(matches!(
             p(&["get", "a/b/c"]).unwrap().sub,
-            ContextSub::Get { .. }
+            ContextSub::Get { output: None, .. }
         ));
         assert!(matches!(
             p(&["remove", "a/b/c"]).unwrap().sub,
             ContextSub::Remove { .. }
         ));
+    }
+
+    #[test]
+    fn parses_get_with_output_export() {
+        let a = p(&["get", "a/b/c", "--output", "/tmp/out"]).unwrap();
+        let ContextSub::Get { handle, output } = a.sub else {
+            panic!("expected Get");
+        };
+        assert_eq!(handle, "a/b/c");
+        assert_eq!(output, Some(PathBuf::from("/tmp/out")));
+    }
+
+    #[test]
+    fn parses_edit_by_name_and_index() {
+        let a = p(&["edit", "a/b/c", "--item", "intro", "--file", "/tmp/new.md"]).unwrap();
+        let ContextSub::Edit(spec) = a.sub else {
+            panic!("expected Edit");
+        };
+        assert!(matches!(spec.selector, ItemSelector::Name(ref n) if n == "intro"));
+        assert_eq!(spec.file, PathBuf::from("/tmp/new.md"));
+        assert!(spec.new_name.is_none());
+
+        let b = p(&[
+            "edit", "a/b/c", "--index", "2", "--file", "/tmp/x", "--name", "renamed",
+        ])
+        .unwrap();
+        let ContextSub::Edit(spec) = b.sub else {
+            panic!("expected Edit");
+        };
+        assert!(matches!(spec.selector, ItemSelector::Index(2)));
+        assert_eq!(spec.new_name.as_deref(), Some("renamed"));
+    }
+
+    #[test]
+    fn parses_remove_item_and_describe() {
+        let a = p(&["remove-item", "a/b/c", "--item", "old"]).unwrap();
+        assert!(matches!(
+            a.sub,
+            ContextSub::RemoveItem {
+                selector: ItemSelector::Name(_),
+                ..
+            }
+        ));
+        let b = p(&["describe", "a/b/c", "--description", "new desc"]).unwrap();
+        let ContextSub::Describe { description, .. } = b.sub else {
+            panic!("expected Describe");
+        };
+        assert_eq!(description, "new desc");
     }
 
     #[test]
@@ -289,12 +712,41 @@ mod tests {
         assert!(p(&["get"]).is_err(), "get needs a handle");
         assert!(
             p(&["add", "a/b/c", "--item", "noequals"]).is_err(),
-            "item needs name=value"
+            "add item needs name=value"
         );
         assert!(
             p(&["add", "a/b/c", "--item", "x=nothex"]).is_err(),
-            "item ref must be hex32"
+            "add item ref must be hex32"
         );
         assert!(p(&["frobnicate"]).is_err(), "unknown subcommand");
+        assert!(
+            p(&["edit", "a/b/c", "--file", "/tmp/x"]).is_err(),
+            "edit needs a selector"
+        );
+        assert!(
+            p(&["edit", "a/b/c", "--item", "x"]).is_err(),
+            "edit needs --file"
+        );
+        assert!(
+            p(&["edit", "a/b/c", "--item", "x", "--index", "0", "--file", "/tmp/x"]).is_err(),
+            "edit rejects both selectors"
+        );
+        assert!(
+            p(&["remove-item", "a/b/c"]).is_err(),
+            "remove-item needs a selector"
+        );
+        assert!(
+            p(&["describe", "a/b/c"]).is_err(),
+            "describe needs --description"
+        );
+    }
+
+    #[test]
+    fn safe_filename_is_path_safe() {
+        assert_eq!(safe_filename("../../etc/passwd", 0), "passwd");
+        assert_eq!(safe_filename("a/b/c.txt", 0), "c.txt");
+        assert_eq!(safe_filename("", 3), "item-3");
+        assert_eq!(safe_filename("..", 1), "item-1");
+        assert_eq!(safe_filename("weird*name?.md", 0), "weird_name_.md");
     }
 }

--- a/crates/kx-gateway/tests/context_edit_e2e.rs
+++ b/crates/kx-gateway/tests/context_edit_e2e.rs
@@ -1,0 +1,389 @@
+//! POC-2 context-edit end-to-end over a REAL bound tonic port. The edit family is
+//! a pure CLIENT compose over EXISTING RPCs — `GetContextBundle` → `PutContent`
+//! (new bytes ⇒ a new server-derived ref, since CAS is immutable) → re-upsert via
+//! `PutContextBundle`. There is no edit RPC and no journal write, so these prove
+//! the server-side primitives every surface (CLI / SDK / UI) composes:
+//!
+//! - **edit round trip**: re-upsert re-points the item at the new ref; the OLD ref
+//!   still resolves (CAS is immutable), the description survives, the `bundle_ref`
+//!   (a content hash of the manifest) moves.
+//! - **dedup**: editing back to identical bytes re-reports `deduplicated`.
+//! - **empty-manifest refusal**: removing the last item (an empty items list) is
+//!   refused — the UI/CLI/SDK "use delete to unbind" guard's server backing.
+//! - **security negatives** (two auth-token parties): cross-party bundle isolation
+//!   (uniform not-found; a same-handle put makes the OTHER party's own row, never
+//!   mutates the author's); fail-closed unknown-ref read; server-derived identity;
+//!   and a PINNED witness of the pre-existing uploads-scope cross-party read gap
+//!   (ticket T-UPLOADS-PRINCIPAL-SCOPE → PR-8) so a future fix flips one assertion.
+
+#![cfg(feature = "embedded-worker")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use kx_gateway::start;
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+use tonic::{Code, Request};
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    common::connect_client(addr).await
+}
+
+fn with_bearer<T>(payload: T, token: &str) -> Request<T> {
+    let mut req = Request::new(payload);
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    req
+}
+
+fn two_party_tokens() -> HashMap<String, String> {
+    HashMap::from([
+        ("tok-alice".to_string(), "alice@acme".to_string()),
+        ("tok-bob".to_string(), "bob@acme".to_string()),
+    ])
+}
+
+/// `PutContent` a payload in the dev-local (no-bearer) scope; return the ref.
+async fn put(c: &mut KxGatewayClient<Channel>, payload: &[u8]) -> Vec<u8> {
+    c.put_content(proto::PutContentRequest {
+        payload: payload.to_vec(),
+        media_type: "text/plain".into(),
+        filename: "item.txt".into(),
+    })
+    .await
+    .unwrap()
+    .into_inner()
+    .content_ref
+}
+
+fn item(name: &str, content_ref: Vec<u8>) -> proto::ContextItem {
+    proto::ContextItem {
+        name: name.into(),
+        content_ref,
+        media_type: "text/plain".into(),
+    }
+}
+
+async fn upsert(
+    c: &mut KxGatewayClient<Channel>,
+    handle: &str,
+    description: &str,
+    items: Vec<proto::ContextItem>,
+) -> proto::PutContextBundleResponse {
+    c.put_context_bundle(proto::PutContextBundleRequest {
+        handle: handle.into(),
+        description: description.into(),
+        items,
+    })
+    .await
+    .unwrap()
+    .into_inner()
+}
+
+/// `GetContent` a ref in the dev-local uploads scope; return the full payload.
+async fn read_uploads(c: &mut KxGatewayClient<Channel>, r: Vec<u8>) -> Vec<u8> {
+    c.get_content(proto::GetContentRequest {
+        content_ref: r,
+        instance_id: Vec::new(),
+    })
+    .await
+    .unwrap()
+    .into_inner()
+    .payload
+}
+
+async fn get_bundle(c: &mut KxGatewayClient<Channel>, handle: &str) -> proto::ContextBundle {
+    c.get_context_bundle(proto::GetContextBundleRequest {
+        handle: handle.into(),
+    })
+    .await
+    .unwrap()
+    .into_inner()
+    .bundle
+    .expect("bundle present")
+}
+
+#[tokio::test]
+async fn edit_round_trip_repoints_the_item_and_keeps_the_old_ref() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // Author a two-item bundle.
+    let a = put(&mut c, b"alpha").await;
+    let b = put(&mut c, b"beta").await;
+    let put0 = upsert(
+        &mut c,
+        "team/ctx/docs",
+        "the docs",
+        vec![item("a", a.clone()), item("b", b.clone())],
+    )
+    .await;
+
+    // EDIT item "a": upload new bytes (a NEW ref) and re-upsert with it re-pointed.
+    let a2 = put(&mut c, b"ALPHA-v2").await;
+    assert_ne!(a2, a, "immutable CAS: new bytes ⇒ a new server-derived ref");
+    let bundle = get_bundle(&mut c, "team/ctx/docs").await;
+    let mut items = bundle.items.clone();
+    items[0].content_ref = a2.clone();
+    let put1 = upsert(&mut c, "team/ctx/docs", &bundle.description, items).await;
+
+    // The manifest changed (its content hash moved) but the description survived.
+    assert_ne!(put1.bundle_ref, put0.bundle_ref);
+    let after = get_bundle(&mut c, "team/ctx/docs").await;
+    assert_eq!(after.description, "the docs");
+    assert_eq!(after.items[0].name, "a", "the advisory name is preserved");
+    assert_eq!(after.items[0].content_ref, a2, "item re-pointed to new ref");
+    assert_eq!(after.items[1].content_ref, b, "the other item is untouched");
+
+    // Both the new AND the old ref still resolve (CAS is immutable — no in-place
+    // mutation, the old bytes are not lost).
+    assert_eq!(read_uploads(&mut c, a2).await, b"ALPHA-v2");
+    assert_eq!(
+        read_uploads(&mut c, a).await,
+        b"alpha",
+        "the old ref is still intact"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dedup_on_edit_back_to_identical_bytes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let a = put(&mut c, b"alpha").await;
+    upsert(&mut c, "team/ctx/d", "", vec![item("a", a.clone())]).await;
+    // Re-uploading identical bytes is a content-store dedup hit (same ref).
+    let again = c
+        .put_content(proto::PutContentRequest {
+            payload: b"alpha".to_vec(),
+            media_type: "text/plain".into(),
+            filename: "item.txt".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(again.content_ref, a);
+    assert!(
+        again.deduplicated,
+        "identical bytes ⇒ dedup at the content layer"
+    );
+    // Re-upserting the identical manifest is also a dedup (same bundle_ref).
+    let re = upsert(&mut c, "team/ctx/d", "", vec![item("a", a)]).await;
+    assert!(
+        re.deduplicated,
+        "identical manifest ⇒ dedup at the bundle layer"
+    );
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn removing_the_last_item_empties_the_manifest_and_is_refused() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let a = put(&mut c, b"alpha").await;
+    upsert(&mut c, "team/ctx/d", "", vec![item("a", a)]).await;
+    // An empty items list (the remove-last-item case) is refused server-side —
+    // this is what the CLI/SDK/UI "use delete to unbind the handle" guard backs.
+    let err = c
+        .put_context_bundle(proto::PutContextBundleRequest {
+            handle: "team/ctx/d".into(),
+            description: String::new(),
+            items: Vec::new(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn cross_party_bundle_isolation_and_server_derived_identity() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, false, two_party_tokens()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // Alice uploads + authors a bundle.
+    let a = c
+        .put_content(with_bearer(
+            proto::PutContentRequest {
+                payload: b"alice secret".to_vec(),
+                media_type: "text/plain".into(),
+                filename: "a.txt".into(),
+            },
+            "tok-alice",
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .content_ref;
+    let alice_put = c
+        .put_context_bundle(with_bearer(
+            proto::PutContextBundleRequest {
+                handle: "team/ctx/secret".into(),
+                description: "alice".into(),
+                items: vec![item("a", a.clone())],
+            },
+            "tok-alice",
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Bob cannot see Alice's bundle (uniform not-found — no cross-party oracle).
+    let bob_get = c
+        .get_context_bundle(with_bearer(
+            proto::GetContextBundleRequest {
+                handle: "team/ctx/secret".into(),
+            },
+            "tok-bob",
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!bob_get.found, "Bob cannot read Alice's bundle");
+    let bob_list = c
+        .list_context_bundles(with_bearer(
+            proto::ListContextBundlesRequest {
+                limit: 0,
+                after_handle: String::new(),
+            },
+            "tok-bob",
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(bob_list.bundles.is_empty(), "Bob lists none of Alice's");
+
+    // Bob putting the SAME (handle, items) makes BOB's OWN row — server-derived
+    // identity means the same manifest yields the same bundle_ref, but it is a
+    // DIFFERENT principal-scoped row; Alice's bundle is never mutated.
+    let bob_put = c
+        .put_context_bundle(with_bearer(
+            proto::PutContextBundleRequest {
+                handle: "team/ctx/secret".into(),
+                description: "alice".into(),
+                items: vec![item("a", a)],
+            },
+            "tok-bob",
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        bob_put.bundle_ref, alice_put.bundle_ref,
+        "same manifest ⇒ same server-derived bundle_ref (SN-8; client cannot forge it)"
+    );
+    // Alice's bundle is unchanged + still hers.
+    let alice_after = c
+        .get_context_bundle(with_bearer(
+            proto::GetContextBundleRequest {
+                handle: "team/ctx/secret".into(),
+            },
+            "tok-alice",
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(alice_after.found);
+    assert_eq!(alice_after.bundle.unwrap().bundle_ref, alice_put.bundle_ref);
+
+    running.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn unknown_uploads_ref_read_is_fail_closed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, false, two_party_tokens()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // A never-uploaded ref read in the uploads scope is a uniform NotAuthorized
+    // (no existence oracle) — the fail-closed default the edit/view path inherits.
+    let err = c
+        .get_content(with_bearer(
+            proto::GetContentRequest {
+                content_ref: vec![0x33; 32],
+                instance_id: Vec::new(),
+            },
+            "tok-alice",
+        ))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::PermissionDenied);
+
+    running.shutdown().await.unwrap();
+}
+
+/// ★ SECURITY GAP (ticket **T-UPLOADS-PRINCIPAL-SCOPE** → PR-8): the uploads-scope
+/// read authorizes by content-ref ALONE — `UploadsLedger::contains` records the
+/// `principal` but does NOT check it (see `kx-gateway-core::view::get_uploaded_content`).
+/// So a KNOWN ref is readable cross-party. Bundles stay principal-scoped, so refs
+/// are not cross-party *discoverable* in normal flows, but this pins the current
+/// behavior as a tracked, test-visible fact. **PR-8 flips this one assertion to
+/// `Code::PermissionDenied` when `contains` becomes principal-scoped.**
+#[tokio::test]
+async fn cross_party_uploaded_ref_read_is_currently_allowed_gap_pr8() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, false, two_party_tokens()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // Alice uploads bytes → ref R.
+    let r = c
+        .put_content(with_bearer(
+            proto::PutContentRequest {
+                payload: b"alice-only bytes".to_vec(),
+                media_type: "text/plain".into(),
+                filename: "a.txt".into(),
+            },
+            "tok-alice",
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .content_ref;
+
+    // Bob reads R in the uploads scope. TODAY this SUCCEEDS (the gap). When PR-8
+    // makes `UploadsLedger::contains` principal-scoped, flip the expectation to a
+    // uniform PermissionDenied (and assert Alice can still read her own ref).
+    let bob = c
+        .get_content(with_bearer(
+            proto::GetContentRequest {
+                content_ref: r,
+                instance_id: Vec::new(),
+            },
+            "tok-bob",
+        ))
+        .await;
+    assert!(
+        bob.is_ok(),
+        "PINNED GAP (T-UPLOADS-PRINCIPAL-SCOPE/PR-8): cross-party uploaded-ref read \
+         is currently ALLOWED; PR-8 flips this to PermissionDenied"
+    );
+    assert_eq!(bob.unwrap().into_inner().payload, b"alice-only bytes");
+
+    running.shutdown().await.unwrap();
+}

--- a/docs/site/docs/context.md
+++ b/docs/site/docs/context.md
@@ -44,6 +44,57 @@ kx context get team/ctx/spec
 kx context remove team/ctx/notes        # unbinds the handle; the blobs stay
 ```
 
+## Edit, import & export items
+
+The content store is **immutable** — a blob's ref is the BLAKE3 of its bytes, so a
+ref never changes meaning. "Editing" an item therefore uploads the new bytes (a
+**new** ref) and **re-points** the item at it, then re-derives the `bundle_ref`.
+This is a pure client compose over the existing RPCs (`GetContextBundle` →
+`PutContent` → `PutContextBundle`), so it touches no journal and the canonical
+digest is invariant by construction. The old ref stays valid (immutable CAS), so a
+run that already captured it replays unchanged — editing a bundle only affects
+**future** attaches, never a run already bound to the old grounding.
+
+```bash
+# Export every item body to a directory (+ a manifest.json):
+kx context get team/ctx/spec --output ./out
+
+# Replace one item's body from a file (re-point + optional rename):
+kx context edit team/ctx/spec --item design --file ./design-v2.md
+kx context edit team/ctx/spec --index 0 --file ./design-v2.md --name design.md
+
+# Drop one item (re-upsert the rest; refuses to empty the bundle):
+kx context remove-item team/ctx/spec --item old-notes
+
+# Re-set the advisory description:
+kx context describe team/ctx/spec --description "the design doc, v2"
+```
+
+Select an item by its advisory `--item <name>` or by `--index <n>`; a duplicate
+name is ambiguous, so pass the index.
+
+### SDK helpers
+
+The SDK exposes the same edit family as convenience methods over the existing
+client surface. Each accepts an optional `expect_bundle_ref` / `expectBundleRef`
+(the `bundle_ref` you last read): when set, a concurrent change to the bundle is
+**refused** (`KxFailedPrecondition`) rather than silently overwritten — the
+content-addressed `bundle_ref` is a free compare-and-swap token.
+
+```python
+body = kx.export_context_item("team/ctx/spec", "design")          # full bytes
+kx.edit_context_item("team/ctx/spec", "design", b"# Design v2\n…",
+                     expect_bundle_ref=bundle.bundle_ref)         # fail-closed on a race
+kx.remove_context_item("team/ctx/spec", "old-notes")
+```
+
+```ts
+const body = await kx.exportContextItem("team/ctx/spec", "design");
+await kx.editContextItem("team/ctx/spec", "design", bytes,
+                         { expectBundleRef: bundle.bundleRef });
+await kx.removeContextItem("team/ctx/spec", "old-notes");
+```
+
 ## Attach a bundle to a run
 
 Pass one or more handles with `--context` (repeatable). The server resolves each
@@ -131,6 +182,12 @@ surface:
   (each upload is a `PutContent`) or by naming an existing content ref.
 - **Review** every bundle you authored — its items (each a content ref) and the
   server-derived bundle ref.
+- **View & edit** an item: expand a row to see its body in the shared viewer, then
+  edit text / markdown / JSON inline (a save uploads the new bytes and re-points
+  the item). Binary and media items are honestly **download-only** — no fake edit.
+- **Rename** an item, **remove** one item (the bundle keeps at least one), or edit
+  the bundle **description** — each a guarded re-upsert (a concurrent change is
+  refused, never silently clobbered).
 - **Delete** a bundle (unbinds the handle; the content-store blobs stay).
 
 In **Chat**, the composer's attach menu has a live **Context** category: pick one
@@ -154,7 +211,8 @@ bundles existed.
 
 ## OSS / Cloud line
 
-Authoring, viewing, and the deterministic identity-bearing injection are **OSS**.
+Authoring, viewing, **editing / import / export**, and the deterministic
+identity-bearing injection are **OSS** (all single-party, in your own scope).
 Cross-party bundle sharing, a hosted bundle marketplace, and managed retention are
 **Cloud** (mirrors the Connections OAuth/marketplace line — see
 [Security](./security.md)).

--- a/ui/e2e/context.spec.ts
+++ b/ui/e2e/context.spec.ts
@@ -62,3 +62,61 @@ test("Context: author a bundle from an uploaded file, see it listed, attach it i
   await page.getByTestId(`context-bundle-delete-${HANDLE}`).click();
   await expect(page.getByTestId(`context-bundle-${HANDLE}`)).toHaveCount(0, { timeout: 30_000 });
 });
+
+test("Context-edit (POC-2): view an item body, edit it (ref changes), rename it, and the last item can't be removed", async ({
+  page,
+}) => {
+  gw = await spawnGateway({ corsOrigin: SPA_ORIGIN });
+  await connectConsole(page, gw);
+
+  // Author a one-item bundle from an uploaded text file.
+  await page.getByTestId("nav-context").click();
+  await expect(page.getByTestId("context-bundles")).toContainText("No context bundles yet", {
+    timeout: 30_000,
+  });
+  const handle = page.getByTestId("context-bundle-handle");
+  await handle.click();
+  await handle.pressSequentially(HANDLE);
+  await page.getByTestId("context-bundle-file-input").setInputFiles({
+    name: "secret.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("the secret is ALPHA\n", "utf-8"),
+  });
+  await expect(page.getByTestId("context-bundle-staged")).toBeVisible({ timeout: 15_000 });
+  await page.getByTestId("context-bundle-submit").click();
+  await expect(page.getByTestId(`context-bundle-${HANDLE}`)).toBeVisible({ timeout: 30_000 });
+
+  const key = `${HANDLE}-0`;
+  const itemChip = page.getByTestId(`context-item-${key}`).getByTestId("digest-chip");
+  const ref1 = await itemChip.getAttribute("title");
+
+  // The last (only) item cannot be removed — that would empty the bundle.
+  await expect(page.getByTestId(`context-item-remove-${key}`)).toBeDisabled();
+
+  // Expand → the body resolves through the shared viewer (full bytes, uploads scope).
+  await page.getByTestId(`context-item-toggle-${key}`).click();
+  await expect(page.getByTestId(`context-item-body-${key}`)).toBeVisible({ timeout: 30_000 });
+
+  // Edit the body in Monaco (drive by keyboard — fill() can't drive Monaco).
+  await page.getByTestId(`context-item-edit-${key}`).click();
+  const editor = page.getByTestId(`context-item-editor-${key}`);
+  await expect(editor.locator(".monaco-editor")).toBeVisible({ timeout: 30_000 });
+  await editor.locator(".monaco-editor").click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.keyboard.type("the secret is now OMEGA");
+  await page.getByTestId(`context-item-save-${key}`).click();
+
+  // Immutable CAS ⇒ the edit produced a NEW content ref: the item's chip changes.
+  await expect.poll(async () => itemChip.getAttribute("title"), { timeout: 30_000 }).not.toBe(ref1);
+
+  // Rename the item (a plain input → guarded re-upsert) and see the new label.
+  await page.getByTestId(`context-item-name-${key}`).click();
+  const nameInput = page.getByTestId(`context-item-name-input-${key}`);
+  await nameInput.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.keyboard.type("renamed.txt");
+  await page.getByTestId(`context-item-rename-save-${key}`).click();
+  await expect(page.getByTestId(`context-item-name-${key}`)).toHaveText("renamed.txt", {
+    timeout: 30_000,
+  });
+});

--- a/ui/src/components/context/ContextBundleList.tsx
+++ b/ui/src/components/context/ContextBundleList.tsx
@@ -8,14 +8,20 @@
  */
 
 import { m } from "framer-motion";
+import { useState } from "react";
 import { fadeUp, hoverLift, stagger } from "../../app/motion";
 import { toUiError } from "../../kx/errors";
-import { useContextBundles, useDeleteContextBundle } from "../../kx/use-context-bundles";
+import {
+  useContextBundles,
+  useDeleteContextBundle,
+  useEditBundleDescription,
+} from "../../kx/use-context-bundles";
 import { DigestChip } from "../DigestChip";
 import { EmptyState } from "../EmptyState";
 import { ErrorNotice } from "../ErrorNotice";
 import { Badge } from "../ds/Badge";
 import { GlowCard } from "../ds/GlowCard";
+import { ContextItemRow } from "./ContextItemRow";
 
 export function ContextBundleList() {
   const { bundles, notWired, isLoading, isError, error, refetch } = useContextBundles();
@@ -115,17 +121,20 @@ function BundleRow({
           <Badge label={`${itemCount} item${itemCount === 1 ? "" : "s"}`} color="var(--teal)" />
           <DigestChip hex={bundleRef} label={`${handle} bundle ref`} />
         </div>
-        {description ? <p className="registry-row__desc muted">{description}</p> : null}
+        <DescriptionEditor handle={handle} bundleRef={bundleRef} description={description} />
         {items.length > 0 ? (
           <ul className="context-bundle__items">
-            {items.map((it) => (
-              <li key={`${it.name}:${it.contentRef}`} className="context-bundle__item">
-                <span className="context-bundle__item-name">{it.name || "(unnamed)"}</span>
-                {it.mediaType ? (
-                  <span className="context-bundle__item-type muted mono">{it.mediaType}</span>
-                ) : null}
-                <DigestChip hex={it.contentRef} label={it.name} />
-              </li>
+            {items.map((it, i) => (
+              <ContextItemRow
+                key={`${i}:${it.contentRef}`}
+                handle={handle}
+                bundleRef={bundleRef}
+                index={i}
+                name={it.name}
+                contentRef={it.contentRef}
+                mediaType={it.mediaType}
+                itemCount={itemCount}
+              />
             ))}
           </ul>
         ) : null}
@@ -141,5 +150,75 @@ function BundleRow({
         {pending ? "Removing…" : "Delete"}
       </button>
     </GlowCard>
+  );
+}
+
+/** The bundle's advisory description with an inline edit affordance (POC-2) — a
+ *  guarded re-upsert (items unchanged). Empty shows an honest "Add a description". */
+function DescriptionEditor({
+  handle,
+  bundleRef,
+  description,
+}: {
+  handle: string;
+  bundleRef: string;
+  description: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(description);
+  const save = useEditBundleDescription();
+  const error = save.error ? toUiError(save.error) : null;
+
+  if (!editing) {
+    return (
+      <p className="registry-row__desc muted" data-testid={`context-bundle-desc-${handle}`}>
+        {description || <span className="muted">No description.</span>}{" "}
+        <button
+          type="button"
+          className="linkbtn"
+          data-testid={`context-bundle-desc-edit-${handle}`}
+          onClick={() => {
+            setDraft(description);
+            setEditing(true);
+          }}
+        >
+          {description ? "Edit" : "Add description"}
+        </button>
+      </p>
+    );
+  }
+  return (
+    <div className="registry-row__desc context-bundle__desc-edit">
+      <input
+        className="builder-input"
+        data-testid={`context-bundle-desc-input-${handle}`}
+        value={draft}
+        aria-label="Bundle description"
+        maxLength={4096}
+        onChange={(e) => setDraft(e.target.value)}
+      />
+      <button
+        type="button"
+        className="linkbtn"
+        data-testid={`context-bundle-desc-save-${handle}`}
+        disabled={save.isPending}
+        onClick={() =>
+          save.mutate(
+            { handle, description: draft, expectBundleRef: bundleRef },
+            { onSuccess: () => setEditing(false) },
+          )
+        }
+      >
+        {save.isPending ? "Saving…" : "Save"}
+      </button>
+      <button type="button" className="linkbtn" onClick={() => setEditing(false)}>
+        Cancel
+      </button>
+      {error ? (
+        <span className="field-error" role="alert">
+          {error.message}
+        </span>
+      ) : null}
+    </div>
   );
 }

--- a/ui/src/components/context/ContextItemRow.tsx
+++ b/ui/src/components/context/ContextItemRow.tsx
@@ -1,0 +1,239 @@
+/**
+ * One context-bundle item with a POC-2 view/edit affordance. Collapsed it shows
+ * the advisory name + media + content `DigestChip`; expanded it lazily fetches the
+ * FULL body ({@link useContextItemBody}) and renders it through the shared
+ * read-only {@link AssetViewer}. Text-like items (json / text / markdown / empty,
+ * not truncated) can be edited in {@link TextEditor} and saved — CAS is immutable,
+ * so a save uploads new bytes and re-points this item (a guarded re-upsert). Items
+ * can be renamed and removed. Binary / media / truncated bodies are honestly
+ * download-only (no fake edit, D142). Every mutation carries the viewed `bundleRef`
+ * so a concurrent change is refused, never silently clobbered.
+ */
+
+import { useState } from "react";
+import { toUiError } from "../../kx/errors";
+import {
+  useEditContextItem,
+  useRemoveContextItem,
+  useRenameContextItem,
+} from "../../kx/use-context-bundles";
+import { useContextItemBody } from "../../kx/use-context-item";
+import type { MonacoLanguage } from "../../lib/monaco/infer-language";
+import { AssetViewer } from "../AssetViewer";
+import { DigestChip } from "../DigestChip";
+import { EmptyState } from "../EmptyState";
+import { ErrorNotice } from "../ErrorNotice";
+import { TextEditor } from "../editor/TextEditor";
+
+const EDITABLE_KINDS = new Set(["json", "text", "markdown", "empty"]);
+
+function editorLanguage(kind: string): MonacoLanguage {
+  if (kind === "json") {
+    return "json";
+  }
+  if (kind === "markdown") {
+    return "markdown";
+  }
+  return "plaintext";
+}
+
+export function ContextItemRow({
+  handle,
+  bundleRef,
+  index,
+  name,
+  contentRef,
+  mediaType,
+  itemCount,
+}: {
+  handle: string;
+  bundleRef: string;
+  index: number;
+  name: string;
+  contentRef: string;
+  mediaType: string;
+  itemCount: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [renaming, setRenaming] = useState(false);
+  const [nameDraft, setNameDraft] = useState(name);
+
+  const body = useContextItemBody(contentRef, mediaType, name, expanded);
+  const edit = useEditContextItem();
+  const rename = useRenameContextItem();
+  const remove = useRemoveContextItem();
+
+  const decoded = body.data;
+  const editable = decoded !== undefined && EDITABLE_KINDS.has(decoded.kind) && !decoded.truncated;
+  const mutationError = edit.error ?? rename.error ?? remove.error;
+  const testKey = `${handle}-${index}`;
+
+  const startEditing = () => {
+    if (decoded) {
+      setDraft(decoded.text);
+      setEditing(true);
+    }
+  };
+
+  const save = () => {
+    edit.mutate(
+      { handle, itemIndex: index, text: draft, mediaType, expectBundleRef: bundleRef },
+      { onSuccess: () => setEditing(false) },
+    );
+  };
+
+  const submitRename = () => {
+    const next = nameDraft.trim();
+    if (next === "" || next === name) {
+      setRenaming(false);
+      return;
+    }
+    rename.mutate(
+      { handle, itemIndex: index, newName: next, expectBundleRef: bundleRef },
+      { onSuccess: () => setRenaming(false) },
+    );
+  };
+
+  return (
+    <li className="context-bundle__item" data-testid={`context-item-${testKey}`}>
+      <div className="context-bundle__item-head">
+        <button
+          type="button"
+          className="linkbtn context-bundle__item-toggle"
+          data-testid={`context-item-toggle-${testKey}`}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((e) => !e)}
+        >
+          {expanded ? "▾" : "▸"}
+        </button>
+        {renaming ? (
+          <span className="context-bundle__item-rename">
+            <input
+              className="builder-input"
+              data-testid={`context-item-name-input-${testKey}`}
+              value={nameDraft}
+              aria-label="Item name"
+              onChange={(e) => setNameDraft(e.target.value)}
+            />
+            <button
+              type="button"
+              className="linkbtn"
+              data-testid={`context-item-rename-save-${testKey}`}
+              disabled={rename.isPending}
+              onClick={submitRename}
+            >
+              {rename.isPending ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              className="linkbtn"
+              onClick={() => {
+                setNameDraft(name);
+                setRenaming(false);
+              }}
+            >
+              Cancel
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="context-bundle__item-name linkbtn"
+            data-testid={`context-item-name-${testKey}`}
+            title="Rename this item"
+            onClick={() => {
+              setNameDraft(name);
+              setRenaming(true);
+            }}
+          >
+            {name || "(unnamed)"}
+          </button>
+        )}
+        {mediaType ? (
+          <span className="context-bundle__item-type muted mono">{mediaType}</span>
+        ) : null}
+        <DigestChip hex={contentRef} label={name} />
+        <button
+          type="button"
+          className="btn-ghost context-bundle__item-remove"
+          data-testid={`context-item-remove-${testKey}`}
+          disabled={remove.isPending || itemCount <= 1}
+          title={
+            itemCount <= 1
+              ? "A bundle needs at least one item — delete the whole bundle instead"
+              : "Remove this item from the bundle"
+          }
+          onClick={() => remove.mutate({ handle, itemIndex: index, expectBundleRef: bundleRef })}
+        >
+          {remove.isPending ? "Removing…" : "Remove"}
+        </button>
+      </div>
+
+      {mutationError ? (
+        <p className="field-error" data-testid={`context-item-error-${testKey}`} role="alert">
+          {toUiError(mutationError).message}
+        </p>
+      ) : null}
+
+      {expanded ? (
+        <div className="context-bundle__item-body" data-testid={`context-item-body-${testKey}`}>
+          {body.isLoading ? (
+            <EmptyState title="Loading…" />
+          ) : body.isError ? (
+            <ErrorNotice error={toUiError(body.error)} onRetry={() => void body.refetch()} />
+          ) : editing && decoded ? (
+            <div className="context-bundle__item-edit">
+              <TextEditor
+                value={draft}
+                language={editorLanguage(decoded.kind)}
+                onChange={setDraft}
+                testId={`context-item-editor-${testKey}`}
+                ariaLabel="Edit item body"
+              />
+              <div className="context-bundle__item-actions">
+                <button
+                  type="button"
+                  className="chip"
+                  data-testid={`context-item-save-${testKey}`}
+                  disabled={edit.isPending}
+                  onClick={save}
+                >
+                  {edit.isPending ? "Saving…" : "Save"}
+                </button>
+                <button type="button" className="linkbtn" onClick={() => setEditing(false)}>
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : decoded ? (
+            <div className="context-bundle__item-view">
+              <AssetViewer
+                content={decoded}
+                stem={name || contentRef.slice(0, 8)}
+                bodyTestId={`context-item-content-${testKey}`}
+              />
+              {editable ? (
+                <button
+                  type="button"
+                  className="chip"
+                  data-testid={`context-item-edit-${testKey}`}
+                  onClick={startEditing}
+                >
+                  Edit
+                </button>
+              ) : (
+                <p className="muted" data-testid={`context-item-readonly-${testKey}`}>
+                  {decoded.truncated
+                    ? "This item is too large to edit inline — download it, edit locally, and re-upload."
+                    : "Binary / media items are download-only — edit locally and re-upload via the bundle form."}
+                </p>
+              )}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/ui/src/components/editor/TextEditor.tsx
+++ b/ui/src/components/editor/TextEditor.tsx
@@ -1,0 +1,43 @@
+/**
+ * An editable text/markdown/JSON control backed by Monaco (offline, lazy) — the
+ * editable sibling of the read-only {@link CodeViewer}, used by the POC-2 context
+ * item editor. It owns ONLY the editing surface; the parent owns Save/Cancel +
+ * any validation. In jsdom it renders a `<textarea id data-testid>` so component
+ * tests drive it by the same handles (Playwright drives it by keyboard, not
+ * `fill()` — Monaco ignores programmatic value sets).
+ */
+
+import type { MonacoLanguage } from "../../lib/monaco/infer-language";
+import { MonacoMount } from "./MonacoMount";
+
+export function TextEditor({
+  id,
+  value,
+  language = "plaintext",
+  onChange,
+  testId = "text-editor",
+  ariaLabel = "Editable content",
+  height = 280,
+}: {
+  id?: string;
+  value: string;
+  language?: MonacoLanguage;
+  onChange: (value: string) => void;
+  testId?: string;
+  ariaLabel?: string;
+  height?: number;
+}) {
+  return (
+    <div className="editor-surface editor-surface--edit">
+      <MonacoMount
+        id={id}
+        value={value}
+        language={language}
+        onChange={onChange}
+        testId={testId}
+        ariaLabel={ariaLabel}
+        height={height}
+      />
+    </div>
+  );
+}

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -44,6 +44,10 @@ export const queryKeys = {
   /** This party's context bundles (`ListContextBundles`, PR-7) — named,
    *  content-addressed grounding. Caller-scoped; `bundleRef` is server-derived (SN-8). */
   contextBundles: (endpoint: string) => ["kx", endpoint, "context-bundles"] as const,
+  /** A context-item's FULL body (POC-2 view/edit, uploads-scope `GetContent`),
+   *  keyed by its content ref — content-addressed ⇒ immutable (cache forever). */
+  contextItemBody: (endpoint: string, contentRef: string) =>
+    ["kx", endpoint, "context-item-body", contentRef] as const,
   /** This party's D155 branches (`ListBranches`) — content-addressed file branches.
    *  Caller-scoped; `branchRef` is server-derived (SN-8). */
   branches: (endpoint: string) => ["kx", endpoint, "branches"] as const,

--- a/ui/src/kx/use-context-bundles.ts
+++ b/ui/src/kx/use-context-bundles.ts
@@ -11,7 +11,8 @@
  * on a gateway without the bundle store (UNIMPLEMENTED).
  */
 
-import type { ContextBundle, ContextItemInput } from "@kortecx/sdk/web";
+import type { ContextBundle, ContextItemInput, PutContextBundleResult } from "@kortecx/sdk/web";
+import { KxError, KxFailedPrecondition } from "@kortecx/sdk/web";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useConnection } from "./connection-context";
 import { toUiError } from "./errors";
@@ -70,6 +71,143 @@ export function useDeleteContextBundle() {
         throw new Error("not connected");
       }
       return client.deleteContextBundle(handle);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });
+    },
+  });
+}
+
+// ----- POC-2 context-edit (item view/edit/rename/remove + description) --------
+// CAS is IMMUTABLE: an item edit uploads NEW bytes (a new ref) then re-upserts the
+// bundle with that item re-pointed — a pure-client compose over existing RPCs, so
+// digest-invariant by construction. Every mutation carries an optional
+// `expectBundleRef` (the manifest the user was viewing): the content-addressed
+// `bundleRef` is a free compare-and-swap token, so a concurrent change is REFUSED
+// (`KxFailedPrecondition`) rather than silently clobbered.
+
+/** Re-read `manifest` + run the stale-base guard. A mismatch ⇒ the bundle changed
+ *  under the editor — fail closed, never a silent last-writer-wins overwrite. */
+function assertFresh(
+  manifest: ContextBundle | null,
+  handle: string,
+  expectBundleRef: string | undefined,
+): ContextBundle {
+  if (manifest === null) {
+    throw new KxError(`context bundle '${handle}' not found`);
+  }
+  if (expectBundleRef !== undefined && manifest.bundleRef !== expectBundleRef) {
+    throw new KxFailedPrecondition(
+      `context bundle '${handle}' changed since you opened it — reload and re-apply your change`,
+    );
+  }
+  return manifest;
+}
+
+export interface EditContextItemVars {
+  readonly handle: string;
+  readonly itemIndex: number;
+  readonly text: string;
+  readonly mediaType?: string;
+  readonly expectBundleRef?: string;
+}
+
+/** Replace one item's body (the headline edit). Delegates to the SDK's
+ *  `editContextItem` (which uploads + re-upserts + runs the stale-base guard). */
+export function useEditContextItem() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<PutContextBundleResult, unknown, EditContextItemVars>({
+    mutationFn: async ({ handle, itemIndex, text, mediaType, expectBundleRef }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.editContextItem(handle, itemIndex, new TextEncoder().encode(text), {
+        mediaType,
+        expectBundleRef,
+      });
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });
+    },
+  });
+}
+
+export interface RemoveContextItemVars {
+  readonly handle: string;
+  readonly itemIndex: number;
+  readonly expectBundleRef?: string;
+}
+
+/** Drop one item (re-upsert the remainder). Refuses to empty the bundle. */
+export function useRemoveContextItem() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<PutContextBundleResult, unknown, RemoveContextItemVars>({
+    mutationFn: async ({ handle, itemIndex, expectBundleRef }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.removeContextItem(handle, itemIndex, { expectBundleRef });
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });
+    },
+  });
+}
+
+export interface RenameContextItemVars {
+  readonly handle: string;
+  readonly itemIndex: number;
+  readonly newName: string;
+  readonly expectBundleRef?: string;
+}
+
+/** Re-label one item (no body change) — a guarded re-upsert with the new name. */
+export function useRenameContextItem() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<PutContextBundleResult, unknown, RenameContextItemVars>({
+    mutationFn: async ({ handle, itemIndex, newName, expectBundleRef }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      const manifest = assertFresh(await client.getContextBundle(handle), handle, expectBundleRef);
+      const items: ContextItemInput[] = manifest.items.map((it, i) => ({
+        name: i === itemIndex ? newName : it.name,
+        contentRef: it.contentRef,
+        mediaType: it.mediaType,
+      }));
+      return client.putContextBundle(handle, items, { description: manifest.description });
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });
+    },
+  });
+}
+
+export interface EditBundleDescriptionVars {
+  readonly handle: string;
+  readonly description: string;
+  readonly expectBundleRef?: string;
+}
+
+/** Re-set a bundle's advisory description — a guarded re-upsert, items unchanged. */
+export function useEditBundleDescription() {
+  const { client, endpoint } = useConnection();
+  const qc = useQueryClient();
+  return useMutation<PutContextBundleResult, unknown, EditBundleDescriptionVars>({
+    mutationFn: async ({ handle, description, expectBundleRef }) => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      const manifest = assertFresh(await client.getContextBundle(handle), handle, expectBundleRef);
+      const items: ContextItemInput[] = manifest.items.map((it) => ({
+        name: it.name,
+        contentRef: it.contentRef,
+        mediaType: it.mediaType,
+      }));
+      return client.putContextBundle(handle, items, { description });
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: queryKeys.contextBundles(endpoint) });

--- a/ui/src/kx/use-context-item.ts
+++ b/ui/src/kx/use-context-item.ts
@@ -1,0 +1,37 @@
+/**
+ * Fetch + decode a context-item's FULL body (POC-2 view/edit). A context item is
+ * an UPLOADS-scope content ref (authored via `PutContent` / `kx context add`), so
+ * it reads through the single `GetContent` uploads path (`instanceId` omitted) —
+ * which returns the WHOLE payload, uncapped. This deliberately does NOT reuse the
+ * `use-content-batch` `PREVIEW_BYTES` (4096) clamp: an edit must seed Monaco with
+ * the complete body, never a truncated preview. Content-addressed ⇒ the query
+ * caches forever per (endpoint, ref); enable it only when the row is expanded so a
+ * wide bundle never N+1-fetches every item body on render.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { type DecodedContent, decodeContent } from "../lib/content-decode";
+import { useConnection } from "./connection-context";
+import { queryKeys } from "./query-keys";
+
+export function useContextItemBody(
+  contentRef: string,
+  mediaType: string,
+  name: string,
+  enabled: boolean,
+) {
+  const { client, endpoint, status } = useConnection();
+  return useQuery({
+    queryKey: queryKeys.contextItemBody(endpoint, contentRef),
+    enabled: enabled && status === "connected" && client !== null,
+    staleTime: Number.POSITIVE_INFINITY, // content-addressed ⇒ immutable
+    retry: false,
+    queryFn: async (): Promise<DecodedContent> => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      const bytes = await client.getContent(contentRef); // uploads scope, FULL bytes
+      return decodeContent(bytes, { mediaType, filename: name });
+    },
+  });
+}

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -3280,17 +3280,67 @@ button.card-grid__title:hover {
 }
 .context-bundle__item {
   display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+}
+/* POC-2 context-edit: the per-item row stacks a head (name + media + chip +
+   controls) over an optional expanded body (viewer / editor). Controls reuse the
+   themed `.linkbtn` / `.btn-ghost` / `.chip` / `.builder-input` tokens, so both
+   themes + AA carry by construction (D142). */
+.context-bundle__item-head {
+  display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.85rem;
+}
+.context-bundle__item-toggle {
+  font-family: var(--font-mono);
+  width: 1.1rem;
+  flex: none;
 }
 .context-bundle__item-name {
   font-weight: 600;
   min-width: 0;
   overflow-wrap: anywhere;
+  text-align: left;
 }
 .context-bundle__item-type {
   font-size: 0.75rem;
+}
+.context-bundle__item-rename {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+.context-bundle__item-remove {
+  margin-left: auto;
+  flex: none;
+  font-size: 0.78rem;
+  padding: 0.1rem 0.5rem;
+}
+.context-bundle__item-body {
+  margin: 0.2rem 0 0.4rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.context-bundle__item-edit,
+.context-bundle__item-view {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.context-bundle__item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.context-bundle__desc-edit {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 /* D155 Phase-3: the per-file agentic Edit affordance in a branch manifest. The
    editor breaks to its own full-width row; controls inherit themed tokens (the

--- a/ui/test/component/use-context-bundles.test.tsx
+++ b/ui/test/component/use-context-bundles.test.tsx
@@ -4,7 +4,11 @@ import { describe, expect, it } from "vitest";
 import {
   useContextBundles,
   useDeleteContextBundle,
+  useEditBundleDescription,
+  useEditContextItem,
   usePutContextBundle,
+  useRemoveContextItem,
+  useRenameContextItem,
 } from "../../src/kx/use-context-bundles";
 import { connectedWrapper } from "../mocks/harness";
 import { makeMockClient } from "../mocks/kx-client";
@@ -71,5 +75,107 @@ describe("usePutContextBundle / useDeleteContextBundle", () => {
       await result.current.mutateAsync({ handle: "team/ctx/spec" });
     });
     expect(deleteContextBundle).toHaveBeenCalledWith("team/ctx/spec");
+  });
+});
+
+describe("POC-2 context-edit mutations", () => {
+  it("edits an item body via the SDK (encoded bytes + stale-base guard ref)", async () => {
+    const { client, editContextItem } = makeMockClient();
+    const { result } = renderHook(() => useEditContextItem(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({
+        handle: "team/ctx/spec",
+        itemIndex: 0,
+        text: "new body",
+        mediaType: "text/markdown",
+        expectBundleRef: "ab".repeat(8),
+      });
+    });
+    expect(editContextItem).toHaveBeenCalledWith(
+      "team/ctx/spec",
+      0,
+      new TextEncoder().encode("new body"),
+      { mediaType: "text/markdown", expectBundleRef: "ab".repeat(8) },
+    );
+  });
+
+  it("removes an item via the SDK", async () => {
+    const { client, removeContextItem } = makeMockClient();
+    const { result } = renderHook(() => useRemoveContextItem(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ handle: "team/ctx/spec", itemIndex: 1 });
+    });
+    expect(removeContextItem).toHaveBeenCalledWith("team/ctx/spec", 1, {
+      expectBundleRef: undefined,
+    });
+  });
+
+  it("renames an item with a guarded re-upsert (re-read → put with the new name)", async () => {
+    const { client, getContextBundle, putContextBundle } = makeMockClient({
+      getContextBundle: async () => BUNDLE,
+    });
+    const { result } = renderHook(() => useRenameContextItem(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({
+        handle: "team/ctx/spec",
+        itemIndex: 0,
+        newName: "renamed.md",
+        expectBundleRef: BUNDLE.bundleRef,
+      });
+    });
+    expect(getContextBundle).toHaveBeenCalledWith("team/ctx/spec");
+    expect(putContextBundle).toHaveBeenCalledWith(
+      "team/ctx/spec",
+      [{ name: "renamed.md", contentRef: "cd".repeat(32), mediaType: "text/markdown" }],
+      { description: "the spec" },
+    );
+  });
+
+  it("edits a bundle description with a guarded re-upsert (items unchanged)", async () => {
+    const { client, putContextBundle } = makeMockClient({
+      getContextBundle: async () => BUNDLE,
+    });
+    const { result } = renderHook(() => useEditBundleDescription(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({
+        handle: "team/ctx/spec",
+        description: "a better spec",
+        expectBundleRef: BUNDLE.bundleRef,
+      });
+    });
+    expect(putContextBundle).toHaveBeenCalledWith(
+      "team/ctx/spec",
+      [{ name: "design.md", contentRef: "cd".repeat(32), mediaType: "text/markdown" }],
+      { description: "a better spec" },
+    );
+  });
+
+  it("the stale-base guard refuses a re-upsert when the bundle changed under the editor", async () => {
+    const { client, putContextBundle } = makeMockClient({
+      // The current manifest has a DIFFERENT bundleRef than the one the user viewed.
+      getContextBundle: async () => ({ ...BUNDLE, bundleRef: "99".repeat(8) }),
+    });
+    const { result } = renderHook(() => useRenameContextItem(), {
+      wrapper: connectedWrapper(client),
+    });
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          handle: "team/ctx/spec",
+          itemIndex: 0,
+          newName: "x.md",
+          expectBundleRef: BUNDLE.bundleRef, // stale
+        }),
+      ).rejects.toThrow(/changed since/);
+    });
+    expect(putContextBundle).not.toHaveBeenCalled();
   });
 });

--- a/ui/test/mocks/kx-client.ts
+++ b/ui/test/mocks/kx-client.ts
@@ -29,6 +29,9 @@ export interface MockClientImpl {
   listContextBundles?: (...args: unknown[]) => Promise<unknown>;
   putContextBundle?: (...args: unknown[]) => Promise<unknown>;
   deleteContextBundle?: (...args: unknown[]) => Promise<unknown>;
+  getContextBundle?: (...args: unknown[]) => Promise<unknown>;
+  editContextItem?: (...args: unknown[]) => Promise<unknown>;
+  removeContextItem?: (...args: unknown[]) => Promise<unknown>;
 }
 
 export function makeMockClient(impl: MockClientImpl = {}) {
@@ -98,6 +101,10 @@ export function makeMockClient(impl: MockClientImpl = {}) {
       (async () => ({ bundleRef: "ab".repeat(8), handle: "", deduplicated: false })),
   );
   const deleteContextBundle = vi.fn(impl.deleteContextBundle ?? (async () => true));
+  const getContextBundle = vi.fn(impl.getContextBundle ?? (async () => null));
+  const putResult = { bundleRef: "ef".repeat(8), handle: "", deduplicated: false };
+  const editContextItem = vi.fn(impl.editContextItem ?? (async () => putResult));
+  const removeContextItem = vi.fn(impl.removeContextItem ?? (async () => putResult));
   const close = vi.fn();
   const client = {
     listSignatures,
@@ -123,6 +130,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listContextBundles,
     putContextBundle,
     deleteContextBundle,
+    getContextBundle,
+    editContextItem,
+    removeContextItem,
     close,
     submitRun: vi.fn(),
     registerSignature: vi.fn(),
@@ -152,6 +162,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listContextBundles,
     putContextBundle,
     deleteContextBundle,
+    getContextBundle,
+    editContextItem,
+    removeContextItem,
     close,
   };
 }


### PR DESCRIPTION
The next item in the POC roadmap (≈D166). Makes the **Context** section a complete, durable curation surface — view an upload-backed item's body, edit/rename/remove it, edit the bundle description, and import/export — the knowledge the runtime grounds chat (POC-1 CHAT-RAG) and future Apps on.

## Design — one re-upsert, composed everywhere
CAS is **immutable**, so an item edit uploads the new bytes (a NEW server-derived ref) and re-points the item via a `PutContextBundle` re-upsert — a **pure CLIENT compose over EXISTING RPCs** (`GetContextBundle` → `PutContent` → `PutContextBundle`). **No proto / journal / checkpoint / `Cargo.lock` change ⇒ canonical projection digest `7d22d4bd` invariant by construction; frozen trio (executor/scheduler/inference) untouched.**

## Cross-surface (GR14)
- **CLI** `kx context`: `get --output` (export each body + a `manifest.json`, path-sanitized), `edit` (`--item`/`--index --file [--name]`), `remove-item`, `describe`. Verb-aware flag parsing + client-side item resolution (ambiguous name → `--index`).
- **SDK** (Py + TS, sync surface like `edit_branch`): `edit_context_item` / `remove_context_item` / `export_context_item` + a shared resolver. An optional `expect_bundle_ref` makes every edit **fail-closed** (`KxFailedPrecondition`) on a concurrent change — the content-addressed `bundle_ref` is a free compare-and-swap token, never a silent clobber.
- **UI**: `ContextItemRow` (expand → shared `AssetViewer` view / editable Monaco `TextEditor`), full-bytes fetch (`useContextItemBody`, bypassing the 4096-byte preview clamp), rename/remove/description controls, the stale-base guard surfaced honestly, and honest-degrade (binary/media/truncated = download-only, no fake edit, D142).
- **Docs**: `docs/site/docs/context.md` — edit/import/export, the immutability + re-upsert model, replay-safety.

## Security
A deterministic two-party negative suite proves **cross-party bundle isolation** + **fail-closed unknown-ref reads** + **server-derived identity**, and **PINS the pre-existing uploads-scope cross-party read gap** (`UploadsLedger::contains` ignores the recorded `principal`) as a tracked test → ticket **T-UPLOADS-PRINCIPAL-SCOPE** flips one assertion in the PR-8 security PR (Rule-1: the trait-seam fix is its own PR).

## Tests
- kx-cli parser units · `context_edit_e2e.rs` (6, incl. the pinned gap) · Py `test_context_edit` (5 unit + 2 server-backed) · TS `context-edit` (3 server-backed) · UI hook tests (5) + **Playwright edit flow** (Monaco body-edit → ref change, rename, remove guard).
- **Live Gemma-4**: grounded answer "FALCON-NINE-ZULU" → `kx context edit` → re-invoke → "OMEGA-SEVEN-DELTA" (editing changed the grounding end-to-end); `--output` round-trips; tool-calling regression intact (`mcp-echo` fired 7×, clean answer).
- Invariants: frozen-trio diff empty · `a0_guard` digest `7d22d4bd` · fmt + clippy `--workspace --all-targets -D warnings` · cargo-deny · doc · codegen-fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)