### PR TITLE
feat(rc3): tool menu + curated agentic prompt + context-engineering (D172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ dependencies = [
  "kx-capture",
  "kx-catalog",
  "kx-content",
+ "kx-context-assembler",
  "kx-coordinator",
  "kx-critic",
  "kx-dataset",

--- a/crates/kx-context-assembler/src/assemble.rs
+++ b/crates/kx-context-assembler/src/assemble.rs
@@ -2,12 +2,14 @@
 //! closure (Data-edge parent `result_ref`s + warrant `tool_grants`) into
 //! byte-deterministic [`crate::AssembledContext`].
 
+use std::collections::BTreeSet;
+
 use bytes::Bytes;
 use kx_content::{ContentRef, ContentStore};
 use kx_mote::{decode_context_items, ConfigKey, EdgeKind, Mote, MoteId, CONTEXT_ITEMS_KEY};
 use kx_projection::Snapshot;
 use kx_tool_registry::{InputSchema, ParamType, ToolDef, ToolRegistry};
-use kx_warrant::WarrantSpec;
+use kx_warrant::{ToolGrant, WarrantSpec};
 
 use crate::errors::AssemblyError;
 use crate::types::{AssembledContext, AssembledItem};
@@ -24,7 +26,13 @@ use crate::types::{AssembledContext, AssembledItem};
 /// advisory prompt bytes only: it lands in `AssembledItem.bytes` (read by the model),
 /// never in `source_ref`/the journal/`MoteId`, so it moves no committed-fact digest.
 fn tool_menu_text(grant_id: &str, def: &ToolDef) -> String {
-    let head = format!("name: {grant_id}\n");
+    // Lead with the EXACT callable name AND the pinned version (PR-1/BUG-32 name-
+    // steering + RC3): the call envelope is `{"name":…,"version":…,"args":…}`, and the
+    // runtime matches the version EXACTLY (SN-8). Without the version in the menu a
+    // model guesses (e.g. emits `"1.0"` for a `"1"` grant) and the call is refused —
+    // observed live on Ollama gemma3 (the llama.cpp grammar enumerates the pair, but
+    // the Ollama honest-degrade path has only the prompt to go on).
+    let head = format!("name: {grant_id}\nversion: {}\n", def.tool_version.0);
     let Some(schema) = &def.input_schema else {
         return format!("{head}{}", def.description);
     };
@@ -86,6 +94,52 @@ fn example_call_json(schema: &InputSchema) -> String {
         parts.push(format!("\"{}\": {val}", p.name));
     }
     format!("{{{}}}", parts.join(", "))
+}
+
+/// RC3 (T-REACT-TOOL-MENU): render the advisory tool MENU a tool-eligible ReAct
+/// turn shows the model so it PROPOSES well-formed calls autonomously. RC2's
+/// grammar only CONSTRAINS a proposal once made; the menu is what makes the model
+/// propose at all. Pure, total and deterministic: it iterates `grants` in
+/// `BTreeSet` `(tool_id, tool_version)` order, looks each one up, and renders it
+/// through the SAME `tool_menu_text` the context-assembly path uses (name
+/// steering, typed params and a worked example) so the harness menu and the
+/// live-serve menu can never drift. A grant the registry cannot resolve degrades
+/// to a name, version and envelope shape only (fail-soft — it never panics a
+/// dispatch and never silently omits a granted tool). It renders ONLY `grants`
+/// (= `warrant.tool_grants`), so no UNGRANTED tool can ever leak. The output is
+/// advisory prompt bytes only (SN-8): the runtime still validates the model's
+/// REAL proposal fail-closed (`kx_toolcall::parse_tool_call` + `validate_args`).
+/// Empty `grants` yields `""`, so the dispatch menu gate prepends nothing and the
+/// canonical no-tools demo stays byte-unchanged.
+#[must_use]
+pub fn render_tool_menu(grants: &BTreeSet<ToolGrant>, registry: &dyn ToolRegistry) -> String {
+    if grants.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("You can call the following tools:\n");
+    for grant in grants {
+        out.push('\n');
+        if let Some(def) = registry.lookup(&grant.tool_id, &grant.tool_version) {
+            out.push_str(&tool_menu_text(&grant.tool_id.0, &def));
+        } else {
+            // Fail-soft: the registry could not resolve a granted tool (a
+            // BUG-33-class id skew or a registry-open race). Emit the name,
+            // version and the canonical envelope shape so the grant is never
+            // silently dropped from the menu. Plain `push_str` (no `format!`)
+            // keeps the clippy `format_push_string` lint clean.
+            out.push_str("name: ");
+            out.push_str(&grant.tool_id.0);
+            out.push_str("\nversion: ");
+            out.push_str(&grant.tool_version.0);
+            out.push_str("\n(schema unavailable — call as {\"tool_call\":{\"name\":\"");
+            out.push_str(&grant.tool_id.0);
+            out.push_str("\",\"version\":\"");
+            out.push_str(&grant.tool_version.0);
+            out.push_str("\",\"args\":{}}})");
+        }
+        out.push('\n');
+    }
+    out
 }
 
 /// Assemble the Mote's explicit dependency closure into byte-deterministic
@@ -293,7 +347,7 @@ mod tool_menu_tests {
         // model emits it verbatim, then the description.
         assert_eq!(
             tool_menu_text("fs-list", &def(None)),
-            "name: fs-list\nList a directory."
+            "name: fs-list\nversion: 1\nList a directory."
         );
     }
 
@@ -303,7 +357,7 @@ mod tool_menu_tests {
         // full callable id (the grant id, not the def's bare name).
         assert_eq!(
             tool_menu_text("kxlocal-a1b2c3d4/multiply", &def(None)),
-            "name: kxlocal-a1b2c3d4/multiply\nList a directory."
+            "name: kxlocal-a1b2c3d4/multiply\nversion: 1\nList a directory."
         );
     }
 
@@ -320,7 +374,7 @@ mod tool_menu_tests {
         // `path` is OPTIONAL, so the minimal valid call has zero required keys: {}.
         assert_eq!(
             tool_menu_text("fs-list", &def(Some(schema))),
-            "name: fs-list\nList a directory.\nInputs:\n  - path (string, optional)\nExample: {}"
+            "name: fs-list\nversion: 1\nList a directory.\nInputs:\n  - path (string, optional)\nExample: {}"
         );
     }
 
@@ -338,7 +392,7 @@ mod tool_menu_tests {
         };
         assert_eq!(
             tool_menu_text("mcp-echo/echo", &def(Some(schema))),
-            "name: mcp-echo/echo\nList a directory.\nInputs:\n  - text (string, required)\n\
+            "name: mcp-echo/echo\nversion: 1\nList a directory.\nInputs:\n  - text (string, required)\n\
              Example: {\"text\": \"<string>\"}"
         );
     }

--- a/crates/kx-context-assembler/src/lib.rs
+++ b/crates/kx-context-assembler/src/lib.rs
@@ -97,7 +97,7 @@ mod assemble;
 mod errors;
 mod types;
 
-pub use assemble::assemble;
+pub use assemble::{assemble, render_tool_menu};
 pub use errors::AssemblyError;
 pub use types::{AssembledContext, AssembledItem};
 

--- a/crates/kx-context-assembler/src/tests.rs
+++ b/crates/kx-context-assembler/src/tests.rs
@@ -205,9 +205,12 @@ fn assemble_two_parents_one_tool() {
     // Parent bytes are resolved content (NEVER hashes).
     assert_eq!(&ctx.items[0].bytes[..], parent_a_bytes);
     assert_eq!(&ctx.items[1].bytes[..], parent_b_bytes);
-    // Tool item leads with the granted name (PR-1/BUG-32 steering), then the
-    // description (this byte change is prompt-only — see `source_ref` below).
-    assert_eq!(&ctx.items[2].bytes[..], b"name: fs-read\nreads files");
+    // Tool item leads with the granted name + pinned version (PR-1/BUG-32 steering +
+    // RC3), then the description (this byte change is prompt-only — see `source_ref`).
+    assert_eq!(
+        &ctx.items[2].bytes[..],
+        b"name: fs-read\nversion: 1\nreads files"
+    );
 }
 
 // -----------------------------------------------------------------
@@ -585,4 +588,123 @@ fn content_ref_changes_with_bytes() {
         }],
     };
     assert_ne!(ctx_a.content_ref(), ctx_b.content_ref());
