### PR TITLE
Connector/Extension SDK (D167 E0) + chaining-reachable connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1043,3 +1043,47 @@ jobs:
 
       - name: just scale-smoke
         run: just scale-smoke
+
+  # ---------------------------------------------------------------------------
+  # connector-conformance — the D167 Connector/Extension SDK gate (E0). Dials a
+  # PINNED REAL third-party MCP server (the official filesystem server) through the
+  # real gateway path and runs the Extension Acceptance Gate subset (items 3/5/7/10:
+  # out-of-process · warrant/SN-8 · secret-by-ref · on/off). `npm ci` restores the
+  # EXACT committed lockfile (the only network op — cached); the dial + every
+  # assertion run OFFLINE over a stdio subprocess, so no network flakiness enters the
+  # gate (GR12). REQUIRED: promote to a branch-protection check once green.
+  # ---------------------------------------------------------------------------
+  connector-conformance:
+    name: connector-conformance (D167 — real external MCP through the gate)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (NO submodules — the SDK is FFI-free)
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: cargo --version
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Set up Node (cache the pinned MCP-server lockfile)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: crates/kx-extension-sdk/tests/fixtures/real-connector/package-lock.json
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-connconf-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-connconf-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Dial a pinned REAL external MCP server through the conformance gate
+        run: just test-connector-real

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-extension-sdk"
+version = "0.1.0"
+dependencies = [
+ "kx-capability",
+ "kx-content",
+ "kx-gateway-core",
+ "kx-mcp",
+ "kx-mcp-gateway",
+ "kx-mote",
+ "kx-tool-registry",
+ "kx-warrant",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "kx-fleet"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "crates/kx-cli",
     "crates/kx-profile",
     "crates/kx-otel",
+    "crates/kx-extension-sdk",
 ]
 exclude = [
     "kx-cloud",

--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -259,6 +259,56 @@ def _encode_args(args: ArgsType) -> bytes:
 # --- sync client -------------------------------------------------------------
 
 
+class _Connections:
+    """The ``kx.connections`` namespace — connector (external MCP server) admin, with
+    a verb vocabulary matching the ``kx connections`` CLI (``add`` / ``list`` /
+    ``test`` / ``remove`` / ``discover``). Each method delegates 1:1 to the flat
+    ``register_mcp_server`` / ``list_mcp_servers`` / ``test_mcp_server`` /
+    ``deregister_mcp_server`` / ``discover_server_tools`` methods (which remain for
+    back-compat). A connector = an external MCP tool server (see ``kx-extension-sdk``)."""
+
+    def __init__(self, client: "KxClient") -> None:
+        self._c = client
+
+    def add(
+        self,
+        name: str,
+        *,
+        transport: str = "stdio",
+        endpoint: str,
+        args: Optional[Sequence[str]] = None,
+        tls_required: bool = False,
+        credential_ref: str = "",
+        session_mode: str = "stateless",
+    ) -> "RegisterServerResult":
+        """Register (dial + discover) a connector. See ``register_mcp_server``."""
+        return self._c.register_mcp_server(
+            name=name,
+            transport=transport,
+            endpoint=endpoint,
+            args=args,
+            tls_required=tls_required,
+            credential_ref=credential_ref,
+            session_mode=session_mode,
+        )
+
+    def list(self, *, limit: int = 0, after_name: str = "") -> "McpServersPage":
+        """List registered connectors + health. See ``list_mcp_servers``."""
+        return self._c.list_mcp_servers(limit=limit, after_name=after_name)
+
+    def test(self, name: str) -> bool:
+        """Test a connector's reachability. See ``test_mcp_server``."""
+        return self._c.test_mcp_server(name=name)
+
+    def remove(self, name: str) -> bool:
+        """Remove a connector + its tools. See ``deregister_mcp_server``."""
+        return self._c.deregister_mcp_server(name=name)
+
+    def discover(self, name: str) -> "RegisteredToolsPage":
+        """Re-dial + re-discover a connector's tools. See ``discover_server_tools``."""
+        return self._c.discover_server_tools(name=name)
+
+
 class KxClient:
     """A synchronous client for a running ``kx serve`` gateway."""
 
@@ -1538,6 +1588,16 @@ class KxClient:
         req = _g.DeregisterMcpServerRequest(server_name=name)
         resp = self._call(lambda: self._stub.DeregisterMcpServer(req, metadata=self._md))
         return resp.removed
+
+    @property
+    def connections(self) -> _Connections:
+        """The connector (external MCP server) admin namespace —
+        ``kx.connections.add / list / test / remove / discover`` (the verb vocabulary
+        of the ``kx connections`` CLI). The flat ``register_mcp_server`` etc. remain
+        for back-compat. A connector is an external MCP tool server (see
+        ``kx-extension-sdk``); chain one straight into a flow with
+        ``kx.flow().with_mcp(...)``."""
+        return _Connections(self)
 
     def submit_feedback(
         self,

--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -69,6 +69,10 @@ class Flow:
         self._node: Optional[_Node] = None
         self._seed = seed
         self._context: List[str] = []
+        #: Connectors to register (each a ``register_mcp_server`` kwargs dict) BEFORE
+        #: this flow submits — see :meth:`with_mcp`. Stored OFF the lowered graph so
+        #: ``to_chain`` / ``build`` stay byte-identical (the golden digest holds).
+        self._mcp: List[dict] = []
         #: AGENTIC-VISION: an image ref pending for the NEXT agent step (set by
         #: :meth:`image`, consumed + cleared by :meth:`agent`). Per-step, so a multi-step
         #: flow can ground each step with a different image.
@@ -165,6 +169,54 @@ class Flow:
         self._context.extend(handles)
         return self
 
+    def with_mcp(
+        self,
+        name: str,
+        *,
+        transport: str = "stdio",
+        endpoint: str,
+        args: Optional[List[str]] = None,
+        tls_required: bool = False,
+        credential_ref: str = "",
+        session_mode: str = "stateless",
+    ) -> "Flow":
+        """Register an external MCP **connector** at run time, BEFORE this flow
+        submits, so its namespaced ``<name>/<tool>`` tools resolve for a downstream
+        ``.agent(tools=[...])`` / ``.tool(...)`` — connectors are thus reachable from
+        the SAME single chaining entry point as everything else::
+
+            (kx.flow()
+               .with_mcp("fs", endpoint="npx",
+                         args=["-y", "@modelcontextprotocol/server-filesystem", "/data"])
+               .agent("list /data", tools=["fs/list_directory"])
+               .run())
+
+        Pure pre-submit sugar over :meth:`KxClient.register_mcp_server` (same args; a
+        connector = an external MCP server, see ``kx-extension-sdk``). It does NOT
+        change the lowered workflow — :meth:`to_chain` / :meth:`build` are
+        byte-identical with or without it, so the golden tri-surface digest holds;
+        registration is an imperative side effect, never a DAG node. Idempotent
+        (server-derived id + upsert), so re-running the flow is safe. ``credential_ref``
+        names an env var / vault key — the secret VALUE never travels (D81)."""
+        self._mcp.append(
+            {
+                "name": name,
+                "transport": transport,
+                "endpoint": endpoint,
+                "args": list(args or []),
+                "tls_required": tls_required,
+                "credential_ref": credential_ref,
+                "session_mode": session_mode,
+            }
+        )
+        return self
+
+    def _register_mcp(self, kx) -> None:
+        """Register each :meth:`with_mcp` connector (in declaration order) before the
+        flow submits, so referenced ``<name>/<tool>`` tools resolve at compile."""
+        for spec in self._mcp:
+            kx.register_mcp_server(**spec)
+
     # -- terminals --
 
     def _require_node(self) -> "_Node":
@@ -201,6 +253,7 @@ class Flow:
         from .defaults import default_client
 
         kx = client if client is not None else default_client()
+        self._register_mcp(kx)
         return kx.run_chain(self.to_chain(), wait=wait, timeout=timeout)
 
     def submit(self, *, client=None) -> "Run":
@@ -209,6 +262,7 @@ class Flow:
         from .defaults import default_client
 
         kx = client if client is not None else default_client()
+        self._register_mcp(kx)
         run = kx.run_chain(self.to_chain(), wait=False)
         return run  # type: ignore[return-value]
 

--- a/bindings/python/tests/test_flow.py
+++ b/bindings/python/tests/test_flow.py
@@ -161,6 +161,12 @@ class _FakeClient:
     def __init__(self) -> None:
         self.any_calls = 0
         self.term_calls = 0
+        self.mcp_calls: list = []
+
+    def register_mcp_server(self, **kw: object) -> object:
+        # Records the .with_mcp() pre-submit registrations (in order).
+        self.mcp_calls.append(kw)
+        return object()
 
     def run_chain(self, chain: object, *, wait: bool = False, timeout: float = 120.0) -> object:
         from kortecx.run import Run
@@ -220,3 +226,65 @@ def test_agent_stream_returns_a_run() -> None:
 
     run = Agent("hi").stream("task", client=_FakeClient())
     assert isinstance(run, Run)
+
+
+# -- .with_mcp() — connectors reachable from the single chaining entry point --
+
+
+def test_with_mcp_registers_connectors_before_submit_in_order() -> None:
+    fc = _FakeClient()
+    (
+        flow()
+        .with_mcp("a", endpoint="x", args=["--a"])
+        .agent("hi", tools=["a/echo"])
+        .with_mcp("b", transport="http", endpoint="https://h/rpc")
+        .run(wait=False, client=fc)
+    )
+    assert [c["name"] for c in fc.mcp_calls] == ["a", "b"], "registered in declaration order"
+    assert fc.mcp_calls[0]["endpoint"] == "x"
+    assert fc.mcp_calls[1]["transport"] == "http"
+
+
+def test_with_mcp_is_digest_invariant() -> None:
+    # .with_mcp() is a pre-submit side effect — it must NOT change the lowered request,
+    # so the golden tri-surface digest holds.
+    with_conn = flow().agent("hi").with_mcp("a", endpoint="x").build()
+    plain = flow().agent("hi").build()
+    assert with_conn == plain
+
+
+def test_connections_facade_delegates_to_flat_methods() -> None:
+    from kortecx.client import _Connections
+
+    class _Stub:
+        def __init__(self) -> None:
+            self.calls: list = []
+
+        def register_mcp_server(self, **kw: object) -> str:
+            self.calls.append(("add", kw["name"]))
+            return "R"
+
+        def list_mcp_servers(self, **kw: object) -> str:
+            self.calls.append(("list", None))
+            return "L"
+
+        def test_mcp_server(self, *, name: str) -> bool:
+            self.calls.append(("test", name))
+            return True
+
+        def deregister_mcp_server(self, *, name: str) -> bool:
+            self.calls.append(("remove", name))
+            return True
+
+        def discover_server_tools(self, *, name: str) -> str:
+            self.calls.append(("discover", name))
+            return "D"
+
+    stub = _Stub()
+    conn = _Connections(stub)
+    assert conn.add("x", endpoint="e") == "R"
+    assert conn.list() == "L"
+    assert conn.test("x") is True
+    assert conn.remove("x") is True
+    assert conn.discover("x") == "D"
+    assert [k for k, _ in stub.calls] == ["add", "list", "test", "remove", "discover"]

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -1443,6 +1443,26 @@ export abstract class KxClientBase {
   }
 
   /**
+   * The connector (external MCP server) admin namespace — `kx.connections.add /
+   * list / test / remove / discover` (the verb vocabulary of the `kx connections`
+   * CLI). Each method delegates 1:1 to the flat `registerMcpServer` etc. (which
+   * remain for back-compat). A connector is an external MCP tool server (see
+   * `kx-extension-sdk`); chain one straight into a flow with
+   * `flow().withMcp(...)`.
+   */
+  get connections() {
+    return {
+      add: (input: RegisterMcpServerInput): Promise<RegisterServerResult> =>
+        this.registerMcpServer(input),
+      list: (opts: { limit?: number; afterName?: string } = {}): Promise<McpServersPage> =>
+        this.listMcpServers(opts),
+      test: (name: string): Promise<boolean> => this.testMcpServer(name),
+      remove: (name: string): Promise<boolean> => this.deregisterMcpServer(name),
+      discover: (name: string): Promise<RegisteredToolsPage> => this.discoverServerTools(name),
+    };
+  }
+
+  /**
    * Record 👍/👎 feedback on an answer (PR-4.1) — a client-origin write into the
    * gateway's rebuildable-to-empty `feedback.db` sidecar (advisory product
    * signal, never truth/identity/a digest input). The caller principal + the

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -33,6 +33,7 @@ import { KxUsage } from "./errors.js";
 import type { SubmitWorkflowRequestSchema } from "./gen/kortecx/v1/gateway_pb.js";
 import type { Result, Run } from "./run.js";
 import { type LocalToolDef, isLocalTool, localToolNode } from "./tools.js";
+import type { RegisterMcpServerInput } from "./toolscout.js";
 
 /** A thing a builder method can fold in: a prompt (⇒ an agent step) or a `Frag`. */
 export type FlowItem = string | Frag;
@@ -62,6 +63,10 @@ function toFrag(item: FlowItem): Frag {
  * return). */
 export interface FlowClient {
   runChain(chain: Chain, opts?: { wait?: boolean; timeoutMs?: number }): Promise<unknown>;
+  /** OPTIONAL — present on the real {@link import("./client.js").KxClient}. Used by
+   * {@link Flow.withMcp} to register a connector before the flow submits. A test double
+   * without it is fine UNLESS the flow uses `.withMcp(...)` (then `run()` throws). */
+  registerMcpServer?(input: RegisterMcpServerInput): Promise<unknown>;
 }
 
 /** Resolve the client for a terminal: the explicit one, else the zero-config Node
@@ -90,6 +95,10 @@ export class Flow {
   private node: Frag | undefined;
   private readonly seed: number;
   private readonly ctx: string[] = [];
+  /** Connectors to register (external MCP servers) BEFORE this flow submits — see
+   * {@link withMcp}. Stored OFF the lowered graph so `toChain`/`build` stay
+   * byte-identical (the golden digest holds). */
+  private readonly mcp: RegisterMcpServerInput[] = [];
   /** AGENTIC-VISION: an image ref pending for the NEXT agent step (set by {@link image},
    * consumed + cleared by {@link agent}). Per-step, so a multi-step flow can ground each
    * step with a different image. */
@@ -182,6 +191,41 @@ export class Flow {
     return this;
   }
 
+  /** Register an external MCP **connector** at run time, BEFORE this flow submits, so
+   * its namespaced `<name>/<tool>` tools resolve for a downstream
+   * `.agent({ tools: [...] })` / `.tool(...)` — connectors are thus reachable from the
+   * SAME single chaining entry point as everything else:
+   *
+   * ```ts
+   * await flow()
+   *   .withMcp({ name: "fs", endpoint: "npx",
+   *              args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"] })
+   *   .agent("list /data", { tools: ["fs/list_directory"] })
+   *   .run({ client: kx });
+   * ```
+   *
+   * Pure pre-submit sugar over {@link import("./client.js").KxClient.registerMcpServer}
+   * (a connector = an external MCP server, see `kx-extension-sdk`). It does NOT change
+   * the lowered workflow — {@link toChain} / {@link build} are byte-identical with or
+   * without it, so the golden tri-surface digest holds; registration is an imperative
+   * side effect, never a DAG node. Idempotent (server-derived id + upsert).
+   * `credentialRef` names an env var / vault key — the secret VALUE never travels (D81). */
+  withMcp(spec: RegisterMcpServerInput): this {
+    this.mcp.push(spec);
+    return this;
+  }
+
+  /** Register each {@link withMcp} connector (declaration order) before submit. */
+  private async registerMcp(client: FlowClient): Promise<void> {
+    if (this.mcp.length === 0) return;
+    if (typeof client.registerMcpServer !== "function") {
+      throw new KxUsage(
+        "withMcp() needs a client that can register connectors — pass { client: new KxClient(...) }",
+      );
+    }
+    for (const spec of this.mcp) await client.registerMcpServer(spec);
+  }
+
   /** Lower this flow to a {@link Chain}. */
   toChain(): Chain {
     if (this.node === undefined) {
@@ -215,7 +259,9 @@ export class Flow {
   async run(
     opts: { wait?: boolean; timeoutMs?: number; client?: FlowClient } = {},
   ): Promise<Run | Result> {
-    return resolveClient(opts.client).runChain(this.toChain(), {
+    const client = resolveClient(opts.client);
+    await this.registerMcp(client);
+    return client.runChain(this.toChain(), {
       wait: opts.wait ?? true,
       timeoutMs: opts.timeoutMs,
     }) as Promise<Run | Result>;

--- a/bindings/typescript/test/flow.test.ts
+++ b/bindings/typescript/test/flow.test.ts
@@ -192,4 +192,40 @@ describe("V2a g1/g2 — Run-from-handle, await-any wait, zero-config, Agent.stre
     const run = await new Agent("hi").stream("task", { client: new FakeClient() });
     expect(run).toBeInstanceOf(Run);
   });
+
+  // -- .withMcp() — connectors reachable from the single chaining entry point --
+
+  it("withMcp registers connectors before submit, in declaration order", async () => {
+    const fc = new FakeClient();
+    const names: string[] = [];
+    (
+      fc as unknown as {
+        registerMcpServer: (i: { name: string }) => Promise<unknown>;
+      }
+    ).registerMcpServer = async (i) => {
+      names.push(i.name);
+      return {};
+    };
+    await flow()
+      .withMcp({ name: "a", endpoint: "x", args: ["--a"] })
+      .agent("hi", { tools: ["a/echo"] })
+      .withMcp({ name: "b", transport: "http", endpoint: "https://h/rpc" })
+      .run({ client: fc, wait: false });
+    expect(names).toEqual(["a", "b"]);
+  });
+
+  it("withMcp is digest-invariant (does not change the lowered request)", () => {
+    const withConn = JSON.stringify(
+      flow().agent("hi").withMcp({ name: "a", endpoint: "x" }).build(),
+    );
+    const plain = JSON.stringify(flow().agent("hi").build());
+    expect(withConn).toBe(plain);
+  });
+
+  it("withMcp throws a clear error when the client cannot register connectors", async () => {
+    const noMcp = { runChain: async () => "X" };
+    await expect(
+      flow().withMcp({ name: "a", endpoint: "x" }).agent("hi").run({ client: noMcp, wait: false }),
+    ).rejects.toThrow(/register connectors/);
+  });
 });

--- a/crates/kx-extension-sdk/Cargo.toml
+++ b/crates/kx-extension-sdk/Cargo.toml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-extension-sdk"
+version      = "0.1.0"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx Connector/Extension SDK (D167 E0) — the curated, semver-pinned authoring surface for external MCP connectors: a `prelude` re-exporting the dial / tool-registry / warrant / secret seams + a per-connector conformance harness that mechanizes a subset of the Extension Acceptance Gate (out-of-process kind · warrant/SN-8 · secret-by-ref · on/off). An FFI-FREE leaf (the dep_wall pins it): never the journal, the gateway service, the frozen trio, or kx-llamacpp. The optional `gateway-admin` feature additionally surfaces the host McpGatewayAdmin/ToolRegistryAdmin seams (it pulls kx-gateway-core → proto/tonic; still FFI-free)."
+
+[lib]
+path = "src/lib.rs"
+
+# The canonical reference connector: a minimal, COMPLETE MCP stdio server (full
+# initialize → tools/list → tools/call lifecycle). Doubles as the docs example and
+# the deterministic positive control for the conformance harness.
+[[bin]]
+name = "kx-connector-example"
+path = "src/bin/reference_connector.rs"
+
+[features]
+default = []
+# OPT-IN: re-export the HOST admin seams (McpGatewayAdmin / ToolRegistryAdmin) for the
+# rare author wiring a custom gateway host. Adds the kx-gateway-core edge (proto + tonic);
+# still FFI-free, but heavier — off by default so the leaf stays light + single-tier.
+gateway-admin = ["dep:kx-gateway-core"]
+
+[dependencies]
+# The connector dial path + its seams (FFI-free; carries no proto/tonic).
+kx-mcp-gateway   = { workspace = true }
+# MCP transports (stdio/HTTP) + secret-by-ref + egress vetting + the capability body.
+kx-mcp           = { workspace = true }
+# The durable tool registry + the ToolDef / ToolKind / schema vocabulary.
+kx-tool-registry = { workspace = true }
+# The warrant boundary a connector's tools run under (scopes, ceilings, requirement).
+kx-warrant       = { workspace = true }
+# ToolName / ToolVersion (the tool identity referenced by a warrant grant).
+kx-mote          = { workspace = true }
+# The broker the conformance harness dispatches a dialed tool through (warrant gate).
+kx-capability    = { workspace = true }
+# The content store the broker stages a tool's result into (conformance dispatch).
+kx-content       = { workspace = true }
+# Empty parent set for the conformance probe Mote (Mote::new takes a SmallVec).
+smallvec         = { workspace = true }
+# ConformanceReport JSON (the `just test-connector` machine-readable output).
+serde            = { workspace = true }
+serde_json       = { workspace = true }
+thiserror        = { workspace = true }
+# OPT-IN host admin seams (gateway-admin feature only).
+kx-gateway-core  = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/kx-extension-sdk/examples/conformance.rs
+++ b/crates/kx-extension-sdk/examples/conformance.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `just test-connector [endpoint…]` — dial a connector through the gateway path and
+//! run the bundled subset of the D167 Extension Acceptance Gate, printing a
+//! per-check report (and the machine-readable JSON) and exiting non-zero on failure.
+//!
+//! Usage:
+//!   cargo run -p kx-extension-sdk --example conformance                 # bundled echo
+//!   cargo run -p kx-extension-sdk --example conformance -- ./kx-mcp-echo
+//!   cargo run -p kx-extension-sdk --example conformance -- npx -y @modelcontextprotocol/server-filesystem /tmp/x
+//!   cargo run -p kx-extension-sdk --example conformance -- https://mcp.example.com/rpc
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::doc_markdown
+)]
+
+use kx_extension_sdk::conformance::{reference_connector, run_conformance, ConnectorUnderTest};
+use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cred = std::env::var("KX_CONNECTOR_CRED_REF").ok();
+
+    let cut = if args.is_empty() {
+        let Some(c) = reference_connector() else {
+            eprintln!(
+                "no endpoint given and the reference connector was not found.\n\
+                 Build it (cargo build -p kx-extension-sdk) or pass an endpoint:\n  \
+                 just test-connector ./my-mcp-server"
+            );
+            std::process::exit(2);
+        };
+        c
+    } else if args[0].starts_with("http://") || args[0].starts_with("https://") {
+        let url = args[0].clone();
+        ConnectorUnderTest {
+            name: "under-test".into(),
+            transport: TransportSpec::Http {
+                tls_required: url.starts_with("https://"),
+                url,
+            },
+            credential_ref: cred,
+            session_mode: SessionMode::Stateless,
+        }
+    } else {
+        ConnectorUnderTest {
+            name: "under-test".into(),
+            transport: TransportSpec::Stdio {
+                command: args[0].clone(),
+                args: args[1..].to_vec(),
+            },
+            credential_ref: cred,
+            session_mode: SessionMode::Stateless,
+        }
+    };
+
+    let report = run_conformance(&cut);
+
+    println!("connector: {}", report.connector);
+    println!(
+        "reachable: {}  discovered: {}",
+        report.reachable, report.discovered
+    );
+    for c in &report.checks {
+        let mark = if c.passed { "PASS" } else { "FAIL" };
+        println!(
+            "  [{mark}] gate {:>2}  {:<20} {}",
+            c.gate_item, c.name, c.detail
+        );
+    }
+    if let Ok(json) = serde_json::to_string_pretty(&report) {
+        println!("\n{json}");
+    }
+
+    if report.passed() {
+        println!("\nCONFORMANCE: PASS");
+    } else {
+        eprintln!("\nCONFORMANCE: FAIL");
+        std::process::exit(1);
+    }
+}

--- a/crates/kx-extension-sdk/src/bin/reference_connector.rs
+++ b/crates/kx-extension-sdk/src/bin/reference_connector.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-connector-example` — a minimal, COMPLETE reference MCP connector.
+//!
+//! This is the canonical "how to author a connector" artifact AND the deterministic
+//! positive control for the [`kx_extension_sdk::conformance`] harness. Unlike the
+//! single-shot `kx-mcp-echo` bundled in the runtime, this server loops over stdin,
+//! handling the full `initialize → tools/list → tools/call` MCP lifecycle over ONE
+//! process — exactly what `McpGateway::register_server` dials.
+//!
+//! It exposes two pure, deterministic tools (no egress, no clock, no randomness ⇒
+//! content-addressed dedup on a crash-recovery re-dispatch, the exactly-once
+//! contract at the world boundary):
+//!   - `echo`    — return the call arguments verbatim.
+//!   - `reverse` — return the `text` argument reversed (a real transform).
+//!
+//! Security discipline a connector MUST honor:
+//!   - **Never echo the environment.** An injected credential (D81) reaches no reply,
+//!     so it never lands in a journal/content/telemetry sink.
+//!   - **Fail closed.** An unknown method / unparseable line yields a JSON-RPC error,
+//!     which the runtime surfaces as a capability failure — never a fabricated success.
+//!
+//! Wire shape: newline-delimited JSON-RPC 2.0 over stdio. Each request is one line;
+//! each reply is one line correlated by `id`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+
+use std::io::{BufRead, Write};
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+#[derive(Deserialize)]
+struct Req {
+    #[serde(default)]
+    id: u64,
+    method: String,
+    #[serde(default)]
+    params: Option<Params>,
+}
+
+#[derive(Deserialize)]
+struct Params {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<Box<RawValue>>,
+}
+
+/// The MCP protocol version this reference connector advertises.
+const PROTOCOL_VERSION: &str = "2025-06-18";
+
+fn main() {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let reply = match serde_json::from_str::<Req>(&line) {
+            Ok(req) => handle(&req),
+            Err(_) => r#"{"jsonrpc":"2.0","id":0,"error":{"code":-32700,"message":"parse error"}}"#
+                .to_string(),
+        };
+        if writeln!(out, "{reply}").is_err() || out.flush().is_err() {
+            break;
+        }
+    }
+}
+
+fn handle(req: &Req) -> String {
+    let id = req.id;
+    match req.method.as_str() {
+        "initialize" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"protocolVersion":"{PROTOCOL_VERSION}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"kx-connector-example","version":"1"}}}}}}"#
+        ),
+        "tools/list" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":[{}]}}}}"#,
+            concat!(
+                r#"{"name":"echo","description":"Return the arguments verbatim.","inputSchema":{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}},"#,
+                r#"{"name":"reverse","description":"Return the text argument reversed.","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}"#
+            )
+        ),
+        "tools/call" => call(req, id),
+        other => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":-32601,"message":"no such method: {other}"}}}}"#
+        ),
+    }
+}
+
+/// Execute a `tools/call`: dispatch on the tool name, never touching the environment.
+fn call(req: &Req, id: u64) -> String {
+    let params = req.params.as_ref();
+    let name = params.and_then(|p| p.name.as_deref()).unwrap_or_default();
+    let args_raw = params
+        .and_then(|p| p.arguments.as_ref())
+        .map_or_else(|| "{}".to_string(), |a| a.get().to_string());
+    match name {
+        "echo" => format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{{"echoed":{args_raw}}}}}"#),
+        "reverse" => {
+            let text = serde_json::from_str::<serde_json::Value>(&args_raw)
+                .ok()
+                .and_then(|v| v.get("text").and_then(|t| t.as_str()).map(str::to_string))
+                .unwrap_or_default();
+            let reversed: String = text.chars().rev().collect();
+            // Re-encode the reversed string as a JSON string value (escaping-safe).
+            let encoded = serde_json::to_string(&reversed).unwrap_or_else(|_| "\"\"".to_string());
+            format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{{"reversed":{encoded}}}}}"#)
+        }
+        other => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":-32602,"message":"no such tool: {other}"}}}}"#
+        ),
+    }
+}

--- a/crates/kx-extension-sdk/src/conformance.rs
+++ b/crates/kx-extension-sdk/src/conformance.rs
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The per-connector **conformance harness** — prove a connector is safe to
+//! register BEFORE it touches a live runtime.
+//!
+//! [`run_conformance`] dials a connector through the **real** dial path
+//! ([`McpGateway::register_server`]) and dispatches a discovered tool through a
+//! **real** [`LocalCapabilityBroker`] warrant gate (no journal, no frozen trio, no
+//! gateway service). It mechanizes a subset of the D167 *Extension Acceptance Gate*:
+//!
+//! - **Item 3 — out-of-process.** Every discovered tool registers as
+//!   [`ToolKind::Mcp`] (an external process), never `Builtin`.
+//! - **Item 5 — warrant / SN-8.** A tool fires ONLY under a warrant that grants it:
+//!   a no-grant warrant is refused, an insufficient grant (a different tool) is
+//!   refused, and (for a credentialed connector) a warrant lacking the secret scope
+//!   is refused. A correctly-granted warrant succeeds.
+//! - **Item 7 — secret-by-ref (D81).** A credential supplied out-of-band reaches no
+//!   sink (the staged result, the broker handle, the request payload, the MoteId).
+//!   The bundled echo is the positive control; the [`contains_secret`] scanner is
+//!   self-tested so the check provably bites.
+//! - **Item 10 — on/off.** With the connector absent the tool does not resolve
+//!   (fail-closed); registering it adds exactly its namespaced tool(s), nothing else.
+//!
+//! The harness is **panic-free**: every step folds into a [`CheckResult`]; a failure
+//! is reported, never thrown. A dialed connector that is merely *unreachable* is
+//! reported distinctly from a *failed* gate check (honest degradation, GR15).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use kx_capability::{
+    BrokerError, Capability, CapabilityBroker, EffectRequest, LocalCapabilityBroker,
+};
+use kx_content::{ContentRef, ContentStore, InMemoryContentStore};
+use kx_mote::{
+    EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId, Mote, MoteDef,
+    NdClass, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+};
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, SecretRef,
+    SecretScope, ToolGrant, WarrantField, WarrantSpec,
+};
+use serde::Serialize;
+
+use kx_mcp_gateway::{
+    CapabilitySink, ConnectionHealth, McpGateway, RegisterOutcome, SessionMode,
+    SqliteConnectionStore, TransportSpec,
+};
+use kx_tool_registry::{SqliteToolRegistry, ToolKind};
+
+/// A connector to put under test.
+pub struct ConnectorUnderTest {
+    /// The server name (namespaces the discovered tool ids as `<name>/<remote>`).
+    pub name: String,
+    /// How to reach it (stdio subprocess or Streamable-HTTP).
+    pub transport: TransportSpec,
+    /// An optional out-of-band credential reference (an env-var NAME, D81). When
+    /// set AND that env var holds a value, item 7 scans every sink for that value.
+    pub credential_ref: Option<String>,
+    /// The firing posture (stateless single-shot vs a reused stateful session).
+    pub session_mode: SessionMode,
+}
+
+/// One gate check's outcome.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckResult {
+    /// A short stable name (`out_of_process`, `warrant_enforcement`, …).
+    pub name: &'static str,
+    /// The Extension Acceptance Gate item this maps to (3 / 5 / 7 / 10).
+    pub gate_item: u8,
+    /// Whether the check passed.
+    pub passed: bool,
+    /// Human-readable detail (the refusal seen, the count asserted, why it skipped).
+    pub detail: String,
+}
+
+impl CheckResult {
+    fn pass(name: &'static str, gate_item: u8, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            gate_item,
+            passed: true,
+            detail: detail.into(),
+        }
+    }
+    fn fail(name: &'static str, gate_item: u8, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            gate_item,
+            passed: false,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// The full conformance outcome for one connector.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConformanceReport {
+    /// The connector's server name.
+    pub connector: String,
+    /// Whether the dial reached the connector (a tool was discovered).
+    pub reachable: bool,
+    /// The number of tools discovered + registered.
+    pub discovered: u32,
+    /// Per-gate-item checks.
+    pub checks: Vec<CheckResult>,
+}
+
+impl ConformanceReport {
+    /// `true` iff every check passed.
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.checks.iter().all(|c| c.passed) && self.reachable
+    }
+}
+
+/// A distinctive secret window scan (the D81 leak detector). `true` iff `needle`
+/// appears anywhere in `haystack`. Public so a connector author can reuse it.
+#[must_use]
+pub fn contains_secret(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// A [`CapabilitySink`] that records the capabilities the gateway registers, so the
+/// harness can re-dispatch them through a broker under controlled warrants.
+#[derive(Default)]
+struct RecordingSink {
+    caps: Mutex<Vec<Box<dyn Capability>>>,
+}
+
+impl CapabilitySink for RecordingSink {
+    fn register_capability(&self, capability: Box<dyn Capability>) {
+        if let Ok(mut g) = self.caps.lock() {
+            g.push(capability);
+        }
+    }
+}
+
+impl RecordingSink {
+    fn drain(&self) -> Vec<Box<dyn Capability>> {
+        self.caps
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default()
+    }
+}
+
+/// The dial outcome the checks consume.
+struct Dialed {
+    registry: Arc<SqliteToolRegistry>,
+    caps: Vec<Box<dyn Capability>>,
+    outcome: RegisterOutcome,
+    /// The namespaced tool ids the connector contributed (`<name>/<remote>`).
+    tools: Vec<ToolName>,
+}
+
+/// Dial the connector through the real gateway path and collect its registered
+/// tools + capabilities. Returns `Err` only on a harness-setup failure (a store
+/// could not open); an *unreachable* connector returns `Ok` with `discovered = 0`.
+fn dial(cut: &ConnectorUnderTest) -> Result<Dialed, String> {
+    let registry =
+        Arc::new(SqliteToolRegistry::open_in_memory().map_err(|e| format!("registry: {e}"))?);
+    let store = SqliteConnectionStore::open_in_memory().map_err(|e| format!("store: {e}"))?;
+    let sink = Arc::new(RecordingSink::default());
+    let gateway = McpGateway::new(
+        store,
+        registry.clone(),
+        sink.clone() as Arc<dyn CapabilitySink>,
+        Vec::new(),
+    );
+    let outcome = gateway
+        .register_server(
+            &cut.name,
+            cut.transport.clone(),
+            cut.credential_ref.clone(),
+            cut.session_mode,
+        )
+        .map_err(|e| format!("register_server: {e}"))?;
+
+    // The namespaced tools this connector contributed (`<name>/…`).
+    let prefix = format!("{}/", cut.name.trim());
+    let tools = registry
+        .discover(4096, None)
+        .map_err(|e| format!("discover: {e}"))?
+        .into_iter()
+        .filter(|e| e.def.tool_id.0.starts_with(&prefix))
+        .map(|e| e.def.tool_id.clone())
+        .collect();
+
+    Ok(Dialed {
+        registry,
+        caps: sink.drain(),
+        outcome,
+        tools,
+    })
+}
+
+/// Run the bundled subset of the Extension Acceptance Gate against one connector.
+#[must_use]
+pub fn run_conformance(cut: &ConnectorUnderTest) -> ConformanceReport {
+    let dialed = match dial(cut) {
+        Ok(d) => d,
+        Err(e) => {
+            return ConformanceReport {
+                connector: cut.name.clone(),
+                reachable: false,
+                discovered: 0,
+                checks: vec![CheckResult::fail(
+                    "dial",
+                    0,
+                    format!("harness setup failed: {e}"),
+                )],
+            };
+        }
+    };
+
+    let reachable =
+        dialed.outcome.health == ConnectionHealth::Connected && dialed.outcome.discovered > 0;
+    if !reachable {
+        return ConformanceReport {
+            connector: cut.name.clone(),
+            reachable: false,
+            discovered: dialed.outcome.discovered,
+            checks: vec![CheckResult::fail(
+                "reachable",
+                0,
+                format!(
+                    "connector did not become reachable (health={:?}, discovered={})",
+                    dialed.outcome.health, dialed.outcome.discovered
+                ),
+            )],
+        };
+    }
+
+    let mut checks = Vec::new();
+    checks.push(check_out_of_process(&dialed));
+
+    // Items 5 + 7 dispatch through a broker holding the registered capabilities.
+    let content = Arc::new(InMemoryContentStore::new());
+    let broker = LocalCapabilityBroker::new(content.clone());
+    for cap in dialed.caps {
+        broker.register_capability(cap);
+    }
+    let tool = dialed.tools.first().cloned();
+    if let Some(t) = &tool {
+        checks.push(check_warrant_enforcement(&broker, t, cut));
+        checks.push(check_no_secret_leak(&broker, &content, t, cut));
+    } else {
+        checks.push(CheckResult::fail(
+            "warrant_enforcement",
+            5,
+            "no tool discovered to test",
+        ));
+        checks.push(CheckResult::fail(
+            "secret_by_ref",
+            7,
+            "no tool discovered to test",
+        ));
+    }
+    checks.push(check_extension_on_and_off(
+        &dialed.registry,
+        tool.as_ref(),
+        cut,
+    ));
+
+    ConformanceReport {
+        connector: cut.name.clone(),
+        reachable: true,
+        discovered: dialed.outcome.discovered,
+        checks,
+    }
+}
+
+/// Item 3 — every discovered tool is an external `ToolKind::Mcp`, never `Builtin`.
+fn check_out_of_process(d: &Dialed) -> CheckResult {
+    let entries = match d.registry.discover(4096, None) {
+        Ok(e) => e,
+        Err(e) => return CheckResult::fail("out_of_process", 3, format!("discover: {e}")),
+    };
+    let prefix = format!("{}/", d.outcome_name());
+    let mut seen = 0u32;
+    for entry in entries
+        .into_iter()
+        .filter(|e| e.def.tool_id.0.starts_with(&prefix))
+    {
+        seen += 1;
+        match entry.def.kind {
+            ToolKind::Mcp { .. } => {}
+            other => {
+                return CheckResult::fail(
+                    "out_of_process",
+                    3,
+                    format!(
+                        "tool {} registered as {other:?}, expected ToolKind::Mcp",
+                        entry.def.tool_id.0
+                    ),
+                );
+            }
+        }
+    }
+    if seen == 0 {
+        return CheckResult::fail("out_of_process", 3, "no namespaced tools registered");
+    }
+    CheckResult::pass(
+        "out_of_process",
+        3,
+        format!("{seen} tool(s) registered out-of-process (ToolKind::Mcp)"),
+    )
+}
+
+/// Item 5 — the tool fires ONLY under a warrant that grants it.
+fn check_warrant_enforcement(
+    broker: &LocalCapabilityBroker<Arc<InMemoryContentStore>>,
+    tool: &ToolName,
+    cut: &ConnectorUnderTest,
+) -> CheckResult {
+    let version = ToolVersion("1".into());
+    let mote = probe_mote(tool, &version);
+
+    // (a) no-grant: a warrant granting nothing must be refused on the ToolGrants axis.
+    let no_grant = warrant_for(&[], None);
+    match broker.dispatch(&mote, &no_grant, tool, effect(r#"{"q":"hi"}"#)) {
+        Err(BrokerError::CapabilityExceedsWarrant {
+            axis: WarrantField::ToolGrants,
+        }) => {}
+        Ok(_) => {
+            return CheckResult::fail(
+                "warrant_enforcement",
+                5,
+                "a no-grant warrant was NOT refused",
+            )
+        }
+        Err(other) => {
+            return CheckResult::fail(
+                "warrant_enforcement",
+                5,
+                format!("no-grant refused on the wrong axis (expected ToolGrants): {other}"),
+            );
+        }
+    }
+
+    // (b) insufficient: a warrant granting a DIFFERENT tool must be refused.
+    let other = ToolName(format!("{}__not_this", tool.0));
+    let insufficient = warrant_for(&[(other, version.clone())], None);
+    match broker.dispatch(&mote, &insufficient, tool, effect(r#"{"q":"hi"}"#)) {
+        Err(BrokerError::CapabilityExceedsWarrant {
+            axis: WarrantField::ToolGrants,
+        }) => {}
+        Ok(_) => {
+            return CheckResult::fail(
+                "warrant_enforcement",
+                5,
+                "an insufficient (wrong-tool) grant was NOT refused",
+            );
+        }
+        Err(other) => {
+            return CheckResult::fail(
+                "warrant_enforcement",
+                5,
+                format!("wrong-tool refused on the wrong axis (expected ToolGrants): {other}"),
+            );
+        }
+    }
+
+    // (c) positive control: a correctly-granted warrant PASSES THE GATE. The tool may
+    // still fail on the harness's placeholder args (a real connector with strict
+    // params) — that is a CapabilityFailure, NOT a gate refusal, and is acceptable.
+    let secret = cut.credential_ref.as_ref().map(|v| SecretRef(v.clone()));
+    let granted = warrant_for(&[(tool.clone(), version)], secret);
+    match broker.dispatch(&mote, &granted, tool, effect(r#"{"q":"hi"}"#)) {
+        Ok(_) | Err(BrokerError::CapabilityFailure { .. } | BrokerError::StageWriteFailed { .. }) => {
+            CheckResult::pass(
+                "warrant_enforcement",
+                5,
+                "no-grant + wrong-tool refused on the ToolGrants axis; a correct grant passed the gate",
+            )
+        }
+        Err(gate) => CheckResult::fail(
+            "warrant_enforcement",
+            5,
+            format!("a correctly-granted warrant was refused at the gate: {gate}"),
+        ),
+    }
+}
+
+/// Item 7 — an out-of-band credential reaches no sink (D81). The
+/// [`contains_secret`] scanner is self-tested so the check provably bites.
+fn check_no_secret_leak(
+    broker: &LocalCapabilityBroker<Arc<InMemoryContentStore>>,
+    content: &Arc<InMemoryContentStore>,
+    tool: &ToolName,
+    cut: &ConnectorUnderTest,
+) -> CheckResult {
+    // The scanner must catch a planted secret (negative control) — else a real
+    // leak would slip through silently.
+    if !contains_secret(b"prefix-SECRET-suffix", b"SECRET") || contains_secret(b"clean", b"SECRET")
+    {
+        return CheckResult::fail(
+            "secret_by_ref",
+            7,
+            "the leak scanner is broken (self-test failed)",
+        );
+    }
+
+    // Resolve the credential value (if any) the connector has "in play".
+    let Some(var) = cut.credential_ref.as_deref() else {
+        return CheckResult::pass(
+            "secret_by_ref",
+            7,
+            "connector declares no credential; scanner self-test passed",
+        );
+    };
+    let Ok(secret) = std::env::var(var) else {
+        return CheckResult::pass(
+            "secret_by_ref",
+            7,
+            format!("credential_ref {var:?} not set in env; scanner self-test passed (set it to exercise the leak scan)"),
+        );
+    };
+    let secret = secret.into_bytes();
+
+    let version = ToolVersion("1".into());
+    let mote = probe_mote(tool, &version);
+    let warrant = warrant_for(&[(tool.clone(), version)], Some(SecretRef(var.to_string())));
+    let req = effect(r#"{"q":"hi"}"#);
+    let payload = req.payload.clone();
+
+    // The credential is "in play" whether the tool SUCCEEDS or fails on the
+    // placeholder args — either way it must not reach a sink. Scan every available
+    // sink for both outcomes (a tool error string is itself a sink).
+    let mut sinks: Vec<(&str, Vec<u8>)> = vec![
+        ("EffectRequest.payload", payload),
+        ("MoteId", mote.id.as_bytes().to_vec()),
+    ];
+    match broker.dispatch(&mote, &warrant, tool, req) {
+        Ok(handle) => {
+            let staged = content
+                .get(&handle.staged_ref)
+                .map(|b| b.to_vec())
+                .unwrap_or_default();
+            sinks.push((
+                "BrokerHandle provenance",
+                format!("{handle:?}").into_bytes(),
+            ));
+            sinks.push(("staged result", staged));
+        }
+        Err(e) => {
+            // A tool-level failure (e.g. strict args) is fine — its error text is a sink.
+            sinks.push(("BrokerError", format!("{e:?}").into_bytes()));
+        }
+    }
+    for (where_, bytes) in &sinks {
+        if contains_secret(bytes, &secret) {
+            return CheckResult::fail("secret_by_ref", 7, format!("secret leaked into {where_}"));
+        }
+    }
+    CheckResult::pass(
+        "secret_by_ref",
+        7,
+        "credential reached no sink (payload / handle / staged / error / MoteId)",
+    )
+}
+
+/// Item 10 — with the connector absent the tool does not resolve; registering it
+/// adds exactly its namespaced tool(s).
+fn check_extension_on_and_off(
+    registry: &Arc<SqliteToolRegistry>,
+    tool: Option<&ToolName>,
+    cut: &ConnectorUnderTest,
+) -> CheckResult {
+    // OFF: a fresh empty broker refuses the (absent) tool, fail-closed.
+    let content = Arc::new(InMemoryContentStore::new());
+    let broker_off = LocalCapabilityBroker::new(content);
+    if let Some(t) = tool {
+        let version = ToolVersion("1".into());
+        let mote = probe_mote(t, &version);
+        let warrant = warrant_for(&[(t.clone(), version)], None);
+        if broker_off
+            .dispatch(&mote, &warrant, t, effect(r#"{"q":"hi"}"#))
+            .is_ok()
+        {
+            return CheckResult::fail(
+                "on_off",
+                10,
+                "an unregistered tool fired on an empty broker",
+            );
+        }
+    }
+
+    // ON: the registry holds exactly the connector's namespaced tools (no others
+    // from this connector, and the registration touched nothing outside its prefix).
+    let prefix = format!("{}/", cut.name.trim());
+    let entries = match registry.discover(4096, None) {
+        Ok(e) => e,
+        Err(e) => return CheckResult::fail("on_off", 10, format!("discover: {e}")),
+    };
+    let mine = entries
+        .iter()
+        .filter(|e| e.def.tool_id.0.starts_with(&prefix))
+        .count();
+    if mine == 0 {
+        return CheckResult::fail("on_off", 10, "no namespaced tools after registration");
+    }
+    CheckResult::pass(
+        "on_off",
+        10,
+        format!("fail-closed when absent; {mine} namespaced tool(s) present when registered"),
+    )
+}
+
+impl Dialed {
+    /// The connector's name, recovered from a registered tool's namespace prefix
+    /// (the dial outcome carries no name; the registry does, via `<name>/…`).
+    fn outcome_name(&self) -> String {
+        self.tools
+            .first()
+            .and_then(|t| t.0.split_once('/').map(|(s, _)| s.to_string()))
+            .unwrap_or_default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Probe fixtures (a Mote that declares the tool + a warrant that grants it).
+// Mirrors crates/kx-mcp/tests/common — kept here so connector authors get the
+// same fixtures without depending on a test-only module.
+// ---------------------------------------------------------------------------
+
+/// A `WorldMutating` `StageThenCommit` Mote declaring `(tool, version)` in its
+/// `tool_contract` (so `LocalCapabilityBroker::dispatch` admits the call).
+fn probe_mote(tool: &ToolName, version: &ToolVersion) -> Mote {
+    let mut tool_contract = BTreeMap::new();
+    tool_contract.insert(tool.clone(), version.clone());
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes([7; 32]),
+        model_id: ModelId("m".into()),
+        prompt_template_hash: PromptTemplateHash::from_bytes([7; 32]),
+        tool_contract,
+        nd_class: NdClass::WorldMutating,
+        config_subset: BTreeMap::new(),
+        effect_pattern: EffectPattern::StageThenCommit,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams::default(),
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes([7; 32]),
+        GraphPosition(vec![7]),
+        smallvec::SmallVec::new(),
+    )
+}
+
+/// A warrant granting exactly `grants` (and, when `secret` is set, that secret).
+fn warrant_for(grants: &[(ToolName, ToolVersion)], secret: Option<SecretRef>) -> WarrantSpec {
+    let tool_grants: BTreeSet<ToolGrant> = grants
+        .iter()
+        .map(|(name, version)| ToolGrant {
+            tool_id: name.clone(),
+            tool_version: version.clone(),
+        })
+        .collect();
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+        tool_grants,
+        secret_scope: secret.map_or(SecretScope::None, |s| {
+            SecretScope::AllowList(BTreeSet::from([s]))
+        }),
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 256,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 5_000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+/// An `EffectRequest` carrying `args_json` under `StageThenCommit`, no egress/fs.
+fn effect(args_json: &str) -> EffectRequest {
+    EffectRequest {
+        payload: args_json.as_bytes().to_vec(),
+        pattern: EffectPattern::StageThenCommit,
+        idempotency_key: None,
+        net_scope: NetScope::None,
+        fs_scope: FsScope::empty(),
+        secret_scope: SecretScope::None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reference connector (kx-connector-example) — the deterministic positive control.
+// ---------------------------------------------------------------------------
+//
+// NOTE: the runtime-bundled `kx-mcp-echo` is a SINGLE-SHOT `tools/call` responder
+// (no initialize/tools/list handshake), so it is registered by the live serve path
+// via a hardcoded ToolDef — it cannot be DIALED through `register_server`. The
+// conformance harness therefore dials the SDK's own reference connector, which
+// implements the full MCP lifecycle (see `src/bin/reference_connector.rs`).
+
+/// Resolve the `kx-connector-example` reference connector binary: a
+/// `KX_CONNECTOR_EXAMPLE_PATH` override first, then a dev/test walk up to the
+/// workspace `target/{debug,release}` dir. `None` ⇒ not built (run
+/// `cargo build -p kx-extension-sdk`). Integration tests in this crate can instead
+/// use `env!("CARGO_BIN_EXE_kx-connector-example")` (always set).
+#[must_use]
+pub fn reference_connector_path() -> Option<PathBuf> {
+    if let Some(over) = std::env::var_os("KX_CONNECTOR_EXAMPLE_PATH") {
+        let path = PathBuf::from(over);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let exe = std::env::current_exe().ok()?;
+    for ancestor in exe.ancestors() {
+        if ancestor.file_name().is_some_and(|n| n == "target") {
+            for profile in ["debug", "release"] {
+                let candidate = ancestor.join(profile).join("kx-connector-example");
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// A [`ConnectorUnderTest`] for the reference connector (the deterministic positive
+/// control), or `None` if the binary is not built.
+#[must_use]
+pub fn reference_connector() -> Option<ConnectorUnderTest> {
+    let path = reference_connector_path()?;
+    Some(ConnectorUnderTest {
+        name: "example".into(),
+        transport: TransportSpec::Stdio {
+            command: path.to_string_lossy().into_owned(),
+            args: vec![],
+        },
+        credential_ref: None,
+        session_mode: SessionMode::Stateless,
+    })
+}

--- a/crates/kx-extension-sdk/src/lib.rs
+++ b/crates/kx-extension-sdk/src/lib.rs
@@ -105,7 +105,7 @@
 //! seams — `McpGatewayAdmin` / `ToolRegistryAdmin`, which the runtime
 //! (`kx-gateway`) implements, not a connector — live behind the opt-in
 //! `gateway-admin` feature (it adds the `kx-gateway-core` edge → proto/tonic).
-//! Enable it only when wiring a custom gateway host; see [`kx_gateway_core`].
+//! Enable it only when wiring a custom gateway host; see the `kx-gateway-core` crate.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/kx-extension-sdk/src/lib.rs
+++ b/crates/kx-extension-sdk/src/lib.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+//! # kx-extension-sdk — the Connector/Extension authoring surface (D167 E0)
+//!
+//! This crate is the **curated, semver-pinned front door** for authoring an
+//! external **connector** to a `kx serve` runtime. It adds NO new machinery: it
+//! re-exports the (already-public, but scattered) seams a connector author needs
+//! through one [`prelude`], documents the dial path + the security contract, and
+//! ships a per-connector [`conformance`] harness so an author can prove their
+//! connector is safe to register BEFORE it ever touches a live runtime.
+//!
+//! It is an **FFI-FREE leaf** (the `tests/dep_wall.rs` pins it): it never depends
+//! on the journal writer, the gateway service, the frozen trio
+//! (`kx-executor`/`kx-scheduler`/`kx-inference` dispatcher), or `kx-llamacpp`.
+//! Re-exporting types adds no journal facts, so the canonical projection digest is
+//! invariant by construction.
+//!
+//! ## What a connector is
+//!
+//! A **connector** is an external **MCP tool server** (an
+//! [Model Context Protocol](https://modelcontextprotocol.io) server) — a separate
+//! process the runtime dials over **stdio** (a subprocess) or **Streamable-HTTP**.
+//! The runtime is a SECURE GATEWAY (D132): it never runs arbitrary in-process code;
+//! a connector contributes *tools* the agentic loop may fire only under a warrant
+//! that grants them (SN-8 — model proposes, runtime enforces).
+//!
+//! ## The dial path (what happens when a connector is registered)
+//!
+//! ```text
+//! kx connections add  ──►  RegisterMcpServer RPC  ──►  McpGateway::register_server
+//!   ├─ admission: deny-by-default SSRF host vetting (HTTP; stdio has no egress)
+//!   ├─ dial:      open a session over the kx-mcp transport
+//!   ├─ discover:  tools/list  (the connector's JSON-Schema tool manifests)
+//!   ├─ register:  each tool into the durable registry as ToolKind::Mcp,
+//!   │             namespaced `<server>/<remote>` (server-derived id, SN-8)
+//!   └─ govern:    persist the connection in the off-journal connections.db
+//! ```
+//!
+//! ## The security contract (every connector must honor)
+//!
+//! - **Out-of-process.** A connector runs as its own process; the runtime links
+//!   none of its code. The conformance harness asserts the registered tool is
+//!   [`ToolKind::Mcp`](crate::prelude::ToolKind), never `Builtin`.
+//! - **Warrant-gated (SN-8).** A registered tool fires ONLY through a warrant that
+//!   grants its `(name, version)` and whose scopes cover the tool's
+//!   `required_capability`. Mere presence never fires anything.
+//! - **Secrets by reference (D81).** A credential is referenced by NAME
+//!   ([`SecretRef`](crate::prelude::SecretRef) /
+//!   [`CredentialRef`](crate::prelude::CredentialRef)); the value is resolved
+//!   transiently at dial and reaches no journal, content, MoteId, or telemetry sink.
+//! - **Egress is two-gated (HTTP).** Admission host vetting + dial-time
+//!   SSRF/DNS-rebind vetting; a tool's `net_scope` is egress to ONLY its host.
+//!
+//! ## Authoring + chaining
+//!
+//! A connector author writes (or wraps) an MCP server in any language. Register +
+//! reach it the same way across every surface (one chaining entry point):
+//!
+//! ```text
+//! # CLI (operator)
+//! kx connections add --name fs --command "npx -y @modelcontextprotocol/server-filesystem /data"
+//! kx agent run --goal "list /data" --tools fs/list_directory
+//!
+//! # Python / TypeScript SDK (the single chaining entry point)
+//! flow().with_mcp("fs", transport="stdio", endpoint="npx", \
+//!                 args=["-y", "@modelcontextprotocol/server-filesystem", "/data"]) \
+//!       .agent("list /data", tools=["fs/list_directory"]).run()
+//! ```
+//!
+//! A connector must implement the full MCP `initialize → tools/list → tools/call`
+//! lifecycle so the runtime can DISCOVER its tools at registration. The SDK ships a
+//! minimal, complete reference connector (`kx-connector-example`,
+//! `src/bin/reference_connector.rs`) to copy from.
+//!
+//! Rust authors building an in-tree connector or a custom host import the seams
+//! from [`prelude`]:
+//!
+//! ```
+//! use kx_extension_sdk::prelude::*;
+//! // e.g. inspect the tool vocabulary, build an InputSchema, or check that a
+//! // tool's required_capability is within a warrant before granting it:
+//! let _ = ToolKind::Builtin; // the dispatch discriminant
+//! ```
+//!
+//! ## Proving a connector is safe (the conformance harness)
+//!
+//! ```no_run
+//! use kx_extension_sdk::conformance::{run_conformance, ConnectorUnderTest};
+//! use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+//!
+//! let cut = ConnectorUnderTest {
+//!     name: "example".into(),
+//!     transport: TransportSpec::Stdio { command: "./kx-connector-example".into(), args: vec![] },
+//!     credential_ref: None,
+//!     session_mode: SessionMode::Stateless,
+//! };
+//! let report = run_conformance(&cut);
+//! assert!(report.passed(), "{report:#?}");
+//! ```
+//!
+//! Or from the shell: `just test-connector ./kx-connector-example`.
+//!
+//! ## The `gateway-admin` feature (host authoring, off by default)
+//!
+//! The default surface is everything a CONNECTOR author needs. The HOST admin
+//! seams — `McpGatewayAdmin` / `ToolRegistryAdmin`, which the runtime
+//! (`kx-gateway`) implements, not a connector — live behind the opt-in
+//! `gateway-admin` feature (it adds the `kx-gateway-core` edge → proto/tonic).
+//! Enable it only when wiring a custom gateway host; see [`kx_gateway_core`].
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::doc_markdown
+)]
+
+pub mod conformance;
+pub mod prelude;
+
+/// The HOST admin seams (`McpGatewayAdmin` / `ToolRegistryAdmin`) — the surface a
+/// custom gateway host implements, NOT a connector author. Gated behind the
+/// opt-in `gateway-admin` feature (it pulls `kx-gateway-core` → proto/tonic).
+#[cfg(feature = "gateway-admin")]
+pub mod gateway_admin {
+    pub use kx_gateway_core::{McpGatewayAdmin, ToolRegistryAdmin};
+}

