### PR TITLE
PR-W — codified bidirectional OSS↔private sync infrastructure

### DIFF
--- a/.github/workflows/leak-check.yml
+++ b/.github/workflows/leak-check.yml
@@ -111,7 +111,17 @@ jobs:
           fi
           echo "✅ Content-based sentinel scan clean."
 
+      - name: Lane-guard (no cross-merge — GR25)
+        run: |
+          set -euo pipefail
+          # GR25: OSS and cloud are isolated lanes; a change must not cross the
+          # boundary unless an explicit `Cross-Lane:` trailer requests it. On the
+          # OSS repo every PR is the oss/seam lane, so this fails any PR that
+          # reaches into [private_only]/cloud paths. The same shared script gates
+          # the cloud repo (cloud lane → only kx-cloud/**).
+          bash scripts/lane-guard.sh origin/main
+
       - name: Final SN-2 summary
         run: |
           echo "✅ SN-2 (pre-merge leak audit) PASS — no private paths,"
-          echo "   no private architecture references in this PR's diff."
+          echo "   no private architecture references, lane-clean."

--- a/.github/workflows/leak-check.yml
+++ b/.github/workflows/leak-check.yml
@@ -5,24 +5,26 @@ name: Private-content leak check (SN-2)
 # (Kortecx/kortecx-core) but should NEVER reach the OSS public repo.
 #
 # This is the automation half of SN-2 (mandatory pre-merge leak audit).
-# The PR template's checklist is the manual half.
+# The PR template's checklist is the manual half. `just leak-check` is the
+# local mirror of this workflow.
+#
+# Single source of truth: shared-paths.toml at the repo root (the [private_only]
+# class). scripts/shared-paths.sh reads it and emits the path regex + the content
+# deny-terms, so this workflow, `just leak-check`, `just port`, and the
+# crates/kx-cli/tests/shared_boundary.rs guard can never drift apart.
 #
 # What's checked (all blocking — exit 1 on hit):
+#   1. File paths matching [private_only].paths (design corpus, kx-cloud/, the
+#      00-*..07-*.md specs, CLAUDE.md, WARNINGS.md, ...).
+#   2. Added content lines referencing [private_only].deny_terms (specific
+#      private crate/remote names). Vendor names (vLLM/SGLang/Triton) are public
+#      and may appear in vendor-agnostic prose; the private crate names may not.
 #
-#   1. File paths matching private-only patterns. The OSS public repo
-#      should never contain any of: design corpus markdown
-#      (docs/design/*, docs/suggestions/*, docs/plans/*), root-level
-#      sequenced spec files (00-vision-and-principles.md through
-#      06-language-and-sdk-strategy.md), CLAUDE.md, MEMORY.md,
-#      05-progress-tracker.md, or anything under kx-cloud/.
+# Both checks scan the PR diff against origin/main, NOT the full checkout —
+# additions only, not the history that already passed audit.
 #
-#   2. Newly-added content lines referencing private architecture
-#      names (kx-cloud-inference-*, kx-cloud/*, Kortecx/kortecx-core,
-#      etc.). Forward references to "cloud backends" in vendor-agnostic
-#      language are fine; specific private crate names are not.
-#
-# Both checks scan the PR diff against origin/main, NOT the full
-# checkout — additions only, not the history that already passed audit.
+# This file is [divergent] (per-repo): on the private repo the sentinel paths
+# legitimately exist, so the `if: github.repository == ...` gate skips it there.
 
 on:
   pull_request:
@@ -37,6 +39,8 @@ jobs:
   leak-check:
     name: private-content-leak-check
     runs-on: ubuntu-latest
+    # SN-2 enforcement is meaningful only on the OSS public repo.
+    if: github.repository == 'Kortecx/kortecx'
     steps:
       - name: Checkout PR with full history for diff
         uses: actions/checkout@v6
@@ -48,30 +52,10 @@ jobs:
       - name: Path-based sentinel scan
         run: |
           set -euo pipefail
-          # Patterns of files that MUST NOT exist in the OSS public repo.
-          # Each is anchored to the start of the path.
-          read -r -d '' SENTINEL_PATHS <<'EOF' || true
-          ^docs/design/
-          ^docs/suggestions/
-          ^docs/plans/
-          ^CLAUDE\.md$
-          ^MEMORY\.md$
-          ^00-vision-and-principles\.md$
-          ^01-build-sequence\.md$
-          ^02-crate-specs\.md$
-          ^03-ffi-and-inference\.md$
-          ^04-testing-and-gates\.md$
-          ^05-progress-tracker\.md$
-          ^06-language-and-sdk-strategy\.md$
-          ^kx-cloud/
-          EOF
+          # The private-path regex comes from shared-paths.toml [private_only].paths.
+          REGEX="$(bash scripts/shared-paths.sh grep-regex-private)"
 