+}
+
+// -----------------------------------------------------------------
+// RC3 (T-REACT-TOOL-MENU): render_tool_menu — the live-serve tool menu the
+// model is shown so it PROPOSES well-formed calls autonomously. Reuses the
+// same tool_menu_text the assembly path uses (one renderer, no drift).
+// -----------------------------------------------------------------
+
+fn echo_like_def() -> ToolDef {
+    ToolDef {
+        tool_id: ToolName("mcp-echo/echo".into()),
+        tool_version: ToolVersion("1".into()),
+        kind: ToolKind::Builtin,
+        required_capability: permissive_req(),
+        description: "echoes its input".into(),
+        idempotency_class: kx_tool_registry::IdempotencyClass::Readback,
+        input_schema: Some(kx_tool_registry::InputSchema {
+            params: vec![kx_tool_registry::ParamSpec {
+                name: "text".into(),
+                ty: kx_tool_registry::ParamType::Str { max_len: 4096 },
+                required: true,
+            }],
+            deny_unknown: true,
+        }),
+    }
+}
+
+#[test]
+fn render_tool_menu_lists_each_granted_tool_with_typed_example() {
+    let mut registry = InMemoryToolRegistry::new();
+    let def = echo_like_def();
+    let _ = registry
+        .register(
+            def.clone(),
+            ToolProvenance::HumanAuthored {
+                author: "ops".into(),
+            },
+        )
+        .unwrap();
+    let grants = BTreeSet::from([ToolGrant {
+        tool_id: def.tool_id.clone(),
+        tool_version: def.tool_version.clone(),
+    }]);
+
+    let menu = render_tool_menu(&grants, &registry);
+
+    // Leads with the exact namespaced callable (PR-1 name-steering / BUG-33) AND the
+    // pinned version (RC3 — so the model emits the EXACT `"version"`, not a guess).
+    assert!(menu.contains("name: mcp-echo/echo"), "menu: {menu}");
+    assert!(
+        menu.contains("version: 1"),
+        "menu must pin the version: {menu}"
+    );
+    assert!(menu.contains("echoes its input"), "menu: {menu}");
+    // Typed-param block + a deterministic worked example with the RIGHT key.
+    assert!(menu.contains("text (string, required)"), "menu: {menu}");
+    assert!(
+        menu.contains("Example: {\"text\": \"<string>\"}"),
+        "menu: {menu}"
+    );
+}
+
+#[test]
+fn render_tool_menu_empty_grants_is_empty_string() {
+    let registry = InMemoryToolRegistry::new();
+    assert_eq!(render_tool_menu(&BTreeSet::new(), &registry), "");
+}
+
+#[test]
+fn render_tool_menu_unresolved_grant_is_fail_soft() {
+    // A grant the registry cannot resolve must STILL appear (name+version+envelope
+    // shape) — never panic, never silently vanish.
+    let registry = InMemoryToolRegistry::new();
+    let grants = BTreeSet::from([ToolGrant {
+        tool_id: ToolName("ghost/tool".into()),
+        tool_version: ToolVersion("9".into()),
+    }]);
+    let menu = render_tool_menu(&grants, &registry);
+    assert!(menu.contains("name: ghost/tool"), "menu: {menu}");
+    assert!(menu.contains("schema unavailable"), "menu: {menu}");
+    assert!(menu.contains("\"name\":\"ghost/tool\""), "menu: {menu}");
+}
+
+#[test]
+fn render_tool_menu_renders_only_granted_tools_and_is_deterministic() {
+    // Two tools registered, only ONE granted ⇒ the other must NOT leak.
+    let mut registry = InMemoryToolRegistry::new();
+    let granted = echo_like_def();
+    let secret = ToolDef {
+        tool_id: ToolName("secret/admin".into()),
+        tool_version: ToolVersion("1".into()),
+        ..echo_like_def()
+    };
+    let _ = registry
+        .register(
+            granted.clone(),
+            ToolProvenance::HumanAuthored {
+                author: "ops".into(),
+            },
+        )
+        .unwrap();
+    let _ = registry
+        .register(
+            secret.clone(),
+            ToolProvenance::HumanAuthored {
+                author: "ops".into(),
+            },
+        )
+        .unwrap();
+    let grants = BTreeSet::from([ToolGrant {
+        tool_id: granted.tool_id.clone(),
+        tool_version: granted.tool_version.clone(),
+    }]);
+
+    let a = render_tool_menu(&grants, &registry);
+    let b = render_tool_menu(&grants, &registry);
+    assert_eq!(a, b, "render_tool_menu must be deterministic");
+    assert!(a.contains("mcp-echo/echo"));
+    assert!(!a.contains("secret/admin"), "ungranted tool leaked: {a}");
 }

--- a/crates/kx-context-assembler/tests/proptest_assembler.rs
+++ b/crates/kx-context-assembler/tests/proptest_assembler.rs
@@ -527,12 +527,13 @@ proptest! {
             "exactly one tool item should be emitted"
         );
         let item = &ctx.items[0];
-        // PR-1/BUG-32: the menu leads with the granted name, then the description.
-        let expected_menu = format!("name: {tool_name_seed}-only\n{description}");
+        // PR-1/BUG-32 + RC3: the menu leads with the granted name, then the pinned
+        // version, then the description (the version steers the exact `"version"`).
+        let expected_menu = format!("name: {tool_name_seed}-only\nversion: 1\n{description}");
         prop_assert_eq!(
             item.bytes.as_ref(),
             expected_menu.as_bytes(),
-            "tool item bytes MUST be the `name:` steering line then the description"
+            "tool item bytes MUST be the `name:`/`version:` steering lines then the description"
         );
         // source_ref MUST be the canonical def hash. We can't recompute the
         // def hash here without rebuilding the ToolDef; but we CAN assert
