### PR TITLE
docs(security): backport 'Known limitations (single-node OSS)' note

### DIFF
--- a/docs/site/docs/security.md
+++ b/docs/site/docs/security.md
@@ -95,3 +95,12 @@ An **off-the-truth-path** JSONL record of the run lifecycle (join-keys only, nev
 payloads or secrets) is available with `kx run --audit-log <path>`. Time lives
 only on the wire DTO, never in the digest — so the audit trail never changes the
 projection digest.
+
+## Known limitations (single-node OSS)
+
+- **Bearer-token comparison is not constant-time.** The single-node OSS gateway
+  compares the auth token with an ordinary equality check; a timing side-channel is
+  possible in principle. This is an **accepted RC limitation** (loopback / trusted
+  single-node deployment), documented rather than fixed here — the constant-time
+  compare + rotation lands in the managed cloud auth layer (D129). It is not an open
+  defect at the release gate.


### PR DESCRIPTION
## What

Backports a security-doc section from the private mirror to OSS so the shared
`docs/site/` surface re-converges.

`just cmp-shared` (introduced in #262 / PR-W) immediately surfaced a pre-existing
**shared-surface drift**: `docs/site/docs/security.md` carried a *"Known limitations
(single-node OSS)"* note — an honest disclosure that the single-node gateway's
bearer-token comparison is not constant-time (an accepted RC limitation; the
constant-time compare lands in the managed cloud auth layer) — on the private side
(added in a §2.210 corpus edit) that was **never backported here**.

This adds that exact section to OSS, making the shared file byte-identical across
repos again so `cmp-shared` is clean.

## Testing

- The OSS file is now `diff`-identical to the private version (byte-equivalent).
- `scripts/lane-guard.sh` clean (oss lane, shared doc).
- Docs-only change; no code, no digest impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)