### PR TITLE
ci: add inference-checks job (clippy + model-free tests under --features inference)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,15 +846,19 @@ jobs:
         run: |
           echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}= -Cmetadata=kortecx-v0" >> $GITHUB_ENV
 
+      # NOTE: deliberately NO `console` feature — its build.rs embeds the built
+      # `ui/dist`, which this job does not build (that is covered by the `ui` +
+      # `verify-quickstart` jobs). The inference-gated code under test
+      # (model lifecycle / cache / model_exec) lives under inference/embedded-worker.
       - name: clippy under --features inference (the cfg(inference) lint gap)
         run: |
-          cargo clippy -p kx-gateway --features inference,embedded-worker,hnsw,console \
+          cargo clippy -p kx-gateway --features inference,embedded-worker,hnsw \
             --all-targets -- -D warnings
           cargo clippy -p kx-inference --features llamacpp --all-targets -- -D warnings
 
       - name: model-free tests under --features inference (the cfg(inference) test gap)
         run: |
-          cargo test -p kx-gateway --features inference,embedded-worker,hnsw,console -- --nocapture
+          cargo test -p kx-gateway --features inference,embedded-worker,hnsw -- --nocapture
 
   # ---------------------------------------------------------------------------
   # real-model-e2e — the GR15 real-model behavioral gate. Serves the public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,6 +803,60 @@ jobs:
         run: just smoke-test-with-model
 
   # ---------------------------------------------------------------------------
+  # inference-checks — clippy (-D warnings) + the MODEL-FREE test suite under the
+  # `inference` feature. Closes two coverage gaps the default jobs miss: the
+  # `clippy`/`test` jobs build DEFAULT features, so `#[cfg(feature="inference")]`
+  # code is NEVER linted and its model-free tests NEVER run (the with-model jobs
+  # need a GGUF + don't run clippy). Builds the llama.cpp FFI once and runs both
+  # checks; the `#[ignore]` live-model tests stay skipped (no GGUF here — those run
+  # in smoke-test-with-model / real-model-e2e). A REQUIRED context once green.
+  # ---------------------------------------------------------------------------
+  inference-checks:
+    name: inference-checks (clippy + model-free tests under --features inference)
+    runs-on: ubuntu-latest
+    needs: [test, ffi-link]
+    steps:
+      - name: Checkout (with submodules for crates/kx-llamacpp-sys/llama.cpp)
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: |
+          rustup show active-toolchain
+
+      - name: Install bindgen + CMake build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev clang cmake build-essential
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-infcheck-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', '.gitmodules') }}
+          restore-keys: |
+            cargo-infcheck-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Configure RUSTFLAGS for path-stripping
+        run: |
+          echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}= -Cmetadata=kortecx-v0" >> $GITHUB_ENV
+
+      - name: clippy under --features inference (the cfg(inference) lint gap)
+        run: |
+          cargo clippy -p kx-gateway --features inference,embedded-worker,hnsw,console \
+            --all-targets -- -D warnings
+          cargo clippy -p kx-inference --features llamacpp --all-targets -- -D warnings
+
+      - name: model-free tests under --features inference (the cfg(inference) test gap)
+        run: |
+          cargo test -p kx-gateway --features inference,embedded-worker,hnsw,console -- --nocapture
+
+  # ---------------------------------------------------------------------------
   # real-model-e2e — the GR15 real-model behavioral gate. Serves the public
   # Qwen3-0.6B stand-in through the FULL serve path (invoke kx/recipes/chat →
   # worker → real in-process inference → commit → GetContent) and asserts the