@@ -687,7 +688,7 @@ fn mixed_parents_and_tools_emit_independent_items_with_correct_shapes() {
         .expect("tool item present");
     assert_eq!(
         &tool_item.bytes[..],
-        b"name: h2-mixed-tool\ndescribes a tool whose description bytes go to the model"
+        b"name: h2-mixed-tool\nversion: 1\ndescribes a tool whose description bytes go to the model"
     );
     assert_ne!(
         tool_item.source_ref,

--- a/crates/kx-gateway/Cargo.toml
+++ b/crates/kx-gateway/Cargo.toml
@@ -66,6 +66,13 @@ kx-toolcall     = { workspace = true }
 # dispatch + injected OFF-MoteDef (off-digest) so a react tool turn is
 # grammar-constrained. FFI-free leaf; the dep_wall keeps the gateway FFI-free.
 kx-grammar      = { workspace = true }
+# RC3 (T-REACT-TOOL-MENU): the SHARED tool-menu text renderer (`render_tool_menu`,
+# the same `tool_menu_text` the context-assembly path uses — one renderer, no
+# harness↔serve drift). Derived at dispatch + prepended OFF-MoteDef (off-digest)
+# so a tool-eligible ReAct turn shows the model its granted-tool menu. Pure FFI-free
+# leaf; OPTIONAL + ridden by `serve-engine` only (its sole caller `model_exec` is
+# serve-engine-gated), so the DEFAULT build closure stays byte-unchanged + dep-wall green.
+kx-context-assembler = { workspace = true, optional = true }
 # Inline parent-edge storage for the PURE Mote built by `pure_run_request`
 # (`Mote::new`'s `parents` is a `SmallVec<[ParentRef; 4]>`). Promoted from a dev-dep
 # (R3) so the helper is a NORMAL public library fn. FFI-free (the dep_wall forbids
@@ -290,6 +297,8 @@ serve-engine = [
     "dep:kx-planner",
     "dep:kx-critic",
     "dep:kx-mcp",
+    # RC3 (T-REACT-TOOL-MENU): the shared tool-menu renderer for the live ReAct prompt.
+    "dep:kx-context-assembler",
     "mcp-gateway",
 ]
 # inference: serve-engine PLUS the in-process llama.cpp backend (the C++ FFI via

--- a/crates/kx-gateway/src/assemble_serve.rs
+++ b/crates/kx-gateway/src/assemble_serve.rs
@@ -22,6 +22,13 @@ use std::fmt;
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_mote::{ContextItemRef, MoteId};
 
+/// RC3 (context-engineering): bytes reserved for the deterministic truncation
+/// marker when [`fit_context_blocks`] / [`fit_trajectory_blocks`] trim an
+/// over-window bundle/trajectory. The longest marker (the trajectory variant with
+/// every count a 20-digit `usize`) is ~127 bytes, so 192 leaves headroom AND
+/// guarantees the trimmed output never exceeds the window cap.
+const TRUNCATION_MARKER_RESERVE: usize = 192;
+
 /// Failure assembling F-7 serve context. Both variants are fail-closed: the model
 /// never runs on partial or unbounded context.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,14 +93,24 @@ pub(crate) fn assemble_from_parent_results(
     Ok(out)
 }
 
-/// PR-7: render a run's attached context-bundle items (decoded from the entry
+/// PR-7 / RC3: render a run's attached context-bundle items (decoded from the entry
 /// Mote's `config_subset[CONTEXT_ITEMS_KEY]`) into a deterministic, labeled text
 /// block, prepended to the model prompt AHEAD of the F-7 parent context. `items`
-/// are already in canonical (decoded) order; each blob is fetched from the shared
-/// store (a `PutContent` ref). Empty ⇒ the empty string (byte-identical to
-/// pre-PR-7); a missing ref OR a window overflow fails closed (never run the model
-/// on partial / unbounded context). Bytes render UTF-8-lossy — consistent with the
-/// F-7 parent block (the serve text path; the harness assembler handles images).
+/// arrive in canonical RELEVANCE order (chat-rag delivers top-k by similarity; an
+/// authored bundle preserves author order); each blob is fetched from the shared
+/// store (a `PutContent` ref). Empty ⇒ the empty string (byte-identical to pre-PR-7);
+/// a missing ref fails closed (never run the model on PARTIAL context).
+///
+/// RC3 (context-engineering, D33 §5(a)): on a WINDOW overflow this no longer fails
+/// closed — it keeps the highest-relevance contiguous PREFIX that fits and appends a
+/// deterministic, bounded truncation MARKER (never silent), via [`fit_context_blocks`].
+/// A single item larger than the window still fails closed (`Overflow`) — there is no
+/// partial-item rendering. The FITS case is byte-identical to pre-RC3. Off-digest:
+/// this block is prepended to the EPHEMERAL prompt, never journaled — the canonical
+/// demo attaches no bundle ⇒ empty ⇒ `7d22d4bd` untouched. (The F-7 PARENT path
+/// [`assemble_from_parent_results`] stays fail-closed: it is `MoteId`-sorted, not
+/// relevance-ordered, so a prefix is not a meaningful trim — trajectory bounding is a
+/// coordinator concern.) Bytes render UTF-8-lossy — the serve text path.
 pub(crate) fn assemble_context_items(
     items: &[ContextItemRef],
     store: &LocalFsContentStore,
@@ -101,7 +118,9 @@ pub(crate) fn assemble_context_items(
     if items.is_empty() {
         return Ok(String::new());
     }
-    let mut out = String::new();
+    // Render every item to its labeled block first (fail closed on a missing ref —
+    // never run the model on partial context). Canonical input order = relevance order.
+    let mut blocks: Vec<String> = Vec::with_capacity(items.len());
     for item in items {
         let cref = ContentRef(item.content_ref);
         let bytes = store
@@ -112,16 +131,138 @@ pub(crate) fn assemble_context_items(
         } else {
             item.name.clone()
         };
-        let block = format!(
+        blocks.push(format!(
             "[context {label}]\n{}\n\n",
             String::from_utf8_lossy(bytes.as_ref())
-        );
-        let needed = out.len() + block.len();
-        let cap = crate::env_caps::window_bytes();
-        if needed > cap {
-            return Err(AssembleError::Overflow { needed, cap });
+        ));
+    }
+    let cap = crate::env_caps::window_bytes();
+    fit_context_blocks(&blocks, cap).map_err(|needed| AssembleError::Overflow { needed, cap })
+}
+
+/// RC3 (context-engineering, D33 §5(a)): fit pre-rendered, relevance-ordered context
+/// `blocks` into `cap` bytes. PURE + total + deterministic (no I/O, no env, no clock)
+/// so it is unit-testable at an explicit cap and replay-stable.
+///
+/// - All blocks fit (`Σ ≤ cap`) ⇒ `Ok(blocks.concat())`, **byte-identical** to the
+///   untrimmed bundle (the pre-RC3 behavior for the common case).
+/// - Otherwise ⇒ keep the highest-relevance contiguous PREFIX that fits within
+///   `cap - TRUNCATION_MARKER_RESERVE`, then append a deterministic, bounded marker
+///   `"[context truncated: kept k/N items, dropped Bb]"` — NEVER silent truncation.
+///   The result is guaranteed `≤ cap` (the reserve bounds the marker).
+/// - `Err(needed)` iff even the first (most-relevant) block cannot fit the budget — a
+///   single oversized item fails closed upstream (`Overflow`), as before.
+fn fit_context_blocks(blocks: &[String], cap: usize) -> Result<String, usize> {
+    let total: usize = blocks.iter().map(String::len).sum();
+    if total <= cap {
+        return Ok(blocks.concat());
+    }
+    let budget = cap.saturating_sub(TRUNCATION_MARKER_RESERVE);
+    let mut running = 0usize;
+    let mut kept = 0usize;
+    for block in blocks {
+        if running + block.len() > budget {
+            break;
         }
-        out.push_str(&block);
+        running += block.len();
+        kept += 1;
+    }
+    if kept == 0 {
+        return Err(blocks.first().map_or(0, String::len));
+    }
+    let dropped_bytes: usize = blocks[kept..].iter().map(String::len).sum();
+    let mut out = String::with_capacity(running + TRUNCATION_MARKER_RESERVE);
+    for block in &blocks[..kept] {
+        out.push_str(block);
+    }
+    // Bounded, deterministic honesty marker — NEVER silent truncation. Built into a
+    // local first (clippy `format_push_string`-clean), then appended.
+    let marker = format!(
+        "[context truncated: kept {kept}/{} items, dropped {dropped_bytes}B]\n\n",
+        blocks.len()
+    );
+    out.push_str(&marker);
+    Ok(out)
+}
+
+/// RC3 (BUG-FIX + context-engineering): render an already-ORDERED ReAct trajectory
+/// — the coordinator's `resolve_parent_context` delivers turns 0..T-1 + their tool
+/// observations in TURN-ascending (transcript) order (D78: the model must read the
+/// conversation in TIME order). Unlike [`assemble_from_parent_results`] this does
+/// **NOT** re-sort by `MoteId` — doing so (the pre-RC3 live-serve path) scrambled the
+/// conversation, because ReAct turn/observation `MoteId`s are run-salted blake3 hashes,
+/// non-monotonic in turn (BUG: the live model read its own steps out of order). Order
+/// is preserved verbatim; it is already deterministic (turn numbers are fixed), so the
+/// leaf `result_ref` stays stable across leases/recovery (R49).
+///
+/// On a window overflow this keeps the most-RECENT contiguous SUFFIX that fits (the
+/// recency window — recent tool observations matter most to the next step) and prepends
+/// a deterministic, bounded marker; a single most-recent item larger than the window
+/// fails closed (`Overflow`). Empty ⇒ `""`. Off-digest: prepended to the EPHEMERAL
+/// prompt, never journaled.
+pub(crate) fn assemble_trajectory(
+    entries: &[(MoteId, ContentRef)],
+    store: &LocalFsContentStore,
+) -> Result<String, AssembleError> {
+    if entries.is_empty() {
+        return Ok(String::new());
+    }
+    // Render each entry IN ORDER (fail closed on a missing ref). No MoteId sort, no
+    // dedup — the coordinator already ordered (and the trajectory has no duplicates).
+    let mut blocks: Vec<String> = Vec::with_capacity(entries.len());
+    for (_mote_id, result_ref) in entries {
+        let bytes = store
+            .get(result_ref)
+            .map_err(|_| AssembleError::UpstreamMissing(*result_ref))?;
+        let label = &result_ref.to_hex()[..16];
+        blocks.push(format!(
+            "[context parent.{label}]\n{}\n\n",
+            String::from_utf8_lossy(bytes.as_ref())
+        ));
+    }
+    let cap = crate::env_caps::window_bytes();
+    fit_trajectory_blocks(&blocks, cap).map_err(|needed| AssembleError::Overflow { needed, cap })
+}
+
+/// RC3 (context-engineering): fit time-ordered (oldest-first) trajectory `blocks` into
+/// `cap` bytes, keeping the most-RECENT contiguous SUFFIX. PURE + deterministic.
+///
+/// - All fit (`Σ ≤ cap`) ⇒ `Ok(blocks.concat())`, byte-identical to the untrimmed
+///   trajectory (the common case — `max_turns` keeps chains short).
+/// - Otherwise ⇒ drop the OLDEST blocks, keep the recent suffix that fits within
+///   `cap - TRUNCATION_MARKER_RESERVE`, and PREPEND a bounded marker noting the drop
+///   (NEVER silent). The result is guaranteed `≤ cap`.
+/// - `Err(needed)` iff even the single most-recent block cannot fit — fail closed.
+fn fit_trajectory_blocks(blocks: &[String], cap: usize) -> Result<String, usize> {
+    let total: usize = blocks.iter().map(String::len).sum();
+    if total <= cap {
+        return Ok(blocks.concat());
+    }
+    let budget = cap.saturating_sub(TRUNCATION_MARKER_RESERVE);
+    let mut running = 0usize;
+    let mut kept = 0usize;
+    // Walk from the END (most recent) backward — the recency window.
+    for block in blocks.iter().rev() {
+        if running + block.len() > budget {
+            break;
+        }
+        running += block.len();
+        kept += 1;
+    }
+    if kept == 0 {
+        return Err(blocks.last().map_or(0, String::len));
+    }
+    let start = blocks.len() - kept;
+    let dropped_bytes: usize = blocks[..start].iter().map(String::len).sum();
+    // Marker FIRST (the dropped context preceded the kept recent turns). Built into a
+    // local (clippy `format_push_string`-clean), then the recent suffix follows.
+    let marker = format!(
+        "[context: dropped {start} older items ({dropped_bytes}B), kept {kept} most recent]\n\n"
+    );
+    let mut out = String::with_capacity(running + marker.len());
+    out.push_str(&marker);
+    for block in &blocks[start..] {
+        out.push_str(block);
     }
     Ok(out)
 }
@@ -246,5 +387,185 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, AssembleError::UpstreamMissing(phantom));
+    }
+
+    // --- RC3 (context-engineering, D33 §5(a)): deterministic relevance trim --------
+
+    fn block(label: &str, body: &str) -> String {
+        format!("[context {label}]\n{body}\n\n")
+    }
+
+    #[test]
+    fn context_items_fits_is_byte_identical() {
+        // Σ ≤ cap ⇒ the untrimmed concatenation, byte-identical to pre-RC3.
+        let blocks = vec![block("a", "alpha"), block("b", "beta")];
+        let cap = 10_000;
+        assert_eq!(
+            fit_context_blocks(&blocks, cap).unwrap(),
+            blocks.concat(),
+            "a bundle that fits is byte-identical to the untrimmed concat"
+        );
+    }
+
+    #[test]
+    fn context_items_overflow_trims_lowest_ranked_suffix_with_marker() {
+        // Three relevance-ordered items; a cap that admits the first two + the marker
+        // budget but not the third ⇒ keep the prefix, drop the suffix, mark it.
+        let blocks = vec![
+            block("first", &"A".repeat(200)),
+            block("second", &"B".repeat(200)),
+            block("third", &"C".repeat(200)),
+        ];
+        // each block ≈ 200 + label/newlines (~30) ≈ 230B. Cap that fits two blocks
+        // (~460B) + the 128B marker reserve but not the third.
+        let cap = 460 + TRUNCATION_MARKER_RESERVE;
+        let out = fit_context_blocks(&blocks, cap).unwrap();
+        assert!(
+            out.contains("[context first]"),
+            "kept the most relevant: {out}"
+        );
+        assert!(out.contains("[context second]"), "kept the 2nd: {out}");
+        assert!(
+            !out.contains("[context third]"),
+            "dropped the suffix: {out}"
+        );
+        assert!(
+            out.contains("[context truncated: kept 2/3 items, dropped"),
+            "honesty marker present: {out}"
+        );
+        assert!(
+            out.len() <= cap,
+            "trimmed output stays within the window cap"
+        );
+    }
+
+    #[test]
+    fn context_items_single_oversized_item_still_fails_closed() {
+        // One item larger than the window ⇒ Err(needed) ⇒ Overflow upstream (no
+        // partial-item rendering — same fail-closed guarantee as the parent path).
+        let blocks = vec![block("huge", &"X".repeat(1000))];
+        let cap = 100;
+        let err = fit_context_blocks(&blocks, cap).unwrap_err();
+        assert_eq!(
+            err,
+            blocks[0].len(),
+            "needed = the oversized block's length"
+        );
+    }
+
+    #[test]
+    fn context_items_trim_is_deterministic() {
+        let blocks = vec![
+            block("one", &"1".repeat(300)),
+            block("two", &"2".repeat(300)),
+            block("three", &"3".repeat(300)),
+        ];
+        let cap = 350 + TRUNCATION_MARKER_RESERVE;
+        let a = fit_context_blocks(&blocks, cap).unwrap();
+        let b = fit_context_blocks(&blocks, cap).unwrap();
+        assert_eq!(a, b, "same blocks + cap ⇒ byte-identical trim");
+    }
+
+    // --- RC3 (BUG-FIX): ReAct trajectory renders in TIME order, not MoteId order -----
+
+    #[test]
+    fn trajectory_preserves_input_time_order_not_moteid() {
+        // Regression pin for the live-serve react ordering bug: the trajectory must
+        // render in the coordinator's TIME order (input order), NOT re-sorted by
+        // MoteId. Entry 0 (first in time) has a HIGH MoteId; entry 1 has a LOW MoteId,
+        // so a MoteId sort would FLIP them.
+        let (_dir, store) = store();
+        let ref_first = store.put(b"turn0-first-in-time").unwrap();
+        let ref_second = store.put(b"turn1-second-in-time").unwrap();
+        let id_hi = mote_id(0x99); // first in time, but high MoteId
+        let id_lo = mote_id(0x01); // second in time, but low MoteId
+        let entries = [(id_hi, ref_first), (id_lo, ref_second)];
+
+        let out = assemble_trajectory(&entries, &store).unwrap();
+        let pos_first = out.find("turn0-first-in-time").unwrap();
+        let pos_second = out.find("turn1-second-in-time").unwrap();
+        assert!(
+            pos_first < pos_second,
+            "trajectory must preserve TIME order regardless of MoteId: {out}"
+        );
+
+        // Contrast: the MoteId-sorted parent path WOULD flip them (documents the bug
+        // the fix avoids — the react path must NOT use this renderer).
+        let moteid_sorted = assemble_from_parent_results(&entries, &store).unwrap();
+        assert!(
+            moteid_sorted.find("turn1-second-in-time").unwrap()
+                < moteid_sorted.find("turn0-first-in-time").unwrap(),
+            "the MoteId-sorted path flips time order (the bug the trajectory path avoids)"
+        );
+    }
+
+    #[test]
+    fn trajectory_empty_is_empty() {
+        let (_dir, store) = store();
+        assert_eq!(assemble_trajectory(&[], &store).unwrap(), String::new());
+    }
+
+    #[test]
+    fn trajectory_missing_ref_fails_closed() {
+        let (_dir, store) = store();
+        let phantom = ContentRef::of(b"never-stored-traj");
+        let err = assemble_trajectory(&[(mote_id(1), phantom)], &store).unwrap_err();
+        assert_eq!(err, AssembleError::UpstreamMissing(phantom));
+    }
+
+    #[test]
+    fn trajectory_overflow_keeps_recent_suffix_with_marker() {
+        // Oldest-first blocks; a cap admitting the two MOST-RECENT + the marker reserve
+        // but not the oldest ⇒ drop the oldest, keep the recent suffix, prepend a marker.
+        let blocks = vec![
+            block("oldest", &"O".repeat(200)),
+            block("middle", &"M".repeat(200)),
+            block("newest", &"N".repeat(200)),
+        ];
+        let cap = 460 + TRUNCATION_MARKER_RESERVE;
+        let out = fit_trajectory_blocks(&blocks, cap).unwrap();
+        assert!(
+            !out.contains("[context oldest]"),
+            "dropped the oldest: {out}"
+        );
+        assert!(out.contains("[context middle]"), "kept the recent: {out}");
+        assert!(
+            out.contains("[context newest]"),
+            "kept the most recent: {out}"
+        );
+        assert!(
+            out.contains("[context: dropped 1 older items"),
+            "honesty marker present: {out}"
+        );
+        // Recency: the kept blocks stay in time order (middle before newest).
+        assert!(out.find("[context middle]").unwrap() < out.find("[context newest]").unwrap());
+        assert!(
+            out.len() <= cap,
+            "trimmed output stays within the window cap"
+        );
+    }
+
+    #[test]
+    fn trajectory_single_oversized_item_still_fails_closed() {
+        let blocks = vec![block("huge", &"X".repeat(1000))];
+        let err = fit_trajectory_blocks(&blocks, 100).unwrap_err();
+        assert_eq!(err, blocks[0].len());
+    }
+
+    #[test]
+    fn trajectory_fits_is_byte_identical_and_deterministic() {
+        let blocks = vec![block("a", "alpha"), block("b", "beta")];
+        let cap = 10_000;
+        let a = fit_trajectory_blocks(&blocks, cap).unwrap();
+        assert_eq!(
+            a,
+            blocks.concat(),
+            "a trajectory that fits is the untrimmed concat"
+        );
+        assert_eq!(
+            a,
+            fit_trajectory_blocks(&blocks, cap).unwrap(),
+            "deterministic"
+        );
     }
 }

