### PR TITLE
PR-A.1 — dual-engine parity: prebuilt serve-engine flip + required FFI-free CI gate + docs matrix + GR10 chat baseline (+ Ollama ctx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,59 @@ jobs:
         run: just build-no-inference
 
   # ---------------------------------------------------------------------------
+  # build-serve-engine — the PR-A.1 dual-engine adoption gate (GR24).
+  #
+  # Proves the prebuilt release feature set (`console,hnsw,serve-engine`) is
+  # GENUINELY FFI-free: this job deliberately checks out WITHOUT submodules and
+  # installs NO native build deps (no libclang/clang/cmake), then asserts via
+  # `cargo tree` that `console,hnsw,serve-engine` pulls no `kx-llamacpp`, and
+  # compiles the serve loop (`--features serve-engine,hnsw`) toolchain-free. So a
+  # `curl | install.sh` user serves local models via Ollama with zero toolchain,
+  # while llama.cpp stays the opt-in `inference` build. The non-required
+  # serve-engine step in `inference-checks` runs WITH the toolchain; this is the
+  # clean-room FFI-FREE complement.
+  #
+  # REQUIRED: promote it to a branch-protection check once green across a few runs
+  # (a separate, explicitly-authorized branch-protection change), mirroring
+  # build-no-inference / ui / sdk-* / scale-smoke.
+  # ---------------------------------------------------------------------------
+  build-serve-engine:
+    name: build-serve-engine (kx serves via Ollama without a C++ toolchain)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (NO submodules — serve-engine must stay FFI-free)
+        uses: actions/checkout@v6
+        # Deliberately NO submodules and NO C++ toolchain install below.
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: |
+          rustup show active-toolchain
+          rustc --version
+          cargo --version
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-serveengine-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-serveengine-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Configure RUSTFLAGS for path-stripping
+        run: |
+          echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}= -Cmetadata=kortecx-v0" >> $GITHUB_ENV
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: just build-serve-engine
+        run: just build-serve-engine
+
+  # ---------------------------------------------------------------------------
   # verify-quickstart — docs-as-test gate (R7). Runs `just verify-quickstart`,
   # which builds the FFI-free `kx` binary and drives the README quickstart
   # (run → crash → replay → digest), asserting the canonical projection digest at

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,17 +60,24 @@ jobs:
           npm --prefix ui ci
           npm --prefix ui run build
 
-      # The FFI wall, asserted on the EXACT feature set this job ships: neither
-      # `console` nor `hnsw` may ever drag the llama.cpp FFI into the closure.
-      - name: FFI wall (console,hnsw stays llama.cpp-free)
+      # The FFI wall, asserted on the EXACT feature set this job ships: none of
+      # `console` / `hnsw` / `serve-engine` may ever drag the llama.cpp FFI into the
+      # closure (serve-engine adds the FFI-FREE Ollama backend; the in-process
+      # llama.cpp path stays the opt-in `inference` build — PR-A.1). The required
+      # `build-serve-engine` CI job re-proves this on a toolchain-free runner.
+      - name: FFI wall (console,hnsw,serve-engine stays llama.cpp-free)
         shell: bash
         run: |
-          if cargo tree -p kx-cli --features console,hnsw -e normal | grep -qE 'kx-llamacpp'; then
-            echo "::error::the console/hnsw features dragged the FFI into kx-cli"; exit 1
+          if cargo tree -p kx-cli --features console,hnsw,serve-engine -e normal | grep -qE 'kx-llamacpp'; then
+            echo "::error::the console/hnsw/serve-engine features dragged the FFI into kx-cli"; exit 1
           fi
 
-      - name: Build kx (FFI-free; embedded console + datasets — D139.4)
-        run: cargo build --release -p kx-cli --features console,hnsw
+      # PR-A.1: the prebuilt now ships `serve-engine` (FFI-free), so a toolchain-free
+      # `curl | install.sh` install AUTO-DETECTS a running Ollama daemon and serves
+      # local models out of the box. llama.cpp stays the opt-in `--features inference`
+      # build (needs a C++ toolchain).
+      - name: Build kx (FFI-free; embedded console + datasets + Ollama serve — PR-A.1)
+        run: cargo build --release -p kx-cli --features console,hnsw,serve-engine
 
       - name: Package + checksum
         shell: bash

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ SDKs**, and the **web console** — same wire, same guarantees.
 
 ```bash
 # Prebuilt binary (Linux x86_64/arm64, macOS arm64) — SHA-256 verified, no sudo,
-# installs to ~/.local/bin. The prebuilt ships the web console + Datasets built in.
+# installs to ~/.local/bin. The prebuilt ships the web console + Datasets, and
+# serves local models via a running Ollama daemon out of the box (no C++ toolchain).
 curl -fsSL https://raw.githubusercontent.com/Kortecx/kortecx/main/scripts/install.sh | sh
 ```
 
@@ -91,8 +92,13 @@ just console-build                                          # + the embedded web
 
 | Tier | You get | You need |
 |---|---|---|
-| **Tier 0 — the runtime** | everything except on-device inference | nothing (prebuilt) or **Rust 1.94+** (source) |
-| **Tier 1 — local LLM inference** | on-device model inference via llama.cpp | a **C++ toolchain** (CMake, clang/libclang) + a **GGUF** model |
+| **Tier 0 — the runtime (prebuilt)** | the full runtime + the web console + Datasets, and serves local models via a running **Ollama** daemon (zero toolchain) | nothing (prebuilt) or **Rust 1.94+** (source); **Ollama** installed for local inference |
+| **Tier 1 — in-process llama.cpp** | self-contained on-device inference (no daemon) + multi-modal / vision | a **C++ toolchain** (CMake, clang/libclang) + a **GGUF** model |
+
+Both engines are co-equal first-class backends — see
+[Local inference engines](docs/site/docs/local-inference-engines.md) for the
+positioning (Ollama = quick/easy; llama.cpp = performance / parallel / multi-modal)
+and the capability matrix.
 
 Run **`just doctor`** (repo checkout) for a tiered preflight that prints the
 exact install command for anything missing. Tier 1 hints — macOS:

--- a/crates/kx-cli/tests/dep_wall.rs
+++ b/crates/kx-cli/tests/dep_wall.rs
@@ -52,3 +52,44 @@ fn cargo_tree_normal_edges_exclude_the_ffi() {
         );
     }
 }
