### PR TITLE
feat(rc4b): agentic RAG — retrieve@1 tool + react-rag/vision-rag recipes (D172)

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -31,6 +31,8 @@ from .capture import CaptureRecord, CaptureRecordPage
 from .chains import Chain, Task, chain, model, pure
 from .client import (
     DEFAULT_ENDPOINT,
+    REACT_RAG_RECIPE_HANDLE,
+    VISION_RAG_RECIPE_HANDLE,
     VISION_RECIPE_HANDLE,
     AsyncKxClient,
     ImageInput,
@@ -147,6 +149,9 @@ __all__ = [
     "AsyncKxClient",
     # PR-B2 vision
     "VISION_RECIPE_HANDLE",
+    # RC4b agentic RAG
+    "REACT_RAG_RECIPE_HANDLE",
+    "VISION_RAG_RECIPE_HANDLE",
     "ImageInput",
     # POC-4 Apps (kortecx.app/v1 envelopes)
     "app",

--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -177,6 +177,19 @@ VISION_RECIPE_HANDLE = "kx/recipes/vision"
 #: ``kx/recipes/react`` prefix, so :func:`_is_react_handle` settles it as a chain.
 REACT_VISION_RECIPE_HANDLE = "kx/recipes/react-vision"
 
+#: RC4b AGENTIC RAG: the dataset-grounded ReAct recipe — a live agent loop whose warrant
+#: grants the read-only ``retrieve`` tool, so the model AUTONOMOUSLY searches a corpus
+#: (hybrid keyword+semantic), reads the passages, and can re-query across turns. Invoke it
+#: with ``{"instruction": <goal>, "dataset": <name>}``; the server folds the dataset name
+#: into the instruction. Shares the ``kx/recipes/react`` prefix, so it settles as a chain.
+REACT_RAG_RECIPE_HANDLE = "kx/recipes/react-rag"
+
+#: RC4b VISION-RAG: a single grounded multimodal completion — the served VLM answers about
+#: an attached image WHILE grounded on a dataset's top-k retrieved TEXT passages (one
+#: generation). Bind ``{"prompt", "image_ref", "model", "dataset", "k"}`` (``chat(image=,
+#: dataset=)`` does this). Datasets stay text-only (image-embedding is post-RC).
+VISION_RAG_RECIPE_HANDLE = "kx/recipes/vision-rag"
+
 ArgsType = Union[dict, bytes, bytearray, str]
 IdType = Union[str, bytes]
 #: PR-B2: an image to attach to :meth:`chat`. Raw ``bytes`` (uploaded), or a dict
@@ -640,6 +653,36 @@ class KxClient:
             raise KxUsage("the kx/recipes/react-vision form does not declare an image_ref slot")
         return REACT_VISION_RECIPE_HANDLE, {**args, "image_ref": image_ref}
 
+    def _bind_vision_rag(
+        self, prompt: str, image_ref: str, dataset: str, k: int
+    ) -> Tuple[str, dict]:
+        """RC4b: bind ``kx/recipes/vision-rag`` — the VLM answers about the image WHILE
+        grounded on the dataset's retrieved text (one generation). Honest-degrades with a
+        clear error when vision-RAG is not provisioned (needs BOTH a vision model AND the
+        dataset/hnsw features) — never silently drops the dataset (GR15)."""
+        try:
+            form = self.get_recipe_form(VISION_RAG_RECIPE_HANDLE)
+        except Exception as e:  # recipe not provisioned (text-only / non-hnsw / old gateway)
+            raise KxUsage(
+                "vision-RAG is not available on this serve — it needs BOTH an image-capable "
+                "model AND the dataset (hnsw) features. Drop 'dataset' for a plain vision "
+                "answer, or serve a vision model with datasets enabled."
+            ) from e
+        by = {f.name: f for f in form.fields}
+        if "image_ref" not in by:
+            raise KxUsage("the kx/recipes/vision-rag form does not declare an image_ref slot")
+        args: dict = {"image_ref": image_ref, "dataset": dataset, "k": k}
+        if "prompt" in by:
+            args["prompt"] = prompt
+        model = by.get("model")
+        if model is not None:
+            args["model"] = (
+                self.default_model
+                if (self.default_model and self.default_model in model.allowed)
+                else model.allowed[0]
+            )
+        return VISION_RAG_RECIPE_HANDLE, args
+
     def chat(
         self,
         prompt: str,
@@ -668,17 +711,16 @@ class KxClient:
 
         PR-B2: pass ``image`` (raw ``bytes`` or ``{"ref": <hex>}``) to attach an image
         and bind ``kx/recipes/vision`` (image→text on a vision-capable model on either
-        engine; also prompted OCR). ``dataset`` + ``image`` together is not yet
-        supported (vision-RAG is a follow-up) — a clear :class:`KxUsage`, never a
-        silent drop."""
+        engine; also prompted OCR). RC4b: ``dataset`` + ``image`` together binds
+        ``kx/recipes/vision-rag`` — the VLM answers about the image WHILE grounded on the
+        dataset's retrieved text (a clear :class:`KxUsage` when vision-RAG is not
+        provisioned, never a silent drop)."""
         if image is not None:
-            if dataset is not None:
-                raise KxUsage(
-                    "chat: 'dataset' and 'image' cannot be combined "
-                    "(vision-RAG is not yet supported)"
-                )
             image_ref = self._resolve_image_ref(image)
-            v_handle, v_args = self._bind_vision(prompt, image_ref)
+            if dataset is not None:
+                v_handle, v_args = self._bind_vision_rag(prompt, image_ref, dataset, k)
+            else:
+                v_handle, v_args = self._bind_vision(prompt, image_ref)
             v_result = self.invoke(v_handle, v_args, wait=True, timeout=timeout)
             assert isinstance(v_result, Result)
             return v_result.text or ""
@@ -2358,6 +2400,33 @@ class AsyncKxClient:
             raise KxUsage("the kx/recipes/react-vision form does not declare an image_ref slot")
         return REACT_VISION_RECIPE_HANDLE, {**args, "image_ref": image_ref}
 
+    async def _bind_vision_rag(
+        self, prompt: str, image_ref: str, dataset: str, k: int
+    ) -> Tuple[str, dict]:
+        """Async mirror of :meth:`KxClient._bind_vision_rag` (RC4b vision-RAG)."""
+        try:
+            form = await self.get_recipe_form(VISION_RAG_RECIPE_HANDLE)
+        except Exception as e:  # recipe not provisioned (text-only / non-hnsw / old gateway)
+            raise KxUsage(
+                "vision-RAG is not available on this serve — it needs BOTH an image-capable "
+                "model AND the dataset (hnsw) features. Drop 'dataset' for a plain vision "
+                "answer, or serve a vision model with datasets enabled."
+            ) from e
+        by = {f.name: f for f in form.fields}
+        if "image_ref" not in by:
+            raise KxUsage("the kx/recipes/vision-rag form does not declare an image_ref slot")
+        args: dict = {"image_ref": image_ref, "dataset": dataset, "k": k}
+        if "prompt" in by:
+            args["prompt"] = prompt
+        model = by.get("model")
+        if model is not None:
+            args["model"] = (
+                self.default_model
+                if (self.default_model and self.default_model in model.allowed)
+                else model.allowed[0]
+            )
+        return VISION_RAG_RECIPE_HANDLE, args
+
     async def chat(
         self,
         prompt: str,
@@ -2371,16 +2440,14 @@ class AsyncKxClient:
         question (optionally AUTO-RAG-grounded against ``dataset``, or image-bearing
         via ``image`` → ``kx/recipes/vision``) and return the committed answer text.
         The server degrades honestly to a plain answer when the dataset is
-        missing/empty (never fakes grounding); ``dataset`` + ``image`` together is a
-        :class:`KxUsage` (vision-RAG is a follow-up)."""
+        missing/empty (never fakes grounding); RC4b: ``dataset`` + ``image`` together
+        binds ``kx/recipes/vision-rag`` (image answer grounded on retrieved text)."""
         if image is not None:
-            if dataset is not None:
-                raise KxUsage(
-                    "chat: 'dataset' and 'image' cannot be combined "
-                    "(vision-RAG is not yet supported)"
-                )
             image_ref = await self._resolve_image_ref(image)
-            v_handle, v_args = await self._bind_vision(prompt, image_ref)
+            if dataset is not None:
+                v_handle, v_args = await self._bind_vision_rag(prompt, image_ref, dataset, k)
+            else:
+                v_handle, v_args = await self._bind_vision(prompt, image_ref)
             v_result = await self.invoke(v_handle, v_args, wait=True, timeout=timeout)
             assert isinstance(v_result, Result)
             return v_result.text or ""

--- a/bindings/python/tests/test_vision_attach.py
+++ b/bindings/python/tests/test_vision_attach.py
@@ -78,8 +78,23 @@ def test_chat_prefers_default_model_when_legal() -> None:
     assert c.invoked[1]["model"] == "gemma3:12b"
 
 
-def test_dataset_and_image_together_is_usage() -> None:
+def test_dataset_and_image_binds_vision_rag() -> None:
+    # RC4b: image + dataset now binds kx/recipes/vision-rag (the VLM answers about the
+    # image WHILE grounded on the dataset's retrieved text) — no longer a usage error.
     c = _VisionFake(_vision_form(["m"]))
+    out = c.chat("describe", image=b"\x01", dataset="docs", k=3)
+    assert out == "a cat"
+    handle, args = c.invoked
+    assert handle == "kx/recipes/vision-rag"
+    assert args["image_ref"] == "ab" * 32
+    assert args["dataset"] == "docs"
+    assert args["k"] == 3
+
+
+def test_dataset_and_image_honest_degrades_when_vision_rag_absent() -> None:
+    # No vision-rag recipe (no image-capable model / non-hnsw serve) ⇒ a clear KxUsage,
+    # never a silent drop of the image or the dataset (GR15).
+    c = _VisionFake(None)
     with pytest.raises(KxUsage):
         c.chat("hi", image=b"\x01", dataset="docs")
 

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -138,6 +138,17 @@ export const VISION_RECIPE_HANDLE = "kx/recipes/vision";
  * so it settles as a react CHAIN (the `isReactHandle` prefix check). */
 export const REACT_VISION_RECIPE_HANDLE = "kx/recipes/react-vision";
 
+/** RC4b AGENTIC RAG: the dataset-grounded ReAct recipe — a live agent loop whose warrant
+ * grants the read-only `retrieve` tool, so the model AUTONOMOUSLY searches a corpus
+ * (hybrid), reads passages, and can re-query. Invoke with `{ instruction, dataset }`;
+ * shares the `kx/recipes/react` prefix, so it settles as a chain. */
+export const REACT_RAG_RECIPE_HANDLE = "kx/recipes/react-rag";
+
+/** RC4b VISION-RAG: a single grounded multimodal completion — the served VLM answers
+ * about an attached image WHILE grounded on a dataset's retrieved TEXT passages (one
+ * generation). `chat(prompt, { image, dataset })` binds it. Text-only datasets. */
+export const VISION_RAG_RECIPE_HANDLE = "kx/recipes/vision-rag";
+
 /**
  * An image to attach to a {@link KxClientBase.chat} call (PR-B2). Either an existing
  * `{ ref }` (a 64-hex `PutContent` ref) or raw `bytes` to upload (a bare `Uint8Array`
@@ -324,17 +335,16 @@ export abstract class KxClientBase {
     opts: { dataset?: string; k?: number; timeoutMs?: number; image?: ImageInput } = {},
   ): Promise<string> {
     // PR-B2 vision: an `image` attaches to the SAME single-entry chat call and binds
-    // the `kx/recipes/vision` recipe (image→text on whichever engine serves a
-    // vision-capable model). `dataset` + `image` together is not yet supported
-    // (vision-RAG is a follow-up) — a clear usage error, never a silent drop.
+    // the `kx/recipes/vision` recipe (image→text). RC4b: `image` + `dataset` together
+    // binds `kx/recipes/vision-rag` — the VLM answers about the image WHILE grounded on
+    // the dataset's retrieved text (a clear usage error when vision-RAG is not
+    // provisioned, never a silent drop).
     if (opts.image !== undefined) {
-      if (opts.dataset !== undefined) {
-        throw new KxUsage(
-          "chat: `dataset` and `image` cannot be combined (vision-RAG is not yet supported)",
-        );
-      }
       const imageRef = await this.resolveImageRef(opts.image);
-      const { handle, args } = await this.bindVision(prompt, imageRef);
+      const { handle, args } =
+        opts.dataset !== undefined
+          ? await this.bindVisionRag(prompt, imageRef, opts.dataset, opts.k ?? 4)
+          : await this.bindVision(prompt, imageRef);
       const result = (await this.invoke(handle, args, {
         wait: true,
         timeoutMs: opts.timeoutMs,
@@ -399,6 +409,42 @@ export abstract class KxClientBase {
           : model.allowed[0];
     }
     return { handle: VISION_RECIPE_HANDLE, args };
+  }
+
+  /**
+   * RC4b: bind `kx/recipes/vision-rag` — the served VLM answers about the image WHILE
+   * grounded on the dataset's top-k retrieved text (`{ prompt, image_ref, model, dataset,
+   * k }`; the server strips + folds `dataset`/`k`). Honest-degrade: a clear usage error
+   * when vision-RAG is not provisioned (needs BOTH a vision model AND dataset/hnsw).
+   */
+  private async bindVisionRag(
+    prompt: string,
+    imageRef: string,
+    dataset: string,
+    k: number,
+  ): Promise<{ handle: string; args: Args }> {
+    let form: RecipeForm;
+    try {
+      form = await this.getRecipeForm(VISION_RAG_RECIPE_HANDLE);
+    } catch {
+      throw new KxUsage(
+        "vision-RAG is not available on this serve — it needs BOTH an image-capable model AND the dataset (hnsw) features. Drop `dataset` for a plain vision answer, or serve a vision model with datasets enabled.",
+      );
+    }
+    const has = (n: string) => form.fields.find((f) => f.name === n);
+    if (!has("image_ref")) {
+      throw new KxUsage("the kx/recipes/vision-rag form does not declare an image_ref slot");
+    }
+    const args: Args = { image_ref: imageRef, dataset, k };
+    if (has("prompt")) args.prompt = prompt;
+    const model = has("model");
+    if (model) {
+      args.model =
+        this.defaultModel !== undefined && model.allowed.includes(this.defaultModel)
+          ? this.defaultModel
+          : model.allowed[0];
+    }
+    return { handle: VISION_RAG_RECIPE_HANDLE, args };
   }
 
   /**

--- a/bindings/typescript/test/vision-attach.test.ts
+++ b/bindings/typescript/test/vision-attach.test.ts
@@ -69,8 +69,20 @@ describe("chat({ image })", () => {
     expect((c.invoked?.args as Record<string, unknown>).model).toBe("gemma3:12b");
   });
 
-  it("rejects dataset + image together (vision-RAG not supported)", async () => {
+  it("binds kx/recipes/vision-rag for image + dataset (grounds the image answer)", async () => {
+    // RC4b: image + dataset is now SUPPORTED — it binds vision-rag with {dataset, k}.
     const c = new VisionFake(visionForm(["m"]));
+    const out = await c.chat("describe", { image: new Uint8Array([1]), dataset: "docs", k: 3 });
+    expect(out).toBe("a cat");
+    expect(c.invoked?.handle).toBe("kx/recipes/vision-rag");
+    const args = c.invoked?.args as Record<string, unknown>;
+    expect(args.image_ref).toBe("ab".repeat(32));
+    expect(args.dataset).toBe("docs");
+    expect(args.k).toBe(3);
+  });
+
+  it("honest-degrades to a clear error when vision-RAG is not provisioned", async () => {
+    const c = new VisionFake(null); // getRecipeForm throws ⇒ no vision-rag recipe
     await expect(
       c.chat("hi", { image: new Uint8Array([1]), dataset: "docs" }),
     ).rejects.toBeInstanceOf(KxUsage);

--- a/crates/kx-cli/src/verbs/agent.rs
+++ b/crates/kx-cli/src/verbs/agent.rs
@@ -23,6 +23,10 @@ const REACT_RECIPE_HANDLE: &str = "kx/recipes/react";
 /// AGENTIC-VISION: the image-grounded ReAct recipe — bound (form-gated) when `--image`
 /// is supplied so the served VLM reasons over the attached image on every turn.
 const REACT_VISION_RECIPE_HANDLE: &str = "kx/recipes/react-vision";
+/// RC4b AGENTIC RAG: the dataset-grounded ReAct recipe — bound (form-gated) when
+/// `--dataset` is supplied so the model AUTONOMOUSLY searches the corpus with the
+/// read-only `retrieve` tool, reads the passages, and can re-query across turns.
+const REACT_RAG_RECIPE_HANDLE: &str = "kx/recipes/react-rag";
 /// The recipe's anchored bounded-loop budget (mirrors the SDK + the UI's planReactArgs).
 const DEFAULT_MAX_TURNS: u32 = 8;
 // T-MULTI-ELEMENT-TOOLCALLS: the default tool-call cap rose 6 → 20 (decoupled from
@@ -51,6 +55,11 @@ pub struct AgentArgs {
     /// the run binds `kx/recipes/react-vision` (form-gated) so the served VLM reasons over
     /// the image on EVERY turn; fail-closed (a usage error) when no vision model is served.
     pub image: Option<String>,
+    /// RC4b AGENTIC RAG: a dataset to ground the agentic run (`--dataset <name>`). When
+    /// set, the run binds `kx/recipes/react-rag` (form-gated) so the model searches the
+    /// corpus with the `retrieve` tool; honest-degrade to a plain agent when react-rag
+    /// is not provisioned (the non-`hnsw` build). Mutually exclusive with `--image`.
+    pub dataset: Option<String>,
     /// Common client flags.
     pub common: ClientCommon,
 }
@@ -74,6 +83,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<AgentArgs, CliErr
     let mut max_turns = DEFAULT_MAX_TURNS;
     let mut max_tool_calls = DEFAULT_MAX_TOOL_CALLS;
     let mut image: Option<String> = None;
+    let mut dataset: Option<String> = None;
     let mut common = ClientCommon::default();
     while let Some(flag) = args.next() {
         if common.try_consume(&flag, &mut args)? {
@@ -109,6 +119,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<AgentArgs, CliErr
                 })?;
             }
             "--image" => image = Some(next_value(&mut args, "--image")?),
+            "--dataset" => dataset = Some(next_value(&mut args, "--dataset")?),
             other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
         }
     }
@@ -122,6 +133,7 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<AgentArgs, CliErr
         max_turns,
         max_tool_calls,
         image,
+        dataset,
         common,
     })
 }
@@ -160,26 +172,27 @@ async fn upload_image(
     Ok(crate::hex::encode(&put.content_ref))
 }
 
-/// Execute `agent run`.
-pub async fn execute(args: AgentArgs) -> Result<(), CliError> {
-    let resolved = args.common.resolve()?;
-    let mut client = resolved.connect().await?;
-
-    let instruction = fold_inputs(&args.goal, &args.inputs);
-    let mut obj = serde_json::Map::new();
-    obj.insert("instruction".to_string(), serde_json::json!(instruction));
-    obj.insert("max_turns".to_string(), serde_json::json!(args.max_turns));
-    obj.insert(
-        "max_tool_calls".to_string(),
-        serde_json::json!(args.max_tool_calls),
-    );
-
-    // AGENTIC-VISION: `--image` binds the image-grounded ReAct recipe (form-gated) so the
-    // served VLM reasons over the attached image on EVERY turn of the chain. Fail-closed
-    // (a usage error) when no vision model is served — never silently run text-only and
-    // drop the image (that would be a lie; GR15).
-    let handle = if let Some(path) = &args.image {
-        let image_ref = upload_image(&mut client, &resolved, std::path::Path::new(path)).await?;
+/// Select the ReAct recipe handle for this run + fold any image/dataset binding into
+/// `obj`. `--image` ⇒ `react-vision` (form-gated, fail-closed when no vision model);
+/// `--dataset` ⇒ `react-rag` (form-gated, honest-degrade to a plain agent); else the
+/// plain `react` recipe. `--image` + `--dataset` is a usage error (no agentic vision-RAG
+/// recipe yet — `kx chat --image --dataset` does single-shot vision-RAG).
+async fn select_handle(
+    client: &mut proto::kx_gateway_client::KxGatewayClient<tonic::transport::Channel>,
+    resolved: &crate::client::Resolved,
+    args: &AgentArgs,
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+) -> Result<&'static str, CliError> {
+    if let Some(path) = &args.image {
+        if args.dataset.is_some() {
+            return Err(CliError::Usage(
+                "--image and --dataset cannot be combined for `kx agent` (an agentic \
+                 vision-RAG loop is not a recipe yet); use `kx chat --image --dataset` for a \
+                 single-shot image + text-RAG answer, or drop one flag"
+                    .into(),
+            ));
+        }
+        let image_ref = upload_image(client, resolved, std::path::Path::new(path)).await?;
         let form = client
             .get_recipe_form(resolved.request(proto::GetRecipeFormRequest {
                 handle: REACT_VISION_RECIPE_HANDLE.to_string(),
@@ -201,10 +214,50 @@ pub async fn execute(args: AgentArgs) -> Result<(), CliError> {
         eprintln!(
             "· image attached — binding the vision agent (reasons over the image every turn)"
         );
-        REACT_VISION_RECIPE_HANDLE
+        Ok(REACT_VISION_RECIPE_HANDLE)
+    } else if let Some(dataset) = &args.dataset {
+        // RC4b: `--dataset` binds the agentic-RAG ReAct recipe so the model searches the
+        // corpus with the read-only `retrieve` tool. Form-gated: honest-degrade to a plain
+        // agent when react-rag is not provisioned (the non-hnsw build), never fake grounding.
+        let provisioned = client
+            .get_recipe_form(resolved.request(proto::GetRecipeFormRequest {
+                handle: REACT_RAG_RECIPE_HANDLE.to_string(),
+            })?)
+            .await
+            .is_ok();
+        if provisioned {
+            obj.insert("dataset".to_string(), serde_json::json!(dataset));
+            eprintln!(
+                "· agentic RAG over dataset '{dataset}' — the model searches it with the retrieve tool"
+            );
+            Ok(REACT_RAG_RECIPE_HANDLE)
+        } else {
+            eprintln!(
+                "· dataset '{dataset}' requested but react-rag is not provisioned (needs the \
+                 hnsw build) — running a plain agent"
+            );
+            Ok(REACT_RECIPE_HANDLE)
+        }
     } else {
-        REACT_RECIPE_HANDLE
-    };
+        Ok(REACT_RECIPE_HANDLE)
+    }
+}
+
+/// Execute `agent run`.
+pub async fn execute(args: AgentArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+
+    let instruction = fold_inputs(&args.goal, &args.inputs);
+    let mut obj = serde_json::Map::new();
+    obj.insert("instruction".to_string(), serde_json::json!(instruction));
+    obj.insert("max_turns".to_string(), serde_json::json!(args.max_turns));
+    obj.insert(
+        "max_tool_calls".to_string(),
+        serde_json::json!(args.max_tool_calls),
+    );
+
+    let handle = select_handle(&mut client, &resolved, &args, &mut obj).await?;
     let req_args = serde_json::Value::Object(obj).to_string().into_bytes();
 
     let resp = client
@@ -308,6 +361,20 @@ mod tests {
         );
         assert!(a.common.json);
         assert_eq!(a.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn run_parses_dataset_for_agentic_rag() {
+        let a = p(&[
+            "run",
+            "--goal",
+            "what does the handbook say",
+            "--dataset",
+            "handbook",
+        ])
+        .unwrap();
+        assert_eq!(a.dataset.as_deref(), Some("handbook"));
+        assert!(a.image.is_none());
     }
 
     #[test]

--- a/crates/kx-cli/src/verbs/chat.rs
+++ b/crates/kx-cli/src/verbs/chat.rs
@@ -21,6 +21,9 @@ use crate::{verbs, wait};
 /// The vision recipe (PR-B2) — `--image` binds it (image→text / prompted OCR on a
 /// vision-capable model on either engine).
 const VISION_CHAT_HANDLE: &str = "kx/recipes/vision";
+/// RC4b VISION-RAG: `--image` + `--dataset` binds this (the served VLM answers about the
+/// image WHILE grounded on the dataset's top-k retrieved text passages — one generation).
+const VISION_RAG_CHAT_HANDLE: &str = "kx/recipes/vision-rag";
 
 /// Default `--wait` timeout (matches `invoke`/`agent`).
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
@@ -117,13 +120,31 @@ pub async fn execute(args: ChatArgs) -> Result<(), CliError> {
     // image_ref slot), print a notice and answer the message plainly — never silently
     // drop the image, never fake an answer about it.
     let (handle, args_json): (String, serde_json::Value) = if let Some(path) = args.image.clone() {
-        if args.dataset.is_some() {
-            return Err(CliError::Usage(
-                "--image and --dataset cannot be combined (vision-RAG is not yet supported)".into(),
-            ));
-        }
-        if let Some(plan) = plan_vision(&mut client, &resolved, &path, &args.message).await? {
+        // RC4b: `--image` + `--dataset` binds `kx/recipes/vision-rag` (the VLM answers about
+        // the image WHILE grounded on the dataset's retrieved text). HONEST-degrade ladder:
+        // vision-rag → plain vision (image only) → plain chat — never silently drop the image
+        // or fake grounding (GR15).
+        let rag = args.dataset.as_deref().map(|d| (d, args.k));
+        if let Some(plan) = plan_vision(&mut client, &resolved, &path, &args.message, rag).await? {
             plan
+        } else if rag.is_some() {
+            // vision-rag not provisioned — try plain vision (image only), then plain chat.
+            if let Some(plan) =
+                plan_vision(&mut client, &resolved, &path, &args.message, None).await?
+            {
+                eprintln!(
+                    "· vision-RAG not available — answering about the image without dataset grounding"
+                );
+                plan
+            } else {
+                eprintln!(
+                    "· image + dataset attached but no image-capable model is served — answering plainly"
+                );
+                (
+                    PLAIN_CHAT_HANDLE.to_string(),
+                    serde_json::json!({ "prompt": args.message }),
+                )
+            }
         } else {
             eprintln!(
                 "· image attached but no image-capable model is served — answering without it"
@@ -208,15 +229,18 @@ async fn plan_text(
     }
 }
 
-/// Plan an image-bearing chat (PR-B2): upload the image, resolve the `kx/recipes/vision`
-/// form, and assemble `{ prompt, image_ref, model }`. Returns `None` when no
-/// image-capable model is served (the form is absent / lacks the `image_ref` slot), so
-/// the caller can honest-degrade to plain chat instead of faking an answer.
+/// Plan an image-bearing chat: upload the image, resolve the recipe form, and assemble
+/// `{ prompt, image_ref, model }` (PR-B2). When `rag = Some((dataset, k))` it targets
+/// `kx/recipes/vision-rag` and ALSO passes `{ dataset, k }` (stripped + folded server-side
+/// into the retrieved-text context) — the VLM answers about the image grounded on the
+/// dataset (RC4b). Returns `None` when the targeted recipe is not provisioned (the form is
+/// absent / lacks the `image_ref` slot), so the caller can honest-degrade.
 async fn plan_vision(
     client: &mut kx_proto::proto::kx_gateway_client::KxGatewayClient<tonic::transport::Channel>,
     resolved: &crate::client::Resolved,
     path: &std::path::Path,
     message: &str,
+    rag: Option<(&str, u32)>,
 ) -> Result<Option<(String, serde_json::Value)>, CliError> {
     let payload =
         std::fs::read(path).map_err(|e| CliError::Io(format!("read {}: {e}", path.display())))?;
@@ -235,11 +259,16 @@ async fn plan_vision(
         .into_inner();
     let image_ref = crate::hex::encode(&put.content_ref);
 
-    // Resolve the vision recipe form (the SAME form-gate the SDK/console use). An
-    // absent form / RPC error ⇒ honest-degrade (`None`).
+    // Resolve the targeted recipe form (vision-rag when grounding, else vision) — the SAME
+    // form-gate the SDK/console use. An absent form / RPC error ⇒ honest-degrade (`None`).
+    let handle = if rag.is_some() {
+        VISION_RAG_CHAT_HANDLE
+    } else {
+        VISION_CHAT_HANDLE
+    };
     let Ok(form_resp) = client
         .get_recipe_form(resolved.request(proto::GetRecipeFormRequest {
-            handle: VISION_CHAT_HANDLE.to_string(),
+            handle: handle.to_string(),
         })?)
         .await
     else {
@@ -261,11 +290,16 @@ async fn plan_vision(
         let chosen = model.allowed.first().cloned().unwrap_or_default();
         obj.insert("model".to_string(), serde_json::json!(chosen));
     }
-    eprintln!("· image attached — binding the vision model (image→text / OCR)");
-    Ok(Some((
-        VISION_CHAT_HANDLE.to_string(),
-        serde_json::Value::Object(obj),
-    )))
+    if let Some((dataset, k)) = rag {
+        // dataset/k are NOT declared slots — the server strips them and folds the
+        // retrieved text into the prompt (the chat-rag grounding path; SN-8 exact refs).
+        obj.insert("dataset".to_string(), serde_json::json!(dataset));
+        obj.insert("k".to_string(), serde_json::json!(k));
+        eprintln!("· image + dataset '{dataset}' — grounding the vision answer on retrieved text");
+    } else {
+        eprintln!("· image attached — binding the vision model (image→text / OCR)");
+    }
+    Ok(Some((handle.to_string(), serde_json::Value::Object(obj))))
 }
 
 #[cfg(test)]
@@ -332,10 +366,11 @@ mod tests {
     }
 
     #[test]
-    fn image_and_dataset_both_parse_execute_rejects() {
-        // Parse accepts both; the mutual-exclusion (vision-RAG unsupported) is enforced
-        // in `execute` after connect (covered by the live e2e). This pins that parse
-        // does not pre-reject the combination.
+    fn image_and_dataset_both_parse_and_route_to_vision_rag() {
+        // RC4b: `--image` + `--dataset` is now SUPPORTED — it parses and (in `execute`,
+        // covered by the live e2e) binds `kx/recipes/vision-rag` with an honest-degrade
+        // ladder (vision-rag → plain vision → plain chat). This pins that parse accepts
+        // the combination (no pre-rejection).
         let a = parse_v(&["hi", "--image", "/tmp/x.png", "--dataset", "docs"]).unwrap();
         assert!(a.image.is_some() && a.dataset.is_some());
     }

--- a/crates/kx-gateway/src/lib.rs
+++ b/crates/kx-gateway/src/lib.rs
@@ -122,6 +122,12 @@ mod metrics;
 // decode arm lives in the serve-engine executor; the MCP adapter is FFI-free).
 #[cfg(feature = "serve-engine")]
 mod mcp_tool;
+// RC4b (agentic RAG): the bundled read-only `retrieve@1` capability + typed ToolDef
+// + serve-broker registration — makes a dataset a first-class tool the live ReAct
+// loop (`kx/recipes/react-rag`) calls autonomously. Needs the serve broker
+// (`serve-engine`) AND the dataset view (`hnsw`); off-digest, SN-8 (scores dropped).
+#[cfg(all(feature = "serve-engine", feature = "hnsw"))]
+mod retrieve_tool;
 // PR-6b-1 (D159): the EXTERNAL MCP gateway host wiring — the McpGatewayAdmin impl
 // over kx_mcp_gateway::McpGateway + the BrokerCapabilitySink. Behind the
 // `mcp-gateway` feature (ON by default); FFI-free, off-journal, off-digest. DIALS
@@ -242,7 +248,8 @@ pub use provision::{
     DemoLibrary, HostRecipeBinder, HostRecipeCatalog, HostSignatureCatalog, HostWorkflowAuthor,
     CHAT_RAG_RECIPE_HANDLE, DEMO_RECIPE_HANDLE, JUDGE_RECIPE_HANDLE, MODEL_RECIPE_HANDLE,
     PASSTHROUGH_DAG_HANDLE, REACT_AUTO_RECIPE_HANDLE, REACT_EDIT_RECIPE_HANDLE,
-    REACT_FS_RECIPE_HANDLE, REACT_RECIPE_HANDLE, REACT_VISION_RECIPE_HANDLE, VISION_RECIPE_HANDLE,
+    REACT_FS_RECIPE_HANDLE, REACT_RAG_RECIPE_HANDLE, REACT_RECIPE_HANDLE,
+    REACT_VISION_RECIPE_HANDLE, VISION_RAG_RECIPE_HANDLE, VISION_RECIPE_HANDLE,
 };
 pub use server::{serve, start, RunningGateway};
 pub use teams::{seed_workspace_team, HostGrantView, HostMembershipView, WORKSPACE_TEAM_HANDLE};

--- a/crates/kx-gateway/src/provision.rs
+++ b/crates/kx-gateway/src/provision.rs
@@ -274,6 +274,48 @@ const REACT_VISION_LOGIC_REF: [u8; 32] = [0x57; 32];
 /// with `react-edit`). `0x59` is the next free sentinel after chat-rag (`0x58`).
 const APP_SCAFFOLD_WRITE_LOGIC_REF: [u8; 32] = [0x59; 32];
 
+/// RC4b (agentic RAG): the wire handle of the `react-rag` recipe — a live ReAct loop
+/// like [`REACT_RECIPE_HANDLE`] BUT whose server-built warrant grants the read-only
+/// `retrieve@1` tool (RC4a hybrid `HostDatasetView::query`) instead of `mcp-echo@1`,
+/// so the model AUTONOMOUSLY searches a dataset and re-queries across turns. The
+/// query-rewrite is FREE: the retrieve-call turn IS the committed `ReadOnlyNondet`
+/// rewrite. A SEPARATE recipe BY DESIGN (the react-fs precedent) so the canonical
+/// `kx/recipes/react` + the projection digest stay byte-unchanged. Seeded only when a
+/// model is served AND the retrieve capability is registered (`hnsw`); reuses the
+/// react free-param contract, with a `dataset` selector folded ADVISORILY into the
+/// instruction (the model copies it into the retrieve args). The SDK prefix detector
+/// (`startswith("kx/recipes/react")`) settles it as a react CHAIN.
+pub const REACT_RAG_RECIPE_HANDLE: &str = "kx/recipes/react-rag";
+
+/// A DISTINCT placeholder `logic_ref` for the `react-rag` seed step (the BUG-25 class —
+/// react-rag's body differs from `kx/recipes/react` ONLY by its server-built warrant
+/// [echo grant → retrieve grant], so a shared logic ref maps both to the same manifest
+/// id with different bytes and panics at seed). `0x5a` is the next free sentinel after
+/// app-scaffold-write (`0x59`).
+const REACT_RAG_LOGIC_REF: [u8; 32] = [0x5a; 32];
+
+/// The react-rag args key naming the dataset the model should search (stripped from the
+/// args before free-param binding — it is NOT a declared slot; the binder folds it into
+/// the instruction). Absent ⇒ the model retrieves only if the instruction names a dataset.
+const REACT_RAG_DATASET_KEY: &str = "dataset";
+
+/// RC4b VISION-RAG: the wire handle of the `vision-rag` recipe — the `vision` recipe
+/// (a single PURE greedy model step with REQUIRED `image_ref` + `model` slots) PLUS the
+/// chat-rag dataset fold: a `dataset` arg retrieves the top-k TEXT passages (hybrid) and
+/// folds the EXACT refs into `CONTEXT_ITEMS_KEY`, so the served VLM answers grounded on
+/// BOTH the image AND the retrieved text in ONE generation (`dispatch_model` already
+/// composes context-items + image). Datasets stay TEXT-only (image-embedding deferred
+/// post-RC). A SEPARATE recipe BY DESIGN (the vision/react-fs precedent) so the canonical
+/// recipes + the projection digest stay byte-unchanged. NOT a react chain (a single PURE
+/// step — it settles on its terminal mote, and `kx/recipes/vision-rag` does NOT match the
+/// `kx/recipes/react` prefix). Seeded only when an IMAGE-capable model is served AND
+/// datasets are available (`retrieve_tool = Some`).
+pub const VISION_RAG_RECIPE_HANDLE: &str = "kx/recipes/vision-rag";
+
+/// A DISTINCT placeholder `logic_ref` for the `vision-rag` seed step (the BUG-25 class).
+/// `0x5b` is the next free sentinel after react-rag (`0x5a`).
+const VISION_RAG_LOGIC_REF: [u8; 32] = [0x5b; 32];
+
 /// T-AGENT2: the opt-in self-checking model recipe — a single greedy model
 /// PRODUCER step (a `prompt` free-param) gated by an LLM-JUDGE critic that grades
 /// the answer against a fixed rubric using the served model. The terminal is the
@@ -433,6 +475,7 @@ impl DemoLibrary {
             parties,
             None,
             None,
+            None,
             false,
             None,
             false,
@@ -461,6 +504,7 @@ impl DemoLibrary {
             exec_class,
             parties,
             serve_model.as_ref(),
+            None,
             None,
             false,
             None,
@@ -495,6 +539,8 @@ impl DemoLibrary {
             parties,
             serve_model,
             react_tool,
+            // open_complete predates RC4b's RAG recipes; serve wires them via open_serve.
+            None,
             vision,
             fs_list,
             autogrant,
@@ -510,12 +556,14 @@ impl DemoLibrary {
     /// # Errors
     /// [`GatewayError::Catalog`] on a ledger open / seed failure.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn open_serve(
         dir: &Path,
         exec_class: ExecutorClass,
         parties: &[String],
         serve_model: Option<&ModelId>,
         react_tool: Option<&(ToolName, ToolVersion)>,
+        retrieve_tool: Option<&(ToolName, ToolVersion)>,
         vision: bool,
         fs_list: Option<(&[(ToolName, ToolVersion)], &Path)>,
         autogrant: bool,
@@ -527,6 +575,7 @@ impl DemoLibrary {
             parties,
             serve_model,
             react_tool,
+            retrieve_tool,
             vision,
             fs_list,
             autogrant,
@@ -549,6 +598,11 @@ impl DemoLibrary {
         parties: &[String],
         serve_model: Option<&ModelId>,
         react_tool: Option<&(ToolName, ToolVersion)>,
+        // RC4b: the `retrieve@1` tool identity, `Some` exactly when the retrieve
+        // capability is registered (the `hnsw`+serve build) ⇒ provision `react-rag`
+        // (grants it) and signal that datasets are available for `vision-rag`. `None`
+        // ⇒ neither RAG recipe is seeded (byte-identical to before).
+        retrieve_tool: Option<&(ToolName, ToolVersion)>,
         vision: bool,
         fs_list: Option<(&[(ToolName, ToolVersion)], &Path)>,
         autogrant: bool,
@@ -897,6 +951,84 @@ impl DemoLibrary {
                 RecipeMeta {
                     owner_root: react_fs_w,
                     free_params: react_contract(),
+                },
+            ));
+        }
+
+        // (react-rag) RC4b AGENTIC RAG: a SEPARATE live ReAct recipe whose server-built
+        // warrant grants the read-only `retrieve@1` tool (RC4a hybrid
+        // `HostDatasetView::query`), so the served model AUTONOMOUSLY searches a dataset
+        // and re-queries across turns — the retrieve-call turn IS the committed
+        // `ReadOnlyNondet` query-rewrite (no separate Mote). Seeded only when a model is
+        // served AND the retrieve capability is registered (the `hnsw` build passes
+        // `retrieve_tool = Some`). Reuses the react free-param contract but carries its OWN
+        // logic ref (BUG-25 — react-rag's body differs from `kx/recipes/react` ONLY by its
+        // warrant [echo grant → retrieve grant], so a shared ref panics at seed). The bind
+        // folds a `dataset` selector into the instruction (advisory). `react_warrant`
+        // already leaves `fs_scope` empty / `net_scope` None — exactly retrieve@1's
+        // declared requirement — so the broker precheck passes with no fs root.
+        if let (Some(model_id), Some(retrieve)) = (serve_model, retrieve_tool) {
+            let react_rag_w = react_warrant(exec_class, model_id, retrieve);
+            let react_rag_h = react_rag_handle()?;
+            seed_recipe(
+                &versions,
+                &bodies,
+                &grants,
+                &owner,
+                parties,
+                &react_rag_h,
+                recipe_body(
+                    LogicRef::from_bytes(REACT_RAG_LOGIC_REF),
+                    &react_rag_w,
+                    &[
+                        kx_mote::REACT_INSTRUCTION_KEY,
+                        kx_mote::REACT_MAX_TURNS_KEY,
+                        kx_mote::REACT_MAX_TOOL_CALLS_KEY,
+                    ],
+                ),
+                &react_rag_w,
+            )?;
+            recipes.push((
+                react_rag_h,
+                RecipeMeta {
+                    owner_root: react_rag_w,
+                    free_params: react_contract(),
+                },
+            ));
+        }
+
+        // (vision-rag) RC4b: the vision recipe (a single PURE greedy step with REQUIRED
+        // `image_ref` + `model` slots) PLUS the chat-rag dataset fold — a `dataset` arg
+        // retrieves the top-k TEXT passages (hybrid) at bind and folds the EXACT refs into
+        // CONTEXT_ITEMS, so the served VLM answers grounded on BOTH the image AND the
+        // retrieved text in ONE generation (`dispatch_model` already composes context-items
+        // + image_ref). Seeded only when an IMAGE-capable model is served AND datasets are
+        // available (`retrieve_tool = Some` signals the hnsw build). OWN logic ref (BUG-25);
+        // NOT a react chain (a single PURE step — it settles on its terminal mote). The
+        // warrant raises `mem_bytes` to the vision image ceiling (the BUG-26 class).
+        if let (Some(model_id), Some(_)) = (serve_model.filter(|_| vision), retrieve_tool) {
+            let mut vision_rag_w = model_warrant(exec_class, model_id);
+            vision_rag_w.resource_ceiling.mem_bytes = VISION_MAX_IMAGE_BYTES;
+            let vision_rag_h = vision_rag_handle()?;
+            seed_recipe(
+                &versions,
+                &bodies,
+                &grants,
+                &owner,
+                parties,
+                &vision_rag_h,
+                recipe_body(
+                    LogicRef::from_bytes(VISION_RAG_LOGIC_REF),
+                    &vision_rag_w,
+                    &[PROMPT_KEY, IMAGE_REF_KEY, VISION_MODEL_KEY],
+                ),
+                &vision_rag_w,
+            )?;
+            recipes.push((
+                vision_rag_h,
+                RecipeMeta {
+                    owner_root: vision_rag_w,
+                    free_params: vision_contract(),
                 },
             ));
         }
@@ -1359,6 +1491,14 @@ fn recipe_advisory(handle: &str) -> (&'static str, &'static [&'static str]) {
             "ReAct-FS — a live agent loop with read-only filesystem tools (list directory entries + read a file's contents) under the granted root.",
             &["agent", "react", "tools", "filesystem", "fs-list", "fs-read"],
         ),
+        REACT_RAG_RECIPE_HANDLE => (
+            "ReAct-RAG — an agentic-RAG loop: the model autonomously SEARCHES a dataset with the read-only `retrieve` tool (hybrid keyword+semantic), reads the passages, can re-query, and answers grounded in what it found. Pass a `dataset` arg to point it at a corpus.",
+            &["agent", "react", "rag", "retrieval", "dataset", "tools", "grounding", "search"],
+        ),
+        VISION_RAG_RECIPE_HANDLE => (
+            "Vision-RAG — a grounded multimodal completion: answers about an attached image while ALSO retrieving the top-k text passages from a `dataset` (hybrid) and folding them into the prompt; honest plain vision when no dataset/index.",
+            &["vision", "image", "multimodal", "rag", "retrieval", "dataset", "grounding"],
+        ),
         REACT_AUTO_RECIPE_HANDLE => (
             "ReAct-Auto — a live agent loop that auto-grants the registered/dialed tool set (the model picks from all live tools).",
             &["agent", "react", "tools", "auto-grant", "mcp"],
@@ -1700,14 +1840,72 @@ impl HostRecipeBinder {
     /// empty prompt, or any retrieval failure (unknown dataset / no embedder / empty
     /// index) ⇒ the stripped args + the ORIGINAL refs (a plain, ungrounded chat —
     /// never a faked grounding, never a failed turn).
+    /// RC4b: rewrite a `react-rag` bind's args — STRIP the `dataset` selector (not a
+    /// declared slot, so it never reaches schema validation) and, when present, APPEND a
+    /// directive to the `instruction` free-param naming the dataset to search with the
+    /// `retrieve@1` tool. The model retrieves LIVE in the loop (no bind-time retrieval),
+    /// so the context refs are unchanged. Honest no-op when there is no dataset arg (the
+    /// instruction may already name one in prose).
+    fn fold_react_rag_dataset<'a>(
+        args: &'a [u8],
+        context_refs: &'a [String],
+    ) -> Result<GroundedArgs<'a>, BinderError> {
+        let mut value: serde_json::Value = if args.is_empty() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            serde_json::from_slice(args)
+                .map_err(|e| BinderError::InvalidArgs(format!("react-rag args parse: {e}")))?
+        };
+        let obj = value.as_object_mut().ok_or_else(|| {
+            BinderError::InvalidArgs("react-rag args must be a JSON object".into())
+        })?;
+        let dataset = obj.remove(REACT_RAG_DATASET_KEY);
+        let dataset = dataset.as_ref().and_then(serde_json::Value::as_str);
+        if let Some(dataset) = dataset.filter(|d| !d.is_empty()) {
+            let base = obj
+                .get(kx_mote::REACT_INSTRUCTION_KEY)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            // NOTE: do NOT show a literal `{"dataset":...}` call example here — the RC3
+            // tool MENU already renders the exact call envelope, and a second inline
+            // example primes some models to emit a stray `call:`-style prefix that breaks
+            // native `<|tool_call>` recovery (RC4b live-witness finding on Gemma-4). Name
+            // the dataset + the tool; let the menu own the format.
+            let folded = format!(
+                "{base}\n\nYou have a `retrieve` tool that searches text datasets. Use it to \
+                 search the \"{dataset}\" dataset for relevant passages before you answer; you \
+                 may search again with a refined query if the first result is not enough."
+            );
+            obj.insert(
+                kx_mote::REACT_INSTRUCTION_KEY.to_string(),
+                serde_json::Value::String(folded),
+            );
+        }
+        let stripped = serde_json::to_vec(&value)
+            .map_err(|e| BinderError::InvalidArgs(format!("react-rag args re-encode: {e}")))?;
+        Ok((Cow::Owned(stripped), Cow::Borrowed(context_refs)))
+    }
+
     fn ground_chat_rag<'a>(
         &self,
         asset_path: &AssetPath,
         args: &'a [u8],
         context_refs: &'a [String],
     ) -> Result<GroundedArgs<'a>, BinderError> {
-        let is_chat_rag = parse_handle(CHAT_RAG_RECIPE_HANDLE).is_some_and(|p| p == *asset_path);
-        if !is_chat_rag {
+        // RC4b react-rag: fold the `dataset` selector into the instruction so the model
+        // copies it into the retrieve@1 args. The model retrieves LIVE in the loop (no
+        // bind-time retrieval, no context-ref fold) — the agentic half of RAG.
+        if parse_handle(REACT_RAG_RECIPE_HANDLE).is_some_and(|p| p == *asset_path) {
+            return Self::fold_react_rag_dataset(args, context_refs);
+        }
+        // chat-rag AND vision-rag share the SAME dataset fold: strip `dataset`/`k`, read
+        // `prompt` as the query, retrieve the top-k passages (hybrid), and append their
+        // EXACT refs to CONTEXT_ITEMS. vision-rag's `image_ref`/`model` slots are not
+        // selector keys, so they pass through untouched to bind_snapshot (RC4b).
+        let is_rag_fold = [CHAT_RAG_RECIPE_HANDLE, VISION_RAG_RECIPE_HANDLE]
+            .iter()
+            .any(|h| parse_handle(h).is_some_and(|p| p == *asset_path));
+        if !is_rag_fold {
             return Ok((Cow::Borrowed(args), Cow::Borrowed(context_refs)));
         }
         // Read `prompt` (the query text) and pull out the `dataset`/`k` selectors so
@@ -1914,6 +2112,11 @@ impl RecipeBinder for HostRecipeBinder {
                 REACT_FS_RECIPE_HANDLE,
                 REACT_AUTO_RECIPE_HANDLE,
                 REACT_VISION_RECIPE_HANDLE,
+                // RC4b: react-rag is a live ReAct chain (the retrieve@1 loop) ⇒ it MUST
+                // seed the run-salted chain too, else the loop never runs as a chain AND
+                // the empty react_chain_salt makes the client retrieve the wrong chain on
+                // serve's shared journal (BUG-34, the react-vision lesson).
+                REACT_RAG_RECIPE_HANDLE,
             ]
             .iter()
             .any(|h| parse_handle(h).is_some_and(|p| p == asset_path)),
@@ -2992,6 +3195,18 @@ fn tool_step_warrant(
 fn react_fs_handle() -> Result<AssetPath, GatewayError> {
     parse_handle(REACT_FS_RECIPE_HANDLE)
         .ok_or_else(|| GatewayError::Catalog("invalid react-fs recipe handle".into()))
+}
+
+/// RC4b: the `react-rag` recipe handle (the agentic-RAG live ReAct loop).
+fn react_rag_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(REACT_RAG_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid react-rag recipe handle".into()))
+}
+
+/// RC4b: the `vision-rag` recipe handle (image + dataset-grounded completion).
+fn vision_rag_handle() -> Result<AssetPath, GatewayError> {
+    parse_handle(VISION_RAG_RECIPE_HANDLE)
+        .ok_or_else(|| GatewayError::Catalog("invalid vision-rag recipe handle".into()))
 }
 
 /// D155 Phase-3: the server-built `react-edit` step warrant. A bounded live ReAct
@@ -5324,6 +5539,7 @@ mod tests {
                 &parties,
                 Some(&primary),
                 None,
+                None,
                 false,
                 None,
                 false,
@@ -5345,6 +5561,7 @@ mod tests {
                 ExecutorClass::Bwrap,
                 &parties,
                 Some(&primary),
+                None,
                 None,
                 false,
                 None,
@@ -5430,6 +5647,153 @@ mod tests {
             w.resource_ceiling.wall_clock_ms >= 300_000,
             "the wall clock must comfortably exceed a full-budget greedy decode"
         );
+    }
+
+    #[test]
+    fn react_rag_recipe_seeded_only_with_the_retrieve_tool() {
+        // RC4b: react-rag is a SEPARATE recipe, seeded only when a model is served AND
+        // the retrieve@1 capability is registerable (the hnsw build passes Some). None ⇒
+        // the canonical set is byte-unchanged (no react-rag).
+        let model = ModelId("kx-serve:m".to_string());
+        let parties = ["alice@acme".to_string()];
+        let retrieve = (ToolName("retrieve".into()), ToolVersion("1".into()));
+
+        // retrieve tool present ⇒ react-rag seeded, granting exactly retrieve@1.
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open_serve(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &parties,
+            Some(&model),
+            None,
+            Some(&retrieve),
+            false,
+            None,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(
+            lib.recipe_handles()
+                .contains(&REACT_RAG_RECIPE_HANDLE.to_string()),
+            "react-rag is provisioned when the retrieve tool is available"
+        );
+
+        // no retrieve tool ⇒ NOT seeded (canonical set unchanged).
+        let dir2 = tempfile::tempdir().unwrap();
+        let lib2 = DemoLibrary::open_serve(
+            dir2.path(),
+            ExecutorClass::Bwrap,
+            &parties,
+            Some(&model),
+            None,
+            None,
+            false,
+            None,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(
+            !lib2
+                .recipe_handles()
+                .contains(&REACT_RAG_RECIPE_HANDLE.to_string()),
+            "no retrieve tool ⇒ no react-rag (byte-identical to before)"
+        );
+    }
+
+    #[test]
+    fn vision_rag_recipe_seeded_only_with_vision_and_datasets() {
+        // RC4b: vision-rag needs BOTH an image-capable model (vision=true) AND datasets
+        // available (retrieve_tool=Some). Either absent ⇒ not seeded.
+        let model = ModelId("kx-serve:m".to_string());
+        let parties = ["alice@acme".to_string()];
+        let retrieve = (ToolName("retrieve".into()), ToolVersion("1".into()));
+
+        // vision + datasets ⇒ seeded.
+        let dir = tempfile::tempdir().unwrap();
+        let lib = DemoLibrary::open_serve(
+            dir.path(),
+            ExecutorClass::Bwrap,
+            &parties,
+            Some(&model),
+            None,
+            Some(&retrieve),
+            true,
+            None,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(lib
+            .recipe_handles()
+            .contains(&VISION_RAG_RECIPE_HANDLE.to_string()));
+
+        // datasets but NO vision ⇒ not seeded.
+        let dir2 = tempfile::tempdir().unwrap();
+        let lib2 = DemoLibrary::open_serve(
+            dir2.path(),
+            ExecutorClass::Bwrap,
+            &parties,
+            Some(&model),
+            None,
+            Some(&retrieve),
+            false,
+            None,
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(!lib2
+            .recipe_handles()
+            .contains(&VISION_RAG_RECIPE_HANDLE.to_string()));
+        // distinct logic ref (BUG-25).
+        assert_ne!(VISION_RAG_LOGIC_REF, REACT_RAG_LOGIC_REF);
+        assert_ne!(VISION_RAG_LOGIC_REF, VISION_LOGIC_REF);
+    }
+
+    #[test]
+    fn react_rag_warrant_grants_exactly_the_retrieve_tool() {
+        // The react-rag warrant grants retrieve@1 and (like the echo react warrant)
+        // leaves fs/net empty — matching retrieve@1's declared requirement so the broker
+        // precheck passes with no fs root.
+        let retrieve = (ToolName("retrieve".into()), ToolVersion("1".into()));
+        let w = react_warrant(ExecutorClass::Bwrap, &ModelId("m".to_string()), &retrieve);
+        assert_eq!(w.tool_grants.len(), 1);
+        let g = w.tool_grants.iter().next().unwrap();
+        assert_eq!(g.tool_id.0, "retrieve");
+        assert_eq!(g.tool_version.0, "1");
+        assert!(w.fs_scope.mounts.is_empty(), "retrieve has no fs scope");
+        assert_eq!(w.net_scope, NetScope::None, "retrieve has no egress");
+        // Distinct logic ref (BUG-25) — never collides with the echo react body.
+        assert_ne!(REACT_RAG_LOGIC_REF, REACT_LOGIC_REF);
+        assert_ne!(REACT_RAG_LOGIC_REF, REACT_FS_LOGIC_REF);
+    }
+
+    #[test]
+    fn react_rag_folds_the_dataset_into_the_instruction() {
+        // The bind strips the `dataset` selector (not a declared slot) and folds it into
+        // the instruction so the model copies it into the retrieve args.
+        let args = serde_json::json!({
+            "instruction": "What does the handbook say about parental leave?",
+            "dataset": "handbook",
+        });
+        let bytes = serde_json::to_vec(&args).unwrap();
+        let (folded_args, _refs) = HostRecipeBinder::fold_react_rag_dataset(&bytes, &[]).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&folded_args).unwrap();
+        // dataset key stripped (it is not a declared free-param)...
+        assert!(v.get(REACT_RAG_DATASET_KEY).is_none());
+        // ...and the instruction now names the dataset + the retrieve tool.
+        let instr = v[kx_mote::REACT_INSTRUCTION_KEY].as_str().unwrap();
+        assert!(instr.contains("parental leave"), "keeps the user's ask");
+        assert!(instr.contains("handbook"), "names the dataset");
+        assert!(instr.contains("retrieve"), "names the tool");
+
+        // No dataset arg ⇒ instruction untouched (honest no-op; prose may name one).
+        let plain = serde_json::to_vec(&serde_json::json!({"instruction": "hi"})).unwrap();
+        let (out, _) = HostRecipeBinder::fold_react_rag_dataset(&plain, &[]).unwrap();
+        let v2: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v2[kx_mote::REACT_INSTRUCTION_KEY], "hi");
     }
 
     #[test]

--- a/crates/kx-gateway/src/retrieve_tool.rs
+++ b/crates/kx-gateway/src/retrieve_tool.rs
@@ -1,0 +1,445 @@
+//! RC4b (agentic RAG) — the bundled read-only `retrieve@1` capability + its typed
+//! [`ToolDef`] + the serve-broker registration. A model in a `kx/recipes/react-rag`
+//! ReAct turn proposes `{"dataset": <name>, "query": <search text>, "k": <1..64>}`;
+//! this runs the RC4a HYBRID (BM25 + dense, RRF-fused, MMR-reranked)
+//! [`DatasetView::query`] and returns the ordered passages (content hash + text +
+//! chunk provenance) as the Observation Mote's `result_ref` — the agent reads them,
+//! refines its query, and grounds its answer.
+//!
+//! # Why this is the "agentic" half of RAG
+//!
+//! RC4a made retrieval high-quality but PASSIVE (a fixed DAG node / a one-shot
+//! host-side fold). `retrieve@1` makes a dataset a FIRST-CLASS TOOL the agent calls
+//! autonomously: the model decides WHEN to search, phrases its OWN query (the
+//! committed `ReadOnlyNondet` retrieve-call turn IS the query-rewrite — no separate
+//! Mote), reads the passages, and can RE-QUERY on the next turn. It is the exact
+//! sibling of the read-only `fs-list@1` / `fs-read@1` capabilities (PR-6a / D155):
+//! a host-side read over live process state, granted by a server-built recipe warrant.
+//!
+//! # Boundaries (load-bearing)
+//!
+//! - **SN-8.** The committed observation carries the ordered EXACT chunk content-refs
+//!   (+ text for the model to read) — the similarity `score` is DROPPED here, never
+//!   committed, never an identity input. (Mirrors `kx-model-harness::rag::query_corpus`.)
+//! - **Read-only.** `IdempotencyClass::Readback` ⇒ the HITL gate auto-proceeds it; no
+//!   egress (`NetScope::None`), no fs (`FsScope::empty()` — the SQLite store is reached
+//!   via the in-process `Arc<dyn DatasetView>`, NOT through `fs_scope`).
+//! - **Flat builtin id.** `retrieve@1` is a `ToolKind::Builtin` (like `fs-list@1`):
+//!   the model proposes the FULL name `retrieve`, which `kx_toolcall::resolve_granted_name`
+//!   matches by EXACT equality (`id_matches`). The `<server>/<remote>` convention is
+//!   ONLY for MCP tools where the model emits the bare remote leaf (the BUG-33 guard);
+//!   a builtin needs no `/` and using one would be semantically wrong (no MCP server).
+//! - **Fail-SOFT, never dead-letter.** A missing/unavailable/stale dataset (every
+//!   recoverable [`DatasetError`]) returns an EMPTY-passage observation the model reads
+//!   and recovers from; only a hard `DatasetError::Internal` (poisoned lock) returns
+//!   `Err` and dead-letters the chain. A weak embedder or no hits is an honest empty,
+//!   not a crash.
+
+use std::sync::Arc;
+
+use kx_capability::{Capability, CapabilityFailureReason, EffectRequest, LocalCapabilityBroker};
+use kx_content::{ContentRef, ContentStore};
+use kx_gateway_core::{DatasetError, DatasetView, RetrievalMode};
+use kx_mote::{EffectPattern, ToolName, ToolVersion};
+use kx_tool_registry::{IdempotencyClass, InputSchema, ParamSpec, ParamType, ToolDef, ToolKind};
+use kx_warrant::{FsScope, NetScope, ResourceCeiling, ToolRequirement};
+use serde::{Deserialize, Serialize};
+
+/// retrieve observes the world (a read over the dataset index) and commits its bytes
+/// as a `result_ref` — the same stage-then-commit content-addressed path fs-list uses.
+const PATTERNS: &[EffectPattern] = &[EffectPattern::StageThenCommit];
+
+/// The default top-k when the model omits `k` (matches the chat-rag default).
+const DEFAULT_K: usize = 4;
+
+/// The hard top-k ceiling (also enforced by the typed schema + `HostDatasetView`).
+const MAX_K: usize = 64;
+
+/// The bundled read-only dataset-retrieval capability (`retrieve@1`).
+pub(crate) struct RetrieveCapability {
+    name: ToolName,
+    version: ToolVersion,
+    datasets: Arc<dyn DatasetView>,
+}
+
+impl RetrieveCapability {
+    /// Construct `retrieve@1` over the live in-process dataset view.
+    pub(crate) fn new(datasets: Arc<dyn DatasetView>) -> Self {
+        Self {
+            name: ToolName("retrieve".into()),
+            version: ToolVersion("1".into()),
+            datasets,
+        }
+    }
+}
+
+/// The model's proposed argument bag (the typed `inputSchema` validated this
+/// upstream at coordinator settle; we re-parse fail-closed against smuggled keys).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RetrieveArgs {
+    dataset: String,
+    query: String,
+    #[serde(default)]
+    k: Option<u32>,
+}
+
+/// One retrieved passage — content hash + text + chunk provenance. NO `score`
+/// (SN-8: the committed observation is the ordered EXACT-ref set only).
+#[derive(Serialize)]
+struct Passage {
+    /// Hex of the retrieved CHUNK's content ref (the citation key).
+    r#ref: String,
+    /// The chunk text the model grounds its answer on.
+    text: String,
+    /// Hex of the parent document's content ref (== `ref` for un-chunked corpora).
+    parent_ref: String,
+    /// 0-based ordinal of this chunk within its parent.
+    chunk_index: u32,
+}
+
+/// The committed observation the agent reads. `passages` is empty (with an honest
+/// `note`) on every recoverable failure — the model re-queries or answers from what
+/// it has, the chain never dead-letters.
+#[derive(Serialize)]
+struct Observation {
+    dataset: String,
+    query: String,
+    passages: Vec<Passage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+}
+
+fn encode(obs: &Observation) -> Result<Vec<u8>, CapabilityFailureReason> {
+    serde_json::to_vec(obs)
+        .map_err(|e| CapabilityFailureReason::Other(format!("retrieve: encode: {e}")))
+}
+
+impl Capability for RetrieveCapability {
+    fn name(&self) -> &ToolName {
+        &self.name
+    }
+
+    fn version(&self) -> &ToolVersion {
+        &self.version
+    }
+
+    fn supported_patterns(&self) -> &[EffectPattern] {
+        PATTERNS
+    }
+
+    fn invoke(&self, request: &EffectRequest) -> Result<Vec<u8>, CapabilityFailureReason> {
+        let args: RetrieveArgs = serde_json::from_slice(&request.payload)
+            .map_err(|e| CapabilityFailureReason::Other(format!("retrieve: bad args: {e}")))?;
+        let k = args.k.map_or(DEFAULT_K, |k| (k as usize).clamp(1, MAX_K));
+
+        // HYBRID (RC4a): query_embedding = None ⇒ the host embeds `query` internally.
+        match self
+            .datasets
+            .query(&args.dataset, None, &args.query, k, RetrievalMode::Hybrid)
+        {
+            Ok(hits) => {
+                let passages = hits
+                    .into_iter()
+                    .map(|h| Passage {
+                        r#ref: ContentRef::from_bytes(h.content_ref).to_hex(),
+                        text: String::from_utf8_lossy(&h.content).into_owned(),
+                        parent_ref: ContentRef::from_bytes(h.parent_ref).to_hex(),
+                        chunk_index: h.chunk_index,
+                        // h.score is intentionally DROPPED here (SN-8).
+                    })
+                    .collect::<Vec<_>>();
+                let note = passages
+                    .is_empty()
+                    .then(|| "no matching passages found".to_string());
+                encode(&Observation {
+                    dataset: args.dataset,
+                    query: args.query,
+                    passages,
+                    note,
+                })
+            }
+            // SOFT-FAIL every recoverable error → an honest empty observation the model
+            // reads + recovers from (re-query a different dataset, or answer from prior
+            // turns). NEVER dead-letter the chain on a recoverable retrieval miss.
+            Err(
+                DatasetError::NotFound
+                | DatasetError::StaleIndex(_)
+                | DatasetError::DimMismatch(_)
+                | DatasetError::EmbedderUnavailable
+                | DatasetError::InvalidArgument(_),
+            ) => encode(&Observation {
+                dataset: args.dataset,
+                query: args.query,
+                passages: Vec::new(),
+                note: Some(
+                    "no passages (dataset missing, empty, stale, or no embedder available)"
+                        .to_string(),
+                ),
+            }),
+            // A hard backend fault (poisoned lock) is NOT recoverable ⇒ dead-letter honestly.
+            Err(DatasetError::Internal(detail)) => Err(CapabilityFailureReason::Other(format!(
+                "retrieve: {detail}"
+            ))),
+        }
+    }
+}
+
+/// The bundled retrieval tool's identity — `retrieve@1` (a FLAT builtin id, the
+/// `fs-list@1` precedent; a model proposes the full `retrieve`, resolved by exact
+/// `id_matches` equality).
+#[must_use]
+pub(crate) fn retrieve_tool() -> (ToolName, ToolVersion) {
+    (ToolName("retrieve".into()), ToolVersion("1".into()))
+}
+
+/// The `retrieve@1` [`ToolDef`]: a read-only dataset-retrieval tool with NO egress /
+/// NO fs scope (the dataset store is reached via the in-process view), a typed
+/// `{dataset, query, k?}` schema (unknown keys refused), `Readback` (HITL
+/// auto-proceeds). Seeded into `tools.db` so `render_tool_menu` / `validate_args` /
+/// `resolve_tool_args` resolve a model-proposed `retrieve` call.
+#[must_use]
+pub(crate) fn retrieve_tool_def() -> ToolDef {
+    let (tool_id, tool_version) = retrieve_tool();
+    ToolDef {
+        tool_id,
+        tool_version,
+        kind: ToolKind::Builtin,
+        required_capability: ToolRequirement {
+            net_scope_required: NetScope::None,
+            fs_scope_required: FsScope::empty(),
+            syscall_profile_ref: ContentRef::from_bytes([0; 32]),
+            min_resource_ceiling: ResourceCeiling {
+                cpu_milli: 0,
+                mem_bytes: 0,
+                wall_clock_ms: 0,
+                fd_count: 0,
+                disk_bytes: 0,
+            },
+        },
+        description: "Retrieve the most relevant passages from a TEXT dataset by hybrid (keyword + semantic) search. Arg: {\"dataset\": <name>, \"query\": <search text>, \"k\": <1..64, optional>}. Returns ordered passages (content hash + text + chunk index). Read-only; idempotent.".into(),
+        idempotency_class: IdempotencyClass::Readback,
+        input_schema: Some(InputSchema {
+            params: vec![
+                ParamSpec {
+                    name: "dataset".into(),
+                    ty: ParamType::Str { max_len: 128 },
+                    required: true,
+                },
+                ParamSpec {
+                    name: "query".into(),
+                    ty: ParamType::Str { max_len: 4096 },
+                    required: true,
+                },
+                ParamSpec {
+                    name: "k".into(),
+                    ty: ParamType::Int {
+                        min: Some(1),
+                        max: Some(64), // == MAX_K (the host + capability also clamp)
+                    },
+                    required: false,
+                },
+            ],
+            deny_unknown: true,
+        }),
+    }
+}
+
+/// Register the bundled read-only [`RetrieveCapability`] (`retrieve@1`) on the serve
+/// broker over the live `Arc<dyn DatasetView>`. Called AFTER `dataset_view` is built
+/// (the broker's `register_capability` is `&self`/interior-mutable, so late
+/// registration on the same broker is supported). Operator-reachable only when a
+/// model is served + `hnsw` (the `kx/recipes/react-rag` seed gate).
+pub(crate) fn register_retrieve_capability<S: ContentStore + Send + Sync>(
+    broker: &LocalCapabilityBroker<S>,
+    datasets: Arc<dyn DatasetView>,
+) {
+    broker.register_capability(Box::new(RetrieveCapability::new(datasets)));
+    tracing::info!("RC4b: read-only retrieve@1 capability registered (kx/recipes/react-rag)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_gateway_core::{DatasetHitEntry, DatasetSummaryEntry, IngestDoc, IngestOutcome};
+    use kx_warrant::SecretScope;
+
+    /// A stub [`DatasetView`] that returns canned hits OR a fixed error, so the
+    /// capability's mapping + soft-fail behaviour is tested with no model / no index.
+    struct StubView {
+        hits: Vec<DatasetHitEntry>,
+        err: Option<DatasetError>,
+    }
+
+    impl StubView {
+        fn ok(hits: Vec<DatasetHitEntry>) -> Arc<dyn DatasetView> {
+            Arc::new(Self { hits, err: None })
+        }
+        fn fail(err: DatasetError) -> Arc<dyn DatasetView> {
+            Arc::new(Self {
+                hits: Vec::new(),
+                err: Some(err),
+            })
+        }
+    }
+
+    impl DatasetView for StubView {
+        fn list_datasets(&self) -> Vec<DatasetSummaryEntry> {
+            Vec::new()
+        }
+        fn ingest(
+            &self,
+            _dataset: &str,
+            _docs: &[IngestDoc<'_>],
+        ) -> Result<IngestOutcome, DatasetError> {
+            Err(DatasetError::Internal("stub".into()))
+        }
+        fn query(
+            &self,
+            _dataset: &str,
+            _query_embedding: Option<&[f32]>,
+            _query_text: &str,
+            _k: usize,
+            _mode: RetrievalMode,
+        ) -> Result<Vec<DatasetHitEntry>, DatasetError> {
+            match &self.err {
+                Some(DatasetError::NotFound) => Err(DatasetError::NotFound),
+                Some(DatasetError::StaleIndex(d)) => Err(DatasetError::StaleIndex(d.clone())),
+                Some(DatasetError::DimMismatch(d)) => Err(DatasetError::DimMismatch(d.clone())),
+                Some(DatasetError::EmbedderUnavailable) => Err(DatasetError::EmbedderUnavailable),
+                Some(DatasetError::InvalidArgument(d)) => {
+                    Err(DatasetError::InvalidArgument(d.clone()))
+                }
+                Some(DatasetError::Internal(d)) => Err(DatasetError::Internal(d.clone())),
+                None => Ok(self.hits.clone()),
+            }
+        }
+    }
+
+    fn hit(tag: u8, text: &str, score: f32, chunk_index: u32) -> DatasetHitEntry {
+        DatasetHitEntry {
+            content_ref: [tag; 32],
+            content: text.as_bytes().to_vec(),
+            score,
+            parent_ref: [tag.wrapping_add(100); 32],
+            chunk_index,
+            chunk_count: 3,
+        }
+    }
+
+    fn req(payload: &[u8]) -> EffectRequest {
+        EffectRequest {
+            payload: payload.to_vec(),
+            pattern: EffectPattern::StageThenCommit,
+            idempotency_key: None,
+            net_scope: NetScope::None,
+            fs_scope: FsScope::empty(),
+            secret_scope: SecretScope::None,
+        }
+    }
+
+    #[test]
+    fn returns_ordered_passages_and_drops_the_score() {
+        let cap = RetrieveCapability::new(StubView::ok(vec![
+            hit(1, "photosynthesis converts sunlight", 0.91, 0),
+            hit(2, "plants use chlorophyll", 0.74, 1),
+        ]));
+        let out = cap
+            .invoke(&req(
+                br#"{"dataset":"docs","query":"how plants make energy"}"#,
+            ))
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        // The observation carries the ordered passages...
+        let passages = v["passages"].as_array().unwrap();
+        assert_eq!(passages.len(), 2);
+        assert_eq!(passages[0]["text"], "photosynthesis converts sunlight");
+        assert_eq!(passages[0]["ref"], ContentRef::from_bytes([1; 32]).to_hex());
+        assert_eq!(
+            passages[0]["parent_ref"],
+            ContentRef::from_bytes([101; 32]).to_hex()
+        );
+        assert_eq!(passages[0]["chunk_index"], 0);
+        // ...and NEVER the score (SN-8: the committed fact is the ref set, scores out).
+        assert!(
+            !String::from_utf8_lossy(&out).contains("score"),
+            "the committed observation must not carry a similarity score (SN-8)"
+        );
+        assert!(passages[0].get("score").is_none());
+    }
+
+    #[test]
+    fn default_k_when_omitted_and_clamps_an_oversize_k() {
+        // (k is validated upstream by the typed schema; the capability clamps defensively.)
+        let cap = RetrieveCapability::new(StubView::ok(vec![hit(1, "x", 0.5, 0)]));
+        // Omitted k → no panic, returns the hit.
+        let out = cap.invoke(&req(br#"{"dataset":"d","query":"q"}"#)).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&out).unwrap()["passages"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn soft_fails_every_recoverable_error_to_an_empty_observation() {
+        for err in [
+            DatasetError::NotFound,
+            DatasetError::StaleIndex("stale".into()),
+            DatasetError::DimMismatch("dim".into()),
+            DatasetError::EmbedderUnavailable,
+            DatasetError::InvalidArgument("bad".into()),
+        ] {
+            let cap = RetrieveCapability::new(StubView::fail(err));
+            let out = cap
+                .invoke(&req(br#"{"dataset":"missing","query":"q"}"#))
+                .expect("recoverable errors must NOT dead-letter the chain");
+            let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+            assert!(v["passages"].as_array().unwrap().is_empty());
+            assert!(v["note"].is_string(), "an honest note explains the empty");
+        }
+    }
+
+    #[test]
+    fn hard_internal_error_dead_letters() {
+        let cap =
+            RetrieveCapability::new(StubView::fail(DatasetError::Internal("poisoned".into())));
+        assert!(
+            cap.invoke(&req(br#"{"dataset":"d","query":"q"}"#)).is_err(),
+            "a hard backend fault must surface as Err (dead-letter), not a fake empty"
+        );
+    }
+
+    #[test]
+    fn refuses_unknown_arg_key_and_malformed_json() {
+        let cap = RetrieveCapability::new(StubView::ok(vec![]));
+        assert!(cap
+            .invoke(&req(br#"{"dataset":"d","query":"q","evil":1}"#))
+            .is_err());
+        assert!(cap.invoke(&req(br#"{"dataset":"d"}"#)).is_err()); // missing required `query`
+        assert!(cap.invoke(&req(b"not json")).is_err());
+    }
+
+    #[test]
+    fn tool_def_is_flat_builtin_with_typed_schema() {
+        let (name, ver) = retrieve_tool();
+        assert_eq!(name.0, "retrieve");
+        assert!(
+            !name.0.contains('/'),
+            "a builtin id is flat (the fs-list precedent)"
+        );
+        assert_eq!(ver.0, "1");
+        let def = retrieve_tool_def();
+        assert!(matches!(def.kind, ToolKind::Builtin));
+        assert_eq!(def.idempotency_class, IdempotencyClass::Readback);
+        assert_eq!(def.required_capability.net_scope_required, NetScope::None);
+        let schema = def.input_schema.expect("typed schema");
+        assert!(schema.deny_unknown);
+        let names: Vec<&str> = schema.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, ["dataset", "query", "k"]);
+        assert!(!schema.params[0].name.is_empty());
+        assert!(!schema.params[2].required, "k is optional");
+    }
+}

--- a/crates/kx-gateway/src/server.rs
+++ b/crates/kx-gateway/src/server.rs
@@ -843,6 +843,20 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
             }
         }
     }
+    // RC4b (agentic RAG): seed retrieve@1 into the durable registry so DiscoverTools +
+    // the react-rag tool menu show it, exactly when the retrieve capability is
+    // registerable (the hnsw + serve build). The capability itself registers below, once
+    // the dataset view is built (the broker's register_capability is interior-mutable).
+    #[cfg(all(feature = "serve-engine", feature = "hnsw"))]
+    if let Err(error) = tool_registry.register_server_tool(
+        crate::retrieve_tool::retrieve_tool_def(),
+        kx_tool_registry::ToolProvenance::HumanAuthored {
+            author: "kx-gateway".to_string(),
+        },
+        None,
+    ) {
+        tracing::warn!(%error, "RC4b: failed to seed retrieve@1 into tools.db");
+    }
     // Batch A: vision is a SERVE FACT derived from what actually registered
     // (the catalog entry declares "image" iff the projector resolved + the
     // backend built) — the vision recipe seeds exactly when the dispatch path
@@ -876,12 +890,22 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
         .collect();
     #[cfg(not(feature = "serve-engine"))]
     let secondary_models: Vec<kx_mote::ModelId> = Vec::new();
+    // RC4b: the retrieve@1 tool identity the react-rag recipe's warrant grants — `Some`
+    // exactly when the retrieve capability is registerable (the hnsw + serve build), so
+    // the react-rag recipe is provisioned (+ vision-rag knows datasets are available).
+    // `None` ⇒ neither RAG recipe is seeded (byte-identical to before).
+    #[cfg(all(feature = "serve-engine", feature = "hnsw"))]
+    let retrieve_tool_id: Option<(kx_mote::ToolName, kx_mote::ToolVersion)> =
+        Some(crate::retrieve_tool::retrieve_tool());
+    #[cfg(not(all(feature = "serve-engine", feature = "hnsw")))]
+    let retrieve_tool_id: Option<(kx_mote::ToolName, kx_mote::ToolVersion)> = None;
     let demo = Arc::new(DemoLibrary::open_serve(
         &catalog_dir,
         default_executor_class(),
         &parties,
         serve_model.as_ref(),
         react_tool.as_ref(),
+        retrieve_tool_id.as_ref(),
         vision_supported,
         fs_list_binding,
         autogrant,
@@ -947,6 +971,15 @@ async fn start_impl(cfg: GatewayConfig) -> Result<RunningGateway, GatewayError> 
             }
         });
     }
+    // RC4b (agentic RAG): register the read-only retrieve@1 capability on the SAME serve
+    // broker, over the live dataset view (the broker's register_capability is
+    // interior-mutable, so this late registration — after the dataset view is built — is
+    // supported; the kx/recipes/react-rag recipe seeded above grants exactly this tool).
+    #[cfg(all(feature = "serve-engine", feature = "hnsw"))]
+    crate::retrieve_tool::register_retrieve_capability(
+        &local_broker,
+        dataset_view.clone() as std::sync::Arc<dyn kx_gateway_core::DatasetView>,
+    );
     let binder: Arc<dyn RecipeBinder> = {
         #[cfg_attr(not(feature = "hnsw"), allow(unused_mut))]
         let mut host_binder = if autogrant {

--- a/crates/kx-gateway/src/toolscout.rs
+++ b/crates/kx-gateway/src/toolscout.rs
@@ -46,6 +46,10 @@ fn curated_keywords(tool_id: &str) -> Vec<&'static str> {
         "fs-write" => vec!["file", "write", "save", "filesystem", "disk", "store"],
         "text-summarize" => vec!["text", "summarize", "summary", "condense", "digest"],
         "mcp-echo" => vec!["echo", "repeat", "mirror", "ping"],
+        // RC4b: the agentic-RAG dataset-search tool (seeded on an hnsw + serve build).
+        "retrieve" => vec![
+            "retrieve", "search", "dataset", "rag", "passage", "find", "lookup",
+        ],
         _ => vec![],
     }
 }

--- a/crates/kx-gateway/tests/react_rag_serve.rs
+++ b/crates/kx-gateway/tests/react_rag_serve.rs
@@ -1,0 +1,182 @@
+//! Live agentic-RAG e2e witness — `kx serve` drives a chain where the model
+//! autonomously searches a dataset with the `retrieve` tool and answers grounded in
+//! what it found. The hard assertion is that the chain ANSWERS; whether the model
+//! fired `retrieve` is logged (a live tool proposal is probabilistic — the
+//! deterministic wiring is unit-tested in `retrieve_tool` + `provision`).
+//!
+//! ```text
+//! Flow: ingest a paraphrase corpus (server-embed) -> Invoke kx/recipes/react-rag
+//!   -> the binder folds the dataset into the instruction, react_seed=true
+//!   -> the coordinator seed-swap anchors the run-salted chain
+//!   -> the worker runs REAL inference; on a retrieve proposal the broker runs the
+//!      hybrid HostDatasetView::query and commits the passages as the Observation
+//!   -> the chain settles a terminal Answer (durable facts via ListReactTurns).
+//!
+//! Drive on BOTH engines (GR24; #[ignore], runtime-skips without a served model):
+//!   # llama.cpp (decoder-as-embedder honest-degrade, or set KX_SERVE_EMBED_MODEL):
+//!   KX_SERVE_MODEL_GGUF=.../gemma-4-12b-it-q4_k_m.gguf \
+//!     cargo test -p kx-gateway --features inference,hnsw --test react_rag_serve -- --ignored --nocapture
+//!   # Ollama:
+//!   KX_SERVE_OLLAMA=1 KX_SERVE_OLLAMA_MODELS=gemma3:12b,embeddinggemma:latest \
+//!     KX_SERVE_EMBED_MODEL=embeddinggemma:latest \
+//!     cargo test -p kx-gateway --features inference,hnsw --test react_rag_serve -- --ignored --nocapture
+//! ```
+
+#![cfg(all(feature = "inference", feature = "hnsw"))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_gateway::{start, REACT_RAG_RECIPE_HANDLE};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+/// The serve model GGUF (llama.cpp path): `KX_SERVE_MODEL_GGUF` if set, else the
+/// public stand-in. `None` ⇒ runtime-skip (unless an Ollama serve is configured).
+fn serve_model() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("KX_SERVE_MODEL_GGUF") {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let standin = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/models/qwen3-0.6b-q4_k_m.gguf");
+    standin.is_file().then_some(standin)
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+/// One server-embed document (empty embedding ⇒ the host embeds `content`).
+fn doc(content: &[u8]) -> proto::IngestDocument {
+    proto::IngestDocument {
+        content: content.to_vec(),
+        embedding: Vec::new(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real LLM inference + dataset embedding; needs a served Gemma model; opt in with --ignored"]
+async fn react_rag_chain_searches_a_dataset_and_answers() {
+    // The llama.cpp path needs a GGUF; the Ollama path is selected via KX_SERVE_OLLAMA.
+    let ollama = std::env::var_os("KX_SERVE_OLLAMA").is_some();
+    if !ollama {
+        let Some(gguf) = serve_model() else {
+            eprintln!("skipping: no serve model — set KX_SERVE_MODEL_GGUF or KX_SERVE_OLLAMA=1");
+            return;
+        };
+        std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+    }
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    // react-rag is provisioned only on a model + hnsw serve (the retrieve capability).
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_RAG_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: kx/recipes/react-rag not provisioned (needs a served model + hnsw)");
+        running.shutdown().await.unwrap();
+        return;
+    }
+
+    // Ingest a tiny paraphrase corpus (server-embed). The target doc never uses the
+    // word "photosynthesis" — only the agent's own retrieve query can surface it.
+    let ingest = c
+        .ingest_documents(proto::IngestDocumentsRequest {
+            dataset: "science".to_string(),
+            documents: vec![
+                doc(b"Plants turn sunlight, water, and carbon dioxide into sugar and oxygen inside their leaves."),
+                doc(b"The mitochondria is the powerhouse of the cell, producing ATP from glucose."),
+                doc(b"Tectonic plates drift over the mantle, causing earthquakes at their boundaries."),
+            ],
+        })
+        .await;
+    if ingest.is_err() {
+        eprintln!("skipping: ingest failed (no embedder wired) — set KX_SERVE_EMBED_MODEL");
+        running.shutdown().await.unwrap();
+        return;
+    }
+
+    // Invoke react-rag: the dataset is folded into the instruction; the model must
+    // search it with `retrieve` to answer (the corpus paraphrases the question).
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_RAG_RECIPE_HANDLE.to_string(),
+            args: br#"{"instruction":"How do plants make energy from the sun? Answer briefly using the dataset.","dataset":"science","max_turns":4,"max_tool_calls":3}"#
+                .to_vec(),
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke kx/recipes/react-rag")
+        .into_inner();
+    assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
+    let step_salt = (!resp.react_chain_salt.is_empty()).then(|| resp.react_chain_salt.clone());
+
+    // Await settle: the chain freezes a terminal Answer (be generous — inference is slow).
+    let mut answered = false;
+    let mut retrieved = false;
+    for _ in 0..900 {
+        let turns = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+                step_salt: step_salt.clone(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        for t in &turns.turns {
+            if t.branch == "tool" && t.tool_id == "retrieve" {
+                retrieved = true;
+            }
+            if t.branch == "answer" {
+                answered = true;
+            }
+        }
+        if answered {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        answered,
+        "the live agentic-RAG chain settled a terminal Answer"
+    );
+    // The agentic-RAG proof: did the model AUTONOMOUSLY call retrieve? Logged, not
+    // hard-required (a live model's tool-proposal is probabilistic — RC3 menu + RC2
+    // grammar make it likely; the deterministic wiring is unit-tested elsewhere).
+    if retrieved {
+        eprintln!("✓ agentic RAG: the model fired the `retrieve` tool autonomously");
+    } else {
+        eprintln!("· note: the model answered without firing `retrieve` (check the prompt/menu)");
+    }
+
+    running.shutdown().await.unwrap();
+}

--- a/crates/kx-gateway/tests/toolscout_e2e.rs
+++ b/crates/kx-gateway/tests/toolscout_e2e.rs
@@ -56,16 +56,34 @@ async fn list_tool_manifests_enumerates_the_builtins() {
         .into_inner()
         .manifests;
 
+    // `mcp-echo/echo` registers only when the bundled bin is present (env-dependent — in
+    // CI's inference-checks it is absent), so filter it out and assert the DETERMINISTIC
+    // registry builtins. RC4b: the read-only `retrieve@1` tool is seeded whenever datasets
+    // are available (a `serve-engine` + `hnsw` build), so it joins the OSS builtins in the
+    // advisory discovery surface — sorted between `fs-write` and `text-summarize`.
     let ids: Vec<(&str, &str)> = manifests
         .iter()
         .map(|m| (m.tool_id.as_str(), m.tool_version.as_str()))
+        .filter(|(id, _)| !id.starts_with("mcp-echo"))
         .collect();
+    #[cfg(all(feature = "serve-engine", feature = "hnsw"))]
+    let expected = vec![
+        ("fs-read", "1"),
+        ("fs-write", "1"),
+        ("retrieve", "1"),
+        ("text-summarize", "1"),
+    ];
+    #[cfg(not(all(feature = "serve-engine", feature = "hnsw")))]
+    let expected = vec![("fs-read", "1"), ("fs-write", "1"), ("text-summarize", "1")];
     assert_eq!(
-        ids,
-        vec![("fs-read", "1"), ("fs-write", "1"), ("text-summarize", "1")],
+        ids, expected,
         "the OSS builtins, in deterministic (tool_id, tool_version) order"
     );
-    for m in &manifests {
+    // (skip the env-dependent `mcp-echo/echo` — it is kind `Mcp`, not `Builtin`).
+    for m in manifests
+        .iter()
+        .filter(|m| !m.tool_id.starts_with("mcp-echo"))
+    {
         assert_eq!(m.kind, "Builtin");
         assert!(
             !m.description.is_empty(),
@@ -100,7 +118,21 @@ async fn score_task_bundle_ranks_deterministically_and_stays_advisory() {
 
     // Every manifest ranked, best first; the exact intent keywords ("read",
     // "file", "disk") hit fs-read's curated keyword set at the 10 000 ceiling.
-    assert_eq!(first.ranked.len(), 3, "every registered manifest is ranked");
+    // Filter the env-dependent `mcp-echo/echo`; RC4b: +1 (retrieve@1) on a serve-engine +
+    // hnsw build (see the manifests test).
+    let ranked_builtins = first
+        .ranked
+        .iter()
+        .filter(|r| !r.tool_id.starts_with("mcp-echo"))
+        .count();
+    #[cfg(all(feature = "serve-engine", feature = "hnsw"))]
+    let expected_count = 4;
+    #[cfg(not(all(feature = "serve-engine", feature = "hnsw")))]
+    let expected_count = 3;
+    assert_eq!(
+        ranked_builtins, expected_count,
+        "every registered manifest is ranked"
+    );
     assert_eq!(first.ranked[0].tool_id, "fs-read");
     assert_eq!(first.ranked[0].score_bp, 10_000);
     assert!(

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -152,6 +152,74 @@ fn extract_gemma_native(text: &str) -> Option<NativeCall<'_>> {
     Some(NativeCall { raw_name, args })
 }
 
+/// Gemma-4 sometimes wraps the FULL `{"tool_call":{…}}` ENVELOPE inside its native
+/// delimiters — `<|tool_call>call:{"tool_call":{…}}<tool_call|>` — instead of the bare
+/// `call:NAME{ARGS}`. The `NAME{ARGS}` arm ([`extract_gemma_native`]) reads an EMPTY name
+/// there (the `{` follows the optional `call:`) and bails, so this returns the inner
+/// brace-balanced `{…}` object for the envelope decoder to recover. DEFINED-delimiter
+/// only (the marker is the boundary; [`balanced_object`] bounds the JSON) — never a
+/// mid-string `{` search, so the SN-8 injection boundary is unchanged. `None` unless the
+/// text opens with the Gemma marker AND the body is a leading brace-balanced object.
+/// Total + panic-free.
+fn gemma_marked_envelope(text: &str) -> Option<&str> {
+    let after_open = text.trim_start().strip_prefix(GEMMA_TOOL_OPEN)?;
+    let after_marker_ws = after_open.trim_start();
+    let after_marker = after_marker_ws
+        .strip_prefix(GEMMA_CALL_MARKER)
+        .unwrap_or(after_marker_ws)
+        .trim_start();
+    if after_marker.starts_with('{') {
+        balanced_object(after_marker)
+    } else {
+        None
+    }
+}
+
+/// Resolve a decoded `{"tool_call":{name,version,args}}` envelope to a granted
+/// [`ToolCall`], or a LOUD [`DecodeError`]. Exact `(name, version)` crypto-equality
+/// FIRST (SN-8); only an empty version resolves the name to a UNIQUE grant (the menu-label
+/// drift shape); a non-empty wrong version stays `UngrantedTool`. Args carried verbatim,
+/// size-capped (IMP-16). Shared by the bare-envelope path AND the Gemma-marked-envelope
+/// recovery so the authority surface is identical. Total + panic-free.
+fn resolve_envelope_call(
+    raw: RawToolCall,
+    warrant: &WarrantSpec,
+    max_args_bytes: usize,
+) -> Result<ToolCall, DecodeError> {
+    let name = ToolName(raw.name);
+    let version = ToolVersion(raw.version);
+    let exact = ToolGrant {
+        tool_id: name.clone(),
+        tool_version: version.clone(),
+    };
+    let grant = if warrant.tool_grants.contains(&exact) {
+        exact
+    } else if version.0.trim().is_empty() {
+        match resolve_name(&name.0, warrant) {
+            NameResolution::Unique(g) => g,
+            NameResolution::Ambiguous(candidates) => {
+                return Err(DecodeError::Ambiguous { name, candidates })
+            }
+            NameResolution::Unresolved => return Err(DecodeError::UngrantedTool { name, version }),
+        }
+    } else {
+        return Err(DecodeError::UngrantedTool { name, version });
+    };
+    let args_bytes =
+        args_value_bytes(&raw.args).unwrap_or_else(|| raw.args.get().as_bytes().to_vec());
+    if args_bytes.len() > max_args_bytes {
+        return Err(DecodeError::Oversize {
+            got: args_bytes.len(),
+            max: max_args_bytes,
+        });
+    }
+    Ok(ToolCall {
+        name: grant.tool_id,
+        version: grant.tool_version,
+        args_bytes,
+    })
+}
+
 /// Return the prefix of `s` (which MUST start with `{`) spanning the first
 /// brace-balanced JSON object, ignoring braces inside double-quoted strings
 /// (with `\"` escapes). `None` if unbalanced or past `MAX_DEPTH`. Total +
@@ -805,6 +873,23 @@ pub fn parse_tool_call(
         return Ok(Some(resolve_native_call(&native, warrant, max_args_bytes)?));
     }
 
+    // (1a') Gemma-4 sometimes wraps the `{"tool_call":…}` ENVELOPE inside its native
+    //       markers (`<|tool_call>call:{"tool_call":{…}}<tool_call|>`) rather than the
+    //       bare `call:NAME{ARGS}`. The native arm above reads an EMPTY name there (the
+    //       `{` follows the optional `call:`), so recover the inner envelope through the
+    //       SAME exact-grant resolution + args cap as a bare envelope — SN-8 unchanged (the
+    //       DEFINED marker is the boundary, never a `{` search). A wrapped object that is
+    //       NOT a `tool_call` envelope falls through to a normal completion. (Live
+    //       RC4b witness: Gemma-4 emits this for the `retrieve` tool — T-GEMMA-ENVELOPE-IN-MARKER.)
+    if let Some(inner) = gemma_marked_envelope(trimmed) {
+        if let Ok(Envelope {
+            tool_call: Some(raw),
+        }) = serde_json::from_str::<Envelope>(inner)
+        {
+            return Ok(Some(resolve_envelope_call(raw, warrant, max_args_bytes)?));
+        }
+    }
+
     // (1b) Llama-3.1 `<|python_tag|>{…}` and Qwen3/Hermes `<tool_call>{…}</tool_call>`
     //      — two MORE DEFINED-delimiter shapes (markers required; never a `{` search),
     //      each wrapping a `{"name":…, "arguments"|"parameters"|"args":…}` object.
@@ -852,57 +937,11 @@ pub fn parse_tool_call(
         return decode_markerless(trimmed, warrant, max_args_bytes);
     };
 
-    // (3) The model committed to a tool call. Enforce tool ∈ warrant.tool_grants.
-    //     EXACT (name, version) crypto-equality is tried FIRST — byte-identical to
-    //     every prior row (SN-8 / D70). Only on an exact MISS *with an empty
-    //     version* (the `mcp-echo:echo` separator/version-drift shape a model emits
-    //     when it copies the menu label) do we resolve the name to a UNIQUE grant
-    //     and take the GRANT's version — never the model's. A NON-empty wrong
-    //     version stays `UngrantedTool` (the model pinned a different tool — SN-8;
-    //     keeps `ungranted_tool_is_refused` valid). The returned call is an element
-    //     of `tool_grants` by construction (never widens the set).
-    let name = ToolName(raw.name);
-    let version = ToolVersion(raw.version);
-    let exact = ToolGrant {
-        tool_id: name.clone(),
-        tool_version: version.clone(),
-    };
-    let grant = if warrant.tool_grants.contains(&exact) {
-        exact
-    } else if version.0.trim().is_empty() {
-        // A committed `tool_call` envelope ⇒ a non-unique name is a LOUD refusal:
-        // ambiguity carries the candidate full-ids for the disambiguating re-prompt;
-        // no grant stays `UngrantedTool` (preserving the model's pinned name+version).
-        match resolve_name(&name.0, warrant) {
-            NameResolution::Unique(g) => g,
-            NameResolution::Ambiguous(candidates) => {
-                return Err(DecodeError::Ambiguous { name, candidates })
-            }
-            NameResolution::Unresolved => return Err(DecodeError::UngrantedTool { name, version }),
-        }
-    } else {
-        return Err(DecodeError::UngrantedTool { name, version });
-    };
-
-    // (4) Carry the args verbatim, size-capped (IMP-16). An args OBJECT is carried
-    //     byte-for-byte (the PR-2d-1 pin); a pre-serialized JSON-STRING value (some
-    //     models emit `"args":"{…}"`) is unescaped to its inner JSON, then repaired +
-    //     schema-validated downstream — the envelope-side complement to PR-3's args
-    //     repair. A non-object/non-string value carries verbatim (refused downstream).
-    let args_bytes =
-        args_value_bytes(&raw.args).unwrap_or_else(|| raw.args.get().as_bytes().to_vec());
-    if args_bytes.len() > max_args_bytes {
-        return Err(DecodeError::Oversize {
-            got: args_bytes.len(),
-            max: max_args_bytes,
-        });
-    }
-
-    Ok(Some(ToolCall {
-        name: grant.tool_id,
-        version: grant.tool_version,
-        args_bytes,
-    }))
+    // (3) The model committed to a tool call. Enforce tool ∈ warrant.tool_grants via the
+    //     SHARED envelope resolver (exact (name, version) crypto-equality FIRST, SN-8;
+    //     empty-version name-resolve for the menu-label drift shape; args carried verbatim
+    //     + size-capped) — the SAME path the Gemma-marked-envelope recovery uses.
+    Ok(Some(resolve_envelope_call(raw, warrant, max_args_bytes)?))
 }
 
 /// Decode ALL model-proposed tool calls from raw model output, fail-closed —
@@ -1334,6 +1373,55 @@ mod tests {
         assert_eq!(call.name, ToolName("fs-list".into())); // `_`→`-` normalized
         assert_eq!(call.version, ToolVersion("1".into())); // resolved from the grant
         assert_eq!(call.args_bytes, b"{}".to_vec());
+    }
+
+    #[test]
+    fn gemma_marked_envelope_is_recovered_to_a_granted_call() {
+        // RC4b live-witness (T-GEMMA-ENVELOPE-IN-MARKER): Gemma-4 sometimes wraps the FULL
+        // {"tool_call":{…}} envelope INSIDE its native markers (`call:` then a `{`, not a
+        // bare name). The native NAME{ARGS} arm reads an EMPTY name; the envelope must be
+        // recovered through the same exact-grant resolution + args cap (SN-8).
+        let w = warrant_granting(Some(("retrieve", "1")));
+        let env = br#"<|tool_call>call:{"tool_call":{"name":"retrieve","version":"1","args":{"dataset":"science","query":"plants energy sun"}}}<tool_call|>"#;
+        let call = parse_tool_call(env, &w, 4096)
+            .unwrap()
+            .expect("the marked envelope recovers to a granted call");
+        assert_eq!(call.name, ToolName("retrieve".into()));
+        assert_eq!(call.version, ToolVersion("1".into()));
+        assert_eq!(
+            call.args_bytes,
+            br#"{"dataset":"science","query":"plants energy sun"}"#.to_vec()
+        );
+    }
+
+    #[test]
+    fn gemma_marked_envelope_without_call_marker_is_recovered() {
+        // The `call:` marker is optional — `<|tool_call>{envelope}` recovers too.
+        let w = warrant_granting(Some(("retrieve", "1")));
+        let env = br#"<|tool_call>{"tool_call":{"name":"retrieve","version":"1","args":{"dataset":"d","query":"q"}}}"#;
+        let call = parse_tool_call(env, &w, 4096).unwrap().expect("recovered");
+        assert_eq!(call.name, ToolName("retrieve".into()));
+    }
+
+    #[test]
+    fn gemma_marked_envelope_ungranted_is_refused_not_silent() {
+        // SN-8: a marked envelope naming an UNGRANTED tool is a LOUD refusal, never prose —
+        // the recovery still flows through the exact-grant authority gate.
+        let w = warrant_granting(Some(("retrieve", "1")));
+        let env = br#"<|tool_call>call:{"tool_call":{"name":"rm-rf","version":"1","args":{}}}<tool_call|>"#;
+        assert!(matches!(
+            parse_tool_call(env, &w, 4096),
+            Err(DecodeError::UngrantedTool { .. })
+        ));
+    }
+
+    #[test]
+    fn gemma_marked_non_envelope_object_is_a_normal_completion() {
+        // A Gemma marker wrapping a NON-tool_call object is prose, not a refusal (the
+        // model emitted structured non-call JSON). Degrades to a normal completion.
+        let w = warrant_granting(Some(("retrieve", "1")));
+        let env = br#"<|tool_call>call:{"thought":"I should search"}<tool_call|>"#;
+        assert!(parse_tool_call(env, &w, 4096).unwrap().is_none());
     }
 
     #[test]

--- a/docs/site/docs/agent-runner.md
+++ b/docs/site/docs/agent-runner.md
@@ -74,6 +74,17 @@ kx agent run --goal "Use the echo tool to repeat 'pong'." --max-tool-calls 20 --
 > the granted tool set is fixed and part of the step's identity. There is no separate
 > chains `agent()` node by design (it would be a second, divergent wire shape).
 
+## Searching a dataset (agentic RAG)
+
+Pass `--dataset <name>` and the agent gets a read-only **`retrieve` tool** — it decides
+when to search, phrases its own query, reads the passages, re-queries, and answers grounded
+in what it found (the `kx/recipes/react-rag` recipe over the hybrid index). See
+**[Agentic RAG](./agentic-rag.md)** for the full cross-surface walkthrough.
+
+```bash
+kx agent run --goal "What does the handbook say about parental leave?" --dataset handbook
+```
+
 ## Vision in agents (agentic vision)
 
 Attach an **image** and the agent reasons over it on **every turn** of the loop — not

--- a/docs/site/docs/agentic-rag.md
+++ b/docs/site/docs/agentic-rag.md
@@ -1,0 +1,129 @@
+---
+id: agentic-rag
+title: Agentic RAG
+sidebar_label: Agentic RAG
+description: Let a local agent search your datasets autonomously — the model decides when to retrieve, phrases its own query, reads the passages, re-queries, and answers grounded in what it found (the retrieve tool + the react-rag recipe). Plus vision-RAG (ground an image answer on retrieved text).
+---
+
+# Agentic RAG
+
+Plain [RAG](./datasets.md) retrieves **once** and folds the passages into the prompt
+(`kx/recipes/chat-rag`). **Agentic RAG** hands the agent a **`retrieve` tool** instead:
+the model decides *when* to search, *phrases its own query*, reads the passages, **re-queries**
+if the first result is thin, and answers grounded in what it found — a `reason → retrieve →
+reason` loop over the same hybrid (keyword + semantic) index. The retrieval is durable and
+replayable: each retrieve call commits the **ordered content-refs** of the passages it read
+(scores stay out — model proposes, the runtime records exact references only).
+
+This is the `kx/recipes/react-rag` recipe (a sibling of [`react`](./agent-runner.md) and
+`react-fs`), provisioned automatically on a serve with datasets enabled (the `hnsw` build).
+It is reachable from the **one entry point** — `kx` / `KxClient` — exactly like every other
+capability.
+
+## The `retrieve` tool
+
+The agent's warrant grants a single read-only built-in tool:
+
+```json
+retrieve@1 — {"dataset": <name>, "query": <search text>, "k": <1..64, optional>}
+→ ordered passages: [{ "ref": <chunk hash>, "text": ..., "parent_ref": <doc hash>, "chunk_index": N }]
+```
+
+It runs the [hybrid retrieval](./datasets.md) path (BM25 + dense, RRF-fused, MMR-reranked),
+so a keyword a weak local embedder mis-ranks is still caught. It is **read-only**
+(`Readback` — the human-in-the-loop gate auto-proceeds it), has **no egress and no filesystem
+scope**, and **fails soft**: an unknown / empty / stale dataset returns an empty observation the
+agent reads and recovers from — the loop never dead-letters on a retrieval miss.
+
+## Run it
+
+Point the agent at a dataset with `--dataset`; it does the rest.
+
+**CLI** — `kx agent run --dataset`:
+
+```bash
+# Ingest a corpus once (see Data Lab), then:
+kx agent run --goal "What does the handbook say about parental leave?" --dataset handbook
+# · agentic RAG over dataset 'handbook' — the model searches it with the retrieve tool
+# { "answer": "...", "actions": [{ "tool_id": "retrieve", "tool_version": "1", "turn": 0, ... }], ... }
+```
+
+The audited `actions` show every `retrieve` call the agent made (and any re-query) in turn order
+— the same `ListReactTurns` trace `kx react list` reads back.
+
+**Python** — `client.invoke(REACT_RAG_RECIPE_HANDLE, …)`:
+
+```python
+from kortecx import KxClient, REACT_RAG_RECIPE_HANDLE
+
+kx = KxClient("http://127.0.0.1:50151")
+answer = kx.invoke(
+    REACT_RAG_RECIPE_HANDLE,
+    {"instruction": "What does the handbook say about parental leave?", "dataset": "handbook"},
+    wait=True,
+)
+print(answer.text)
+# async: await AsyncKxClient(...).invoke(REACT_RAG_RECIPE_HANDLE, {...}, wait=True)
+```
+
+**TypeScript** — `client.invoke(REACT_RAG_RECIPE_HANDLE, …)`:
+
+```ts
+import { KxClient, REACT_RAG_RECIPE_HANDLE } from "@kortecx/sdk";
+
+const kx = new KxClient("http://127.0.0.1:50151");
+const answer = (await kx.invoke(
+  REACT_RAG_RECIPE_HANDLE,
+  { instruction: "What does the handbook say about parental leave?", dataset: "handbook" },
+  { wait: true },
+)) as { text?: string };
+console.log(answer.text ?? "");
+```
+
+**Console** — open **New Chat**, turn on **Agent mode**, and pick a dataset. Each message routes
+to `react-rag`; the agent's `retrieve` calls and the passages it read stream into the reasoning
+trace, so you can watch it search, re-query, and ground its answer.
+
+> **react-rag vs chat-rag.** Use **chat-rag** (`kx chat --dataset`) for a fast, single-shot
+> grounded answer. Use **react-rag** (`kx agent run --dataset`) when the question may need the
+> agent to **decide what to search for**, refine the query, or search more than once. The
+> production chat path is already hybrid; agentic RAG adds the autonomy.
+
+## Vision-RAG
+
+Combine an **image** and a **dataset** to ground a multimodal answer: the served vision model
+answers about the image *while* grounded on the dataset's top-k retrieved **text** passages — in
+one generation (`kx/recipes/vision-rag`). Datasets stay text-only (image embeddings are a later
+addition); the image is attached, the text is retrieved.
+
+```bash
+kx chat --image ./invoice.png --dataset policies "Does this invoice comply with our expense policy?"
+# · image + dataset 'policies' — grounding the vision answer on retrieved text
+```
+
+```python
+kx.chat("Does this invoice comply with our expense policy?",
+        image=open("invoice.png", "rb").read(), dataset="policies")
+```
+
+```ts
+await kx.chat("Does this invoice comply with our expense policy?",
+              { image: invoiceBytes, dataset: "policies" });
+```
+
+Every surface **honest-degrades**: no dataset → plain agent / plain vision; no vision model →
+plain chat — it never silently drops the image or fakes grounding.
+
+## Operator notes
+
+- `kx/recipes/react-rag` is seeded automatically when a model is served **and** datasets are
+  available (the `hnsw` build). `kx/recipes/vision-rag` additionally needs an image-capable model.
+- Retrieval quality is the [Data Lab](./datasets.md) hybrid pipeline — the same chunking, BM25 +
+  dense fusion, MMR rerank, and embed-model recommendation apply. Prefer a dedicated embedding
+  model (e.g. `embeddinggemma`) over a decoder LLM for the corpus.
+- Everything is **off the canonical projection digest** — the recipes are catalog entries, and the
+  committed retrieval fact is the ordered chunk-ref set (scores excluded). A crashed agent recovers
+  to its exact recall state.
+
+See also: [Data Lab](./datasets.md) · [Agents & reasoning](./agent-runner.md) ·
+[Tools](./tools.md) · [Local inference engines](./local-inference-engines.md).

--- a/docs/site/docs/datasets.md
+++ b/docs/site/docs/datasets.md
@@ -55,6 +55,12 @@ dataset's summary shows `chunked` + the distinct `chunk_count` alongside `doc_co
 (parent documents). Existing (pre-chunking) corpora keep working — a whole document is
 treated as a single chunk.
 
+:::tip Let an agent search it
+The same hybrid pipeline powers **[Agentic RAG](./agentic-rag.md)** — hand a dataset to an
+agent (`kx agent run --dataset <name>`) and the model searches it autonomously with the
+`retrieve` tool, re-querying until it can answer.
+:::
+
 ## Embedding: server-side or bring-your-own vectors
 
 Ingest and query are **pluggable** on embedding:

--- a/docs/site/docs/tools.md
+++ b/docs/site/docs/tools.md
@@ -102,6 +102,17 @@ KX_SERVE_FS_ROOT=/path/to/readable/dir kx serve --features inference
 `fs-list` never reads file *contents* — it returns names only, confined to the
 granted mount (canonicalized; no traversal out).
 
+## The `retrieve` built-in
+
+`retrieve@1` is the read-only **dataset-search** tool that powers
+**[Agentic RAG](./agentic-rag.md)**. On a serve with datasets enabled (the `hnsw` build)
+the runtime grants it to the `kx/recipes/react-rag` loop, so the model can search a corpus
+on its own: `{"dataset": <name>, "query": <text>, "k": <1..64>}` → ordered passages (chunk
+hash + text + provenance) over the [hybrid](./datasets.md) index. No egress, no filesystem
+scope, `Readback` (auto-proceeds the HITL gate); the committed Observation is the ordered
+chunk-ref set (scores excluded, SN-8). A missing/empty dataset returns an empty observation
+the agent recovers from — the loop never dead-letters on a retrieval miss.
+
 ## Reviewing what agents produce
 
 Every committed tool output (and every model turn) is captured in the **Data Lab →

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -41,6 +41,7 @@ const sidebars: SidebarsConfig = {
         "models",
         "local-inference-engines",
         "datasets",
+        "agentic-rag",
         "branches",
         "scripts",
         "reading-run-outputs",

--- a/ui/src/components/chat/useChatController.ts
+++ b/ui/src/components/chat/useChatController.ts
@@ -129,7 +129,10 @@ export function useChatController(config: ChatControllerConfig = {}): ChatContro
     promptKey: backing.promptKey,
     modelId,
     agentMode: agentTurn,
-    dataset: agentTurn ? undefined : dataset,
+    // RC4b: pass the dataset in BOTH modes — a plain turn grounds via chat-rag, an agent
+    // turn routes to react-rag (the model searches it with the `retrieve` tool). The
+    // recipe form-gate honest-degrades when react-rag is not provisioned.
+    dataset,
     contextRefs: config.contextRefs,
   });
 

--- a/ui/src/kx/use-chat.ts
+++ b/ui/src/kx/use-chat.ts
@@ -66,6 +66,18 @@ export const REACT_AUTO_RECIPE_HANDLE = "kx/recipes/react-auto";
  *  prefix, so it settles as a react CHAIN. */
 export const REACT_VISION_RECIPE_HANDLE = "kx/recipes/react-vision";
 
+/** RC4b AGENTIC RAG: the dataset-grounded ReAct loop — agent mode + a selected dataset
+ *  route here so the model AUTONOMOUSLY searches the corpus with the read-only `retrieve`
+ *  tool (hybrid), reads passages, and can re-query. Provisioned only on an `hnsw` serve;
+ *  absent ⇒ agent mode honest-degrades to the plain react loop (the dataset is dropped).
+ *  Shares the `kx/recipes/react` prefix, so it settles as a react CHAIN. */
+export const REACT_RAG_RECIPE_HANDLE = "kx/recipes/react-rag";
+
+/** RC4b VISION-RAG: image + a selected dataset route here — the served VLM answers about
+ *  the image WHILE grounded on the dataset's retrieved text (one generation). Provisioned
+ *  only on a vision + `hnsw` serve; absent ⇒ honest-degrade to plain vision (image only). */
+export const VISION_RAG_RECIPE_HANDLE = "kx/recipes/vision-rag";
+
 interface ActiveTurn {
   readonly assistantId: string;
   readonly instanceId: string;
@@ -89,10 +101,11 @@ export interface UseChatOptions {
    *  the model reasons + fires tools until it answers. Only honored when the
    *  react recipe is provisioned (the caller gates the toggle). */
   readonly agentMode?: boolean;
-  /** POC-1 CHAT-RAG: ground each turn over this dataset (embed → top-k → fold the
-   *  exact refs). `undefined` ⇒ a plain chat. Ignored in agent mode (the loop has
-   *  its own context carry). The server honestly degrades to a plain answer when
-   *  the dataset is missing/empty. */
+  /** POC-1 CHAT-RAG / RC4b: ground each turn over this dataset. In a PLAIN turn the
+   *  server embeds → top-k → folds the exact refs (chat-rag). In AGENT mode it routes to
+   *  react-rag — the model autonomously searches the corpus with the `retrieve` tool.
+   *  `undefined` ⇒ a plain chat. The server/recipe honestly degrades when the dataset is
+   *  missing/empty (grounding is never faked). */
   readonly dataset?: string;
   /** POC-5d (AppChat): App-fixed context refs (bundle handles) attached to EVERY
    *  turn, in ADDITION to any per-message context. Optional + additive — existing
@@ -215,6 +228,47 @@ export function planReactVisionArgs(
   return args;
 }
 
+/**
+ * RC4b: build the arg set for an agentic-RAG turn — the react args (`instruction` + budget
+ * caps) PLUS a `dataset` selector the server strips + folds into the instruction (the model
+ * searches it with the `retrieve` tool). `null` when the react-rag form lacks `instruction`
+ * (then agent mode honest-degrades to the plain react loop). Pure — unit-testable.
+ */
+export function planReactRagArgs(
+  form: Pick<RecipeForm, "fields">,
+  text: string,
+  dataset: string,
+): Record<string, unknown> | null {
+  const args = planReactArgs(form, text);
+  if (args === null) {
+    return null;
+  }
+  args.dataset = dataset;
+  return args;
+}
+
+/**
+ * RC4b: build the arg set for a vision-RAG turn — the vision args (`prompt`/`image_ref`/
+ * `model`) PLUS a `dataset` + `k` the server strips + folds into the retrieved-text context.
+ * `null` when the vision-rag form lacks `image_ref` (then honest-degrade to plain vision).
+ */
+export function planVisionRagArgs(
+  form: Pick<RecipeForm, "fields">,
+  text: string,
+  imageRef: string,
+  modelId: string | undefined,
+  dataset: string,
+  k: number,
+): Record<string, unknown> | null {
+  const args = planVisionArgs(form, text, imageRef, modelId);
+  if (args === null) {
+    return null;
+  }
+  args.dataset = dataset;
+  args.k = k;
+  return args;
+}
+
 export function useChat({
   handle,
   promptKey,
@@ -237,6 +291,10 @@ export function useChat({
   // AGENTIC-VISION: the react-vision form (agent mode + an image probes it; `null` = the
   // serve has no vision model ⇒ agent mode runs text-only, the image stays display-only).
   const reactVisionFormRef = useRef<RecipeForm | null | undefined>(undefined);
+  // RC4b: the react-rag + vision-rag forms (agent/image + a dataset probe them; `null` =
+  // the serve has no hnsw datasets ⇒ honest-degrade to plain react / plain vision).
+  const reactRagFormRef = useRef<RecipeForm | null | undefined>(undefined);
+  const visionRagFormRef = useRef<RecipeForm | null | undefined>(undefined);
 
   const projection = useProjection(
     active?.instanceId,
@@ -418,6 +476,36 @@ export function useChat({
     return reactVisionFormRef.current;
   }, [client]);
 
+  /** RC4b: the react-rag recipe's form, probed once (absent ⇒ agent mode drops the dataset
+   *  and runs the plain react loop). */
+  const reactRagForm = useCallback(async (): Promise<RecipeForm | null> => {
+    if (reactRagFormRef.current !== undefined) {
+      return reactRagFormRef.current;
+    }
+    try {
+      reactRagFormRef.current = client ? await client.getRecipeForm(REACT_RAG_RECIPE_HANDLE) : null;
+    } catch {
+      reactRagFormRef.current = null; // no hnsw datasets — plain react handles the turn
+    }
+    return reactRagFormRef.current;
+  }, [client]);
+
+  /** RC4b: the vision-rag recipe's form, probed once (absent ⇒ image + dataset degrades to
+   *  plain vision, the image answer is ungrounded). */
+  const visionRagForm = useCallback(async (): Promise<RecipeForm | null> => {
+    if (visionRagFormRef.current !== undefined) {
+      return visionRagFormRef.current;
+    }
+    try {
+      visionRagFormRef.current = client
+        ? await client.getRecipeForm(VISION_RAG_RECIPE_HANDLE)
+        : null;
+    } catch {
+      visionRagFormRef.current = null; // no vision+hnsw — plain vision handles the turn
+    }
+    return visionRagFormRef.current;
+  }, [client]);
+
   /** Plan the turn: agent task (+ image → vision agent) → react loop; image → vision; else chat. */
   const planTurn = useCallback(
     async (text: string, attachments: readonly MessageAttachment[]): Promise<TurnPlan> => {
@@ -435,6 +523,18 @@ export function useChat({
             }
           }
         }
+        // RC4b: agent mode + a selected dataset (no image) → the agentic-RAG loop, so the
+        // model searches the corpus with the `retrieve` tool. Form-gated; absent ⇒ fall
+        // through to the plain react loop (the dataset is dropped, honestly).
+        if (dataset && !image) {
+          const rform = await reactRagForm();
+          if (rform) {
+            const args = planReactRagArgs(rform, text, dataset);
+            if (args !== null) {
+              return { handle: REACT_RAG_RECIPE_HANDLE, args };
+            }
+          }
+        }
         const form = await reactForm();
         if (form) {
           const args = planReactArgs(form, text);
@@ -445,6 +545,24 @@ export function useChat({
       }
       const image = attachments.find((a) => a.mediaType.startsWith("image/"));
       if (image) {
+        // RC4b: image + a selected dataset → vision-RAG (the VLM answers about the image
+        // grounded on the dataset's retrieved text). Form-gated; absent ⇒ plain vision.
+        if (dataset) {
+          const vrform = await visionRagForm();
+          if (vrform) {
+            const args = planVisionRagArgs(
+              vrform,
+              text,
+              image.ref,
+              modelId,
+              dataset,
+              CHAT_RAG_DEFAULT_K,
+            );
+            if (args !== null) {
+              return { handle: VISION_RAG_RECIPE_HANDLE, args };
+            }
+          }
+        }
         const form = await visionForm();
         if (form) {
           const args = planVisionArgs(form, text, image.ref, modelId);
@@ -464,7 +582,18 @@ export function useChat({
       }
       return { handle, args: { [promptKey]: text } };
     },
-    [handle, promptKey, modelId, agentMode, dataset, reactForm, reactVisionForm, visionForm],
+    [
+      handle,
+      promptKey,
+      modelId,
+      agentMode,
+      dataset,
+      reactForm,
+      reactRagForm,
+      reactVisionForm,
+      visionForm,
+      visionRagForm,
+    ],
   );
 
   const startTurn = useCallback(


### PR DESCRIPTION
## RC4b — Agentic RAG (`kx/recipes/react-rag` + `retrieve@1` tool + vision-RAG)

The OSS RC's agentic-RAG PR (D172; after RC1 kx-eval / RC2 grammar / RC3 tool-menu / RC4a hybrid-RAG). RC4a made retrieval high-quality but **passive**; RC4b makes a dataset a **first-class tool** the live ReAct loop calls autonomously — reason → retrieve → reason — so the model decides when to search, phrases its own query, reads the passages, re-queries, and answers grounded.

### What's in
- **`retrieve@1`** — a read-only in-process `kx_capability::Capability` (`crates/kx-gateway/src/retrieve_tool.rs`) over the RC4a hybrid `HostDatasetView::query`. Flat builtin id (the `fs-list` precedent). Committed fact = ordered chunk content-refs, **scores dropped (SN-8)**; soft-fails recoverable errors to an empty observation, dead-letters only a hard `Internal` fault.
- **`kx/recipes/react-rag`** (`logic_ref 0x5a`) — a live ReAct chain granting `retrieve@1`. The retrieve-call turn **is** the committed `ReadOnlyNondet` query-rewrite (no separate Mote). The `dataset` selector folds advisorily into the instruction at bind. Added to the `react_seed` set.
- **`kx/recipes/vision-rag`** (`logic_ref 0x5b`) — the vision recipe + the chat-rag dataset fold: the VLM answers about an image **while** grounded on the dataset's retrieved text, in one generation. Un-defers the `--image`+`--dataset` gate.
- **Cross-surface (single-entry chaining):** `kx agent run --dataset` (react-rag) · `kx chat --image --dataset` (vision-rag) · Py/TS `REACT_RAG`/`VISION_RAG` consts + `chat(image=, dataset=)` routing (sync+async) · UI agent-mode+dataset → react-rag (the controller no longer drops the dataset) · NEW `docs/site/docs/agentic-rag.md` + cross-links.

### Live dual-engine witness (GR15/GR24, Gemma only)
- **llama.cpp Gemma-4 + Ollama embeddinggemma:** the agent autonomously fired `retrieve` (turn 0) and answered **grounded** — *"Plants turn sunlight, water, and carbon dioxide into sugar and oxygen inside their leaves."* Vision-RAG answered about the image **and** the dataset in one generation — *"The shape in the image is red. According to the dataset, plants make sugar and oxygen from sunlight."*
- **Ollama gemma3:12b + embeddinggemma:** the model proposes `retrieve` with an intelligently-expanded query ("make energy from the sun" → "plants photosynthesis energy sun"); host-side chat-rag grounding returns the exact target passage. (Ollama clean-fire pending the pre-existing `T-OLLAMA-GRAMMAR-FORMAT`.)

### Bug found + fixed by the witness (`T-GEMMA-ENVELOPE-IN-MARKER`)
Gemma-4 sometimes wraps the full `{"tool_call":…}` envelope **inside** its native markers (`<|tool_call>call:{"tool_call":{…}}<tool_call|>`) rather than the bare `call:NAME{ARGS}` — the parser's native arm read an **empty name**, so the agentic tool never fired (settled as a prose answer). `kx-toolcall` now recovers the marked envelope through the **same exact-grant authority gate** (`resolve_envelope_call`; SN-8 preserved — ungranted → loud refusal, non-envelope → completion). +4 unit tests. (`kx-toolcall` is **not** frozen-trio.)

### GR8 pre-flight
- **Compat:** both recipes seed **only** on `serve_model + hnsw`, so the no-model reference run is byte-unchanged. **No proto change** (rides `Invoke`/`GetRecipeForm`/`ListRecipes`/`ListReactTurns`). **No new dep** (`Cargo.lock` unchanged). Dataset binding is **advisory** (no journal v-bump).
- **Perf:** the retrieve tool reuses the RC4a hybrid path; no new hot path.
- **Security:** `retrieve` args are bounded by a typed schema (dataset ≤128, query ≤4096, k∈[1,64]); read-only, no egress, no fs scope; the recovered envelope still flows through the exact-grant gate.

### Invariants
digest `7d22d4bd` invariant (a0_guard + `check-reproducible`) · frozen-trio (`kx-scheduler`/`kx-executor`/`kx-inference`) diff-EMPTY · additive-only proto (none) · SN-8 (scores out, ungranted refused) · GR24 dual-engine · workspace tests 0-fail · default + feature-combo clippy clean · Py ruff/mypy · TS tsc/biome · UI tsc/biome · `just eval` PASS (5/5 ≥ baseline, suite_digest unchanged).

### Tests
Unit: retrieve capability mapping/soft-fail/SN-8 score-drop (8) · react-rag + vision-rag recipe seed-gating + the dataset fold (5) · the envelope-in-marker parser recovery (4). Gated live dual-engine e2e: `crates/kx-gateway/tests/react_rag_serve.rs`.

### Deferred → RC4c ("workflow-DAG RAG enhancements")
- LLM **listwise rerank** (a `kx-inference` grammar-carrier change + a coordinator rerank-turn).
- **DAG-hybrid** (`rag_pipeline_hybrid` + `query_corpus_hybrid` — a new `kx-model-harness → kx-dataset-bm25` dep edge). *Both live serve RAG paths are already hybrid; only the authored-workflow recipe builder stays dense.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