--- a/crates/kx-gateway/src/mcp_tool.rs
+++ b/crates/kx-gateway/src/mcp_tool.rs
@@ -256,6 +256,39 @@ pub(crate) fn grammar_constrained_enabled() -> bool {
     }
 }
 
+/// RC3 (T-REACT-TOOL-MENU): the operator SERVE-LEVEL kill-switch for the
+/// granted-tool MENU prepend (`KX_SERVE_REACT_TOOL_MENU`). Default-ON (unset /
+/// `"1"` / `"true"` ⇒ `true`) — byte-mirrors [`grammar_constrained_enabled`]; set
+/// `"0"` / `"false"` / `"off"` to skip menu derivation for every dispatch (the
+/// reliable global opt-out ⇒ byte-identical to pre-RC3). The menu is advisory
+/// prompt bytes only (SN-8) and is derived OFF the MoteId, so the toggle changes
+/// only the live prompt, never a committed fact or the digest.
+pub(crate) fn tool_menu_enabled() -> bool {
+    match std::env::var_os("KX_SERVE_REACT_TOOL_MENU") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            let v = v.trim();
+            !(v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off"))
+        }
+        None => true,
+    }
+}
+
+/// RC3: the operator's optional per-DEPLOYMENT override of the curated agentic
+/// system prompt (`KX_SERVE_REACT_SYSTEM` — e.g. a domain persona). `Some(text)`
+/// iff set to a non-empty (trimmed) value; else `None` ⇒ the built-in `REACT_SYSTEM`.
+/// Presentation only (SN-8), off the MoteId / off-digest — a different persona never
+/// changes a Mote's identity or any committed fact. Per-RUN (per-invocation) system
+/// prompts are a ticketed follow-up (`T-REACT-SYSTEM-PROMPT-PER-RUN`): they need the
+/// recipe `SlotBinding::Optional` model + a durable `ReactRound` carry across the
+/// seed-swap, so they ship as their own focused PR, not here.
+pub(crate) fn react_system_override() -> Option<String> {
+    std::env::var("KX_SERVE_REACT_SYSTEM")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 /// Resolve a bundled MCP tool binary's path: an explicit `env_override` var
 /// first, then the fixed in-image path, then a dev/test walk up to the workspace
 /// `target/` dir (the `real_body_binary_path` precedent). `None` ⇒ no binary on

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -514,15 +514,36 @@ const AGENT_MIN_CTX_TOKENS: u32 = 2048;
 /// ChatML system turn) — so the system prompt is identical on both paths.
 const SERVE_SYSTEM: &str = "You are a precise assistant. Follow the instruction exactly.";
 
-/// Qwen ChatML wrapping of a user prompt — the **training contract** the
-/// companion model repo mirrors (kept byte-identical to
+/// RC3 (T-REACT-TOOL-MENU): the curated AGENTIC/ReAct system contract used for
+/// tool-eligible ReAct turns (selected by turn kind in `dispatch_model`). It states
+/// the loop + the canonical tool-call envelope (the exact shape
+/// `kx_toolcall::parse_tool_call` accepts — `crates/kx-toolcall/src/parse.rs`) so a
+/// real model knows the PROTOCOL even before the per-turn menu names specific tools,
+/// plus the act-vs-answer decision. Presentation only (SN-8): fed to `render_chat` /
+/// [`chatml_with`] exactly like [`SERVE_SYSTEM`] ⇒ off the MoteId / off-digest /
+/// never journaled (so `7d22d4bd` and recovery are untouched). The model is told to
+/// use ONLY listed tools; the runtime still enforces grant membership + the arg
+/// schema fail-closed (`parse_tool_call` + `validate_args`).
+const REACT_SYSTEM: &str = "You are a precise, autonomous assistant that can call tools to \
+accomplish the task. Think step by step. When a tool is needed, reply with EXACTLY one JSON \
+object and nothing else: {\"tool_call\":{\"name\":\"<tool name>\",\"version\":\"<tool version>\",\
+\"args\":{ ... }}} — use a name and version from the provided tool list and fill args per that \
+tool's inputs. After a tool result is returned, keep reasoning. When you have enough information, \
+reply with the final answer as plain text and do NOT emit a tool_call. Never invent a tool, \
+version, or argument that is not listed.";
+
+/// Qwen ChatML wrapping of a user prompt with an EXPLICIT system message — the
+/// **training contract** the companion model repo mirrors (kept byte-identical to
 /// `kx_model_harness::prompt::chatml`; duplicated here so the production gateway
-/// need not depend on the eval harness). The FALLBACK used when the backend
-/// cannot render the model's own chat template (PR-1 model-agnostic templating).
+/// need not depend on the eval harness). The FALLBACK used when the backend cannot
+/// render the model's own chat template (PR-1 model-agnostic templating). RC3
+/// selects the system per turn kind in `dispatch_model` (`REACT_SYSTEM` for a
+/// tool-eligible ReAct turn, else [`SERVE_SYSTEM`]); the system text is
+/// presentation only (SN-8) — never an identity/journal input.
 #[must_use]
-fn chatml(prompt: &str) -> String {
+fn chatml_with(system: &str, prompt: &str) -> String {
     format!(
-        "<|im_start|>system\n{SERVE_SYSTEM}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
     )
 }
 
@@ -999,6 +1020,14 @@ pub(crate) struct ModelRouterExecutor<B: InferenceBackend> {
     /// streaming `dispatch` is taken); out-of-band — never journal / digest /
     /// identity.
     token_publisher: Option<Arc<crate::token_broker::TokenBroker>>,
+    /// RC3 (T-REACT-TOOL-MENU): the live serve tool registry (the SAME `Arc` the
+    /// coordinator settle + broker share, `server.rs`). When set, a tool-eligible
+    /// ReAct turn derives the granted-tool MENU from `warrant.tool_grants` at
+    /// dispatch and prepends it to the EPHEMERAL instruction so the model proposes
+    /// well-formed calls (RC2's grammar only constrains a proposal once made). Off
+    /// the MoteDef identity — never written to `config_subset` / journaled — exactly
+    /// like the RC2 grammar carrier. `None` ⇒ no menu ⇒ byte-identical dispatch.
+    tool_registry: Option<Arc<dyn kx_tool_registry::ToolRegistry>>,
 }
 
 impl<B: InferenceBackend> ModelRouterExecutor<B> {
@@ -1022,6 +1051,7 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             image_ref_ctx: Mutex::new(None),
             usage: None,
             token_publisher: None,
+            tool_registry: None,
         }
     }
 
@@ -1040,6 +1070,19 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         broker: Arc<crate::token_broker::TokenBroker>,
     ) -> Self {
         self.token_publisher = Some(broker);
+        self
+    }
+
+    /// RC3 (T-REACT-TOOL-MENU): wire the live serve tool registry so a tool-eligible
+    /// ReAct turn prepends the granted-tool MENU to its ephemeral instruction (the
+    /// model then proposes well-formed calls; RC2 grammar only constrains a proposal
+    /// once made). Off-MoteDef / off-digest (mirrors `with_token_publisher`'s
+    /// out-of-band posture). Unset ⇒ byte-identical dispatch.
+    pub(crate) fn with_tool_registry(
+        mut self,
+        registry: Arc<dyn kx_tool_registry::ToolRegistry>,
+    ) -> Self {
+        self.tool_registry = Some(registry);
         self
     }
 