+
+/// PR-A.1 (GR24 dual-engine parity): the prebuilt release feature set
+/// (`console,hnsw,serve-engine`) must stay FFI-free — serve-engine adds the
+/// FFI-FREE Ollama backend (`kx-ollama`), never the llama.cpp FFI (that rides the
+/// opt-in `inference`). The deterministic in-test complement to the
+/// `build-serve-engine` CI/justfile clean-room gate.
+#[test]
+fn cargo_tree_serve_engine_features_exclude_the_ffi() {
+    let output = std::process::Command::new(env!("CARGO"))
+        .args([
+            "tree",
+            "-p",
+            "kx-cli",
+            "--features",
+            "console,hnsw,serve-engine",
+            "--edges",
+            "normal",
+            "--prefix",
+            "none",
+        ])
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        // cargo-tree may be unavailable in sandboxed CI; skip rather than false-fail.
+        _ => return,
+    };
+    let tree = String::from_utf8_lossy(&output.stdout);
+    for forbidden in FORBIDDEN {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the kx-cli console,hnsw,serve-engine tree:\n{tree}"
+        );
+    }
+    // Sanity: serve-engine MUST wire the FFI-free Ollama backend — otherwise the
+    // FFI-free assertion above would be vacuously true on a build that can't serve.
+    assert!(
+        tree.lines()
+            .any(|l| l.trim_start().starts_with("kx-ollama")),
+        "serve-engine did not pull the kx-ollama backend:\n{tree}"
+    );
+}

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -332,7 +332,7 @@ fn build_ollama_engine(
         .iter()
         .enumerate()
         // The GLOBAL primary uses `kx/recipes/chat`; everything else `kx/recipes/m-<id>`.
-        .map(|(i, id)| ollama_catalog_entry(id, !have_gguf && i == primary_idx))
+        .map(|(i, id)| ollama_catalog_entry(&backend, id, !have_gguf && i == primary_idx))
         .collect();
     let primary = ids[primary_idx].clone();
     tracing::info!(count, primary = %primary.0, %url, "registered Ollama models");
@@ -353,7 +353,11 @@ fn parse_ollama_allowlist() -> Option<Vec<String>> {
 }
 
 /// The `ListModels` display entry for an Ollama-served model (engine `"kx-ollama"`).
-fn ollama_catalog_entry(model_id: &ModelId, serving: bool) -> kx_gateway_core::ModelSummaryEntry {
+fn ollama_catalog_entry(
+    backend: &kx_ollama::OllamaBackend,
+    model_id: &ModelId,
+    serving: bool,
+) -> kx_gateway_core::ModelSummaryEntry {
     kx_gateway_core::ModelSummaryEntry {
         model_id: model_id.0.clone(),
         // PR-B will surface Ollama vision/embedding modalities; text for PR-A.
@@ -361,8 +365,10 @@ fn ollama_catalog_entry(model_id: &ModelId, serving: bool) -> kx_gateway_core::M
         // The tag is its own honest description (the daemon owns the GGUF metadata).
         description: model_id.0.clone(),
         serving,
-        // The daemon owns the context window; `/api/show` per-model is a PR-B detail.
-        context_len: 0,
+        // The daemon owns the context window; surfaced best-effort via `/api/show`
+        // at discovery (`0` when the daemon doesn't report one). Display-only (SN-8),
+        // un-clamped — the daemon serves its own window, unlike the GGUF KV ceiling.
+        context_len: backend.context_len(model_id),
         loaded: false,
         chat_handle: crate::provision::chat_handle_for(model_id, serving),
         engine: "kx-ollama".to_string(),

--- a/crates/kx-gateway/tests/dep_wall.rs
+++ b/crates/kx-gateway/tests/dep_wall.rs
@@ -67,6 +67,46 @@ fn cargo_tree_normal_edges_exclude_the_ffi() {
     }
 }
 
+/// PR-A.1 (GR24 dual-engine parity): the FFI-FREE serve loop (`serve-engine,hnsw`)
+/// must stay llama.cpp-free — serve-engine pulls the Ollama backend (`kx-ollama`)
+/// plus the planner/critic/MCP, never `kx-llamacpp`/`kx-model-harness` (those ride
+/// the opt-in `inference`). The deterministic in-test complement to the
+/// `build-serve-engine` clean-room gate.
+#[test]
+fn cargo_tree_serve_engine_features_exclude_the_ffi() {
+    let output = std::process::Command::new(env!("CARGO"))
+        .args([
+            "tree",
+            "-p",
+            "kx-gateway",
+            "--features",
+            "serve-engine,hnsw",
+            "--edges",
+            "normal",
+            "--prefix",
+            "none",
+        ])
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        // cargo-tree may be unavailable in sandboxed CI; skip rather than false-fail.
+        _ => return,
+    };
+    let tree = String::from_utf8_lossy(&output.stdout);
+    for forbidden in FORBIDDEN {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the kx-gateway serve-engine,hnsw tree:\n{tree}"
+        );
+    }
+    // Sanity: serve-engine MUST wire the FFI-free Ollama backend.
+    assert!(
+        tree.lines()
+            .any(|l| l.trim_start().starts_with("kx-ollama")),
+        "serve-engine did not pull the kx-ollama backend:\n{tree}"
+    );
+}
+
 #[test]
 fn cargo_manifest_includes_the_catalog_edge() {
     // R2a intentionally adds kx-catalog (the signature registry) to the host. It

--- a/crates/kx-ollama/src/backend.rs
+++ b/crates/kx-ollama/src/backend.rs
@@ -7,7 +7,7 @@
 //! HTTP egress. The inherent `warm`/`evict`/`resident` mirror the llama backend's
 //! lifecycle surface so the host can drive both engines through one trait.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -33,17 +33,30 @@ pub struct OllamaBackend {
     /// The tags this backend serves (the `/api/tags` set, optionally narrowed by an
     /// operator allowlist). Membership is the `supports()` gate.
     models: BTreeSet<String>,
+    /// Per-tag declared context window from `/api/show` (populated best-effort at
+    /// discovery; `0` when the daemon doesn't report one). Display/discovery only
+    /// (SN-8) — it never authorizes a route, and it is never journaled.
+    context_len: BTreeMap<String, u32>,
 }
 
 impl OllamaBackend {
-    /// Construct a backend that serves exactly `models` through `client`.
+    /// Construct a backend that serves exactly `models` through `client`. Context
+    /// windows are left empty (reported `0`); [`Self::discover`] is the path that
+    /// populates them from `/api/show`.
     #[must_use]
     pub fn new(client: Arc<OllamaClient>, models: BTreeSet<String>) -> Self {
-        Self { client, models }
+        Self {
+            client,
+            models,
+            context_len: BTreeMap::new(),
+        }
     }
 
     /// Discover the served set from the daemon's `/api/tags`, optionally narrowed to
     /// an operator allowlist (an empty / absent allowlist serves every installed tag).
+    /// Also fetches each served tag's declared context window via `/api/show`
+    /// (best-effort: a failed/absent window honest-degrades to `0` and never blocks
+    /// serving).
     ///
     /// # Errors
     /// Propagates the [`OllamaClient::tags`] transport / status / protocol failure.
@@ -61,13 +74,31 @@ impl OllamaBackend {
             }
             _ => tags.into_iter().collect(),
         };
-        Ok(Self::new(client, models))
+        // One `/api/show` per served tag, best-effort. `unwrap_or(0)` so a daemon
+        // that errors / omits the window never blocks startup (honest-degrade).
+        let context_len = models
+            .iter()
+            .map(|tag| (tag.clone(), client.show_context_length(tag).unwrap_or(0)))
+            .collect();
+        Ok(Self {
+            client,
+            models,
+            context_len,
+        })
     }
 
     /// The model ids this backend serves (for the host's model catalog).
     #[must_use]
     pub fn model_ids(&self) -> Vec<ModelId> {
         self.models.iter().cloned().map(ModelId).collect()
+    }
+
+    /// The declared context window for `model_id` (fetched from `/api/show` at
+    /// discovery), or `0` when unknown. Display/discovery only (SN-8) — for parity
+    /// with the llama backend's GGUF `n_ctx`, surfaced in `kx models list`.
+    #[must_use]
+    pub fn context_len(&self, model_id: &ModelId) -> u32 {
+        self.context_len.get(&model_id.0).copied().unwrap_or(0)
     }
 
     /// Warm `model_id` into the daemon's memory (`keep_alive = -1`). Fail-closed:

--- a/crates/kx-ollama/src/client.rs
+++ b/crates/kx-ollama/src/client.rs
@@ -135,6 +135,35 @@ impl OllamaClient {
         Ok(model_names(&value))
     }
 