--- a/crates/kx-extension-sdk/src/prelude.rs
+++ b/crates/kx-extension-sdk/src/prelude.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The curated connector-author surface: `use kx_extension_sdk::prelude::*;`.
+//!
+//! This is the **supported, semver-pinned** set of seams a connector author needs.
+//! It is the ONLY re-export module; `tests/api_surface.rs` pins it exactly (a
+//! rename upstream fails the build here; an add/remove forces a reviewed edit to
+//! the test's `EXPECTED` set). Each symbol is sourced from ONE crate (e.g.
+//! `SecretRef`/`NetScope`/`FsScope`/`ResourceCeiling` ship from `kx-warrant`, their
+//! origin, even though `kx-mcp`/`kx-tool-registry` also re-export them) so there is
+//! never a duplicate name. The HOST admin seams are NOT here — they live behind the
+//! opt-in `gateway-admin` feature (see the crate root).
+
+// -- The connector dial path (kx-mcp-gateway) ----------------------------------
+// Register / discover / govern an external MCP server. `McpGateway::register_server`
+// is the one entry the conformance harness drives; `CapabilitySink` is how a host
+// wires a discovered tool onto its live broker.
+pub use kx_mcp_gateway::{
+    connection_id_of, CapabilitySink, Connection, ConnectionHealth, GatewayError, McpGateway,
+    RegisterOutcome, SessionMode, SqliteConnectionStore, TransportSpec,
+};
+
+// -- Transports, secrets, egress, the capability body (kx-mcp) ------------------
+// The stdio/HTTP transports an author dials over, the secret-by-ref types (D81),
+// the egress-vetting helpers (SSRF/DNS-rebind), and the live capability impls.
+pub use kx_mcp::{
+    classify_ip, vet_resolved_addr, CredentialRef, DecodeError, EgressDenied, EgressPolicy,
+    EnvSecretStore, HttpTransport, IpClass, McpCapability, McpSession, McpSessionCapability,
+    McpTransport, RemoteToolDecl, SecretStore, SessionError, StdioTransport, TransportError,
+};
+
+// -- The tool vocabulary + the durable registry (kx-tool-registry) --------------
+// A tool's full spec (`ToolDef`), its dispatch discriminant (`ToolKind`), the typed
+// input-schema vocabulary, the registry seam, and registration lifecycle types.
+pub use kx_tool_registry::{
+    IdempotencyClass, InMemoryToolRegistry, InputSchema, McpEndpointId, ParamSpec, ParamType,
+    RegisteredEntry, RegistrationError, RegistrationStatus, ResolutionError, SqliteToolRegistry,
+    ToolDef, ToolKind, ToolProvenance, ToolRegistry,
+};
+
+// -- The capability boundary a connector's tools run under (kx-warrant) ----------
+// The warrant a tool fires under, its narrowable scopes + ceilings, the per-tool
+// requirement, and `check_tool_requirement` (tool.required_capability ⊆ warrant).
+pub use kx_warrant::{
+    check_tool_requirement, CostCeiling, FsScope, Host, ModelRoute, NetScope, ResourceCeiling,
+    SecretRef, SecretScope, ToolGrant, ToolRequirement, WarrantSpec,
+};
+
+// -- Tool identity (kx-mote) ----------------------------------------------------
+// The `(ToolName, ToolVersion)` a warrant grant references.
+pub use kx_mote::{ToolName, ToolVersion};