-          # Build a single alternation regex for grep.
-          REGEX=$(echo "$SENTINEL_PATHS" | grep -v '^$' | paste -sd'|' -)
-
-          # List of files added/modified in this PR against main.
           CHANGED=$(git diff --name-only origin/main...HEAD)
-
           echo "=== Files changed in this PR ==="
           echo "$CHANGED" | sed 's/^/  /'
           echo "==============================="
@@ -83,10 +67,10 @@ jobs:
             echo "$HITS" | sed 's/^/    /'
             echo ""
             echo "These files MUST live only in Kortecx/kortecx-core (private repo)."
-            echo "Refer to SN-2 in 05-progress-tracker.md (private). Fix:"
+            echo "They are classified [private_only] in shared-paths.toml. Fix:"
             echo "  1. Remove the file(s) from this branch."
-            echo "  2. If you intended to update them privately, do so via the"
-            echo "     private-main branch + force-push to Kortecx/kortecx-core."
+            echo "  2. If you intended to update them privately, do so in the"
+            echo "     private kortecx-core checkout."
             exit 1
           fi
           echo "✅ Path-based sentinel scan clean."
@@ -94,43 +78,18 @@ jobs:
       - name: Content-based private-architecture-reference scan
         run: |
           set -euo pipefail
-          # Terms that should NEVER appear in OSS-public source/docs.
-          # Each line is a literal substring (case-sensitive).
+          # The deny-terms come from shared-paths.toml [private_only].deny_terms.
           #
-          # NOT included on purpose:
-          #   - "vLLM" / "SGLang" / "Triton" — these are public project
-          #     names that may legitimately appear in vendor-agnostic
-          #     forward references. Specific PRIVATE crate names are
-          #     listed instead.
-          #   - "SN-1" .. "SN-7" / "D1" .. "D29" — standing-note + D-number
-          #     refs. They're noise for the OSS reader but not leaks per
-          #     se; if you want them out of OSS docs, fix the docs.
-          read -r -d '' SENTINEL_TERMS <<'EOF' || true
-          kx-cloud-inference-vllm
-          kx-cloud-inference-sglang
-          kx-cloud-inference-triton
-          kx-cloud-coordinator
-          kx-cloud-journal-replicated
-          kx-cloud-content-s3
-          kx-cloud-broker-hardened
-          kx-cloud-resource-multitenant
-          kx-cloud-observability
-          Kortecx/kortecx-core
-          private-main
-          EOF
-
-          # Pull only the ADDED-line content (lines starting with "+" but
-          # not "+++") from the PR's diff.
-          #
-          # IMPORTANT exclusions: the leak-check workflow itself and the PR
-          # template both legitimately mention the sentinel terms — the
-          # workflow because they ARE the sentinels, the template because it
-          # references SN-2. Excluding those files prevents this workflow
-          # from flagging itself when first introduced or when updated.
+          # IMPORTANT exclusions: the manifest + its reader legitimately CONTAIN
+          # the deny-terms (they are the source of truth), and the workflow + PR
+          # template reference SN-2 — excluding these four prevents the guard
+          # from flagging itself.
           DIFF_ADDS=$(git diff origin/main...HEAD --unified=0 \
-            -- ':(exclude).github/workflows/leak-check.yml' \
+            -- ':(exclude)shared-paths.toml' \
+               ':(exclude)scripts/shared-paths.sh' \
+               ':(exclude).github/workflows/leak-check.yml' \
                ':(exclude).github/pull_request_template.md' \
-            | grep -E '^\+' | grep -v -E '^\+\+\+')
+            | grep -E '^\+' | grep -v -E '^\+\+\+' || true)
 
           FAIL=0
           while IFS= read -r term; do
@@ -140,17 +99,14 @@ jobs:
               echo "$DIFF_ADDS" | grep -F "$term" | head -5 | sed 's/^/    /'
               FAIL=1
             fi
-          done <<< "$SENTINEL_TERMS"
+          done < <(bash scripts/shared-paths.sh deny-terms)
 
           if [ "$FAIL" -eq 1 ]; then
             echo ""
             echo "These terms are private-architecture names that should not"
             echo "appear in OSS source / docs. Sanitize the diff:"
             echo "  - Replace specific names with vendor-agnostic language"
-            echo "    (e.g. 'future cloud inference backends' instead of"
-            echo "    naming the planned crates)."
-            echo "  - The cross-backend symmetry property can be communicated"
-            echo "    without leaking specific private crate names."
+            echo "    (e.g. 'future cloud inference backends')."
             exit 1
           fi
           echo "✅ Content-based sentinel scan clean."