@@ -1182,9 +1225,7 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         // byte-identical to pre-F-7. A missing/oversized upstream fails closed.
         let instruction = match self.take_parent_context(mote.id) {
             Some(parents) if !parents.is_empty() => {
-                let context =
-                    crate::assemble_serve::assemble_from_parent_results(&parents, &self.store)
-                        .map_err(|e| internal(&format!("assemble F-7 context: {e}")))?;
+                let context = self.assemble_parent_context(mote, &parents)?;
                 format!("{context}{instruction}")
             }
             _ => instruction,
@@ -1230,6 +1271,16 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         // think/no-think directive. ABSENT ⇒ byte-identical (the directive is a
         // no-op for `Default`), so a no-reasoning Mote's prompt is unchanged.
         let instruction = apply_reasoning_directive(instruction, reasoning_mode_from_config(mote));
+        // RC3 (T-REACT-TOOL-MENU): on a tool-eligible ReAct turn, prepend the
+        // granted-tool MENU so the model PROPOSES well-formed calls AUTONOMOUSLY
+        // (RC2's grammar only CONSTRAINS a proposal once made — it is dormant until
+        // the model proposes; the menu is the unblocker). The menu is derived OFF the
+        // MoteDef identity and prepended to the EPHEMERAL `instruction` only (see
+        // [`Self::react_tool_menu`]); `7d22d4bd` and replay are untouched.
+        let instruction = match self.react_tool_menu(mote, warrant) {
+            Some(menu) => format!("{menu}\n{instruction}"),
+            None => instruction,
+        };
         // Batch A (vision): a Mote carrying `config_subset[IMAGE_REF_KEY]` (the
         // bound `kx/recipes/vision` arg) dispatches MULTIMODAL — the media
         // marker heads the user turn (the projector splices the image in marker
@@ -1246,10 +1297,15 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         // to pre-PR-1 for those paths. The wrapping is presentation only, never an
         // identity/authority input (SN-8); the raw `instruction` already fixed the
         // Mote identity via `config_subset[PROMPT_KEY]`.
+        // RC3: a ReAct turn uses the curated AGENTIC contract (or the operator
+        // `KX_SERVE_REACT_SYSTEM` persona override); all other turns keep the
+        // precise-assistant `SERVE_SYSTEM`. Presentation only (SN-8) — off-MoteDef /
+        // off-digest, never journaled. (See [`Self::dispatch_system_prompt`].)
+        let system = Self::dispatch_system_prompt(mote);
         let format = |user: &str| -> String {
             self.backend
-                .render_chat(&mote.def.model_id, SERVE_SYSTEM, user)
-                .unwrap_or_else(|| chatml(user))
+                .render_chat(&mote.def.model_id, &system, user)
+                .unwrap_or_else(|| chatml_with(&system, user))
         };
         // AGENTIC-VISION: turn 0 (and single-shot vision) carries the image INLINE in
         // `config_subset[IMAGE_REF_KEY]`; a SUCCESSOR ReAct turn carries NO inline image,
@@ -1346,6 +1402,64 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             .config_subset
             .get(&ConfigKey(REACT_UNCONSTRAINED_KEY.to_string()))
             .is_some_and(|v| matches!(v.0.as_slice(), b"true" | b"1"))
+    }
+
+    /// RC3 (T-REACT-TOOL-MENU): the granted-tool MENU to prepend to a tool-eligible
+    /// ReAct turn's EPHEMERAL instruction, or `None` when no menu applies — not a
+    /// react turn, no grants, an `unconstrained` opt-out, the `KX_SERVE_REACT_TOOL_MENU`
+    /// kill-switch, no wired registry, or an empty render. Derived from
+    /// `warrant.tool_grants` via the SHARED [`kx_context_assembler::render_tool_menu`]
+    /// (the SAME renderer the context-assembly path uses — no harness↔serve drift),
+    /// gated EXACTLY like the RC2 grammar path. The menu is advisory prompt bytes only
+    /// (SN-8) and is computed OFF the MoteDef identity (never written to
+    /// `config_subset` / journaled), so the canonical no-tools demo renders nothing
+    /// and `7d22d4bd` + replay are untouched.
+    fn react_tool_menu(&self, mote: &Mote, warrant: &WarrantSpec) -> Option<String> {
+        let reg = self.tool_registry.as_ref()?;
+        let eligible = Self::is_react_turn(mote)
+            && !warrant.tool_grants.is_empty()
+            && !Self::is_unconstrained(mote)
+            && crate::mcp_tool::tool_menu_enabled();
+        if !eligible {
+            return None;
+        }
+        let menu = kx_context_assembler::render_tool_menu(&warrant.tool_grants, reg.as_ref());
+        (!menu.is_empty()).then_some(menu)
+    }
+
+    /// RC3: the system prompt for this dispatch. A ReAct turn uses the operator
+    /// `KX_SERVE_REACT_SYSTEM` persona override if set, else the curated agentic
+    /// contract [`REACT_SYSTEM`]; every other turn keeps the precise-assistant
+    /// [`SERVE_SYSTEM`] (byte-identical to pre-RC3). Presentation only (SN-8) — never
+    /// an identity / journal input, so it is off-MoteDef and off-digest.
+    fn dispatch_system_prompt(mote: &Mote) -> std::borrow::Cow<'static, str> {
+        if !Self::is_react_turn(mote) {
+            return std::borrow::Cow::Borrowed(SERVE_SYSTEM);
+        }
+        crate::mcp_tool::react_system_override().map_or(
+            std::borrow::Cow::Borrowed(REACT_SYSTEM),
+            std::borrow::Cow::Owned,
+        )
+    }
+
+    /// RC3: assemble this Mote's delivered upstream context. A ReAct turn's trajectory
+    /// is delivered by the coordinator in TIME order (turn0, obs0, turn1, … — D78), so
+    /// it renders ORDER-PRESERVING (+ recency-trim on overflow); the pre-RC3 path
+    /// re-sorted by MoteId (run-salted blake3 → non-monotonic), scrambling the
+    /// conversation the model reads. A non-react F-7 / critic context is genuinely
+    /// unordered Data parents ⇒ keep the MoteId-sorted render. Off-digest (ephemeral
+    /// prompt); a missing / oversized upstream still fails closed.
+    fn assemble_parent_context(
+        &self,
+        mote: &Mote,
+        parents: &[(MoteId, ContentRef)],
+    ) -> Result<String, MoteExecutorError> {
+        let assembled = if Self::is_react_turn(mote) {
+            crate::assemble_serve::assemble_trajectory(parents, &self.store)
+        } else {
+            crate::assemble_serve::assemble_from_parent_results(parents, &self.store)
+        };
+        assembled.map_err(|e| internal(&format!("assemble F-7 context: {e}")))
     }
 
     /// Run a ReAct TURN Mote: `dispatch_model` verbatim (the F-7 trajectory