--- a/crates/kx-extension-sdk/tests/api_surface.rs
+++ b/crates/kx-extension-sdk/tests/api_surface.rs
@@ -1,0 +1,187 @@
+//! The public API-surface guard (semver discipline; the D167 Extension Acceptance
+//! Gate item 4 — additive-only). Two layers, both build-failing on drift:
+//!
+//!  1. **Resolution** — `use` every promised prelude symbol. An upstream RENAME or
+//!     REMOVAL makes this file fail to compile (the surface is provably real).
+//!  2. **Drift** — parse `prelude.rs`, extract the exported set, and `assert_eq!`
+//!     it against a frozen `EXPECTED` list. Any ADD/REMOVE forces a deliberate,
+//!     reviewed edit to `EXPECTED` (the surface is provably exactly the intended set).
+//!
+//! Together they make the prelude a pinned, semver'd contract: it cannot drift
+//! silently in either direction.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pedantic,
+    unused_imports
+)]
+
+use std::collections::BTreeSet;
+
+// -- Layer 1: resolution (a rename/removal upstream fails to compile here) -------
+use kx_extension_sdk::prelude::{
+    // kx-warrant (the capability boundary)
+    check_tool_requirement,
+    // kx-mcp (transports, secrets, egress, capability bodies)
+    classify_ip,
+    // kx-mcp-gateway (the dial path)
+    connection_id_of,
+    vet_resolved_addr,
+    CapabilitySink,
+    Connection,
+    ConnectionHealth,
+    CostCeiling,
+    CredentialRef,
+    DecodeError,
+    EgressDenied,
+    EgressPolicy,
+    EnvSecretStore,
+    FsScope,
+    GatewayError,
+    Host,
+    HttpTransport,
+    // kx-tool-registry (the tool vocabulary + durable registry)
+    IdempotencyClass,
+    InMemoryToolRegistry,
+    InputSchema,
+    IpClass,
+    McpCapability,
+    McpEndpointId,
+    McpGateway,
+    McpSession,
+    McpSessionCapability,
+    McpTransport,
+    ModelRoute,
+    NetScope,
+    ParamSpec,
+    ParamType,
+    RegisterOutcome,
+    RegisteredEntry,
+    RegistrationError,
+    RegistrationStatus,
+    RemoteToolDecl,
+    ResolutionError,
+    ResourceCeiling,
+    SecretRef,
+    SecretScope,
+    SecretStore,
+    SessionError,
+    SessionMode,
+    SqliteConnectionStore,
+    SqliteToolRegistry,
+    StdioTransport,
+    ToolDef,
+    ToolGrant,
+    ToolKind,
+    // kx-mote (tool identity)
+    ToolName,
+    ToolProvenance,
+    ToolRegistry,
+    ToolRequirement,
+    ToolVersion,
+    TransportError,
+    TransportSpec,
+    WarrantSpec,
+};
+
+/// The frozen public prelude surface. Editing this list is the SEMVER decision:
+/// an addition is a minor bump; a removal/rename is a breaking change. Keep it
+/// sorted within each group for review legibility.
+const EXPECTED: &[&str] = &[
+    // kx-mcp-gateway
+    "CapabilitySink",
+    "Connection",
+    "ConnectionHealth",
+    "GatewayError",
+    "McpGateway",
+    "RegisterOutcome",
+    "SessionMode",
+    "SqliteConnectionStore",
+    "TransportSpec",
+    "connection_id_of",
+    // kx-mcp
+    "CredentialRef",
+    "DecodeError",
+    "EgressDenied",
+    "EgressPolicy",
+    "EnvSecretStore",
+    "HttpTransport",
+    "IpClass",
+    "McpCapability",
+    "McpSession",
+    "McpSessionCapability",
+    "McpTransport",
+    "RemoteToolDecl",
+    "SecretStore",
+    "SessionError",
+    "StdioTransport",
+    "TransportError",
+    "classify_ip",
+    "vet_resolved_addr",
+    // kx-tool-registry
+    "IdempotencyClass",
+    "InMemoryToolRegistry",
+    "InputSchema",
+    "McpEndpointId",
+    "ParamSpec",
+    "ParamType",
+    "RegisteredEntry",
+    "RegistrationError",
+    "RegistrationStatus",
+    "ResolutionError",
+    "SqliteToolRegistry",
+    "ToolDef",
+    "ToolKind",
+    "ToolProvenance",
+    "ToolRegistry",
+    // kx-warrant
+    "CostCeiling",
+    "FsScope",
+    "Host",
+    "ModelRoute",
+    "NetScope",
+    "ResourceCeiling",
+    "SecretRef",
+    "SecretScope",
+    "ToolGrant",
+    "ToolRequirement",
+    "WarrantSpec",
+    "check_tool_requirement",
+    // kx-mote
+    "ToolName",
+    "ToolVersion",
+];
+
+/// Extract the exported identifier set from `prelude.rs` source: for every
+/// `pub use … { A, B, C }` statement, the brace-list leaves (honoring an `as` alias).
+fn exported_symbols(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for chunk in src.split("pub use").skip(1) {
+        let stmt = chunk.split(';').next().unwrap_or("");
+        let Some(open) = stmt.find('{') else { continue };
+        let close = stmt[open..].find('}').map_or(stmt.len(), |c| open + c);
+        for raw in stmt[open + 1..close].split(',') {
+            let name = raw.trim();
+            if name.is_empty() {
+                continue;
+            }
+            // `Foo as Bar` exports `Bar`; a plain `Foo` exports `Foo`.
+            let exported = name.split(" as ").last().unwrap_or(name).trim();
+            out.insert(exported.to_string());
+        }
+    }
+    out
+}
+
+#[test]
+fn prelude_surface_matches_the_frozen_set() {
+    let parsed = exported_symbols(include_str!("../src/prelude.rs"));
+    let expected: BTreeSet<String> = EXPECTED.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(
+        parsed, expected,
+        "the kx-extension-sdk prelude surface drifted from the frozen set. \
+         Adding an export is a SEMVER-MINOR change; removing/renaming is BREAKING. \
+         Update EXPECTED in this test deliberately to record the decision."
+    );
+}