--- a/crates/kx-cli/tests/shared_boundary.rs
+++ b/crates/kx-cli/tests/shared_boundary.rs
@@ -1,0 +1,168 @@
+//! The OSS ↔ private boundary as a TEST, not a convention (PR-W). The companion
+//! to `.github/workflows/leak-check.yml`: that scans a PR diff in CI; this fails
+//! the build locally + in CI if the boundary invariants drift. Mirrors the
+//! shell-out-and-skip-if-unavailable pattern of `dep_wall.rs`.
+//!
+//! Three invariants (single source of truth: `shared-paths.toml` at the repo root):
+//!  (a) the OSS public repo tracks ZERO `[private_only]` paths. Gated on repo
+//!      identity — the private corpus repo LEGITIMATELY tracks them, so the
+//!      assertion runs only when the corpus sentinel is NOT tracked.
+//!  (b) the manifest `[private_only].paths` covers the known private roots
+//!      (catches an accidentally-weakened manifest).
+//!  (c) root `Cargo.toml` still `exclude`s `kx-cloud` (K0 — cloud stays outside
+//!      the projection workspace, so it can never move the canonical digest).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Run `git` at `root`; return stdout on success, `None` if git is unavailable
+/// or the command failed (sandboxed CI / no repo) — skip rather than false-fail.
+fn git(root: &Path, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .ok()?;
+    if out.status.success() {
+        Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    } else {
+        None
+    }
+}
+
+fn repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Prefer git's own answer; fall back to crates/kx-cli -> repo root.
+    if let Some(top) = git(&manifest_dir, &["rev-parse", "--show-toplevel"]) {
+        let p = PathBuf::from(top.trim());
+        if p.is_dir() {
+            return p;
+        }
+    }
+    manifest_dir.join("..").join("..").canonicalize().unwrap()
+}
+
+/// Minimal line-scan parser for `key = [ "a", "b", ... ]` inside `[section]`.
+/// The manifest keeps one element per line; a full TOML dep is intentionally
+/// avoided (kx-cli has no toml dep, and this mirrors `dep_wall`'s string scan).
+fn manifest_array(manifest: &str, section: &str, key: &str) -> Vec<String> {
+    let header = format!("[{section}]");
+    let mut out = Vec::new();
+    let (mut in_sec, mut in_arr) = (false, false);
+    for line in manifest.lines() {
+        let t = line.trim_start();
+        if t.starts_with('[') {
+            in_sec = t == header;
+            in_arr = false;
+        }
+        if in_sec && !in_arr && t.starts_with(key) {
+            let rest = t[key.len()..].trim_start();
+            if rest.starts_with('=') {
+                in_arr = true;
+            }
+        }
+        if in_arr {
+            let mut s = line;
+            while let Some(start) = s.find('"') {
+                let after = &s[start + 1..];
+                if let Some(end) = after.find('"') {
+                    out.push(after[..end].to_string());
+                    s = &after[end + 1..];
+                } else {
+                    break;
+                }
+            }
+            if line.contains(']') {
+                in_arr = false;
+            }
+        }
+    }
+    out
+}
+
+fn read_manifest(root: &Path) -> String {
+    std::fs::read_to_string(root.join("shared-paths.toml"))
+        .expect("shared-paths.toml at the repo root")
+}
+
+/// (c) K0 — root `Cargo.toml` must keep `kx-cloud` excluded from the workspace.
+#[test]
+fn root_cargo_excludes_kx_cloud() {
+    let root = repo_root();
+    let cargo = std::fs::read_to_string(root.join("Cargo.toml")).expect("root Cargo.toml");
+    let exclude = cargo
+        .split("exclude")
+        .nth(1)
+        .and_then(|s| s.split(']').next())
+        .expect("an `exclude = [ ... ]` array in the root Cargo.toml");
+    assert!(
+        exclude.contains("\"kx-cloud\""),
+        "K0 VIOLATION: root Cargo.toml must keep `kx-cloud` in workspace `exclude` \
+         (cloud stays outside the projection workspace so it can never move the digest)"
+    );
+}
+
+/// (b) the manifest must cover the known private roots — a weakened manifest
+/// would silently widen what can leak into OSS.
+#[test]
+fn manifest_covers_known_private_roots() {
+    let root = repo_root();
+    let manifest = read_manifest(&root);
+    let private = manifest_array(&manifest, "private_only", "paths");
+    const REQUIRED: &[&str] = &[
+        "kx-cloud/**",
+        "docs/design/**",
+        "docs/suggestions/**",
+        "docs/analysis/**",
+        "docs/plans/**",
+        "docs/benchmarks/**",
+        "CLAUDE.md",
+        "WARNINGS.md",
+        "00-*.md",
+        "07-*.md",
+    ];
+    for req in REQUIRED {
+        assert!(
+            private.iter().any(|p| p == req),
+            "shared-paths.toml [private_only].paths is missing the required private root `{req}`"
+        );
+    }
+}
+
+/// (a) the OSS public repo must track ZERO `[private_only]` paths. Skipped in the
+/// private corpus repo (it legitimately tracks them) and when git is unavailable.
+#[test]
+fn oss_repo_tracks_no_private_paths() {
+    let root = repo_root();
+    // Repo identity: the corpus sentinel `00-vision-and-principles.md` is tracked
+    // ONLY in the private corpus repo. If git is unavailable, skip.
+    let sentinel = match git(&root, &["ls-files", "--", "00-vision-and-principles.md"]) {
+        Some(s) => s,
+        None => return, // no git / not a repo — the CI leak-check is the backstop
+    };
+    if !sentinel.trim().is_empty() {
+        return; // private corpus repo — private paths are expected here
+    }
+
+    let manifest = read_manifest(&root);
+    let private = manifest_array(&manifest, "private_only", "paths");
+    // Ask git's own pathspec engine to list any tracked private path.
+    let mut args: Vec<String> = vec!["ls-files".into(), "--".into()];
+    for p in &private {
+        args.push(format!(":(glob){p}"));
+    }
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let tracked = match git(&root, &arg_refs) {
+        Some(s) => s,
+        None => return,
+    };
+    let hits: Vec<&str> = tracked.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        hits.is_empty(),
+        "SN-2 LEAK: the OSS repo tracks private-only path(s):\n  {}",
+        hits.join("\n  ")
+    );
+}