@@ -1957,10 +2071,12 @@ mod tests {
 
     #[test]
     fn chatml_is_the_training_contract() {
-        let p = chatml("hi");
+        let p = chatml_with(SERVE_SYSTEM, "hi");
         assert!(p.starts_with("<|im_start|>system\n"));
         assert!(p.ends_with("<|im_start|>assistant\n"));
         assert!(p.contains("<|im_start|>user\nhi<|im_end|>"));
+        // The default (non-react) system is unchanged from pre-RC3.
+        assert!(p.contains("You are a precise assistant. Follow the instruction exactly."));
     }
 
     // --- PR-4 (T-FEAT1): the opt-in reasoning-mode knob (config_subset) ---
@@ -2822,6 +2938,190 @@ mod tests {
             None,
             "unconstrained=true ⇒ grammar skipped"
         );
+    }
+
+    // --- RC3 (T-REACT-TOOL-MENU): the granted-tool menu + curated system prompt ---
+
+    /// A live tool registry holding the tool `granted_warrant` grants (`mcp-echo` v1),
+    /// WITH a typed schema, so a granted react turn renders a rich menu. Reuses the
+    /// bundled `echo_tool_def` (the real schema), re-id'd to match the grant.
+    fn menu_registry() -> Arc<dyn kx_tool_registry::ToolRegistry> {
+        use kx_tool_registry::ToolRegistry as _; // bring `register` into scope.
+        let mut reg = kx_tool_registry::InMemoryToolRegistry::new();
+        let mut def = crate::mcp_tool::echo_tool_def();
+        def.tool_id = kx_mote::ToolName("mcp-echo".into()); // match granted_warrant
+        reg.register(
+            def,
+            kx_tool_registry::ToolProvenance::HumanAuthored {
+                author: "test".into(),
+            },
+        )
+        .expect("register echo def");
+        Arc::new(reg)
+    }
+
+    /// The LEAD fix: a tool-eligible ReAct turn with grants + a wired registry
+    /// prepends the granted-tool MENU (name + schema + worked example) to the prompt,
+    /// so a real model can PROPOSE a call without the instruction describing the format.
+    #[test]
+    fn menu_is_injected_on_a_granted_react_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(&store, b"blue", None);
+        let exec = exec.with_tool_registry(menu_registry());
+        exec.run(&react_turn_mote(), &granted_warrant(), None)
+            .expect("react turn dispatches");
+        let prompt = backend.last_prompt.lock().unwrap().clone().unwrap();
+        assert!(
+            prompt.contains("You can call the following tools:"),
+            "menu header absent: {prompt}"
+        );
+        assert!(
+            prompt.contains("name: mcp-echo"),
+            "tool name absent: {prompt}"
+        );
+        assert!(
+            prompt.contains("Example: "),
+            "worked example absent: {prompt}"
+        );
+        // The user's instruction still rides AFTER the menu.
+        assert!(
+            prompt.contains("list the files"),
+            "instruction absent: {prompt}"
+        );
+    }
+
+    /// No grant ⇒ no menu (the canonical-demo / answer-only invariant — same posture
+    /// as the grammar gate, so `7d22d4bd` is untouched).
+    #[test]
+    fn no_menu_on_a_react_turn_without_grants() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(&store, b"blue", None);
+        let exec = exec.with_tool_registry(menu_registry());
+        exec.run(
+            &react_turn_mote(),
+            &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+            None,
+        )
+        .expect("react turn dispatches");
+        let prompt = backend.last_prompt.lock().unwrap().clone().unwrap();
+        assert!(
+            !prompt.contains("You can call the following tools:"),
+            "no grant ⇒ no menu, got: {prompt}"
+        );
+    }
+
+    /// A non-react (shaper) turn is NEVER menu-injected, even with a granted warrant.
+    #[test]
+    fn no_menu_on_a_non_react_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(
+            &store,
+            TWO_CHILD_PROPOSAL,
+            Some(worker_recipes(&model_id())),
+        );
+        let exec = exec.with_tool_registry(menu_registry());
+        exec.run(&shaper_mote(), &granted_warrant(), None)
+            .expect("shaper dispatches");
+        let prompt = backend.last_prompt.lock().unwrap().clone().unwrap();
+        assert!(
+            !prompt.contains("You can call the following tools:"),
+            "a shaper turn is never menu-injected, got: {prompt}"
+        );
+    }
+
+    /// No registry wired ⇒ no menu (the `None` path is byte-identical to pre-RC3 —
+    /// the menu is purely additive and unset means unchanged dispatch).
+    #[test]
+    fn no_menu_when_registry_not_wired() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+        let (exec, backend) = executor(&store, b"blue", None);
+        exec.run(&react_turn_mote(), &granted_warrant(), None)
+            .expect("react turn dispatches");
+        let prompt = backend.last_prompt.lock().unwrap().clone().unwrap();
+        assert!(
+            !prompt.contains("You can call the following tools:"),
+            "no registry ⇒ no menu, got: {prompt}"
+        );
+    }
+
+    /// RC3 curated system prompt: a ReAct turn is framed by the AGENTIC contract
+    /// (`REACT_SYSTEM`); a non-react (shaper) turn keeps the precise-assistant
+    /// `SERVE_SYSTEM` (byte-identical to pre-RC3). Asserted via the ChatML fallback
+    /// the stub backend takes (`render_chat` returns `None`), which embeds the system.
+    #[test]
+    fn react_turn_uses_curated_agentic_system_else_serve_system() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFsContentStore::open(dir.path()).unwrap();
+
+        // ReAct turn → REACT_SYSTEM.
+        let (exec, backend) = executor(&store, b"blue", None);
+        exec.run(
+            &react_turn_mote(),
+            &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+            None,
+        )
+        .expect("react turn dispatches");
+        let react_prompt = backend.last_prompt.lock().unwrap().clone().unwrap();
+        assert!(
+            react_prompt.contains("autonomous assistant that can call tools"),
+            "react turn should use the agentic system prompt: {react_prompt}"
+        );
+
+        // Shaper turn → SERVE_SYSTEM (unchanged).
+        let (exec2, backend2) = executor(
+            &store,
+            TWO_CHILD_PROPOSAL,
+            Some(worker_recipes(&model_id())),
+        );
+        exec2
+            .run(
+                &shaper_mote(),
+                &shaper_warrant(&model_id(), ExecutorClass::MacOsSandbox),
+                None,
+            )
+            .expect("shaper dispatches");
+        let shaper_prompt = backend2.last_prompt.lock().unwrap().clone().unwrap();
+        assert!(
+            shaper_prompt.contains("You are a precise assistant. Follow the instruction exactly."),
+            "shaper turn should keep SERVE_SYSTEM: {shaper_prompt}"
+        );
+    }
+
+    /// RC3: the agentic system prompt is selected by turn kind — a ReAct turn gets the
+    /// curated `REACT_SYSTEM` (absent an env override), every other turn keeps
+    /// `SERVE_SYSTEM`. Tested without the env (the `KX_SERVE_REACT_SYSTEM` override is
+    /// the thin process-global wrapper, exercised by the live witness).
+    #[test]
+    fn dispatch_system_prompt_selects_by_turn_kind() {
+        let react = ModelRouterExecutor::<StubBackend>::dispatch_system_prompt(&react_turn_mote());
+        assert!(
+            react.contains("autonomous assistant that can call tools"),
+            "react turn ⇒ curated agentic contract: {react}"
+        );
+        let shaper = ModelRouterExecutor::<StubBackend>::dispatch_system_prompt(&shaper_mote());
+        assert_eq!(&*shaper, SERVE_SYSTEM, "non-react turn keeps SERVE_SYSTEM");
+    }
+
+    /// Render↔parse coherence: the canonical tool-call envelope the curated
+    /// `REACT_SYSTEM` instructs the model to emit (and the menu names) is EXACTLY the
+    /// shape the authority gate `kx_toolcall::parse_tool_call` accepts — so a model
+    /// that follows the prompt produces a call the runtime resolves to the granted
+    /// tool. (Format coverage over the same envelope is gated in `kx-eval`; this pins
+    /// the serve-side curated-prompt↔parser agreement.)
+    #[test]
+    fn react_system_envelope_round_trips_through_parse_tool_call() {
+        let warrant = granted_warrant(); // grants mcp-echo v1
+        let envelope = br#"{"tool_call":{"name":"mcp-echo","version":"1","args":{"text":"ping"}}}"#;
+        let call =
+            kx_toolcall::parse_tool_call(envelope, &warrant, kx_toolcall::max_args_bytes(&warrant))
+                .expect("the curated envelope parses")
+                .expect("a tool call is decoded");
+        assert_eq!(call.name, kx_mote::ToolName("mcp-echo".into()));
+        assert_eq!(call.version, kx_mote::ToolVersion("1".into()));
     }
 
     /// PR-9d (model-side half): `dispatch_model` PREPENDS the carried grounding context

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -611,7 +611,13 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
                 .with_usage_sink(Arc::new(telemetry_ledger.sink()))
                 // PR-4.2: the ADVISORY token publisher — streams each model mote's
                 // tokens out-of-band (keyed by mote.id). Byte-identical dispatch.
-                .with_token_publisher(token_broker.clone()),
+                .with_token_publisher(token_broker.clone())
+                // RC3 (T-REACT-TOOL-MENU): the SAME live `Arc<SqliteToolRegistry>` the
+                // coordinator settle + broker share (resolved at :479). A tool-eligible
+                // ReAct turn renders its granted-tool menu from this registry at
+                // dispatch — off-MoteDef / off-digest (the canonical no-tools demo
+                // renders no menu). Unsized-coerces to `Arc<dyn ToolRegistry>`.
+                .with_tool_registry(tool_registry.clone()),
             );
             let sink: Arc<dyn kx_worker::ContextSink> = model_exec.clone();
             let wrapped: Arc<dyn MoteExecutor> = model_exec;

--- a/crates/kx-gateway/tests/eval_real_model.rs
+++ b/crates/kx-gateway/tests/eval_real_model.rs
@@ -325,3 +325,146 @@ async fn grammar_forces_and_witnesses_a_tool_fire() {
         "the forcing chain settled a terminal branch"
     );
 }