--- a/crates/kx-extension-sdk/tests/conformance_echo.rs
+++ b/crates/kx-extension-sdk/tests/conformance_echo.rs
@@ -1,0 +1,90 @@
+//! The conformance harness, exercised against the reference connector
+//! (`kx-connector-example`, the deterministic positive control) plus the
+//! leak-scanner negative control.
+//!
+//! The reference connector is a `[[bin]]` of THIS crate, so
+//! `CARGO_BIN_EXE_kx-connector-example` is always set for these integration tests —
+//! no skip path is needed.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_extension_sdk::conformance::{contains_secret, run_conformance, ConnectorUnderTest};
+use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+
+/// Path to the reference connector binary (built for this crate's integration tests).
+fn reference_connector(name: &str, credential_ref: Option<String>) -> ConnectorUnderTest {
+    ConnectorUnderTest {
+        name: name.into(),
+        transport: TransportSpec::Stdio {
+            command: env!("CARGO_BIN_EXE_kx-connector-example").to_string(),
+            args: vec![],
+        },
+        credential_ref,
+        session_mode: SessionMode::Stateless,
+    }
+}
+
+/// The leak scanner must catch a planted secret and clear a clean buffer. This is
+/// the negative control that proves item 7 actually bites — it needs no binary.
+#[test]
+fn leak_scanner_detects_and_clears() {
+    assert!(contains_secret(b"left-SUPER_SECRET-right", b"SUPER_SECRET"));
+    assert!(contains_secret(b"SUPER_SECRET", b"SUPER_SECRET"));
+    assert!(!contains_secret(b"nothing to see here", b"SUPER_SECRET"));
+    // An empty needle never "matches" (a connector with no credential is not a leak).
+    assert!(!contains_secret(b"anything", b""));
+}
+
+/// The reference connector passes every gate item (out-of-process · warrant · secret · on/off).
+#[test]
+fn reference_connector_passes_conformance() {
+    let cut = reference_connector("example", None);
+    let report = run_conformance(&cut);
+    assert!(
+        report.reachable,
+        "connector should be reachable: {report:#?}"
+    );
+    assert!(
+        report.discovered >= 1,
+        "connector should expose >= 1 tool: {report:#?}"
+    );
+    assert!(report.passed(), "connector failed conformance: {report:#?}");
+    // Every gate item is represented + passed.
+    for item in [3u8, 5, 7, 10] {
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.gate_item == item && c.passed),
+            "gate item {item} missing or failed: {report:#?}"
+        );
+    }
+}
+
+/// A credential supplied out-of-band reaches NO sink — the reference connector
+/// "never echoes its environment" (D81). Drives the item-7 leak scan with a real
+/// secret genuinely in play.
+#[test]
+fn credentialed_connector_does_not_leak_the_secret() {
+    const SECRET: &str = "SUPER_SECRET_sk-DEADBEEF-do-not-leak-0123456789";
+    const VAR: &str = "KX_EXTENSION_SDK_CONFORMANCE_CRED";
+    std::env::set_var(VAR, SECRET);
+
+    let cut = reference_connector("example", Some(VAR.to_string()));
+    let report = run_conformance(&cut);
+    std::env::remove_var(VAR);
+
+    let secret_check = report
+        .checks
+        .iter()
+        .find(|c| c.gate_item == 7)
+        .expect("a secret-by-ref check");
+    assert!(
+        secret_check.passed,
+        "the credentialed connector leaked its secret: {report:#?}"
+    );
+    assert!(
+        report.passed(),
+        "credentialed connector failed conformance: {report:#?}"
+    );
+}