--- a/bindings/typescript/test/fixtures/serve.ts
+++ b/bindings/typescript/test/fixtures/serve.ts
@@ -112,34 +112,57 @@ const SERVERS: Server[] = [];
 /** Spawn a gateway with the given extra flags; tracked for {@link stopAllServers}. */
 export async function spawnServer(...extra: string[]): Promise<Server> {
   const kxBin = findOrBuildKx();
-  const [port, wsPort] = await Promise.all([freePort(), freePort()]);
   const tmp = await mkdtemp(path.join(tmpdir(), "kxsrv-"));
-  const endpoint = `http://127.0.0.1:${port}`;
-  const wsEndpoint = `ws://127.0.0.1:${wsPort}`;
-  const proc = spawn(
-    kxBin,
-    [
-      "serve",
-      "--journal",
-      path.join(tmp, "kx.db"),
-      "--content",
-      path.join(tmp, "blobs"),
-      "--listen",
-      `127.0.0.1:${port}`,
-      "--ws-listen",
-      `127.0.0.1:${wsPort}`,
-      // A console-enabled binary would otherwise bind the DEFAULT :8888 —
-      // concurrent test servers then collide (a console-less binary accepts
-      // the flag as a no-op). Every test spawn disables the console.
-      "--no-console",
-      ...extra,
-    ],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const server = new Server(endpoint, wsEndpoint, proc);
-  SERVERS.push(server);
-  await waitReady(endpoint, proc);
-  return server;
+  // `freePort()` releases the OS-assigned port the instant it closes its probe
+  // socket, so another process can grab it before `kx serve` binds (a TOCTOU race
+  // that flakes on a busy CI runner: "bind: Address already in use"). Retry the
+  // whole spawn with FRESH ports on that specific early-exit; rethrow anything
+  // else loudly. Mirrors the Python `conftest.py` spawn-retry.
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const [port, wsPort] = await Promise.all([freePort(), freePort()]);
+    const endpoint = `http://127.0.0.1:${port}`;
+    const wsEndpoint = `ws://127.0.0.1:${wsPort}`;
+    const proc = spawn(
+      kxBin,
+      [
+        "serve",
+        "--journal",
+        path.join(tmp, "kx.db"),
+        "--content",
+        path.join(tmp, "blobs"),
+        "--listen",
+        `127.0.0.1:${port}`,
+        "--ws-listen",
+        `127.0.0.1:${wsPort}`,
+        // A console-enabled binary would otherwise bind the DEFAULT :8888 —
+        // concurrent test servers then collide (a console-less binary accepts
+        // the flag as a no-op). Every test spawn disables the console.
+        "--no-console",
+        ...extra,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stderr = "";
+    proc.stderr?.on("data", (c) => {
+      stderr += String(c);
+    });
+    try {
+      await waitReady(endpoint, proc);
+      const server = new Server(endpoint, wsEndpoint, proc);
+      SERVERS.push(server);
+      return server;
+    } catch (e) {
+      lastErr = e;
+      proc.kill("SIGKILL");
+      // Only the port-bind race is retried; a real startup failure fails loudly.
+      if (!stderr.includes("Address already in use")) {
+        throw e;
+      }
+      await sleep(200);
+    }
+  }
+  throw new Error(`kx serve never bound a free port after retries: ${String(lastErr)}`);
 }
 
 /** A loopback `--dev-allow-local` gateway (no token needed). */


### PR DESCRIPTION
## CI hardening — close the inference-coverage gaps

Surfaced during POC-3 (#249): the `clippy` and `test` jobs build **default features**, so `#[cfg(feature="inference")]` code is **never linted** and its **model-free tests never run** (the with-model jobs need a GGUF and don't run clippy). This let a `single_match_else` lint and the `model_lifecycle` host tests sit entirely outside the gate.

This adds an **`inference-checks`** job that builds the llama.cpp FFI once and runs:
- `cargo clippy --features inference,… -- -D warnings` on `kx-gateway` + `kx-inference` (the cfg(inference) lint gap)
- `cargo test --features inference,…` on `kx-gateway` (the cfg(inference) model-free test gap)

The `#[ignore]` live-model tests stay in `smoke-test-with-model` / `real-model-e2e`.

Pairs with #249's `features-guard` fix (`kx-gateway --no-default-features` is now in the clippy job) to **close the local `just ci` ↔ GitHub-CI divergence** that let a breakage merge red on `main`.

Validated locally: both inference clippy targets clean, `kx-gateway` inference tests 227 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114GPU3yiaTUWhuZ6cjV2Hw