### PR TITLE
feat(integrations): bundled Gmail MCP connector + integrations/ folder (PR-G0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-connector-gmail"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "kx-extension-sdk",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "ureq",
+]
+
+[[package]]
 name = "kx-content"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ members = [
     "crates/kx-extension-sdk",
     "crates/kx-pricing",
     "crates/kx-eval",
+    # Integrations — bundled app connectors (external MCP-server processes the
+    # runtime dials). Each is a self-contained leaf with NO kx-* runtime
+    # dependency, kept under `integrations/` (not `crates/`) to separate the
+    # extension surface from the core library crates. See `integrations/README.md`.
+    "integrations/kx-connector-gmail",
 ]
 exclude = [
     "kx-cloud",

--- a/feature-ledger.toml
+++ b/feature-ledger.toml
@@ -148,3 +148,16 @@ covers   = [
 ]
 inherits = ["rc4c-2a-rerank-substrate"]
 notes    = "RC4c-2 SPLIT (RC4c-2b): the LIVE coordinator rerank-turn (both react-rag + chat-rag), building on rc4c-2a's ReRankRound fact + ListReRankTurns. A sole-writer-spine change ⇒ its own focused, recovery-tested, dual-engine-validated PR. Fully MAPPED (materialize/settle/recover mirror of the ReAct lifecycle) — a direct build, not a re-exploration."
+
+[[feature]]
+id       = "gmail-integration"
+lane     = "oss"
+state    = "in-progress"
+branch   = "feat/gmail-connector-sidecar"
+covers   = [
+  "crates/kx-connector-gmail: a bundled Gmail MCP connector — a standalone [[bin]] stdio JSON-RPC 2.0 server (initialize -> tools/list -> tools/call) exposing gmail/{search,read,draft,send}; FFI-free (serde_json/ureq/base64/thiserror only), NO kx-* runtime dependency (not in the gateway or frozen-trio closure)",
+  "credential-by-reference (D81): OAuth {client_id,client_secret,refresh_token} injected as KX_GMAIL_CREDENTIAL, refresh->access exchanged INSIDE the sidecar; secret never in a reply/log/error; header-injection guard on to/subject",
+  "offline KX_GMAIL_FAKE mode (canned responses) → deterministic unit tests + the run_conformance gate (Extension Acceptance Gate items 3/5/7/10) with a live-#[ignore] dual-engine witness deferred to registration",
+]
+inherits = ["connector-extension-sdk", "integrations-foundation"]
+notes    = "PR-G0 (extension lane, isolated per the user's core/extension split): the FIRST bundled app-connector sidecar. Digest 7d22d4bd invariant (a0_guard PASS — the crate is an external process, outside the projection workspace); frozen-trio untouched; no proto/journal change; Cargo.lock += only the crate node (no new external crate; serde_json `raw_value` feature adds no dep); cargo-deny clean. Runtime behaviour = a dialed external MCP process (bucket i). NEXT (separate sessions, core changes): G1 first-class Gmail Integration UI/CLI/SDK, G2 App-pointer->run wiring (references.connections + guards.secret_scope), G3 cross-instance import."

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,113 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# `integrations/` — bundled app connectors
+
+This directory holds **app-integration connectors**: standalone MCP-server processes
+the runtime *dials* (via `kx connections add`) to let agents consume, generate, and
+publish through external services (Gmail, Slack, Discord, Notion, …).
+
+Each connector is a **self-contained leaf crate** with **no `kx-*` runtime
+dependency** — it is an external process, never linked into the gateway, the
+journal, or the frozen trio. Building or running a connector therefore cannot move
+the projection digest (`7d22d4bd…`) or perturb the core. They live under
+`integrations/` (not `crates/`) to keep the extension surface visibly separate from
+the core library crates. They are workspace members (so `cargo`/`clippy`/`fmt`
+cover them) and are registered in `shared-paths.toml` (`integrations/**` is shared)
+and in `feature-ledger.toml`.
+
+Authoring conventions follow the Connector/Extension SDK (D167 E0): build on the
+`kx-extension-sdk` template (`crates/kx-extension-sdk/src/bin/reference_connector.rs`)
+and gate with its `run_conformance` harness (Extension Acceptance Gate items
+3/5/7/10: out-of-process · warrant/SN-8 · secret-by-ref · on/off).
+
+## Connectors
+
+| Crate | Provider | Tools | Status |
+|---|---|---|---|
+| `kx-connector-gmail` | Gmail | `search` · `read` · `draft` · `send` | connector shipped (PR-G0); core wiring pending (below) |
+
+### `kx-connector-gmail`
+
+A newline-delimited JSON-RPC 2.0 stdio MCP server. Credential-by-reference (D81):
+the OAuth credential is injected out-of-band as the env var `KX_GMAIL_CREDENTIAL`
+(JSON `{"client_id","client_secret","refresh_token"}`); the connector does the
+refresh→access-token exchange **inside its own process** and calls the Gmail REST
+API. The secret value never appears in a reply, a log, or an error.
+
+Register it against a running `kx serve`:
+
+```sh
+kx secrets set --name KX_GMAIL_CREDENTIAL \
+  --value '{"client_id":"…","client_secret":"…","refresh_token":"…"}'
+kx connections add --name gmail \
+  --command kx-connector-gmail \
+  --credential-ref KX_GMAIL_CREDENTIAL
+# an agent granted gmail/* can now fire the tools:
+kx connections fire --name gmail --tool search --args '{"query":"is:unread"}'
+```
+
+Offline/CI mode: set `KX_GMAIL_FAKE=1` for deterministic canned responses (no
+network, no credential) — used by the unit tests and the conformance gate. A live
+GR15/GR24 witness is `tests/live_smoke.rs` (`#[ignore]`; needs a real credential).
+
+---
+
+## Core wiring still needed (the "make integrations first-class" roadmap)
+
+The connector above is complete and dialable **today** — an operator can register it
+and an agent granted its tools can call Gmail. What is **not yet wired in the core**
+is the ergonomic, by-pointer app experience: a first-class "Gmail" entry in the
+Integrations UI, and Apps that carry a *pointer* to the integration and resolve the
+caller's own credentials at run time. These are **core changes** (gateway /
+provision / UI / proto) taken up in their own sessions **after RC4c-2b**, each
+off-journal + additive (digest `7d22d4bd…` invariant, frozen trio untouched).
+
+### G1 — first-class Gmail Integration across UI / CLI / SDK
+- **What:** a curated "Gmail" provider in the Integrations section ("Connect Gmail"
+  → store the OAuth secret → register the connection), instead of the generic
+  "add MCP server" form. Cross-surface: UI + `kx` + Py/TS SDK + a docs page.
+- **How:** pure client-side curation over the **existing** RPCs — no new proto.
+  Reuses `RegisterMcpServer` + `PutSecret`, `ui/src/components/tools/ConnectionsPanel.tsx`
+  + `ui/src/kx/use-connections.ts`, and `crates/kx-cli/src/verbs/{connections,secrets}.rs`.
+- **Effort:** S–M. **Blast radius:** low; off-journal; shared UI files ⇒ serialize on
+  the shared lane.
+
+### G2 — App-pointer → run resolution (the load-bearing gap)
+- **What:** make an App actually *use* its integration pointer. Today at run time
+  only the App **blueprint** is submitted; the envelope's
+  `references.connections` and `guards.secret_scope` are dropped
+  (`crates/kx-gateway/tests/app_live_serve.rs` submits `blueprint`, not `references`;
+  `RecipeBinder::bind` in `crates/kx-gateway/src/provision.rs` has no app-references
+  parameter). Wire it so that, at bind/run, the App's `ConnectionRef`s resolve the
+  **caller's own** registered connection by name and the App's `secret_scope` names
+  are injected into the run warrant's `SecretScope::AllowList`
+  (`crates/kx-warrant/src/secret.rs`) so the broker precheck gates the Gmail secret.
+- **Why it matters:** this is what makes "build an App that uses the Gmail pointer to
+  consume/generate/publish" fire — and, because the pointer is a bare *name*, what
+  makes a shared App resolve **each user's own** credentials.
+- **How:** `crates/kx-gateway/src/provision.rs` (`RecipeBinder::bind`) + a
+  gateway-core seam (`crates/kx-gateway-core/src/mcp_gateway_admin.rs`) + possibly one
+  additive field on the app-run path. Off-journal, additive; the coordinator is
+  editable (not frozen) but on the RC lane, so serialize.
+- **Effort:** M. **Blast radius:** medium (touches the bind path; digest-invariant).
+
+### G3 — cross-instance App import + rebind (the "share to others" story)
+- **What:** the deferred cross-instance import entrypoint (today
+  `gateway.proto:1033,2170`: "NO cross-instance import entrypoint (deferred)"). Build
+  it so an App exported from one instance and imported on another rebinds to **that**
+  instance's connections/secrets by name — the App carries no authority (it "grants
+  nothing; references intersect with the importer's own grants ∩ the step warrant").
+- **Security negatives to close first (POC-4 deferral):** (1) envelope-authority
+  leakage, (2) credential-namespace collision (the importer's secret must win),
+  (3) warrant/principal spoofing (validate the importer's warrant covers the App's
+  requested grants, server-side, before bind).
+- **How:** additive import RPC + `crates/kx-gateway/src/apps.rs` (the party-scoped
+  `apps.db` catalog) + rebind validation. Off-journal, additive (no journal fact).
+- **Effort:** L. **Blast radius:** medium + a real security surface.
+
+### Out of scope for OSS (Cloud)
+Per-party credential isolation on a **single shared instance** (multiple users, each
+with their own credentials resolved per-caller): connections/secrets are
+operator-global today (`connections.db` PK is `name`; the OS keychain is
+per-machine), and D129 / D170.b allocate multi-tenant secrets + a KMS/HSM vault +
+the connector marketplace to **Cloud**. Cross-instance sharing (each user runs their
+own `kx serve`, per G3) is the OSS path.

--- a/integrations/kx-connector-gmail/Cargo.toml
+++ b/integrations/kx-connector-gmail/Cargo.toml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-connector-gmail"
+version      = "0.1.0"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx bundled Gmail MCP connector — a standalone MCP stdio server (initialize -> tools/list -> tools/call) exposing gmail/{search,read,draft,send}. Authenticates by-reference (D81): the OAuth refresh-token credential is injected out-of-band BY NAME and exchanged for an access token INSIDE this process; the secret value never appears in a reply, a log, or the runtime. An external process the runtime DIALS via `kx connections add` — never linked into the gateway or the frozen trio (no kx-* dependency)."
+
+[lib]
+path = "src/lib.rs"
+
+# The Gmail MCP connector binary — a full initialize -> tools/list -> tools/call
+# stdio server the runtime dials via `kx connections add --command kx-connector-gmail`.
+[[bin]]
+name = "kx-connector-gmail"
+path = "src/main.rs"
+
+[dependencies]
+# JSON-RPC request/response + tool argument decoding (fail-closed).
+serde      = { workspace = true }
+# `raw_value` lets us keep `tools/call` arguments as opaque JSON (decoded per tool).
+serde_json = { workspace = true, features = ["raw_value"] }
+# Blocking HTTP to Google's OAuth token endpoint + the Gmail REST API (TLS; no json feature).
+ureq       = { workspace = true }
+# base64url-encode the RFC-2822 message for the Gmail `raw` field (drafts/send).
+base64     = { workspace = true }
+# Typed connector errors (mapped to fail-closed JSON-RPC errors; never leak the token).
+thiserror  = { workspace = true }
+
+[dev-dependencies]
+# The conformance harness (dials THIS bin through the real register_server path).
+kx-extension-sdk = { path = "../../crates/kx-extension-sdk", version = "0.1.0" }
+
+[lints]
+workspace = true

--- a/integrations/kx-connector-gmail/src/gmail.rs
+++ b/integrations/kx-connector-gmail/src/gmail.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The Gmail client: the OAuth token exchange + the Gmail REST calls — or a
+//! deterministic offline `fake` mode for tests / CI / conformance.
+//!
+//! ## Credential (D81)
+//! The OAuth credential arrives by-reference in the environment variable named by
+//! [`CREDENTIAL_ENV`] (`KX_GMAIL_CREDENTIAL`), as a JSON object holding
+//! `client_id`, `client_secret`, and `refresh_token`. It is read here, exchanged
+//! for a short-lived access token against Google's token endpoint, and used to call
+//! the Gmail REST API. The credential value is never returned in a tool result, a
+//! log line, or an error string.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::message;
+
+/// The environment variable the operator wires as the connection's `credential_ref`.
+/// It holds the OAuth credential as JSON: `{"client_id","client_secret","refresh_token"}`.
+pub const CREDENTIAL_ENV: &str = "KX_GMAIL_CREDENTIAL";
+
+/// When set to a truthy value, the connector runs OFFLINE with canned responses —
+/// no network, no credential. Used by tests, CI, and the conformance harness.
+pub const FAKE_ENV: &str = "KX_GMAIL_FAKE";
+
+const TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const API_BASE: &str = "https://gmail.googleapis.com/gmail/v1/users/me";
+
+/// A typed connector error. Rendered into a fail-closed JSON-RPC error message;
+/// no variant ever carries the credential value.
+#[derive(Debug, thiserror::Error)]
+pub enum GmailError {
+    /// The tool arguments were missing or ill-typed.
+    #[error("invalid arguments: {0}")]
+    BadArgs(String),
+    /// No usable credential was injected (the connection has no resolvable `credential_ref`).
+    #[error("no Gmail credential available (set the connection's credential_ref)")]
+    NoCredential,
+    /// The Gmail API returned a non-success HTTP status.
+    #[error("gmail api error (status {0})")]
+    Status(u16),
+    /// The Gmail API (or the token endpoint) could not be reached.
+    #[error("gmail unreachable: {0}")]
+    Unreachable(String),
+    /// The Gmail API returned a body that did not match the expected shape.
+    #[error("unexpected gmail response")]
+    BadResponse,
+}
+
+/// The OAuth credential, parsed from [`CREDENTIAL_ENV`]. Private — never serialized back.
+#[derive(Deserialize)]
+struct OAuthConfig {
+    client_id: String,
+    client_secret: String,
+    refresh_token: String,
+}
+
+/// The connector's Gmail client — an offline fake or a live OAuth client. The mode
+/// is a private detail; construct via [`GmailClient::from_env`] or [`GmailClient::fake`].
+pub struct GmailClient {
+    mode: Mode,
+}
+
+/// Private client state — kept out of the public API so `OAuthConfig` stays internal.
+enum Mode {
+    Fake,
+    Live(Option<OAuthConfig>),
+}
+
+impl GmailClient {
+    /// Build from the process environment.
+    ///
+    /// `KX_GMAIL_FAKE` (truthy) selects offline mode. Otherwise the injected
+    /// `KX_GMAIL_CREDENTIAL` JSON is parsed; an absent or malformed value yields a
+    /// live client with no credential, so tool calls fail closed (the runtime is
+    /// never handed a fabricated credential).
+    #[must_use]
+    pub fn from_env() -> Self {
+        if fake_enabled() {
+            return Self::fake();
+        }
+        let cfg = std::env::var(CREDENTIAL_ENV)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .and_then(|raw| serde_json::from_str::<OAuthConfig>(&raw).ok());
+        Self {
+            mode: Mode::Live(cfg),
+        }
+    }
+
+    /// A client that always returns deterministic offline responses (tests / embedding).
+    #[must_use]
+    pub fn fake() -> Self {
+        Self { mode: Mode::Fake }
+    }
+
+    /// Search the mailbox; returns `{messages:[{id,thread_id}], result_size_estimate}`.
+    ///
+    /// # Errors
+    /// [`GmailError::NoCredential`] when live with no credential, or a `Status` /
+    /// `Unreachable` / `BadResponse` error from the token exchange or the API call.
+    pub fn search(&self, query: &str, max_results: u32) -> Result<String, GmailError> {
+        if let Mode::Fake = self.mode {
+            return Ok(fake::search(query));
+        }
+        let token = self.access_token()?;
+        let max = max_results.clamp(1, 50);
+        let url = format!(
+            "{API_BASE}/messages?maxResults={max}&q={}",
+            urlencode(query)
+        );
+        let v = parse(&http_get(&url, &token)?)?;
+        let messages = v.get("messages").cloned().unwrap_or_else(|| json!([]));
+        let estimate = v
+            .get("resultSizeEstimate")
+            .cloned()
+            .unwrap_or_else(|| json!(0));
+        Ok(stringify(&json!({
+            "messages": normalize_ids(&messages),
+            "result_size_estimate": estimate,
+        })))
+    }
+
+    /// Read one message: headers, snippet, and a plain-text body when present.
+    ///
+    /// # Errors
+    /// [`GmailError::BadArgs`] for an empty id, [`GmailError::NoCredential`], or a
+    /// `Status` / `Unreachable` / `BadResponse` error from the API call.
+    pub fn read(&self, message_id: &str) -> Result<String, GmailError> {
+        if let Mode::Fake = self.mode {
+            return Ok(fake::read(message_id));
+        }
+        if message_id.is_empty() {
+            return Err(GmailError::BadArgs("message_id is required".to_string()));
+        }
+        let token = self.access_token()?;
+        let url = format!("{API_BASE}/messages/{}?format=full", urlencode(message_id));
+        let v = parse(&http_get(&url, &token)?)?;
+        Ok(stringify(&shape_message(&v)))
+    }
+
+    /// Create a draft (does not send); returns `{draft_id, message}`.
+    ///
+    /// # Errors
+    /// [`GmailError::BadArgs`] on header injection, [`GmailError::NoCredential`], or
+    /// a `Status` / `Unreachable` / `BadResponse` error from the API call.
+    pub fn draft(&self, to: &str, subject: &str, body: &str) -> Result<String, GmailError> {
+        if let Mode::Fake = self.mode {
+            return Ok(fake::draft());
+        }
+        let raw = message::build_raw(to, subject, body)?;
+        let token = self.access_token()?;
+        let url = format!("{API_BASE}/drafts");
+        let v = parse(&http_post_json(
+            &url,
+            &token,
+            &json!({ "message": { "raw": raw } }),
+        )?)?;
+        Ok(stringify(&json!({
+            "draft_id": v.get("id").and_then(Value::as_str).unwrap_or_default(),
+            "message": v.get("message").cloned().unwrap_or(Value::Null),
+        })))
+    }
+
+    /// Send an email immediately; returns `{message_id, thread_id, label_ids}`.
+    ///
+    /// # Errors
+    /// [`GmailError::BadArgs`] on header injection, [`GmailError::NoCredential`], or
+    /// a `Status` / `Unreachable` / `BadResponse` error from the API call.
+    pub fn send(&self, to: &str, subject: &str, body: &str) -> Result<String, GmailError> {
+        if let Mode::Fake = self.mode {
+            return Ok(fake::send());
+        }
+        let raw = message::build_raw(to, subject, body)?;
+        let token = self.access_token()?;
+        let url = format!("{API_BASE}/messages/send");
+        let v = parse(&http_post_json(&url, &token, &json!({ "raw": raw }))?)?;
+        Ok(stringify(&json!({
+            "message_id": v.get("id").and_then(Value::as_str).unwrap_or_default(),
+            "thread_id": v.get("threadId").and_then(Value::as_str).unwrap_or_default(),
+            "label_ids": v.get("labelIds").cloned().unwrap_or_else(|| json!([])),
+        })))
+    }
+
+    /// Exchange the refresh token for a short-lived access token (live mode only).
+    fn access_token(&self) -> Result<String, GmailError> {
+        match &self.mode {
+            Mode::Fake => Ok("fake-access-token".to_string()),
+            Mode::Live(cfg) => {
+                let cfg = cfg.as_ref().ok_or(GmailError::NoCredential)?;
+                let body = ureq::post(TOKEN_URL)
+                    .send_form(&[
+                        ("client_id", cfg.client_id.as_str()),
+                        ("client_secret", cfg.client_secret.as_str()),
+                        ("refresh_token", cfg.refresh_token.as_str()),
+                        ("grant_type", "refresh_token"),
+                    ])
+                    .map_err(classify)?
+                    .into_string()
+                    .map_err(|e| GmailError::Unreachable(e.to_string()))?;
+                parse(&body)?
+                    .get("access_token")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .ok_or(GmailError::BadResponse)
+            }
+        }
+    }
+}
+
+fn fake_enabled() -> bool {
+    std::env::var(FAKE_ENV).is_ok_and(|v| {
+        let v = v.to_ascii_lowercase();
+        !v.is_empty() && v != "0" && v != "false"
+    })
+}
+
+/// Reduce a Gmail `messages` array to `[{id, thread_id}]` (drop everything else).
+fn normalize_ids(messages: &Value) -> Value {
+    let Some(arr) = messages.as_array() else {
+        return json!([]);
+    };
+    let out: Vec<Value> = arr
+        .iter()
+        .map(|m| {
+            json!({
+                "id": m.get("id").and_then(Value::as_str).unwrap_or_default(),
+                "thread_id": m.get("threadId").and_then(Value::as_str).unwrap_or_default(),
+            })
+        })
+        .collect();
+    Value::Array(out)
+}
+
+/// Extract the useful fields of a full Gmail message into a flat, model-friendly object.
+fn shape_message(v: &Value) -> Value {
+    let payload = v.get("payload");
+    let header = |name: &str| -> String {
+        payload
+            .and_then(|p| p.get("headers"))
+            .and_then(Value::as_array)
+            .and_then(|hs| {
+                hs.iter().find(|h| {
+                    h.get("name")
+                        .and_then(Value::as_str)
+                        .is_some_and(|n| n.eq_ignore_ascii_case(name))
+                })
+            })
+            .and_then(|h| h.get("value"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    json!({
+        "id": v.get("id").and_then(Value::as_str).unwrap_or_default(),
+        "thread_id": v.get("threadId").and_then(Value::as_str).unwrap_or_default(),
+        "from": header("From"),
+        "to": header("To"),
+        "subject": header("Subject"),
+        "date": header("Date"),
+        "snippet": v.get("snippet").and_then(Value::as_str).unwrap_or_default(),
+        "body": payload.and_then(decode_body).unwrap_or_default(),
+    })
+}
+
+/// Best-effort decode of a message's `text/plain` body (recursing into parts).
+fn decode_body(payload: &Value) -> Option<String> {
+    if let Some(data) = payload
+        .get("body")
+        .and_then(|b| b.get("data"))
+        .and_then(Value::as_str)
+    {
+        if let Some(text) = b64url_decode(data).and_then(|b| String::from_utf8(b).ok()) {
+            return Some(text);
+        }
+    }
+    let parts = payload.get("parts").and_then(Value::as_array)?;
+    parts
+        .iter()
+        .find(|p| p.get("mimeType").and_then(Value::as_str) == Some("text/plain"))
+        .and_then(decode_body)
+        .or_else(|| parts.iter().find_map(decode_body))
+}
+
+fn b64url_decode(s: &str) -> Option<Vec<u8>> {
+    use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+    use base64::Engine;
+    URL_SAFE
+        .decode(s)
+        .ok()
+        .or_else(|| URL_SAFE_NO_PAD.decode(s).ok())
+}
+
+/// Percent-encode a query value (RFC-3986 unreserved set passes through).
+fn urlencode(s: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(HEX[(b >> 4) as usize] as char);
+                out.push(HEX[(b & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+/// GET a URL with a bearer token; returns the response body as a string.
+fn http_get(url: &str, token: &str) -> Result<String, GmailError> {
+    ureq::get(url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+        .map_err(classify)?
+        .into_string()
+        .map_err(|e| GmailError::Unreachable(e.to_string()))
+}
+
+/// POST a JSON body with a bearer token; returns the response body as a string.
+fn http_post_json(url: &str, token: &str, body: &Value) -> Result<String, GmailError> {
+    let payload = serde_json::to_string(body).map_err(|_| GmailError::BadResponse)?;
+    ureq::post(url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .set("Content-Type", "application/json")
+        .send_string(&payload)
+        .map_err(classify)?
+        .into_string()
+        .map_err(|e| GmailError::Unreachable(e.to_string()))
+}
+
+fn parse(body: &str) -> Result<Value, GmailError> {
+    serde_json::from_str::<Value>(body).map_err(|_| GmailError::BadResponse)
+}
+
+fn stringify(v: &Value) -> String {
+    serde_json::to_string(v).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn classify(err: ureq::Error) -> GmailError {
+    match err {
+        ureq::Error::Status(code, _) => GmailError::Status(code),
+        ureq::Error::Transport(t) => GmailError::Unreachable(t.to_string()),
+    }
+}
+
+/// Deterministic canned responses for offline mode (no network, no credential).
+mod fake {
+    /// A search hit list that echoes the (non-secret) query for test assertions.
+    pub(super) fn search(query: &str) -> String {
+        let q = serde_json::to_string(query).unwrap_or_else(|_| "\"\"".to_string());
+        format!(
+            r#"{{"messages":[{{"id":"fake-msg-1","thread_id":"fake-thread-1"}}],"result_size_estimate":1,"echoed_query":{q}}}"#
+        )
+    }
+
+    /// A single fake message.
+    pub(super) fn read(id: &str) -> String {
+        let id = serde_json::to_string(id).unwrap_or_else(|_| "\"fake\"".to_string());
+        format!(
+            r#"{{"id":{id},"thread_id":"fake-thread-1","from":"alice@example.com","to":"me@example.com","subject":"Hello","date":"Tue, 01 Jul 2026 10:00:00 +0000","snippet":"a fake message","body":"This is a fake message body."}}"#
+        )
+    }
+
+    /// A fake draft id.
+    pub(super) fn draft() -> String {
+        r#"{"draft_id":"fake-draft-1","message":{"id":"fake-msg-2"}}"#.to_string()
+    }
+
+    /// A fake sent-message id.
+    pub(super) fn send() -> String {
+        r#"{"message_id":"fake-msg-3","thread_id":"fake-thread-1","label_ids":["SENT"]}"#
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fake_enabled, shape_message, urlencode, GmailClient, Mode};
+    use serde_json::json;
+
+    #[test]
+    fn urlencode_escapes_spaces_and_specials() {
+        assert_eq!(
+            urlencode("is:unread from:a b"),
+            "is%3Aunread%20from%3Aa%20b"
+        );
+        assert_eq!(urlencode("plain-text_1.0~"), "plain-text_1.0~");
+    }
+
+    #[test]
+    fn shape_message_pulls_headers_snippet_and_body() {
+        let raw = json!({
+            "id": "m1", "threadId": "t1", "snippet": "hi there",
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "a@b.com"},
+                    {"name": "Subject", "value": "Hello"},
+                ],
+                "body": {"data": "SGVsbG8gYm9keQ=="}
+            }
+        });
+        let shaped = shape_message(&raw);
+        assert_eq!(shaped.get("from").unwrap(), "a@b.com");
+        assert_eq!(shaped.get("subject").unwrap(), "Hello");
+        assert_eq!(shaped.get("snippet").unwrap(), "hi there");
+        assert_eq!(shaped.get("body").unwrap(), "Hello body");
+    }
+
+    #[test]
+    fn live_without_credential_fails_closed() {
+        let client = GmailClient {
+            mode: Mode::Live(None),
+        };
+        let err = client.search("q", 5).unwrap_err();
+        assert!(matches!(err, super::GmailError::NoCredential));
+    }
+
+    #[test]
+    fn fake_env_truthiness() {
+        std::env::set_var(super::FAKE_ENV, "1");
+        assert!(fake_enabled());
+        std::env::set_var(super::FAKE_ENV, "false");
+        assert!(!fake_enabled());
+        std::env::remove_var(super::FAKE_ENV);
+        assert!(!fake_enabled());
+    }
+}

--- a/integrations/kx-connector-gmail/src/lib.rs
+++ b/integrations/kx-connector-gmail/src/lib.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-connector-gmail` — a bundled Gmail MCP connector.
+//!
+//! A standalone Model Context Protocol server: newline-delimited JSON-RPC 2.0 over
+//! stdio, speaking the full `initialize` -> `tools/list` -> `tools/call` lifecycle
+//! that `kx-mcp-gateway`'s `register_server` dials. It exposes four tools that
+//! let an agent consume / generate / publish Gmail:
+//!   - `search` — find messages with a Gmail query,
+//!   - `read`   — read one message (headers, snippet, plain-text body),
+//!   - `draft`  — create a draft (does not send),
+//!   - `send`   — send an email.
+//!
+//! ## Credential discipline (D81 — secret-by-reference)
+//! The connector authenticates with an OAuth refresh-token credential supplied
+//! **out-of-band**: the runtime resolves the connection's `credential_ref` NAME
+//! against the caller's own secret store and injects the value into this process's
+//! environment (the `KX_GMAIL_CREDENTIAL` variable). The connector reads it, does
+//! the refresh -> access-token exchange **inside this process**, and calls the Gmail
+//! REST API. The secret value is never placed in a reply, a log line, or an error —
+//! so it never reaches the runtime's journal, a `MoteId`, or a staged effect.
+//!
+//! ## Offline mode (tests / CI / conformance)
+//! When `KX_GMAIL_FAKE` is set the connector runs fully offline with deterministic
+//! canned responses (no network, no credential), so the MCP protocol, argument
+//! validation, and the secret-never-echoed contract can be gated without live
+//! Gmail credentials. See [`gmail::GmailClient::from_env`].
+//!
+//! This crate is an **external process** the runtime dials — it has no dependency on
+//! the gateway, the journal, or the frozen trio, so building or running it cannot
+//! move the projection digest or perturb the core.
+
+// Natural for a single-provider connector crate: the provider name recurs in the
+// `GmailClient` / `GmailError` types. Re-exported at the crate root for callers.
+#![allow(clippy::module_name_repetitions)]
+// Test modules may unwrap/expect on known-good literals + relax pedantic style
+// (per the workspace convention for tests).
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)
+)]
+
+pub mod gmail;
+pub mod mcp;
+pub mod message;
+pub mod tools;
+
+pub use gmail::{GmailClient, GmailError};
+pub use mcp::handle_line;

--- a/integrations/kx-connector-gmail/src/main.rs
+++ b/integrations/kx-connector-gmail/src/main.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The `kx-connector-gmail` binary: a newline-delimited JSON-RPC 2.0 MCP server
+//! over stdio. It builds its Gmail client from the environment (the injected
+//! credential, D81) once at start, then answers one request per input line. The
+//! credential value is never written to stdout, stderr, or a log.
+
+use std::io::{BufRead, Write};
+
+use kx_connector_gmail::{handle_line, GmailClient};
+
+fn main() {
+    let client = GmailClient::from_env();
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let reply = handle_line(&line, &client);
+        if writeln!(out, "{reply}").is_err() || out.flush().is_err() {
+            break;
+        }
+    }
+}

--- a/integrations/kx-connector-gmail/src/mcp.rs
+++ b/integrations/kx-connector-gmail/src/mcp.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The MCP JSON-RPC 2.0 protocol surface: `initialize` -> `tools/list` ->
+//! `tools/call`, newline-delimited over stdio. Every reply is fail-closed — an
+//! unparseable line or unknown method yields a JSON-RPC error, never a fabricated
+//! success.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use crate::gmail::GmailClient;
+use crate::tools;
+
+/// The MCP protocol version advertised at `initialize`.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// One JSON-RPC 2.0 request line. `jsonrpc` is ignored (unknown fields dropped).
+#[derive(Deserialize)]
+pub struct Req {
+    /// The request id, echoed on the reply. Absent -> `0`.
+    #[serde(default)]
+    pub id: u64,
+    /// The method name (`initialize` / `tools/list` / `tools/call`).
+    pub method: String,
+    /// Method parameters (present for `tools/call`).
+    #[serde(default)]
+    pub params: Option<Params>,
+}
+
+/// The `tools/call` parameters: the tool `name` and its opaque `arguments` object.
+#[derive(Deserialize)]
+pub struct Params {
+    /// The tool name to invoke.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// The tool arguments, kept as raw JSON (decoded fail-closed per tool).
+    #[serde(default)]
+    pub arguments: Option<Box<RawValue>>,
+}
+
+/// Parse one newline-delimited JSON-RPC request and produce its reply line.
+///
+/// Fail-closed: an unparseable line yields a JSON-RPC parse error (`-32700`).
+#[must_use]
+pub fn handle_line(line: &str, client: &GmailClient) -> String {
+    match serde_json::from_str::<Req>(line) {
+        Ok(req) => handle(&req, client),
+        Err(_) => error(0, -32700, "parse error"),
+    }
+}
+
+fn handle(req: &Req, client: &GmailClient) -> String {
+    let id = req.id;
+    match req.method.as_str() {
+        "initialize" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"protocolVersion":"{PROTOCOL_VERSION}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"kx-connector-gmail","version":"1"}}}}}}"#
+        ),
+        "tools/list" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":{}}}}}"#,
+            tools::catalog_json()
+        ),
+        "tools/call" => tools::call(req, client),
+        other => error(id, -32601, &format!("no such method: {other}")),
+    }
+}
+
+/// Build a fail-closed JSON-RPC error reply. Never carries a credential value.
+#[must_use]
+pub fn error(id: u64, code: i64, message: &str) -> String {
+    // Encode the message as a JSON string so quotes / control chars cannot break the frame.
+    let msg = serde_json::to_string(message).unwrap_or_else(|_| "\"error\"".to_string());
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":{code},"message":{msg}}}}}"#)
+}
+
+/// Build a JSON-RPC success reply wrapping a `result` object given as raw JSON text.
+#[must_use]
+pub fn result(id: u64, result_json: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{result_json}}}"#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{handle_line, PROTOCOL_VERSION};
+    use crate::gmail::GmailClient;
+
+    fn fake() -> GmailClient {
+        GmailClient::fake()
+    }
+
+    #[test]
+    fn initialize_advertises_protocol_and_name() {
+        let reply = handle_line(r#"{"id":1,"method":"initialize"}"#, &fake());
+        assert!(reply.contains(PROTOCOL_VERSION));
+        assert!(reply.contains("kx-connector-gmail"));
+        assert!(reply.contains(r#""id":1"#));
+    }
+
+    #[test]
+    fn tools_list_exposes_the_four_tools() {
+        let reply = handle_line(r#"{"id":2,"method":"tools/list"}"#, &fake());
+        for tool in ["search", "read", "draft", "send"] {
+            assert!(reply.contains(tool), "tools/list missing {tool}: {reply}");
+        }
+    }
+
+    #[test]
+    fn unparseable_line_is_a_parse_error() {
+        let reply = handle_line("not json", &fake());
+        assert!(reply.contains("-32700"));
+        assert!(reply.contains("error"));
+    }
+
+    #[test]
+    fn unknown_method_is_fail_closed() {
+        let reply = handle_line(r#"{"id":3,"method":"frobnicate"}"#, &fake());
+        assert!(reply.contains("-32601"));
+    }
+}

--- a/integrations/kx-connector-gmail/src/message.rs
+++ b/integrations/kx-connector-gmail/src/message.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Build an RFC-2822 message and base64url-encode it for the Gmail `raw` field.
+
+use base64::Engine;
+
+use crate::gmail::GmailError;
+
+/// Build a minimal RFC-2822 `text/plain` message and return its base64url encoding
+/// (the shape Gmail's `drafts.create` / `messages.send` want in the `raw` field).
+///
+/// # Errors
+/// Returns [`GmailError::BadArgs`] if `to` or `subject` contain a CR or LF byte
+/// (header injection — a newline in a header field could smuggle extra headers).
+pub fn build_raw(to: &str, subject: &str, body: &str) -> Result<String, GmailError> {
+    if has_crlf(to) || has_crlf(subject) {
+        return Err(GmailError::BadArgs(
+            "the `to` and `subject` fields must not contain CR or LF".to_string(),
+        ));
+    }
+    let msg = format!(
+        "To: {to}\r\nSubject: {subject}\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=\"UTF-8\"\r\n\r\n{body}"
+    );
+    Ok(base64::engine::general_purpose::URL_SAFE.encode(msg.as_bytes()))
+}
+
+fn has_crlf(s: &str) -> bool {
+    s.contains('\r') || s.contains('\n')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_raw;
+    use base64::Engine;
+
+    #[test]
+    fn round_trips_headers_and_body() {
+        let raw = build_raw("a@b.com", "Hello", "Body text").unwrap();
+        let bytes = base64::engine::general_purpose::URL_SAFE
+            .decode(raw)
+            .unwrap();
+        let msg = String::from_utf8(bytes).unwrap();
+        assert!(msg.contains("To: a@b.com"));
+        assert!(msg.contains("Subject: Hello"));
+        assert!(msg.ends_with("Body text"));
+    }
+
+    #[test]
+    fn rejects_header_injection() {
+        assert!(build_raw("a@b.com\r\nBcc: evil@x.com", "Hi", "x").is_err());
+        assert!(build_raw("a@b.com", "Hi\nX-Injected: 1", "x").is_err());
+    }
+}

--- a/integrations/kx-connector-gmail/src/tools.rs
+++ b/integrations/kx-connector-gmail/src/tools.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The Gmail tool catalog (the `tools/list` payload) and `tools/call` routing.
+//!
+//! Argument decoding is fail-closed: a missing/ill-typed field yields a JSON-RPC
+//! invalid-params error (`-32602`), never a fabricated call. A Gmail execution
+//! failure yields a server error (`-32000`) carrying the typed reason — never the
+//! credential.
+
+use serde::Deserialize;
+
+use crate::gmail::{GmailClient, GmailError};
+use crate::mcp::{error, result, Req};
+
+/// The `tools/list` array: the four Gmail tools with typed JSON-Schema inputs.
+#[must_use]
+pub fn catalog_json() -> &'static str {
+    concat!(
+        r#"[{"name":"search","description":"Search the mailbox with a Gmail query (e.g. 'from:alice is:unread'). Returns matching message ids.","inputSchema":{"type":"object","properties":{"query":{"type":"string"},"max_results":{"type":"integer"}},"required":["query"]}},"#,
+        r#"{"name":"read","description":"Read one message by id: headers (from/to/subject/date), snippet, and a plain-text body when present.","inputSchema":{"type":"object","properties":{"message_id":{"type":"string"}},"required":["message_id"]}},"#,
+        r#"{"name":"draft","description":"Create a draft email (does not send). Returns the draft id.","inputSchema":{"type":"object","properties":{"to":{"type":"string"},"subject":{"type":"string"},"body":{"type":"string"}},"required":["to","subject","body"]}},"#,
+        r#"{"name":"send","description":"Send an email immediately. Returns the sent message id.","inputSchema":{"type":"object","properties":{"to":{"type":"string"},"subject":{"type":"string"},"body":{"type":"string"}},"required":["to","subject","body"]}}]"#
+    )
+}
+
+#[derive(Deserialize)]
+struct SearchArgs {
+    query: String,
+    #[serde(default)]
+    max_results: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct ReadArgs {
+    message_id: String,
+}
+
+#[derive(Deserialize)]
+struct ComposeArgs {
+    to: String,
+    subject: String,
+    body: String,
+}
+
+/// Route a `tools/call` request to the Gmail client and frame the reply.
+///
+/// Unknown tool or bad arguments -> invalid-params (`-32602`); a Gmail failure ->
+/// server error (`-32000`); success -> a JSON-RPC `result` object. Never returns
+/// the credential in any branch.
+#[must_use]
+pub fn call(req: &Req, client: &GmailClient) -> String {
+    let id = req.id;
+    let params = req.params.as_ref();
+    let name = params.and_then(|p| p.name.as_deref()).unwrap_or_default();
+    let args_raw = params
+        .and_then(|p| p.arguments.as_ref())
+        .map_or_else(|| "{}".to_string(), |a| a.get().to_string());
+
+    match name {
+        "search" => match decode::<SearchArgs>(&args_raw) {
+            Ok(a) => finish(id, client.search(&a.query, a.max_results.unwrap_or(10))),
+            Err(e) => error(id, -32602, &e),
+        },
+        "read" => match decode::<ReadArgs>(&args_raw) {
+            Ok(a) => finish(id, client.read(&a.message_id)),
+            Err(e) => error(id, -32602, &e),
+        },
+        "draft" => match decode::<ComposeArgs>(&args_raw) {
+            Ok(a) => finish(id, client.draft(&a.to, &a.subject, &a.body)),
+            Err(e) => error(id, -32602, &e),
+        },
+        "send" => match decode::<ComposeArgs>(&args_raw) {
+            Ok(a) => finish(id, client.send(&a.to, &a.subject, &a.body)),
+            Err(e) => error(id, -32602, &e),
+        },
+        other => error(id, -32602, &format!("no such tool: {other}")),
+    }
+}
+
+/// Frame a Gmail result (or its typed error) as a JSON-RPC reply.
+fn finish(id: u64, outcome: Result<String, GmailError>) -> String {
+    match outcome {
+        Ok(result_json) => result(id, &result_json),
+        Err(e) => error(id, -32000, &e.to_string()),
+    }
+}
+
+/// Fail-closed argument decode; the `Err` string is a human-readable reason.
+fn decode<T: serde::de::DeserializeOwned>(raw: &str) -> Result<T, String> {
+    serde_json::from_str::<T>(raw).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::call;
+    use crate::gmail::GmailClient;
+    use crate::mcp::{Params, Req};
+
+    fn call_tool(name: &str, args: &str) -> String {
+        let req = Req {
+            id: 7,
+            method: "tools/call".to_string(),
+            params: Some(Params {
+                name: Some(name.to_string()),
+                arguments: Some(
+                    serde_json::value::RawValue::from_string(args.to_string()).unwrap(),
+                ),
+            }),
+        };
+        call(&req, &GmailClient::fake())
+    }
+
+    #[test]
+    fn search_fake_returns_a_result_and_echoes_the_query() {
+        let reply = call_tool("search", r#"{"query":"is:unread"}"#);
+        assert!(reply.contains(r#""result""#));
+        assert!(reply.contains("is:unread"));
+        assert!(reply.contains("fake-msg-1"));
+    }
+
+    #[test]
+    fn send_fake_returns_a_message_id() {
+        let reply = call_tool("send", r#"{"to":"a@b.com","subject":"hi","body":"yo"}"#);
+        assert!(reply.contains("message_id"));
+        assert!(reply.contains("SENT"));
+    }
+
+    #[test]
+    fn missing_required_arg_is_invalid_params() {
+        let reply = call_tool("search", r#"{}"#);
+        assert!(reply.contains("-32602"));
+    }
+
+    #[test]
+    fn unknown_tool_is_invalid_params() {
+        let reply = call_tool("delete_everything", r#"{}"#);
+        assert!(reply.contains("-32602"));
+        assert!(reply.contains("no such tool"));
+    }
+}

--- a/integrations/kx-connector-gmail/tests/conformance.rs
+++ b/integrations/kx-connector-gmail/tests/conformance.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Conformance: the bundled Gmail connector passes the Extension Acceptance Gate
+//! subset (out-of-process · warrant/SN-8 · secret-by-ref · on/off), driven OFFLINE
+//! (`KX_GMAIL_FAKE`) so it needs no Gmail credentials and no network.
+//!
+//! The connector is a `[[bin]]` of THIS crate, so `CARGO_BIN_EXE_kx-connector-gmail`
+//! is always set for these integration tests — no skip path is needed.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_extension_sdk::conformance::{run_conformance, ConnectorUnderTest};
+use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+
+fn gmail_connector(credential_ref: Option<String>) -> ConnectorUnderTest {
+    ConnectorUnderTest {
+        name: "gmail".into(),
+        transport: TransportSpec::Stdio {
+            command: env!("CARGO_BIN_EXE_kx-connector-gmail").to_string(),
+            args: vec![],
+        },
+        credential_ref,
+        session_mode: SessionMode::Stateless,
+    }
+}
+
+/// Offline, with a distinctive credential in play: the Gmail connector is reachable,
+/// exposes its four tools, fires under a correct warrant (and is refused without
+/// one), and never echoes the injected secret. Combined into one test so the
+/// process-global `KX_GMAIL_FAKE` / credential env vars are set/cleared serially.
+#[test]
+fn gmail_connector_passes_conformance_offline() {
+    const SECRET: &str = "SEKRET-refresh-DEADBEEF-do-not-leak-0123456789";
+    const CRED_VAR: &str = "KX_GMAIL_CREDENTIAL";
+
+    std::env::set_var("KX_GMAIL_FAKE", "1");
+    std::env::set_var(CRED_VAR, SECRET);
+
+    let cut = gmail_connector(Some(CRED_VAR.to_string()));
+    let report = run_conformance(&cut);
+
+    std::env::remove_var(CRED_VAR);
+    std::env::remove_var("KX_GMAIL_FAKE");
+
+    assert!(
+        report.reachable,
+        "connector should be reachable: {report:#?}"
+    );
+    assert!(
+        report.discovered >= 4,
+        "expected the 4 gmail tools: {report:#?}"
+    );
+    assert!(
+        report.passed(),
+        "gmail connector failed conformance: {report:#?}"
+    );
+
+    // Every gate item (out-of-process · warrant · secret-by-ref · on/off) present + passed.
+    for item in [3u8, 5, 7, 10] {
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.gate_item == item && c.passed),
+            "gate item {item} missing or failed: {report:#?}"
+        );
+    }
+}

--- a/integrations/kx-connector-gmail/tests/live_smoke.rs
+++ b/integrations/kx-connector-gmail/tests/live_smoke.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Live witness (GR15) — `#[ignore]` by default because it needs a REAL Gmail OAuth
+//! credential and network access, neither of which belong in CI.
+//!
+//! To run it, export a real credential and drop offline mode, then:
+//! ```text
+//! export KX_GMAIL_CREDENTIAL='{"client_id":"...","client_secret":"...","refresh_token":"..."}'
+//! unset KX_GMAIL_FAKE
+//! cargo test -p kx-connector-gmail --test live_smoke -- --ignored --nocapture
+//! ```
+//! The full agentic witness (a live Gemma ReAct loop firing `gmail/search` then
+//! `gmail/draft` on BOTH engines) is run at registration time via a `kx serve`
+//! end-to-end, per GR24 — this smoke test just proves the connector reaches Gmail.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_connector_gmail::GmailClient;
+
+#[test]
+#[ignore = "requires a real Gmail OAuth credential in KX_GMAIL_CREDENTIAL + network"]
+fn live_search_reaches_gmail() {
+    // Build straight from the environment (real credential, offline mode NOT set).
+    let client = GmailClient::from_env();
+    let out = client
+        .search("in:inbox", 1)
+        .expect("a live Gmail search should succeed with a valid credential");
+    // A real response carries the messages envelope; the secret is never echoed.
+    assert!(out.contains("messages"), "unexpected search shape: {out}");
+    assert!(
+        !out.contains("refresh_token"),
+        "the credential must never appear in a tool result"
+    );
+}

--- a/shared-paths.toml
+++ b/shared-paths.toml
@@ -30,6 +30,7 @@ schema = 1
 # The public code surface + shared config. Everything here is Apache-2.0 OSS.
 include = [
   "crates/**",
+  "integrations/**",
   "bindings/**",
   "ui/**",
   "scripts/**",


### PR DESCRIPTION
## What

The first **bundled app connector**: `integrations/kx-connector-gmail` — a standalone MCP stdio server (`initialize → tools/list → tools/call`) exposing `gmail/{search,read,draft,send}`. The runtime dials it via `kx connections add`; it's a self-contained leaf crate with **no `kx-*` runtime dependency**, so it's never in the gateway / journal / frozen-trio closure and cannot move the projection digest.

Also introduces a top-level **`integrations/`** folder to keep app connectors cleanly separated from the core library crates.

## How it works

- **Credential-by-reference (D81):** the OAuth credential (`{client_id, client_secret, refresh_token}`) is injected out-of-band as `KX_GMAIL_CREDENTIAL` and exchanged for an access token **inside the sidecar**; the secret value never appears in a reply, log, or error. A header-injection guard rejects CR/LF in `to`/`subject`.
- **Offline mode (`KX_GMAIL_FAKE`):** deterministic canned responses drive the unit tests + the `run_conformance` gate (Extension Acceptance Gate items 3/5/7/10) with no network/credential. A live `#[ignore]` GR15 witness (`tests/live_smoke.rs`) is ready to run with a real credential.

Register + use:

```sh
kx secrets set --name KX_GMAIL_CREDENTIAL \
  --value '{"client_id":"…","client_secret":"…","refresh_token":"…"}'
kx connections add --name gmail --command kx-connector-gmail \
  --credential-ref KX_GMAIL_CREDENTIAL
```

## Invariants (Golden Rule 8)

- **Digest `7d22d4bd` invariant** (`a0_guard` PASS) · **frozen-trio diff EMPTY** · additive-only.
- `Cargo.lock` += only the crate node — no new external crate (the `serde_json` `raw_value` feature adds no dep); cargo-deny clean.
- `shared-paths.toml [shared] += integrations/**` (mirror boundary); `feature-ledger.toml` registers `gmail-integration`.

## Tests / CI

**Full `just ci` PASS**: fmt-check · clippy `-D warnings` · test `--workspace` (incl. the connector's 14 unit tests + offline conformance) · eval · deny · doc `-D warnings` · ffi-link · build-no-inference · build-serve-engine · features-guard · check-reproducible · scale-smoke · **test-connector-real → CONFORMANCE: PASS**.

## Not in this PR (deferred to dedicated sessions after RC4c-2b)

Documented in `integrations/README.md`:
- **G1** — first-class Gmail Integration across UI / CLI / SDK (client curation over existing RPCs; no new proto).
- **G2** — App-pointer→run wiring: resolve an App's `references.connections` + inject `guards.secret_scope` at `RecipeBinder::bind` so Apps use the integration pointer (and a shared App resolves the importer's own credential).
- **G3** — cross-instance App import + rebind (the deferred entrypoint + 3 security negatives).
- Per-party credentials on one shared instance stay **Cloud** (D129 / D170.b).
- The **live Gmail dual-engine agentic witness** (GR15/GR24) needs real OAuth credentials — the `#[ignore]` smoke test is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