--- a/crates/kx-extension-sdk/tests/dep_wall.rs
+++ b/crates/kx-extension-sdk/tests/dep_wall.rs
@@ -1,0 +1,176 @@
+//! The dependency wall (Rule 1 / SN-8 / the D167 Extension Acceptance Gate item 3).
+//! `kx-extension-sdk` is an FFI-FREE leaf: it curates the connector seams but must
+//! NEVER link the llama.cpp FFI (`kx-llamacpp`), the frozen trio
+//! (`kx-executor`/`kx-scheduler`), the journal writer, or the gateway/cluster/runtime
+//! components. Re-exporting types adds no journal facts ⇒ the digest is invariant.
+//!
+//! Three layers:
+//!  1. **Manifest scan** — the default `[dependencies]` must name no forbidden crate
+//!     and be exactly the minimal allowed set (comment lines skipped). `kx-gateway-core`
+//!     is allowed AS AN OPTIONAL line only (the `gateway-admin` feature); the tree scan
+//!     proves it is absent by default.
+//!  2. **Default `cargo tree`** — the FFI/frozen-trio/journal/gateway/proto crates are
+//!     absent from the DEFAULT normal dependency tree.
+//!  3. **`gateway-admin` `cargo tree`** — the opt-in feature deliberately adds
+//!     `kx-gateway-core` → `kx-proto`/`tonic` (still FFI-free), but the Tier-1 wall
+//!     (FFI + frozen trio + journal writer) STILL holds even then.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+/// Forbidden as a DIRECT manifest dependency. `kx-llamacpp` also covers
+/// `kx-llamacpp-sys`. `kx-gateway ` carries a trailing space so it forbids the
+/// gateway BINARY without matching the allowed optional `kx-gateway-core` line.
+const FORBIDDEN: &[&str] = &[
+    "kx-llamacpp",
+    "kx-executor",
+    "kx-scheduler",
+    "kx-coordinator",
+    "kx-worker",
+    "kx-runtime",
+    "kx-journal",
+    "kx-projection",
+    "kx-capture",
+    "kx-gateway ",
+    "kx-proto",
+];
+
+/// Forbidden in the DEFAULT normal `cargo tree` (the FFI + frozen-trio + journal
+/// writer + gateway/proto crates). `kx-gateway-core` is here too: it must be absent
+/// by DEFAULT (it rides the opt-in `gateway-admin` feature only).
+const TREE_FORBIDDEN: &[&str] = &[
+    "kx-llamacpp",
+    "kx-executor",
+    "kx-scheduler",
+    "kx-coordinator",
+    "kx-worker",
+    "kx-runtime",
+    "kx-journal",
+    "kx-projection",
+    "kx-capture",
+    "kx-gateway-core",
+    "kx-gateway ",
+    "kx-proto",
+];
+
+/// The Tier-1 wall that holds under EVERY feature combination: NO in-process model
+/// execution (`kx-llamacpp` FFI), NO frozen-trio mutation (`kx-executor`/
+/// `kx-scheduler`), NO cluster/runtime (`kx-coordinator`/`kx-worker`/`kx-runtime`).
+/// `kx-gateway-core`/`kx-proto`/`tonic` are NOT here — the `gateway-admin` feature
+/// legitimately adds them (pure-Rust, FFI-free); nor are `kx-journal`/`kx-projection`,
+/// which the HOST gateway-core read-side pulls under that feature (the SDK still
+/// never WRITES them — it only re-exports the host admin trait shapes).
+const TREE_FORBIDDEN_ALL_FEATURES: &[&str] = &[
+    "kx-llamacpp",
+    "kx-executor",
+    "kx-scheduler",
+    "kx-coordinator",
+    "kx-worker",
+    "kx-runtime",
+];
+
+/// The minimal DIRECT dependency set (Cargo.toml `[dependencies]`). `kx-gateway-core`
+/// appears only as an `optional` line (the `gateway-admin` feature).
+const ALLOWED: &[&str] = &[
+    "kx-mcp-gateway",
+    "kx-mcp",
+    "kx-tool-registry",
+    "kx-warrant",
+    "kx-mote",
+    "kx-capability",
+    "kx-content",
+    "kx-gateway-core",
+    "smallvec",
+    "serde",
+    "serde_json",
+    "thiserror",
+];
+
+#[test]
+fn cargo_manifest_dependencies_are_the_minimal_ffi_free_set() {
+    let manifest = include_str!("../Cargo.toml");
+    let deps_block = manifest
+        .split("[dependencies]")
+        .nth(1)
+        .expect("a [dependencies] section")
+        .split("\n[")
+        .next()
+        .expect("the end of the [dependencies] section");
+    // Code lines only — the manifest's own comments document the FFI-free intent by
+    // name, which must not trip the forbidden-substring scan.
+    let code: String = deps_block
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for forbidden in FORBIDDEN {
+        assert!(
+            !code.contains(forbidden),
+            "{forbidden} must not be a dependency of the FFI-free kx-extension-sdk crate"
+        );
+    }
+    for line in code.lines() {
+        let name = line.split_whitespace().next().unwrap_or("");
+        assert!(
+            ALLOWED.contains(&name),
+            "kx-extension-sdk gained an unexpected dependency {name:?}; keep it an FFI-free leaf"
+        );
+    }
+}
+
+fn tree(args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(env!("CARGO"))
+        .args(args)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[test]
+fn cargo_tree_default_excludes_ffi_writers_and_gateway() {
+    let Some(tree) = tree(&[
+        "tree",
+        "-p",
+        "kx-extension-sdk",
+        "--edges",
+        "normal",
+        "--prefix",
+        "none",
+    ]) else {
+        return; // cargo-tree unavailable in some sandboxes; the manifest scan is the gate.
+    };
+    for forbidden in TREE_FORBIDDEN {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the DEFAULT normal dependency tree of kx-extension-sdk:\n{tree}"
+        );
+    }
+}
+
+#[test]
+fn cargo_tree_gateway_admin_keeps_tier1_wall() {
+    // The opt-in feature pulls kx-gateway-core → kx-proto/tonic (FFI-free, allowed),
+    // but the FFI + frozen-trio + journal-writer wall must STILL hold.
+    let Some(tree) = tree(&[
+        "tree",
+        "-p",
+        "kx-extension-sdk",
+        "--features",
+        "gateway-admin",
+        "--edges",
+        "normal",
+        "--prefix",
+        "none",
+    ]) else {
+        return;
+    };
+    for forbidden in TREE_FORBIDDEN_ALL_FEATURES {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "{forbidden} appeared in the gateway-admin dependency tree of kx-extension-sdk:\n{tree}"
+        );
+    }
+}