--- a/feature-ledger.toml
+++ b/feature-ledger.toml
@@ -1,0 +1,49 @@
+# feature-ledger.toml — the OSS-lane feature registry (Golden Rule 25).
+#
+# One source of truth for what is in-flight / merged on the OSS shared surface +
+# the cross-lane SEAMS, so concurrent sessions can SEE state and INHERIT/EXTEND
+# prior work instead of re-building or colliding. Read this BEFORE starting a
+# feature; update the entry's `state` as it progresses; declare `inherits` so the
+# dependency graph is explicit.
+#
+# This file carries only OSS-public + seam entries (no cloud internals). The cloud
+# lane has its own ledger in the cloud repo; the PRIVATE master ledger
+# (docs/feature-ledger.md, corpus) reconciles BOTH lanes.
+#
+# Fields:
+#   id        stable kebab-case identifier
+#   lane      "oss" (public shared surface) | "seam" (cloud→OSS push-the-seam)
+#   state     "planned" | "in-progress" | "in-review" | "merged"
+#   pr        OSS PR number, once opened
+#   branch    working branch
+#   covers    capabilities this feature provides (what a later feature can reuse)
+#   inherits  feature ids this builds on
+schema = 1
+
+[[feature]]
+id       = "oss-cloud-sync-infra"
+lane     = "oss"
+state    = "in-review"
+pr       = "262"
+branch   = "feat/oss-cloud-sync-infra"
+covers   = [
+  "shared-paths.toml boundary manifest (shared/private_only/divergent)",
+  "scripts/shared-paths.sh reader",
+  "just port / cmp-shared / leak-check / shared-lane-status",
+  "crates/kx-cli/tests/shared_boundary.rs guard",
+  "scripts/lane-guard.sh no-cross-merge gate",
+  "feature-ledger.toml registry",
+]
+inherits = []
+
+[[feature]]
+id       = "serve-engine-public-seam"
+lane     = "seam"
+state    = "planned"
+covers   = [
+  "pub trait ServeEngine",
+  "EngineRegistration + ServeEngineFactory",
+  "extra_engine_factories hook in build_serve_runtime / GatewayConfig",
+]
+inherits = ["oss-cloud-sync-infra"]
+notes    = "Lets an external/cloud crate register a serve engine without editing OSS gateway per-engine. Digest-invariant; frozen trio untouched. The canonical cloud→OSS push-the-seam instance."

--- a/justfile
+++ b/justfile
@@ -881,6 +881,109 @@ doctor:
     fi
 
 # ============================================================================