+    /// `POST /api/show` — the model's declared context window (`model_info`
+    /// `<arch>.context_length`). The body is `{ "model": <tag> }`. The returned
+    /// number is the direct analogue of the GGUF `.context_length` the in-process
+    /// llama backend reads, so `kx models list` shows the same kind of value for
+    /// either engine. Carries the short control-plane timeout (it is called once
+    /// per tag at startup — a hung daemon must not stall serving).
+    ///
+    /// # Errors
+    /// [`OllamaError::Unreachable`] / [`OllamaError::Status`] / [`OllamaError::Protocol`]
+    /// (the last also when the response carries no `*.context_length` key).
+    pub fn show_context_length(&self, model: &str) -> Result<u32, OllamaError> {
+        let body = serde_json::json!({ "model": model });
+        let bytes = to_body(&body)?;
+        let url = format!("{}/api/show", self.base);
+        let resp = self
+            .agent
+            .post(&url)
+            .timeout(Duration::from_millis(CONTROL_TIMEOUT_MS))
+            .set("Content-Type", "application/json")
+            .send_bytes(&bytes)
+            .map_err(classify)?;
+        let text = resp
+            .into_string()
+            .map_err(|e| OllamaError::Protocol(e.to_string()))?;
+        let value: serde_json::Value = parse_json(&text)?;
+        context_length_of(&value)
+            .ok_or_else(|| OllamaError::Protocol("no context_length in /api/show".to_string()))
+    }
+
     /// Load (`keep_alive = -1`) or unload (`keep_alive = 0`) `model` via an
     /// empty-prompt `/api/generate` — the daemon's documented warm/evict control.
     ///
@@ -354,6 +383,22 @@ fn eval_count_of(value: &serde_json::Value) -> u32 {
         .unwrap_or(0)
 }
 