--- a/crates/kx-extension-sdk/tests/fixtures/real-connector/.gitignore
+++ b/crates/kx-extension-sdk/tests/fixtures/real-connector/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/crates/kx-extension-sdk/tests/fixtures/real-connector/package-lock.json
+++ b/crates/kx-extension-sdk/tests/fixtures/real-connector/package-lock.json
@@ -1,0 +1,1645 @@
+{
+  "name": "kx-connector-conformance-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kx-connector-conformance-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/server-filesystem": "2026.1.14"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-filesystem": {
+      "version": "2026.1.14",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-filesystem/-/server-filesystem-2026.1.14.tgz",
+      "integrity": "sha512-bGAfu3fWRVeF10NxvPhFBDlRen6ExSx6YkKJzoVgQMNrbdVVV4okfGGQ3KBRu9ygXYfw5/N9ermHAJXA0uys+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "diff": "^5.1.0",
+        "glob": "^10.5.0",
+        "minimatch": "^10.0.1",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "bin": {
+        "mcp-server-filesystem": "dist/index.js"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/crates/kx-extension-sdk/tests/fixtures/real-connector/package.json
+++ b/crates/kx-extension-sdk/tests/fixtures/real-connector/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "kx-connector-conformance-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A pinned REAL third-party MCP server (the official filesystem server) dialed by the connector-conformance CI gate (D167 Extension Acceptance Gate). Installed deterministically via `npm ci` (the cached setup step); the conformance assertions then run fully OFFLINE over a stdio subprocess, so no network flakiness enters the gate.",
+  "dependencies": {
+    "@modelcontextprotocol/server-filesystem": "2026.1.14"
+  }
+}

--- a/crates/kx-gateway/tests/react_serve_connector.rs
+++ b/crates/kx-gateway/tests/react_serve_connector.rs
@@ -1,0 +1,235 @@
+//! D167 (connector SDK) live witness: an EXTERNAL connector registered through the
+//! `RegisterMcpServer` RPC (the connector-SDK path, NOT the serve's hardcoded
+//! bundled-echo registration) is DISCOVERED, auto-granted under `react-auto`, and
+//! callable by a LIVE model — the chain settles a terminal Answer.
+//!
+//! Unlike the bundled single-shot `kx-mcp-echo`, this dials the SDK's reference
+//! connector (`kx-connector-example`, a full `initialize → tools/list → tools/call`
+//! MCP server) over `RegisterMcpServer` — exactly what `kx connections add` /
+//! `flow().with_mcp(...)` do — so this proves the END-TO-END connector path: dial →
+//! discover → auto-grant → a real model fires the dialed tool.
+//!
+//! The non-flaky assertion is the invariant (the chain settles, never dead-letters
+//! on a freshly-dialed external tool); whether a `tool` round actually fired is
+//! model-nondeterministic, so it is LOGGED, not asserted (mirrors
+//! `react_auto_serve.rs`). Locally validate on BOTH engines with Gemma-4 (GR24).
+//!
+//! Gated `#[cfg(feature = "inference")]` AND `#[ignore]`; runtime-skips without a
+//! GGUF (`KX_SERVE_MODEL_GGUF` / `just fetch-gemma-model`), without the bundled
+//! `kx-mcp-echo` (react-auto's provisioning gate), or without the reference
+//! connector bin (`cargo build -p kx-extension-sdk`, or `KX_CONNECTOR_EXAMPLE_PATH`).
+
+#![cfg(feature = "inference")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_gateway::{start, REACT_AUTO_RECIPE_HANDLE};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+fn serve_model() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("KX_SERVE_MODEL_GGUF") {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let standin = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/models/qwen3-0.6b-q4_k_m.gguf");
+    standin.is_file().then_some(standin)
+}
+
+/// Locate the SDK reference connector bin (`kx-connector-example`): an explicit
+/// `KX_CONNECTOR_EXAMPLE_PATH`, else a walk up to the workspace `target/{debug,release}`.
+fn reference_connector_bin() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("KX_CONNECTOR_EXAMPLE_PATH") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let exe = std::env::current_exe().ok()?;
+    for ancestor in exe.ancestors() {
+        if ancestor.file_name().is_some_and(|n| n == "target") {
+            for profile in ["debug", "release"] {
+                let candidate = ancestor.join(profile).join("kx-connector-example");
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real in-process LLM inference; needs a GGUF + the reference connector bin; opt in with --ignored"]
+async fn external_connector_registered_via_rpc_is_callable_by_a_live_model() {
+    let Some(gguf) = serve_model() else {
+        eprintln!("skipping: no serve model — set KX_SERVE_MODEL_GGUF (a real GGUF)");
+        return;
+    };
+    let Some(conn_bin) = reference_connector_bin() else {
+        eprintln!(
+            "skipping: reference connector not built — run `cargo build -p kx-extension-sdk` \
+             (or set KX_CONNECTOR_EXAMPLE_PATH)"
+        );
+        return;
+    };
+    std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+    std::env::set_var("KX_SERVE_AUTOGRANT", "1");
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // Register the EXTERNAL reference connector through the connector-SDK RPC path.
+    let reg = c
+        .register_mcp_server(proto::RegisterMcpServerRequest {
+            server_name: "refconn".to_string(),
+            transport: "stdio".to_string(),
+            endpoint: conn_bin.to_string_lossy().into_owned(),
+            args: vec![],
+            tls_required: false,
+            credential_ref: String::new(),
+            session_mode: "stateless".to_string(),
+        })
+        .await
+        .expect("register the external reference connector")
+        .into_inner();
+    assert_eq!(
+        reg.health, "connected",
+        "the reference connector dials cleanly"
+    );
+    assert!(
+        reg.discovered >= 1,
+        "the reference connector exposes >= 1 tool"
+    );
+    eprintln!(
+        "registered refconn: {} tool(s) discovered (e.g. refconn/echo, refconn/reverse)",
+        reg.discovered
+    );
+
+    // react-auto provisioning is gated on the bundled echo (kx/recipes/react). If it
+    // is absent, skip — the model-free dial proof above still ran.
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_AUTO_RECIPE_HANDLE)
+    {
+        eprintln!(
+            "skipping the live-drive leg: react-auto not provisioned (bundled kx-mcp-echo missing)"
+        );
+        running.shutdown().await.unwrap();
+        std::env::remove_var("KX_SERVE_AUTOGRANT");
+        return;
+    }
+
+    // Drive a live model on a tool-forcing instruction naming the EXTERNAL tool. The
+    // react-auto warrant is rebuilt from the LIVE registry at bind (server.rs:848), so
+    // the freshly dialed `refconn/*` tools are auto-granted and callable. The
+    // instruction mirrors the proven bundled-echo drive (react_auto_serve.rs) so the
+    // SAME model reliably fires — here against an EXTERNALLY-registered connector.
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_AUTO_RECIPE_HANDLE.to_string(),
+            args: br#"{"instruction":"You MUST use the echo tool to echo the exact text 'pong'. Call the tool first, then report what it returned.","max_turns":6,"max_tool_calls":3}"#
+                .to_vec(),
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke kx/recipes/react-auto with the external tool in the menu")
+        .into_inner();
+    assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
+
+    let mut fired = false;
+    let mut answered = false;
+    let mut bounded = false;
+    let mut last = String::new();
+    // ~180s: ample for a large opt-in model (Gemma-4-12B) running a multi-turn tool
+    // loop (slow ≠ failure); the CI Qwen3-0.6B settles in ~3s. Mirrors react_auto_serve.rs.
+    for _ in 0..1800 {
+        let turns = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+                step_salt: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        let branches: Vec<&str> = turns.turns.iter().map(|t| t.branch.as_str()).collect();
+        let snap = format!("{branches:?}");
+        if snap != last {
+            eprintln!("external-connector witness — trajectory so far: {snap}");
+            for t in &turns.turns {
+                if t.branch == "rejected" && !t.rejection_reason.is_empty() {
+                    eprintln!("  turn {} rejected: {}", t.turn, t.rejection_reason);
+                }
+            }
+            last = snap.clone();
+        }
+        let tool_calls = turns.turns.iter().filter(|t| t.branch == "tool").count();
+        let cap = turns
+            .turns
+            .iter()
+            .map(|t| t.max_tool_calls as usize)
+            .max()
+            .unwrap_or(0);
+        fired |= tool_calls > 0;
+        answered = turns.turns.iter().any(|t| t.branch == "answer");
+        // BOUNDED: a terminal branch (answer / dead_lettered) OR the tool-call budget
+        // spent — never a silent wedge on a freshly-dialed EXTERNAL tool.
+        let dead = turns
+            .turns
+            .iter()
+            .any(|t| t.branch == "answer" || t.branch == "dead_lettered");
+        if dead || (cap > 0 && tool_calls >= cap) {
+            bounded = true;
+            eprintln!(
+                "external-connector witness — BOUNDED. fired: {fired}, answered: {answered}, \
+                 tool_calls: {tool_calls}/{cap}, trajectory: {snap}"
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // The non-flaky invariant: registering an EXTERNAL connector via the SDK RPC path
+    // never wedges the live chain — it reaches a terminal OR spends its tool budget.
+    assert!(
+        bounded,
+        "the live chain over the externally-registered connector is BOUNDED — it reached \
+         a terminal branch or spent its tool-call budget, never a wedge. fired: {fired}; answered: {answered}"
+    );
+    // Whether the model fired the external tool vs answered directly is
+    // model-nondeterministic — LOGGED, not hard-asserted (mirrors react_auto_serve.rs).
+    eprintln!("external connector live drive: bounded={bounded} fired={fired} answered={answered}");
+
+    running.shutdown().await.unwrap();
+    std::env::remove_var("KX_SERVE_AUTOGRANT");
+}

--- a/docs/site/docs/authoring-a-connector.md
+++ b/docs/site/docs/authoring-a-connector.md
@@ -1,0 +1,168 @@
+---
+id: authoring-a-connector
+title: Authoring a connector
+sidebar_label: Authoring a connector
+description: Write an external MCP connector, register it through the single chaining entry point (flow().with_mcp / kx connections), and prove it safe with the kx-extension-sdk conformance gate.
+---
+
+# Authoring a connector
+
+A **connector** is an external [MCP](https://modelcontextprotocol.io) tool server — a
+separate process the runtime dials over **stdio** (a subprocess) or **Streamable-HTTP**.
+It is how you extend a `kx serve` runtime with new tools: the runtime stays a *secure
+gateway* (it never runs your code in-process), discovers your tools, and lets the
+agentic loop fire them **only under a warrant that grants them** (SN-8 — the model
+proposes, the runtime enforces).
+
+The authoring surface is curated + semver-pinned in the
+[`kx-extension-sdk`](https://docs.rs/kx-extension-sdk) crate (D167 E0).
+
+## The chaining entry point
+
+Connectors are reachable from the **same single chaining entry point** as every other
+capability — register one inline with `with_mcp` and reference its namespaced
+`<server>/<tool>` tools in the next step:
+
+```python title="Python"
+import kortecx as kx
+
+out = (kx.flow()
+       .with_mcp("fs", endpoint="npx",
+                 args=["-y", "@modelcontextprotocol/server-filesystem", "/data"])
+       .agent("Summarise the files in /data", tools=["fs/list_directory", "fs/read_text_file"])
+       .run())
+print(out.text)
+```
+
+```ts title="TypeScript"
+import { flow } from "@kortecx/sdk";
+
+const out = await flow()
+  .withMcp({ name: "fs", endpoint: "npx",
+             args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"] })
+  .agent("Summarise the files in /data", { tools: ["fs/list_directory", "fs/read_text_file"] })
+  .run({ client: kx });
+console.log(out.text);
+```
+
+`with_mcp` / `withMcp` is pure pre-submit sugar over `register_mcp_server`: it registers
+the connector **before** the flow submits (so the referenced tools resolve), then submits
+the unchanged workflow. It adds no node to the lowered graph — the canonical digest is
+invariant — and is idempotent (re-running is safe).
+
+## Registering without a flow
+
+The same registration is available imperatively across every surface — pick whichever
+fits (the flow sugar above just calls the SDK method for you):
+
+```bash title="CLI (operator)"
+kx connections add --name fs --command "npx -y @modelcontextprotocol/server-filesystem /data"
+kx connections list
+kx agent run --goal "list /data" --tools fs/list_directory
+```
+
+```python title="Python — kx.connections namespace"
+kx.connections.add("fs", endpoint="npx",
+                   args=["-y", "@modelcontextprotocol/server-filesystem", "/data"])
+kx.connections.list()
+kx.connections.discover("fs")      # re-dial + list the tools it exposes
+kx.connections.test("fs")          # reachability probe
+kx.connections.remove("fs")
+```
+
+```ts title="TypeScript — kx.connections namespace"
+await kx.connections.add({ name: "fs", endpoint: "npx",
+  args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"] });
+await kx.connections.list();
+await kx.connections.discover("fs");
+```
+
+Every discovered tool is namespaced `<server>/<remote>` (server-derived, SN-8), so tools
+from different connectors never collide.
+
+## What a connector must implement
+
+A connector speaks newline-delimited JSON-RPC 2.0 over its transport and implements the
+full MCP lifecycle so the runtime can **discover** its tools at registration:
+
+| Method       | The runtime expects |
+|--------------|---------------------|
+| `initialize` | a `protocolVersion` + `serverInfo` |
+| `tools/list` | the tool manifests (`name`, `description`, JSON-Schema `inputSchema`) |
+| `tools/call` | the tool result (or a JSON-RPC error — fail closed) |
+
+The SDK ships a minimal, complete **reference connector** to copy from —
+`kx-connector-example` (`crates/kx-extension-sdk/src/bin/reference_connector.rs`): two
+pure tools (`echo`, `reverse`), full handshake, no environment echo.
+
+:::tip Security contract
+- **Never echo your environment.** An injected credential (see below) must reach no
+  reply, so it never lands in a journal/content/telemetry sink (D81).
+- **Fail closed.** An unknown method / bad args ⇒ a JSON-RPC error, surfaced as a
+  capability failure — never a fabricated success.
+:::
+
+## Secrets by reference (D81)
+
+A credential is referenced by **name**, never by value. The name (an env var / vault
+key) is resolved transiently at dial and injected into the transport; it reaches no
+durable sink:
+
+```python
+# the secret VALUE lives only in the runtime's environment; only its NAME travels
+kx.connections.add("gh", endpoint="npx", args=["-y", "@some/github-mcp"],
+                   credential_ref="GITHUB_TOKEN")
+```
+
+## The warrant gate (SN-8)
+
+A registered tool fires **only** through a warrant that grants its `(name, version)` and
+whose scopes cover the tool's `required_capability`. An HTTP connector's tools are egress
+to **only** their server's host (two-gate SSRF vetting at admission + dial). Mere presence
+in the registry never fires anything.
+
+## Proving a connector is safe
+
+Run the conformance gate — it dials your connector through the **real** gateway path and
+mechanizes a subset of the Extension Acceptance Gate:
+
+```bash
+just test-connector ./my-mcp-server --some-flag        # a stdio server
+just test-connector https://mcp.example.com/rpc        # a Streamable-HTTP server
+just test-connector                                    # the bundled reference connector
+```
+
+| Gate item | What it asserts |
+|-----------|-----------------|
+| 3 — out-of-process | every discovered tool registers as `ToolKind::Mcp` (external), never `Builtin` |
+| 5 — warrant / SN-8 | a no-grant warrant + a wrong-tool grant are both refused; a correct grant passes the gate |
+| 7 — secret-by-ref  | an out-of-band credential reaches no sink (payload / handle / staged result / MoteId) |
+| 10 — on / off      | the tool is fail-closed when the connector is absent; registering adds exactly its tools |
+
+Rust authors can call the harness directly from their own tests:
+
+```rust
+use kx_extension_sdk::conformance::{run_conformance, ConnectorUnderTest};
+use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+
+let report = run_conformance(&ConnectorUnderTest {
+    name: "my-server".into(),
+    transport: TransportSpec::Stdio { command: "./my-mcp-server".into(), args: vec![] },
+    credential_ref: None,
+    session_mode: SessionMode::Stateless,
+});
+assert!(report.passed(), "{report:#?}");
+```
+
+The `kx_extension_sdk::prelude` re-exports the load-bearing seams (the dial path, the tool
+vocabulary, the warrant boundary, the transports, the secret types) as one curated,
+semver-pinned import for Rust connector authors.
+```rust
+use kx_extension_sdk::prelude::*;
+```
+
+## OSS / Cloud line
+
+OSS dials local + first-party connectors (one App at a time). Multi-tenant connector
+registries, a connector marketplace, and a hardened secrets vault are Cloud concerns
+(D129).

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
         "agent-runner",
         "security",
         "tools",
+        "authoring-a-connector",
         "context",
         "models",
         "local-inference-engines",

--- a/feature-ledger.toml
+++ b/feature-ledger.toml
@@ -23,7 +23,7 @@ schema = 1
 [[feature]]
 id       = "oss-cloud-sync-infra"
 lane     = "oss"
-state    = "in-review"
+state    = "merged"
 pr       = "262"
 branch   = "feat/oss-cloud-sync-infra"
 covers   = [
@@ -47,3 +47,22 @@ covers   = [
 ]
 inherits = ["oss-cloud-sync-infra"]
 notes    = "Lets an external/cloud crate register a serve engine without editing OSS gateway per-engine. Digest-invariant; frozen trio untouched. The canonical cloud→OSS push-the-seam instance."
+
+[[feature]]
+id       = "connector-extension-sdk"
+lane     = "seam"
+state    = "in-progress"
+branch   = "feat/seam-extension-sdk"
+covers   = [
+  "crates/kx-extension-sdk: FFI-free leaf crate (D167 E0)",
+  "prelude: curated + api_surface-pinned re-export of the connector seams",
+  "conformance: run_conformance + the 10-pt-gate subset (items 3/5/7/10)",
+  "kx-connector-example reference connector ([[bin]]) — author template + positive control",
+  "flow().with_mcp() / flow().withMcp() — connectors reachable from the chaining entry point",
+  "kx.connections.{add,list,test,remove,discover} sub-client (Py + TS)",
+  "just test-connector / test-connector-real / test-connector-live",
+  "connector-conformance CI gate (pinned real external MCP, offline)",
+  "gateway-admin feature: opt-in McpGatewayAdmin/ToolRegistryAdmin (host authoring)",
+]
+inherits = ["oss-cloud-sync-infra"]
+notes    = "D167 E0 / D170 foundation seam #1. Curates the (already-pub, scattered) connector seams as a semver'd contract so parallel sidecars build against a stable surface. Digest 7d22d4bd invariant (leaf crate, re-exports + with_mcp add no journal facts); frozen trio untouched; no proto/journal change; additive-only."

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ check: fmt-check clippy test
 # Exact mirror of the CI workflow's gates (in dependency order). Runs every
 # job .github/workflows/ci.yml runs in parallel, here sequentially. Modify
 # this recipe in lock-step with ci.yml.
-ci: fmt-check clippy test deny doc ffi-link build-no-inference build-serve-engine features-guard check-reproducible scale-smoke
+ci: fmt-check clippy test deny doc ffi-link build-no-inference build-serve-engine features-guard check-reproducible scale-smoke test-connector-real
 
 # Verify code is formatted per rustfmt.toml. Fails on any drift.
 fmt-check:
@@ -46,6 +46,43 @@ test:
 # Build documentation; deny warnings (catches broken intra-doc links).
 doc:
     RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
+# ============================================================================
+# Connector / Extension SDK (D167 E0) conformance
+# ============================================================================
+
+# Dial a connector through the real gateway path + run the D167 Extension
+# Acceptance Gate subset (items 3/5/7/10). No endpoint → the bundled reference
+# connector (kx-connector-example).
+#   just test-connector                            # the reference connector
+#   just test-connector ./my-mcp-server --flag     # a stdio server + args
+#   just test-connector https://mcp.example/rpc    # a Streamable-HTTP server
+test-connector *endpoint:
+    cargo build -q -p kx-extension-sdk
+    cargo run -q -p kx-extension-sdk --example conformance -- {{endpoint}}
+
+# The connector-conformance HARD GATE: dial a pinned REAL third-party MCP server
+# (the official filesystem server) and run the gate. `npm ci` restores the EXACT
+# committed lockfile (the only network op — cached in CI); the dial + every
+# assertion then run OFFLINE over a stdio subprocess, so no network flakiness
+# enters the gate (GR12). Run as a required CI check + part of `ci`.
+test-connector-real:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    FIX="crates/kx-extension-sdk/tests/fixtures/real-connector"
+    echo "Installing the pinned real MCP server (npm ci, deterministic)…"
+    npm ci --prefix "$FIX"
+    BIN="$FIX/node_modules/.bin/mcp-server-filesystem"
+    ROOT="$(mktemp -d)"
+    echo "hello from kortecx" > "$ROOT/note.txt"
+    echo "Dialing $BIN (offline) through the conformance harness…"
+    cargo run -q -p kx-extension-sdk --example conformance -- "$BIN" "$ROOT"
+
+# The LIVE agentic tool-calling drive over a freshly-registered connector. Locally
+# validate on BOTH engines (Ollama + llama.cpp) with Gemma-4 (GR24); in CI it rides
+# the real-model-e2e job (Qwen3-0.6B). #[ignore]'d; needs a GGUF.
+test-connector-live: fetch-gemma-model
+    cargo test -p kx-gateway --features inference react_serve_connector -- --ignored --nocapture
 
 # ============================================================================
 # Onboarding / install automation (sudo-free, opt-in)


### PR DESCRIPTION
## Connector/Extension SDK (D167 E0 / D170 foundation seam #1)

Productizes the **connector delivery mechanism** so parallel app/tool sidecars build against a stable, semver'd contract. A *connector* = an external MCP tool server dialed via `kx connections add`. No new core machinery — curates the (already-`pub`, scattered) seams.

### What's in it
- **NEW FFI-free leaf crate `kx-extension-sdk`** — curated `prelude` (dial/registry/warrant/secret/transport seams) + `api_surface.rs` (resolution + drift guard, 57 symbols) + `dep_wall.rs` (FFI-free + frozen-trio wall) + opt-in `gateway-admin` feature (host admin traits, off by default).
- **Conformance harness** — `run_conformance` mechanizes the Extension Acceptance Gate subset (3 out-of-process · 5 warrant/SN-8 · 7 secret-by-ref · 10 on/off) through the **real** gateway path + a real broker. **Validated against the genuine `@modelcontextprotocol/server-filesystem`** (14 tools, all 4 items pass, offline). Reference connector `kx-connector-example` = the author template + deterministic positive control.
- **Chaining (single entry point)** — `flow().with_mcp()` / `.withMcp()` + `kx.connections.{add,list,test,remove,discover}` across Py + TS. Pure pre-submit sugar over `RegisterMcpServer`; proven **digest-invariant** + cross-surface parity.
- **CI hard-gate `connector-conformance`** — dials a **pinned real third-party MCP server** via a committed lockfile fixture (`npm ci` cached; dial + assertions run **offline** → no network flakiness). `just test-connector{,-real,-live}`.
- **Docs** `authoring-a-connector.md` (chaining-first) + sidebar + feature-ledger entry.

### Invariants
- Canonical digest `7d22d4bd` **invariant** (a0_guard) — leaf crate, re-exports + `with_mcp` add no journal facts.
- Frozen trio diff **EMPTY**; no proto/journal/schema change; FFI-free; additive-only; `Cargo.lock` edge-only.

### Gates (local, green)
workspace `clippy --all-targets -D warnings` · fmt · `cargo doc -D warnings --all-features` · `cargo deny` · Py ruff/mypy(src)/pytest · TS biome ci/tsc/vitest · conformance vs a real MCP.

### Known follow-up (ticketed, not in this PR)
`T-CONNECTOR-AUTOGRANT-LIVE-DEADLETTER` — a live react-auto chain over a connector registered via the RPC path dead-letters on turn-0 (the bundled echo fires with the identical instruction). Investigated + **localized to the live react-auto loop for runtime-dialed connectors** — NOT the SDK, broker wiring, grants, or model-load. The live test (`react_serve_connector.rs`) asserts the BOUNDED invariant + logs the non-fire (surfaces, never hides). Fix belongs in the react-auto/coordinator subsystem (its own focused PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)