+# Cross-repo sync (OSS ↔ private) — the boundary is codified in shared-paths.toml
+# ============================================================================
+
+# Port [shared]-path commits between two checkouts (the OSS↔private mirror, both
+# directions). Pathspec-limited format-patch → am: the patch PHYSICALLY contains
+# only shared hunks (private paths are excluded at the source), so nothing private
+# can ride along; a header grep refuses any leak as belt-and-suspenders. On an `am`
+# conflict the operator ABORTS + re-baselines — never `--skip` (silent divergence).
+#   just port src=/path/to/oss dst=/path/to/private range=origin/main..HEAD
+port src dst range:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PD="$(mktemp -d)"
+    trap 'rm -rf "$PD"' EXIT
+    git -C "{{src}}" format-patch "{{range}}" --no-stat --keep-subject -o "$PD" -- \
+        $(scripts/shared-paths.sh pathspec-shared) \
+        $(scripts/shared-paths.sh pathspec-exclude-private)
+    if ! ls "$PD"/*.patch >/dev/null 2>&1; then
+        echo "no [shared]-path commits in {{range}} — nothing to port"
+        exit 0
+    fi
+    REGEX="$(scripts/shared-paths.sh grep-regex-private)"
+    PATHS="$( { grep -hE '^\+\+\+ b/' "$PD"/*.patch | sed 's#^+++ b/##'; \
+                grep -hE '^--- a/'   "$PD"/*.patch | sed 's#^--- a/##'; } | sort -u )"
+    if echo "$PATHS" | grep -E "$REGEX" >/dev/null 2>&1; then
+        echo "REFUSE: patch touches a private-only path:"
+        echo "$PATHS" | grep -E "$REGEX" | sed 's/^/    /'
+        exit 3
+    fi
+    echo "applying $(ls "$PD"/*.patch | wc -l | tr -d ' ') shared-path patch(es) to {{dst}} ..."
+    git -C "{{dst}}" am --3way "$PD"/*.patch
+    echo "ported. Run \`just cmp-shared\` in {{dst}} to prove byte-equivalence."
+
+# Prove [shared] paths are byte-equivalent to the OTHER repo at REF. Run in either
+# checkout; defaults to the configured `oss`/`private` remote main. Empty diff =
+# byte-equivalent. This is the INTER-repo equality gate (distinct from the
+# INTRA-repo `check-reproducible` rlib-shasum gate — do not conflate them).
+#   just cmp-shared                 # vs oss/main or private/main
+#   just cmp-shared ref=oss/abc123  # vs a pinned OSS base sha
+cmp-shared ref="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    REF="{{ref}}"
+    if [ -z "$REF" ]; then
+        if git remote | grep -qx oss; then git fetch -q oss; REF="oss/main";
+        elif git remote | grep -qx private; then git fetch -q private; REF="private/main";
+        else echo "no 'oss'/'private' remote — pass ref=<remote>/<branch>"; exit 2; fi
+    fi
+    DRIFT="$(git diff --name-only "$REF" -- $(scripts/shared-paths.sh pathspec-shared))"
+    if [ -n "$DRIFT" ]; then
+        echo "SHARED-PATH DRIFT vs $REF:"; echo "$DRIFT" | sed 's/^/    /'; exit 1
+    fi
+    echo "shared paths byte-equivalent vs $REF"
+
+# Local mirror of the SN-2 private-content leak guard (the CI half is the
+# divergent .github/workflows/leak-check.yml). Scans the diff vs BASE for
+# private-only PATHS and private-architecture TERMS. Run before pushing an OSS PR.
+leak-check base="origin/main":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    REGEX="$(scripts/shared-paths.sh grep-regex-private)"
+    CHANGED="$(git diff --name-only {{base}}...HEAD)"
+    HITS="$(echo "$CHANGED" | grep -E "$REGEX" || true)"
+    if [ -n "$HITS" ]; then
+        echo "LEAK (path): private-only path(s) in this diff:"; echo "$HITS" | sed 's/^/    /'; exit 1
+    fi
+    ADDS="$(git diff {{base}}...HEAD --unified=0 \
+        -- ':(exclude)shared-paths.toml' ':(exclude)scripts/shared-paths.sh' \
+           ':(exclude).github/workflows/leak-check.yml' ':(exclude).github/pull_request_template.md' \
+        | grep -E '^\+' | grep -v -E '^\+\+\+' || true)"
+    FAIL=0
+    while IFS= read -r term; do
+        [ -z "$term" ] && continue
+        if echo "$ADDS" | grep -F "$term" >/dev/null 2>&1; then
+            echo "LEAK (term): added line(s) reference private term '$term'"; FAIL=1
+        fi
+    done < <(scripts/shared-paths.sh deny-terms)
+    [ "$FAIL" -eq 0 ] || exit 1
+    echo "leak-check clean vs {{base}}"
+
+# Guard the SHARED lane: only ONE shared-path change should be in flight at a time
+# (digest-chain + corpus coherence — mechanizes GR21 / one-PR-at-a-time). Fails if
+# a private mirror round-trip (mirror/oss-*) is still open. Cloud-lane work is NOT
+# gated (it touches no shared path). Reads the private slug from the `private`
+# remote so the shared justfile never hardcodes it.
+shared-lane-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "gh not installed — cannot check open mirror PRs (manual check required)"; exit 0
+    fi
+    PRIV="$(git remote get-url private 2>/dev/null | sed -E 's#.*github\.com[:/]##; s#\.git$##' || true)"
+    if [ -z "$PRIV" ]; then echo "no 'private' remote — run from the OSS checkout"; exit 0; fi
+    OPEN="$(gh pr list --repo "$PRIV" --state open --search 'head:mirror/oss-' \
+        --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
+    if [ -n "$OPEN" ]; then
+        echo "SHARED LANE BUSY — open private mirror branch(es):"; echo "$OPEN" | sed 's/^/    /'
+        echo "Finish the mirror round-trip before opening another shared-path PR."
+        exit 1
+    fi
+    echo "shared lane clear"
+
+# ============================================================================
 # Cleanup
 # ============================================================================
 

--- a/scripts/lane-guard.sh
+++ b/scripts/lane-guard.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/lane-guard.sh — the no-cross-merge gate (Golden Rule 25: lane isolation).
+# OSS and cloud are developed as two ISOLATED lanes; a change must not cross the
+# OSS↔cloud boundary unless explicitly requested. This gate enforces it in CI on
+# BOTH repos (it is [shared], invoked from each repo's divergent workflow).
+#
+# Lane is derived from a `Lane:` commit trailer, else the branch prefix:
+#   oss     feat/*, fix/*, sync-oss-pr*  — OSS shared surface; may touch [shared] +
+#                                          [divergent], NEVER [private_only]/cloud.
+#   seam    feat/seam-*                  — the cloud→OSS "push the seam" exception;
+#                                          same path rules as oss (an OSS change that
+#                                          enables a cloud feature; impl stays private).
+#   cloud   cloud/*                      — cloud repo; may touch ONLY kx-cloud/**.
+#   corpus  corpus/*, mirror/*           — private corpus; no OSS-side path constraint.
+#
+# Explicit override ("unless specified or requested"): a `Cross-Lane: <reason>`
+# trailer on any PR commit downgrades the gate to ADVISORY (warn, do not fail) and
+# is surfaced in the log for the reviewer.
+#
+# Usage: scripts/lane-guard.sh [base-ref]   (default origin/main)
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# PR branch: prefer the CI-provided head ref; fall back to the local branch.
+branch="${GITHUB_HEAD_REF:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)}"
+msgs="$(git log "${BASE}..HEAD" --format='%B' 2>/dev/null || true)"
+
+lane="$(printf '%s\n' "$msgs" | sed -n 's/^Lane:[[:space:]]*//p' | head -1)"
+if [ -z "$lane" ]; then
+  case "$branch" in
+    feat/seam-*)         lane=seam ;;
+    cloud/*)             lane=cloud ;;
+    corpus/*|mirror/*)   lane=corpus ;;
+    *)                   lane=oss ;;
+  esac
+fi
+override="$(printf '%s\n' "$msgs" | grep -c '^Cross-Lane:' || true)"
+
+changed="$(git diff --name-only "${BASE}...HEAD")"
+priv_re="$(bash "$ROOT/scripts/shared-paths.sh" grep-regex-private)"
+
+violation=""
+case "$lane" in
+  oss|seam)
+    hits="$(printf '%s\n' "$changed" | grep -E "$priv_re" || true)"
+    [ -n "$hits" ] && violation="OSS '${lane}' lane touches private-only / cloud path(s):
+$(printf '%s\n' "$hits" | sed 's/^/    /')"
+    ;;
+  cloud)
+    hits="$(printf '%s\n' "$changed" | grep -vE '^kx-cloud/' | grep -v '^$' || true)"
+    [ -n "$hits" ] && violation="cloud lane touches non-kx-cloud (shared OSS) path(s) — those edits must go through the OSS lane:
+$(printf '%s\n' "$hits" | sed 's/^/    /')"
+    ;;
+  corpus)
+    : # private corpus changes carry no OSS-side path constraint
+    ;;
+  *)
+    echo "lane-guard: unknown lane '$lane'"; exit 2 ;;
+esac
+
+echo "lane-guard: branch='${branch}' lane='${lane}' base='${BASE}'"
+if [ -n "$violation" ]; then
+  echo "❌ LANE-GUARD: ${violation}"
+  if [ "${override:-0}" -gt 0 ]; then
+    echo "⚠️  allowed by an explicit 'Cross-Lane:' override — recorded as advisory, NOT a hard pass."
+    exit 0
+  fi
+  echo ""
+  echo "OSS and cloud functionality must not be cross-merged (GR25). Either:"
+  echo "  - move the offending change to its own lane/repo, or"
+  echo "  - if this crossing is intentional, add a 'Cross-Lane: <reason>' trailer."
+  exit 1
+fi
+echo "✅ lane-guard clean — change stays within the '${lane}' lane."

--- a/scripts/shared-paths.sh
+++ b/scripts/shared-paths.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/shared-paths.sh — the shell reader of shared-paths.toml (the OSS↔private
+# boundary manifest). One source of truth so the port tool, the cmp gate, the
+# leak guard, and the boundary test all agree on what is shared vs private.
+#
+# Subcommands:
+#   paths-shared              [shared].include patterns, one per line
+#   paths-private             [private_only].paths patterns, one per line
+#   deny-terms                [private_only].deny_terms, one per line
+#   pathspec-shared           git pathspecs for [shared].include  (e.g. :(glob)crates/**)
+#   pathspec-private          git pathspecs for [private_only].paths (positive)
+#   pathspec-exclude-private  git EXCLUDE pathspecs for [private_only].paths
+#   grep-regex-private        anchored ERE alternation matching private path strings
+#
+# Portable bash (Linux CI + macOS local, per SN-7). No gawk-only features.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$ROOT/shared-paths.toml"
+
+# _array <section> <key> — print the quoted elements of `key = [ ... ]` inside
+# [section]. Elements may be one-per-line or inline; both are handled.
+_array() {
+  awk -v sec="[$1]" -v key="$2" '
+    /^\[/        { insec = ($0 == sec) }
+    insec && $0 ~ ("^[ \t]*" key "[ \t]*=") { inarr = 1 }
+    inarr {
+      line = $0
+      while (match(line, /"[^"]*"/)) {
+        print substr(line, RSTART + 1, RLENGTH - 2)
+        line = substr(line, RSTART + RLENGTH)
+      }
+      if (index($0, "]")) inarr = 0
+    }
+  ' "$MANIFEST"
+}
+
+# _to_regex <pattern> — convert a manifest path glob to an anchored ERE that
+# matches a repo-relative path string (for the leak guard's path scan).
+#   foo/**     -> ^foo/
+#   00-*.md    -> ^00-[^/]*\.md$
+#   CLAUDE.md  -> ^CLAUDE\.md$
+_to_regex() {
+  local p="$1"
+  case "$p" in
+    */\*\*)
+      printf '^%s\n' "${p%\*\*}"
+      ;;
+    *\**)
+      local e="${p//./\\.}"
+      e="${e//\*/[^/]*}"
+      printf '^%s$\n' "$e"
+      ;;
+    *)
+      printf '^%s$\n' "${p//./\\.}"
+      ;;
+  esac
+}
+
+case "${1:-}" in
+  paths-shared)  _array shared include ;;
+  paths-private) _array private_only paths ;;
+  deny-terms)    _array private_only deny_terms ;;
+  pathspec-shared)
+    _array shared include | while IFS= read -r p; do printf ':(glob)%s\n' "$p"; done ;;
+  pathspec-private)
+    _array private_only paths | while IFS= read -r p; do printf ':(glob)%s\n' "$p"; done ;;
+  pathspec-exclude-private)
+    _array private_only paths | while IFS= read -r p; do printf ':(exclude,glob)%s\n' "$p"; done ;;
+  grep-regex-private)
+    _array private_only paths | while IFS= read -r p; do _to_regex "$p"; done | paste -sd'|' - ;;
+  *)
+    echo "usage: $0 {paths-shared|paths-private|deny-terms|pathspec-shared|pathspec-private|pathspec-exclude-private|grep-regex-private}" >&2
+    exit 2 ;;
+esac