+
+/// RC3 menu witness (Tier-B, observe-not-gate per GR16): the LEAD proof for
+/// T-REACT-TOOL-MENU. Unlike the grammar witness above, the instruction describes
+/// only the DESIRED EFFECT — NOT the tool name, args, or call format. Pre-RC3 a real
+/// model could not fire a tool from such a goal (the live prompt showed NO tool
+/// menu); RC3 prepends the granted-tool MENU (+ the curated agentic system prompt) so
+/// the model proposes the call AUTONOMOUSLY, and the RC2 grammar then constrains it.
+/// This PRINTS each turn's raw output + whether a tool fired (the headline signal,
+/// observed not gated) and soft-asserts the chain settles. Run on BOTH engines
+/// (restart-per-run): `KX_SERVE_OLLAMA=on KX_SERVE_OLLAMA_MODELS=gemma3:12b just
+/// eval-real` and `KX_SERVE_MODEL_GGUF=<gemma-4-12b-it-q4_k_m.gguf> just eval-real`.
+/// T-OLLAMA-GEMMA3-GGUF-SKEW: the llama.cpp arm needs the HF unsloth GGUF (`just
+/// fetch-gemma-model`), NOT Ollama's gemma3 blob.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real LLM; witnesses that the tool MENU (not a format hint) elicits an autonomous tool fire"]
+async fn menu_elicits_a_tool_without_format_instructions() {
+    if let Some(gguf) = serve_gguf() {
+        std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+    } else if !ollama_opted_in() {
+        eprintln!("skipping: no model");
+        return;
+    }
+    std::env::set_var("KX_SERVE_AUTOGRANT", "1");
+    // The menu is on by default; assert it is NOT disabled for this witness.
+    std::env::remove_var("KX_SERVE_REACT_TOOL_MENU");
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: react not provisioned (bundled bins missing)");
+        running.shutdown().await.unwrap();
+        std::env::remove_var("KX_SERVE_AUTOGRANT");
+        return;
+    }
+
+    // Goal describes the EFFECT only — no tool name, no args, no envelope. A tool fire
+    // here is attributable to the MENU, not to the instruction describing the format.
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_AUTO_RECIPE_HANDLE.to_string(),
+            args: {
+                let instruction =
+                    std::env::var("KX_MENU_WITNESS_INSTRUCTION").unwrap_or_else(|_| {
+                        "Use your available tools to echo the word 'kortecx', then tell me \
+                     exactly what the tool returned."
+                            .to_string()
+                    });
+                format!(r#"{{"instruction":"{instruction}","max_turns":4,"max_tool_calls":3}}"#)
+                    .into_bytes()
+            },
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke react-auto")
+        .into_inner();
+
+    let mut settled = None;
+    for _ in 0..1500 {
+        let t = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+                step_salt: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if t.turns
+            .iter()
+            .any(|x| x.branch == "answer" || x.branch == "dead_lettered")
+        {
+            settled = Some(t);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let turns = settled.expect("the chain settled a terminal branch").turns;
+
+    let view = c
+        .get_projection(proto::GetProjectionRequest {
+            instance_id: resp.instance_id.clone(),
+            at_seq: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut fired: Vec<String> = Vec::new();
+    for t in &turns {
+        let raw = view
+            .motes
+            .iter()
+            .find(|m| m.mote_id == t.turn_mote_id)
+            .and_then(|m| m.result_ref.clone());
+        let text = match raw {
+            Some(rref) => c
+                .get_content(proto::GetContentRequest {
+                    content_ref: rref,
+                    instance_id: resp.instance_id.clone(),
+                })
+                .await
+                .ok()
+                .map(|r| String::from_utf8_lossy(&r.into_inner().payload).into_owned())
+                .unwrap_or_default(),
+            None => String::new(),
+        };
+        eprintln!(
+            "MENU-WITNESS turn={} branch={} tool_id={} raw={:?}",
+            t.turn, t.branch, t.tool_id, text
+        );
+        if t.branch == "tool" {
+            fired.push(t.tool_id.clone());
+        }
+    }
+    eprintln!(
+        "MENU-WITNESS: fired tools (from a NO-format-hint goal) = {fired:?} \
+         — non-empty proves the menu elicited an autonomous tool proposal"
+    );
+
+    running.shutdown().await.unwrap();
+    std::env::remove_var("KX_SERVE_AUTOGRANT");
+
+    assert!(
+        turns
+            .iter()
+            .any(|t| t.branch == "answer" || t.branch == "dead_lettered"),
+        "the menu-driven chain settled a terminal branch"
+    );
+}

--- a/docs/site/docs/agentic-prompts.md
+++ b/docs/site/docs/agentic-prompts.md
@@ -1,0 +1,107 @@
+---
+id: agentic-prompts
+title: Agentic prompts & the tool menu
+sidebar_label: Agentic prompts
+description: How Kortecx frames a ReAct agent — the curated agentic system prompt, the granted-tool menu that lets local models propose tools autonomously, and the serve-level controls.
+---
+
+# Agentic prompts & the tool menu
+
+Kortecx runs **local OSS models** (Gemma via Ollama or llama.cpp) as ReAct agents.
+For a small model to use tools *reliably*, three things have to line up: it must
+**know which tools it has**, **know the call format**, and have its **conversation
+in order**. Kortecx assembles all three at dispatch — automatically, off-digest, and
+identically across engines.
+
+## What the agent is told
+
+On every tool-eligible ReAct turn the runtime builds the model prompt from:
+
+1. **A curated agentic system contract.** It states the reason → act → observe loop,
+   the canonical tool-call envelope, and when to stop and answer in plain text. This
+   is what makes a 4B–12B model follow the protocol instead of free-styling.
+2. **The granted-tool menu.** The tools granted to *this run* (and only those),
+   each rendered with its exact callable name, description, typed inputs, and a
+   worked example — so the model proposes a **well-formed** call, not a guess.
+3. **The conversation so far.** Prior turns and their tool observations, in **time
+   order**, so the model reads what it already did and what each tool returned.
+
+The model then proposes a call as:
+
+```json
+{"tool_call":{"name":"<granted-tool>","version":"<v>","args":{ … }}}
+```
+
+…and [grammar-constrained decoding](./tools.md#grammar-constrained-tool-calls)
+guarantees the proposal is well-formed, while the warrant grant-check and
+`inputSchema` validation remain the **only** authority (a model can never call a
+tool it was not granted — SN-8).
+
+## Serve-level controls
+
+These are set when you start `kx serve` (operator scope, per deployment). All are
+**off-digest** — they shape the live prompt only, never a committed fact or a run's
+identity.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KX_SERVE_AUTOGRANT` | off | Provision `kx/recipes/react-auto` + auto-grant the bundled/dialed tools so the model can choose tools turn-by-turn. |
+| `KX_SERVE_REACT_TOOL_MENU` | **on** | Show the granted-tool menu so the model proposes tools autonomously. Set `0` to omit it. |
+| `KX_SERVE_REACT_GRAMMAR` | **on** | Constrain tool-call decoding to the canonical envelope (llama.cpp lazy GBNF; Ollama relies on the robust parser). Set `0` to disable. |
+| `KX_SERVE_REACT_SYSTEM` | _(built-in)_ | Override the curated agentic contract with a **domain persona** (e.g. an SRE copilot). |
+
+```bash
+# A persona-driven, autonomous tool-using agent server:
+KX_SERVE_AUTOGRANT=1 \
+KX_SERVE_REACT_SYSTEM="You are Ada, a terse SRE copilot. Prefer tools over guessing." \
+  kx serve
+```
+
+## Driving an agent (one entry point, every surface)
+
+The agent runner is the single entry point on every surface — the prompt/menu/order
+machinery above is applied automatically; you just give it a goal:
+
+```bash
+# CLI
+kx agent run --goal "Use your tools to compute 6 * 7, then tell me the result." --json
+```
+
+```python
+# Python
+import kortecx as kx
+result = kx.run_agent("Use your tools to compute 6 * 7, then tell me the result.")
+```
+
+```typescript
+// TypeScript
+import { runAgent } from "@kortecx/sdk";
+const result = await runAgent({ goal: "Use your tools to compute 6 * 7, then tell me the result." });
+```
+
+```typescript
+// Chains DSL — the .agent() node is the same ReAct loop
+await flow().agent("Use your tools to compute 6 * 7, then tell me the result.").run({ client });
+```
+
+> **Per-run prompts/menus.** The agentic contract and the menu are applied to *every*
+> ReAct turn automatically; there is no per-call flag to set today. A per-**run**
+> system-prompt override (a different persona per invocation) is a planned follow-up
+> — it needs an optional recipe slot plus a durable carry across the run's turn-0
+> anchor, so it ships as its own change. Per-deployment customization is available
+> now via `KX_SERVE_REACT_SYSTEM` above.
+
+## Inspecting what the agent saw
+
+Each tool's menu rendering is previewed in the **Tools** section of the Console (the
+name, description, typed inputs, and worked example the model is shown). Run
+trajectories — every turn, tool call, and observation, in order — are in the
+**Monitoring** section. See [Reading run outputs](./reading-run-outputs.md) and
+[Observability](./observability.md).
+
+## OSS / Cloud line
+
+The curated agentic prompt, the granted-tool menu, grammar-constrained decoding, and
+deterministic conversation ordering are all **OSS** (single-node, local models).
+Hosted/closed model backends, per-tenant persona management, and a prompt/policy
+marketplace are **Cloud**.

--- a/docs/site/docs/context.md
+++ b/docs/site/docs/context.md
@@ -202,9 +202,27 @@ At bind, the runtime resolves each attached handle to its item refs (caller-scop
 fail-closed on an unknown handle) and folds the sorted ref-set into the **entry
 Mote's identity-bearing `config_subset`**. At run time, the model executor fetches
 each blob from the content store and prepends it to the prompt as a labeled
-`[context <name>]` block, ahead of any upstream (parent) context. A missing ref or
-a window overflow **fails closed** — the model never runs on partial or unbounded
-context.
+`[context <name>]` block, ahead of any upstream (parent) context. A missing ref
+still **fails closed** — the model never runs on *partial* context.
+
+### Window budgeting (deterministic, never silent)
+
+Items arrive in relevance order (e.g. a RAG bundle is top-k by similarity). If the
+bundle fits the model window it is rendered verbatim. If it overflows, the runtime
+keeps the **highest-relevance prefix that fits** and appends a bounded, honest
+marker — `[context truncated: kept k/N items, dropped Bb]` — rather than failing the
+run. The cut is fully deterministic (same items + window ⇒ same prompt), so recovery
+re-reads identically. A single item larger than the whole window still fails closed
+(there is no partial-item rendering).
+
+### ReAct conversation order
+
+A multi-turn agent reads its own trajectory — prior turns and their tool
+observations — in **time order** (turn 0, its observation, turn 1, …), so the model
+follows the conversation as it happened. Very long autonomous chains are bounded by
+a **recency window**: the oldest steps are dropped (with an honest marker) to keep
+the most recent context, which is what the next step needs. This is all off-digest
+(it shapes the live prompt only, never a committed fact).
 
 A run that attaches **no** bundle is byte-identical to one authored before context
 bundles existed.

--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -167,6 +167,59 @@ KX_SERVE_REACT_GRAMMAR=0 kx serve     # disable grammar-constrained tool-calling
 (A per-run `.unconstrained()` override on the SDK chain is forward-declared; the
 serve flag is the reliable global switch today.)
 
+### The tool menu (so the model proposes tools)
+
+Grammar-constraint only *shapes* a tool call once the model decides to make one —
+it is dormant until the model proposes. For the model to propose autonomously, it
+has to **know which tools it has**. On a tool-eligible ReAct turn the runtime now
+prepends a **granted-tool menu** to the prompt, derived automatically from the run's
+warrant grants:
+
+```text
+You can call the following tools:
+
+name: mcp-calc/calc
+Bundled deterministic integer arithmetic …
+Inputs:
+  - op (enum, required)
+  - a (integer, required)
+  - b (integer, required)
+Example: {"op": "add", "a": 0, "b": 0}
+```
+
+- **Auto-derived, grant-scoped.** The menu lists *only* the tools granted to that
+  run (`warrant.tool_grants`) — never the full registry, so no ungranted tool ever
+  leaks into the prompt. Each entry leads with the exact callable name, then the
+  description, typed inputs, and a worked example so the model emits the right keys.
+- **One renderer.** It reuses the same renderer the context assembler uses, so the
+  menu the model sees is identical across the harness and the live server.
+- **Off-digest, advisory (SN-8).** The menu is built at dispatch and never journaled
+  or part of a run's identity (the digest is invariant); it is *advisory* — the
+  warrant grant-check and `inputSchema` validation remain the only authority.
+
+On by default; disable per deployment when starting `kx serve`:
+
+```bash
+KX_SERVE_REACT_TOOL_MENU=0 kx serve   # don't show the granted-tool menu
+```
+
+### The agentic system prompt
+
+ReAct turns are framed by a curated **agentic system contract** that states the
+reason→act→observe loop, the canonical tool-call envelope, and when to stop and
+answer — so small local models follow the protocol reliably. Chat/leaf turns keep
+the plain precise-assistant prompt unchanged.
+
+Operators can override the agentic contract with a domain persona per deployment:
+
+```bash
+KX_SERVE_REACT_SYSTEM="You are Ada, a terse SRE copilot. Prefer tools over guessing." kx serve
+```
+
+(Per-**run** system prompts — a different persona per invocation — are a planned
+follow-up; they need an optional recipe slot + a durable carry across the run's
+turn-0 anchor. The serve-level override is the reliable switch today.)
+
 ## Authoring a `tool()` step
 
 Beyond the ReAct loop (where the *model* picks tools), you can author a **`tool()`

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
         "agent-runner",
         "security",
         "tools",
+        "agentic-prompts",
         "authoring-a-connector",
         "managing-secrets",
         "authoring-a-trigger",

--- a/justfile
+++ b/justfile
@@ -579,6 +579,15 @@ build-serve-engine:
     echo " ✓ no kx-llamacpp in the kx-gateway serve-engine,hnsw closure"
     cargo build -p kx-cli --features serve-engine,hnsw
     cargo build -p kx-gateway --features serve-engine,hnsw
+    # RC3 (GR23 CI-hardening): the standard `clippy`/`test` stages run with DEFAULT
+    # features, which EXCLUDE `serve-engine` — so the live `kx serve` model loop
+    # (`model_exec`: dispatch, grammar-constrained tool-calling, the RC3 tool menu +
+    # curated agentic prompt) was previously only `cargo build`-checked, never
+    # clippy-linted or unit-tested in CI. Lint + run its FFI-free inline unit tests
+    # here (this recipe runs in the toolchain-free `build-serve-engine` CI job).
+    echo "Linting + unit-testing the FFI-free serve-engine model loop (model_exec)..."
+    cargo clippy -p kx-gateway --features serve-engine,hnsw --lib -- -D warnings
+    cargo test -p kx-gateway --features serve-engine,hnsw --lib -- --nocapture
     echo " ✓ build-serve-engine: PASS"
 
 # The installed-binary feature matrix stays buildable (the v0.1.0 campaign

--- a/ui/src/components/tools/RegisteredToolsPanel.tsx
+++ b/ui/src/components/tools/RegisteredToolsPanel.tsx
@@ -51,6 +51,15 @@ export function RegisteredToolsPanel() {
 
   return (
     <div data-testid="tools-registered">
+      {/* RC3: a short, honest note on how granted tools reach an agent — the model
+          is shown a menu of its granted tools (name, schema, a worked example) and
+          its proposals are grammar-constrained to the canonical envelope, so local
+          models call tools autonomously. The per-tool envelope is previewed below. */}
+      <p className="muted" data-testid="tools-agentic-note">
+        Agents are shown a <strong>menu</strong> of their granted tools and steered to the canonical
+        call envelope, so they propose tool calls autonomously. Each row previews how the model is
+        told to call it.
+      </p>
       {/* A deregister failure is typically non-retryable (forbidden / not-found),
           so surface it as a dismissable inline message (the RegisterToolForm
           pattern) — it clears on the next deregister attempt. */}
@@ -125,6 +134,16 @@ function RegistryRow({
           <Badge label={tool.registrationStatus} color={statusColor(tool.registrationStatus)} />
         </div>
         {tool.description ? <p className="registry-row__desc muted">{tool.description}</p> : null}
+        {/* RC3: how an agent is told to call this tool — the canonical tool-call
+            envelope the menu + grammar steer the model to emit. See the
+            "Agentic prompts" docs for the full menu (typed inputs + example). */}
+        <p
+          className="registry-row__desc mono"
+          data-testid={`tool-call-format-${tool.toolName}-${tool.toolVersion}`}
+          title="How an agent is told to call this tool — the canonical tool-call envelope"
+        >
+          {`{"tool_call":{"name":"${tool.toolName}","version":"${tool.toolVersion}","args":{ … }}}`}
+        </p>
         <dl className="registry-row__meta">
           <div>
             <dt className="muted">provenance</dt>


### PR DESCRIPTION
## RC3 — agentic excellence on OSS models (D172)

Third code PR of the OSS RC (after RC1 `kx-eval`, RC2 grammar). Makes local OSS-model agents **propose tools autonomously** and ReAct with **engineered context**. Every change is **off-digest** (`7d22d4bd` invariant held), **frozen-trio diff-empty**, **no schema/proto change**.

### LEAD — T-REACT-TOOL-MENU
The live `kx serve` ReAct prompt now prepends a **granted-tool menu** (name + version + typed inputs + worked example), derived at dispatch from `warrant.tool_grants` via the **shared** `render_tool_menu` (reuses the context-assembler's `tool_menu_text` — one renderer, no harness↔serve drift). RC2's grammar was dormant until a proposal; the menu unblocks it. Curated turn-kind-aware `REACT_SYSTEM` (chat/leaf keep `SERVE_SYSTEM` byte-identical). Advisory only (SN-8): `parse_tool_call` + `validate_args` stay the sole authority; only granted tools render.

### Context-engineering
- `assemble_context_items`: window-overflow now trims to the highest-relevance prefix + an honest marker (was fail-closed); fits-case byte-identical.
- NEW order-preserving `assemble_trajectory` for ReAct turns — **fixes a real bug** where the multi-turn trajectory was MoteId-scrambled (run-salted blake3) instead of time-ordered (D78) — + a byte-precise recency window.

### Serve controls (off-digest, operator-scope)
`KX_SERVE_REACT_TOOL_MENU` (default on) · `KX_SERVE_REACT_SYSTEM` (persona override). Per-run system-prompt authoring is deferred (`T-REACT-SYSTEM-PROMPT-PER-RUN`: needs `SlotBinding::Optional` + a durable ReactRound carry).

### CI hardening (GR23)
`build-serve-engine` now clippy-lints + unit-tests the serve-engine model loop (`model_exec`) — the standard `clippy`/`test` stages use default features and skipped it, so the live dispatch/grammar/menu was only build-checked. ~50 new tests.

### Live dual-engine witness (GR24/GR15, restart-per-run)
- **llama.cpp Gemma-4-12B**: fires a tool **autonomously** from a no-format-hint goal, reads the observation in order, answers. ✅ LEAD proven.
- **Ollama gemma3:12b**: proposes the correct tool **+ version** (the menu's version line fixed a "1.0" vs "1" miss); clean-fire pending Ollama strict-format mode (prose preamble + SN-8 no-mid-string-scan — `T-OLLAMA-GRAMMAR-FORMAT`).

### Gates (local, green)
`fmt` · workspace `clippy` · workspace `test` · serve-engine clippy+test (293) · `eval` ≥ baseline (suite_digest unchanged) · `doc` · `deny` · `build-no-inference` · `features-guard` · `ffi-link` · `check-reproducible` (7d22d4bd) · `a0_guard` · frozen-trio diff EMPTY · UI `biome` + `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)