### PR TITLE
feat(integrations): bundled Discord MCP connector + feature-ledger reconcile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kx-connector-discord"
+version = "0.1.0"
+dependencies = [
+ "kx-extension-sdk",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "ureq",
+]
+
+[[package]]
 name = "kx-connector-gmail"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     # dependency, kept under `integrations/` (not `crates/`) to separate the
     # extension surface from the core library crates. See `integrations/README.md`.
     "integrations/kx-connector-gmail",
+    "integrations/kx-connector-discord",
 ]
 exclude = [
     "kx-cloud",

--- a/feature-ledger.toml
+++ b/feature-ledger.toml
@@ -105,7 +105,8 @@ notes    = "D170 foundation seams (after the connector SDK): the local secret st
 [[feature]]
 id       = "autonomy-safety-gates"
 lane     = "oss"
-state    = "in-progress"
+state    = "merged"
+pr       = "267"
 branch   = "feat/autonomy-safety-gates"
 covers   = [
   "D114 HITL pre-action approval: off-DAG journal Approval fact (kind 10, Requested→Granted/Denied/Expired; journal v14→v15) + ReactRound.require_approval posture; deterministic recovery-stable request_id",
@@ -122,7 +123,8 @@ notes    = "The autonomy safety gates (D114 + M11): the last safety prerequisite
 [[feature]]
 id       = "rc4c-2a-rerank-substrate"
 lane     = "oss"
-state    = "in-review"
+state    = "merged"
+pr       = "275"
 branch   = "feat/rc4c-2a-rerank-substrate"
 covers   = [
   "ReRankRound durable journal fact (kind 11, journal v15→v16) + ReRankOutcome{Pending|Reranked{permutation}|FailedClosed}; hand-rolled encode/decode + v15→v16 pure-passthrough migration + pinning test (schema_version_is_v16)",
@@ -152,7 +154,8 @@ notes    = "RC4c-2 SPLIT (RC4c-2b): the LIVE coordinator rerank-turn (both react
 [[feature]]
 id       = "gmail-integration"
 lane     = "oss"
-state    = "in-progress"
+state    = "merged"
+pr       = "276"
 branch   = "feat/gmail-connector-sidecar"
 covers   = [
   "crates/kx-connector-gmail: a bundled Gmail MCP connector — a standalone [[bin]] stdio JSON-RPC 2.0 server (initialize -> tools/list -> tools/call) exposing gmail/{search,read,draft,send}; FFI-free (serde_json/ureq/base64/thiserror only), NO kx-* runtime dependency (not in the gateway or frozen-trio closure)",
@@ -161,3 +164,69 @@ covers   = [
 ]
 inherits = ["connector-extension-sdk", "integrations-foundation"]
 notes    = "PR-G0 (extension lane, isolated per the user's core/extension split): the FIRST bundled app-connector sidecar. Digest 7d22d4bd invariant (a0_guard PASS — the crate is an external process, outside the projection workspace); frozen-trio untouched; no proto/journal change; Cargo.lock += only the crate node (no new external crate; serde_json `raw_value` feature adds no dep); cargo-deny clean. Runtime behaviour = a dialed external MCP process (bucket i). NEXT (separate sessions, core changes): G1 first-class Gmail Integration UI/CLI/SDK, G2 App-pointer->run wiring (references.connections + guards.secret_scope), G3 cross-instance import."
+
+[[feature]]
+id       = "discord-connector"
+lane     = "oss"
+state    = "in-progress"
+branch   = "feat/connector-discord"
+covers   = [
+  "integrations/kx-connector-discord: a bundled Discord MCP connector — a standalone [[bin]] stdio JSON-RPC 2.0 server (initialize -> tools/list -> tools/call) exposing discord/{send_message,read_channel,list_channels}; FFI-free (serde/serde_json/ureq/thiserror only, no base64), NO kx-* runtime dependency (not in the gateway or frozen-trio closure)",
+  "credential-by-reference (D81): a bot token injected as KX_DISCORD_CREDENTIAL ({bot_token}), sent as `Authorization: Bot <token>` INSIDE the sidecar; secret never in a reply/log/error; snowflake-id guard (digits-only channel_id/guild_id) blocks URL path-injection + a 2000-char content bound",
+  "offline KX_DISCORD_FAKE mode (canned responses) → deterministic unit tests + the run_conformance gate (Extension Acceptance Gate items 3/5/7/10) with a live-#[ignore] witness deferred to registration",
+]
+inherits = ["connector-extension-sdk", "integrations-foundation", "gmail-integration"]
+notes    = "The SECOND bundled app-connector sidecar (the template the Slack/Notion connectors clone). Extension lane, isolated per the core/extension split. Digest 7d22d4bd invariant (a0_guard PASS — external process outside the projection workspace); frozen-trio untouched; no proto/journal change; Cargo.lock += only the crate node (all deps already in the tree — no new external crate); cargo-deny clean. Runtime behaviour = a dialed external MCP process. Usable TODAY via `kx connections add --command kx-connector-discord --credential-ref KX_DISCORD_CREDENTIAL`; first-class/by-pointer UX lands with G1/G2/G3 below."
+
+[[feature]]
+id       = "slack-connector"
+lane     = "oss"
+state    = "planned"
+covers   = [
+  "integrations/kx-connector-slack: a bundled Slack MCP connector modelled on kx-connector-discord — slack/{post_message,read_channel,search,list_channels}; bot-token (xoxb-) credential-by-ref KX_SLACK_CREDENTIAL; FFI-free leaf, no kx-* dep",
+]
+inherits = ["discord-connector"]
+notes    = "Extension lane, same template as discord-connector. Zero core blast radius (digest 7d22d4bd invariant, frozen-trio untouched, no proto/journal change)."
+
+[[feature]]
+id       = "notion-connector"
+lane     = "oss"
+state    = "planned"
+covers   = [
+  "integrations/kx-connector-notion: a bundled Notion MCP connector modelled on kx-connector-discord — notion/{search,read_page,create_page,append_block}; integration-token credential-by-ref KX_NOTION_CREDENTIAL; FFI-free leaf, no kx-* dep",
+]
+inherits = ["discord-connector"]
+notes    = "Extension lane, same template as discord-connector. Zero core blast radius (digest 7d22d4bd invariant, frozen-trio untouched, no proto/journal change)."
+
+[[feature]]
+id       = "first-class-integrations"
+lane     = "oss"
+state    = "planned"
+covers   = [
+  "G1 — curated first-class Integration providers (Gmail/Discord/Slack/Notion) in the Integrations UI section + `kx integrations` CLI + Py/TS SDK helpers, over the EXISTING RegisterMcpServer + PutSecret RPCs (no new proto): a 'Connect <provider>' form that stores the secret by name + registers the connection",
+  "optional small static provider catalog (provider id -> command + credential schema + tool list) so the UI/CLI can render a curated 'Connect' flow instead of the generic 'add MCP server' form",
+]
+inherits = ["discord-connector", "integrations-foundation"]
+notes    = "LOW blast radius: mostly client-side curation over existing RPCs. Reuses ui/src/components/tools/ConnectionsPanel.tsx + use-connections/use-secrets + crates/kx-cli/src/verbs/{connections,secrets}.rs. Off-journal; digest 7d22d4bd invariant. Shared UI/CLI/SDK files ⇒ serialize on the shared lane (after RC4c-2b)."
+
+[[feature]]
+id       = "app-pointer-run-resolution"
+lane     = "oss"
+state    = "planned"
+covers   = [
+  "G2 — carry the App envelope's references.connections + guards.secret_scope through the bind/run path so a running App resolves its connection-pointers to the caller's OWN registered connection (by name) and narrows the run warrant's SecretScope::AllowList to the App's secret_scope names",
+  "RecipeBinder::bind gains an app-references parameter (gateway-core seam bump + HostRecipeBinder + mocks); a connection-by-name lookup seam; bind-time warrant secret_scope intersection",
+]
+inherits = ["first-class-integrations", "gmail-integration"]
+notes    = "MEDIUM blast radius: touches the hot bind path (every Invoke) + the app-run handler + an additive proto field. Off-journal + digest 7d22d4bd invariant (connections/secrets off-DAG; the resolved warrant must produce identical journal bytes — recovery-tested). The load-bearing gap for 'an App uses its integration pointer'. Shared CORE lane ⇒ serialize with RC4c-2b."
+
+[[feature]]
+id       = "cross-instance-app-import"
+lane     = "oss"
+state    = "planned"
+covers   = [
+  "G3 — `kx app import <file>` + an additive import RPC (proto currently states 'NO cross-instance import') that re-binds a shared kortecx.app/v1 envelope against the IMPORTER's own by-name connections/secrets, with a 'missing integration' UX listing what the importer must configure",
+  "import validation: authority-leak already prevented by AppEnvelope::validate + secret_leak.rs; credential-namespace collision (importer's secret wins); warrant/principal spoofing (importer's warrant must cover the App's requested grants, server-side, before bind)",
+]
+inherits = ["app-pointer-run-resolution"]
+notes    = "MEDIUM blast radius + a real security surface (security review required). The 'share an App to others; the runtime uses THEIR own integration details by pointer' story. Off-journal + additive (no journal fact); digest 7d22d4bd invariant. Per-INSTANCE model (each person runs their own kx serve) is the OSS path; multiple users on ONE instance with isolated per-person credentials = Cloud (D129)."

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -24,6 +24,7 @@ and gate with its `run_conformance` harness (Extension Acceptance Gate items
 | Crate | Provider | Tools | Status |
 |---|---|---|---|
 | `kx-connector-gmail` | Gmail | `search` · `read` · `draft` · `send` | connector shipped (PR-G0); core wiring pending (below) |
+| `kx-connector-discord` | Discord | `send_message` · `read_channel` · `list_channels` | connector shipped; core wiring pending (below) |
 
 ### `kx-connector-gmail`
 
@@ -48,6 +49,35 @@ kx connections fire --name gmail --tool search --args '{"query":"is:unread"}'
 Offline/CI mode: set `KX_GMAIL_FAKE=1` for deterministic canned responses (no
 network, no credential) — used by the unit tests and the conformance gate. A live
 GR15/GR24 witness is `tests/live_smoke.rs` (`#[ignore]`; needs a real credential).
+
+### `kx-connector-discord`
+
+A newline-delimited JSON-RPC 2.0 stdio MCP server. Credential-by-reference (D81):
+a Discord **bot token** is injected out-of-band as the env var
+`KX_DISCORD_CREDENTIAL` (JSON `{"bot_token":"…"}`); the connector calls the Discord
+REST API with an `Authorization: Bot <token>` header **inside its own process**. The
+secret value never appears in a reply, a log, or an error. Channel/guild ids are
+validated as bare snowflakes (digits only) before any request is built, so a path
+separator can never smuggle into the URL.
+
+Register it against a running `kx serve`:
+
+```sh
+kx secrets set --name KX_DISCORD_CREDENTIAL \
+  --value '{"bot_token":"…"}'
+kx connections add --name discord \
+  --command kx-connector-discord \
+  --credential-ref KX_DISCORD_CREDENTIAL
+# an agent granted discord/* can now fire the tools:
+kx connections fire --name discord --tool list_channels --args '{"guild_id":"…"}'
+kx connections fire --name discord --tool send_message \
+  --args '{"channel_id":"…","content":"hello from kortecx"}'
+```
+
+Offline/CI mode: set `KX_DISCORD_FAKE=1` for deterministic canned responses (no
+network, no credential) — used by the unit tests and the conformance gate. A live
+GR15/GR24 witness is `tests/live_smoke.rs` (`#[ignore]`; needs a real bot token +
+`KX_DISCORD_TEST_GUILD_ID`).
 
 ---
 

--- a/integrations/kx-connector-discord/Cargo.toml
+++ b/integrations/kx-connector-discord/Cargo.toml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-connector-discord"
+version      = "0.1.0"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx bundled Discord MCP connector — a standalone MCP stdio server (initialize -> tools/list -> tools/call) exposing discord/{send_message,read_channel,list_channels}. Authenticates by-reference (D81): a Discord bot token is injected out-of-band BY NAME (KX_DISCORD_CREDENTIAL) and used INSIDE this process; the secret value never appears in a reply, a log, or the runtime. An external process the runtime DIALS via `kx connections add` — never linked into the gateway or the frozen trio (no kx-* dependency)."
+
+[lib]
+path = "src/lib.rs"
+
+# The Discord MCP connector binary — a full initialize -> tools/list -> tools/call
+# stdio server the runtime dials via `kx connections add --command kx-connector-discord`.
+[[bin]]
+name = "kx-connector-discord"
+path = "src/main.rs"
+
+[dependencies]
+# JSON-RPC request/response + tool argument decoding (fail-closed).
+serde      = { workspace = true }
+# `raw_value` lets us keep `tools/call` arguments as opaque JSON (decoded per tool).
+serde_json = { workspace = true, features = ["raw_value"] }
+# Blocking HTTP to the Discord REST API (TLS; no json feature).
+ureq       = { workspace = true }
+# Typed connector errors (mapped to fail-closed JSON-RPC errors; never leak the token).
+thiserror  = { workspace = true }
+
+[dev-dependencies]
+# The conformance harness (dials THIS bin through the real register_server path).
+kx-extension-sdk = { path = "../../crates/kx-extension-sdk", version = "0.1.0" }
+
+[lints]
+workspace = true

--- a/integrations/kx-connector-discord/src/discord.rs
+++ b/integrations/kx-connector-discord/src/discord.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The Discord client: the Discord REST calls authenticated with a bot token — or
+//! a deterministic offline `fake` mode for tests / CI / conformance.
+//!
+//! ## Credential (D81)
+//! The bot token arrives by-reference in the environment variable named by
+//! [`CREDENTIAL_ENV`] (`KX_DISCORD_CREDENTIAL`), as a JSON object holding
+//! `bot_token`. It is read here and sent as an `Authorization: Bot <token>` header
+//! to the Discord REST API. The token value is never returned in a tool result, a
+//! log line, or an error string.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::validate::{check_content, check_snowflake};
+
+/// The environment variable the operator wires as the connection's `credential_ref`.
+/// It holds the credential as JSON: `{"bot_token": "..."}`.
+pub const CREDENTIAL_ENV: &str = "KX_DISCORD_CREDENTIAL";
+
+/// When set to a truthy value, the connector runs OFFLINE with canned responses —
+/// no network, no credential. Used by tests, CI, and the conformance harness.
+pub const FAKE_ENV: &str = "KX_DISCORD_FAKE";
+
+const API_BASE: &str = "https://discord.com/api/v10";
+
+/// Discord requires a descriptive `User-Agent` on REST requests (dev docs).
+const USER_AGENT: &str = "DiscordBot (https://github.com/Kortecx/kortecx, 0.1)";
+
+/// A typed connector error. Rendered into a fail-closed JSON-RPC error message;
+/// no variant ever carries the credential value.
+#[derive(Debug, thiserror::Error)]
+pub enum DiscordError {
+    /// The tool arguments were missing, ill-typed, or failed a guard.
+    #[error("invalid arguments: {0}")]
+    BadArgs(String),
+    /// No usable credential was injected (the connection has no resolvable `credential_ref`).
+    #[error("no Discord credential available (set the connection's credential_ref)")]
+    NoCredential,
+    /// The Discord API returned a non-success HTTP status.
+    #[error("discord api error (status {0})")]
+    Status(u16),
+    /// The Discord API could not be reached.
+    #[error("discord unreachable: {0}")]
+    Unreachable(String),
+    /// The Discord API returned a body that did not match the expected shape.
+    #[error("unexpected discord response")]
+    BadResponse,
+}
+
+/// The bot credential, parsed from [`CREDENTIAL_ENV`]. Private — never serialized back.
+#[derive(Deserialize)]
+struct BotConfig {
+    bot_token: String,
+}
+
+/// The connector's Discord client — an offline fake or a live bot client. The mode
+/// is a private detail; construct via [`DiscordClient::from_env`] or [`DiscordClient::fake`].
+pub struct DiscordClient {
+    mode: Mode,
+}
+
+/// Private client state — kept out of the public API so `BotConfig` stays internal.
+enum Mode {
+    Fake,
+    Live(Option<BotConfig>),
+}
+
+impl DiscordClient {
+    /// Build from the process environment.
+    ///
+    /// `KX_DISCORD_FAKE` (truthy) selects offline mode. Otherwise the injected
+    /// `KX_DISCORD_CREDENTIAL` JSON is parsed; an absent or malformed value yields a
+    /// live client with no credential, so tool calls fail closed (the runtime is
+    /// never handed a fabricated credential).
+    #[must_use]
+    pub fn from_env() -> Self {
+        if fake_enabled() {
+            return Self::fake();
+        }
+        let cfg = std::env::var(CREDENTIAL_ENV)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .and_then(|raw| serde_json::from_str::<BotConfig>(&raw).ok());
+        Self {
+            mode: Mode::Live(cfg),
+        }
+    }
+
+    /// A client that always returns deterministic offline responses (tests / embedding).
+    #[must_use]
+    pub fn fake() -> Self {
+        Self { mode: Mode::Fake }
+    }
+
+    /// Post a message to a channel; returns `{message_id, channel_id}`.
+    ///
+    /// # Errors
+    /// [`DiscordError::BadArgs`] on a bad id/content, [`DiscordError::NoCredential`],
+    /// or a `Status` / `Unreachable` / `BadResponse` error from the API call.
+    pub fn send_message(&self, channel_id: &str, content: &str) -> Result<String, DiscordError> {
+        check_snowflake("channel_id", channel_id)?;
+        check_content(content)?;
+        if let Mode::Fake = self.mode {
+            return Ok(fake::send(channel_id));
+        }
+        let token = self.bot_token()?;
+        let url = format!("{API_BASE}/channels/{channel_id}/messages");
+        let v = parse(&http_post_json(
+            &url,
+            token,
+            &json!({ "content": content }),
+        )?)?;
+        Ok(stringify(&json!({
+            "message_id": v.get("id").and_then(Value::as_str).unwrap_or_default(),
+            "channel_id": channel_id,
+        })))
+    }
+
+    /// Read recent messages from a channel; returns `[{id, author, content, timestamp}]`.
+    ///
+    /// # Errors
+    /// [`DiscordError::BadArgs`] on a bad id, [`DiscordError::NoCredential`], or a
+    /// `Status` / `Unreachable` / `BadResponse` error from the API call.
+    pub fn read_channel(&self, channel_id: &str, limit: u32) -> Result<String, DiscordError> {
+        check_snowflake("channel_id", channel_id)?;
+        if let Mode::Fake = self.mode {
+            return Ok(fake::read());
+        }
+        let token = self.bot_token()?;
+        let max = limit.clamp(1, 100);
+        let url = format!("{API_BASE}/channels/{channel_id}/messages?limit={max}");
+        let v = parse(&http_get(&url, token)?)?;
+        Ok(stringify(&shape_messages(&v)))
+    }
+
+    /// List a guild's channels; returns `[{id, name, type}]`.
+    ///
+    /// # Errors
+    /// [`DiscordError::BadArgs`] on a bad id, [`DiscordError::NoCredential`], or a
+    /// `Status` / `Unreachable` / `BadResponse` error from the API call.
+    pub fn list_channels(&self, guild_id: &str) -> Result<String, DiscordError> {
+        check_snowflake("guild_id", guild_id)?;
+        if let Mode::Fake = self.mode {
+            return Ok(fake::list());
+        }
+        let token = self.bot_token()?;
+        let url = format!("{API_BASE}/guilds/{guild_id}/channels");
+        let v = parse(&http_get(&url, token)?)?;
+        Ok(stringify(&shape_channels(&v)))
+    }
+
+    /// The bot token (live mode only); `NoCredential` when none was injected.
+    fn bot_token(&self) -> Result<&str, DiscordError> {
+        match &self.mode {
+            Mode::Fake => Ok("fake-bot-token"),
+            Mode::Live(cfg) => cfg
+                .as_ref()
+                .map(|c| c.bot_token.as_str())
+                .ok_or(DiscordError::NoCredential),
+        }
+    }
+}
+
+fn fake_enabled() -> bool {
+    std::env::var(FAKE_ENV).is_ok_and(|v| {
+        let v = v.to_ascii_lowercase();
+        !v.is_empty() && v != "0" && v != "false"
+    })
+}
+
+/// Reduce a Discord messages array to `[{id, author, content, timestamp}]`.
+fn shape_messages(v: &Value) -> Value {
+    let Some(arr) = v.as_array() else {
+        return json!([]);
+    };
+    let out: Vec<Value> = arr
+        .iter()
+        .map(|m| {
+            let author = m
+                .get("author")
+                .and_then(|a| {
+                    a.get("global_name")
+                        .and_then(Value::as_str)
+                        .filter(|s| !s.is_empty())
+                        .or_else(|| a.get("username").and_then(Value::as_str))
+                })
+                .unwrap_or_default();
+            json!({
+                "id": m.get("id").and_then(Value::as_str).unwrap_or_default(),
+                "author": author,
+                "content": m.get("content").and_then(Value::as_str).unwrap_or_default(),
+                "timestamp": m.get("timestamp").and_then(Value::as_str).unwrap_or_default(),
+            })
+        })
+        .collect();
+    Value::Array(out)
+}
+
+/// Reduce a Discord channels array to `[{id, name, type}]`.
+fn shape_channels(v: &Value) -> Value {
+    let Some(arr) = v.as_array() else {
+        return json!([]);
+    };
+    let out: Vec<Value> = arr
+        .iter()
+        .map(|c| {
+            json!({
+                "id": c.get("id").and_then(Value::as_str).unwrap_or_default(),
+                "name": c.get("name").and_then(Value::as_str).unwrap_or_default(),
+                "type": c.get("type").and_then(Value::as_u64).unwrap_or_default(),
+            })
+        })
+        .collect();
+    Value::Array(out)
+}
+
+/// GET a URL with the bot token; returns the response body as a string.
+fn http_get(url: &str, token: &str) -> Result<String, DiscordError> {
+    ureq::get(url)
+        .set("Authorization", &format!("Bot {token}"))
+        .set("User-Agent", USER_AGENT)
+        .call()
+        .map_err(classify)?
+        .into_string()
+        .map_err(|e| DiscordError::Unreachable(e.to_string()))
+}
+
+/// POST a JSON body with the bot token; returns the response body as a string.
+fn http_post_json(url: &str, token: &str, body: &Value) -> Result<String, DiscordError> {
+    let payload = serde_json::to_string(body).map_err(|_| DiscordError::BadResponse)?;
+    ureq::post(url)
+        .set("Authorization", &format!("Bot {token}"))
+        .set("User-Agent", USER_AGENT)
+        .set("Content-Type", "application/json")
+        .send_string(&payload)
+        .map_err(classify)?
+        .into_string()
+        .map_err(|e| DiscordError::Unreachable(e.to_string()))
+}
+
+fn parse(body: &str) -> Result<Value, DiscordError> {
+    serde_json::from_str::<Value>(body).map_err(|_| DiscordError::BadResponse)
+}
+
+fn stringify(v: &Value) -> String {
+    serde_json::to_string(v).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn classify(err: ureq::Error) -> DiscordError {
+    match err {
+        ureq::Error::Status(code, _) => DiscordError::Status(code),
+        ureq::Error::Transport(t) => DiscordError::Unreachable(t.to_string()),
+    }
+}
+
+/// Deterministic canned responses for offline mode (no network, no credential).
+mod fake {
+    /// A fake sent-message id, echoing the (non-secret) channel for test assertions.
+    pub(super) fn send(channel_id: &str) -> String {
+        let ch = serde_json::to_string(channel_id).unwrap_or_else(|_| "\"\"".to_string());
+        format!(r#"{{"message_id":"fake-msg-3","channel_id":{ch}}}"#)
+    }
+
+    /// A fake one-message history.
+    pub(super) fn read() -> String {
+        r#"[{"id":"fake-msg-1","author":"alice","content":"a fake message","timestamp":"2026-07-01T10:00:00.000000+00:00"}]"#
+            .to_string()
+    }
+
+    /// A fake channel list.
+    pub(super) fn list() -> String {
+        r#"[{"id":"fake-chan-1","name":"general","type":0}]"#.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fake_enabled, shape_channels, shape_messages, DiscordClient, Mode};
+    use serde_json::json;
+
+    #[test]
+    fn shape_messages_pulls_author_content_and_timestamp() {
+        let raw = json!([
+            {
+                "id": "m1",
+                "author": {"username": "bob", "global_name": "Bob B"},
+                "content": "hi there",
+                "timestamp": "2026-07-01T10:00:00+00:00"
+            }
+        ]);
+        let shaped = shape_messages(&raw);
+        let first = &shaped.as_array().unwrap()[0];
+        assert_eq!(first.get("id").unwrap(), "m1");
+        assert_eq!(first.get("author").unwrap(), "Bob B");
+        assert_eq!(first.get("content").unwrap(), "hi there");
+    }
+
+    #[test]
+    fn shape_messages_falls_back_to_username() {
+        let raw = json!([{ "id": "m2", "author": {"username": "carol"}, "content": "x" }]);
+        let shaped = shape_messages(&raw);
+        assert_eq!(
+            shaped.as_array().unwrap()[0].get("author").unwrap(),
+            "carol"
+        );
+    }
+
+    #[test]
+    fn shape_channels_pulls_id_name_type() {
+        let raw = json!([{ "id": "c1", "name": "general", "type": 0 }]);
+        let shaped = shape_channels(&raw);
+        let first = &shaped.as_array().unwrap()[0];
+        assert_eq!(first.get("name").unwrap(), "general");
+        assert_eq!(first.get("type").unwrap(), 0);
+    }
+
+    #[test]
+    fn live_without_credential_fails_closed() {
+        let client = DiscordClient {
+            mode: Mode::Live(None),
+        };
+        let err = client.send_message("123", "hi").unwrap_err();
+        assert!(matches!(err, super::DiscordError::NoCredential));
+    }
+
+    #[test]
+    fn bad_channel_id_fails_before_any_network() {
+        // A non-digit id is rejected by the guard regardless of credential/mode.
+        let client = DiscordClient {
+            mode: Mode::Live(None),
+        };
+        let err = client.read_channel("../secrets", 5).unwrap_err();
+        assert!(matches!(err, super::DiscordError::BadArgs(_)));
+    }
+
+    #[test]
+    fn fake_env_truthiness() {
+        std::env::set_var(super::FAKE_ENV, "1");
+        assert!(fake_enabled());
+        std::env::set_var(super::FAKE_ENV, "false");
+        assert!(!fake_enabled());
+        std::env::remove_var(super::FAKE_ENV);
+        assert!(!fake_enabled());
+    }
+}

--- a/integrations/kx-connector-discord/src/lib.rs
+++ b/integrations/kx-connector-discord/src/lib.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `kx-connector-discord` — a bundled Discord MCP connector.
+//!
+//! A standalone Model Context Protocol server: newline-delimited JSON-RPC 2.0 over
+//! stdio, speaking the full `initialize` -> `tools/list` -> `tools/call` lifecycle
+//! that `kx-mcp-gateway`'s `register_server` dials. It exposes three tools that let
+//! an agent consume / generate / publish Discord:
+//!   - `send_message`  — post a message to a channel (publish),
+//!   - `read_channel`  — read recent messages from a channel (consume),
+//!   - `list_channels` — list a guild's channels (consume).
+//!
+//! ## Credential discipline (D81 — secret-by-reference)
+//! The connector authenticates with a Discord **bot token** supplied
+//! **out-of-band**: the runtime resolves the connection's `credential_ref` NAME
+//! against the caller's own secret store and injects the value into this process's
+//! environment (the `KX_DISCORD_CREDENTIAL` variable, a JSON object holding
+//! `bot_token`). The connector reads it and calls the Discord REST API with an
+//! `Authorization: Bot <token>` header. The secret value is never placed in a
+//! reply, a log line, or an error — so it never reaches the runtime's journal, a
+//! `MoteId`, or a staged effect.
+//!
+//! ## Offline mode (tests / CI / conformance)
+//! When `KX_DISCORD_FAKE` is set the connector runs fully offline with deterministic
+//! canned responses (no network, no credential), so the MCP protocol, argument
+//! validation, and the secret-never-echoed contract can be gated without a live
+//! Discord bot token. See [`discord::DiscordClient::from_env`].
+//!
+//! This crate is an **external process** the runtime dials — it has no dependency on
+//! the gateway, the journal, or the frozen trio, so building or running it cannot
+//! move the projection digest or perturb the core.
+
+// Natural for a single-provider connector crate: the provider name recurs in the
+// `DiscordClient` / `DiscordError` types. Re-exported at the crate root for callers.
+#![allow(clippy::module_name_repetitions)]
+// Test modules may unwrap/expect on known-good literals + relax pedantic style
+// (per the workspace convention for tests).
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)
+)]
+
+pub mod discord;
+pub mod mcp;
+pub mod tools;
+pub mod validate;
+
+pub use discord::{DiscordClient, DiscordError};
+pub use mcp::handle_line;

--- a/integrations/kx-connector-discord/src/main.rs
+++ b/integrations/kx-connector-discord/src/main.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The `kx-connector-discord` binary: a newline-delimited JSON-RPC 2.0 MCP server
+//! over stdio. It builds its Discord client from the environment (the injected
+//! bot-token credential, D81) once at start, then answers one request per input
+//! line. The credential value is never written to stdout, stderr, or a log.
+
+use std::io::{BufRead, Write};
+
+use kx_connector_discord::{handle_line, DiscordClient};
+
+fn main() {
+    let client = DiscordClient::from_env();
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let reply = handle_line(&line, &client);
+        if writeln!(out, "{reply}").is_err() || out.flush().is_err() {
+            break;
+        }
+    }
+}

--- a/integrations/kx-connector-discord/src/mcp.rs
+++ b/integrations/kx-connector-discord/src/mcp.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The MCP JSON-RPC 2.0 protocol surface: `initialize` -> `tools/list` ->
+//! `tools/call`, newline-delimited over stdio. Every reply is fail-closed — an
+//! unparseable line or unknown method yields a JSON-RPC error, never a fabricated
+//! success.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use crate::discord::DiscordClient;
+use crate::tools;
+
+/// The MCP protocol version advertised at `initialize`.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// One JSON-RPC 2.0 request line. `jsonrpc` is ignored (unknown fields dropped).
+#[derive(Deserialize)]
+pub struct Req {
+    /// The request id, echoed on the reply. Absent -> `0`.
+    #[serde(default)]
+    pub id: u64,
+    /// The method name (`initialize` / `tools/list` / `tools/call`).
+    pub method: String,
+    /// Method parameters (present for `tools/call`).
+    #[serde(default)]
+    pub params: Option<Params>,
+}
+
+/// The `tools/call` parameters: the tool `name` and its opaque `arguments` object.
+#[derive(Deserialize)]
+pub struct Params {
+    /// The tool name to invoke.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// The tool arguments, kept as raw JSON (decoded fail-closed per tool).
+    #[serde(default)]
+    pub arguments: Option<Box<RawValue>>,
+}
+
+/// Parse one newline-delimited JSON-RPC request and produce its reply line.
+///
+/// Fail-closed: an unparseable line yields a JSON-RPC parse error (`-32700`).
+#[must_use]
+pub fn handle_line(line: &str, client: &DiscordClient) -> String {
+    match serde_json::from_str::<Req>(line) {
+        Ok(req) => handle(&req, client),
+        Err(_) => error(0, -32700, "parse error"),
+    }
+}
+
+fn handle(req: &Req, client: &DiscordClient) -> String {
+    let id = req.id;
+    match req.method.as_str() {
+        "initialize" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"protocolVersion":"{PROTOCOL_VERSION}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"kx-connector-discord","version":"1"}}}}}}"#
+        ),
+        "tools/list" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":{}}}}}"#,
+            tools::catalog_json()
+        ),
+        "tools/call" => tools::call(req, client),
+        other => error(id, -32601, &format!("no such method: {other}")),
+    }
+}
+
+/// Build a fail-closed JSON-RPC error reply. Never carries a credential value.
+#[must_use]
+pub fn error(id: u64, code: i64, message: &str) -> String {
+    // Encode the message as a JSON string so quotes / control chars cannot break the frame.
+    let msg = serde_json::to_string(message).unwrap_or_else(|_| "\"error\"".to_string());
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":{code},"message":{msg}}}}}"#)
+}
+
+/// Build a JSON-RPC success reply wrapping a `result` object given as raw JSON text.
+#[must_use]
+pub fn result(id: u64, result_json: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{result_json}}}"#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{handle_line, PROTOCOL_VERSION};
+    use crate::discord::DiscordClient;
+
+    fn fake() -> DiscordClient {
+        DiscordClient::fake()
+    }
+
+    #[test]
+    fn initialize_advertises_protocol_and_name() {
+        let reply = handle_line(r#"{"id":1,"method":"initialize"}"#, &fake());
+        assert!(reply.contains(PROTOCOL_VERSION));
+        assert!(reply.contains("kx-connector-discord"));
+        assert!(reply.contains(r#""id":1"#));
+    }
+
+    #[test]
+    fn tools_list_exposes_the_three_tools() {
+        let reply = handle_line(r#"{"id":2,"method":"tools/list"}"#, &fake());
+        for tool in ["send_message", "read_channel", "list_channels"] {
+            assert!(reply.contains(tool), "tools/list missing {tool}: {reply}");
+        }
+    }
+
+    #[test]
+    fn unparseable_line_is_a_parse_error() {
+        let reply = handle_line("not json", &fake());
+        assert!(reply.contains("-32700"));
+        assert!(reply.contains("error"));
+    }
+
+    #[test]
+    fn unknown_method_is_fail_closed() {
+        let reply = handle_line(r#"{"id":3,"method":"frobnicate"}"#, &fake());
+        assert!(reply.contains("-32601"));
+    }
+}

--- a/integrations/kx-connector-discord/src/tools.rs
+++ b/integrations/kx-connector-discord/src/tools.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The Discord tool catalog (the `tools/list` payload) and `tools/call` routing.
+//!
+//! Argument decoding is fail-closed: a missing/ill-typed field yields a JSON-RPC
+//! invalid-params error (`-32602`), never a fabricated call. A Discord execution
+//! failure yields a server error (`-32000`) carrying the typed reason — never the
+//! credential.
+
+use serde::Deserialize;
+
+use crate::discord::{DiscordClient, DiscordError};
+use crate::mcp::{error, result, Req};
+
+/// The `tools/list` array: the three Discord tools with typed JSON-Schema inputs.
+#[must_use]
+pub fn catalog_json() -> &'static str {
+    concat!(
+        r#"[{"name":"send_message","description":"Post a message to a Discord channel. Returns the new message id.","inputSchema":{"type":"object","properties":{"channel_id":{"type":"string"},"content":{"type":"string"}},"required":["channel_id","content"]}},"#,
+        r#"{"name":"read_channel","description":"Read recent messages from a Discord channel (most recent first). Returns [{id,author,content,timestamp}].","inputSchema":{"type":"object","properties":{"channel_id":{"type":"string"},"limit":{"type":"integer"}},"required":["channel_id"]}},"#,
+        r#"{"name":"list_channels","description":"List the channels of a Discord guild (server). Returns [{id,name,type}].","inputSchema":{"type":"object","properties":{"guild_id":{"type":"string"}},"required":["guild_id"]}}]"#
+    )
+}
+
+#[derive(Deserialize)]
+struct SendArgs {
+    channel_id: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ReadArgs {
+    channel_id: String,
+    #[serde(default)]
+    limit: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct ListArgs {
+    guild_id: String,
+}
+
+/// Route a `tools/call` request to the Discord client and frame the reply.
+///
+/// Unknown tool or bad arguments -> invalid-params (`-32602`); a Discord failure ->
+/// server error (`-32000`); success -> a JSON-RPC `result` object. Never returns
+/// the credential in any branch.
+#[must_use]
+pub fn call(req: &Req, client: &DiscordClient) -> String {
+    let id = req.id;
+    let params = req.params.as_ref();
+    let name = params.and_then(|p| p.name.as_deref()).unwrap_or_default();
+    let args_raw = params
+        .and_then(|p| p.arguments.as_ref())
+        .map_or_else(|| "{}".to_string(), |a| a.get().to_string());
+
+    match name {
+        "send_message" => match decode::<SendArgs>(&args_raw) {
+            Ok(a) => finish(id, client.send_message(&a.channel_id, &a.content)),
+            Err(e) => error(id, -32602, &e),
+        },
+        "read_channel" => match decode::<ReadArgs>(&args_raw) {
+            Ok(a) => finish(
+                id,
+                client.read_channel(&a.channel_id, a.limit.unwrap_or(20)),
+            ),
+            Err(e) => error(id, -32602, &e),
+        },
+        "list_channels" => match decode::<ListArgs>(&args_raw) {
+            Ok(a) => finish(id, client.list_channels(&a.guild_id)),
+            Err(e) => error(id, -32602, &e),
+        },
+        other => error(id, -32602, &format!("no such tool: {other}")),
+    }
+}
+
+/// Frame a Discord result (or its typed error) as a JSON-RPC reply.
+fn finish(id: u64, outcome: Result<String, DiscordError>) -> String {
+    match outcome {
+        Ok(result_json) => result(id, &result_json),
+        Err(e) => error(id, -32000, &e.to_string()),
+    }
+}
+
+/// Fail-closed argument decode; the `Err` string is a human-readable reason.
+fn decode<T: serde::de::DeserializeOwned>(raw: &str) -> Result<T, String> {
+    serde_json::from_str::<T>(raw).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::call;
+    use crate::discord::DiscordClient;
+    use crate::mcp::{Params, Req};
+
+    fn call_tool(name: &str, args: &str) -> String {
+        let req = Req {
+            id: 7,
+            method: "tools/call".to_string(),
+            params: Some(Params {
+                name: Some(name.to_string()),
+                arguments: Some(
+                    serde_json::value::RawValue::from_string(args.to_string()).unwrap(),
+                ),
+            }),
+        };
+        call(&req, &DiscordClient::fake())
+    }
+
+    #[test]
+    fn send_message_fake_returns_a_message_id_and_echoes_channel() {
+        let reply = call_tool(
+            "send_message",
+            r#"{"channel_id":"123","content":"hello world"}"#,
+        );
+        assert!(reply.contains(r#""result""#));
+        assert!(reply.contains("message_id"));
+        assert!(reply.contains("123"));
+    }
+
+    #[test]
+    fn read_channel_fake_returns_messages() {
+        let reply = call_tool("read_channel", r#"{"channel_id":"123"}"#);
+        assert!(reply.contains(r#""result""#));
+        assert!(reply.contains("fake-msg-1"));
+    }
+
+    #[test]
+    fn list_channels_fake_returns_channels() {
+        let reply = call_tool("list_channels", r#"{"guild_id":"999"}"#);
+        assert!(reply.contains(r#""result""#));
+        assert!(reply.contains("general"));
+    }
+
+    #[test]
+    fn missing_required_arg_is_invalid_params() {
+        let reply = call_tool("send_message", r#"{"channel_id":"123"}"#);
+        assert!(reply.contains("-32602"));
+    }
+
+    #[test]
+    fn unknown_tool_is_invalid_params() {
+        let reply = call_tool("delete_everything", r#"{}"#);
+        assert!(reply.contains("-32602"));
+        assert!(reply.contains("no such tool"));
+    }
+}

--- a/integrations/kx-connector-discord/src/validate.rs
+++ b/integrations/kx-connector-discord/src/validate.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Fail-closed argument guards for the Discord REST surface.
+//!
+//! The connector interpolates ids into URL path segments (`/channels/{id}/...`),
+//! so ids are validated as bare Discord **snowflakes** (ASCII digits only) BEFORE
+//! any request is built — a `/`, `?`, `#`, or `..` can never smuggle into the path.
+//! Message content is bounded to Discord's 2000-character limit. Both reject
+//! fail-closed with [`DiscordError::BadArgs`] and never carry the credential.
+
+use crate::discord::DiscordError;
+
+/// Discord's per-message content limit (characters, not bytes).
+pub const MAX_CONTENT_CHARS: usize = 2000;
+
+/// Validate a Discord snowflake id (a channel/guild id): non-empty and ASCII digits
+/// only. This is also the path-injection guard — a digits-only id cannot contain a
+/// path separator or query/fragment delimiter.
+///
+/// # Errors
+/// [`DiscordError::BadArgs`] when `id` is empty or contains a non-digit byte.
+pub fn check_snowflake(field: &str, id: &str) -> Result<(), DiscordError> {
+    if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(DiscordError::BadArgs(format!(
+            "`{field}` must be a Discord id (digits only)"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate message content: non-empty and within Discord's 2000-char limit.
+///
+/// # Errors
+/// [`DiscordError::BadArgs`] when `content` is empty or exceeds [`MAX_CONTENT_CHARS`].
+pub fn check_content(content: &str) -> Result<(), DiscordError> {
+    if content.is_empty() {
+        return Err(DiscordError::BadArgs(
+            "`content` must not be empty".to_string(),
+        ));
+    }
+    if content.chars().count() > MAX_CONTENT_CHARS {
+        return Err(DiscordError::BadArgs(format!(
+            "`content` exceeds Discord's {MAX_CONTENT_CHARS}-character limit"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{check_content, check_snowflake, MAX_CONTENT_CHARS};
+
+    #[test]
+    fn snowflake_accepts_digits_only() {
+        assert!(check_snowflake("channel_id", "123456789012345678").is_ok());
+    }
+
+    #[test]
+    fn snowflake_rejects_empty_and_non_digits() {
+        assert!(check_snowflake("channel_id", "").is_err());
+        assert!(check_snowflake("channel_id", "12/34").is_err());
+        assert!(check_snowflake("channel_id", "../secrets").is_err());
+        assert!(check_snowflake("channel_id", "abc").is_err());
+    }
+
+    #[test]
+    fn content_bounds_are_enforced() {
+        assert!(check_content("hi").is_ok());
+        assert!(check_content("").is_err());
+        let too_long: String = "x".repeat(MAX_CONTENT_CHARS + 1);
+        assert!(check_content(&too_long).is_err());
+        let at_limit: String = "x".repeat(MAX_CONTENT_CHARS);
+        assert!(check_content(&at_limit).is_ok());
+    }
+}

--- a/integrations/kx-connector-discord/tests/conformance.rs
+++ b/integrations/kx-connector-discord/tests/conformance.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Conformance: the bundled Discord connector passes the Extension Acceptance Gate
+//! subset (out-of-process · warrant/SN-8 · secret-by-ref · on/off), driven OFFLINE
+//! (`KX_DISCORD_FAKE`) so it needs no Discord credentials and no network.
+//!
+//! The connector is a `[[bin]]` of THIS crate, so `CARGO_BIN_EXE_kx-connector-discord`
+//! is always set for these integration tests — no skip path is needed.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_extension_sdk::conformance::{run_conformance, ConnectorUnderTest};
+use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+
+fn discord_connector(credential_ref: Option<String>) -> ConnectorUnderTest {
+    ConnectorUnderTest {
+        name: "discord".into(),
+        transport: TransportSpec::Stdio {
+            command: env!("CARGO_BIN_EXE_kx-connector-discord").to_string(),
+            args: vec![],
+        },
+        credential_ref,
+        session_mode: SessionMode::Stateless,
+    }
+}
+
+/// Offline, with a distinctive credential in play: the Discord connector is reachable,
+/// exposes its three tools, fires under a correct warrant (and is refused without
+/// one), and never echoes the injected secret. Combined into one test so the
+/// process-global `KX_DISCORD_FAKE` / credential env vars are set/cleared serially.
+#[test]
+fn discord_connector_passes_conformance_offline() {
+    const SECRET: &str = "SEKRET-bottoken-DEADBEEF-do-not-leak-0123456789";
+    const CRED_VAR: &str = "KX_DISCORD_CREDENTIAL";
+
+    std::env::set_var("KX_DISCORD_FAKE", "1");
+    std::env::set_var(CRED_VAR, SECRET);
+
+    let cut = discord_connector(Some(CRED_VAR.to_string()));
+    let report = run_conformance(&cut);
+
+    std::env::remove_var(CRED_VAR);
+    std::env::remove_var("KX_DISCORD_FAKE");
+
+    assert!(
+        report.reachable,
+        "connector should be reachable: {report:#?}"
+    );
+    assert!(
+        report.discovered >= 3,
+        "expected the 3 discord tools: {report:#?}"
+    );
+    assert!(
+        report.passed(),
+        "discord connector failed conformance: {report:#?}"
+    );
+
+    // Every gate item (out-of-process · warrant · secret-by-ref · on/off) present + passed.
+    for item in [3u8, 5, 7, 10] {
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.gate_item == item && c.passed),
+            "gate item {item} missing or failed: {report:#?}"
+        );
+    }
+}

--- a/integrations/kx-connector-discord/tests/live_smoke.rs
+++ b/integrations/kx-connector-discord/tests/live_smoke.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Live witness (GR15) — `#[ignore]` by default because it needs a REAL Discord bot
+//! token and network access, neither of which belong in CI.
+//!
+//! To run it, export a real credential and drop offline mode, then:
+//! ```text
+//! export KX_DISCORD_CREDENTIAL='{"bot_token":"..."}'
+//! export KX_DISCORD_TEST_GUILD_ID='...'   # a guild the bot has joined
+//! unset KX_DISCORD_FAKE
+//! cargo test -p kx-connector-discord --test live_smoke -- --ignored --nocapture
+//! ```
+//! The full agentic witness (a live Gemma ReAct loop firing `discord/read_channel`
+//! then `discord/send_message` on BOTH engines) is run at registration time via a
+//! `kx serve` end-to-end, per GR24 — this smoke test just proves the connector
+//! reaches Discord.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_connector_discord::DiscordClient;
+
+#[test]
+#[ignore = "requires a real Discord bot token in KX_DISCORD_CREDENTIAL + KX_DISCORD_TEST_GUILD_ID + network"]
+fn live_list_channels_reaches_discord() {
+    let guild_id = std::env::var("KX_DISCORD_TEST_GUILD_ID")
+        .expect("set KX_DISCORD_TEST_GUILD_ID to a guild the bot joined");
+    // Build straight from the environment (real credential, offline mode NOT set).
+    let client = DiscordClient::from_env();
+    let out = client
+        .list_channels(&guild_id)
+        .expect("a live list_channels should succeed with a valid bot token");
+    // A real response is a JSON array of channels; the secret is never echoed.
+    assert!(out.starts_with('['), "unexpected list shape: {out}");
+    assert!(
+        !out.contains("bot_token"),
+        "the credential must never appear in a tool result"
+    );
+}


### PR DESCRIPTION
## Summary

The **second bundled app-connector sidecar** — `integrations/kx-connector-discord` — the template the Slack/Notion connectors will clone, plus a `feature-ledger.toml` reconcile.

A standalone stdio JSON-RPC 2.0 MCP server (`initialize` → `tools/list` → `tools/call`) exposing **`discord/{send_message, read_channel, list_channels}`** so an agent can consume / generate / publish Discord.

- **Credential-by-reference (D81):** a bot token is injected out-of-band by name (`KX_DISCORD_CREDENTIAL` = `{"bot_token":"…"}`) and sent as `Authorization: Bot <token>` **inside the process**; the secret never appears in a reply, log, or error.
- **Guards:** snowflake-id validation (digits-only `channel_id`/`guild_id`) blocks URL path-injection; a 2000-char content bound. Offline `KX_DISCORD_FAKE` mode gives deterministic, network-free tests.
- **Conformance:** passes the Extension Acceptance Gate subset (items 3/5/7/10 — out-of-process · warrant/SN-8 · secret-by-ref · on/off) via `run_conformance`; a live `#[ignore]` witness (`tests/live_smoke.rs`) needs a real bot token.

Usable **today** against a running `kx serve`:
```sh
kx secrets set --name KX_DISCORD_CREDENTIAL --value '{"bot_token":"…"}'
kx connections add --name discord --command kx-connector-discord --credential-ref KX_DISCORD_CREDENTIAL
kx connections fire --name discord --tool list_channels --args '{"guild_id":"…"}'
```

## Blast radius — zero core

FFI-free **leaf crate, NO `kx-*` runtime dependency** (`kx-extension-sdk` is a dev-dep only, for the conformance harness). By construction:
- **Digest `7d22d4bd` invariant** (external process, outside the projection workspace; a0_guard unaffected) · **frozen trio untouched** · no proto / journal / checkpoint change.
- **`Cargo.lock` += only the `kx-connector-discord` node** — every dependency (`serde`/`serde_json`/`ureq`/`thiserror`) is already in the tree; no new external crate ⇒ cargo-deny clean.

## Ledger reconcile

Marked merged: `gmail-integration` (#276), `autonomy-safety-gates` (#267), `rc4c-2a-rerank-substrate` (#275). Registered `discord-connector` (in-progress) + `slack-connector` / `notion-connector` / `first-class-integrations` (G1) / `app-pointer-run-resolution` (G2) / `cross-instance-app-import` (G3) as planned.

## Test plan

- `cargo test -p kx-connector-discord` — 18 unit tests + offline conformance (gate items 3/5/7/10) pass; live witness `#[ignore]`.
- `cargo clippy -p kx-connector-discord --all-targets -- -D warnings` — clean · `cargo fmt --check` — clean · `cargo doc -D warnings` — clean.
- Real `[[bin]]` driven over stdio (offline): full MCP lifecycle + all 3 tools return correctly-shaped results; `../secrets` path-injection blocked fail-closed; the injected secret never appears in output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
