### PR TITLE
feat(inference): RC2 grammar-constrained tool-calling + dedup loop-hardening (D172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ dependencies = [
  "kx-executor",
  "kx-fleet",
  "kx-gateway-core",
+ "kx-grammar",
  "kx-inference",
  "kx-invoke",
  "kx-journal",
@@ -1701,12 +1702,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-grammar"
+version = "0.1.1"
+dependencies = [
+ "kx-content",
+ "kx-mote",
+ "kx-tool-registry",
+ "kx-toolcall",
+ "kx-warrant",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kx-inference"
 version = "0.1.1"
 dependencies = [
  "bytes",
  "kx-content",
  "kx-context-assembler",
+ "kx-grammar",
  "kx-journal",
  "kx-llamacpp",
  "kx-memoizer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/kx-warrant",
     "crates/kx-toolcall",
     "crates/kx-tool-registry",
+    "crates/kx-grammar",
     "crates/kx-context-assembler",
     "crates/kx-memoizer",
     "crates/kx-normalizer",
@@ -137,6 +138,11 @@ kx-warrant           = { path = "crates/kx-warrant",           version = "0.1.1"
 # drifted would silently admit an ungranted tool (SN-8).
 kx-toolcall          = { path = "crates/kx-toolcall",          version = "0.1.1" }
 kx-tool-registry     = { path = "crates/kx-tool-registry",     version = "0.1.1" }
+# RC2: the engine-agnostic grammar/constraint spec — renders a granted tool set
+# to GBNF (llama.cpp) OR a JSON Schema (Ollama) for constrained tool-calling.
+# FFI-free pure leaf (kx-tool-registry for InputSchema only); never journaled —
+# the rendered constraint is derived at dispatch + carried off-digest (D108.2).
+kx-grammar           = { path = "crates/kx-grammar",           version = "0.1.1" }
 kx-context-assembler = { path = "crates/kx-context-assembler", version = "0.1.1" }
 kx-memoizer          = { path = "crates/kx-memoizer",          version = "0.1.1" }
 kx-normalizer        = { path = "crates/kx-normalizer",        version = "0.1.1" }

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -3334,6 +3334,54 @@ fn chain_is_agentic_launch(
         .is_some_and(|r| r.is_agentic_launch)
 }
 
+/// RC2 loop hardening: the tool calls fired by PRIOR turns of this chain — the
+/// settled `Tool`/`ToolBatch` turns with `turn < this_turn`, re-decoded from their
+/// committed output through the ONE authority gate ([`kx_toolcall::parse_tool_calls`]).
+/// Pure over committed facts ⇒ recovery-stable; bounded by the per-run turn budget,
+/// so the re-decode is cheap. Used to fail-closed a redundant re-proposal (the
+/// minimal dedup slice).
+fn collect_prior_fired_calls(
+    store: &LocalFsContentStore,
+    projection: &Projection,
+    rounds: &[ReactRoundRecord],
+    this_turn: u32,
+    warrant: &WarrantSpec,
+    max_args: usize,
+) -> Vec<kx_toolcall::ToolCall> {
+    // The latest fact per prior turn (a turn is `Pending` then a frozen branch;
+    // highest seq wins) — the same selection `resolve_parent_context` uses.
+    let mut latest: BTreeMap<u32, &ReactRoundRecord> = BTreeMap::new();
+    for r in rounds.iter().filter(|r| r.turn < this_turn) {
+        latest
+            .entry(r.turn)
+            .and_modify(|slot| {
+                if r.seq > slot.seq {
+                    *slot = r;
+                }
+            })
+            .or_insert(r);
+    }
+    let mut out: Vec<kx_toolcall::ToolCall> = Vec::new();
+    for r in latest.values() {
+        if !matches!(
+            r.branch,
+            ReactBranch::Tool { .. } | ReactBranch::ToolBatch { .. }
+        ) {
+            continue;
+        }
+        let Some(result_ref) = projection.result_ref_of(&r.turn_mote_id) else {
+            continue;
+        };
+        let Ok(raw) = store.get(&result_ref) else {
+            continue;
+        };
+        if let Ok(calls) = kx_toolcall::parse_tool_calls(raw.as_ref(), warrant, max_args) {
+            out.extend(calls);
+        }
+    }
+    out
+}
+
 /// Drive ONE chain's reason→tool→observe loop one pass (the PR-2d-1/2d-2 logic,
 /// now chain-keyed by `(instance_id, step_salt)`). Bounded: at most one branch fact
 /// plus one advance per pass (the next pass continues). Returns whether the chain can
@@ -3495,12 +3543,35 @@ fn drive_react_chain<J: Journal>(
             // any call that fails validation (or a malformed/oversize/ungranted
             // envelope) freezes a `Rejected` round (the next turn self-corrects under
             // the budget). The SINGLE path is byte-identical to PR-2d-2's `Tool` arm.
-            let branch = match kx_toolcall::parse_tool_calls(raw.as_ref(), &warrant, max_args) {
-                Ok(calls) => settle_calls_to_branch(&calls, tool_registry),
+            let decoded = kx_toolcall::parse_tool_calls(raw.as_ref(), &warrant, max_args);
+            // RC2 loop hardening (minimal dedup slice): a SINGLE `Tool` proposal that
+            // EXACTLY repeats a call already fired this run is frozen `Rejected` — the
+            // re-prompt steers the model to use the result it already has (bounded loop
+            // progress) instead of re-firing the identical effect. Pure over committed
+            // facts (a re-decode of prior `Tool`/`ToolBatch` turns) ⇒ recovery-stable;
+            // the reason is the SHARED `kx_toolcall` twin string. Only the lone-`Tool`
+            // case is deduped (the dominant loop-waste); a `ToolBatch` rides the budget.
+            let dup_reason: Option<String> = match &decoded {
+                Ok(calls) if calls.len() == 1 => {
+                    let prior = collect_prior_fired_calls(
+                        store, projection, &rounds, turn, &warrant, max_args,
+                    );
+                    kx_toolcall::is_duplicate_call(&calls[0], &prior).then(|| {
+                        crate::react_shape::bounded_reason(kx_toolcall::duplicate_call_reason(
+                            &calls[0],
+                        ))
+                    })
+                }
+                _ => None,
+            };
+            let branch = match (decoded, dup_reason) {
+                // A duplicate single call overrides the would-be `Tool` with `Rejected`.
+                (Ok(_), Some(reason)) => ReactBranch::Rejected { reason },
+                (Ok(calls), None) => settle_calls_to_branch(&calls, tool_registry),
                 // Malformed / oversize / a name that decoded to no grant ⇒ a
                 // `Rejected` round (the committed turn fact remains; the model
                 // gets a chance to re-propose under the budget).
-                Err(error) => ReactBranch::Rejected {
+                (Err(error), _) => ReactBranch::Rejected {
                     // Twin of `kx_model_harness::react_reason::decode_error_reason`
                     // (byte-identical — pinned across the dep wall so the re-prompted
                     // turn's MoteId matches on a cold re-fold).

--- a/crates/kx-coordinator/tests/react_live.rs
+++ b/crates/kx-coordinator/tests/react_live.rs
@@ -42,6 +42,15 @@ const MAC: ProtoExecutorClass = ProtoExecutorClass::MacosSandbox;
 const INSTRUCTION: &str = "List the files, then answer.";
 const MODEL: &str = "react-v1";
 const TOOL_ENVELOPE: &[u8] = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{"q":"x"}}}"#;
+/// A tool-proposing envelope whose args VARY per turn — a NON-redundant tool loop
+/// (the model calls a tool every turn but never answers, with DIFFERENT args each
+/// time). The budget / settle-nudge tests use this so they exercise the budget bound
+/// WITHOUT tripping the RC2 identical-call dedup (a separate loop-breaker; the
+/// identical-repeat path has its own test `identical_repeat_call_is_deduped`).
+fn varied_tool_envelope(n: u32) -> Vec<u8> {
+    format!(r#"{{"tool_call":{{"name":"mcp-echo","version":"1","args":{{"q":"x{n}"}}}}}}"#)
+        .into_bytes()
+}
 /// PR-9a (the BUG-28 regression pin): Gemma-4's NATIVE tool-call shape
 /// (`<|tool_call>call:NAME{ARGS}<tool_call|>`) — `mcp_echo` (underscore) exercises
 /// the parser's separator-only `_`→`-` name normalization. BUG-28 was a real-model
@@ -1507,9 +1516,19 @@ async fn chain_is_bounded_by_the_durable_budget() {
         };
         let mote: Mote = item.mote.unwrap().try_into().unwrap();
         if mote.def.tool_contract.is_empty() {
-            // A TURN: commit the tool-proposing envelope.
+            // A TURN: propose a tool again — with per-turn-varied args so the loop
+            // is bounded by the budget (not short-circuited by the identical-call
+            // dedup; that path has its own test).
+            commit_raw(
+                &svc,
+                &store,
+                &mote,
+                &w,
+                &varied_tool_envelope(turns_leased),
+                worker,
+            )
+            .await;
             turns_leased += 1;
-            commit_raw(&svc, &store, &mote, &w, TOOL_ENVELOPE, worker).await;
         } else {
             // The OBSERVATION: leases with args, commits the staged result.
             assert!(item.tool_args.is_some(), "observations lease WITH args");
@@ -1555,6 +1574,56 @@ async fn chain_is_bounded_by_the_durable_budget() {
     }
 }
 
+/// RC2 loop hardening (the dedup slice): a turn that proposes a tool call IDENTICAL
+/// to one already fired this run is frozen `Rejected` with the shared `kx_toolcall`
+/// dedup reason (the re-prompt steers the model off the redundant loop) — NOT
+/// re-fired. So the world-mutating effect fires EXACTLY ONCE even though the model
+/// keeps re-proposing it. Model-free + deterministic; recovery-stable (pure over the
+/// committed facts).
+#[tokio::test]
+async fn identical_repeat_call_is_deduped() {
+    let dir = TempDir::new().unwrap();
+    let (svc, store) = coordinator(&dir);
+    let w = warrant(true);
+
+    let (_, _) = submit_react(&svc, &seed_mote(), &w).await;
+    let worker = common::register(&svc, "w").await;
+
+    // Every turn proposes the IDENTICAL call. Turn 0 fires; turn 1+ are deduped.
+    let mut fired_observations = 0u32;
+    for _ in 0..24 {
+        let leased = common::lease_work(&svc, worker, MAC, 16).await;
+        let Some(item) = leased.into_iter().next() else {
+            break;
+        };
+        let mote: Mote = item.mote.unwrap().try_into().unwrap();
+        if mote.def.tool_contract.is_empty() {
+            commit_raw(&svc, &store, &mote, &w, TOOL_ENVELOPE, worker).await;
+        } else {
+            fired_observations += 1;
+            commit_raw(&svc, &store, &mote, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
+        }
+    }
+
+    // The world-mutating effect fired EXACTLY ONCE (turn 0); every identical repeat
+    // was deduped to a `Rejected` round instead of re-firing.
+    assert_eq!(
+        fired_observations, 1,
+        "the identical repeat never re-fires the effect"
+    );
+    let facts = react_facts(&svc, &dir).await;
+    assert!(
+        facts.iter().any(|f| matches!(
+            f,
+            JournalEntry::ReactRound {
+                branch: ReactBranch::Rejected { reason },
+                ..
+            } if reason.contains("already called")
+        )),
+        "an identical repeat freezes a Rejected round with the shared dedup reason"
+    );
+}
+
 /// Read a turn Mote's instruction (the bytes that ride `config_subset[PROMPT_KEY]`).
 fn turn_prompt(mote: &Mote) -> String {
     mote.def
@@ -1587,9 +1656,11 @@ async fn last_useful_turn_is_settle_nudged() {
         };
         let mote: Mote = item.mote.unwrap().try_into().unwrap();
         if mote.def.tool_contract.is_empty() {
-            // A TURN — record its instruction, then propose a tool again.
+            // A TURN — record its instruction, then propose a tool again (varied
+            // per-turn args ⇒ a budget-bounded loop, not a dedup short-circuit).
+            let n = u32::try_from(turn_prompts.len()).unwrap_or(u32::MAX);
             turn_prompts.push(turn_prompt(&mote));
-            commit_raw(&svc, &store, &mote, &w, TOOL_ENVELOPE, worker).await;
+            commit_raw(&svc, &store, &mote, &w, &varied_tool_envelope(n), worker).await;
         } else {
             // The OBSERVATION fires its staged result.
             commit_raw(&svc, &store, &mote, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;
@@ -1641,6 +1712,7 @@ async fn settle_nudge_lets_a_looping_model_answer() {
     let worker = common::register(&svc, "w").await;
 
     let mut answered_on_nudge = false;
+    let mut turn_n = 0u32;
     for _ in 0..24 {
         let leased = common::lease_work(&svc, worker, MAC, 16).await;
         let Some(item) = leased.into_iter().next() else {
@@ -1653,7 +1725,18 @@ async fn settle_nudge_lets_a_looping_model_answer() {
                 answered_on_nudge = true;
                 commit_raw(&svc, &store, &mote, &w, b"the final answer", worker).await;
             } else {
-                commit_raw(&svc, &store, &mote, &w, TOOL_ENVELOPE, worker).await;
+                // Varied per-turn args ⇒ a budget-bounded loop reaches the nudge
+                // (not a dedup short-circuit on identical repeats).
+                commit_raw(
+                    &svc,
+                    &store,
+                    &mote,
+                    &w,
+                    &varied_tool_envelope(turn_n),
+                    worker,
+                )
+                .await;
+                turn_n += 1;
             }
         } else {
             commit_raw(&svc, &store, &mote, &w, br#"{"echoed":{"q":"x"}}"#, worker).await;

--- a/crates/kx-eval/corpus/golden-v1/baseline.json
+++ b/crates/kx-eval/corpus/golden-v1/baseline.json
@@ -1,6 +1,6 @@
 {
   "suite_id": "golden-v1",
-  "suite_digest": "f05cb658ee50469bba21ffd0c5f9c5da90dd0b4c4db45e7d9f9810fcc3427f98",
+  "suite_digest": "5c1456fc9ae2371af2adc685a3c2ff3b1e65e4bc5d96783798e6279658483a5e",
   "gates": [
     {
       "id": "task_success",

--- a/crates/kx-eval/corpus/golden-v1/format_cases.json
+++ b/crates/kx-eval/corpus/golden-v1/format_cases.json
@@ -2,7 +2,9 @@
   "grants": [
     { "tool_id": "mcp-echo/echo", "tool_version": "1" },
     { "tool_id": "kv/get", "tool_version": "1" },
-    { "tool_id": "calc/add", "tool_version": "1" }
+    { "tool_id": "calc/add", "tool_version": "1" },
+    { "tool_id": "mcp-calc/calc", "tool_version": "1" },
+    { "tool_id": "mcp-kv/get", "tool_version": "1" }
   ],
   "cases": [
     {
@@ -69,6 +71,16 @@
       "format": "empty_output",
       "raw": "",
       "expect": { "type": "no_call" }
+    },
+    {
+      "format": "grammar_envelope_calc",
+      "raw": "{\"tool_call\":{\"name\":\"mcp-calc/calc\",\"version\":\"1\",\"args\":{\"op\":\"add\",\"a\":2,\"b\":3}}}",
+      "expect": { "type": "call", "tool_id": "mcp-calc/calc", "tool_version": "1" }
+    },
+    {
+      "format": "grammar_envelope_kv",
+      "raw": "{\"tool_call\":{\"name\":\"mcp-kv/get\",\"version\":\"1\",\"args\":{\"key\":\"alpha\"}}}",
+      "expect": { "type": "call", "tool_id": "mcp-kv/get", "tool_version": "1" }
     }
   ]
 }

--- a/crates/kx-eval/tests/deterministic_core.rs
+++ b/crates/kx-eval/tests/deterministic_core.rs
@@ -54,7 +54,9 @@ fn aggregate_gate_values_are_pinned() {
     // The rejection-recovery task spends one extra turn ⇒ the aggregate is below perfect:
     // (1000×6 + 750) / 7 = 964 per-mille (integer floor).
     assert_eq!(gate("loop_efficiency"), Some(964));
-    // All 13 model-output formats decode as intended (the committed "before").
+    // Every model-output format decodes as intended — the 13 RC1 "before" formats
+    // PLUS the RC2 grammar-shaped multi-tool envelopes (mcp-calc/calc, mcp-kv/get):
+    // the canonical envelope the grammar enforces is the parser's strongest path.
     assert_eq!(gate("format_coverage"), Some(1000));
 }
 

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -62,6 +62,10 @@ kx-refusal      = { workspace = true }
 # PR-2d-1: the model-proposed tool-call AUTHORITY GATE — the react turn arm's
 # pre-commit fence decodes through the ONE shared crate (never a byte-mirror).
 kx-toolcall     = { workspace = true }
+# RC2: render the warrant's granted tool set to a grammar spec, derived at
+# dispatch + injected OFF-MoteDef (off-digest) so a react tool turn is
+# grammar-constrained. FFI-free leaf; the dep_wall keeps the gateway FFI-free.
+kx-grammar      = { workspace = true }
 # Inline parent-edge storage for the PURE Mote built by `pure_run_request`
 # (`Mote::new`'s `parents` is a `SmallVec<[ParentRef; 4]>`). Promoted from a dev-dep
 # (R3) so the helper is a NORMAL public library fn. FFI-free (the dep_wall forbids

--- a/crates/kx-gateway/src/mcp_tool.rs
+++ b/crates/kx-gateway/src/mcp_tool.rs
@@ -239,18 +239,35 @@ pub(crate) fn autogrant_enabled() -> bool {
     }
 }
 
-/// Resolve the bundled tool binary's path: an explicit `KX_MCP_ECHO_PATH`
-/// override first, then the fixed in-image path, then a dev/test walk up to the
-/// workspace `target/` dir (the `real_body_binary_path` precedent). `None` ⇒
-/// no tool available on this host/image.
-fn echo_binary_path() -> Option<PathBuf> {
-    if let Some(over) = std::env::var_os("KX_MCP_ECHO_PATH") {
+/// RC2: the operator SERVE-LEVEL kill-switch for grammar-constrained tool-calling
+/// (`KX_SERVE_REACT_GRAMMAR`). Default-ON (unset / `"1"` / `"true"` ⇒ `true`) — the
+/// always-on posture; set to `"0"` / `"false"` to disable grammar derivation for
+/// every dispatch (the reliable global opt-out). A per-run / per-mote opt-out rides
+/// `config_subset[REACT_UNCONSTRAINED_KEY]` (the SDK `.unconstrained()`); full
+/// per-turn propagation across a chain is a ticketed follow-on (T-GRAMMAR-PERRUN-OPTOUT).
+pub(crate) fn grammar_constrained_enabled() -> bool {
+    match std::env::var_os("KX_SERVE_REACT_GRAMMAR") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            let v = v.trim();
+            !(v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off"))
+        }
+        None => true,
+    }
+}
+
+/// Resolve a bundled MCP tool binary's path: an explicit `env_override` var
+/// first, then the fixed in-image path, then a dev/test walk up to the workspace
+/// `target/` dir (the `real_body_binary_path` precedent). `None` ⇒ no binary on
+/// this host/image (fail-soft). Shared by every bundled stdio tool.
+fn bundled_binary_path(bin: &str, env_override: &str) -> Option<PathBuf> {
+    if let Some(over) = std::env::var_os(env_override) {
         let path = PathBuf::from(over);
         if path.exists() {
             return Some(path);
         }
     }
-    let in_image = PathBuf::from("/usr/local/libexec/kx/kx-mcp-echo");
+    let in_image = PathBuf::from(format!("/usr/local/libexec/kx/{bin}"));
     if in_image.exists() {
         return Some(in_image);
     }
@@ -258,7 +275,7 @@ fn echo_binary_path() -> Option<PathBuf> {
     for ancestor in exe.ancestors() {
         if ancestor.file_name().is_some_and(|n| n == "target") {
             for profile in ["debug", "release"] {
-                let candidate = ancestor.join(profile).join("kx-mcp-echo");
+                let candidate = ancestor.join(profile).join(bin);
                 if candidate.exists() {
                     return Some(candidate);
                 }
@@ -266,6 +283,163 @@ fn echo_binary_path() -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// The bundled echo binary's path (`KX_MCP_ECHO_PATH` override).
+fn echo_binary_path() -> Option<PathBuf> {
+    bundled_binary_path("kx-mcp-echo", "KX_MCP_ECHO_PATH")
+}
+
+// ---- RC2 (S6 / T-EVAL-LIVE-MULTITOOL): the bundled calc + kv ORACLE tools ----
+// Two more deterministic, no-egress stdio tools (RC1) wired into the live
+// `react-auto` auto-grant set so the autonomous loop can FIRE a genuine
+// multi-tool / sequential chain (a kv lookup feeding a calc). Both mirror the
+// echo registration shape; both are read-only (`Readback` ⇒ the HITL gate
+// auto-proceeds them). The MCP binaries compute purely from `arguments` (the
+// remote method name is unused), so the typed `input_schema` is what
+// `validate_args` (and the RC2 arg-schema grammar stretch) gates on.
+
+/// The bundled integer-arithmetic tool's identity — `mcp-calc/calc@1`. The
+/// `<server>/<remote>` shape (last segment = the MCP remote method) lets a model
+/// emit the bare leaf `calc` and still resolve (BUG-33 guard).
+#[must_use]
+pub(crate) fn calc_tool() -> (ToolName, ToolVersion) {
+    (ToolName("mcp-calc/calc".into()), ToolVersion("1".into()))
+}
+
+/// The `mcp-calc/calc@1` [`ToolDef`]: one op over two integers, no egress. The
+/// typed schema (`op` enum + two required `Int`s, unknown keys refused) matches
+/// the binary's `{op,a,b}` contract so `validate_args` gates every proposed call.
+#[must_use]
+pub(crate) fn calc_tool_def() -> ToolDef {
+    let (tool_id, tool_version) = calc_tool();
+    ToolDef {
+        tool_id,
+        tool_version,
+        kind: ToolKind::Mcp {
+            endpoint: McpEndpointId("stdio://kx-mcp-calc".into()),
+            remote_name: "calc".into(),
+        },
+        required_capability: ToolRequirement {
+            net_scope_required: NetScope::None,
+            fs_scope_required: FsScope::empty(),
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+        },
+        description: "Bundled deterministic integer arithmetic: {\"op\":\"add|sub|mul|div\",\"a\":<int>,\"b\":<int>}. No egress; read-only/idempotent.".into(),
+        idempotency_class: IdempotencyClass::Readback,
+        input_schema: Some(InputSchema {
+            params: vec![
+                ParamSpec {
+                    name: "op".into(),
+                    ty: ParamType::Enum {
+                        allowed: ["add", "sub", "mul", "div"]
+                            .iter()
+                            .map(|s| (*s).to_string())
+                            .collect(),
+                    },
+                    required: true,
+                },
+                ParamSpec { name: "a".into(), ty: ParamType::Int { min: None, max: None }, required: true },
+                ParamSpec { name: "b".into(), ty: ParamType::Int { min: None, max: None }, required: true },
+            ],
+            deny_unknown: true,
+        }),
+    }
+}
+
+/// The bundled key-value lookup tool's identity — `mcp-kv/get@1`.
+#[must_use]
+pub(crate) fn kv_tool() -> (ToolName, ToolVersion) {
+    (ToolName("mcp-kv/get".into()), ToolVersion("1".into()))
+}
+
+/// The `mcp-kv/get@1` [`ToolDef`]: a fixed-seed key lookup, no egress. One
+/// required `key: Str` param (unknown keys refused), matching the binary.
+#[must_use]
+pub(crate) fn kv_tool_def() -> ToolDef {
+    let (tool_id, tool_version) = kv_tool();
+    ToolDef {
+        tool_id,
+        tool_version,
+        kind: ToolKind::Mcp {
+            endpoint: McpEndpointId("stdio://kx-mcp-kv".into()),
+            remote_name: "get".into(),
+        },
+        required_capability: ToolRequirement {
+            net_scope_required: NetScope::None,
+            fs_scope_required: FsScope::empty(),
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+        },
+        description: "Bundled deterministic key-value lookup: {\"key\":<string>} → the seed value. No egress; read-only/idempotent.".into(),
+        idempotency_class: IdempotencyClass::Readback,
+        input_schema: Some(InputSchema {
+            params: vec![ParamSpec {
+                name: "key".into(),
+                ty: ParamType::Str { max_len: 256 },
+                required: true,
+            }],
+            deny_unknown: true,
+        }),
+    }
+}
+
+/// Register the bundled calc + kv ORACLE capabilities on the serve broker, each
+/// fail-soft (a missing binary is skipped). Returns the identities that actually
+/// registered — the live `react-auto` auto-grant union grants exactly this set,
+/// so the autonomous loop can fire a real multi-tool chain. Mirrors
+/// [`register_echo_capability`].
+pub(crate) fn register_oracle_capabilities<S: ContentStore + Send + Sync>(
+    broker: &LocalCapabilityBroker<S>,
+) -> Vec<(ToolName, ToolVersion)> {
+    let mut registered = Vec::new();
+    for (def_fn, bin, env_override, remote) in [
+        (
+            calc_tool_def as fn() -> ToolDef,
+            "kx-mcp-calc",
+            "KX_MCP_CALC_PATH",
+            "calc",
+        ),
+        (
+            kv_tool_def as fn() -> ToolDef,
+            "kx-mcp-kv",
+            "KX_MCP_KV_PATH",
+            "get",
+        ),
+    ] {
+        let Some(path) = bundled_binary_path(bin, env_override) else {
+            continue;
+        };
+        let def = def_fn();
+        let (tool_id, tool_version) = (def.tool_id.clone(), def.tool_version.clone());
+        let endpoint = match &def.kind {
+            ToolKind::Mcp { endpoint, .. } => endpoint.clone(),
+            _ => continue,
+        };
+        broker.register_capability(Box::new(McpCapability::new(
+            tool_id.clone(),
+            tool_version.clone(),
+            endpoint,
+            remote,
+            Box::new(StdioTransport::new(path.to_string_lossy().as_ref())),
+        )));
+        tracing::info!(bin = %path.display(), tool = %tool_id.0, "RC2: bundled oracle tool registered (react-auto multi-tool)");
+        registered.push((tool_id, tool_version));
+    }
+    registered
 }
 
 #[cfg(test)]
@@ -295,5 +469,62 @@ mod tests {
             ),
             _ => panic!("bundled echo must be an MCP tool"),
         }
+    }
+
+    /// RC2 (S6): the calc + kv oracle ids are `<server>/<remote>` (so the model's
+    /// bare leaf resolves) and their leaf equals the MCP remote method, mirroring
+    /// the echo BUG-33 guard.
+    #[test]
+    fn oracle_tool_ids_are_server_slash_remote() {
+        for (name, def) in [
+            (calc_tool().0, calc_tool_def()),
+            (kv_tool().0, kv_tool_def()),
+        ] {
+            assert!(
+                name.0.contains('/'),
+                "oracle id must be <server>/<remote>: {:?}",
+                name.0
+            );
+            let leaf = name.0.rsplit('/').next().unwrap();
+            match &def.kind {
+                ToolKind::Mcp { remote_name, .. } => {
+                    assert_eq!(leaf, remote_name, "leaf must equal the MCP remote name");
+                }
+                _ => panic!("oracle tool must be an MCP tool"),
+            }
+        }
+    }
+
+    /// The oracle schemas match the BINARY contracts so `validate_args` gates a
+    /// proposed call: calc = op(enum)+a(int)+b(int); kv = key(str). Unknown keys
+    /// refused on both; both read-only (`Readback`).
+    #[test]
+    fn oracle_tool_defs_have_typed_schemas() {
+        let calc = calc_tool_def().input_schema.expect("calc schema");
+        assert!(calc.deny_unknown);
+        let names: Vec<&str> = calc.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, ["op", "a", "b"], "calc params");
+        assert!(
+            matches!(calc.params[0].ty, ParamType::Enum { .. }),
+            "op is an enum"
+        );
+        assert!(
+            matches!(calc.params[1].ty, ParamType::Int { .. }),
+            "a is an int"
+        );
+
+        let kv = kv_tool_def().input_schema.expect("kv schema");
+        assert!(kv.deny_unknown);
+        assert_eq!(kv.params.len(), 1);
+        assert_eq!(kv.params[0].name, "key");
+        assert!(
+            matches!(kv.params[0].ty, ParamType::Str { .. }),
+            "key is a str"
+        );
+        assert_eq!(
+            calc_tool_def().idempotency_class,
+            IdempotencyClass::Readback
+        );
+        assert_eq!(kv_tool_def().idempotency_class, IdempotencyClass::Readback);
     }
 }

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -34,6 +34,7 @@ use kx_inference::{inference_params_from_mote, InferenceBackend, InferenceInput,
 // generic executor below without them. The `RoutingBackend` (which both engines ride)
 // is the seam the shaper/executor wiring actually holds.
 use crate::routing_backend::RoutingBackend;
+use kx_grammar::{ToolEnvelopeSpec, ToolSpec};
 #[cfg(feature = "inference")]
 use kx_inference::LlamaInferenceBackend;
 #[cfg(feature = "inference")]
@@ -44,8 +45,9 @@ use kx_model_validator::{
     RequiredCapabilities, ValidatorOutcome,
 };
 use kx_mote::{
-    decode_context_items, ConfigKey, EffectPattern, InferenceParams, LogicRef, ModelId, Mote,
-    MoteId, NdClass, PromptTemplateHash, RoleId, ToolName, CONTEXT_ITEMS_KEY, PROMPT_KEY,
+    decode_context_items, ConfigKey, EffectPattern, Grammar, InferenceParams, LogicRef, ModelId,
+    Mote, MoteId, NdClass, PromptTemplateHash, RoleId, ToolName, CONTEXT_ITEMS_KEY, PROMPT_KEY,
+    REACT_UNCONSTRAINED_KEY,
 };
 use kx_planner::{
     decode_loop_proposal, decode_replan_proposal, lower_loop_to_topology_decision, max_plan_bytes,
@@ -125,6 +127,27 @@ pub(crate) fn shaper_warrant(model_id: &ModelId, exec_class: ExecutorClass) -> W
         executor_class: exec_class,
         ..Default::default()
     }
+}
+
+/// RC2: derive a grammar-constraint carrier from the warrant's granted tools, for a
+/// tool-eligible ReAct turn. Returns `None` when no tools are granted (so the
+/// canonical demo + any answer-only turn stay unconstrained ⇒ digest `7d22d4bd`
+/// invariant). The carrier is a serialized [`ToolEnvelopeSpec`] (envelope + name
+/// enum; envelope-first — args stay a generic object, the per-tool arg-schema
+/// stretch is a follow-on once live results justify it). The grammar is the
+/// ACCEPT-side constraint only; the authority gate stays `kx_toolcall` (SN-8).
+fn build_tool_grammar(warrant: &WarrantSpec) -> Option<Grammar> {
+    if warrant.tool_grants.is_empty() {
+        return None;
+    }
+    let tools: Vec<ToolSpec> = warrant
+        .tool_grants
+        .iter()
+        .map(|g| ToolSpec::new(g.tool_id.0.clone(), g.tool_version.0.clone()))
+        .collect();
+    // Serialization of the closed spec types does not fail in practice; on the
+    // off chance it does, degrade to unconstrained (never panic on a dispatch).
+    ToolEnvelopeSpec::new(tools).to_raw().ok().map(Grammar::new)
 }
 
 /// Build the shaper runtime from the resolved serve backend. The `worker` role maps
@@ -1245,8 +1268,26 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             },
             None => InferenceInput::text(format(&instruction)),
         };
-        let params = inference_params_from_mote(mote, warrant)
+        let mut params = inference_params_from_mote(mote, warrant)
             .map_err(|e| internal(&format!("inference params: {e}")))?;
+        // RC2 grammar-constrained tool-calling: on a tool-eligible ReAct turn (the
+        // model PROPOSES a tool call), derive a grammar from the warrant's granted
+        // tools and arm it — OFF the MoteDef identity (a clone of the dispatch
+        // params), so it is off-digest (D108.2) and the canonical demo (which grants
+        // no tools ⇒ `build_tool_grammar` returns `None`) keeps `7d22d4bd`. The
+        // backend decides HOW to honor it (llama.cpp = lazy/triggered GBNF; Ollama =
+        // honest-degrade). A per-run `unconstrained` opt-out skips it. Shaper / leaf
+        // / answer-only turns are never constrained (the `is_react_turn` gate). A
+        // per-mote `unconstrained` opt-out OR the serve-level `KX_SERVE_REACT_GRAMMAR=0`
+        // kill-switch disables it.
+        if Self::is_react_turn(mote)
+            && !Self::is_unconstrained(mote)
+            && crate::mcp_tool::grammar_constrained_enabled()
+        {
+            if let Some(grammar) = build_tool_grammar(warrant) {
+                params.grammar = Some(grammar);
+            }
+        }
         // PR-4.2 (T-STREAM1): when a token broker is wired, stream this mote's
         // tokens out-of-band (keyed by `mote.id`) and `finish` the mote on BOTH
         // the Ok and Err paths so a subscriber's stream always ends. The streamed
@@ -1293,6 +1334,18 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         mote.def
             .config_subset
             .contains_key(&kx_mote::ConfigKey(kx_mote::REACT_TURN_KEY.to_string()))
+    }
+
+    /// `true` iff this Mote opts OUT of RC2 grammar-constrained tool-calling via
+    /// `config_subset[REACT_UNCONSTRAINED_KEY] = true` (the SDK `.unconstrained()`
+    /// / CLI `--unconstrained` escape hatch). Absent ⇒ `false` ⇒ grammar is armed
+    /// (the always-on default). The value is a canonical-JSON / raw boolean, so a
+    /// recipe-bound `Bool` (`true`) and a directly-built `b"true"` both match.
+    fn is_unconstrained(mote: &Mote) -> bool {
+        mote.def
+            .config_subset
+            .get(&ConfigKey(REACT_UNCONSTRAINED_KEY.to_string()))
+            .is_some_and(|v| matches!(v.0.as_slice(), b"true" | b"1"))
     }
 
     /// Run a ReAct TURN Mote: `dispatch_model` verbatim (the F-7 trajectory
@@ -2023,18 +2076,23 @@ mod tests {
         /// PR-9d: the last `Text` prompt the backend was dispatched (so a test can
         /// assert what `dispatch_model` assembled — e.g. the carried context prefix).
         last_prompt: std::sync::Mutex<Option<String>>,
+        /// RC2: the last dispatched `params.grammar` (`None` = unconstrained;
+        /// `Some(g)` = a grammar carrier was injected). The tests dispatch exactly
+        /// once, so this reads the single call's grammar (off-digest injection).
+        last_grammar: std::sync::Mutex<Option<Grammar>>,
     }
     impl InferenceBackend for StubBackend {
         fn dispatch(
             &self,
             model_id: &ModelId,
             input: &InferenceInput,
-            _params: &kx_mote::InferenceParams,
+            params: &kx_mote::InferenceParams,
             _warrant: &WarrantSpec,
         ) -> Result<InferenceOutput, InferenceError> {
             if let InferenceInput::Text(s) = input {
                 *self.last_prompt.lock().unwrap() = Some(s.clone());
             }
+            *self.last_grammar.lock().unwrap() = params.grammar.clone();
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(InferenceOutput {
                 bytes: self.reply.clone(),
@@ -2111,6 +2169,7 @@ mod tests {
             reply: reply.to_vec(),
             calls: AtomicUsize::new(0),
             last_prompt: std::sync::Mutex::new(None),
+            last_grammar: std::sync::Mutex::new(None),
         });
         let exec = ModelRouterExecutor::new(
             Arc::new(NeverInner),
@@ -2662,6 +2721,107 @@ mod tests {
         let bytes = store.get(&out.result_ref).unwrap();
         assert_eq!(bytes.as_ref(), b"The answer is blue.");
         assert_eq!(out.result_ref, ContentRef::of(b"The answer is blue."));
+    }
+
+    /// A react turn mote carrying an `unconstrained=true` opt-out (RC2 / S5).
+    fn react_turn_mote_unconstrained() -> Mote {
+        let mut m = react_turn_mote();
+        let mut def = m.def.clone();
+        def.config_subset.insert(
+            ConfigKey(REACT_UNCONSTRAINED_KEY.to_string()),
+            ConfigVal(b"true".to_vec()),
+        );
+        // Rebuild so the MoteId reflects the opt-out config (identity-bearing).
+        m = Mote::new(
+            def,
+            InputDataId::from_bytes([2u8; 32]),
+            GraphPosition(vec![2u8]),
+            SmallVec::new(),
+        );
+        m
+    }
+
+    /// RC2 (S5): a tool-eligible ReAct turn ARMS grammar — `dispatch_model` derives
+    /// a `ToolEnvelopeSpec` from the warrant's granted tools and injects it into the
+    /// dispatch params (off the MoteDef identity). The carrier deserializes to the
+    /// granted `(name, version)`.
+    #[test]
+    fn grammar_is_armed_on_a_granted_react_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(&store, b"blue", None);
+        // A prose answer commits cleanly while still exercising the dispatch.
+        exec.run(&react_turn_mote(), &granted_warrant(), None)
+            .expect("react turn dispatches");
+        let grammar = backend
+            .last_grammar
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("grammar armed on a granted react turn");
+        let spec = kx_grammar::ToolEnvelopeSpec::from_raw(&grammar.raw).expect("valid carrier");
+        assert!(
+            spec.tools
+                .iter()
+                .any(|t| t.name == "mcp-echo" && t.version == "1"),
+            "the granted tool is in the spec: {:?}",
+            spec.tools
+        );
+    }
+
+    /// No grant ⇒ no grammar (the canonical-demo / answer-only invariant that keeps
+    /// the digest `7d22d4bd` — `build_tool_grammar` returns `None`).
+    #[test]
+    fn no_grammar_on_a_react_turn_without_grants() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(&store, b"blue", None);
+        exec.run(
+            &react_turn_mote(),
+            &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+            None,
+        )
+        .expect("react turn dispatches");
+        assert_eq!(
+            *backend.last_grammar.lock().unwrap(),
+            None,
+            "no grant ⇒ no grammar"
+        );
+    }
+
+    /// A non-react (shaper) turn is NEVER constrained, even with a granted warrant —
+    /// the shaper proposes a TopologyDecision, not a tool call.
+    #[test]
+    fn no_grammar_on_a_non_react_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(
+            &store,
+            TWO_CHILD_PROPOSAL,
+            Some(worker_recipes(&model_id())),
+        );
+        exec.run(&shaper_mote(), &granted_warrant(), None)
+            .expect("shaper dispatches");
+        assert_eq!(
+            *backend.last_grammar.lock().unwrap(),
+            None,
+            "a shaper turn is never grammar-constrained"
+        );
+    }
+
+    /// The per-run `unconstrained` opt-out skips grammar even on a granted react turn.
+    #[test]
+    fn unconstrained_opt_out_skips_grammar() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(&store, b"blue", None);
+        exec.run(&react_turn_mote_unconstrained(), &granted_warrant(), None)
+            .expect("react turn dispatches");
+        assert_eq!(
+            *backend.last_grammar.lock().unwrap(),
+            None,
+            "unconstrained=true ⇒ grammar skipped"
+        );
     }
 
     /// PR-9d (model-side half): `dispatch_model` PREPENDS the carried grounding context

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -683,6 +683,18 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     let autogrant = serve_model.is_some() && crate::mcp_tool::autogrant_enabled();
     #[cfg(not(feature = "serve-engine"))]
     let autogrant = false;
+    // RC2 (S6 / T-EVAL-LIVE-MULTITOOL): when auto-grant is on, register the bundled
+    // calc + kv ORACLE capabilities so the autonomous `react-auto` loop can FIRE a
+    // real multi-tool chain (a kv lookup feeding a calc). Fail-soft per binary;
+    // auto-grant OFF ⇒ not registered ⇒ byte-identical serve.
+    #[cfg(feature = "serve-engine")]
+    let react_oracle_tools: Vec<(kx_mote::ToolName, kx_mote::ToolVersion)> = if autogrant {
+        crate::mcp_tool::register_oracle_capabilities(&local_broker)
+    } else {
+        Vec::new()
+    };
+    #[cfg(not(feature = "serve-engine"))]
+    let react_oracle_tools: Vec<(kx_mote::ToolName, kx_mote::ToolVersion)> = Vec::new();
     let broker: Arc<dyn CapabilityBroker> = local_broker.clone();
     let worker = Worker::register(
         client,
@@ -752,6 +764,7 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
     let react_supported = serve_model.is_some();
     let registered_tools: std::collections::BTreeSet<(String, String)> = react_tool
         .iter()
+        .chain(react_oracle_tools.iter())
         .map(|(id, ver)| (id.0.clone(), ver.0.clone()))
         .collect();
     // PR-6a: seed the bundled tools into the durable registry so `DiscoverTools`
@@ -769,6 +782,30 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
             None,
         ) {
             tracing::warn!(%error, "PR-6a: failed to seed mcp-echo@1 into tools.db");
+        }
+    }
+    // RC2 (S6): seed the calc + kv oracle tools into the durable registry (so
+    // DiscoverTools shows the real runnable set + the react-auto union grants them)
+    // exactly when their capabilities registered.
+    #[cfg(feature = "serve-engine")]
+    {
+        let oracle_set: std::collections::BTreeSet<_> =
+            react_oracle_tools.iter().cloned().collect();
+        for def in [
+            crate::mcp_tool::calc_tool_def(),
+            crate::mcp_tool::kv_tool_def(),
+        ] {
+            if oracle_set.contains(&(def.tool_id.clone(), def.tool_version.clone())) {
+                if let Err(error) = tool_registry.register_server_tool(
+                    def,
+                    kx_tool_registry::ToolProvenance::HumanAuthored {
+                        author: "kx-gateway".to_string(),
+                    },
+                    None,
+                ) {
+                    tracing::warn!(%error, "RC2: failed to seed an oracle tool into tools.db");
+                }
+            }
         }
     }
     // PR-6a/D155 (fs-list): seed fs-list@1 into the durable registry (so

--- a/crates/kx-gateway/tests/eval_real_model.rs
+++ b/crates/kx-gateway/tests/eval_real_model.rs
@@ -184,3 +184,144 @@ async fn score_run_over_a_live_react_chain() {
     running.shutdown().await.unwrap();
     std::env::remove_var("KX_SERVE_AUTOGRANT");
 }
+
+/// RC2 grammar witness (Tier-B, observe-not-gate per GR16): FORCE a tool the model
+/// cannot answer without (a kv lookup of an arbitrary key), then PRINT each
+/// committed turn's RAW output so the emitted tool-call FORMAT is visible, and
+/// OBSERVE whether a tool fired. The lazy GBNF triggers on the `{"tool_call"`
+/// opener, so this reveals whether the model emits that JSON envelope (the grammar
+/// bites + structurally constrains) or a native format (the robust parser recovers
+/// it). Soft assertion: the chain SETTLES with no crash (the firing path itself is
+/// gated deterministically in kx-coordinator/kx-toolcall).
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real LLM; forces a tool to witness the grammar-constrained fire + emitted format"]
+async fn grammar_forces_and_witnesses_a_tool_fire() {
+    if let Some(gguf) = serve_gguf() {
+        std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+    } else if !ollama_opted_in() {
+        eprintln!("skipping: no model");
+        return;
+    }
+    std::env::set_var("KX_SERVE_AUTOGRANT", "1");
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: react not provisioned (bundled bins missing)");
+        running.shutdown().await.unwrap();
+        std::env::remove_var("KX_SERVE_AUTOGRANT");
+        return;
+    }
+
+    // A kv lookup of an ARBITRARY key the model cannot know without the tool.
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_AUTO_RECIPE_HANDLE.to_string(),
+            args: {
+                // The live serve react prompt presents NO tool menu/schema (SERVE_SYSTEM
+                // is generic) — so a real model can only fire a tool when the instruction
+                // itself describes the call format. Override via KX_WITNESS_INSTRUCTION.
+                let instruction = std::env::var("KX_WITNESS_INSTRUCTION").unwrap_or_else(|_| {
+                    "To use a tool, output ONLY a JSON object exactly like \
+                     {\\\"tool_call\\\":{\\\"name\\\":\\\"<tool>\\\",\\\"version\\\":\\\"1\\\",\\\"args\\\":{...}}}. \
+                     The value for key 'x' lives in a key-value store you cannot see; call the tool \
+                     \\\"mcp-kv/get\\\" with args {\\\"key\\\":\\\"x\\\"} to retrieve it, then tell me ONLY that value."
+                        .to_string()
+                });
+                format!(
+                    r#"{{"instruction":"{instruction}","max_turns":4,"max_tool_calls":3}}"#
+                )
+                .into_bytes()
+            },
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke react-auto")
+        .into_inner();
+
+    let mut settled = None;
+    for _ in 0..1500 {
+        let t = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+                step_salt: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if t.turns
+            .iter()
+            .any(|x| x.branch == "answer" || x.branch == "dead_lettered")
+        {
+            settled = Some(t);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let turns = settled.expect("the chain settled a terminal branch").turns;
+
+    // Map each committed turn mote -> its result_ref to fetch the RAW emitted output.
+    let view = c
+        .get_projection(proto::GetProjectionRequest {
+            instance_id: resp.instance_id.clone(),
+            at_seq: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut fired: Vec<String> = Vec::new();
+    for t in &turns {
+        let raw = view
+            .motes
+            .iter()
+            .find(|m| m.mote_id == t.turn_mote_id)
+            .and_then(|m| m.result_ref.clone());
+        let text = match raw {
+            Some(rref) => c
+                .get_content(proto::GetContentRequest {
+                    content_ref: rref,
+                    instance_id: resp.instance_id.clone(),
+                })
+                .await
+                .ok()
+                .map(|r| String::from_utf8_lossy(&r.into_inner().payload).into_owned())
+                .unwrap_or_default(),
+            None => String::new(),
+        };
+        eprintln!(
+            "GRAMMAR-WITNESS turn={} branch={} tool_id={} raw={:?}",
+            t.turn, t.branch, t.tool_id, text
+        );
+        if t.branch == "tool" {
+            fired.push(t.tool_id.clone());
+        }
+    }
+    eprintln!("GRAMMAR-WITNESS: fired tools = {fired:?}");
+
+    running.shutdown().await.unwrap();
+    std::env::remove_var("KX_SERVE_AUTOGRANT");
+
+    // Observe-not-gate: a terminal branch with no crash is the bounded invariant.
+    assert!(
+        turns
+            .iter()
+            .any(|t| t.branch == "answer" || t.branch == "dead_lettered"),
+        "the forcing chain settled a terminal branch"
+    );
+}

--- a/crates/kx-grammar/Cargo.toml
+++ b/crates/kx-grammar/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name         = "kx-grammar"
+version      = "0.1.1"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx engine-agnostic constrained-generation spec (RC2). Renders a granted tool set to GBNF (llama.cpp) OR a JSON Schema (Ollama) so a model CANNOT emit a malformed or ungranted tool call — structurally eradicating the T-GEMMA-PAREN parse-fragility class. Pure, FFI-free leaf: it constrains the ACCEPT side only and is derived at dispatch from `warrant.tool_grants` (never journaled, never in MoteId, off-digest per D108.2); the authority gate stays the exact-equality `kx-toolcall` parser (SN-8)."
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# InputSchema / ParamType / ParamSpec — the closed, integer-/bytes-typed tool
+# arg contract the per-tool (stretch) grammar is rendered from.
+kx-tool-registry = { workspace = true }
+serde            = { workspace = true }
+serde_json       = { workspace = true, features = ["raw_value"] }
+
+[dev-dependencies]
+# Round-trip contract: a rendered envelope must be ACCEPTED by the real
+# authority-gate parser. Building a WarrantSpec to feed it needs these.
+kx-toolcall = { workspace = true }
+kx-warrant  = { workspace = true }
+kx-mote     = { workspace = true }
+kx-content  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kx-grammar/src/error.rs
+++ b/crates/kx-grammar/src/error.rs
@@ -1,0 +1,28 @@
+//! [`GrammarError`] — the fail-closed error for deserializing a carried spec.
+
+use std::fmt;
+
+/// Why a [`crate::ToolEnvelopeSpec`] could not be recovered from the opaque
+/// `kx_mote::Grammar.raw` carrier. An engine leg that hits this MUST fail the
+/// dispatch closed (never silently fall back to unconstrained generation), so a
+/// corrupt carrier can never quietly disable the constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrammarError {
+    /// The carrier bytes did not deserialize into a [`crate::ToolEnvelopeSpec`].
+    Malformed {
+        /// A short, non-secret diagnostic.
+        diagnostic: String,
+    },
+}
+
+impl fmt::Display for GrammarError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GrammarError::Malformed { diagnostic } => {
+                write!(f, "malformed grammar spec carrier: {diagnostic}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GrammarError {}

--- a/crates/kx-grammar/src/gbnf.rs
+++ b/crates/kx-grammar/src/gbnf.rs
@@ -1,0 +1,171 @@
+//! GBNF rendering (llama.cpp dialect) of a [`crate::ToolEnvelopeSpec`].
+//!
+//! Produces a grammar whose ONLY accepting strings are canonical tool-call
+//! envelopes `{"tool_call":{"name":<granted>,"version":<granted>,"args":{…}}}`
+//! with the `(name, version)` pair drawn from the spec. The args are either a
+//! generic JSON object (envelope-first default) or the tool's typed parameter
+//! object (the per-tool arg-schema stretch).
+//!
+//! The grammar is fed to `llama_sampler_init_grammar{,_lazy_patterns}` as the
+//! `root`-rooted GBNF. Conservative syntax only (no `\xNN`, no `{n}` counts) so it
+//! parses on the pinned llama.cpp.
+
+use std::fmt::Write as _;
+
+use kx_tool_registry::{ParamSpec, ParamType};
+
+use crate::spec::ToolEnvelopeSpec;
+
+/// The shared JSON value rules — emitted once, referenced by the per-tool rules.
+/// `ws` is whitespace; `jstring`/`jchar`/`hex` are a conservative JSON string;
+/// `integer`/`number` cover the numeric forms; `object`/`array`/`value` are the
+/// generic JSON value used for envelope-mode (untyped) args.
+const SHARED_RULES: &str = concat!(
+    "object ::= \"{\" ws ( member ( ws \",\" ws member )* )? ws \"}\"\n",
+    "member ::= jstring ws \":\" ws value\n",
+    "array ::= \"[\" ws ( value ( ws \",\" ws value )* )? ws \"]\"\n",
+    "value ::= object | array | jstring | number | \"true\" | \"false\" | \"null\"\n",
+    "jstring ::= \"\\\"\" jchar* \"\\\"\"\n",
+    "jchar ::= [^\"\\\\] | \"\\\\\" ([\"\\\\/bfnrt] | \"u\" hex hex hex hex)\n",
+    "hex ::= [0-9a-fA-F]\n",
+    "integer ::= \"-\"? (\"0\" | [1-9] [0-9]*)\n",
+    "number ::= integer (\".\" [0-9]+)? ([eEfF] [-+]? [0-9]+)?\n",
+    "ws ::= [ \\t\\n]*\n",
+);
+
+/// Render the spec to a complete, `root`-rooted GBNF grammar string.
+pub(crate) fn render(spec: &ToolEnvelopeSpec) -> String {
+    // Defensive: an empty spec must never emit an empty alternation (invalid
+    // GBNF). The caller guarantees this is non-empty before arming a grammar;
+    // if it ever isn't, fall back to "any JSON object" rather than a broken rule.
+    if spec.tools.is_empty() {
+        return format!("root ::= object\n{SHARED_RULES}");
+    }
+
+    let mut out = String::new();
+
+    // root: the tool_call envelope wrapper.
+    out.push_str("root ::= \"{\" ws ");
+    out.push_str(&str_terminal("\"tool_call\""));
+    out.push_str(" ws \":\" ws call ws \"}\"\n");
+
+    // call: one branch per granted tool.
+    out.push_str("call ::= ");
+    let branches: Vec<String> = (0..spec.tools.len()).map(|i| format!("call{i}")).collect();
+    out.push_str(&branches.join(" | "));
+    out.push('\n');
+
+    // call{i}: the name/version pair pinned + the args rule for that tool.
+    let mut typed_args = String::new();
+    for (i, tool) in spec.tools.iter().enumerate() {
+        let args_ref = match &tool.arg_schema {
+            None => "object".to_string(),
+            Some(_) => format!("args{i}"),
+        };
+        let _ = writeln!(
+            out,
+            "call{i} ::= \"{{\" ws {name_key} ws \":\" ws {name_val} ws \",\" ws \
+             {ver_key} ws \":\" ws {ver_val} ws \",\" ws {args_key} ws \":\" ws {args_ref} ws \"}}\"",
+            name_key = str_terminal("\"name\""),
+            name_val = json_string_terminal(&tool.name),
+            ver_key = str_terminal("\"version\""),
+            ver_val = json_string_terminal(&tool.version),
+            args_key = str_terminal("\"args\""),
+        );
+        if let Some(schema) = &tool.arg_schema {
+            typed_args.push_str(&render_typed_args(i, &schema.params));
+        }
+    }
+
+    out.push_str(&typed_args);
+    out.push_str(SHARED_RULES);
+    out
+}
+
+/// Render `args{idx} ::= …` constraining the object to the declared params:
+/// required params in canonical order, optional params as trailing optional
+/// groups (the model emits a fixed order the order-tolerant `validate_args`
+/// accepts). Numeric bounds / lengths are left to `validate_args` (a tight GBNF
+/// digit-range is brittle for weak models — D108.2 envelope-first rationale).
+fn render_typed_args(idx: usize, params: &[ParamSpec]) -> String {
+    let required: Vec<&ParamSpec> = params.iter().filter(|p| p.required).collect();
+    let optional: Vec<&ParamSpec> = params.iter().filter(|p| !p.required).collect();
+
+    let members = if !required.is_empty() {
+        let mut s = required
+            .iter()
+            .map(|p| member_fragment(p))
+            .collect::<Vec<_>>()
+            .join(" ws \",\" ws ");
+        for p in &optional {
+            let _ = write!(s, " ( ws \",\" ws {} )?", member_fragment(p));
+        }
+        s
+    } else if optional.is_empty() {
+        String::new()
+    } else {
+        // All-optional: the first opens the group, the rest are nested optionals.
+        let mut s = format!("( {}", member_fragment(optional[0]));
+        for p in &optional[1..] {
+            let _ = write!(s, " ( ws \",\" ws {} )?", member_fragment(p));
+        }
+        s.push_str(" )?");
+        s
+    };
+
+    if members.is_empty() {
+        format!("args{idx} ::= \"{{\" ws \"}}\"\n")
+    } else {
+        format!("args{idx} ::= \"{{\" ws {members} ws \"}}\"\n")
+    }
+}
+
+/// A single declared member: `"<key>" ws ":" ws <value-rule>`.
+fn member_fragment(p: &ParamSpec) -> String {
+    format!(
+        "{key} ws \":\" ws {val}",
+        key = json_string_terminal(&p.name),
+        val = value_fragment(&p.ty),
+    )
+}
+
+/// The GBNF value fragment for a declared [`ParamType`].
+fn value_fragment(ty: &ParamType) -> String {
+    match ty {
+        ParamType::Bool => "( \"true\" | \"false\" )".to_string(),
+        ParamType::Int { .. } => "integer".to_string(),
+        ParamType::Str { .. } | ParamType::Bytes { .. } => "jstring".to_string(),
+        ParamType::Enum { allowed } => {
+            if allowed.is_empty() {
+                "jstring".to_string()
+            } else {
+                let alts: Vec<String> = allowed.iter().map(|v| json_string_terminal(v)).collect();
+                format!("( {} )", alts.join(" | "))
+            }
+        }
+    }
+}
+
+/// A GBNF terminal matching the JSON encoding of `value` as a string (i.e. the
+/// model must emit `"<value>"`, JSON-escaped). Used for tool names, versions,
+/// param keys, and enum values.
+fn json_string_terminal(value: &str) -> String {
+    let json = serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string());
+    str_terminal(&json)
+}
+
+/// A GBNF double-quoted terminal matching the EXACT characters of `text`,
+/// escaping `"` and `\` for GBNF.
+fn str_terminal(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for c in text.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/crates/kx-grammar/src/lib.rs
+++ b/crates/kx-grammar/src/lib.rs
@@ -1,0 +1,34 @@
+//! `kx-grammar` — the engine-agnostic constrained-generation spec for RC2
+//! grammar-constrained tool-calling.
+//!
+//! A model running a `ReAct` tool turn must emit a tool call the runtime can
+//! decode and authorize. Small OSS models emit them in ~13 fragile formats
+//! (the `T-GEMMA-PAREN` class), which the `kx_toolcall` parser recovers with
+//! heuristics. This crate removes the fragility at the SOURCE: it derives a
+//! grammar from the granted tool set so the model can ONLY emit the canonical
+//! tool-call envelope `{"tool_call":{"name":…,"version":…,"args":{…}}}` with a
+//! `name`/`version` pair drawn from `warrant.tool_grants`.
+//!
+//! ## Two dialects, one spec
+//! llama.cpp wants **GBNF**; Ollama wants a **JSON Schema**. [`ToolEnvelopeSpec`]
+//! is the neutral middle: built once from the granted tools, serialized into the
+//! opaque `kx_mote::Grammar.raw` carrier at dispatch, then rendered per engine —
+//! [`ToolEnvelopeSpec::to_gbnf`] for llama.cpp, [`ToolEnvelopeSpec::to_ollama_format`]
+//! for Ollama.
+//!
+//! ## Boundaries (SN-8 / D108.2)
+//! - **Accept-side only.** The grammar can only NARROW what the model emits. It
+//!   is NOT the authority gate — `kx_toolcall::parse_tool_call` still resolves
+//!   the name against `warrant.tool_grants` by exact equality and `validate_args`
+//!   still type-checks the args. A grammar bug can never mint an ungranted tool.
+//! - **Off-digest.** The spec is derived at dispatch and carried off-digest; it is
+//!   never journaled and never participates in `MoteId`. This crate is pure and
+//!   FFI-free — it produces strings, it does not touch any engine.
+
+mod error;
+mod gbnf;
+mod ollama;
+mod spec;
+
+pub use error::GrammarError;
+pub use spec::{ToolEnvelopeSpec, ToolSpec};

--- a/crates/kx-grammar/src/ollama.rs
+++ b/crates/kx-grammar/src/ollama.rs
@@ -1,0 +1,48 @@
+//! Ollama `format` JSON-Schema rendering of a [`crate::ToolEnvelopeSpec`].
+//!
+//! Ollama constrains the WHOLE response to a JSON Schema (it has no lazy /
+//! triggered mode — see `kx-ollama`'s honest-degrade). RC2 renders the envelope
+//! level: the `name` is an enum over the granted tool ids, `version`/`args` are
+//! structurally pinned. Per-tool argument TYPING is carried in the spec for the
+//! GBNF (llama.cpp) leg; Ollama keeps generic-object args in RC2 (the accept-side
+//! `validate_args` gate enforces the types identically on both engines).
+
+use serde_json::{json, Value};
+
+use crate::spec::ToolEnvelopeSpec;
+
+/// Render the spec to an Ollama `format` JSON Schema.
+pub(crate) fn render(spec: &ToolEnvelopeSpec) -> Value {
+    if spec.tools.is_empty() {
+        // Defensive: caller guards `is_empty`; a generic object is the safest
+        // never-broken fallback.
+        return json!({ "type": "object" });
+    }
+
+    // Distinct granted names, in the spec's canonical order (sorted by
+    // (name, version), so equal names are adjacent — dedup keeps order).
+    let mut names: Vec<Value> = Vec::with_capacity(spec.tools.len());
+    let mut last: Option<&str> = None;
+    for tool in &spec.tools {
+        if last != Some(tool.name.as_str()) {
+            names.push(Value::String(tool.name.clone()));
+            last = Some(tool.name.as_str());
+        }
+    }
+
+    json!({
+        "type": "object",
+        "properties": {
+            "tool_call": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "enum": names },
+                    "version": { "type": "string" },
+                    "args": { "type": "object" }
+                },
+                "required": ["name", "version", "args"]
+            }
+        },
+        "required": ["tool_call"]
+    })
+}

--- a/crates/kx-grammar/src/spec.rs
+++ b/crates/kx-grammar/src/spec.rs
@@ -1,0 +1,119 @@
+//! [`ToolEnvelopeSpec`] — the neutral, engine-agnostic constraint spec.
+
+use kx_tool_registry::InputSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::error::GrammarError;
+
+/// One granted tool the model may call this turn: the exact `name`/`version` the
+/// envelope must carry, plus an optional typed arg schema.
+///
+/// `name` is the tool's full id (e.g. `mcp-echo/echo`) — the most specific form,
+/// which resolves UNIQUELY through `kx_toolcall`'s `id_matches`. `version` is the
+/// granted version (authoritative; the parser ignores the envelope's version for
+/// resolution but the grammar pins it so the committed envelope is an exact member
+/// of `warrant.tool_grants`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolSpec {
+    /// The full tool id the model must emit as `name`.
+    pub name: String,
+    /// The granted version the model must emit as `version`.
+    pub version: String,
+    /// The tool's typed arg schema. `None` ⇒ args are constrained to a generic
+    /// JSON object (the RC2 envelope-first default); `Some` ⇒ args are constrained
+    /// to the declared parameters (the per-tool arg-schema STRETCH).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arg_schema: Option<InputSchema>,
+}
+
+impl ToolSpec {
+    /// A tool spec with generic-object args (envelope-first).
+    #[must_use]
+    pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            arg_schema: None,
+        }
+    }
+
+    /// A tool spec whose args are constrained to `schema` (the stretch).
+    #[must_use]
+    pub fn with_schema(
+        name: impl Into<String>,
+        version: impl Into<String>,
+        schema: InputSchema,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            arg_schema: Some(schema),
+        }
+    }
+}
+
+/// The set of tools a tool-eligible `ReAct` turn may call — the engine-agnostic
+/// constraint. Built once at dispatch from `warrant.tool_grants`, serialized into
+/// `kx_mote::Grammar.raw`, then rendered per engine via [`Self::to_gbnf`] /
+/// [`Self::to_ollama_format`].
+///
+/// The tool order is CANONICAL (sorted by `(name, version)`) so the rendered
+/// grammar is deterministic across calls with the same grant set — a property the
+/// memoizer + replay rely on (same warrant ⇒ byte-identical grammar).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolEnvelopeSpec {
+    /// The granted tools, in canonical `(name, version)` order.
+    pub tools: Vec<ToolSpec>,
+}
+
+impl ToolEnvelopeSpec {
+    /// Build a spec from a granted tool set, sorting into canonical order. An
+    /// empty set yields an empty spec (the caller MUST NOT arm a grammar for a
+    /// turn with no granted tools — `is_empty` guards that at the call site).
+    #[must_use]
+    pub fn new(mut tools: Vec<ToolSpec>) -> Self {
+        tools.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.version.cmp(&b.version)));
+        tools.dedup();
+        Self { tools }
+    }
+
+    /// True when no tools are granted — a grammar must not be derived.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+
+    /// Serialize into the opaque `kx_mote::Grammar.raw` carrier (canonical JSON).
+    ///
+    /// # Errors
+    /// [`GrammarError::Malformed`] only if serialization fails (not reachable for
+    /// the closed spec types, but surfaced rather than panicking).
+    pub fn to_raw(&self) -> Result<String, GrammarError> {
+        serde_json::to_string(self).map_err(|e| GrammarError::Malformed {
+            diagnostic: e.to_string(),
+        })
+    }
+
+    /// Recover a spec from the opaque `kx_mote::Grammar.raw` carrier.
+    ///
+    /// # Errors
+    /// [`GrammarError::Malformed`] if `raw` is not a serialized spec — the engine
+    /// leg must fail the dispatch CLOSED on this (never silently unconstrain).
+    pub fn from_raw(raw: &str) -> Result<Self, GrammarError> {
+        serde_json::from_str(raw).map_err(|e| GrammarError::Malformed {
+            diagnostic: e.to_string(),
+        })
+    }
+
+    /// Render this spec to a GBNF grammar (llama.cpp dialect).
+    #[must_use]
+    pub fn to_gbnf(&self) -> String {
+        crate::gbnf::render(self)
+    }
+
+    /// Render this spec to a JSON Schema (Ollama `format` dialect).
+    #[must_use]
+    pub fn to_ollama_format(&self) -> serde_json::Value {
+        crate::ollama::render(self)
+    }
+}

--- a/crates/kx-grammar/tests/render.rs
+++ b/crates/kx-grammar/tests/render.rs
@@ -1,0 +1,286 @@
+// Integration tests for kx-grammar: the rendered constraint must (1) target the
+// EXACT envelope the authority-gate parser accepts, and (2) render deterministic,
+// well-formed GBNF / Ollama schemas. Tests use `.unwrap()`/`.expect()` for
+// fixture construction (workspace lints deny these in lib code, allow in tests).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+//! Integration tests for `kx-grammar`: the rendered constraint targets the exact
+//! envelope the authority-gate parser accepts, and renders deterministic GBNF /
+//! Ollama schemas (incl. the typed-args stretch).
+
+use std::collections::BTreeSet;
+
+use kx_grammar::{ToolEnvelopeSpec, ToolSpec};
+use kx_tool_registry::{InputSchema, ParamSpec, ParamType};
+use kx_toolcall::parse_tool_call;
+use kx_warrant::{
+    ExecutorClass, FsScope, ModelRoute, MoteClass, NetScope, ResourceCeiling, ToolGrant,
+    WarrantSpec,
+};
+
+use kx_mote::{ModelId, ToolName, ToolVersion};
+
+/// A warrant granting the given `(tool_id, version)` pairs — mirrors the
+/// `kx-toolcall` test helper so the round-trip exercises the REAL gate.
+fn warrant_granting(tools: &[(&str, &str)]) -> WarrantSpec {
+    let mut tool_grants = BTreeSet::new();
+    for (id, ver) in tools {
+        tool_grants.insert(ToolGrant {
+            tool_id: ToolName((*id).into()),
+            tool_version: ToolVersion((*ver).into()),
+        });
+    }
+    WarrantSpec {
+        mote_class: MoteClass::WorldMutating,
+        nd_class: MoteClass::WorldMutating,
+        fs_scope: FsScope::empty(),
+        net_scope: NetScope::None,
+        syscall_profile_ref: kx_content::ContentRef::from_bytes([0; 32]),
+        tool_grants,
+        model_route: ModelRoute {
+            model_id: ModelId("m".into()),
+            max_input_tokens: 1024,
+            max_output_tokens: 256,
+            max_calls: 8,
+        },
+        resource_ceiling: ResourceCeiling {
+            cpu_milli: 0,
+            mem_bytes: 0,
+            wall_clock_ms: 1000,
+            fd_count: 0,
+            disk_bytes: 0,
+        },
+        environment_ref: None,
+        executor_class: ExecutorClass::Bwrap,
+        ..Default::default()
+    }
+}
+
+/// THE contract: an envelope of the exact shape the grammar enforces is ACCEPTED
+/// by the real authority-gate parser, for EACH granted tool. If this holds, a
+/// grammar-constrained model produces only parser-decodable calls.
+#[test]
+fn rendered_envelope_shape_is_accepted_by_the_parser() {
+    let tools = [("mcp-echo/echo", "1"), ("calc/add", "1"), ("kv/get", "1")];
+    let spec = ToolEnvelopeSpec::new(tools.iter().map(|(n, v)| ToolSpec::new(*n, *v)).collect());
+    assert!(!spec.is_empty());
+    let warrant = warrant_granting(&tools);
+
+    for (name, ver) in tools {
+        // Exactly what the grammar's `call{i}` branch admits: name+version pinned,
+        // args a JSON object.
+        let envelope =
+            format!(r#"{{"tool_call":{{"name":"{name}","version":"{ver}","args":{{"x":1}}}}}}"#);
+        let decoded = parse_tool_call(envelope.as_bytes(), &warrant, 4096)
+            .unwrap_or_else(|e| panic!("grammar-shaped envelope for {name} must parse, got {e:?}"))
+            .unwrap_or_else(|| panic!("grammar-shaped envelope for {name} must be a call"));
+        // Resolves to the SAME granted tool the grammar pinned (SN-8 exact grant).
+        assert_eq!(
+            decoded.name,
+            ToolName(name.into()),
+            "name resolves to the grant"
+        );
+        assert_eq!(
+            decoded.args_bytes,
+            br#"{"x":1}"#.to_vec(),
+            "args carried verbatim"
+        );
+    }
+}
+
+/// The GBNF has one `call{i}` branch per tool, each pinning the JSON-string name
+/// and version, plus a complete `root` and the shared JSON rules.
+#[test]
+fn gbnf_pins_each_granted_tool() {
+    let spec = ToolEnvelopeSpec::new(vec![
+        ToolSpec::new("calc/add", "1"),
+        ToolSpec::new("mcp-echo/echo", "2"),
+    ]);
+    let gbnf = spec.to_gbnf();
+
+    assert!(
+        gbnf.starts_with("root ::= \"{\" ws "),
+        "rooted envelope: {gbnf}"
+    );
+    assert!(
+        gbnf.contains("call ::= call0 | call1\n"),
+        "one branch per tool: {gbnf}"
+    );
+    // Sorted canonical order: calc/add before mcp-echo/echo.
+    assert!(
+        gbnf.contains(r#""\"calc/add\"""#),
+        "calc name pinned as JSON string"
+    );
+    assert!(
+        gbnf.contains(r#""\"mcp-echo/echo\"""#),
+        "echo name pinned as JSON string"
+    );
+    assert!(gbnf.contains(r#""\"version\"""#) && gbnf.contains(r#""\"args\"""#));
+    // Shared JSON rules are present so the grammar is self-contained.
+    for rule in [
+        "object ::=",
+        "value ::=",
+        "jstring ::=",
+        "number ::=",
+        "ws ::=",
+    ] {
+        assert!(gbnf.contains(rule), "missing shared rule {rule}");
+    }
+    // Envelope-first: args reference the generic object (no args{i} rule).
+    assert!(gbnf.contains("ws \"args\"") || gbnf.contains(r#""\"args\"" ws"#));
+    assert!(
+        !gbnf.contains("args0 ::="),
+        "envelope-first has no typed args rule"
+    );
+}
+
+/// With a per-tool arg schema, the GBNF emits a typed `args{i}` rule: required
+/// params mandatory, optionals trailing, enum as alternation, bool as true|false.
+#[test]
+fn gbnf_renders_typed_args_for_the_stretch() {
+    let schema = InputSchema {
+        params: vec![
+            ParamSpec {
+                name: "a".into(),
+                ty: ParamType::Int {
+                    min: None,
+                    max: None,
+                },
+                required: true,
+            },
+            ParamSpec {
+                name: "op".into(),
+                ty: ParamType::Enum {
+                    allowed: ["add", "sub"].iter().map(|s| (*s).into()).collect(),
+                },
+                required: true,
+            },
+            ParamSpec {
+                name: "verbose".into(),
+                ty: ParamType::Bool,
+                required: false,
+            },
+        ],
+        deny_unknown: true,
+    };
+    let spec = ToolEnvelopeSpec::new(vec![ToolSpec::with_schema("calc/add", "1", schema)]);
+    let gbnf = spec.to_gbnf();
+
+    assert!(gbnf.contains("call0 ::="), "the single tool branch");
+    assert!(gbnf.contains("args0 ::="), "a typed args rule is emitted");
+    // required `a`(int) then `op`(enum) joined by a comma; optional `verbose` trailing.
+    assert!(
+        gbnf.contains(r#""\"a\"" ws ":" ws integer"#),
+        "int param a: {gbnf}"
+    );
+    assert!(
+        gbnf.contains(r#"( "\"add\"" | "\"sub\"" )"#)
+            || gbnf.contains(r#"( "\"sub\"" | "\"add\"" )"#),
+        "enum alternation: {gbnf}"
+    );
+    assert!(
+        gbnf.contains(r#"( "true" | "false" )"#),
+        "bool value: {gbnf}"
+    );
+    assert!(
+        gbnf.contains(r#"( ws "," ws "\"verbose\""#),
+        "optional verbose is a trailing group"
+    );
+}
+
+/// The Ollama JSON schema constrains the tool name to the granted-id enum.
+#[test]
+fn ollama_format_enumerates_granted_names() {
+    let spec = ToolEnvelopeSpec::new(vec![
+        ToolSpec::new("calc/add", "1"),
+        ToolSpec::new("kv/get", "1"),
+    ]);
+    let schema = spec.to_ollama_format();
+    let names = &schema["properties"]["tool_call"]["properties"]["name"]["enum"];
+    assert_eq!(
+        names,
+        &serde_json::json!(["calc/add", "kv/get"]),
+        "name enum = granted ids"
+    );
+    let required = &schema["properties"]["tool_call"]["required"];
+    assert_eq!(required, &serde_json::json!(["name", "version", "args"]));
+}
+
+/// The spec serializes to / from the opaque `Grammar.raw` carrier byte-faithfully.
+#[test]
+fn spec_round_trips_through_the_carrier() {
+    let spec = ToolEnvelopeSpec::new(vec![
+        ToolSpec::new("calc/add", "1"),
+        ToolSpec::new("kv/get", "1"),
+    ]);
+    let raw = spec.to_raw().expect("serialize");
+    let back = ToolEnvelopeSpec::from_raw(&raw).expect("deserialize");
+    assert_eq!(spec, back, "round-trip identity");
+    // A corrupt carrier fails CLOSED (never silently unconstrains).
+    assert!(ToolEnvelopeSpec::from_raw("not json").is_err());
+}
+
+/// Tools are canonicalized: sorted by (name, version) and de-duplicated, so the
+/// rendered grammar is deterministic regardless of input order.
+#[test]
+fn tools_are_canonicalized() {
+    let a = ToolEnvelopeSpec::new(vec![
+        ToolSpec::new("kv/get", "1"),
+        ToolSpec::new("calc/add", "1"),
+        ToolSpec::new("calc/add", "1"), // duplicate
+    ]);
+    let b = ToolEnvelopeSpec::new(vec![
+        ToolSpec::new("calc/add", "1"),
+        ToolSpec::new("kv/get", "1"),
+    ]);
+    assert_eq!(a, b, "order + dedup canonicalized");
+    assert_eq!(a.tools.len(), 2);
+    assert_eq!(a.to_gbnf(), b.to_gbnf(), "deterministic GBNF");
+}
+
+/// An empty spec never emits a broken alternation (defensive — callers guard
+/// `is_empty`, but a bug must degrade to valid GBNF, not invalid).
+#[test]
+fn empty_spec_renders_valid_fallback() {
+    let spec = ToolEnvelopeSpec::new(vec![]);
+    assert!(spec.is_empty());
+    let gbnf = spec.to_gbnf();
+    assert!(
+        gbnf.starts_with("root ::= object\n"),
+        "empty falls back to any-object: {gbnf}"
+    );
+    assert!(!gbnf.contains("call ::= \n"), "no empty alternation");
+}
+
+/// Full GBNF golden for the bundled-oracle grant set. This EXACT string is also
+/// fed to `kx-llamacpp`'s `smoke_grammar_from_kx_grammar` test (which proves it
+/// PARSES + builds a lazy sampler in llama.cpp). If this golden changes, re-sync
+/// that smoke test — the two together close the loop: kx-grammar renders shape X,
+/// llama.cpp accepts shape X. (kx-llamacpp can't depend on kx-grammar — layering.)
+#[test]
+fn gbnf_golden_for_bundled_oracles() {
+    let spec = ToolEnvelopeSpec::new(vec![
+        ToolSpec::new("calc/add", "1"),
+        ToolSpec::new("kv/get", "1"),
+    ]);
+    let expected = concat!(
+        "root ::= \"{\" ws \"\\\"tool_call\\\"\" ws \":\" ws call ws \"}\"\n",
+        "call ::= call0 | call1\n",
+        "call0 ::= \"{\" ws \"\\\"name\\\"\" ws \":\" ws \"\\\"calc/add\\\"\" ws \",\" ws \"\\\"version\\\"\" ws \":\" ws \"\\\"1\\\"\" ws \",\" ws \"\\\"args\\\"\" ws \":\" ws object ws \"}\"\n",
+        "call1 ::= \"{\" ws \"\\\"name\\\"\" ws \":\" ws \"\\\"kv/get\\\"\" ws \",\" ws \"\\\"version\\\"\" ws \":\" ws \"\\\"1\\\"\" ws \",\" ws \"\\\"args\\\"\" ws \":\" ws object ws \"}\"\n",
+        "object ::= \"{\" ws ( member ( ws \",\" ws member )* )? ws \"}\"\n",
+        "member ::= jstring ws \":\" ws value\n",
+        "array ::= \"[\" ws ( value ( ws \",\" ws value )* )? ws \"]\"\n",
+        "value ::= object | array | jstring | number | \"true\" | \"false\" | \"null\"\n",
+        "jstring ::= \"\\\"\" jchar* \"\\\"\"\n",
+        "jchar ::= [^\"\\\\] | \"\\\\\" ([\"\\\\/bfnrt] | \"u\" hex hex hex hex)\n",
+        "hex ::= [0-9a-fA-F]\n",
+        "integer ::= \"-\"? (\"0\" | [1-9] [0-9]*)\n",
+        "number ::= integer (\".\" [0-9]+)? ([eEfF] [-+]? [0-9]+)?\n",
+        "ws ::= [ \\t\\n]*\n",
+    );
+    assert_eq!(
+        spec.to_gbnf(),
+        expected,
+        "GBNF golden drift — re-sync the smoke test"
+    );
+}

--- a/crates/kx-inference/Cargo.toml
+++ b/crates/kx-inference/Cargo.toml
@@ -30,6 +30,10 @@ kx-llamacpp          = { workspace = true, optional = true }
 # the in-process backend consumes it; a bring-your-own backend pulls it directly
 # if it wants the registry. FFI-free, so it never affects `build-no-inference`.
 kx-model-store       = { workspace = true, optional = true }
+# RC2 grammar-constrained tool-calling: render a granted tool set to GBNF for the
+# in-process llama.cpp sampler. FFI-free + optional behind `llamacpp` (only the
+# concrete backend's sampler uses it; the bring-your-own-backend build drops it).
+kx-grammar           = { workspace = true, optional = true }
 serde                = { workspace = true }
 thiserror            = { workspace = true }
 tracing              = { workspace = true }
@@ -47,7 +51,7 @@ smallvec             = { workspace = true }
 # --workspace` keep the FFI ON because kx-model-harness (the only consumer of the
 # concrete backend) opts back in with `features = ["llamacpp"]`.
 default  = ["llamacpp"]
-llamacpp = ["dep:kx-llamacpp", "dep:kx-model-store"]
+llamacpp = ["dep:kx-llamacpp", "dep:kx-model-store", "dep:kx-grammar"]
 
 [dev-dependencies]
 kx-journal         = { workspace = true }

--- a/crates/kx-inference/src/cache.rs
+++ b/crates/kx-inference/src/cache.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use kx_content::ContentRef;
+use kx_grammar::ToolEnvelopeSpec;
 use kx_llamacpp::{
     Bitmap, ChatMessage, Context, ContextParams, Generator, LlamaBackend, LlamaError, Model,
     ModelWithProjector, Mtmd, PoolingType, Sampler, Vocab,
@@ -641,14 +642,50 @@ fn get_or_load<'a, 'b>(
     Ok(&mut lru[idx].1)
 }
 
-/// Build the sampler for `params` (greedy when `temperature_bps == 0`, else
-/// temp/top-k/top-p). Shared by the text and multi-modal generation paths.
+/// The start symbol of the GBNF `kx_grammar` renders.
+const GRAMMAR_ROOT: &str = "root";
+
+/// Lazy-grammar trigger: the canonical JSON tool-call envelope opener. Prose
+/// answers flow free until the model emits `{"tool_call"`, at which point the
+/// grammar arms and constrains the rest of the envelope to a grant-pinned shape.
+/// Native-marker tool-call formats (Gemma `<|tool_call>`, Llama `<|python_tag|>`,
+/// Qwen `<tool_call>`) never match this opener, so they pass through UNCONSTRAINED
+/// to the fail-closed `kx_toolcall` parser — an honest GR15 capability gap, not a
+/// silent one (the accept-side gate is identical for both paths).
+const TOOL_CALL_TRIGGERS: [&str; 1] = [r#"[\s\S]*?(\{[ \t\n]*"tool_call")"#];
+
+/// Build the sampler for `params`. The SELECTION stages are unchanged (greedy
+/// when `temperature_bps == 0`, else top-k/top-p/temp/dist) — byte-identical to
+/// the prior `Sampler::greedy`/`Sampler::typical` shapes when no grammar is set.
+///
+/// RC2: when `params.grammar` is present (a serialized [`ToolEnvelopeSpec`] in the
+/// off-digest carrier), prepend a LAZY GBNF stage FIRST in the chain. The grammar
+/// only MASKS logits (to grammar-valid tokens); the selection stage still picks
+/// within that masked set, so greedy + grammar = argmax over valid tokens (no
+/// extra `dist` stage needed). A malformed carrier fails CLOSED (the dispatch
+/// errors) rather than silently dropping the constraint.
 fn build_sampler<'b>(
     backend: &'b LlamaBackend,
+    vocab: &Vocab<'_, '_>,
     params: &InferenceParams,
 ) -> Result<Sampler<'b>, InferenceError> {
-    if params.temperature_bps == 0 {
-        Sampler::greedy(backend).map_err(map_llama_err)
+    let mut chain = Sampler::chain(backend);
+
+    if let Some(grammar) = &params.grammar {
+        let spec = ToolEnvelopeSpec::from_raw(&grammar.raw).map_err(|e| {
+            InferenceError::BackendFailure {
+                backend: BACKEND_NAME,
+                message: format!("grammar spec carrier: {e}"),
+            }
+        })?;
+        let gbnf = spec.to_gbnf();
+        chain = chain
+            .add_grammar_lazy(vocab, &gbnf, GRAMMAR_ROOT, &TOOL_CALL_TRIGGERS)
+            .map_err(map_llama_err)?;
+    }
+
+    let chain = if params.temperature_bps == 0 {
+        chain.add_greedy().map_err(map_llama_err)?
     } else {
         #[allow(clippy::cast_precision_loss)]
         let temp = (params.temperature_bps as f32) / 10_000.0;
@@ -656,8 +693,17 @@ fn build_sampler<'b>(
         let top_p = (params.top_p_bps as f32) / 10_000.0;
         #[allow(clippy::cast_possible_wrap)]
         let top_k = params.top_k as i32;
-        Sampler::typical(backend, temp, top_k, top_p, params.seed).map_err(map_llama_err)
-    }
+        chain
+            .add_top_k(top_k)
+            .map_err(map_llama_err)?
+            .add_top_p(top_p, 1)
+            .map_err(map_llama_err)?
+            .add_temp(temp)
+            .map_err(map_llama_err)?
+            .add_dist(params.seed)
+            .map_err(map_llama_err)?
+    };
+    chain.build().map_err(map_llama_err)
 }
 
 /// The token-emission loop: pull tokens from `generator`, detokenize into bytes,
@@ -732,7 +778,7 @@ fn generate(
         .map_err(map_llama_err)?;
     check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
 
-    let mut sampler = build_sampler(backend, &job.params)?;
+    let mut sampler = build_sampler(backend, &vocab, &job.params)?;
     let generator =
         Generator::new(&mut ctx, &mut sampler, &vocab, prompt_tokens).map_err(map_llama_err)?;
     run_generation(generator, &vocab, job, start, timeout)
@@ -820,7 +866,7 @@ fn generate_multimodal(
     check_timeout(start.elapsed(), timeout, job.wall_clock_ms)?;
 
     let vocab = model.vocab();
-    let mut sampler = build_sampler(backend, &job.params)?;
+    let mut sampler = build_sampler(backend, &vocab, &job.params)?;
     let generator = Generator::from_prefilled(&mut ctx, &mut sampler, &vocab, n_past);
     run_generation(generator, &vocab, job, start, timeout)
 }

--- a/crates/kx-inference/src/lib.rs
+++ b/crates/kx-inference/src/lib.rs
@@ -7,13 +7,14 @@
 //! participates in the idempotency key (kx-mote → `MoteDef.model_id`) so
 //! model changes correctly bust the cache.
 //!
-//! PR 8 ships two forward-compat trait-shape hooks to prevent breaking
-//! trait changes when multimodal + constrained-generation features land:
-//! `InferenceInput::Multimodal` (reserved variant) and
-//! `InferenceParams.grammar` (reserved Option field). The OSS v0.1
-//! `LlamaInferenceBackend` returns `Err(InferenceError::Unsupported)` on
-//! either path — see `roadmap-multimodal-synthesis-post-pr9` for the
-//! future-PR sequencing commitment.
+//! PR 8 shipped two forward-compat trait-shape hooks; both are now IMPLEMENTED.
+//! `InferenceInput::Multimodal` serves image dispatch on a vision model, and
+//! `InferenceParams.grammar` (RC2) constrains tool-call decoding: when set, the
+//! `LlamaInferenceBackend` renders the carried `kx_grammar::ToolEnvelopeSpec` to
+//! GBNF and prepends a lazy/triggered sampler stage (`build_sampler`) — never in
+//! the frozen `dispatcher.rs`, and only on a real model load (a malformed grammar
+//! carrier fails closed). A backend that cannot honor a variant still returns
+//! `Err(InferenceError::Unsupported)`.
 //!
 //! # Quick example
 //!

--- a/crates/kx-inference/src/llama.rs
+++ b/crates/kx-inference/src/llama.rs
@@ -355,14 +355,14 @@ impl LlamaInferenceBackend {
         warrant: &WarrantSpec,
         token_sink: Option<crate::TokenSink>,
     ) -> Result<InferenceOutput, InferenceError> {
-        // ---- Grammar reservation gate (fires before any model work) -------
-        // Constrained generation is a distinct, still-reserved seam; it gates
-        // every input variant.
-        if params.grammar.is_some() {
-            return Err(InferenceError::Unsupported {
-                reason: "constrained generation (grammar) reserved; see HANDOFF",
-            });
-        }
+        // ---- Grammar (RC2): IMPLEMENTED. A `params.grammar` carrier (a
+        // serialized `kx_grammar::ToolEnvelopeSpec`) is honored by `build_sampler`
+        // in the owner thread — it renders GBNF and prepends a lazy/triggered
+        // grammar stage so a tool turn can only emit the canonical grant-pinned
+        // envelope. No reservation gate here any more; a malformed carrier fails
+        // CLOSED at sampler-build time (never silently unconstrains). Grammar is
+        // derived at dispatch + carried off-digest (D108.2) — `dispatcher.rs` is
+        // untouched.
 
         // ---- Warrant gates (D30 + D35) — authorize BEFORE touching content -
         if model_id != &warrant.model_route.model_id {

--- a/crates/kx-inference/tests/multimodal_dispatch.rs
+++ b/crates/kx-inference/tests/multimodal_dispatch.rs
@@ -6,9 +6,11 @@
 //! generate) is exercised by the `model-smoke-test-multimodal` gate against a
 //! real VLM.
 //!
-//! Gate order under test (`LlamaInferenceBackend::dispatch`): grammar → warrant
-//! route → scope → resolve descriptor → [image] capability → content store
-//! bound → ref resolves → size cap → image sniff → mmproj present → cache.
+//! Gate order under test (`LlamaInferenceBackend::dispatch`): warrant route →
+//! scope → resolve descriptor → [image] capability → content store bound → ref
+//! resolves → size cap → image sniff → mmproj present → cache. (RC2 removed the
+//! former leading grammar-reservation gate — grammar is now honored at
+//! sampler-build time, never rejected here.)
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
 

--- a/crates/kx-inference/tests/proptest_dispatch.rs
+++ b/crates/kx-inference/tests/proptest_dispatch.rs
@@ -5,8 +5,9 @@
 //!   1. `Unsupported`-on-Multimodal is deterministic — for any prompt,
 //!      seed, and content-ref set, the backend returns the SAME error
 //!      string. (Reservation semantics are invariant across inputs.)
-//!   2. `Unsupported`-on-grammar=Some is deterministic — for any
-//!      `Grammar` payload, the backend returns the same error.
+//!   2. grammar=Some takes the SAME gate path as grammar=None (RC2: grammar is
+//!      honored at sampler-build, not gated as Unsupported) — for any `Grammar`
+//!      payload, the gate outcome is identical to no grammar.
 //!   3. `WarrantDeniesModel` fires whenever `requested_model_id !=
 //!      warrant.model_route.model_id`, regardless of any other field.
 //!      (Prefix-monotonic on the model-route axis: changing other
@@ -97,11 +98,15 @@ proptest! {
         prop_assert!(is_unsupported);
     }
 
-    /// Property 2: `Unsupported` on grammar=Some is deterministic
-    /// across any payload string. Same invariance argument as
-    /// Property 1 but on the grammar field.
+    /// Property 2 (RC2): grammar is no longer a reserved-`Unsupported` gate — it
+    /// is HONORED in `build_sampler` once a real model loads. So at the dispatch
+    /// gate level, a `grammar=Some` request takes the SAME path as `grammar=None`:
+    /// against an unloadable model BOTH fail identically at the load stage, and
+    /// NEITHER returns the old "constrained generation (grammar) reserved"
+    /// `Unsupported`. (The honored-grammar path is covered live by kx-llamacpp's
+    /// `smoke_grammar_from_kx_grammar` + the kx-gateway real-model tests.)
     #[test]
-    fn prop_grammar_some_always_unsupported(
+    fn prop_grammar_some_takes_same_path_as_none(
         raw in ".{0,256}",
     ) {
         let id = ModelId("any-model".into());
@@ -111,14 +116,20 @@ proptest! {
         );
         let warrant = warrant_with_route(id.clone(), 512);
         let input = InferenceInput::Text("hi".into());
-        let params = InferenceParams {
+        let with_grammar = InferenceParams {
             grammar: Some(Grammar::new(raw)),
             ..InferenceParams::default()
         };
-        let err = backend.dispatch(&id, &input, &params, &warrant)
-            .expect_err("grammar=Some must be Unsupported");
-        let is_unsupported_grammar = matches!(err, InferenceError::Unsupported { .. });
-        prop_assert!(is_unsupported_grammar);
+        let without = InferenceParams::default();
+        let e1 = backend.dispatch(&id, &input, &with_grammar, &warrant)
+            .expect_err("unloadable model must error");
+        let e2 = backend.dispatch(&id, &input, &without, &warrant)
+            .expect_err("unloadable model must error");
+        // The reservation is gone: grammar=Some never short-circuits to the old
+        // grammar-reserved Unsupported, and the gate outcome is identical to None.
+        let reserved = matches!(&e1, InferenceError::Unsupported { reason } if reason.contains("grammar"));
+        prop_assert!(!reserved, "grammar reservation must be gone");
+        prop_assert_eq!(format!("{e1}"), format!("{e2}"), "grammar must not alter the gate outcome");
     }
 
     /// Property 3: `WarrantDeniesModel` is invariant on every other

--- a/crates/kx-llamacpp/src/error.rs
+++ b/crates/kx-llamacpp/src/error.rs
@@ -65,10 +65,20 @@ pub enum LlamaError {
     /// A constructor for a particular sampler returned NULL.
     ///
     /// **Reachability (SN-4 #4):** like [`Self::SamplerChainFailed`], NULL
-    /// from `llama_sampler_init_*` only occurs under host-OOM. Kept for API
-    /// completeness; not testable without a fault-injection harness.
+    /// from `llama_sampler_init_*` only occurs under host-OOM **except** for
+    /// the grammar samplers, where NULL ALSO signals a GBNF parse failure
+    /// (`llama_sampler_init_grammar{,_lazy_patterns}` returns NULL when
+    /// `grammar_str` does not parse). So a `SamplerInitFailed("grammar")` is
+    /// the fail-closed boundary for a malformed grammar — reachable and tested.
     #[error("failed to construct sampler: {0}")]
     SamplerInitFailed(&'static str),
+
+    /// A grammar / grammar-root / trigger-pattern string could not be converted
+    /// to a C string (interior NUL byte). The fail-closed boundary for an
+    /// untrusted grammar payload before it reaches llama.cpp — surfaced rather
+    /// than panicking on `CString::new`.
+    #[error("grammar string is not representable as a C string (interior nul)")]
+    GrammarStringInvalid,
 
     /// Embedding readout requested but the context was not configured with
     /// `with_embeddings(true)` — or the requested seq_id has no pooled vector.

--- a/crates/kx-llamacpp/src/sampler.rs
+++ b/crates/kx-llamacpp/src/sampler.rs
@@ -11,6 +11,7 @@
 //! Lifetime: a [`Sampler`] borrows the [`crate::LlamaBackend`] so that the
 //! backend outlives every sampler chain.
 
+use std::ffi::CString;
 use std::ptr::NonNull;
 
 use kx_llamacpp_sys as sys;
@@ -18,7 +19,7 @@ use kx_llamacpp_sys as sys;
 use crate::backend::LlamaBackend;
 use crate::context::Context;
 use crate::error::LlamaError;
-use crate::vocab::Token;
+use crate::vocab::{Token, Vocab};
 
 /// RAII handle to a `llama_sampler` chain.
 ///
@@ -196,6 +197,95 @@ impl<'b> SamplerChainBuilder<'b> {
     pub fn add_temp_ext(self, t: f32, delta: f32, exponent: f32) -> Result<Self, LlamaError> {
         let ptr = unsafe { sys::llama_sampler_init_temp_ext(t, delta, exponent) };
         self.add(ptr, "temp_ext")
+    }
+
+    /// Append a **GBNF grammar** stage that masks every token which would
+    /// violate `grammar` (rooted at `root`) to `-inf`, so the downstream
+    /// selection stage (greedy / dist) can only pick a grammar-valid
+    /// continuation. Place this FIRST in the chain — before any top-k / top-p
+    /// truncation — so truncation can never remove the only grammar-valid
+    /// token.
+    ///
+    /// The grammar is parsed at init; an unparseable GBNF makes
+    /// `llama_sampler_init_grammar` return NULL, surfaced as
+    /// [`LlamaError::SamplerInitFailed`] (the fail-closed boundary for a
+    /// malformed grammar).
+    ///
+    /// # Safety contract
+    /// The constructed grammar sampler stores `vocab`'s raw pointer internally
+    /// and dereferences it at sampling time. The resulting [`Sampler`] therefore
+    /// MUST NOT outlive the [`crate::Model`] that owns `vocab`. Call sites build
+    /// and consume the sampler within a single generation scope where the model
+    /// is live, which upholds this.
+    ///
+    /// # Errors
+    /// [`LlamaError::GrammarStringInvalid`] if `grammar` / `root` contains an
+    /// interior NUL; [`LlamaError::SamplerInitFailed`] on a GBNF parse failure
+    /// (or host-OOM).
+    pub fn add_grammar(
+        self,
+        vocab: &Vocab<'_, '_>,
+        grammar: &str,
+        root: &str,
+    ) -> Result<Self, LlamaError> {
+        let grammar_c = CString::new(grammar).map_err(|_| LlamaError::GrammarStringInvalid)?;
+        let root_c = CString::new(root).map_err(|_| LlamaError::GrammarStringInvalid)?;
+        // SAFETY: vocab ptr is borrowed from a live model; the two CStrings
+        // outlive this call; llama.cpp parses the grammar during init and
+        // returns NULL on parse failure (mapped to SamplerInitFailed by `add`).
+        let ptr = unsafe {
+            sys::llama_sampler_init_grammar(vocab.as_ptr(), grammar_c.as_ptr(), root_c.as_ptr())
+        };
+        self.add(ptr, "grammar")
+    }
+
+    /// Append a **lazy / triggered** GBNF grammar stage: generation flows
+    /// completely unconstrained until one of `trigger_patterns` matches from the
+    /// start of the output, at which point the grammar (rooted at `root`) is fed
+    /// content starting at the pattern's first match group. This is what lets a
+    /// ReAct turn emit a free-form prose answer OR commit to a constrained
+    /// tool-call envelope (the grammar arms only once the model types the
+    /// tool-call opener).
+    ///
+    /// Same FIRST-in-chain placement + [safety contract](Self::add_grammar) as
+    /// [`Self::add_grammar`]. No trigger *tokens* are used (only patterns).
+    ///
+    /// # Errors
+    /// [`LlamaError::GrammarStringInvalid`] if `grammar` / `root` / any pattern
+    /// contains an interior NUL; [`LlamaError::SamplerInitFailed`] on a GBNF
+    /// parse failure (or host-OOM).
+    pub fn add_grammar_lazy(
+        self,
+        vocab: &Vocab<'_, '_>,
+        grammar: &str,
+        root: &str,
+        trigger_patterns: &[&str],
+    ) -> Result<Self, LlamaError> {
+        let grammar_c = CString::new(grammar).map_err(|_| LlamaError::GrammarStringInvalid)?;
+        let root_c = CString::new(root).map_err(|_| LlamaError::GrammarStringInvalid)?;
+        let pattern_cs: Vec<CString> = trigger_patterns
+            .iter()
+            .map(|p| CString::new(*p).map_err(|_| LlamaError::GrammarStringInvalid))
+            .collect::<Result<_, _>>()?;
+        let mut pattern_ptrs: Vec<*const core::ffi::c_char> =
+            pattern_cs.iter().map(|c| c.as_ptr()).collect();
+        // SAFETY: vocab ptr borrowed from a live model; the grammar/root CStrings
+        // and the pattern CStrings (kept alive in `pattern_cs`) outlive this
+        // call; `pattern_ptrs` is a contiguous array of `pattern_ptrs.len()`
+        // valid C-string pointers; no trigger tokens (null + 0). NULL on parse
+        // failure is mapped to SamplerInitFailed by `add`.
+        let ptr = unsafe {
+            sys::llama_sampler_init_grammar_lazy_patterns(
+                vocab.as_ptr(),
+                grammar_c.as_ptr(),
+                root_c.as_ptr(),
+                pattern_ptrs.as_mut_ptr(),
+                pattern_ptrs.len(),
+                core::ptr::null(),
+                0,
+            )
+        };
+        self.add(ptr, "grammar_lazy")
     }
 
     /// Finalize the chain into a [`Sampler`].

--- a/crates/kx-llamacpp/src/vocab.rs
+++ b/crates/kx-llamacpp/src/vocab.rs
@@ -104,6 +104,17 @@ impl<'m, 'b: 'm> Vocab<'m, 'b> {
         }
     }
 
+    /// The raw `llama_vocab` pointer, for the grammar-sampler FFI
+    /// (`llama_sampler_init_grammar{,_lazy_patterns}` take a `const
+    /// llama_vocab *`). `pub(crate)` so the unsafe ptr never escapes the crate;
+    /// the grammar sampler stores this pointer internally, so a sampler built
+    /// from it MUST NOT outlive the model that owns this vocab (upheld at the
+    /// call site, which builds + consumes the sampler within one generation
+    /// scope — see [`crate::SamplerChainBuilder::add_grammar`]).
+    pub(crate) fn as_ptr(&self) -> *const sys::llama_vocab {
+        self.ptr.as_ptr()
+    }
+
     /// Number of distinct tokens in the vocabulary.
     pub fn n_tokens(&self) -> i32 {
         // SAFETY: ptr borrowed from a live model.

--- a/crates/kx-llamacpp/tests/smoke.rs
+++ b/crates/kx-llamacpp/tests/smoke.rs
@@ -1162,3 +1162,112 @@ fn smoke_sampler_seed_determinism() {
     );
     assert!(a.len() >= 2, "expected at least 2 generated tokens");
 }
+
+/// S1 (RC2): the GBNF grammar sampler stages construct over a real vocab.
+/// A valid GBNF builds a sampler; an unparseable GBNF fails CLOSED with
+/// `SamplerInitFailed("grammar")` (llama.cpp returns NULL on a parse error);
+/// the lazy / triggered variant builds with a trigger pattern. This is the
+/// fail-closed boundary RC2's `model_exec` derivation relies on.
+#[test]
+fn smoke_grammar_sampler_stages() {
+    use kx_llamacpp::LlamaError;
+
+    let backend = LlamaBackend::new().expect("backend init");
+    let params = ModelParams::new().with_n_gpu_layers(0);
+    let model = Model::load_with_params(&backend, MODEL_PATH, &params).expect("load stories260K");
+    let vocab = model.vocab();
+
+    // A minimal, valid GBNF rooted at `root`.
+    let good_gbnf = "root ::= \"{\" ws \"}\"\nws ::= [ \\t\\n]*\n";
+    let ok = Sampler::chain(&backend)
+        .add_grammar(&vocab, good_gbnf, "root")
+        .and_then(|b| b.add_greedy())
+        .and_then(|b| b.build());
+    assert!(ok.is_ok(), "valid GBNF must build a grammar sampler");
+
+    // An unparseable GBNF must fail CLOSED (NULL → SamplerInitFailed), never panic.
+    let bad = Sampler::chain(&backend)
+        .add_grammar(&vocab, "root ::= (((", "root")
+        .map(|_| ());
+    assert!(
+        matches!(bad, Err(LlamaError::SamplerInitFailed("grammar"))),
+        "malformed GBNF must fail closed as SamplerInitFailed, got {bad:?}"
+    );
+
+    // The lazy / triggered variant builds with a JSON-envelope trigger pattern.
+    let lazy = Sampler::chain(&backend)
+        .add_grammar_lazy(
+            &vocab,
+            good_gbnf,
+            "root",
+            &[r#"[\s\S]*?(\{[ \t\n]*"tool_call")"#],
+        )
+        .and_then(|b| b.add_greedy())
+        .and_then(|b| b.build());
+    assert!(lazy.is_ok(), "valid lazy GBNF + trigger must build");
+
+    // An interior NUL in the grammar payload is rejected before reaching FFI.
+    let nul = Sampler::chain(&backend)
+        .add_grammar(&vocab, "root ::= \"a\0b\"", "root")
+        .map(|_| ());
+    assert!(
+        matches!(nul, Err(LlamaError::GrammarStringInvalid)),
+        "interior NUL must be rejected as GrammarStringInvalid, got {nul:?}"
+    );
+}
+
+/// S3 (RC2) cross-check: the EXACT envelope GBNF that `kx-grammar` renders (see
+/// its `gbnf_golden_for_bundled_oracles` golden) PARSES in llama.cpp and builds a
+/// LAZY/triggered sampler with the tool-call-opener trigger. This closes the loop
+/// kx-grammar can't (it has no llama.cpp dep): kx-grammar renders shape X, here we
+/// prove llama.cpp accepts shape X. If kx-grammar's golden changes, re-sync this.
+#[test]
+fn smoke_grammar_from_kx_grammar() {
+    let backend = LlamaBackend::new().expect("backend init");
+    let params = ModelParams::new().with_n_gpu_layers(0);
+    let model = Model::load_with_params(&backend, MODEL_PATH, &params).expect("load stories260K");
+    let vocab = model.vocab();
+
+    // MUST match kx_grammar's `gbnf_golden_for_bundled_oracles`.
+    let gbnf = concat!(
+        "root ::= \"{\" ws \"\\\"tool_call\\\"\" ws \":\" ws call ws \"}\"\n",
+        "call ::= call0 | call1\n",
+        "call0 ::= \"{\" ws \"\\\"name\\\"\" ws \":\" ws \"\\\"calc/add\\\"\" ws \",\" ws \"\\\"version\\\"\" ws \":\" ws \"\\\"1\\\"\" ws \",\" ws \"\\\"args\\\"\" ws \":\" ws object ws \"}\"\n",
+        "call1 ::= \"{\" ws \"\\\"name\\\"\" ws \":\" ws \"\\\"kv/get\\\"\" ws \",\" ws \"\\\"version\\\"\" ws \":\" ws \"\\\"1\\\"\" ws \",\" ws \"\\\"args\\\"\" ws \":\" ws object ws \"}\"\n",
+        "object ::= \"{\" ws ( member ( ws \",\" ws member )* )? ws \"}\"\n",
+        "member ::= jstring ws \":\" ws value\n",
+        "array ::= \"[\" ws ( value ( ws \",\" ws value )* )? ws \"]\"\n",
+        "value ::= object | array | jstring | number | \"true\" | \"false\" | \"null\"\n",
+        "jstring ::= \"\\\"\" jchar* \"\\\"\"\n",
+        "jchar ::= [^\"\\\\] | \"\\\\\" ([\"\\\\/bfnrt] | \"u\" hex hex hex hex)\n",
+        "hex ::= [0-9a-fA-F]\n",
+        "integer ::= \"-\"? (\"0\" | [1-9] [0-9]*)\n",
+        "number ::= integer (\".\" [0-9]+)? ([eEfF] [-+]? [0-9]+)?\n",
+        "ws ::= [ \\t\\n]*\n",
+    );
+
+    // Strict build (parses the whole grammar).
+    let strict = Sampler::chain(&backend)
+        .add_grammar(&vocab, gbnf, "root")
+        .and_then(|b| b.add_greedy())
+        .and_then(|b| b.build());
+    assert!(
+        strict.is_ok(),
+        "kx-grammar envelope GBNF must parse in llama.cpp"
+    );
+
+    // Lazy build with the production tool-call-opener trigger (what build_sampler uses).
+    let lazy = Sampler::chain(&backend)
+        .add_grammar_lazy(
+            &vocab,
+            gbnf,
+            "root",
+            &[r#"[\s\S]*?(\{[ \t\n]*"tool_call")"#],
+        )
+        .and_then(|b| b.add_greedy())
+        .and_then(|b| b.build());
+    assert!(
+        lazy.is_ok(),
+        "kx-grammar envelope GBNF must build a lazy sampler"
+    );
+}

--- a/crates/kx-mote/src/inference_params.rs
+++ b/crates/kx-mote/src/inference_params.rs
@@ -10,18 +10,25 @@
 //! (`inference_params_from_mote`, `check_within`) stay in `kx-inference`
 //! since they reference `WarrantSpec`.
 //!
-//! Two forward-compat hooks reserved per the PR 8 strategy plan:
-//!   - [`crate::Grammar`] — opaque constrained-generation payload.
-//!   - [`crate::InferenceParams::grammar`] — reserved Option field.
+//! Constrained-generation hooks (reserved in PR 8, IMPLEMENTED in RC2):
+//!   - [`crate::Grammar`] — opaque constrained-generation payload (RC2 carries a
+//!     serialized `kx_grammar::ToolEnvelopeSpec`; the type stays opaque here).
+//!   - [`crate::InferenceParams::grammar`] — `Option` field, default `None`. When
+//!     `Some`, the OSS backends HONOR it (GBNF on llama.cpp, JSON-mode on Ollama)
+//!     to constrain tool-calling. Identity-bearing (D50) but, in the live serve
+//!     loop, populated OFF-MoteDef at dispatch from the warrant's granted tools
+//!     (off-digest, D108.2) — see `kx-gateway`'s `model_exec`.
 
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-/// Reserved opaque grammar specification for constrained generation.
+/// Opaque grammar specification for constrained generation.
 ///
-/// Future backends interpret the payload (GBNF for llama.cpp, JSON
-/// schema for cloud APIs). OSS v0.1 backends MUST return
-/// `Err(Unsupported)` if [`InferenceParams::grammar`] is `Some(_)`.
+/// The payload is interpreted by the backend (RC2: a serialized
+/// `kx_grammar::ToolEnvelopeSpec` the in-process llama.cpp backend renders to
+/// GBNF and the Ollama backend renders to a JSON Schema). The type stays opaque
+/// here so the identity substrate carries no engine coupling. A backend that
+/// cannot honor a `Some(_)` grammar returns `Err(Unsupported)`.
 ///
 /// # Examples
 ///
@@ -69,8 +76,8 @@ impl Grammar {
 /// ```
 /// use kx_mote::InferenceParams;
 ///
-/// // Defaults are greedy (temperature_bps == 0); grammar is reserved
-/// // for future PRs and defaults to None.
+/// // Defaults are greedy (temperature_bps == 0); grammar defaults to None
+/// // (set per-dispatch from the granted tools to constrain tool-calling).
 /// let p = InferenceParams::default();
 /// assert_eq!(p.temperature_bps, 0);
 /// assert!(p.grammar.is_none());
@@ -103,11 +110,12 @@ pub struct InferenceParams {
     /// Stop tokens / stop sequences. Empty = no stop.
     pub stop_tokens: SmallVec<[String; 4]>,
 
-    /// **Reserved**: opaque grammar specification for constrained
-    /// generation (GBNF / JSON-schema). OSS v0.1 backends MUST return
-    /// `Err(Unsupported)` on `Some(_)`. The field exists ahead of
-    /// implementation so the trait stays additive when grammar support
-    /// lands.
+    /// Opaque grammar specification for constrained generation (GBNF /
+    /// JSON-schema). Default `None` (unconstrained). When `Some(_)`, the OSS
+    /// backends constrain decoding to it (RC2); a backend that cannot returns
+    /// `Err(Unsupported)`. Identity-bearing (D50) — but the live serve loop sets
+    /// it OFF-MoteDef at dispatch (off-digest, D108.2), so the canonical demo
+    /// (which grants no tools) keeps `grammar: None` and the digest is invariant.
     pub grammar: Option<Grammar>,
 }
 

--- a/crates/kx-mote/src/lib.rs
+++ b/crates/kx-mote/src/lib.rs
@@ -93,7 +93,8 @@ pub use ndclass::NdClass;
 pub use strings::{
     ConfigKey, ConfigVal, GraphPosition, ModelId, ToolName, ToolVersion, CONTEXT_ITEMS_KEY,
     IMAGE_REF_KEY, JUDGE_RUBRIC_KEY, PROMPT_KEY, REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY,
-    REACT_MAX_TURNS_KEY, REACT_REQUIRE_APPROVAL_KEY, REACT_TURN_KEY, TOOL_ARGS_KEY,
+    REACT_MAX_TURNS_KEY, REACT_REQUIRE_APPROVAL_KEY, REACT_TURN_KEY, REACT_UNCONSTRAINED_KEY,
+    TOOL_ARGS_KEY,
 };
 pub use topology::{ChildDescriptor, RoleId, TopologyDecision};
 

--- a/crates/kx-mote/src/strings.rs
+++ b/crates/kx-mote/src/strings.rs
@@ -125,6 +125,18 @@ pub const REACT_MAX_TOOL_CALLS_KEY: &str = "max_tool_calls";
 /// budget caps are anchored). Absent ⇒ `false` (no gate; byte-identical to today).
 pub const REACT_REQUIRE_APPROVAL_KEY: &str = "require_approval";
 
+/// The [`ConfigKey`] *name* under which a ReAct Mote may OPT OUT of RC2
+/// grammar-constrained tool-calling (the `kx/recipes/react` `unconstrained`
+/// slot; a canonical-JSON boolean). ABSENT ⇒ `false` ⇒ grammar is armed on a
+/// tool-eligible turn (the always-on default; byte-identical config to pre-RC2
+/// since no prior Mote carries this key, so adding the constant moves no digest).
+/// PRESENT + `true` ⇒ the executor skips the grammar derivation and decodes
+/// unconstrained (relying on the `kx_toolcall` parser). The grammar itself is
+/// derived OFF-MoteDef at dispatch (off-digest, D108.2) — only this OPT-OUT is an
+/// identity-bearing config choice (a different posture ⇒ a different `MoteId`,
+/// the right semantics).
+pub const REACT_UNCONSTRAINED_KEY: &str = "unconstrained";
+
 /// The single canonical [`ConfigKey`] *name* under which a STANDALONE authored
 /// `tool()` Mote (PR-6b-2) carries its tool-call argument object — ONE
 /// canonical-JSON object (e.g. `{"q":"…"}`; `{}` when the call has no args),

--- a/crates/kx-ollama/src/backend.rs
+++ b/crates/kx-ollama/src/backend.rs
@@ -2,10 +2,22 @@
 //! [`OllamaClient`].
 //!
 //! It enforces the SAME warrant gates as the in-process llama backend, in the SAME
-//! order (SN-8 / D35): the grammar reservation, the model-route authorization, the
-//! `max_output_tokens` ceiling, then the served-set membership — all BEFORE any
-//! HTTP egress. The inherent `warm`/`evict`/`resident` mirror the llama backend's
-//! lifecycle surface so the host can drive both engines through one trait.
+//! order (SN-8 / D35): the model-route authorization, the `max_output_tokens`
+//! ceiling, then the served-set membership — all BEFORE any HTTP egress. The
+//! inherent `warm`/`evict`/`resident` mirror the llama backend's lifecycle surface
+//! so the host can drive both engines through one trait.
+//!
+//! **Grammar (RC2) — honest-degrade (GR24).** Constrained tool-call decoding is
+//! genuinely engine-specific: llama.cpp has a LAZY/triggered grammar sampler
+//! (prose flows free until the model commits to a tool call); Ollama's
+//! structured-output `format` constrains the WHOLE response and has no lazy mode,
+//! so forcing it on the react loop's answer-OR-tool turn would break the free-form
+//! answer path. So a `params.grammar` carrier is intentionally NOT applied as an
+//! Ollama `format`; Ollama tool-calling reliability rides the robust `kx_toolcall`
+//! parser + the post-call arg-schema critic + loop hardening (the accept-side
+//! AUTHORITY gate is identical on both engines). Tracked: `T-OLLAMA-GRAMMAR-FORMAT`
+//! (a future opt-in strict / tool-required `format` mode + the cloud
+//! structured-output path use `kx_grammar::ToolEnvelopeSpec::to_ollama_format`).
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, PoisonError, RwLock};
@@ -363,11 +375,17 @@ impl OllamaBackend {
         warrant: &WarrantSpec,
         sink: Option<TokenSink>,
     ) -> Result<InferenceOutput, InferenceError> {
-        // ---- Grammar reservation gate (fires before any model work) ----------
+        // ---- Grammar (RC2): HONEST-DEGRADE — see the module doc (GR24). -------
+        // A grammar carrier is NOT applied as an Ollama whole-response `format`
+        // (no lazy/triggered mode; forcing JSON would break the answer path). We
+        // must NOT fail closed: the live serve loop sets a grammar on EVERY
+        // tool-eligible turn, so erroring here would dead-letter every Ollama tool
+        // turn. So we let it fall through to parser-based tool-calling.
         if params.grammar.is_some() {
-            return Err(InferenceError::Unsupported {
-                reason: "constrained generation (grammar) reserved; see HANDOFF",
-            });
+            tracing::debug!(
+                "ollama: grammar carrier present; honest-degrading to parser-based \
+                 tool-calling (no whole-response format on an answer-eligible turn)"
+            );
         }
         // ---- Warrant gates (D30 + D35) — authorize BEFORE any egress ---------
         if model_id != &warrant.model_route.model_id {
@@ -590,6 +608,24 @@ mod tests {
         // num_predict + seed are always present (mapped from the params).
         assert!(opts.get("num_predict").is_some());
         assert!(opts.get("seed").is_some());
+    }
+
+    /// RC2 honest-degrade: a grammar carrier does NOT leak into the Ollama request
+    /// (no whole-response `format` smuggled into the options), so the body is
+    /// byte-identical to the no-grammar path and Ollama falls through to
+    /// parser-based tool-calling. (That a grammar no longer fails closed /
+    /// dead-letters is validated on the live dual-engine lane.)
+    #[test]
+    fn grammar_carrier_does_not_change_the_request_options() {
+        let without = options_from_params(&InferenceParams::default());
+        let with = options_from_params(&InferenceParams {
+            grammar: Some(kx_mote::Grammar::new(r#"{"tools":[]}"#)),
+            ..InferenceParams::default()
+        });
+        assert_eq!(
+            without, with,
+            "grammar must not leak into the Ollama request options (honest-degrade)"
+        );
     }
 
     #[test]

--- a/crates/kx-toolcall/src/dedup.rs
+++ b/crates/kx-toolcall/src/dedup.rs
@@ -1,0 +1,87 @@
+//! RC2 loop-hardening — redundant-call detection (the minimal dedup slice).
+//!
+//! A small agentic model sometimes loops: it re-proposes the SAME tool with the
+//! SAME arguments turn after turn instead of using the result it already has. This
+//! is an *efficiency* problem, never an authority one — so the helpers here are
+//! pure comparisons, kept in the shared gate crate so the live coordinator settle
+//! and the harness `ReAct` loop render the refusal BYTE-IDENTICAL (the §2.274 twin
+//! discipline): the reason flows into the re-prompted turn's `MoteId`, so a cold
+//! re-fold during recovery must reproduce the exact same string.
+
+use crate::types::ToolCall;
+
+/// `true` iff `call` exactly repeats one of `prior` — the same resolved tool
+/// `(name, version)` AND byte-identical `args_bytes`. **Conservative**: only a
+/// truly identical re-proposal matches, so a legitimate retry with refined or
+/// different arguments always fires. This is purely an efficiency guard; the
+/// warrant grant-check + `inputSchema` validation remain the independent authority
+/// gate (SN-8).
+#[must_use]
+pub fn is_duplicate_call(call: &ToolCall, prior: &[ToolCall]) -> bool {
+    prior.iter().any(|p| {
+        p.name == call.name && p.version == call.version && p.args_bytes == call.args_bytes
+    })
+}
+
+/// The fail-closed reason a settle freezes when a proposal exactly repeats a call
+/// already fired this run. The re-prompt built from it steers the model to use the
+/// result it already has, or to answer — bounded loop progress instead of a wasted
+/// re-fire. Shared so the coordinator + harness render it byte-identical.
+#[must_use]
+pub fn duplicate_call_reason(call: &ToolCall) -> String {
+    format!(
+        "the tool `{}@{}` was already called this run with identical arguments — \
+         use the result you already have, or answer the question directly",
+        call.name.0, call.version.0
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_mote::{ToolName, ToolVersion};
+
+    fn call(name: &str, args: &[u8]) -> ToolCall {
+        ToolCall {
+            name: ToolName(name.into()),
+            version: ToolVersion("1".into()),
+            args_bytes: args.to_vec(),
+        }
+    }
+
+    #[test]
+    fn exact_repeat_is_a_duplicate() {
+        let prior = vec![call("calc/add", br#"{"a":1,"b":2}"#)];
+        assert!(is_duplicate_call(
+            &call("calc/add", br#"{"a":1,"b":2}"#),
+            &prior
+        ));
+    }
+
+    #[test]
+    fn different_args_are_not_a_duplicate() {
+        let prior = vec![call("calc/add", br#"{"a":1,"b":2}"#)];
+        // Different args ⇒ a legitimate new call, never suppressed.
+        assert!(!is_duplicate_call(
+            &call("calc/add", br#"{"a":1,"b":3}"#),
+            &prior
+        ));
+        // Different tool ⇒ not a duplicate.
+        assert!(!is_duplicate_call(
+            &call("kv/get", br#"{"a":1,"b":2}"#),
+            &prior
+        ));
+        // No prior calls ⇒ never a duplicate.
+        assert!(!is_duplicate_call(
+            &call("calc/add", br#"{"a":1,"b":2}"#),
+            &[]
+        ));
+    }
+
+    #[test]
+    fn reason_names_the_tool() {
+        let r = duplicate_call_reason(&call("calc/add", b"{}"));
+        assert!(r.contains("calc/add@1"));
+        assert!(r.contains("already called"));
+    }
+}

--- a/crates/kx-toolcall/src/lib.rs
+++ b/crates/kx-toolcall/src/lib.rs
@@ -21,8 +21,10 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod dedup;
 mod parse;
 mod types;
 
+pub use dedup::{duplicate_call_reason, is_duplicate_call};
 pub use parse::{max_args_bytes, parse_tool_call, parse_tool_calls};
 pub use types::{DecodeError, ToolCall};

--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -133,6 +133,40 @@ shows why each turn was refused:
 | `could not be decoded` / `malformed` | The model emitted a non-tool or broken proposal — usually self-corrects on the next turn. |
 | chain `dead_lettered` after several `rejected` turns | The budget (`max_turns` / `max_tool_calls`) was exhausted without a usable answer — raise the caps or simplify the task/schema. |
 
+### Grammar-constrained tool calls
+
+On a tool-eligible turn the runtime **constrains decoding to the canonical
+tool-call envelope**, derived automatically from the tools granted to that run —
+so a model *cannot* emit a malformed or ungranted tool call. It is **on by
+default**; you do not configure it.
+
+`{"tool_call":{"name":"<granted-tool>","version":"<v>","args":{ … }}}`
+
+- **Auto-derived.** The grammar enumerates exactly the granted `(name, version)`
+  pairs from the run's warrant — nothing else can be named. It is a *generation*
+  constraint, layered **on top of** (never replacing) the fail-closed authority
+  gate: the warrant grant-check and `inputSchema` validation still run on every
+  call.
+- **Answers stay free.** Constraint is *lazy/triggered* — prose flows
+  unconstrained until the model commits to the tool-call opener, so a turn can
+  still answer directly in natural language instead of calling a tool.
+- **Dual-engine (honest-degrade).** Full grammar (GBNF, lazy-triggered) runs on
+  **llama.cpp**. **Ollama** has no lazy mode, so it relies on the same robust
+  parser + schema validation rather than a whole-response constraint — the
+  *authority* gate is identical on both engines, only the generation-time
+  constraint differs.
+- **Off-digest.** The grammar is derived at dispatch and never journaled, never
+  part of a run's identity (the digest is invariant).
+
+**Opt out** (rarely needed) by setting the serve flag when you start `kx serve`:
+
+```bash
+KX_SERVE_REACT_GRAMMAR=0 kx serve     # disable grammar-constrained tool-calling
+```
+
+(A per-run `.unconstrained()` override on the SDK chain is forward-declared; the
+serve flag is the reliable global switch today.)
+
 ## Authoring a `tool()` step
 
 Beyond the ReAct loop (where the *model* picks tools), you can author a **`tool()`


### PR DESCRIPTION
## RC2 — Grammar-constrained tool-calling (D172)

The OSS RC's second code PR. Implements the reserved `InferenceParams.grammar` so a
tool-eligible ReAct turn is constrained to the **canonical, grant-pinned tool-call
envelope** — structurally eradicating the `T-GEMMA-PAREN` parse-fragility class.

- **GBNF lazy/triggered on llama.cpp** (prose flows free until the model commits to
  the `{"tool_call"` opener); **honest-degrade on Ollama** (no lazy mode → robust
  parser-based, GR24).
- **Off the frozen `dispatcher.rs` (D108.2):** the grammar is derived at dispatch from
  the warrant's granted tools, **never journaled, never in `MoteId`** → digest
  `7d22d4bd` invariant, **no journal/checkpoint/proto schema change**, frozen trio
  diff-empty.
- The grammar is the **accept-side** constraint only; the authority gate stays
  `kx_toolcall::parse_tool_call` + `validate_args` (SN-8).

### What shipped
- **NEW `kx-grammar` crate** (FFI-free leaf): `ToolEnvelopeSpec` → GBNF / Ollama
  JSON-schema renderers. The generated GBNF is proven to **parse + build a lazy
  sampler in real llama.cpp**.
- `kx-llamacpp` grammar sampler stages · llama leg honors grammar · Ollama
  honest-degrade · `model_exec` off-digest injection (serve-level
  `KX_SERVE_REACT_GRAMMAR` opt-out).
- **B1** bundled `calc`+`kv` oracle tools wired into the react-auto autogrant (the
  deferred `T-EVAL-LIVE-MULTITOOL`).
- **B2** dedup loop-hardening — an identical re-proposal is frozen `Rejected` (shared
  `kx-toolcall` helper; recovery-stable; the effect fires **exactly once**).
- **B4** finding: post-call arg-schema enforcement already exists at settle
  (`validate_args`) → skip-redundant (GR20).
- eval corpus extended with grammar-shaped multi-tool envelopes + re-baselined;
  `docs/site/docs/tools.md` "Grammar-constrained tool calls".

### Live dual-engine validation (Gemma, restart-per-run — GR24/GR15)
- **llama.cpp Gemma-4-12B:** grammar constrained a **real fire** — Gemma emitted the
  exact canonical envelope `{"tool_call":{"name":"mcp-kv/get","version":"1","args":{"key":"x"}}}`
  → `kv` fired; the **S7 dedup rejected the identical re-proposal**; the chain
  answered `"42"`.
- **Ollama gemma3:12b:** RC2 does not break the loop (clean answer + `ScoreRun`).

### Finding (GR16 — the live validation earned its keep)
The live react prompt presents **no tool menu/schema** (`SERVE_SYSTEM` is generic), so
a real model proposes tools only when the instruction describes the call format.
Ticketed **`T-REACT-TOOL-MENU`** (RC3 prompts/context) — it unblocks autonomous tool
use; the grammar correctly constrains proposals once the model makes them.

### Invariants
Frozen trio diff-empty · digest `7d22d4bd` invariant · no schema/proto change ·
FFI-free wall intact · `just eval ≥ baseline` · ~35 new tests · full `just ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVgyHDG4Bspcs7EKK9iUMq