+/// Extract the model's declared context window from an `/api/show` response. The
+/// daemon reports it under `model_info` as `"<arch>.context_length"` (e.g.
+/// `gemma3.context_length`, `llama.context_length`, `qwen2.context_length`). Matched
+/// by suffix (arch-agnostic — exactly like the GGUF reader keys on `.context_length`)
+/// and clamped into `u32`. `None` when absent / non-numeric so the catalog honest-
+/// degrades to `0` rather than fabricating a window.
+fn context_length_of(value: &serde_json::Value) -> Option<u32> {
+    value
+        .get("model_info")
+        .and_then(serde_json::Value::as_object)?
+        .iter()
+        .find(|(k, _)| k.ends_with(".context_length"))
+        .and_then(|(_, v)| v.as_u64())
+        .and_then(|n| u32::try_from(n).ok())
+}
+
 /// Narrow a JSON `f64` embedding element to the `f32` embeddings are stored in.
 #[allow(clippy::cast_possible_truncation)] // embeddings are f32; the daemon emits f64 JSON numbers
 fn f64_to_f32(f: f64) -> f32 {
@@ -487,5 +532,26 @@ mod tests {
     fn new_allows_loopback() {
         let c = OllamaClient::new("http://127.0.0.1:11434/", false).expect("loopback ok");
         assert_eq!(c.base, "http://127.0.0.1:11434"); // trailing slash trimmed
+    }
+
+    #[test]
+    fn context_length_of_reads_arch_keyed_window() {
+        // Arch-agnostic: any `<arch>.context_length` key under model_info.
+        let gemma = serde_json::json!({ "model_info": { "gemma3.context_length": 131_072 } });
+        assert_eq!(context_length_of(&gemma), Some(131_072));
+        let qwen = serde_json::json!({ "model_info": { "qwen2.context_length": 32_768 } });
+        assert_eq!(context_length_of(&qwen), Some(32_768));
+    }
+
+    #[test]
+    fn context_length_of_degrades_when_absent_or_non_numeric() {
+        // No `*.context_length` key ⇒ None (honest-degrade to 0 at the call site).
+        let none = serde_json::json!({ "model_info": { "general.architecture": "gemma3" } });
+        assert_eq!(context_length_of(&none), None);
+        // A non-numeric value ⇒ None, never a fabricated window.
+        let bad = serde_json::json!({ "model_info": { "gemma3.context_length": "lots" } });
+        assert_eq!(context_length_of(&bad), None);
+        // Missing model_info entirely ⇒ None.
+        assert_eq!(context_length_of(&serde_json::json!({})), None);
     }
 }

--- a/crates/kx-ollama/tests/http_mock.rs
+++ b/crates/kx-ollama/tests/http_mock.rs
@@ -110,6 +110,20 @@ fn ollama_routes(method: &str, path: &str, body: &str) -> (u16, String) {
             r#"{"models":[{"name":"gemma3:12b"},{"name":"qwen2.5:3b"}]}"#.to_string(),
         ),
         ("GET", "/api/ps") => (200, r#"{"models":[{"name":"gemma3:12b"}]}"#.to_string()),
+        ("POST", "/api/show") => {
+            // Per-tag declared window; arch-keyed under model_info (arch-agnostic match).
+            if body.contains("qwen2.5:3b") {
+                (
+                    200,
+                    r#"{"model_info":{"qwen2.context_length":32768}}"#.to_string(),
+                )
+            } else {
+                (
+                    200,
+                    r#"{"model_info":{"gemma3.context_length":131072}}"#.to_string(),
+                )
+            }
+        }
         ("POST", "/api/embed") => (200, r#"{"embeddings":[[0.25,0.5,0.75]]}"#.to_string()),
         ("POST", "/api/generate") => {
             if !body.contains("\"raw\":true") {
@@ -172,6 +186,38 @@ fn discover_filters_by_allowlist() {
     assert_eq!(backend.model_ids(), vec![ModelId("gemma3:12b".to_string())]);
     assert!(backend.supports(&ModelId("gemma3:12b".to_string())));
     assert!(!backend.supports(&ModelId("qwen2.5:3b".to_string())));
+}
+
+#[test]
+fn discover_populates_context_len_from_show() {
+    // `/api/show` per tag at discovery ⇒ the declared window reaches the catalog.
+    // Per-tag + arch-agnostic: gemma3.* vs qwen2.* both resolve by `.context_length`.
+    let base = spawn_mock(ollama_routes);
+    let client = Arc::new(OllamaClient::new(&base, false).unwrap());
+    let backend = OllamaBackend::discover(client, None).unwrap();
+    assert_eq!(
+        backend.context_len(&ModelId("gemma3:12b".to_string())),
+        131072
+    );
+    assert_eq!(
+        backend.context_len(&ModelId("qwen2.5:3b".to_string())),
+        32768
+    );
+}
+
+#[test]
+fn discover_degrades_to_zero_ctx_when_show_unavailable() {
+    // A daemon that serves tags but 404s `/api/show` ⇒ ctx stays 0; serving is never
+    // blocked (the honest-degrade path).
+    let base = spawn_mock(|method, path, body| {
+        if (method, path) == ("POST", "/api/show") {
+            return (404, r#"{"error":"not found"}"#.to_string());
+        }
+        ollama_routes(method, path, body)
+    });
+    let client = Arc::new(OllamaClient::new(&base, false).unwrap());
+    let backend = OllamaBackend::discover(client, None).unwrap();
+    assert_eq!(backend.context_len(&ModelId("gemma3:12b".to_string())), 0);
 }
 
 #[test]

--- a/crates/kx-profile/src/chat_spikes.rs
+++ b/crates/kx-profile/src/chat_spikes.rs
@@ -1,0 +1,375 @@
+//! Attach-mode chat spikes (Golden Rule 10 + GR24 dual-engine parity): time a real
+//! chat turn against a LIVE `kx serve` over gRPC, engine-agnostically. Unlike the
+//! other spikes (which host a fresh in-process echo gateway), this dials an EXTERNAL
+//! serve the operator launched — whichever inference engine it runs (the FFI-free
+//! Ollama backend OR the in-process llama.cpp backend). The harness binary itself
+//! stays FFI-free: it is a pure gRPC client over the frozen `KxGatewayClient` stubs
+//! (no `kx-gateway` `serve-engine`/`inference` feature, no new dependency).
+//!
+//! It calls `ListModels` ONCE to learn which model + engine answers (the PR-A
+//! `engine` field), so the captured JSON self-labels the run; then per iteration it
+//! times `Invoke` → poll `GetProjection` until the terminal Mote commits (the honest
+//! "answer complete" signal), and best-effort records time-to-first-token from
+//! `StreamModelTokens` (an empty/immediate stream — a non-streaming engine or an
+//! unwired broker — yields NO ttft sample rather than a misleading `0`).
+
+use std::time::{Duration, Instant};
+
+use tonic::transport::Channel;
+
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+
+use crate::error::ProfileError;
+
+/// Poll cadence for the commit wait. Tight on purpose: the CLI polls at 250 ms for
+/// UX, which would quantize the measured total to ±250 ms — a measurement artifact,
+/// not an engine property. 25 ms reflects the engine, not the poll.
+const COMMIT_POLL: Duration = Duration::from_millis(25);
+
+/// Per-chat wall-clock ceiling. Generous — a cold 12B model's first turn (load +
+/// decode) can run for many seconds. A run that exceeds this invalidates the sample
+/// (a hung generation's "latency" is not a measurement).
+const MAX_CHAT_MS: u64 = 300_000;
+
+/// The default prompt (a short, deterministic factual turn) when none is given.
+pub const DEFAULT_PROMPT: &str = "What is the capital of France? Answer in one short sentence.";
+
+/// Options for an attach-mode chat run.
+#[derive(Debug, Clone)]
+pub struct ChatOpts {
+    /// Number of TIMED iterations (after one discarded cold warm-up chat).
+    pub iterations: usize,
+    /// The chat prompt sent each iteration.
+    pub prompt: String,
+    /// Optional explicit model id; `None` ⇒ the primary (`serving == true`) model.
+    pub model: Option<String>,
+    /// Optional bearer token (a `--dev-allow-local` serve needs none).
+    pub token: Option<String>,
+}
+
+/// Raw per-iteration chat latency samples (milliseconds) + the self-describing
+/// labels read from `ListModels`.
+#[derive(Debug, Clone)]
+pub struct ChatSamples {
+    /// The serving engine that answered (`"kx-ollama"` / `"kx-llamacpp"`), used as
+    /// the metric-id prefix so an Ollama capture and a llama.cpp capture never
+    /// collide in the trend record.
+    pub engine: String,
+    /// The model id that answered.
+    pub model_id: String,
+    /// The model's declared context window (tokens), for the record.
+    pub context_len: u32,
+    /// The cold FIRST chat's total latency (model load included) — recorded
+    /// separately so it never skews the warm p50/p99.
+    pub warmup_first_ms: f64,
+    /// Per-iteration total latency (Invoke → terminal Mote Committed), warm.
+    pub total_ms: Vec<f64>,
+    /// Per-iteration time-to-first-token (best-effort; may be EMPTY when the engine
+    /// does not stream / the broker is unwired).
+    pub ttft_ms: Vec<f64>,
+}
+
+/// Dial an external `kx serve` endpoint. Accepts a bare `host:port` (assumed
+/// plaintext loopback) or a full `http://host:port` URL. TLS (`https://`) attach is
+/// a follow-up — the focused dual-engine baseline runs against a loopback
+/// `--dev-allow-local` serve.
+///
+/// # Errors
+/// [`ProfileError::Client`] if the endpoint is malformed or unreachable.
+pub async fn connect(endpoint: &str) -> Result<Channel, ProfileError> {
+    let uri = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else {
+        format!("http://{endpoint}")
+    };
+    let ep = Channel::from_shared(uri)
+        .map_err(|e| ProfileError::Client(format!("bad --serve endpoint: {e}")))?;
+    // Bounded connect-retry (25 ms → 400 ms): a just-started `kx serve` accepts TCP
+    // before the HTTP/2 stack is ready, so the first dial can transport-error.
+    let mut delay = Duration::from_millis(25);
+    let mut last = String::new();
+    for _ in 0..8 {
+        match ep.connect().await {
+            Ok(channel) => return Ok(channel),
+            Err(e) => {
+                last = e.to_string();
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(Duration::from_millis(400));
+            }
+        }
+    }
+    Err(ProfileError::Client(format!(
+        "could not reach {endpoint}: {last}"
+    )))
+}
+
+/// Measure attach-mode chat latency over `opts.iterations` against a connected
+/// `channel` (an external `kx serve`).
+///
+/// # Errors
+/// [`ProfileError::Client`] if `ListModels` returns no model, a chat fails, or a
+/// chat exceeds the per-chat wall-clock ceiling.
+pub async fn measure(channel: &Channel, opts: &ChatOpts) -> Result<ChatSamples, ProfileError> {
+    let mut client = client(channel);
+
+    // Learn which model + engine answers (self-labels the capture).
+    let models = client
+        .list_models(authed(proto::ListModelsRequest {}, opts.token.as_deref())?)
+        .await
+        .map_err(|s| ProfileError::Client(s.to_string()))?
+        .into_inner()
+        .models;
+    let model = match &opts.model {
+        Some(id) => models.iter().find(|m| &m.model_id == id),
+        None => models.iter().find(|m| m.serving),
+    }
+    .ok_or_else(|| {
+        ProfileError::Client(
+            "no served model on the attached serve (an FFI-free build with no engine \
+             answers ListModels empty; launch `kx serve` with --features serve-engine \
+             [+ a running Ollama daemon] or --features inference [+ a GGUF])"
+                .to_string(),
+        )
+    })?;
+    let handle = if model.chat_handle.is_empty() {
+        "kx/recipes/chat".to_string()
+    } else {
+        model.chat_handle.clone()
+    };
+    let engine = if model.engine.is_empty() {
+        "unknown".to_string()
+    } else {
+        model.engine.clone()
+    };
+    let model_id = model.model_id.clone();
+    let context_len = model.context_len;
+
+    // Each iteration sends a UNIQUE prompt (the base + a per-iteration tag) so the
+    // runtime memoizer never short-circuits a model Mote whose inputs already
+    // committed — we want to measure the engine's GENERATION latency, not a cache
+    // hit. (A fixed prompt would memoize after the first turn and report sub-ms
+    // "latency" that is the projection fold, not inference.) The tag is a short
+    // trailing clause, so the answer stays a one-liner across iterations.
+    let warmup_prompt = format!("{} (warm-up)", opts.prompt);
+    let (warmup_first_ms, _) =
+        one_chat(channel, &handle, &warmup_prompt, opts.token.as_deref()).await?;
+
+    let mut total_ms = Vec::with_capacity(opts.iterations);
+    let mut ttft_ms = Vec::with_capacity(opts.iterations);
+    for i in 0..opts.iterations {
+        let prompt = format!("{} (variant {i})", opts.prompt);
+        let (total, ttft) = one_chat(channel, &handle, &prompt, opts.token.as_deref()).await?;
+        total_ms.push(total);
+        if let Some(ttft) = ttft {
+            ttft_ms.push(ttft);
+        }
+    }
+
+    Ok(ChatSamples {
+        engine,
+        model_id,
+        context_len,
+        warmup_first_ms,
+        total_ms,
+        ttft_ms,
+    })
+}
+
+/// Run one chat turn: `Invoke` → (best-effort first-token) → poll until the terminal
+/// Mote commits. Returns `(total_ms, ttft_ms)`.
+async fn one_chat(
+    channel: &Channel,
+    handle: &str,
+    prompt: &str,
+    token: Option<&str>,
+) -> Result<(f64, Option<f64>), ProfileError> {
+    let args = serde_json::to_vec(&serde_json::json!({ "prompt": prompt }))
+        .map_err(|e| ProfileError::Client(e.to_string()))?;
+    let mut client = client(channel);
+    let t0 = Instant::now();
+    let inv = client
+        .invoke(authed(
+            proto::InvokeRequest {
+                handle: handle.to_string(),
+                args,
+                context_bundles: Vec::new(),
+                context_refs: Vec::new(),
+            },
+            token,
+        )?)
+        .await
+        .map_err(|s| ProfileError::Client(s.to_string()))?
+        .into_inner();
+
+    // TTFT (best-effort): the first non-empty streamed piece. Returns as soon as the
+    // first token arrives, then we poll for commit — t0 is fixed, so total stays
+    // honest (Invoke → commit).
+    let budget = Duration::from_millis(MAX_CHAT_MS);
+    let ttft = first_token_ms(
+        channel,
+        &inv.instance_id,
+        &inv.terminal_mote_id,
+        token,
+        t0,
+        budget,
+    )
+    .await;
+
+    let total = wait_committed_ms(
+        &mut client,
+        &inv.instance_id,
+        &inv.terminal_mote_id,
+        token,
+        t0,
+        budget,
+    )
+    .await?;
+    Ok((total, ttft))
+}
+
+/// Poll `GetProjection` until the run's `terminal_mote_id` is `Committed`; return the
+/// elapsed-since-`t0` total. A `Failed`/anomaly terminal or a budget overrun
+/// invalidates the sample (a failed generation's latency is not a measurement).
+async fn wait_committed_ms(
+    client: &mut KxGatewayClient<Channel>,
+    instance_id: &[u8],
+    terminal_mote_id: &[u8],
+    token: Option<&str>,
+    t0: Instant,
+    budget: Duration,
+) -> Result<f64, ProfileError> {
+    let committed = proto::MoteSnapshotState::Committed as i32;
+    let pending = proto::MoteSnapshotState::Pending as i32;
+    let scheduled = proto::MoteSnapshotState::Scheduled as i32;
+    loop {
+        let view = client
+            .get_projection(authed(
+                proto::GetProjectionRequest {
+                    instance_id: instance_id.to_vec(),
+                    at_seq: None,
+                },
+                token,
+            )?)
+            .await
+            .map_err(|s| ProfileError::Client(s.to_string()))?
+            .into_inner();
+        if let Some(state) = view
+            .motes
+            .iter()
+            .find(|m| m.mote_id == terminal_mote_id)
+            .map(|m| m.state)
+        {
+            if state == committed {
+                return Ok(t0.elapsed().as_secs_f64() * 1000.0);
+            }
+            if state != pending && state != scheduled {
+                return Err(ProfileError::Client(format!(
+                    "chat terminal Mote reached non-committed state {state} (failed run)"
+                )));
+            }
+        }
+        if t0.elapsed() >= budget {
+            return Err(ProfileError::Timeout {
+                what: "the chat terminal Mote to commit".to_string(),
+                elapsed_ms: u64::try_from(budget.as_millis()).unwrap_or(u64::MAX),
+            });
+        }
+        tokio::time::sleep(COMMIT_POLL).await;
+    }
+}
+
+/// Best-effort time-to-first-token: open `StreamModelTokens` and return the elapsed
+/// at the first non-empty `text_piece`. `None` on ANY difficulty (no stream, the
+/// broker unwired → an immediately-ending empty stream, error, or budget) — the
+/// caller then records NO ttft sample rather than a misleading `0`.
+async fn first_token_ms(
+    channel: &Channel,
+    instance_id: &[u8],
+    mote_id: &[u8],
+    token: Option<&str>,
+    t0: Instant,
+    budget: Duration,
+) -> Option<f64> {
+    let mut client = client(channel);
+    let req = authed(
+        proto::StreamModelTokensRequest {
+            instance_id: instance_id.to_vec(),
+            mote_id: mote_id.to_vec(),
+            since_seq: 0,
+        },
+        token,
+    )
+    .ok()?;
+    let mut stream = tokio::time::timeout(budget, client.stream_model_tokens(req))
+        .await
+        .ok()?
+        .ok()?
+        .into_inner();
+    loop {
+        match tokio::time::timeout(budget, stream.message()).await {
+            Ok(Ok(Some(chunk))) => {
+                if !chunk.text_piece.is_empty() {
+                    return Some(t0.elapsed().as_secs_f64() * 1000.0);
+                }
+                if chunk.done {
+                    return None;
+                }
+            }
+            // End of stream / transport error / budget — no first-token signal.
+            _ => return None,
+        }
+    }
+}
+
+/// A gateway client over a cloned channel with a generous decode limit (chat
+/// answers + projection views can exceed the default 4 MiB cap).
+fn client(channel: &Channel) -> KxGatewayClient<Channel> {
+    KxGatewayClient::new(channel.clone()).max_decoding_message_size(64 * 1024 * 1024)
+}
+
+/// Wrap a request with the `authorization: Bearer <token>` metadata when a token is
+/// configured (mirrors the CLI's per-request auth). A `--dev-allow-local` serve
+/// needs none.
+fn authed<T>(msg: T, token: Option<&str>) -> Result<tonic::Request<T>, ProfileError> {
+    let mut req = tonic::Request::new(msg);
+    if let Some(token) = token {
+        let value = tonic::metadata::MetadataValue::try_from(format!("Bearer {token}"))
+            .map_err(|e| ProfileError::Client(format!("bad auth token: {e}")))?;
+        req.metadata_mut().insert("authorization", value);
+    }
+    Ok(req)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spikes;
+    use kx_gateway::start;
+
+    /// The attach spike against an FFI-free in-process gateway (no served model)
+    /// fails CLEANLY with a "no served model" client error — the client path is
+    /// exercised deterministically without any engine. (The live both-engine
+    /// numbers are captured separately and persisted to the private benchmarks.)
+    #[tokio::test]
+    async fn measure_errors_cleanly_when_no_model_is_served() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let running = start(spikes::config(dir.path()).unwrap()).await.unwrap();
+        let channel = connect(&running.local_addr().to_string()).await.unwrap();
+        let opts = ChatOpts {
+            iterations: 1,
+            prompt: DEFAULT_PROMPT.to_string(),
+            model: None,
+            token: None,
+        };
+        let err = measure(&channel, &opts).await.unwrap_err();
+        match err {
+            ProfileError::Client(msg) => assert!(
+                msg.contains("no served model"),
+                "expected a no-served-model error, got: {msg}"
+            ),
+            other => panic!("expected a Client error, got: {other:?}"),
+        }
+        running.shutdown().await.unwrap();
+    }
+}

--- a/crates/kx-profile/src/lib.rs
+++ b/crates/kx-profile/src/lib.rs
@@ -23,6 +23,7 @@
     allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)
 )]
 
+pub mod chat_spikes;
 pub mod content_spikes;
 pub mod env;
 pub mod error;
@@ -31,6 +32,7 @@ pub mod react_spikes;
 pub mod report;
 pub mod spikes;
 
+pub use chat_spikes::{ChatOpts, ChatSamples};
 pub use content_spikes::ContentSamples;
 pub use env::{capture_git_sha, Environment};
 pub use error::ProfileError;

--- a/crates/kx-profile/src/main.rs
+++ b/crates/kx-profile/src/main.rs
@@ -8,13 +8,17 @@
 //! spikes; the captured JSON is then copied into the PRIVATE
 //! `docs/benchmarks/` trend record (never committed to OSS — SN-2).
 //!
-//! Usage: `kx-profile [--iterations N] [--out PATH]` (default `N = 8`).
+//! Usage:
+//! - In-process spikes (default): `kx-profile [--iterations N] [--out PATH]` (`N = 8`).
+//! - Attach mode (GR24 dual-engine chat baseline): `kx-profile --serve <addr> chat
+//!   [--iterations N] [--prompt "..."] [--model <id>] [--token <t> | --token-file <p>]`
+//!   — times a real chat against an EXTERNAL `kx serve` (whichever engine it runs).
 
 use std::path::PathBuf;
 
 use kx_profile::{
-    capture_git_sha, content_spikes, mote_detail_spikes, percentile, react_spikes, spikes,
-    Environment, Metric, ProfileError, Report,
+    capture_git_sha, chat_spikes, content_spikes, mote_detail_spikes, percentile, react_spikes,
+    spikes, ChatOpts, Environment, Metric, ProfileError, Report,
 };
 
 #[tokio::main]
@@ -51,82 +55,14 @@ async fn run() -> Result<(), ProfileError> {
         n = args.iterations,
     );
 
-    let mut metrics = Vec::new();
-    // Warm-up + submit→Committed (the latter doubles as the PR-2 admission-
-    // persist overhead measurement against the pre-PR-2 baseline).
-    let samples = spikes::measure(args.iterations).await?;
-    push_spikes(
-        &mut metrics,
-        &[
-            ("warmup_to_serving_p50", percentile(&samples.warmup_ms, 50)),
-            (
-                "submit_to_committed_p50",
-                percentile(&samples.submit_ms, 50),
-            ),
-            (
-                "submit_to_committed_p99",
-                percentile(&samples.submit_ms, 99),
-            ),
-        ],
-    );
-
-    // PR-2d-2 — M7a/M7b: the live react chain's settle machinery, model-free at
-    // the coordinator layer (M7b fires the REAL bundled stdio tool; skipped —
-    // empty samples — when the bin is absent).
-    let react = react_spikes::measure(args.iterations).await?;
-    push_spikes(
-        &mut metrics,
-        &[
-            ("react_answer_settle_p50", percentile(&react.answer_ms, 50)),
-            ("react_answer_settle_p99", percentile(&react.answer_ms, 99)),
-        ],
-    );
-    if !react.tool_round_ms.is_empty() {
-        push_spikes(
-            &mut metrics,
-            &[
-                ("react_tool_round_p50", percentile(&react.tool_round_ms, 50)),
-                ("react_tool_round_p99", percentile(&react.tool_round_ms, 99)),
-            ],
-        );
-    }
-
-    // Batch A — the content path: a 1 MiB client upload (the first client
-    // write path) + the full 64-ref × 4 KiB batch read (the N+1 collapse).
-    let content = content_spikes::measure(args.iterations).await?;
-    push_spikes(
-        &mut metrics,
-        &[
-            ("put_content_1mib_p50", percentile(&content.put_1mib_ms, 50)),
-            ("put_content_1mib_p95", percentile(&content.put_1mib_ms, 95)),
-            (
-                "content_batch_64x4k_p50",
-                percentile(&content.batch_64x4k_ms, 50),
-            ),
-            (
-                "content_batch_64x4k_p95",
-                percentile(&content.batch_64x4k_ms, 95),
-            ),
-        ],
-    );
-
-    // Batch B — the inspector path: GetMoteDetail cold (fold + store get +
-    // decode) and warm (the host's def cache).
-    let detail = mote_detail_spikes::measure(args.iterations).await?;
-    push_spikes(
-        &mut metrics,
-        &[
-            ("mote_detail_cold", percentile(&detail.detail_cold_ms, 50)),
-            (
-                "mote_detail_warm_p50",
-                percentile(&detail.detail_warm_ms, 50),
-            ),
-            (
-                "mote_detail_warm_p95",
-                percentile(&detail.detail_warm_ms, 95),
-            ),
-        ],
-    );
+    // Attach mode (`--serve <addr>`): profile a real chat against an EXTERNAL
+    // `kx serve` (whichever engine it runs — Ollama or llama.cpp), the GR10/GR24
+    // dual-engine baseline. Otherwise run the in-process FFI-free spikes.
+    let metrics = if let Some(endpoint) = args.serve.clone() {
+        attach_chat_metrics(&endpoint, &args).await?
+    } else {
+        inproc_metrics(args.iterations).await?
+    };
 
     let report = Report::new(git_sha.clone(), env, metrics);
     let json = report
@@ -148,6 +84,152 @@ async fn run() -> Result<(), ProfileError> {
     Ok(())
 }
 
+/// The in-process FFI-free spikes (warm-up + submit→Committed, react settle,
+/// content path, inspector path). The default profile when `--serve` is absent.
+async fn inproc_metrics(iterations: usize) -> Result<Vec<Metric>, ProfileError> {
+    let mut metrics = Vec::new();
+    // Warm-up + submit→Committed (the latter doubles as the PR-2 admission-
+    // persist overhead measurement against the pre-PR-2 baseline).
+    let samples = spikes::measure(iterations).await?;
+    push_spikes(
+        &mut metrics,
+        &[
+            ("warmup_to_serving_p50", percentile(&samples.warmup_ms, 50)),
+            (
+                "submit_to_committed_p50",
+                percentile(&samples.submit_ms, 50),
+            ),
+            (
+                "submit_to_committed_p99",
+                percentile(&samples.submit_ms, 99),
+            ),
+        ],
+    );
+
+    // PR-2d-2 — M7a/M7b: the live react chain's settle machinery, model-free at
+    // the coordinator layer (M7b fires the REAL bundled stdio tool; skipped —
+    // empty samples — when the bin is absent).
+    let react = react_spikes::measure(iterations).await?;
+    push_spikes(
+        &mut metrics,
+        &[
+            ("react_answer_settle_p50", percentile(&react.answer_ms, 50)),
+            ("react_answer_settle_p99", percentile(&react.answer_ms, 99)),
+        ],
+    );
+    if !react.tool_round_ms.is_empty() {
+        push_spikes(
+            &mut metrics,
+            &[
+                ("react_tool_round_p50", percentile(&react.tool_round_ms, 50)),
+                ("react_tool_round_p99", percentile(&react.tool_round_ms, 99)),
+            ],
+        );
+    }
+
+    // Batch A — the content path: a 1 MiB client upload (the first client
+    // write path) + the full 64-ref × 4 KiB batch read (the N+1 collapse).
+    let content = content_spikes::measure(iterations).await?;
+    push_spikes(
+        &mut metrics,
+        &[
+            ("put_content_1mib_p50", percentile(&content.put_1mib_ms, 50)),
+            ("put_content_1mib_p95", percentile(&content.put_1mib_ms, 95)),
+            (
+                "content_batch_64x4k_p50",
+                percentile(&content.batch_64x4k_ms, 50),
+            ),
+            (
+                "content_batch_64x4k_p95",
+                percentile(&content.batch_64x4k_ms, 95),
+            ),
+        ],
+    );
+
+    // Batch B — the inspector path: GetMoteDetail cold (fold + store get +
+    // decode) and warm (the host's def cache).
+    let detail = mote_detail_spikes::measure(iterations).await?;
+    push_spikes(
+        &mut metrics,
+        &[
+            ("mote_detail_cold", percentile(&detail.detail_cold_ms, 50)),
+            (
+                "mote_detail_warm_p50",
+                percentile(&detail.detail_warm_ms, 50),
+            ),
+            (
+                "mote_detail_warm_p95",
+                percentile(&detail.detail_warm_ms, 95),
+            ),
+        ],
+    );
+    Ok(metrics)
+}
+
+/// Profile a real chat against an EXTERNAL `kx serve` at `endpoint` (GR10 + GR24
+/// dual-engine baseline). Each metric id is prefixed with the engine that answered
+/// (`chat__kx-ollama__…` / `chat__kx-llamacpp__…`) so an Ollama capture and a
+/// llama.cpp capture never collide in the private trend record.
+async fn attach_chat_metrics(endpoint: &str, args: &Args) -> Result<Vec<Metric>, ProfileError> {
+    let channel = chat_spikes::connect(endpoint).await?;
+    let token = match (&args.token, &args.token_file) {
+        (Some(t), _) => Some(t.clone()),
+        (None, Some(path)) => Some(read_token_file(path)?),
+        (None, None) => None,
+    };
+    let opts = ChatOpts {
+        iterations: args.iterations,
+        prompt: args
+            .prompt
+            .clone()
+            .unwrap_or_else(|| chat_spikes::DEFAULT_PROMPT.to_string()),
+        model: args.model.clone(),
+        token,
+    };
+    let chat = chat_spikes::measure(&channel, &opts).await?;
+    eprintln!(
+        "kx-profile: chat baseline | engine={engine} | model={model} | ctx={ctx} | \
+         {n} timed iter(s){ttft}",
+        engine = chat.engine,
+        model = chat.model_id,
+        ctx = chat.context_len,
+        n = chat.total_ms.len(),
+        ttft = if chat.ttft_ms.is_empty() {
+            " | ttft: unavailable (no token stream)"
+        } else {
+            ""
+        },
+    );
+    let p = |m: &str| format!("chat__{}__{m}", chat.engine);
+    let mut metrics = Vec::new();
+    push_spikes(
+        &mut metrics,
+        &[
+            (p("warmup_first_ms").as_str(), chat.warmup_first_ms),
+            (p("total_p50").as_str(), percentile(&chat.total_ms, 50)),
+            (p("total_p95").as_str(), percentile(&chat.total_ms, 95)),
+            (p("total_p99").as_str(), percentile(&chat.total_ms, 99)),
+        ],
+    );
+    if !chat.ttft_ms.is_empty() {
+        push_spikes(
+            &mut metrics,
+            &[
+                (p("ttft_p50").as_str(), percentile(&chat.ttft_ms, 50)),
+                (p("ttft_p99").as_str(), percentile(&chat.ttft_ms, 99)),
+            ],
+        );
+    }
+    Ok(metrics)
+}
+
+/// Read a bearer token from a file (trimmed of surrounding whitespace).
+fn read_token_file(path: &str) -> Result<String, ProfileError> {
+    std::fs::read_to_string(path)
+        .map(|s| s.trim().to_string())
+        .map_err(|e| ProfileError::Client(format!("read token file {path}: {e}")))
+}
+
 /// Push a batch of millisecond spike metrics (one `Metric::spike` per pair).
 fn push_spikes(metrics: &mut Vec<Metric>, spikes: &[(&str, f64)]) {
     for (id, value) in spikes {
@@ -159,12 +241,28 @@ fn push_spikes(metrics: &mut Vec<Metric>, spikes: &[(&str, f64)]) {
 struct Args {
     iterations: usize,
     out: Option<PathBuf>,
+    /// `--serve <addr>`: profile a real chat against an EXTERNAL `kx serve` (attach
+    /// mode). Absent ⇒ run the in-process FFI-free spikes.
+    serve: Option<String>,
+    /// `--prompt <text>`: the chat prompt in attach mode (default in `chat_spikes`).
+    prompt: Option<String>,
+    /// `--model <id>`: chat a specific served model (default = the primary).
+    model: Option<String>,
+    /// `--token <bearer>`: auth metadata for a non-dev serve.
+    token: Option<String>,
+    /// `--token-file <path>`: read the bearer token from a file.
+    token_file: Option<String>,
 }
 
 impl Args {
     fn parse(mut argv: impl Iterator<Item = String>) -> Self {
         let mut iterations = 8usize;
         let mut out = None;
+        let mut serve = None;
+        let mut prompt = None;
+        let mut model = None;
+        let mut token = None;
+        let mut token_file = None;
         while let Some(flag) = argv.next() {
             match flag.as_str() {
                 "--iterations" | "-n" => {
@@ -179,12 +277,38 @@ impl Args {
                 "--out" | "-o" => {
                     out = argv.next().map(PathBuf::from);
                 }
+                "--serve" => {
+                    serve = argv.next();
+                }
+                "--prompt" => {
+                    prompt = argv.next();
+                }
+                "--model" => {
+                    model = argv.next();
+                }
+                "--token" => {
+                    token = argv.next();
+                }
+                "--token-file" => {
+                    token_file = argv.next();
+                }
+                // The attach subverb marker; the only mode today (presence of
+                // `--serve` selects attach), accepted so it is not flagged.
+                "chat" => {}
                 other => {
                     eprintln!("kx-profile: ignoring unrecognized argument {other:?}");
                 }
             }
         }
-        Self { iterations, out }
+        Self {
+            iterations,
+            out,
+            serve,
+            prompt,
+            model,
+            token,
+            token_file,
+        }
     }
 }
 

--- a/docs/site/docs/local-inference-engines.md
+++ b/docs/site/docs/local-inference-engines.md
@@ -16,11 +16,48 @@ description: Serve local models with zero friction via Ollama, or the self-conta
 | **Ollama** (recommended) | a precompiled installer; no C++ toolchain | zero-friction onboarding, GPU on every platform |
 | **llama.cpp** (`--features inference`) | builds from source (CMake + clang) | a single self-contained binary, no background daemon |
 
+The **prebuilt binary** (`curl | install.sh`) ships the serve engine, so it
+**auto-detects a running Ollama daemon and serves local models out of the box** —
+no build, no C++ toolchain. llama.cpp is the opt-in `--features inference` build.
+
 Whichever engine serves a model is shown everywhere: `kx models list` prints an
 engine badge (`[text · ollama]`), the SDKs expose `ModelSummary.engine`, and the
 **Models** view shows an engine badge per card. The engine is a display/audit field
 only — it never authorizes a route (SN-8), and it is **never journaled**, so the
 canonical projection digest is unaffected by which engine answered.
+
+## Which engine? (positioning)
+
+The two engines are **co-equal first-class backends** — pick by what you need, and
+switch (or run both) at any time:
+
+- **Ollama — the quick/easy path for agent users.** Zero-friction onboarding (no C++
+  toolchain), auto-detected on the loopback port, `ollama pull` model management. The
+  default recommendation for *"just run an agent now."*
+- **llama.cpp — the performance / parallel / multi-modal path.** A self-contained
+  single binary with in-process control (KV-cache capacity, batched serving, vision
+  via an mmproj projector). The recommendation when you need throughput, parallelism,
+  or multi-modal input.
+
+### Capability parity
+
+Every core capability rides the shared `InferenceBackend` seam, so it behaves the
+same on either engine. Where a capability is engine-specific today, it is an honest
+gap (a visible "unavailable on this engine"), never a silent one:
+
+| Capability | Ollama | llama.cpp |
+|---|---|---|
+| Chat + agentic ReAct / tool loop | ✅ | ✅ |
+| Model lifecycle (load / offload / residency) | ✅ | ✅ |
+| Streaming tokens | ✅ | ✅ |
+| Context window surfaced (`kx models list` `ctx=`) | ✅ (`/api/show`) | ✅ (GGUF `n_ctx`) |
+| Tool-call parsing (multi-format) | ✅ | ✅ |
+| Embeddings / RAG (Datasets) | ⏳ planned | ✅ |
+| Vision / multi-modal input | ⏳ planned | ✅ (mmproj) |
+| Constrained decode (grammar) | reserved | reserved |
+
+⏳ *planned* capabilities land in a follow-up release; until then the gateway
+honest-degrades (e.g. a vision turn on an Ollama-only serve is refused, not faked).
 
 ## Option A — Ollama (zero-friction)
 
@@ -39,8 +76,13 @@ for you.
 
 ```sh
 kx models list
-# gemma3:12b  [text · ollama]  ctx=0  gemma3:12b  (serving)
+# gemma3:12b  [text · ollama]  ctx=131072  gemma3:12b  (serving)
 ```
+
+The `ctx=` window is read from the daemon's `/api/show` (the model's declared
+context length) — the same kind of number the llama.cpp path reads from the GGUF.
+It is best-effort: if the daemon doesn't report one, `ctx=0` is shown rather than a
+fabricated value.
 
 ### Configuration (operator-only, SN-8)
 

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ check: fmt-check clippy test
 # Exact mirror of the CI workflow's gates (in dependency order). Runs every
 # job .github/workflows/ci.yml runs in parallel, here sequentially. Modify
 # this recipe in lock-step with ci.yml.
-ci: fmt-check clippy test deny doc ffi-link build-no-inference features-guard check-reproducible scale-smoke
+ci: fmt-check clippy test deny doc ffi-link build-no-inference build-serve-engine features-guard check-reproducible scale-smoke
 
 # Verify code is formatted per rustfmt.toml. Fails on any drift.
 fmt-check:
@@ -513,6 +513,36 @@ build-no-inference:
     cargo build -p kx-cli
     cargo build -p kx-inference --no-default-features
     echo " ✓ build-no-inference: PASS"
+
+# PR-A.1 / GR24 (dual-engine parity): prove the prebuilt release feature set
+# (`console,hnsw,serve-engine`) serves local models via Ollama with NO C++
+# toolchain. Asserts the EXACT shipped graph pulls no llama.cpp FFI, then compiles
+# the FFI-relevant serve loop (`serve-engine,hnsw`). `console` is skipped in the
+# build (it needs a node `ui/dist`, built by the `ui` job) but IS covered by the
+# cargo-tree scan. CI runs this on a runner WITHOUT a C++ toolchain or submodule,
+# so a regression that leaks the FFI into the serve-engine closure fails loudly.
+# The `inference-checks` serve-engine step runs WITH the toolchain; this is the
+# clean-room FFI-FREE complement.
+build-serve-engine:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Asserting kx-cli --features console,hnsw,serve-engine stays FFI-free (the prebuilt artifact)..."
+    if cargo tree -p kx-cli --features console,hnsw,serve-engine -e normal | grep -qE 'kx-llamacpp'; then
+        echo " ✗ FAIL: console,hnsw,serve-engine dragged the FFI into kx-cli"
+        cargo tree -p kx-cli --features console,hnsw,serve-engine -e normal | grep -E 'kx-llamacpp' || true
+        exit 1
+    fi
+    echo " ✓ no kx-llamacpp in the prebuilt (console,hnsw,serve-engine) closure"
+    echo "Asserting kx-gateway --features serve-engine,hnsw stays FFI-free..."
+    if cargo tree -p kx-gateway --features serve-engine,hnsw -e normal | grep -qE 'kx-llamacpp'; then
+        echo " ✗ FAIL: serve-engine,hnsw dragged the FFI into kx-gateway"
+        cargo tree -p kx-gateway --features serve-engine,hnsw -e normal | grep -E 'kx-llamacpp' || true
+        exit 1
+    fi
+    echo " ✓ no kx-llamacpp in the kx-gateway serve-engine,hnsw closure"
+    cargo build -p kx-cli --features serve-engine,hnsw
+    cargo build -p kx-gateway --features serve-engine,hnsw
+    echo " ✓ build-serve-engine: PASS"
 
 # The installed-binary feature matrix stays buildable (the v0.1.0 campaign
 # guard): `cargo install -p kx-cli --features hnsw` (Datasets, FFI-free) and


### PR DESCRIPTION
## What & why

Closes the four PR-A (#255) follow-ups under **GR24 (dual-engine parity)**, so a user can run an agent *immediately* on whichever local engine they have, and the FFI-free guarantee is machine-proven:

1. **Prebuilt release flip** — the prebuilt `kx` now ships `console,hnsw,serve-engine`, so a toolchain-free `curl | install.sh` install **auto-detects a running Ollama daemon and serves local models out of the box**. llama.cpp stays the opt-in `--features inference` build. The release FFI wall now asserts the new feature set stays llama.cpp-free.
2. **Required FFI-free `build-serve-engine` CI gate** — a clean-room job (no submodules, no C++ toolchain, mirroring `build-no-inference`) that asserts via `cargo tree` that `console,hnsw,serve-engine` pulls no `kx-llamacpp` and compiles the serve loop toolchain-free. Plus a local `just build-serve-engine` recipe wired into `just ci` (GR23 close-the-gap). The existing `inference-checks` serve-engine step runs *with* the toolchain; this is the clean-room complement. **Promote to a required branch-protection check once green** (mirrors `ui` / `sdk-*` / `scale-smoke`).
3. **Dual-engine docs matrix** — positioning (Ollama = quick/easy agents; llama.cpp = performance / parallel / multi-modal) + a capability-parity table on `local-inference-engines.md`; README Tier matrix + prebuilt note refreshed.
4. **GR10 chat baseline harness** — a new `kx-profile --serve <addr> chat` attach mode: an FFI-free gRPC client that times a real chat against an external `kx serve` (either engine), self-labeling the engine in the metric id. The reusable harness for the Ollama-vs-llama.cpp baseline (numbers live in the private trend record, SN-2).

**Bundled small items** (tightly coupled): the local `just` gate, the dep_wall pins, the README refresh, and **Ollama `/api/show` context-window surfacing** — `kx models list` now shows a real `ctx=` for Ollama models instead of `0`, closing a Models-badge parity gap. Populate-only: no proto/schema change.

## Invariants (proven)

- **Projection digest `7d22d4bd` INVARIANT** — verify-quickstart clean run + crash-replay + fresh fold all produce the canonical digest. No proto / journal / checkpoint change; `engine`/`ctx` are display/audit-only and never journaled.
- **Frozen trio (executor/scheduler/dispatcher.rs) + kx-coordinator diff EMPTY.** No `InferenceBackend`/`EmbeddingBackend` trait change (the Ollama ctx accessor is a new method on the concrete backend).
- **`Cargo.lock` unchanged, no new dependency, no `deny.toml` change.**

## Risk analysis (GR8)

- **Better:** usable-immediately from a prebuilt on either engine; the FFI-free guarantee is now gated; dual-engine positioning is documented; Ollama Models view reaches ctx parity.
- **Perf:** +N best-effort `/api/show` calls at serve startup (≤2s each, never blocks — honest-degrades to `ctx=0`). No hot-path cost. The profiler is non-gating (model-gated).
- **Security (SN-8):** Ollama URL stays operator-env config, loopback default; `/api/show` rides the same loopback/allow-remote gate; tags are daemon-sourced, never client/Mote-controlled. No new untrusted-input or egress surface.
- **Fwd/back-compat:** the prebuilt is a functional superset; old/new binaries read identical journals; no migration.

## Test plan

- `just ci` **green** (now incl. the new `build-serve-engine` gate), plus: `cargo test -p kx-ollama` (new `/api/show` ctx tests incl. honest-degrade-to-0), `cargo test -p kx-profile` (attach-spike deterministic no-served-model error), serve-engine **and** inference lane clippy + lib tests, dep_wall (both crates), workspace clippy + test, doc `-D warnings`, biome + tsc (no UI/SDK code changed).
- **Live dual-engine validation (GR15, Gemma only; serve restarted between engines):** Ollama `gemma3:12b` → real non-echo answer, `[text · ollama]` badge, **`ctx=131072`** (was `0`); llama.cpp `Gemma-4-12B GGUF` → real non-echo answer, `[text · llamacpp]` badge, `ctx=8192` (clamped GGUF n_ctx — the intended dual-engine distinction). A chat latency baseline (total p50/p95/p99 + TTFT + warm-up) was captured for each via the new attach-mode profiler and persisted to the private benchmark record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)