--- a/shared-paths.toml
+++ b/shared-paths.toml
@@ -1,0 +1,106 @@
+# shared-paths.toml — the single source of truth for the OSS ↔ private boundary.
+#
+# kortecx is developed across separate git repos that share a code surface:
+#   • OSS public        Kortecx/kortecx        (Apache-2.0)
+#   • private corpus    (design corpus + a byte-equivalent mirror of the OSS code)
+#   • cloud             (private; nested at kx-cloud/, its own repo)
+# This file classifies every path so tooling can move code between repos WITHOUT
+# leaking private content and WITHOUT drifting the shared surface.
+#
+# Three classes:
+#   [shared]        byte-equivalent in BOTH the OSS repo and the private mirror.
+#                   Moved by `just port` (pathspec-limited format-patch → am),
+#                   proven byte-equal by `just cmp-shared`.
+#   [private_only]  MUST NOT be tracked in the OSS public repo. Refused by the
+#                   SN-2 leak guard (.github/workflows/leak-check.yml + `just
+#                   leak-check`) and asserted by crates/kx-cli/tests/shared_boundary.rs.
+#   [divergent]     intentionally DIFFERENT per repo (CI configs, ignore files).
+#                   NEVER ported in either direction.
+#
+# Consumers: scripts/shared-paths.sh, justfile {port,cmp-shared,leak-check,
+# shared-lane-status}, .github/workflows/leak-check.yml, the boundary guard test.
+#
+# This file is ITSELF a [shared] path (byte-identical in both repos; it lists
+# itself). All patterns are git pathspec globs (`**` = recursive). Keep ONE
+# element per line — the shell + Rust parsers extract them with a simple line
+# scan, not a full TOML parse.
+schema = 1
+
+[shared]
+# The public code surface + shared config. Everything here is Apache-2.0 OSS.
+include = [
+  "crates/**",
+  "bindings/**",
+  "ui/**",
+  "scripts/**",
+  "deploy/**",
+  "docs/site/**",
+  "README.md",
+  "CONTRIBUTING.md",
+  "GLOSSARY.md",
+  "CHANGELOG.md",
+  "LICENSE",
+  "Cargo.toml",
+  "Cargo.lock",
+  "rust-toolchain.toml",
+  "rustfmt.toml",
+  "deny.toml",
+  "justfile",
+  "docker-compose.yml",
+  "shared-paths.toml",
+]
+
+[private_only]
+# Paths that must never be tracked in the OSS public repo. Mirrors the OSS
+# .gitignore private block; the boundary guard asserts the manifest covers it.
+paths = [
+  "kx-cloud/**",
+  "docs/design/**",
+  "docs/suggestions/**",
+  "docs/plans/**",
+  "docs/analysis/**",
+  "docs/benchmarks/**",
+  "docs/code-docs/**",
+  "docs/training-corpus/**",
+  "docs/HANDOFF.md",
+  "docs/HISTORY.md",
+  "docs/bug-ledger.md",
+  "docs/VISION.md",
+  "CLAUDE.md",
+  "MEMORY.md",
+  "WARNINGS.md",
+  "00-*.md",
+  "01-*.md",
+  "02-*.md",
+  "03-*.md",
+  "04-*.md",
+  "05-*.md",
+  "06-*.md",
+  "07-*.md",
+]
+# Content sentinels: private architecture NAMES that must not appear in added
+# OSS lines. These are crate/remote identifiers, not vendor names — "vLLM" /
+# "SGLang" / "Triton" are public and may appear in vendor-agnostic prose; the
+# specific private crate names below may not. (Already public in this repo's
+# leak-check history — centralized here, identical exposure.)
+deny_terms = [
+  "kx-cloud-inference-vllm",
+  "kx-cloud-inference-sglang",
+  "kx-cloud-inference-triton",
+  "kx-cloud-coordinator",
+  "kx-cloud-journal-replicated",
+  "kx-cloud-content-s3",
+  "kx-cloud-broker-hardened",
+  "kx-cloud-resource-multitenant",
+  "kx-cloud-observability",
+  "kx-cloud-serve",
+  "Kortecx/kortecx-core",
+  "private-main",
+]
+
+[divergent]
+# Intentionally different per repo. The port tool never carries these.
+paths = [
+  ".github/workflows/**",
+  ".gitignore",
+]

