### PR TITLE
AGENTIC-VISION live-fix — BUG-34 (react-vision chain-salt) + BUG-35 (image carry) + guard tests

### DIFF
--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -2002,6 +2002,13 @@ fn submit_and_capture<J: Journal>(
     // never crash-recover (the durability law).
     let mut react_caps: Option<(u32, u32)> = None;
     let mut react_chain_salt: Option<[u8; 32]> = None;
+    // BUG-35 (+ PR-9d context sibling): the ORIGINAL seed's ANCHOR-BOUND config (the
+    // grounding image + grounding-context bundle), captured BEFORE the swap discards the
+    // seed (the swapped turn-0 carries only the clean instruction). Both keys are dropped
+    // by `build_chain_turn` and re-derived by every successor turn from the anchor, so both
+    // MUST be re-injected onto the anchor clone — enumerated in ONE place (`seed_anchor_cfg`)
+    // so a future anchor-bound key can never be silently half-carried again.
+    let mut react_anchor_cfg: Vec<(ConfigKey, kx_mote::ConfigVal)> = Vec::new();
     let mote = if react_seed {
         if store.is_none() {
             return Err(CoordinatorError::ReactSeedRefused(
@@ -2014,6 +2021,10 @@ fn submit_and_capture<J: Journal>(
         // the clean instruction; the caps go to the durable anchor.
         let (instruction, caps) = react_seed_params(&mote)?;
         react_caps = Some(caps);
+        // BUG-35 (+ context sibling): capture the seed's anchor-bound config HERE (`mote`
+        // is still the original seed) so the anchor records it — `build_chain_turn` below
+        // rebuilds turn-0 from the instruction ONLY, dropping the image AND context bundle.
+        react_anchor_cfg = seed_anchor_cfg(&mote);
         // PR-R1 — per-invocation run identity (FINDING-REACT-SHARED-INSTANCE). `kx
         // serve` shares ONE journal / `instance_id` across every Invoke, so a run-
         // level react chain salted by `instance_id` alone collides at turn-0 and the
@@ -2043,7 +2054,14 @@ fn submit_and_capture<J: Journal>(
     // so a re-submitted-but-already-committed shaper (recovery: the in-memory dispatch.defs
     // + materialized children are gone on restart, but the journal still has the committed
     // shaper fact) can re-materialize its children below.
-    let turn0_for_anchor = react_seed.then(|| mote.clone());
+    // BUG-35 (+ context sibling): carry the original seed's anchor-bound config (image +
+    // context bundle) onto the anchor-clone so `write_react_anchor` records both on the
+    // turn-0 ReactRound. Every turn (incl. turn 0 — the DISPATCHED swapped mote has neither
+    // inline) then re-derives them EDGE-FREE from the anchor via the carried `ContextSink`
+    // path. Without this the loop runs BLIND (the model never sees the image / grounding
+    // context). A config-only mutation ⇒ the clone's `id` is unchanged (it stays the
+    // dispatched turn-0's anchor id).
+    let turn0_for_anchor = react_seed.then(|| react_anchor_clone(&mote, &react_anchor_cfg));
     let shaper_def = mote.def.is_topology_shaper.then(|| mote.def.clone());
     let shaper_mote_id = mote.id;
     let shaper_warrant = warrant.clone();
@@ -2585,6 +2603,43 @@ fn react_seed_params(seed: &Mote) -> Result<(String, (u32, u32)), CoordinatorErr
         ));
     }
     Ok((instruction, (max_turns, max_tool_calls)))
+}
+
+/// The react seed's ANCHOR-BOUND config keys — the grounding image ([`IMAGE_REF_KEY`],
+/// AGENTIC-VISION) and the grounding-context bundle ([`CONTEXT_ITEMS_KEY`], PR-9d). BOTH
+/// are dropped by the seed-swap (`build_chain_turn` rebuilds turn 0 from the instruction
+/// alone) yet are re-derived by every successor turn from the turn-0 anchor — so both MUST
+/// ride the anchor clone. Enumerated in ONE place so a future anchor-bound key cannot be
+/// silently half-carried again (the BUG-35 class).
+const REACT_ANCHOR_BOUND_KEYS: [&str; 2] = [IMAGE_REF_KEY, CONTEXT_ITEMS_KEY];
+
+/// BUG-35 (+ PR-9d context sibling): the ORIGINAL seed's anchor-bound config (image +
+/// context bundle), captured from the seed BEFORE the seed-swap discards it (the swapped
+/// turn 0 is rebuilt from the instruction alone). Empty for a plain text-only react seed.
+fn seed_anchor_cfg(seed: &Mote) -> Vec<(ConfigKey, kx_mote::ConfigVal)> {
+    REACT_ANCHOR_BOUND_KEYS
+        .iter()
+        .filter_map(|k| {
+            let key = ConfigKey((*k).to_string());
+            seed.def.config_subset.get(&key).map(|v| (key, v.clone()))
+        })
+        .collect()
+}
+
+/// BUG-35 (+ context sibling): build the turn-0 anchor clone for a react seed — the
+/// DISPATCHED swapped mote PLUS the ORIGINAL seed's anchor-bound config (image + context
+/// bundle) re-injected. The seed-swap rebuilds turn 0 from the instruction alone (dropping
+/// both inline keys), so the coordinator captures them BEFORE the swap and re-attaches them
+/// here, on the clone `write_react_anchor` records — every successor turn then re-derives
+/// them EDGE-FREE from that anchor. A config-only mutation ⇒ the clone's `id` is unchanged
+/// (it stays the dispatched turn-0's anchor id). Empty `anchor_cfg` ⇒ a plain clone
+/// (byte-identical to the pre-AGENTIC-VISION / pre-PR-9d text path).
+fn react_anchor_clone(dispatched: &Mote, anchor_cfg: &[(ConfigKey, kx_mote::ConfigVal)]) -> Mote {
+    let mut m = dispatched.clone();
+    for (key, val) in anchor_cfg {
+        m.def.config_subset.insert(key.clone(), val.clone());
+    }
+    m
 }
 
 /// Write the run's turn-0 ReAct ANCHOR (PR-2d-1): content-store the run-fixed base

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -27,8 +27,8 @@ use kx_coordinator::{CoordinatorService, InMemoryWorkerRegistry, MoteState, Work
 use kx_journal::{Journal, JournalEntry, ReactBranch, SqliteJournal};
 use kx_mote::{
     ConfigKey, ConfigVal, EdgeMeta, EffectPattern, GraphPosition, InputDataId, LogicRef, ModelId,
-    Mote, MoteDef, NdClass, ParentRef, PromptTemplateHash, MOTE_DEF_SCHEMA_VERSION, PROMPT_KEY,
-    REACT_TURN_KEY,
+    Mote, MoteDef, NdClass, ParentRef, PromptTemplateHash, CONTEXT_ITEMS_KEY, IMAGE_REF_KEY,
+    MOTE_DEF_SCHEMA_VERSION, PROMPT_KEY, REACT_TURN_KEY,
 };
 use kx_warrant::{
     warrant_ref_of, ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling,
@@ -95,6 +95,44 @@ fn seed_mote_with(instruction: &str) -> Mote {
         inference_params: kx_mote::InferenceParams::default(),
         schema_version: MOTE_DEF_SCHEMA_VERSION,
     };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([7u8; 32]),
+        GraphPosition(vec![7u8]),
+        SmallVec::new(),
+    )
+}
+
+/// AGENTIC-VISION: a SEED Mote carrying `instruction` PLUS an inline grounding image
+/// under `IMAGE_REF_KEY` — the react-vision launch shape (the recipe binder binds the
+/// client's uploaded image ref here). Stored raw-hex (`ContentRef::from_arg` accepts it,
+/// agreeing with the binder's JSON-string form by construction). The image folds into
+/// the seed's def hash, so its MoteId (hence the PR-R1 chain salt) differs from the
+/// text-only seed — a distinct goal ⇒ a distinct chain.
+fn seed_mote_with_image(instruction: &str, image: &ContentRef) -> Mote {
+    let mut def = seed_mote_with(instruction).def;
+    def.config_subset.insert(
+        ConfigKey(IMAGE_REF_KEY.to_string()),
+        ConfigVal(image.to_hex().into_bytes()),
+    );
+    Mote::new(
+        def,
+        InputDataId::from_bytes([7u8; 32]),
+        GraphPosition(vec![7u8]),
+        SmallVec::new(),
+    )
+}
+
+/// PR-9d / BUG-35 context sibling: a SEED Mote carrying `instruction` PLUS an inline
+/// grounding-context bundle under `CONTEXT_ITEMS_KEY` — the RAG/context-in-react launch
+/// shape (the `bind` `inject_entry_config` precedent). The bundle BYTES (not a ref) ride
+/// the seed; `write_react_anchor` stages them into the content store and records the ref.
+fn seed_mote_with_context(instruction: &str, bundle: &[u8]) -> Mote {
+    let mut def = seed_mote_with(instruction).def;
+    def.config_subset.insert(
+        ConfigKey(CONTEXT_ITEMS_KEY.to_string()),
+        ConfigVal(bundle.to_vec()),
+    );
     Mote::new(
         def,
         InputDataId::from_bytes([7u8; 32]),
@@ -405,6 +443,103 @@ async fn react_seed_swaps_in_a_salted_turn0_and_anchors() {
             .map(|v| v.0.clone()),
         Some(INSTRUCTION.as_bytes().to_vec())
     );
+}
+
+/// AGENTIC-VISION regression guard (BUG-35, caught by the live dual-engine Gemma pass).
+/// A react seed carrying an inline grounding image (`config_subset[IMAGE_REF_KEY]` — a
+/// react-vision launch) MUST record that image on the turn-0 anchor. The seed-swap
+/// DISCARDS the seed (the swapped turn 0 is rebuilt from the instruction alone), so the
+/// coordinator must capture the image BEFORE the swap and re-inject it onto the anchor —
+/// every successor turn then re-derives the image EDGE-FREE from this anchor. The bug:
+/// the anchor-clone was taken from the POST-swap mote (no image) ⇒ the agentic-vision
+/// loop ran BLIND (the model never saw the image; it answered "please provide the image").
+#[tokio::test]
+async fn react_vision_seed_records_the_grounding_image_on_the_anchor() {
+    let dir = TempDir::new().unwrap();
+    let (svc, _store) = coordinator(&dir);
+    let w = warrant(false);
+    // The image ref the client `PutContent`'d, carried inline on the react-vision seed.
+    let image = ContentRef::from_bytes([0xab; 32]);
+    let seed = seed_mote_with_image(INSTRUCTION, &image);
+
+    let (turn0_id, instance_id) = submit_react(&svc, &seed, &w).await;
+
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(facts.len(), 1, "exactly the turn-0 anchor");
+    match &facts[0] {
+        JournalEntry::ReactRound {
+            turn,
+            turn_mote_id,
+            instance_id: fact_instance,
+            image_ref,
+            ..
+        } => {
+            assert_eq!(*turn, 0);
+            assert_eq!(turn_mote_id.as_bytes().to_vec(), turn0_id);
+            assert_eq!(fact_instance.to_vec(), instance_id);
+            assert_eq!(
+                *image_ref,
+                Some(image),
+                "BUG-35: the seed's grounding image MUST survive the seed-swap onto the \
+                 turn-0 anchor (else every successor turn re-derives None and the loop runs blind)"
+            );
+        }
+        other => panic!("expected a ReactRound anchor, got {other:?}"),
+    }
+}
+
+/// AGENTIC-VISION regression guard (BUG-35 CONTEXT SIBLING — caught by the pre-merge audit).
+/// The SAME seed-swap that dropped the image ALSO drops `CONTEXT_ITEMS_KEY` (PR-9d's
+/// RAG/context-in-react grounding bundle): `build_chain_turn` rebuilds turn-0 from the
+/// instruction alone, so a react seed launched WITH a context bundle must have that bundle
+/// captured before the swap and re-injected onto the anchor — else `write_react_anchor`
+/// records `context_items_ref=None` and every successor turn re-derives None ⇒ the chain
+/// runs blind (RAG-in-react ungrounded). PR-9d's intent ("close the grounding-context drop
+/// where build_react_turn omits CONTEXT_ITEMS_KEY") was never realized on the submit path —
+/// `turn0_for_anchor` was the POST-swap clone since PR-2d-1; the image fix made it symmetric.
+#[tokio::test]
+async fn react_seed_with_context_bundle_records_context_items_on_the_anchor() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(false);
+    let bundle = b"ctx-bundle-payload-for-grounding".to_vec();
+    let seed = seed_mote_with_context(INSTRUCTION, &bundle);
+
+    let _ = submit_react(&svc, &seed, &w).await;
+
+    let facts = react_facts(&svc, &dir).await;
+    assert_eq!(facts.len(), 1, "exactly the turn-0 anchor");
+    match &facts[0] {
+        JournalEntry::ReactRound {
+            context_items_ref, ..
+        } => {
+            assert_eq!(
+                *context_items_ref,
+                Some(store.put(&bundle).unwrap()),
+                "BUG-35 context sibling: the seed's grounding-context bundle MUST survive the \
+                 seed-swap onto the turn-0 anchor (else RAG-in-react runs blind)"
+            );
+        }
+        other => panic!("expected a ReactRound anchor, got {other:?}"),
+    }
+}
+
+/// The text control for the guard above: a PLAIN react seed (no `IMAGE_REF_KEY`)
+/// anchors with `image_ref == None`, proving the carry is conditional on an attached
+/// image, not a blanket default — byte-identical to pre-AGENTIC-VISION for the text path.
+#[tokio::test]
+async fn plain_react_seed_anchors_without_an_image() {
+    let dir = TempDir::new().unwrap();
+    let (svc, _store) = coordinator(&dir);
+    let w = warrant(false);
+    let _ = submit_react(&svc, &seed_mote(), &w).await;
+    let facts = react_facts(&svc, &dir).await;
+    match &facts[0] {
+        JournalEntry::ReactRound { image_ref, .. } => {
+            assert_eq!(*image_ref, None, "a text react chain anchors with no image");
+        }
+        other => panic!("expected a ReactRound anchor, got {other:?}"),
+    }
 }
 
 /// `react_seed = false` keeps today's behavior byte-identical: the admitted

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -1842,12 +1842,17 @@ impl RecipeBinder for HostRecipeBinder {
             // PR-6a/D155: react-fs is ALSO a live ReAct chain (same machinery,
             // fs-list grant) ⇒ it MUST set react_seed too, else the loop never runs.
             // PR-6b-4: react-auto is the same machinery (union tool grant).
+            // AGENTIC-VISION: react-vision is the SAME live ReAct chain (react warrant +
+            // an image_ref) ⇒ it MUST set react_seed too, else the loop never runs as a
+            // chain AND the empty react_chain_salt makes the client retrieve the wrong
+            // chain on serve's shared journal (BUG-34, caught by the live dual-engine pass).
             // (D155 Phase-3 `react-edit` is a SINGLE model step, NOT a react chain
             // — it is deliberately absent here; it settles on its terminal mote.)
             react_seed: [
                 REACT_RECIPE_HANDLE,
                 REACT_FS_RECIPE_HANDLE,
                 REACT_AUTO_RECIPE_HANDLE,
+                REACT_VISION_RECIPE_HANDLE,
             ]
             .iter()
             .any(|h| parse_handle(h).is_some_and(|p| p == asset_path)),
@@ -4981,6 +4986,79 @@ mod tests {
         let image = field(IMAGE_REF_KEY);
         assert_eq!(image.kind, RecipeParamKind::Bytes);
         assert_eq!(image.max_len, Some(64), "a 32-byte ref as 64 hex chars");
+    }
+
+    /// AGENTIC-VISION regression guard (BUG-34, caught by the live dual-engine Gemma pass).
+    /// Binding `react-vision` MUST set `react_seed = true` — it is a live ReAct chain (the
+    /// same machinery as plain `react`, just with an attached image). The bug: react-vision
+    /// was MISSING from the binder's `react_seed` handle list, so it bound with
+    /// `react_seed = false` ⇒ the coordinator never seed-swapped it ⇒ the empty
+    /// `react_chain_salt` made the CLI retrieve the WRONG (prior) chain on serve's SHARED
+    /// journal (a different goal's answer came back). The guard also pins that the bound
+    /// seed carries the image inline under `IMAGE_REF_KEY` (the coordinator's BUG-35 input).
+    #[tokio::test]
+    async fn react_vision_binds_with_react_seed_true_and_carries_the_image() {
+        let echo = (ToolName("mcp-echo".into()), ToolVersion("1".into()));
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open_complete(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &["alice@acme".to_string()],
+            Some(&ModelId("kx-serve:vlm".to_string())),
+            Some(&echo),
+            true, // vision ⇒ react-vision IS provisioned
+            None,
+            false,
+        )
+        .unwrap();
+        let binder = HostRecipeBinder::new(lib);
+
+        // react-vision: instruction + the two caps + a 64-hex image ref (the four-field form).
+        let img = "ab".repeat(32);
+        let vision_args = format!(
+            r#"{{"instruction":"inspect the image","max_turns":4,"max_tool_calls":2,"image_ref":"{img}"}}"#
+        );
+        let vision = binder
+            .bind(
+                "alice@acme",
+                REACT_VISION_RECIPE_HANDLE,
+                vision_args.as_bytes(),
+                &[],
+                &[],
+            )
+            .await
+            .expect("react-vision binds for a granted party");
+        assert!(
+            vision.react_seed,
+            "BUG-34: react-vision is a live ReAct chain — it MUST seed (else empty \
+             chain_salt → wrong-chain retrieval on serve's shared journal)"
+        );
+        assert!(
+            vision
+                .motes
+                .first()
+                .unwrap()
+                .0
+                .def
+                .config_subset
+                .contains_key(&ConfigKey(IMAGE_REF_KEY.to_string())),
+            "the bound react-vision seed carries the image ref inline (the anchor's input)"
+        );
+
+        // The plain-react control: the SAME machinery also seeds (the pre-existing
+        // invariant the missing-list-entry bug did NOT break — proving the gap was
+        // react-vision-specific, a new variant absent from the seed list).
+        let react = binder
+            .bind(
+                "alice@acme",
+                REACT_RECIPE_HANDLE,
+                br#"{"instruction":"do the thing","max_turns":4,"max_tool_calls":2}"#,
+                &[],
+                &[],
+            )
+            .await
+            .expect("react binds for a granted party");
+        assert!(react.react_seed, "plain react seeds a ReAct chain");
     }
 
     #[test]


### PR DESCRIPTION
## What

The owed **live dual-engine Gemma-4 parity pass** for AGENTIC-VISION (#260) — run on a clean Gemma-only slate across **Ollama ∥ llama.cpp** — found the feature **broken end-to-end**. A subsequent **adversarial pre-merge audit** then caught a sibling bug in the fix itself. All fixed + guard-tested here (pure fix; the AGENTIC-VISION + PR-9d schemas are already merged).

### BUG-34 — react-vision bound with `react_seed = false` (kx-gateway/provision.rs)
The binder's `react_seed` handle list was missing `REACT_VISION_RECIPE_HANDLE`. The coordinator never seed-swapped a react-vision launch ⇒ the empty `react_chain_salt` made the CLI retrieve the **wrong (prior) chain** on serve's shared journal — a *different goal's* answer came back.
**Class:** a new react variant must be registered at ALL sites (SDK prefix · recipe seed · recipe_card · lib re-export · **the gateway bind `react_seed` list** — the one missed).

### BUG-35 — the loop ran **blind** on BOTH anchor-bound keys (kx-coordinator/state.rs)
The seed-swap rebuilds turn-0 from the instruction alone (`build_chain_turn`), dropping the seed's inline anchor-bound config. The turn-0 anchor clone was taken from the **post-swap** mote, so `write_react_anchor` recorded `None` for:
- `IMAGE_REF_KEY` — AGENTIC-VISION's grounding image (the live-found bug → "please provide the image"), and
- `CONTEXT_ITEMS_KEY` — **PR-9d's RAG/context-in-react grounding bundle** (the pre-merge-audit-found sibling: a **latent PR-9d regression** — its intent "close the grounding-context drop where build_react_turn omits CONTEXT_ITEMS_KEY" was never realized on the submit path; `turn0_for_anchor` has been the post-swap clone since PR-2d-1).

**Class-complete fix:** capture the seed's anchor-bound config **before** the swap and re-inject onto the anchor clone, with the anchor-bound keys enumerated in **one place** (`REACT_ANCHOR_BOUND_KEYS` + `seed_anchor_cfg` + `react_anchor_clone`) so a future key can never be silently half-carried again (GR5.2: make the omission unrepresentable).

## Guard tests (each verified to BITE — fails with its fix / the key reverted)
- `kx-gateway` `react_vision_binds_with_react_seed_true_and_carries_the_image`
- `kx-coordinator` react_live `react_vision_seed_records_the_grounding_image_on_the_anchor` + `react_seed_with_context_bundle_records_context_items_on_the_anchor` + `plain_react_seed_anchors_without_an_image` (text control)

## Live-verified (GR15, Gemma-4, BOTH engines)
`kx agent run --image red_square.png` + Py `run_agent(image=)` → **"Red."** — the model sees the image through the loop, each its **own** chain. Full GR24 matrix at parity (chat · vision · ReAct · AGENTIC-VISION · RAG · lifecycle · cross-surface).

## Invariants
Frozen trio **untouched** · digest **`7d22d4bd`** invariant (`verify-quickstart` 8/8) · **no** proto/journal/schema change · clippy/fmt clean.

## Known follow-ups (ticketed, separate PRs)
- **T-STALE-RECIPE-MODEL-ROUTE-ON-ENGINE-SWITCH** (high) — reusing the catalog dir across an engine switch routes to the prior engine's now-unserved model → runs fail-closed. Workaround: a fresh catalog dir per engine.
- **T-OLLAMA-EMBED-COLD-TIMEOUT** (low) — the first cold `/api/embed` times out; retry succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNFXJpjgM1aGyaDQ45pD3p