### PR TITLE
fix(datasets): exact NN for tiny corpora — kill the HNSW discover flake (T-DATASETS-HNSW-DISCOVER-FLAKE)

### DIFF
--- a/crates/kx-dataset-hnsw/src/index.rs
+++ b/crates/kx-dataset-hnsw/src/index.rs
@@ -139,17 +139,37 @@ impl RetrievalIndex for HnswRetrievalIndex {
             return Vec::new();
         }
         let ef = self.params.ef_search.max(k);
-        let neighbours = self.hnsw.search(query, k, ef);
-        let mut hits: Vec<Hit> = neighbours
-            .iter()
-            .filter_map(|n| {
-                self.ids.get(n.get_origin_id()).map(|&id| Hit {
-                    id,
-                    // DistCosine distance == 1 - cosine_similarity → similarity == 1 - distance.
-                    score: 1.0 - n.get_distance(),
+        // EXACT search when the corpus fits the search width (`n <= ef`): HNSW's
+        // approximate graph traversal buys nothing once `ef >= n`, and on a TINY
+        // graph the crate's randomized layer assignment can occasionally MISS the
+        // true nearest neighbour even with `ef >= n` (the
+        // `T-DATASETS-HNSW-DISCOVER-FLAKE` class — a non-deterministic top-hit on a
+        // small corpus). A brute-force pass over the stored vectors is exhaustive,
+        // deterministic, and cheaper here; above `ef` we keep the HNSW path
+        // unchanged for large corpora. `score = cosine similarity` matches the HNSW
+        // arm's `1.0 - DistCosine` (DistCosine == 1 - cosine_similarity).
+        let mut hits: Vec<Hit> = if self.ids.len() <= ef {
+            self.vectors
+                .iter()
+                .enumerate()
+                .map(|(data_id, v)| Hit {
+                    id: self.ids[data_id],
+                    score: cosine_similarity(query, v),
                 })
-            })
-            .collect();
+                .collect()
+        } else {
+            self.hnsw
+                .search(query, k, ef)
+                .iter()
+                .filter_map(|n| {
+                    self.ids.get(n.get_origin_id()).map(|&id| Hit {
+                        id,
+                        // DistCosine distance == 1 - cosine_similarity → similarity == 1 - distance.
+                        score: 1.0 - n.get_distance(),
+                    })
+                })
+                .collect()
+        };
         // Deterministic order for the committed ordered-ref fact: score desc, then
         // ascending content ref — mirrors InMemoryRetrievalIndex's stable tiebreak.
         hits.sort_by(|a, b| {
@@ -163,5 +183,26 @@ impl RetrievalIndex for HnswRetrievalIndex {
 
     fn len(&self) -> usize {
         self.ids.len()
+    }
+}
+
+/// Cosine similarity in `[-1, 1]`, matching `1.0 - DistCosine` (the HNSW arm's
+/// score). Used by the exact small-corpus path in [`HnswRetrievalIndex::query`].
+/// Pure + total: a zero-norm vector (no direction) yields `0.0` rather than a
+/// `NaN` division; inputs are already validated finite upstream.
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom == 0.0 {
+        0.0
+    } else {
+        dot / denom
     }
 }

--- a/crates/kx-dataset-hnsw/src/tests.rs
+++ b/crates/kx-dataset-hnsw/src/tests.rs
@@ -61,6 +61,34 @@ fn deterministic_repeat_query_on_fixed_graph() {
 }
 
 #[test]
+fn tiny_corpus_query_is_exact_and_deterministic() {
+    // Regression for T-DATASETS-HNSW-DISCOVER-FLAKE: on a tiny corpus (n <= ef) the
+    // query takes the EXACT brute-force path, so the true nearest neighbour is ALWAYS
+    // the top hit — the approximate HNSW graph could occasionally MISS it (a random
+    // top-hit on a small graph). The gateway `discover_returns_exact_out_refs_and_bp_scores`
+    // flake lived here. Rebuild the index 50× (a fresh randomized graph each time) to
+    // pin that the result no longer depends on the graph's random layer assignment.
+    for _ in 0..50 {
+        let mut idx = HnswRetrievalIndex::new();
+        idx.insert(cref(0), onehot(3, 0)); // alpha   (axis 0)
+        idx.insert(cref(1), onehot(3, 1)); // bravo   (axis 1)
+        idx.insert(cref(2), onehot(3, 2)); // charlie (axis 2)
+        let hits = idx.query(&onehot(3, 1), 3); // closest to axis 1 ⇒ bravo (cosine 1.0)
+        assert_eq!(hits.len(), 3);
+        assert_eq!(
+            hits[0].id,
+            cref(1),
+            "the exact nearest (bravo) must ALWAYS rank first"
+        );
+        assert!(
+            (hits[0].score - 1.0).abs() < 1e-6,
+            "the exact-match cosine score is ~1.0, got {}",
+            hits[0].score
+        );
+    }
+}
+
+#[test]
 fn idempotent_duplicate_insert() {
     let mut idx = HnswRetrievalIndex::new();
     idx.insert(cref(1), onehot(4, 0));


### PR DESCRIPTION
The RC3 (#270) follow-up — fixes the only non-required CI flake surfaced by RC3.

## Problem
`inference-checks` occasionally failed on `datasets::tests::discover_returns_exact_out_refs_and_bp_scores`: HNSW's **approximate** graph traversal can miss the true nearest neighbour on a tiny corpus even with `ef ≥ n` (randomized layer assignment). Pre-existing (not RC3); passes locally under the exact CI combo, flakes in CI.

## Fix
`HnswRetrievalIndex::query()` takes an **exact brute-force** pass over the stored vectors when the corpus fits the search width (`n ≤ ef`) — HNSW buys nothing there, and exact is exhaustive, deterministic, and cheaper; above `ef` the HNSW path is unchanged for large corpora. `score = cosine_similarity` matches the HNSW arm's `1.0 - DistCosine`.

**CLASS:** an approximate-ANN assertion on a small corpus is non-deterministic.

## Tests
- New `tiny_corpus_query_is_exact_and_deterministic` — rebuilds the index 50× (fresh random graph each) and always ranks the exact match first.
- The originally-flaky gateway test now passes **20/20** under `--features inference,embedded-worker,hnsw`.
- `top1_parity_with_inmemory` (16 docs) now takes the exact path ⇒ its latent flake is gone too.
- Large-corpus scale test (HNSW path) unchanged.

## Invariants
digest `7d22d4bd` held (check-reproducible I1.c PASS) · frozen-trio diff EMPTY · no schema/proto change · 2 files, kx-dataset-hnsw only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)