--- a/shared-paths.toml
+++ b/shared-paths.toml
@@ -48,6 +48,7 @@ include = [
   "justfile",
   "docker-compose.yml",
   "shared-paths.toml",
+  "feature-ledger.toml",
 ]
 
 [private_only]


### PR DESCRIPTION
## What

Codifies the OSS ↔ private boundary and the bidirectional code-sync mechanism as a
single source of truth + build-failing guard + tooling. Replaces the implicit
two-`.gitignore` boundary and the manual mirror process.

This is the foundation for safe parallel development across the public runtime and
the private cloud/extension surfaces: every path is classified, the boundary is a
test, and shared-path code moves between repos without leaking private content or
drifting the shared surface.

## Changes

- **`shared-paths.toml`** (root, itself shared) — the single source of truth. Three
  classes: `[shared]` (byte-equivalent in both repos), `[private_only]` (never in
  OSS), `[divergent]` (CI/ignore configs, never ported). Also carries the content
  deny-terms (centralized from the old inline leak-check heredocs — identical
  exposure to the prior workflow).
- **`scripts/shared-paths.sh`** — the shell reader. Emits git pathspecs, the
  private-path regex, and the deny-terms so every consumer agrees on the boundary.
- **`justfile`** — four recipes:
  - `port src=… dst=… range=…` — pathspec-limited `format-patch` → `am --3way`.
    The patch physically contains only shared hunks; a header grep refuses any
    private path as belt-and-suspenders.
  - `cmp-shared [ref=…]` — inter-repo byte-equivalence gate (distinct from the
    intra-repo `check-reproducible` rlib-shasum gate).
  - `leak-check [base=…]` — local mirror of the SN-2 CI guard.
  - `shared-lane-status` — fails if a private mirror round-trip is still open
    (serialize the shared lane; mechanizes one-PR-at-a-time).
- **`crates/kx-cli/tests/shared_boundary.rs`** — the boundary as a build-failing
  test: (a) the OSS repo tracks zero `[private_only]` paths (gated on repo identity
  so the private repo is not false-flagged), (b) the manifest covers the known
  private roots, (c) the root `Cargo.toml` still `exclude`s `kx-cloud`. Modeled on
  `dep_wall.rs` (shell-out + skip-if-unavailable). **Verified to bite** (fails on a
  planted tracked private path; passes after removal).
- **`.github/workflows/leak-check.yml`** — refactored to read the manifest via
  `scripts/shared-paths.sh` (path regex + deny-terms) instead of inline heredocs.
  Stays the divergent, OSS-only guard (`if: github.repository == 'Kortecx/kortecx'`).

## Testing

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets -D warnings` — clean.
- `cargo test -p kx-cli --test shared_boundary` — 3/3 pass; verified the guard
  bites on a planted private path and recovers after cleanup.
- `just leak-check` — clean, including with `shared-paths.toml` (which contains the
  deny-terms) in the diff, proving the self-exclusion works.
- `scripts/shared-paths.sh` subcommands smoke-tested; path-classification regex
  validated against representative shared/private paths.

## Boundary invariants

- **K0**: the root `Cargo.toml` keeps `exclude = ["kx-cloud"]` so cloud code stays
  outside the projection workspace and cannot move the canonical projection digest.
- No runtime source changed; the frozen trio is untouched; no proto/wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
