### PR TITLE
feat(rc4c-2b): live LLM rerank-turn in kx serve — react-rag + chat-rag durable rerank (D172)

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -93,6 +93,7 @@ from .recipes import (
     recipe_param_type_name,
 )
 from .replan import ReplanRound, ReplanRoundPage
+from .rerank import ReRankTurn, ReRankTurnPage
 from .run import AsyncRun, Result, Run
 from .run_agent import run_agent, run_agent_async
 from .runs import RunInputs, RunPage, RunSummary
@@ -185,6 +186,8 @@ __all__ = [
     "ReactTurnPage",
     "ReplanRound",
     "ReplanRoundPage",
+    "ReRankTurn",
+    "ReRankTurnPage",
     "CaptureRecord",
     "CaptureRecordPage",
     "RecipeForm",

--- a/bindings/python/src/kortecx/client.py
+++ b/bindings/python/src/kortecx/client.py
@@ -69,6 +69,7 @@ from .motes import MoteDetail
 from .react import ReactTurn, ReactTurnPage
 from .recipes import RecipeForm, RecipeInfo, ScoredRecipe
 from .replan import ReplanRound, ReplanRoundPage
+from .rerank import ReRankTurn, ReRankTurnPage
 from .run import AsyncRun, Result, Run
 from .runs import RunInputs, RunPage, RunSummary
 from .secrets import SecretName, SecretNamesPage
@@ -1558,6 +1559,24 @@ class KxClient:
             rounds=[ReplanRound.from_proto(r) for r in resp.rounds], has_more=resp.has_more
         )
 
+    def list_rerank_turns(
+        self, *, instance_id: Optional[str] = None, limit: Optional[int] = None
+    ) -> ReRankTurnPage:
+        """Enumerate a live listwise LLM re-rank loop's durable turn facts
+        (newest-first, paginated; RC4c-2) — the queryable re-rank history with the
+        enforced permutation per settled turn. ``instance_id`` (hex) scopes to one
+        run; absent enumerates every run. The server clamps ``limit`` to its max
+        page."""
+        req = _g.ListReRankTurnsRequest()
+        if instance_id is not None:
+            req.instance_id = hexids.decode(instance_id)
+        if limit is not None:
+            req.limit = limit
+        resp = self._call(lambda: self._stub.ListReRankTurns(req, metadata=self._md))
+        return ReRankTurnPage(
+            turns=[ReRankTurn.from_proto(t) for t in resp.turns], has_more=resp.has_more
+        )
+
     def list_capture_records(
         self, *, instance_id: Optional[str] = None, limit: Optional[int] = None
     ) -> CaptureRecordPage:
@@ -2714,6 +2733,20 @@ class AsyncKxClient:
         resp = await self._acall(self._stub.ListReplanRounds(req, metadata=self._md))
         return ReplanRoundPage(
             rounds=[ReplanRound.from_proto(r) for r in resp.rounds], has_more=resp.has_more
+        )
+
+    async def list_rerank_turns(
+        self, *, instance_id: Optional[str] = None, limit: Optional[int] = None
+    ) -> ReRankTurnPage:
+        """Async :meth:`KxClient.list_rerank_turns`."""
+        req = _g.ListReRankTurnsRequest()
+        if instance_id is not None:
+            req.instance_id = hexids.decode(instance_id)
+        if limit is not None:
+            req.limit = limit
+        resp = await self._acall(self._stub.ListReRankTurns(req, metadata=self._md))
+        return ReRankTurnPage(
+            turns=[ReRankTurn.from_proto(t) for t in resp.turns], has_more=resp.has_more
         )
 
     async def list_capture_records(

--- a/bindings/python/src/kortecx/rerank.py
+++ b/bindings/python/src/kortecx/rerank.py
@@ -1,0 +1,56 @@
+"""Re-rank-turn view — one ``ReRankRound`` fact enumerated by ``ListReRankTurns``.
+
+The durable, queryable history of a live listwise LLM re-rank loop in ``kx serve``
+(RC4c-2): each turn's run-salted re-rank Mote id, the resolved model, the settled
+``outcome`` (``pending`` | ``reranked`` | ``failed_closed``), the candidate count,
+and — for a ``reranked`` outcome — the exact ``permutation`` (reordered source
+indices) the runtime enforced. Kept in its own module (the react.py / replan.py
+module-per-concern precedent). SN-8: every id is server-derived; the SDK only
+hex-encodes the bytes, and the permutation is an exact reordering, never a score.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from . import hexids
+from .v1 import gateway_pb2 as _g
+
+
+@dataclass(frozen=True)
+class ReRankTurn:
+    """One re-rank turn fact: the round index, the run-salted re-rank Mote id, the
+    resolved model, the settled outcome, the candidate count, the enforced
+    permutation (set iff outcome == ``reranked``), and the journal seq (the
+    pagination cursor)."""
+
+    round: int
+    rerank_mote_id: str  # hex
+    instance_id: str  # hex
+    model_id: str
+    outcome: str  # "pending" | "reranked" | "failed_closed"
+    candidate_count: int
+    permutation: List[int]  # reordered source indices; set iff outcome == "reranked"
+    seq: int
+
+    @classmethod
+    def from_proto(cls, r: "_g.ReRankTurnSummary") -> "ReRankTurn":
+        return cls(
+            round=r.round,
+            rerank_mote_id=hexids.encode(r.rerank_mote_id),
+            instance_id=hexids.encode(r.instance_id),
+            model_id=r.model_id,
+            outcome=r.outcome,
+            candidate_count=r.candidate_count,
+            permutation=list(r.permutation),
+            seq=r.seq,
+        )
+
+
+@dataclass(frozen=True)
+class ReRankTurnPage:
+    """One newest-first page of :class:`ReRankTurn` plus the ``has_more`` flag."""
+
+    turns: List[ReRankTurn]
+    has_more: bool

--- a/bindings/typescript/src/client.ts
+++ b/bindings/typescript/src/client.ts
@@ -79,6 +79,7 @@ import { MoteDetail } from "./motes.js";
 import { ReactTurn, type ReactTurnPage } from "./react.js";
 import { RecipeForm, RecipeInfo, ScoredRecipe } from "./recipes.js";
 import { ReplanRound, type ReplanRoundPage } from "./replan.js";
+import { ReRankTurn, type ReRankTurnPage } from "./rerank.js";
 import { Result, Run } from "./run.js";
 import { RunInputs, type RunPage, RunSummary } from "./runs.js";
 import { SecretNameRow, type SecretNamesPage } from "./secrets.js";
@@ -1289,6 +1290,22 @@ export abstract class KxClientBase {
   async listReplanRounds(opts: { limit?: number } = {}): Promise<ReplanRoundPage> {
     const resp = await rpc(this.grpc.listReplanRounds({ limit: opts.limit }));
     return { rounds: resp.rounds.map((r) => ReplanRound.fromProto(r)), hasMore: resp.hasMore };
+  }
+
+  /**
+   * Enumerate a live listwise LLM re-rank loop's durable turn facts (newest-first,
+   * paginated; RC4c-2) — the queryable re-rank history with the enforced
+   * permutation per settled turn. `instanceId` (hex) scopes to one run; absent
+   * enumerates every run. The server clamps `limit` to its max page. An old
+   * gateway without this RPC throws {@link KxUnimplemented}.
+   */
+  async listRerankTurns(
+    opts: { instanceId?: string; limit?: number } = {},
+  ): Promise<ReRankTurnPage> {
+    const instanceId =
+      opts.instanceId === undefined ? undefined : asBytes(opts.instanceId, INSTANCE_LEN);
+    const resp = await rpc(this.grpc.listReRankTurns({ instanceId, limit: opts.limit }));
+    return { turns: resp.turns.map((t) => ReRankTurn.fromProto(t)), hasMore: resp.hasMore };
   }
 
   /**

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -58,6 +58,9 @@ export { TokenChunk } from "./tokens.js";
 export { ReplanRound } from "./replan.js";
 export type { ReplanRoundPage } from "./replan.js";
 
+export { ReRankTurn } from "./rerank.js";
+export type { ReRankTurnPage } from "./rerank.js";
+
 export { CaptureRecord } from "./capture.js";
 export type { CaptureRecordPage } from "./capture.js";
 

--- a/bindings/typescript/src/rerank.ts
+++ b/bindings/typescript/src/rerank.ts
@@ -1,0 +1,65 @@
+/**
+ * The re-rank-turn view — one `ReRankRound` fact enumerated by `ListReRankTurns`
+ * (RC4c-2): the durable, queryable history of a live listwise LLM re-rank loop in
+ * `kx serve`. Each turn carries its run-salted re-rank Mote id, the resolved model,
+ * the settled `outcome` (`pending` | `reranked` | `failed_closed`), the candidate
+ * count, and — for a `reranked` outcome — the exact `permutation` (reordered source
+ * indices) the runtime enforced. Kept in its own module (the react.ts / replan.ts
+ * module-per-concern precedent).
+ *
+ * SN-8: every id is server-derived; the SDK only *encodes* the bytes to hex, and
+ * the permutation is an exact reordering the runtime enforced, never a score.
+ */
+
+import type { ReRankTurnSummary as PbReRankTurnSummary } from "./gen/kortecx/v1/gateway_pb.js";
+import { encode } from "./hexids.js";
+
+/** One re-rank turn fact: the round index, the run-salted re-rank Mote id, the
+ *  resolved model, the settled outcome, the candidate count, the enforced
+ *  permutation (set iff `outcome === "reranked"`), and the journal seq (cursor). */
+export class ReRankTurn {
+  constructor(
+    readonly round: number,
+    readonly rerankMoteId: string,
+    readonly instanceId: string,
+    readonly modelId: string,
+    readonly outcome: string,
+    readonly candidateCount: number,
+    /** The reordered source indices; set iff `outcome === "reranked"`. */
+    readonly permutation: number[],
+    readonly seq: number,
+  ) {}
+
+  static fromProto(t: PbReRankTurnSummary): ReRankTurn {
+    return new ReRankTurn(
+      t.round,
+      encode(t.rerankMoteId),
+      encode(t.instanceId),
+      t.modelId,
+      t.outcome,
+      t.candidateCount,
+      [...t.permutation],
+      Number(t.seq),
+    );
+  }
+
+  /** A plain snake_case object (stable wire-shaped serialization for UIs/logs). */
+  toJSON() {
+    return {
+      round: this.round,
+      rerank_mote_id: this.rerankMoteId,
+      instance_id: this.instanceId,
+      model_id: this.modelId,
+      outcome: this.outcome,
+      candidate_count: this.candidateCount,
+      permutation: this.permutation,
+      seq: this.seq,
+    };
+  }
+}
+
+/** One page of {@link ReRankTurn} (newest-first) plus the `hasMore` cursor flag. */
+export interface ReRankTurnPage {
+  readonly turns: ReRankTurn[];
+  readonly hasMore: boolean;
+}

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -66,6 +66,7 @@ usage: kx <command> [args]
     kx feedback list [--instance <hex16>] [--limit N] [--before-rowid N]
     kx replan list [--limit N]                   (re-plan rounds, newest-first)
     kx react list [--instance <hex16>] [--chain <hex32>] [--limit N]   (ReAct turns, newest-first)
+    kx rerank list [--instance <hex16>] [--limit N]   (LLM-rerank turns, newest-first)
     kx capture list [--instance <hex16>] [--limit N]   (captured actions, newest-first)
     kx alerts list [--instance <hex16>] [--limit N] [--before-seq N]   (terminal-failure alerts, newest-first)
     kx signatures list | get --id <hex32> | register --manifest-file <path>
@@ -133,6 +134,8 @@ pub enum Cli {
     Replan(verbs::replan::ReplanArgs),
     /// ReAct-turn observability (PR-2d-1 `ListReactTurns`; read-only).
     React(verbs::react::ReactArgs),
+    /// LLM-rerank-turn observability (RC4c-2 `ListReRankTurns`; read-only).
+    ReRank(verbs::rerank::ReRankArgs),
     /// Captured-action records (`ListCaptureRecords`; read-only join keys).
     Capture(verbs::capture::CaptureArgs),
     /// The operator alerts inbox (W1a-2 `ListAlerts`; read-only view).
@@ -214,6 +217,7 @@ impl Cli {
             Some("feedback") => Ok(Cli::Feedback(verbs::feedback::parse(args)?)),
             Some("replan") => Ok(Cli::Replan(verbs::replan::parse(args)?)),
             Some("react") => Ok(Cli::React(verbs::react::parse(args)?)),
+            Some("rerank") => Ok(Cli::ReRank(verbs::rerank::parse(args)?)),
             Some("capture") => Ok(Cli::Capture(verbs::capture::parse(args)?)),
             Some("alerts") => Ok(Cli::Alerts(verbs::alerts::parse(args)?)),
             Some("signatures") => Ok(Cli::Signatures(verbs::signatures::parse(args)?)),
@@ -296,6 +300,7 @@ async fn dispatch(cli: Cli) -> Result<(), CliError> {
         Cli::Feedback(a) => verbs::feedback::execute(a).await,
         Cli::Replan(a) => verbs::replan::execute(a).await,
         Cli::React(a) => verbs::react::execute(a).await,
+        Cli::ReRank(a) => verbs::rerank::execute(a).await,
         Cli::Capture(a) => verbs::capture::execute(a).await,
         Cli::Alerts(a) => verbs::alerts::execute(a).await,
         Cli::Signatures(a) => verbs::signatures::execute(a).await,
@@ -663,6 +668,16 @@ kx react list [--instance <hex16>] [--chain <hex32>] [--limit N] [client flags]
   branch, and the run's durable budget caps. Newest-first; --instance scopes to
   one run, --chain to a single chain within it (a serve's shared journal carries
   one chain per Invoke plus agentic-step chains)."
+            .into(),
+        "rerank" => "\
+kx rerank list [--instance <hex16>] [--limit N] [client flags]
+  LLM-rerank-turn observability (read-only): the durable ReRankRound facts the
+  live RAG chain commits when it reorders retrieved candidates with a model —
+  each turn's run-salted rerank Mote id, the resolved model, the frozen outcome
+  (pending | reranked | failed_closed), the candidate count, and (for a reranked
+  outcome) the exact permutation the runtime enforced (SN-8: a permutation, never
+  a similarity score). Newest-first; --instance scopes to one run (a serve's
+  journal is shared)."
             .into(),
         "capture" => "\
 kx capture list [--instance <hex16>] [--limit N] [client flags]

--- a/crates/kx-cli/src/format.rs
+++ b/crates/kx-cli/src/format.rs
@@ -2368,6 +2368,72 @@ pub fn render_react_turns(resp: &proto::ListReactTurnsResponse, json: bool) -> S
     }
 }
 
+/// Render `rerank list` (RC4c-2 observability): newest-first LLM-rerank turns.
+/// `--json` field names mirror the SDK snake_case shape; byte ids are hex. The
+/// `permutation` (the reordered SOURCE indices, NEW-rank order) is present only
+/// for a `reranked` outcome (SN-8: an exact permutation, never a score).
+#[must_use]
+pub fn render_rerank_turns(resp: &proto::ListReRankTurnsResponse, json: bool) -> String {
+    if json {
+        let turns: Vec<Value> = resp
+            .turns
+            .iter()
+            .map(|t| {
+                json!({
+                    "round": t.round,
+                    "rerank_mote_id": hex::encode(&t.rerank_mote_id),
+                    "instance_id": hex::encode(&t.instance_id),
+                    "model_id": t.model_id,
+                    "outcome": t.outcome,
+                    "candidate_count": t.candidate_count,
+                    "permutation": t.permutation,
+                    "seq": t.seq,
+                })
+            })
+            .collect();
+        json!({ "turns": turns, "has_more": resp.has_more }).to_string()
+    } else if resp.turns.is_empty() {
+        "(no rerank turns)".to_string()
+    } else {
+        let mut out = String::new();
+        for t in &resp.turns {
+            // The permutation is set iff outcome == "reranked"; show a compact
+            // NEW-rank ordering (e.g. `perm [2,0,1]`) else a dash.
+            let perm = if t.permutation.is_empty() {
+                "-".to_string()
+            } else {
+                let inner = t
+                    .permutation
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("[{inner}]")
+            };
+            // The leading 16 hex chars of the run-salted rerank Mote id (a stable
+            // join key without the full 64-char id in a table row).
+            let mote = hex::encode(&t.rerank_mote_id);
+            let mote_short = mote.get(..16).unwrap_or(&mote);
+            let _ = write!(
+                out,
+                "{}round {}  {}  model {}  candidates {}  perm {}  seq {}  mote {}",
+                if out.is_empty() { "" } else { "\n" },
+                t.round,
+                t.outcome,
+                t.model_id,
+                t.candidate_count,
+                perm,
+                t.seq,
+                mote_short,
+            );
+        }
+        if resp.has_more {
+            out.push_str("\n(more — raise --limit)");
+        }
+        out
+    }
+}
+
 /// Render `capture list` (the Morphic Data Engine read surface): newest-first
 /// captured-action join keys. `--json` field names mirror the SDK snake_case
 /// shape; an absent `react_turn` is `null` (the Mote is not a ReAct turn).
@@ -2994,6 +3060,64 @@ mod tests {
                 false
             ),
             "(no capture records)"
+        );
+    }
+
+    #[test]
+    fn rerank_turns_json_mirrors_proto_and_human_is_compact() {
+        let rerank = proto::ListReRankTurnsResponse {
+            turns: vec![
+                // A reranked turn carries the frozen permutation on both surfaces.
+                proto::ReRankTurnSummary {
+                    round: 0,
+                    rerank_mote_id: vec![0xabu8; 32],
+                    instance_id: vec![6u8; 16],
+                    model_id: "gemma-4".into(),
+                    outcome: "reranked".into(),
+                    candidate_count: 3,
+                    permutation: vec![2, 0, 1],
+                    seq: 33,
+                },
+                // A failed-closed turn carries no permutation.
+                proto::ReRankTurnSummary {
+                    round: 0,
+                    rerank_mote_id: vec![0xcdu8; 32],
+                    instance_id: vec![6u8; 16],
+                    model_id: "gemma-4".into(),
+                    outcome: "failed_closed".into(),
+                    candidate_count: 3,
+                    permutation: vec![],
+                    seq: 32,
+                },
+            ],
+            has_more: true,
+        };
+        let v: Value = serde_json::from_str(&render_rerank_turns(&rerank, true)).unwrap();
+        assert_eq!(v["turns"][0]["rerank_mote_id"], "ab".repeat(32));
+        assert_eq!(v["turns"][0]["instance_id"], "06".repeat(16));
+        assert_eq!(v["turns"][0]["outcome"], "reranked");
+        assert_eq!(v["turns"][0]["candidate_count"], 3);
+        assert_eq!(v["turns"][0]["permutation"][0], 2);
+        assert_eq!(v["turns"][1]["outcome"], "failed_closed");
+        assert!(v["turns"][1]["permutation"].as_array().unwrap().is_empty());
+        assert_eq!(v["has_more"], true);
+        let human = render_rerank_turns(&rerank, false);
+        // The reranked turn shows the NEW-rank permutation + the mote-id prefix.
+        assert!(human.contains("reranked") && human.contains("perm [2,0,1]"));
+        assert!(human.contains("candidates 3") && human.contains("mote abababab"));
+        // The failed-closed turn shows a dash for the (absent) permutation.
+        assert!(human.contains("failed_closed") && human.contains("perm -"));
+        assert!(human.contains("(more — raise --limit)"));
+        // Empty is an honest placeholder, not an empty string.
+        assert_eq!(
+            render_rerank_turns(
+                &proto::ListReRankTurnsResponse {
+                    turns: vec![],
+                    has_more: false
+                },
+                false
+            ),
+            "(no rerank turns)"
         );
     }
 

--- a/crates/kx-cli/src/verbs/mod.rs
+++ b/crates/kx-cli/src/verbs/mod.rs
@@ -28,6 +28,7 @@ pub mod projection;
 pub mod react;
 pub mod recipe;
 pub mod replan;
+pub mod rerank;
 pub mod runs;
 pub mod secrets;
 pub mod signatures;

--- a/crates/kx-cli/src/verbs/rerank.rs
+++ b/crates/kx-cli/src/verbs/rerank.rs
@@ -1,0 +1,116 @@
+//! `kx rerank list` — LLM-rerank-turn observability over the gateway
+//! (`ListReRankTurns`, RC4c-2). The durable `ReRankRound` facts the live RAG
+//! chain commits when it reorders retrieved candidates with a model: each turn's
+//! run-salted rerank Mote id, the resolved model, the frozen outcome
+//! (`pending` | `reranked` | `failed_closed`), how many candidates were ranked,
+//! and — for a `reranked` outcome — the exact permutation the runtime enforced
+//! (SN-8: a permutation, never a similarity score). Read-only, newest-first;
+//! `--instance` scopes to one run (serve's journal is shared).
+
+use kx_proto::proto;
+
+use crate::client::{next_value, take_fixed, ClientCommon};
+use crate::error::CliError;
+use crate::format;
+
+/// Parsed `rerank` arguments.
+#[derive(Debug)]
+pub struct ReRankArgs {
+    /// Common client flags.
+    pub common: ClientCommon,
+    /// Scope to one run (16B instance id).
+    pub instance: Option<[u8; 16]>,
+    /// Page size (server clamps to its max page).
+    pub limit: Option<u32>,
+}
+
+/// Parse `rerank` args (the verb already consumed). The first token selects the
+/// subcommand (only `list` today).
+pub fn parse(mut args: impl Iterator<Item = String>) -> Result<ReRankArgs, CliError> {
+    let kw = args
+        .next()
+        .ok_or_else(|| CliError::Usage("rerank requires a subcommand: list".into()))?;
+    if kw != "list" {
+        return Err(CliError::Usage(format!(
+            "unknown rerank subcommand {kw:?} (expected: list)"
+        )));
+    }
+    let mut common = ClientCommon::default();
+    let mut instance = None;
+    let mut limit = None;
+    while let Some(flag) = args.next() {
+        if common.try_consume(&flag, &mut args)? {
+            continue;
+        }
+        match flag.as_str() {
+            "--instance" => instance = Some(take_fixed::<_, 16>(&mut args, "--instance")?),
+            "--limit" => {
+                let v = next_value(&mut args, "--limit")?;
+                limit = Some(v.parse::<u32>().map_err(|_| {
+                    CliError::Usage(format!("--limit must be a positive integer, got {v:?}"))
+                })?);
+            }
+            other => return Err(CliError::Usage(format!("unknown flag {other:?}"))),
+        }
+    }
+    Ok(ReRankArgs {
+        common,
+        instance,
+        limit,
+    })
+}
+
+/// Execute `rerank list`.
+pub async fn execute(args: ReRankArgs) -> Result<(), CliError> {
+    let resolved = args.common.resolve()?;
+    let mut client = resolved.connect().await?;
+    let resp = client
+        .list_re_rank_turns(resolved.request(proto::ListReRankTurnsRequest {
+            limit: args.limit,
+            instance_id: args.instance.map(|b| b.to_vec()),
+        })?)
+        .await
+        .map_err(CliError::from_status)?
+        .into_inner();
+    println!("{}", format::render_rerank_turns(&resp, args.common.json));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(parts: &[&str]) -> Result<ReRankArgs, CliError> {
+        parse(parts.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn list_parses_with_instance_limit_and_json() {
+        let a = p(&["list"]).unwrap();
+        assert!(a.instance.is_none() && a.limit.is_none());
+        let a = p(&[
+            "list",
+            "--instance",
+            &"ab".repeat(16),
+            "--limit",
+            "8",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(a.instance, Some([0xab; 16]));
+        assert_eq!(a.limit, Some(8));
+        assert!(a.common.json);
+    }
+
+    #[test]
+    fn bad_inputs_are_usage_errors() {
+        assert!(p(&[]).is_err(), "no subcommand");
+        assert!(p(&["turns"]).is_err(), "unknown subcommand");
+        assert!(p(&["list", "--limit"]).is_err(), "missing value");
+        assert!(p(&["list", "--limit", "many"]).is_err());
+        assert!(p(&["list", "--bogus"]).is_err());
+        // Wrong hex length / non-hex --instance is rejected.
+        assert!(p(&["list", "--instance", &"ab".repeat(32)]).is_err());
+        assert!(p(&["list", "--instance", "zz"]).is_err());
+    }
+}

--- a/crates/kx-context-assembler/src/assemble.rs
+++ b/crates/kx-context-assembler/src/assemble.rs
@@ -3,6 +3,7 @@
 //! byte-deterministic [`crate::AssembledContext`].
 
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 
 use bytes::Bytes;
 use kx_content::{ContentRef, ContentStore};
@@ -140,6 +141,44 @@ pub fn render_tool_menu(grants: &BTreeSet<ToolGrant>, registry: &dyn ToolRegistr
         out.push('\n');
     }
     out
+}
+
+/// RC4c-2b: bound a listwise-rerank turn's output — the permutation array (`n`
+/// indices ≈ 6 tokens each) PLUS generous headroom for a model that reasons before
+/// answering (e.g. Gemma's `<|channel>…<channel|>` preamble). Too tight a cap
+/// truncates the decode before the array and the parse fail-closes to input order;
+/// still bounded so a runaway decode can't burn the budget. The SHARED renderer for
+/// BOTH the authored-DAG harness rerank (`kx-model-harness::rag`) and the LIVE serve
+/// rerank turn (`kx-gateway::model_exec`), so the two paths never drift (the
+/// `render_tool_menu` precedent). Pure + FFI-free.
+#[must_use]
+pub fn rerank_output_cap(n: usize) -> u32 {
+    const REASONING_HEADROOM: usize = 256;
+    u32::try_from(n.saturating_mul(6).saturating_add(REASONING_HEADROOM)).unwrap_or(u32::MAX)
+}
+
+/// RC4c-2b: build the listwise-rerank prompt — the query + the `n` candidate passages
+/// (each truncated to `SNIPPET_MAX` chars), instructing the model to emit ONLY a
+/// permutation array of indices. The SHARED renderer for the harness rerank and the
+/// live serve rerank turn (byte-identical prompts ⇒ no harness↔serve drift). The
+/// runtime still enforces validity fail-closed via `kx_toolcall::parse_permutation`
+/// (SN-8: the model proposes an order; the parser is authority). Pure + FFI-free.
+#[must_use]
+pub fn render_rerank_prompt(query: &str, texts: &[String]) -> String {
+    const SNIPPET_MAX: usize = 400;
+    let n = texts.len();
+    let mut p = String::with_capacity(128 + n * SNIPPET_MAX);
+    let _ = write!(
+        p,
+        "Rank the passages by how well each answers the query. Respond with ONLY a JSON \
+         array of the passage indices, most relevant first — a permutation of 0..{n} with no \
+         duplicates (example: [2,0,1]).\n\nQuery: {query}\n\nPassages:\n"
+    );
+    for (i, t) in texts.iter().enumerate() {
+        let snippet: String = t.chars().take(SNIPPET_MAX).collect();
+        let _ = writeln!(p, "[{i}] {snippet}");
+    }
+    p
 }
 
 /// Assemble the Mote's explicit dependency closure into byte-deterministic

--- a/crates/kx-context-assembler/src/lib.rs
+++ b/crates/kx-context-assembler/src/lib.rs
@@ -97,7 +97,7 @@ mod assemble;
 mod errors;
 mod types;
 
-pub use assemble::{assemble, render_tool_menu};
+pub use assemble::{assemble, render_rerank_prompt, render_tool_menu, rerank_output_cap};
 pub use errors::AssemblyError;
 pub use types::{AssembledContext, AssembledItem};
 

--- a/crates/kx-coordinator/src/react_shape.rs
+++ b/crates/kx-coordinator/src/react_shape.rs
@@ -28,7 +28,8 @@ use kx_journal::INSTANCE_ID_LEN;
 use kx_mote::{
     ConfigKey, ConfigVal, EdgeMeta, EffectPattern, GraphPosition, InferenceParams, InputDataId,
     LogicRef, ModelId, Mote, MoteDef, MoteId, NdClass, ParentRef, PromptTemplateHash, ToolName,
-    ToolVersion, MOTE_DEF_SCHEMA_VERSION, PROMPT_KEY, REACT_TURN_KEY,
+    ToolVersion, MOTE_DEF_SCHEMA_VERSION, PROMPT_KEY, REACT_TURN_KEY, RERANK_CANDIDATES_KEY,
+    RERANK_QUERY_KEY, RERANK_TURN_KEY,
 };
 use smallvec::SmallVec;
 
@@ -282,6 +283,108 @@ pub(crate) fn build_react_tool(
             edge: EdgeMeta::data(),
         })
         .collect::<SmallVec<[ParentRef; 4]>>(),
+    )
+}
+
+// ===========================================================================
+// RC4c-2b — the live LLM RERANK turn builder.
+//
+// A rerank turn is a coordinator-materialized, OFF-DAG, OFF-BUDGET Mote that
+// reorders a RAG retrieval's candidate passages by relevance (a permutation).
+// It mirrors the ReAct-turn SHAPE (ROND, edge-free, worker-sampled →
+// coordinator-decoded) but is a SINGLE bounded turn per retrieval (no successor
+// chain, no `max_turns`/`max_tool_calls` consumption). Its identity namespace is
+// cryptographically distinct (`b"kx-rerank-turn"`), salted by the content-addressed
+// base results + query so each distinct retrieval reranks under a distinct identity.
+// ===========================================================================
+
+/// The 32-byte identity material for a live LLM RERANK turn (RC4c-2b):
+/// `blake3(b"kx-rerank-turn" ‖ instance_id ‖ base_results_ref ‖ query_ref)`.
+/// Cryptographically distinct from every react/agentic/shaper namespace (different
+/// domain tag). Salted by the (content-addressed) base results + query, so each
+/// distinct retrieval reranks under a distinct identity and two byte-identical
+/// retrievals in one run dedup to ONE rerank (idempotent — identical inputs yield the
+/// identical order). Both salts are recorded on the `ReRankRound` anchor, so recovery
+/// re-derives this material byte-identically (R49).
+#[must_use]
+pub(crate) fn rerank_turn_id_material(
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    base_results_ref: &ContentRef,
+    query_ref: &ContentRef,
+) -> [u8; 32] {
+    let mut material = b"kx-rerank-turn".to_vec();
+    material.extend_from_slice(instance_id);
+    material.extend_from_slice(base_results_ref.as_bytes());
+    material.extend_from_slice(query_ref.as_bytes());
+    *ContentRef::of(&material).as_bytes()
+}
+
+/// Build a live LLM RERANK turn `Mote` (RC4c-2b) — the coordinator-materialized,
+/// off-DAG Mote that reorders a RAG retrieval's candidate passages by relevance.
+///
+/// Shape mirrors [`build_react_turn`]: ROND (the model samples a permutation; the
+/// COMMITTED output is the served fact, re-decoded — never re-sampled — on replay),
+/// **EDGE-FREE** (empty parents — the candidates travel via `config_subset` refs, so
+/// the turn never moves the canonical digest via `encode_state` edges), NOT a topology
+/// shaper, no `tool_contract` (a rerank fires nothing; it PROPOSES an order the
+/// coordinator settle enforces). Three identity-bearing config values: the
+/// [`RERANK_TURN_KEY`] routing marker (value = `instance_id`, mirroring
+/// [`REACT_TURN_KEY`]), the [`RERANK_QUERY_KEY`] query ref, and the
+/// [`RERANK_CANDIDATES_KEY`] base-results ref. The worker's `run_rerank_turn` resolves
+/// both refs, renders the shared rerank prompt, arms `Grammar::Permutation(n)`
+/// OFF-MoteDef (digest-neutral, like the RC2 react grammar), and commits the RAW
+/// permutation; the coordinator's `settle_rerank_rounds` is the sole
+/// `parse_permutation` authority.
+///
+/// `max_output_tokens` is the warrant's output ceiling (identity-bearing, mirrors
+/// [`build_react_turn`]); the worker additionally bounds the decode by
+/// `kx_context_assembler::rerank_output_cap(n)` at dispatch.
+#[must_use]
+pub(crate) fn build_rerank_turn(
+    model_id: &ModelId,
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    base_results_ref: &ContentRef,
+    query_ref: &ContentRef,
+    max_output_tokens: u32,
+) -> Mote {
+    let id_bytes = rerank_turn_id_material(instance_id, base_results_ref, query_ref);
+
+    let mut config_subset = BTreeMap::new();
+    config_subset.insert(
+        ConfigKey(RERANK_TURN_KEY.to_string()),
+        ConfigVal(instance_id.to_vec()),
+    );
+    config_subset.insert(
+        ConfigKey(RERANK_QUERY_KEY.to_string()),
+        ConfigVal(query_ref.as_bytes().to_vec()),
+    );
+    config_subset.insert(
+        ConfigKey(RERANK_CANDIDATES_KEY.to_string()),
+        ConfigVal(base_results_ref.as_bytes().to_vec()),
+    );
+    let def = MoteDef {
+        critic_check: None,
+        logic_ref: LogicRef::from_bytes(id_bytes),
+        model_id: model_id.clone(),
+        prompt_template_hash: PromptTemplateHash::from_bytes(id_bytes),
+        // No tool_contract: the rerank PROPOSES an order; it fires nothing.
+        tool_contract: BTreeMap::new(),
+        nd_class: NdClass::ReadOnlyNondet,
+        config_subset,
+        effect_pattern: EffectPattern::IdempotentByConstruction,
+        critic_for: None,
+        is_topology_shaper: false,
+        inference_params: InferenceParams {
+            max_output_tokens,
+            ..InferenceParams::default()
+        },
+        schema_version: MOTE_DEF_SCHEMA_VERSION,
+    };
+    Mote::new(
+        def,
+        InputDataId::from_bytes(id_bytes),
+        GraphPosition(id_bytes.to_vec()),
+        SmallVec::new(),
     )
 }
 
@@ -618,6 +721,82 @@ mod tests {
         assert_ne!(build_react_turn(&model, "p2", 1, &[1; 16], 64).id, x.id);
         assert_ne!(build_react_turn(&model, "p", 2, &[1; 16], 64).id, x.id);
         assert_ne!(build_react_turn(&model, "p", 1, &[1; 16], 65).id, x.id);
+    }
+
+    // -----------------------------------------------------------------------
+    // RC4c-2b — live LLM rerank turn builder.
+    // -----------------------------------------------------------------------
+
+    /// The frozen golden `MoteId` for a rerank turn built from fixed inputs — a
+    /// regression pin (the rerank turn is serve-only, so there is NO harness twin;
+    /// this guards against accidental identity drift). Inputs: model
+    /// `kx-test:q8:deadbeef`, salt `[0x4d; 16]`, `base_results_ref =
+    /// ContentRef::of(b"base")`, `query_ref = ContentRef::of(b"query")`,
+    /// `max_output_tokens` 512.
+    const RERANK_TURN0_GOLDEN: &str =
+        "c2bc06a8f71290b6325a3214a68f44092f3aec25bb8c8ed6e29d5949bfac7565";
+
+    #[test]
+    fn rerank_turn_is_deterministic_edge_free_and_isolated() {
+        let model = ModelId("kx-test:q8:deadbeef".to_string());
+        let salt = [0x4d_u8; 16];
+        let base = ContentRef::of(b"base");
+        let query = ContentRef::of(b"query");
+        let turn = build_rerank_turn(&model, &salt, &base, &query, 512);
+        // Frozen identity.
+        assert_eq!(hex(turn.id.as_bytes()), RERANK_TURN0_GOLDEN);
+        // Off-DAG contract: edge-free, ROND, not a shaper, no tool_contract (fires nothing).
+        assert!(turn.parents.is_empty(), "a rerank turn MUST be edge-free");
+        assert!(!turn.def.is_topology_shaper);
+        assert!(turn.def.tool_contract.is_empty());
+        assert_eq!(turn.def.nd_class, NdClass::ReadOnlyNondet);
+        // The routing marker + the two candidate/query refs.
+        assert_eq!(
+            turn.def
+                .config_subset
+                .get(&ConfigKey(RERANK_TURN_KEY.to_string()))
+                .map(|v| v.0.clone()),
+            Some(salt.to_vec())
+        );
+        assert_eq!(
+            turn.def
+                .config_subset
+                .get(&ConfigKey(RERANK_QUERY_KEY.to_string()))
+                .map(|v| v.0.clone()),
+            Some(query.as_bytes().to_vec())
+        );
+        assert_eq!(
+            turn.def
+                .config_subset
+                .get(&ConfigKey(RERANK_CANDIDATES_KEY.to_string()))
+                .map(|v| v.0.clone()),
+            Some(base.as_bytes().to_vec())
+        );
+        // Deterministic + salted by (run, base_results, query).
+        assert_eq!(
+            build_rerank_turn(&model, &salt, &base, &query, 512).id,
+            turn.id
+        );
+        assert_ne!(
+            build_rerank_turn(&model, &[0x01; 16], &base, &query, 512).id,
+            turn.id,
+            "run-isolated"
+        );
+        assert_ne!(
+            build_rerank_turn(&model, &salt, &ContentRef::of(b"other"), &query, 512).id,
+            turn.id,
+            "base-results-salted"
+        );
+        assert_ne!(
+            build_rerank_turn(&model, &salt, &base, &ContentRef::of(b"other"), 512).id,
+            turn.id,
+            "query-salted"
+        );
+        // Cryptographically distinct namespace from the react turn at the same run-salt.
+        assert_ne!(
+            rerank_turn_id_material(&salt, &base, &query),
+            react_turn_id_material(&salt, 0)
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kx-coordinator/src/state.rs
+++ b/crates/kx-coordinator/src/state.rs
@@ -22,16 +22,18 @@ use std::sync::Arc;
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_journal::{
     approval_request_id, ApprovalState, FailureReason, IdempotencyClassTag, Journal, JournalEntry,
-    ReactBranch, RepudiationReason, ResolvedCapabilityRecord, ResolvedKindTag, INSTANCE_ID_LEN,
+    ReRankOutcome, ReactBranch, RepudiationReason, ResolvedCapabilityRecord, ResolvedKindTag,
+    INSTANCE_ID_LEN,
 };
 use kx_mote::{
     ConfigKey, EdgeKind, EffectPattern, ModelId, Mote, MoteDef, MoteId, NdClass, ToolName,
     ToolVersion, CONTEXT_ITEMS_KEY, IMAGE_REF_KEY, PROMPT_KEY, REACT_INSTRUCTION_KEY,
     REACT_MAX_TOOL_CALLS_KEY, REACT_MAX_TURNS_KEY, REACT_REQUIRE_APPROVAL_KEY, REACT_TURN_KEY,
-    TOOL_ARGS_KEY,
+    RERANK_CANDIDATES_KEY, RERANK_TURN_KEY, TOOL_ARGS_KEY,
 };
 use kx_projection::{
-    ContentStoreVerdicts, MoteState, Projection, ReactRoundRecord, RegisterMote, ReplanRoundRecord,
+    ContentStoreVerdicts, MoteState, Projection, ReRankRoundRecord, ReactRoundRecord, RegisterMote,
+    ReplanRoundRecord,
 };
 use kx_refusal::{validate_mote_submission, ToolResolution};
 use kx_scheduler::{LocalPlacement, Placement, Scheduler, SchedulerError, WorkerId};
@@ -773,6 +775,13 @@ fn lease_ready(
             if is_agentic_launch(mote) {
                 continue;
             }
+            // RC4c-2b: HOLD a grounded chat-rag/vision-rag answer until its durable
+            // rerank settles (the suppression gate) — it is edge-free + ready-at-submit,
+            // so without this it would dispatch on the base order before the rerank.
+            // Un-held (settled or not-eligible) answers fall through unchanged.
+            if chat_rag_rerank_holds(mote, warrant, projection, store) {
+                continue;
+            }
             if warrant.executor_class == executor_class {
                 if placement.place(&mote_id) == worker {
                     preferred.push(mote_id);
@@ -788,7 +797,8 @@ fn lease_ready(
         .take(max)
         .filter_map(|id| {
             submitted_defs.get(&id).and_then(|(mote, warrant)| {
-                let parent_results = resolve_parent_context(mote, projection, submitted_defs);
+                let parent_results =
+                    resolve_parent_context(mote, projection, submitted_defs, store);
                 // PR-2d-2: a ReAct OBSERVATION leases WITH its coordinator-
                 // validated args or NOT AT ALL — a transient resolution fault
                 // (store I/O) skips the item this poll (fail-safe retry, the
@@ -829,7 +839,11 @@ fn lease_ready(
                 // ReAct turn from the chain's turn-0 anchor (pure over committed facts,
                 // edge-free). `None` for turn 0 / a non-react leaf (which carries its
                 // bundle inline) ⇒ the wire payload is byte-identical to pre-PR-9d.
-                let context_items = resolve_react_context_items(mote, projection);
+                // RC4c-2b: a settled-Reranked chat-rag/vision-rag answer delivers its
+                // RERANKED bundle out-of-band (replacing the inline base order via the
+                // dispatch double-prepend fix); every other Mote is unchanged.
+                let context_items = chat_rag_delivered_context(mote, warrant, projection, store)
+                    .or_else(|| resolve_react_context_items(mote, projection));
                 // AGENTIC-VISION: re-derive the run's grounding-image ref for a SUCCESSOR
                 // ReAct turn from the chain's turn-0 anchor (pure over committed facts,
                 // edge-free). `None` for turn 0 / a non-vision leaf (which carries its
@@ -1278,6 +1292,7 @@ fn resolve_parent_context(
     mote: &Mote,
     projection: &Projection,
     submitted_defs: &BTreeMap<MoteId, (Mote, WarrantSpec)>,
+    store: Option<&LocalFsContentStore>,
 ) -> Vec<(MoteId, ContentRef)> {
     // PR-2c-3 critic-live (B1): a native deterministic critic evaluates its declared
     // check over EXACTLY its producer's committed bytes (`critic_for`) — byte-for-byte
@@ -1373,7 +1388,14 @@ fn resolve_parent_context(
                             r.turn_mote_id,
                         );
                         if let Some(obs_ref) = projection.result_ref_of(&obs.id) {
-                            out.push((obs.id, obs_ref));
+                            // RC4c-2b: deliver the RERANKED passage order for a retrieve
+                            // observation (when durably reranked); else the base order.
+                            // Off-DAG/off-digest — a presentation-only reorder of the
+                            // committed observation (the identity/obs.id is unchanged).
+                            let delivered =
+                                rerank_delivered_ref(projection, store, &instance_id, obs_ref)
+                                    .unwrap_or(obs_ref);
+                            out.push((obs.id, delivered));
                         }
                     }
                 }
@@ -1718,7 +1740,7 @@ struct Dispatch {
 
 /// The owner-thread loop. Recovers the projection from the journal, then services
 /// commands until every sender drops (the channel closes on coordinator shutdown).
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn core_loop<J: Journal>(
     journal: &J,
     store: Option<&LocalFsContentStore>,
@@ -1754,6 +1776,27 @@ fn core_loop<J: Journal>(
     // PR-2d-1: re-derive the live ReAct chains from committed facts (re-insert the
     // in-flight turn, re-decode + settle the committed tail). A no-op when no run
     // has anchored a chain (the has_react_turn sentinel) — the demo is untouched.
+    // RC4c-2b: re-insert any in-flight rerank Mote lost on restart (rebuilt from its
+    // durable `ReRankRound` anchor), then settle any that committed before the crash.
+    // A no-op when no run has anchored a rerank. Runs BEFORE the react recovery so a
+    // reranked observation's frozen order is ready when the react chain re-drives.
+    recover_rerank_chain(
+        journal,
+        store,
+        &mut projection,
+        &mut folded_through,
+        &mut dispatch,
+    );
+    // RC4c-2b: re-anchor + re-stage held chat-rag reranks after a restart (idempotent;
+    // a held answer re-inserted into `dispatch.defs` re-drives its rerank). No-op when
+    // the flag is off / no eligible answer.
+    settle_chat_rag_reranks(
+        journal,
+        store,
+        &mut projection,
+        &mut folded_through,
+        &mut dispatch,
+    );
     let mut react_cache = ReactSettleCache::default();
     recover_react_chain(
         journal,
@@ -3149,6 +3192,14 @@ fn run_settle_passes<J: Journal>(
 ) {
     settle_replan_rounds(journal, store, projection, folded_through, dispatch);
     settle_agentic_launches(journal, store, projection, folded_through, dispatch);
+    // RC4c-2b: freeze any COMMITTED rerank BEFORE the react settle, so the react-rag
+    // gate sees the frozen outcome and advances in the SAME drain (mirrors the
+    // agentic-launch pass running before the react settle). Zero-cost when idle.
+    settle_rerank_rounds(journal, store, projection, folded_through);
+    // RC4c-2b: anchor + materialize the rerank for any held chat-rag/vision-rag answer,
+    // and stage its reordered bundle once settled (runs AFTER the generic settle freezes
+    // a committed chat-rag rerank). Zero-cost when the flag is off / no eligible answer.
+    settle_chat_rag_reranks(journal, store, projection, folded_through, dispatch);
     settle_react_rounds(
         journal,
         store,
@@ -4088,6 +4139,23 @@ fn progress_tool_batch<J: Journal>(
         all_committed = false;
     }
     if all_committed {
+        // RC4c-2b react-rag gate: durably rerank the retrieved passages (if enabled)
+        // BEFORE advancing, so the next turn reasons over the reranked order. In flight
+        // ⇒ Active (re-check next pass); settled / not-applicable ⇒ fall through. The
+        // rerank is OFF-BUDGET (a `ReRankRound` fact, never a `ReactRound`).
+        if let Some(status) = maybe_gate_on_rerank(
+            journal,
+            store,
+            projection,
+            folded_through,
+            dispatch,
+            anchor,
+            turn,
+            turn_mote_id,
+            calls,
+        ) {
+            return status;
+        }
         // BACK-PRESSURE: every observation in the batch has committed ⇒ advance to
         // the next turn under the budget gate (re-prompt ONCE with all N results).
         return advance_react_chain(
@@ -4747,6 +4815,768 @@ fn recover_react_chain<J: Journal>(
         cache,
         tool_registry,
     );
+}
+
+// ===========================================================================
+// RC4c-2b — the live LLM RERANK-turn coordinator drivers.
+//
+// A faithful, OFF-BUDGET mirror of the ReAct-turn sole-writer lifecycle for a
+// SINGLE bounded rerank per retrieval: write a durable `ReRankRound` anchor
+// (Pending) BEFORE materializing the edge-free rerank Mote (fact-before-materialize
+// crash order), settle it by re-decoding the COMMITTED permutation ON THE SOLE
+// WRITER (the `parse_permutation` authority), and recover an in-flight rerank by
+// re-inserting the byte-identical Mote from its anchor (R49). The rerank never
+// touches a `ReactRound` fact ⇒ it consumes NO `max_turns`/`max_tool_calls`, and its
+// distinct `RERANK_TURN_KEY` namespace keeps it off the react settle/recover paths.
+// ===========================================================================
+
+/// Write the durable turn-0 `ReRankRound` anchor (`Pending`) for a rerank Mote —
+/// fact-BEFORE-materialize, so a crash between anchor and commit re-derives the
+/// in-flight Mote from committed facts on recovery. Idempotent: an existing anchor
+/// (any outcome) for this `rerank_mote_id` is a no-op (replay / re-drive). The
+/// `base_results_ref` / `query_ref` / `warrant_ref` are already content-store refs
+/// (the caller staged them); `candidate_count` is the `Permutation(n)` bound.
+#[allow(clippy::too_many_arguments)]
+fn write_rerank_anchor<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    rerank_mote: &Mote,
+    instance_id: [u8; INSTANCE_ID_LEN],
+    base_results_ref: ContentRef,
+    query_ref: ContentRef,
+    warrant_ref: ContentRef,
+    candidate_count: u32,
+) -> Result<(), CoordinatorError> {
+    if projection.latest_rerank_round(&rerank_mote.id).is_some() {
+        return Ok(()); // already anchored (idempotent re-drive / replay)
+    }
+    let entry = JournalEntry::ReRankRound {
+        round: 0,
+        rerank_mote_id: rerank_mote.id,
+        instance_id,
+        base_results_ref,
+        query_ref,
+        warrant_ref,
+        model_id: rerank_mote.def.model_id.0.clone(),
+        candidate_count,
+        outcome: ReRankOutcome::Pending,
+        seq: 0,
+    };
+    let durable = journal.append(entry)?;
+    let seq = durable.seq();
+    if seq > *folded_through {
+        projection.fold(&durable)?;
+        *folded_through = seq;
+    }
+    Ok(())
+}
+
+/// Append the FROZEN settled outcome for a rerank round (idempotent: a non-`Pending`
+/// outcome already recorded for this `rerank_mote_id` is a no-op — a recovery
+/// re-drive re-reads the decision, never re-samples). The settle is the SOLE
+/// authority: the worker committed the RAW permutation; the coordinator re-decodes.
+fn append_rerank_outcome<J: Journal>(
+    journal: &J,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    anchor: &ReRankRoundRecord,
+    outcome: ReRankOutcome,
+) {
+    if projection
+        .latest_rerank_round(&anchor.rerank_mote_id)
+        .is_some_and(|r| !matches!(r.outcome, ReRankOutcome::Pending))
+    {
+        return; // already settled (recovery re-drive)
+    }
+    let entry = JournalEntry::ReRankRound {
+        round: anchor.round,
+        rerank_mote_id: anchor.rerank_mote_id,
+        instance_id: anchor.instance_id,
+        base_results_ref: anchor.base_results_ref,
+        query_ref: anchor.query_ref,
+        warrant_ref: anchor.warrant_ref,
+        model_id: anchor.model_id.clone(),
+        candidate_count: anchor.candidate_count,
+        outcome,
+        seq: 0,
+    };
+    match journal.append(entry) {
+        Ok(durable) => {
+            let seq = durable.seq();
+            if seq > *folded_through && projection.fold(&durable).is_ok() {
+                *folded_through = seq;
+            }
+        }
+        Err(error) => tracing::error!(%error, "failed to append ReRankRound outcome fact"),
+    }
+}
+
+/// The distinct Pending frontier: one `ReRankRoundRecord` per `rerank_mote_id` whose
+/// LATEST outcome is still `Pending` (the work not yet settled). Bounded + cheap
+/// (reranks are opt-in + off by default; a run writes at most a few).
+fn pending_rerank_frontier(projection: &Projection) -> Vec<ReRankRoundRecord> {
+    let mut seen: BTreeSet<MoteId> = BTreeSet::new();
+    let mut out = Vec::new();
+    for r in projection.rerank_rounds() {
+        if !seen.insert(r.rerank_mote_id) {
+            continue;
+        }
+        if let Some(latest) = projection.latest_rerank_round(&r.rerank_mote_id) {
+            if matches!(latest.outcome, ReRankOutcome::Pending) {
+                out.push(latest.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Settle every Pending rerank round whose Mote reached a TERMINAL state: decode a
+/// COMMITTED permutation on the sole writer (`parse_permutation`) → freeze
+/// `Reranked`/`FailedClosed`; a FAILED Mote (crash OR permanent) freezes
+/// `FailedClosed` (best-effort — a rerank is never worth wedging an answerable RAG
+/// turn, unlike a react observation whose permanent failure dead-letters the chain).
+/// In-flight Motes stay `Pending` (re-checked next pass; recovery re-inserts them).
+/// Zero-cost when no rerank is pending.
+fn settle_rerank_rounds<J: Journal>(
+    journal: &J,
+    store: Option<&LocalFsContentStore>,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+) {
+    let pending = pending_rerank_frontier(projection);
+    if pending.is_empty() {
+        return;
+    }
+    let Some(store) = store else {
+        return;
+    };
+    for anchor in pending {
+        let state = projection.state_of(&anchor.rerank_mote_id);
+        let outcome = if state == MoteState::Committed {
+            match projection
+                .result_ref_of(&anchor.rerank_mote_id)
+                .and_then(|r| store.get(&r).ok())
+            {
+                Some(bytes) => {
+                    let text = String::from_utf8_lossy(bytes.as_ref());
+                    match kx_toolcall::parse_permutation(&text, anchor.candidate_count as usize) {
+                        Some(perm) => ReRankOutcome::Reranked {
+                            permutation: perm
+                                .into_iter()
+                                .map(|i| u32::try_from(i).unwrap_or(u32::MAX))
+                                .collect(),
+                        },
+                        None => ReRankOutcome::FailedClosed, // fail-closed to upstream order
+                    }
+                }
+                None => continue, // transient store fault ⇒ re-check next pass
+            }
+        } else if is_terminal(state) {
+            // A failed rerank Mote (crash flavor OR permanent) ⇒ fail-closed. A rerank
+            // is best-effort + off-budget, so it never dead-letters the RAG chain.
+            ReRankOutcome::FailedClosed
+        } else {
+            continue; // Pending / Scheduled / in-flight ⇒ re-check next pass
+        };
+        // On a successful rerank, PRE-STAGE the reordered delivery blob so the read-path
+        // `resolve_parent_context` (which recomputes the SAME deterministic
+        // content-addressed ref) finds the content. `base_results_ref` = the retrieve
+        // observation itself; a shape/parse fault silently leaves the base order. Pure
+        // content-store put (off-DAG, off-digest); idempotent (content-addressed).
+        if let ReRankOutcome::Reranked { permutation } = &outcome {
+            if let Ok(obs_bytes) = store.get(&anchor.base_results_ref) {
+                if let Some(reordered) =
+                    reorder_retrieval_observation(obs_bytes.as_ref(), permutation)
+                {
+                    let _ = store.put(&reordered);
+                }
+            }
+        }
+        append_rerank_outcome(journal, projection, folded_through, &anchor, outcome);
+    }
+}
+
+/// Recover the live rerank chains after a restart: re-insert each in-flight rerank
+/// Mote (its anchor is `Pending` and its Mote is not yet terminal) so a worker
+/// re-leases it, rebuilt byte-identically from the anchor (R49 — the id is derived
+/// from the committed `(instance_id, base_results_ref, query_ref)`; a divergence
+/// fail-closes). Then settle any that committed before the crash. Zero-cost when no
+/// rerank is pending. Reuses [`materialize_react_turn`] — a generic edge-free
+/// register+admit (the rerank Mote is edge-free like a react turn).
+fn recover_rerank_chain<J: Journal>(
+    journal: &J,
+    store: Option<&LocalFsContentStore>,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+) {
+    let Some(store) = store else {
+        return;
+    };
+    let pending = pending_rerank_frontier(projection);
+    if pending.is_empty() {
+        return;
+    }
+    for anchor in &pending {
+        if is_terminal(projection.state_of(&anchor.rerank_mote_id)) {
+            continue; // committed/failed ⇒ settle (below) decodes/freezes it
+        }
+        let Ok(warrant_bytes) = store.get(&anchor.warrant_ref) else {
+            continue;
+        };
+        let Ok(warrant) = decode_warrant(warrant_bytes.as_ref()) else {
+            continue;
+        };
+        let rebuilt = crate::react_shape::build_rerank_turn(
+            &ModelId(anchor.model_id.clone()),
+            &anchor.instance_id,
+            &anchor.base_results_ref,
+            &anchor.query_ref,
+            warrant.model_route.max_output_tokens,
+        );
+        if rebuilt.id != anchor.rerank_mote_id {
+            tracing::error!(
+                expected = ?anchor.rerank_mote_id,
+                rebuilt = ?rebuilt.id,
+                "rerank turn rebuild diverged from the durable fact — not re-inserting (fail-closed)"
+            );
+            continue;
+        }
+        materialize_react_turn(
+            projection,
+            dispatch,
+            Some(store),
+            &rebuilt,
+            anchor.warrant_ref,
+            warrant,
+        );
+    }
+    // Complete any rerank that committed before the crash (idempotent).
+    settle_rerank_rounds(journal, Some(store), projection, folded_through);
+}
+
+/// RC4c-2b: the serve-wide LLM-rerank enable flag — `KX_SERVE_RAG_LLM_RERANK` truthy
+/// (`1`/`true`/`yes`/`on`, case-insensitive) ⇒ the react-rag / chat-rag paths insert a
+/// DURABLE LLM rerank of the retrieved passages before the model reasons. A host-config
+/// read OFF the identity/digest path (checked ONLY when a rerank is first anchored; a
+/// committed rerank always completes on recovery regardless of the flag). Default-off
+/// ⇒ byte-identical to today (the canonical demo writes no rerank). Mirrors
+/// [`serve_require_approval_default`].
+fn serve_llm_rerank_enabled() -> bool {
+    std::env::var("KX_SERVE_RAG_LLM_RERANK")
+        .ok()
+        .is_some_and(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+}
+
+/// Parse a committed `retrieve@1` observation JSON for the rerank inputs: the query
+/// text + the candidate count. The ONE coupling to the retrieve observation's JSON
+/// shape (gated strictly on the `retrieve@1` tool id at the call site); generic
+/// `serde_json` so it never depends on the gateway's private `Observation` struct.
+/// `None` on any parse fault (the caller fails open to a base-order advance).
+fn parse_retrieve_query_and_count(obs_bytes: &[u8]) -> Option<(String, usize)> {
+    let v: serde_json::Value = serde_json::from_slice(obs_bytes).ok()?;
+    let query = v.get("query")?.as_str()?.to_string();
+    let n = v.get("passages")?.as_array()?.len();
+    Some((query, n))
+}
+
+/// Apply a rerank `permutation` to a `retrieve@1` observation's `passages` array,
+/// re-serialized deterministically. Produced by `settle_rerank_rounds` (sole writer,
+/// stores the bytes) and re-derived byte-identically by the read-path
+/// `resolve_parent_context` (content-addressed, so the same ref resolves). `None` on
+/// a shape drift / parse fault (the caller falls back to the base order).
+fn reorder_retrieval_observation(obs_bytes: &[u8], permutation: &[u32]) -> Option<Vec<u8>> {
+    let mut v: serde_json::Value = serde_json::from_slice(obs_bytes).ok()?;
+    let passages = v.get("passages")?.as_array()?;
+    if passages.len() != permutation.len() {
+        return None; // shape drift ⇒ leave the base order
+    }
+    let reordered: Vec<serde_json::Value> = permutation
+        .iter()
+        .map(|&i| passages.get(i as usize).cloned())
+        .collect::<Option<Vec<_>>>()?;
+    v["passages"] = serde_json::Value::Array(reordered);
+    serde_json::to_vec(&v).ok()
+}
+
+/// The reranked delivery ref for a retrieve observation (read path): if a `Reranked`
+/// `ReRankRound` exists for `obs_ref` (= its `base_results_ref`), the content-addressed
+/// ref of its reordered passages (already staged by `settle_rerank_rounds`), else
+/// `None` (base order). Cheap early-out when the run wrote no rerank.
+fn rerank_delivered_ref(
+    projection: &Projection,
+    store: Option<&LocalFsContentStore>,
+    instance_id: &[u8; INSTANCE_ID_LEN],
+    obs_ref: ContentRef,
+) -> Option<ContentRef> {
+    let store = store?;
+    // Zero-cost early-out: a run that wrote no rerank fact returns immediately.
+    projection.rerank_rounds_of(instance_id).next()?;
+    let rr = projection.latest_rerank_round_by_base(instance_id, &obs_ref)?;
+    let ReRankOutcome::Reranked { permutation } = &rr.outcome else {
+        return None; // Pending / FailedClosed ⇒ base order
+    };
+    let obs_bytes = store.get(&obs_ref).ok()?;
+    let reordered = reorder_retrieval_observation(obs_bytes.as_ref(), permutation)?;
+    Some(ContentRef::of(&reordered))
+}
+
+/// RC4c-2b react-rag gate: if LLM rerank is enabled and this batch committed a
+/// `retrieve@1` observation, ensure its passages are DURABLY reranked before the chain
+/// advances. Returns `Some(Active)` while the rerank is in flight (re-check next pass),
+/// or `None` when no rerank applies OR it has settled (proceed to advance — a settled
+/// `Reranked` reorders the next turn's trajectory via `resolve_parent_context`; a
+/// `FailedClosed` leaves the base order). OFF-BUDGET + best-effort: every error path
+/// falls through to `None` (advance with the base order — never wedge an answerable
+/// RAG turn). Only the FIRST retrieve call in a batch is reranked (react-rag proposes
+/// `retrieve` alone; a rare multi-retrieve batch reranks the first, the rest base order).
+#[allow(clippy::too_many_arguments)]
+fn maybe_gate_on_rerank<J: Journal>(
+    journal: &J,
+    store: &LocalFsContentStore,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+    anchor: &ReactRoundRecord,
+    turn: u32,
+    turn_mote_id: MoteId,
+    calls: &[(String, String)],
+) -> Option<ReactChainStatus> {
+    if !serve_llm_rerank_enabled() {
+        return None;
+    }
+    let call_index = calls
+        .iter()
+        .position(|(id, ver)| id == "retrieve" && ver == "1")?;
+    let obs = crate::react_shape::build_chain_tool(
+        &ModelId(anchor.model_id.clone()),
+        &ToolName("retrieve".to_string()),
+        &ToolVersion("1".to_string()),
+        turn,
+        &anchor.instance_id,
+        anchor.step_salt,
+        u32::try_from(call_index).unwrap_or(u32::MAX),
+        turn_mote_id,
+    );
+    let obs_ref = projection.result_ref_of(&obs.id)?; // committed retrieve observation
+    let obs_bytes = store.get(&obs_ref).ok()?;
+    let (query, n) = parse_retrieve_query_and_count(obs_bytes.as_ref())?;
+    if n < 2 {
+        return None; // 0/1 passages ⇒ nothing to reorder
+    }
+    let Ok(query_ref) = store.put(query.as_bytes()) else {
+        return None; // store fault ⇒ fail-open to base-order advance
+    };
+    let warrant = {
+        let bytes = store.get(&anchor.warrant_ref).ok()?;
+        decode_warrant(bytes.as_ref()).ok()?
+    };
+    // base_results_ref = the committed retrieve observation itself (the passages the
+    // model reorders — no scores, SN-8); the worker + settle read it back.
+    let rerank_mote = crate::react_shape::build_rerank_turn(
+        &ModelId(anchor.model_id.clone()),
+        &anchor.instance_id,
+        &obs_ref,
+        &query_ref,
+        warrant.model_route.max_output_tokens,
+    );
+    match projection
+        .latest_rerank_round(&rerank_mote.id)
+        .map(|r| r.outcome.clone())
+    {
+        None => {
+            // First sighting: fact BEFORE materialize (crash-safety order). A fault ⇒
+            // fail-open (advance with the base order — the rerank is best-effort).
+            if write_rerank_anchor(
+                journal,
+                projection,
+                folded_through,
+                &rerank_mote,
+                anchor.instance_id,
+                obs_ref,
+                query_ref,
+                anchor.warrant_ref,
+                u32::try_from(n).unwrap_or(u32::MAX),
+            )
+            .is_err()
+            {
+                return None;
+            }
+            materialize_react_turn(
+                projection,
+                dispatch,
+                Some(store),
+                &rerank_mote,
+                anchor.warrant_ref,
+                warrant,
+            );
+            Some(ReactChainStatus::Active) // wait for the rerank to commit + settle
+        }
+        Some(ReRankOutcome::Pending) => Some(ReactChainStatus::Active), // in flight
+        Some(ReRankOutcome::Reranked { .. } | ReRankOutcome::FailedClosed) => None, // settled ⇒ advance
+    }
+}
+
+// ===========================================================================
+// RC4c-2b — the chat-rag / vision-rag SUPPRESSION GATE (durable LLM rerank of a
+// grounded single-step answer's context bundle, BEFORE it dispatches).
+//
+// A chat-rag / vision-rag answer is an EDGE-FREE model step grounded INLINE at bind
+// (`config_subset[CONTEXT_ITEMS_KEY]`) — ready-at-submit, no react chain to gate on.
+// So the coordinator HOLDS it from lease (mirroring the agentic-launch park) until a
+// durable `ReRankRound` over its grounded passages settles, then delivers the
+// reranked bundle OUT-OF-BAND (`WorkItem.context_items`, the successor-turn rail) —
+// the answer Mote's IDENTITY is untouched (its inline base-order bundle is the
+// fallback), so this is fully digest-invariant even for the answer. Reuses the SAME
+// `build_rerank_turn` + `settle_rerank_rounds` machinery; the query is the answer's
+// `PROMPT`, the candidates its grounded context items.
+// ===========================================================================
+
+/// `true` iff `mote` is a rerank-eligible grounded answer — an EDGE-FREE model step
+/// (chat-rag / vision-rag) carrying a grounding bundle + a prompt, and NOT a
+/// react / rerank / authored-tool / critic / shaper Mote. (The serve rerank flag +
+/// the settled-outcome check are applied by the callers.)
+fn is_chat_rag_rerank_answer(mote: &Mote) -> bool {
+    mote.parents.is_empty()
+        && mote.def.critic_check.is_none()
+        && !mote.def.is_topology_shaper
+        && mote.def.tool_contract.is_empty()
+        && mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(PROMPT_KEY.to_string()))
+        && mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(CONTEXT_ITEMS_KEY.to_string()))
+        && !mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(REACT_TURN_KEY.to_string()))
+        && !mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(RERANK_TURN_KEY.to_string()))
+        && !mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(RERANK_CANDIDATES_KEY.to_string()))
+}
+
+/// Prepare a chat-rag answer's rerank inputs from its INLINE grounding bundle: build a
+/// synthetic `{query, passages:[{ref,text}]}` observation (so the worker + settle reuse
+/// the react-rag rerank path VERBATIM) + the query ref. `None` when the bundle has < 2
+/// items (nothing to reorder) or a store fault. `query` = the answer's `PROMPT`.
+fn chat_rag_rerank_prep(
+    mote: &Mote,
+    store: &LocalFsContentStore,
+) -> Option<(ContentRef, ContentRef, u32)> {
+    let bundle = mote
+        .def
+        .config_subset
+        .get(&ConfigKey(CONTEXT_ITEMS_KEY.to_string()))?;
+    let items = kx_mote::decode_context_items(&bundle.0);
+    if items.len() < 2 {
+        return None;
+    }
+    let query = mote
+        .def
+        .config_subset
+        .get(&ConfigKey(PROMPT_KEY.to_string()))
+        .map(|v| String::from_utf8_lossy(&v.0).into_owned())?;
+    let passages: Vec<serde_json::Value> = items
+        .iter()
+        .map(|it| {
+            let cref = ContentRef::from_bytes(it.content_ref);
+            let text = store
+                .get(&cref)
+                .ok()
+                .map(|b| String::from_utf8_lossy(b.as_ref()).into_owned())
+                .unwrap_or_default();
+            serde_json::json!({ "ref": cref.to_hex(), "text": text })
+        })
+        .collect();
+    let obs = serde_json::json!({ "query": query, "passages": passages });
+    let obs_bytes = serde_json::to_vec(&obs).ok()?;
+    let base_results_ref = store.put(&obs_bytes).ok()?;
+    let query_ref = store.put(query.as_bytes()).ok()?;
+    Some((
+        base_results_ref,
+        query_ref,
+        u32::try_from(items.len()).unwrap_or(u32::MAX),
+    ))
+}
+
+/// Apply a rerank `permutation` to a grounding `CONTEXT_ITEMS` bundle — decode →
+/// reorder the items → re-encode. Produced by `settle_chat_rag_reranks` (stores the
+/// bytes) + re-derived byte-identically on the read path (content-addressed). `None`
+/// on a length mismatch (the caller falls back to the base order).
+fn reorder_context_items_bundle(bundle_bytes: &[u8], permutation: &[u32]) -> Option<Vec<u8>> {
+    let items = kx_mote::decode_context_items(bundle_bytes);
+    if items.len() != permutation.len() {
+        return None;
+    }
+    let reordered: Vec<kx_mote::ContextItemRef> = permutation
+        .iter()
+        .map(|&i| items.get(i as usize).cloned())
+        .collect::<Option<Vec<_>>>()?;
+    // ORDER-PRESERVING encode: `encode_context_items` canonically SORTS (which would
+    // discard the rerank); the reranked bundle is off-digest out-of-band delivery, so
+    // it uses the ordered variant, and the serve assembler renders in decoded order.
+    Some(kx_mote::encode_context_items_ordered(&reordered))
+}
+
+/// The rerank `MoteId` for a chat-rag answer (its salt = the run instance ‖ its
+/// synthetic base-results ref ‖ its query ref). `None` when not eligible / no run
+/// registered / < 2 items. Shared by the lease hold, the delivery, and the settle pass
+/// so all three agree by construction (the `max_output_tokens` MUST be the answer's
+/// warrant cap in every caller).
+fn chat_rag_rerank_id(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    projection: &Projection,
+    store: &LocalFsContentStore,
+) -> Option<(MoteId, ContentRef, ContentRef, u32, [u8; INSTANCE_ID_LEN])> {
+    let (instance_id, _) = projection.run_registration()?;
+    let (base_ref, query_ref, n) = chat_rag_rerank_prep(mote, store)?;
+    let id = crate::react_shape::build_rerank_turn(
+        &mote.def.model_id,
+        &instance_id,
+        &base_ref,
+        &query_ref,
+        warrant.model_route.max_output_tokens,
+    )
+    .id;
+    Some((id, base_ref, query_ref, n, instance_id))
+}
+
+/// Whether to HOLD a chat-rag answer from lease this poll: eligible + serve rerank
+/// enabled + its `ReRankRound` has not reached a terminal outcome. Holds even BEFORE
+/// the rerank is anchored (`None`), so a lease that races ahead of the settle pass
+/// never dispatches the answer on the base order.
+fn chat_rag_rerank_holds(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    projection: &Projection,
+    store: Option<&LocalFsContentStore>,
+) -> bool {
+    if !serve_llm_rerank_enabled() || !is_chat_rag_rerank_answer(mote) {
+        return false;
+    }
+    let Some(store) = store else {
+        return false;
+    };
+    let Some((id, ..)) = chat_rag_rerank_id(mote, warrant, projection, store) else {
+        return false; // < 2 items / no run ⇒ nothing to hold for
+    };
+    !matches!(
+        projection.latest_rerank_round(&id).map(|r| &r.outcome),
+        Some(ReRankOutcome::Reranked { .. } | ReRankOutcome::FailedClosed)
+    )
+}
+
+/// The reranked `CONTEXT_ITEMS` bundle ref to deliver OUT-OF-BAND for a chat-rag answer
+/// (read path): `Some(reordered_ref)` when its rerank settled `Reranked` (the bytes
+/// were staged by `settle_chat_rag_reranks`; the ref is recomputed deterministically),
+/// else `None` (deliver nothing ⇒ the worker uses the INLINE base-order bundle —
+/// `FailedClosed` or not-eligible).
+fn chat_rag_delivered_context(
+    mote: &Mote,
+    warrant: &WarrantSpec,
+    projection: &Projection,
+    store: Option<&LocalFsContentStore>,
+) -> Option<ContentRef> {
+    if !serve_llm_rerank_enabled() || !is_chat_rag_rerank_answer(mote) {
+        return None;
+    }
+    let store = store?;
+    let (id, ..) = chat_rag_rerank_id(mote, warrant, projection, store)?;
+    let rr = projection.latest_rerank_round(&id)?;
+    let ReRankOutcome::Reranked { permutation } = &rr.outcome else {
+        return None;
+    };
+    let bundle = mote
+        .def
+        .config_subset
+        .get(&ConfigKey(CONTEXT_ITEMS_KEY.to_string()))?;
+    let reordered = reorder_context_items_bundle(&bundle.0, permutation)?;
+    Some(ContentRef::of(&reordered))
+}
+
+/// Settle pass: for every ADMITTED (not-yet-committed) chat-rag answer whose rerank is
+/// enabled, ANCHOR + materialize its rerank Mote (first sighting) and STAGE the reordered
+/// bundle once it settles `Reranked`. Zero-cost when the flag is off / no eligible answer
+/// is admitted. Idempotent (anchor + stage dedup on the durable fact).
+fn settle_chat_rag_reranks<J: Journal>(
+    journal: &J,
+    store: Option<&LocalFsContentStore>,
+    projection: &mut Projection,
+    folded_through: &mut u64,
+    dispatch: &mut Dispatch,
+) {
+    if !serve_llm_rerank_enabled() {
+        return;
+    }
+    let Some(store) = store else {
+        return;
+    };
+    if projection.run_registration().is_none() {
+        return;
+    }
+    // Snapshot the eligible answers (clone out to avoid borrowing `dispatch` while we
+    // mutate `projection`/`dispatch` below).
+    let answers: Vec<(Mote, WarrantSpec)> = dispatch
+        .defs
+        .values()
+        .filter(|(m, _)| is_chat_rag_rerank_answer(m) && !is_terminal(projection.state_of(&m.id)))
+        .cloned()
+        .collect();
+    for (answer, warrant) in answers {
+        let Some((id, base_ref, query_ref, n, instance_id)) =
+            chat_rag_rerank_id(&answer, &warrant, projection, store)
+        else {
+            continue;
+        };
+        match projection
+            .latest_rerank_round(&id)
+            .map(|r| r.outcome.clone())
+        {
+            None => {
+                // First sighting: encode the answer's warrant + anchor (fact BEFORE
+                // materialize) + admit the rerank Mote. Fail-open on a fault (the answer
+                // stays held; a later pass retries — or the hold's own eligibility lapses).
+                let Ok(warrant_ref) = store.put(&encode_warrant(&warrant)) else {
+                    continue;
+                };
+                let rerank_mote = crate::react_shape::build_rerank_turn(
+                    &answer.def.model_id,
+                    &instance_id,
+                    &base_ref,
+                    &query_ref,
+                    warrant.model_route.max_output_tokens,
+                );
+                if write_rerank_anchor(
+                    journal,
+                    projection,
+                    folded_through,
+                    &rerank_mote,
+                    instance_id,
+                    base_ref,
+                    query_ref,
+                    warrant_ref,
+                    n,
+                )
+                .is_ok()
+                {
+                    materialize_react_turn(
+                        projection,
+                        dispatch,
+                        Some(store),
+                        &rerank_mote,
+                        warrant_ref,
+                        warrant,
+                    );
+                }
+            }
+            Some(ReRankOutcome::Reranked { permutation }) => {
+                // Stage the reordered bundle so the lease read path's deterministic ref
+                // resolves. Idempotent (content-addressed put).
+                if let Some(bundle) = answer
+                    .def
+                    .config_subset
+                    .get(&ConfigKey(CONTEXT_ITEMS_KEY.to_string()))
+                {
+                    if let Some(reordered) = reorder_context_items_bundle(&bundle.0, &permutation) {
+                        let _ = store.put(&reordered);
+                    }
+                }
+            }
+            Some(ReRankOutcome::Pending | ReRankOutcome::FailedClosed) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod rerank_delivery_tests {
+    use super::*;
+
+    #[test]
+    fn parse_and_reorder_retrieval_observation() {
+        let obs = br#"{"dataset":"kb","query":"how does recovery work?","passages":[{"ref":"a","text":"zero"},{"ref":"b","text":"one"},{"ref":"c","text":"two"}]}"#;
+        let (q, n) = parse_retrieve_query_and_count(obs).expect("parses");
+        assert_eq!(q, "how does recovery work?");
+        assert_eq!(n, 3);
+        // Reorder by [2,0,1] ⇒ passages become [two, zero, one]; query + dataset preserved.
+        let reordered = reorder_retrieval_observation(obs, &[2, 0, 1]).expect("reorders");
+        let v: serde_json::Value = serde_json::from_slice(&reordered).unwrap();
+        let texts: Vec<&str> = v["passages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(texts, ["two", "zero", "one"]);
+        assert_eq!(v["query"], "how does recovery work?");
+        assert_eq!(v["dataset"], "kb");
+        // Identity permutation is order-preserving.
+        let same = reorder_retrieval_observation(obs, &[0, 1, 2]).expect("identity");
+        let v2: serde_json::Value = serde_json::from_slice(&same).unwrap();
+        let t2: Vec<&str> = v2["passages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(t2, ["zero", "one", "two"]);
+    }
+
+    #[test]
+    fn reorder_retrieval_observation_fails_closed_on_shape_drift() {
+        let obs = br#"{"query":"q","passages":[{"text":"a"},{"text":"b"}]}"#;
+        // A permutation whose length differs from the passage count ⇒ None (base order).
+        assert!(reorder_retrieval_observation(obs, &[0]).is_none());
+        assert!(reorder_retrieval_observation(obs, &[0, 1, 2]).is_none());
+        // Non-JSON / missing fields ⇒ None (never panics on a malformed observation).
+        assert!(reorder_retrieval_observation(b"not json", &[0, 1]).is_none());
+        assert!(parse_retrieve_query_and_count(b"not json").is_none());
+        assert!(parse_retrieve_query_and_count(br#"{"passages":[]}"#).is_none());
+        // no query
+    }
+
+    #[test]
+    fn reorder_context_items_bundle_permutes_and_fails_closed() {
+        use kx_mote::{decode_context_items, encode_context_items, ContextItemRef};
+        let items = vec![
+            ContextItemRef {
+                name: "a".into(),
+                content_ref: [1; 32],
+            },
+            ContextItemRef {
+                name: "b".into(),
+                content_ref: [2; 32],
+            },
+            ContextItemRef {
+                name: "c".into(),
+                content_ref: [3; 32],
+            },
+        ];
+        let bundle = encode_context_items(&items);
+        // Reorder [2,0,1] ⇒ c, a, b.
+        let reordered = reorder_context_items_bundle(&bundle, &[2, 0, 1]).expect("reorders");
+        let out = decode_context_items(&reordered);
+        assert_eq!(
+            out.iter().map(|i| i.name.as_str()).collect::<Vec<_>>(),
+            ["c", "a", "b"]
+        );
+        // A length mismatch fails closed to the base order.
+        assert!(reorder_context_items_bundle(&bundle, &[0, 1]).is_none());
+    }
 }
 
 /// Resolve the warrant's tool grants ONCE per fresh submit (canonical

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -150,6 +150,37 @@ fn build_tool_grammar(warrant: &WarrantSpec) -> Option<Grammar> {
     ToolEnvelopeSpec::new(tools).to_raw().ok().map(Grammar::new)
 }
 
+/// RC4c-2b: read a 32-byte `ContentRef` from a Mote's `config_subset` at `key` — the
+/// rerank turn's base-results / query refs are stored as raw 32-byte values by
+/// `react_shape::build_rerank_turn`. `None` on a missing key / bad length.
+fn config_ref(mote: &Mote, key: &str) -> Option<ContentRef> {
+    mote.def
+        .config_subset
+        .get(&ConfigKey(key.to_string()))
+        .and_then(|v| <[u8; 32]>::try_from(v.0.as_slice()).ok())
+        .map(ContentRef::from_bytes)
+}
+
+/// RC4c-2b: parse a committed `retrieve@1` observation JSON for its passage TEXTS
+/// (the rerank candidates), in retrieval order — one entry per passage (a
+/// text-less passage yields `""`, so the count MATCHES the coordinator's
+/// `candidate_count`, avoiding a length-mismatch fail-closed). Generic `serde_json`
+/// (no coupling to the gateway's private `Observation` struct); `None` on a parse fault.
+fn parse_retrieve_passages(obs_bytes: &[u8]) -> Option<Vec<String>> {
+    let v: serde_json::Value = serde_json::from_slice(obs_bytes).ok()?;
+    let arr = v.get("passages")?.as_array()?;
+    Some(
+        arr.iter()
+            .map(|p| {
+                p.get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect(),
+    )
+}
+
 /// Build the shaper runtime from the resolved serve backend. The `worker` role maps
 /// (in the recipe allowlist) to a PURE model step and (in the role registry) to the
 /// shaper's own warrant — so a lowered child inherits the model route and runs its
@@ -1259,39 +1290,34 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             }
             _ => instruction,
         };
-        // PR-7: prepend a run's ATTACHED context-bundle items (the entry Mote's
-        // identity-bearing `config_subset[CONTEXT_ITEMS_KEY]`), AHEAD of the F-7
-        // parent context. Absent ⇒ byte-identical to pre-PR-7 (the canonical run
-        // attaches no bundle); a missing ref / overflow fails closed.
-        let instruction = match mote
-            .def
-            .config_subset
-            .get(&ConfigKey(CONTEXT_ITEMS_KEY.to_string()))
-        {
-            Some(encoded) => {
-                let items = decode_context_items(&encoded.0);
-                let context = crate::assemble_serve::assemble_context_items(&items, &self.store)
-                    .map_err(|e| internal(&format!("assemble context items: {e}")))?;
-                format!("{context}{instruction}")
-            }
-            None => instruction,
-        };
-        // PR-9d (per-turn context-carry): a SUCCESSOR ReAct turn carries NO inline
-        // CONTEXT_ITEMS_KEY (the seed-swap drops it), so its grounding context arrives
-        // OUT-OF-BAND via the ContextSink — the run's turn-0 anchor bundle ref, re-
-        // derived edge-free by the coordinator. Prepend it in the SAME slot the inline
-        // bundle occupies (ahead of the F-7 trajectory). Turn 0 / a leaf returns `None`
-        // here (it used the inline path above) ⇒ never double-prepended; absent ⇒
-        // byte-identical to pre-PR-9d. A missing / oversized bundle fails closed.
-        let instruction = match self.take_context_items(mote.id) {
-            Some(items_ref) => {
-                let encoded = self
-                    .store
+        // PR-7 / PR-9d / RC4c-2b: prepend the run's grounding context bundle AHEAD of the
+        // F-7 trajectory, from EXACTLY ONE source. The OUT-OF-BAND bundle (ContextSink)
+        // takes PRECEDENCE over the inline `config_subset[CONTEXT_ITEMS_KEY]`:
+        // - a SUCCESSOR ReAct turn carries only out-of-band (the seed-swap drops inline);
+        // - a leaf / turn-0 carries only inline;
+        // - a RC4c-2b RERANKED chat-rag/vision-rag answer carries BOTH — the out-of-band
+        //   REORDERED bundle REPLACES its inline base order (the double-prepend fix: the
+        //   inline is the identity/fallback, delivered only when NO out-of-band arrives).
+        // Absent both ⇒ byte-identical to pre-PR-7; a missing / oversized bundle fails closed.
+        let carried_bundle: Option<Vec<u8>> = match self.take_context_items(mote.id) {
+            Some(items_ref) => Some(
+                self.store
                     .get(&items_ref)
-                    .map_err(|e| internal(&format!("fetch carried context bundle: {e}")))?;
+                    .map_err(|e| internal(&format!("fetch carried context bundle: {e}")))?
+                    .as_ref()
+                    .to_vec(),
+            ),
+            None => mote
+                .def
+                .config_subset
+                .get(&ConfigKey(CONTEXT_ITEMS_KEY.to_string()))
+                .map(|encoded| encoded.0.clone()),
+        };
+        let instruction = match carried_bundle {
+            Some(encoded) => {
                 let items = decode_context_items(&encoded);
                 let context = crate::assemble_serve::assemble_context_items(&items, &self.store)
-                    .map_err(|e| internal(&format!("assemble carried context items: {e}")))?;
+                    .map_err(|e| internal(&format!("assemble context items: {e}")))?;
                 format!("{context}{instruction}")
             }
             None => instruction,
@@ -1421,6 +1447,18 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
             .contains_key(&kx_mote::ConfigKey(kx_mote::REACT_TURN_KEY.to_string()))
     }
 
+    /// `true` iff `mote` is a coordinator-materialized live LLM RERANK turn (RC4c-2b)
+    /// — the [`kx_mote::RERANK_TURN_KEY`] routing marker. A rerank turn carries NO
+    /// `PROMPT_KEY` (its prompt is rendered at dispatch from `config_subset` refs), so
+    /// the `run` router checks this BEFORE the `has_prompt` gate; the marker is
+    /// identity-bearing (`config_subset` → `MoteId`), so it can never be dropped in
+    /// transit (structurally fail-closed, like [`Self::is_react_turn`]).
+    fn is_rerank_turn(mote: &Mote) -> bool {
+        mote.def
+            .config_subset
+            .contains_key(&kx_mote::ConfigKey(kx_mote::RERANK_TURN_KEY.to_string()))
+    }
+
     /// `true` iff this Mote opts OUT of RC2 grammar-constrained tool-calling via
     /// `config_subset[REACT_UNCONSTRAINED_KEY] = true` (the SDK `.unconstrained()`
     /// / CLI `--unconstrained` escape hatch). Absent ⇒ `false` ⇒ grammar is armed
@@ -1532,6 +1570,68 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         let result_ref = self
             .store
             .put(&bytes)
+            .map_err(|e| internal(&format!("content store put: {e}")))?;
+        Ok(MoteExecutionResult {
+            result_ref,
+            started_at_epoch_ms: 0,
+            finished_at_epoch_ms: 0,
+        })
+    }
+
+    /// Run a live LLM RERANK turn (RC4c-2b): resolve the candidate passages + query
+    /// from the turn's `config_subset` refs, render the SHARED rerank prompt, arm
+    /// `Grammar::Permutation(n)` OFF-MoteDef (Ollama strict whole-response `format` /
+    /// llama.cpp fail-closed parser degrade — T-RERANK-GBNF-CRASH), greedy-decode
+    /// (a permutation is a decision, not creative output), and commit the RAW model
+    /// output. The coordinator's `settle_rerank_rounds` is the SOLE `parse_permutation`
+    /// authority — a malformed permutation there freezes `FailedClosed` (base order;
+    /// a rerank NEVER dead-letters the RAG chain), and a dispatch/store fault here
+    /// fails the Mote (→ settle `FailedClosed`). Nothing is ever pre-applied here
+    /// (the sole-writer contract: the worker PROPOSES the order, the coordinator owns
+    /// the decision — mirroring `run_react_turn`).
+    fn run_rerank_turn(
+        &self,
+        mote: &Mote,
+        warrant: &WarrantSpec,
+    ) -> Result<MoteExecutionResult, MoteExecutorError> {
+        let base_ref = config_ref(mote, kx_mote::RERANK_CANDIDATES_KEY)
+            .ok_or_else(|| internal("rerank turn missing base_results_ref"))?;
+        let query_ref = config_ref(mote, kx_mote::RERANK_QUERY_KEY)
+            .ok_or_else(|| internal("rerank turn missing query_ref"))?;
+        let query = {
+            let bytes = self
+                .store
+                .get(&query_ref)
+                .map_err(|e| internal(&format!("rerank query fetch: {e}")))?;
+            String::from_utf8_lossy(bytes.as_ref()).into_owned()
+        };
+        let obs_bytes = self
+            .store
+            .get(&base_ref)
+            .map_err(|e| internal(&format!("rerank candidates fetch: {e}")))?;
+        let texts = parse_retrieve_passages(obs_bytes.as_ref())
+            .ok_or_else(|| internal("rerank: unreadable base results"))?;
+        let n = texts.len();
+        let carrier = kx_grammar::GrammarSpec::Permutation(kx_grammar::PermutationSpec::new(
+            u32::try_from(n).unwrap_or(u32::MAX),
+        ))
+        .to_raw()
+        .map_err(|e| internal(&format!("rerank grammar carrier: {e}")))?;
+        let params = InferenceParams {
+            grammar: Some(Grammar::new(carrier)),
+            temperature_bps: 0,
+            max_output_tokens: kx_context_assembler::rerank_output_cap(n),
+            ..InferenceParams::default()
+        };
+        let input =
+            InferenceInput::text(kx_context_assembler::render_rerank_prompt(&query, &texts));
+        let out = self
+            .backend
+            .dispatch(&mote.def.model_id, &input, &params, warrant)
+            .map_err(|e| internal(&format!("rerank dispatch: {e}")))?;
+        let result_ref = self
+            .store
+            .put(&out.bytes)
             .map_err(|e| internal(&format!("content store put: {e}")))?;
         Ok(MoteExecutionResult {
             result_ref,
@@ -1801,6 +1901,20 @@ impl<B: InferenceBackend> MoteExecutor for ModelRouterExecutor<B> {
             } else {
                 self.run_critic(mote)
             };
+        }
+        // RC4c-2b: a live LLM RERANK turn is a model Mote WITHOUT a `PROMPT_KEY` (its
+        // prompt is rendered at dispatch from `config_subset` refs), so it must route
+        // BEFORE the `has_prompt` gate — else it would fall to the inner PURE/demo
+        // router and commit the wrong bytes. Fail closed on an unserved model (never
+        // the demo executor); the coordinator settle owns the permutation decode.
+        if Self::is_rerank_turn(mote) {
+            if !self.backend.supports(&mote.def.model_id) {
+                return Err(internal(&format!(
+                    "rerank turn {:?} routes to an unserved model {:?} (fail-closed)",
+                    mote.id, mote.def.model_id
+                )));
+            }
+            return self.run_rerank_turn(mote, warrant);
         }
         // A prompt-bearing Mote is a MODEL step. If the backend does NOT serve its
         // model_id, FAIL CLOSED — never delegate to the inner demo/echo executor.

--- a/crates/kx-gateway/tests/rerank_serve.rs
+++ b/crates/kx-gateway/tests/rerank_serve.rs
@@ -1,0 +1,257 @@
+//! Live LLM-rerank e2e witness (RC4c-2b) — `kx serve` with `KX_SERVE_RAG_LLM_RERANK=1`
+//! reranks the retrieved passages via a DURABLE, replayable coordinator rerank-turn, on
+//! BOTH live RAG paths:
+//!   - chat-rag: the grounded answer is HELD until a rerank of its context bundle settles
+//!     (the hard witness — chat-rag always grounds, so a `ReRankRound` MUST fire);
+//!   - react-rag: the agent's `retrieve@1` observation is reranked before the next turn
+//!     (soft — the model's retrieve proposal is probabilistic, so the rerank is logged).
+//!
+//! Drive on BOTH engines (GR24; #[ignore], runtime-skips without a served model):
+//! ```text
+//!   # llama.cpp (Gemma-4 GGUF; degrade-to-parser on the permutation grammar):
+//!   KX_SERVE_MODEL_GGUF=.../gemma-4-12b-it-q4_k_m.gguf KX_SERVE_RAG_LLM_RERANK=1 \
+//!     cargo test -p kx-gateway --features inference,hnsw --test rerank_serve -- --ignored --nocapture
+//!   # Ollama (gemma3:12b; strict whole-response `format`):
+//!   KX_SERVE_OLLAMA=1 KX_SERVE_OLLAMA_MODELS=gemma3:12b,embeddinggemma:latest \
+//!     KX_SERVE_EMBED_MODEL=embeddinggemma:latest KX_SERVE_RAG_LLM_RERANK=1 \
+//!     cargo test -p kx-gateway --features inference,hnsw --test rerank_serve -- --ignored --nocapture
+//! ```
+
+#![cfg(all(feature = "inference", feature = "hnsw"))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kx_gateway::{start, CHAT_RAG_RECIPE_HANDLE, REACT_RAG_RECIPE_HANDLE};
+use kx_proto::proto;
+use kx_proto::proto::kx_gateway_client::KxGatewayClient;
+use tonic::transport::Channel;
+
+fn serve_model() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("KX_SERVE_MODEL_GGUF") {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let standin = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/models/qwen3-0.6b-q4_k_m.gguf");
+    standin.is_file().then_some(standin)
+}
+
+async fn client(addr: SocketAddr) -> KxGatewayClient<Channel> {
+    let endpoint = format!("http://{addr}");
+    for _ in 0..100 {
+        if let Ok(c) = KxGatewayClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("client connects to the gateway at {endpoint}");
+}
+
+fn doc(content: &[u8]) -> proto::IngestDocument {
+    proto::IngestDocument {
+        content: content.to_vec(),
+        embedding: Vec::new(),
+        ..Default::default()
+    }
+}
+
+/// Select the engine (llama.cpp GGUF or Ollama) + FORCE the LLM rerank on. Returns
+/// `false` ⇒ runtime-skip (no served model). Must run before `start`.
+fn configure_serve_with_rerank() -> bool {
+    std::env::set_var("KX_SERVE_RAG_LLM_RERANK", "1");
+    if std::env::var_os("KX_SERVE_OLLAMA").is_some() {
+        return true;
+    }
+    match serve_model() {
+        Some(gguf) => {
+            std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+            true
+        }
+        None => {
+            eprintln!("skipping: no serve model — set KX_SERVE_MODEL_GGUF or KX_SERVE_OLLAMA=1");
+            false
+        }
+    }
+}
+
+async fn ingest_science(c: &mut KxGatewayClient<Channel>) -> bool {
+    c.ingest_documents(proto::IngestDocumentsRequest {
+        dataset: "science".to_string(),
+        documents: vec![
+            doc(b"Tectonic plates drift over the mantle, causing earthquakes at their boundaries."),
+            doc(b"The mitochondria is the powerhouse of the cell, producing ATP from glucose."),
+            doc(b"Plants turn sunlight, water, and carbon dioxide into sugar and oxygen inside their leaves."),
+            doc(b"The Great Barrier Reef is the world's largest coral reef system off Australia."),
+        ],
+    })
+    .await
+    .is_ok()
+}
+
+/// CHAT-RAG (the HARD witness): a grounded answer is HELD until a durable rerank of its
+/// context bundle settles, so a `ReRankRound` with a terminal outcome MUST appear.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real LLM inference + dataset embedding; needs a served Gemma model; opt in with --ignored"]
+async fn chat_rag_grounded_answer_is_reranked() {
+    if !configure_serve_with_rerank() {
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == CHAT_RAG_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: kx/recipes/chat-rag not provisioned (needs a served model + hnsw)");
+        running.shutdown().await.unwrap();
+        return;
+    }
+    if !ingest_science(&mut c).await {
+        eprintln!("skipping: ingest failed (no embedder wired) — set KX_SERVE_EMBED_MODEL");
+        running.shutdown().await.unwrap();
+        return;
+    }
+
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: CHAT_RAG_RECIPE_HANDLE.to_string(),
+            args: br#"{"prompt":"How do plants make energy from the sun? Answer briefly using the dataset.","dataset":"science"}"#
+                .to_vec(),
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke kx/recipes/chat-rag")
+        .into_inner();
+    assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
+
+    // Await the rerank round (be generous — a 12B rerank turn is slow).
+    let mut outcome: Option<String> = None;
+    for _ in 0..3000 {
+        let rounds = c
+            .list_re_rank_turns(proto::ListReRankTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(t) = rounds.turns.iter().find(|t| t.outcome != "pending") {
+            outcome = Some(t.outcome.clone());
+            eprintln!(
+                "✓ chat-rag rerank fired: outcome={} candidates={} permutation={:?}",
+                t.outcome, t.candidate_count, t.permutation
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    running.shutdown().await.unwrap();
+    let outcome = outcome.expect("a chat-rag ReRankRound must settle (reranked | failed_closed)");
+    assert!(
+        outcome == "reranked" || outcome == "failed_closed",
+        "the rerank must settle a terminal outcome, got {outcome}"
+    );
+}
+
+/// REACT-RAG (soft): the agent's `retrieve@1` observation is reranked before the next
+/// turn. The retrieve proposal is probabilistic, so the rerank is LOGGED; the hard
+/// assertion is only that the chain answers.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real LLM inference + dataset embedding; needs a served Gemma model; opt in with --ignored"]
+async fn react_rag_reranks_the_retrieved_passages() {
+    if !configure_serve_with_rerank() {
+        return;
+    }
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let recipes = c
+        .list_recipes(proto::ListRecipesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    if !recipes
+        .recipes
+        .iter()
+        .any(|r| r.handle == REACT_RAG_RECIPE_HANDLE)
+    {
+        eprintln!("skipping: kx/recipes/react-rag not provisioned");
+        running.shutdown().await.unwrap();
+        return;
+    }
+    if !ingest_science(&mut c).await {
+        eprintln!("skipping: ingest failed — set KX_SERVE_EMBED_MODEL");
+        running.shutdown().await.unwrap();
+        return;
+    }
+
+    let resp = c
+        .invoke(proto::InvokeRequest {
+            handle: REACT_RAG_RECIPE_HANDLE.to_string(),
+            args: br#"{"instruction":"How do plants make energy from the sun? Answer briefly using the dataset.","dataset":"science","max_turns":4,"max_tool_calls":3}"#
+                .to_vec(),
+            context_bundles: vec![],
+            context_refs: vec![],
+        })
+        .await
+        .expect("invoke kx/recipes/react-rag")
+        .into_inner();
+    let step_salt = (!resp.react_chain_salt.is_empty()).then(|| resp.react_chain_salt.clone());
+
+    let mut answered = false;
+    let mut reranked = false;
+    for _ in 0..3000 {
+        let turns = c
+            .list_react_turns(proto::ListReactTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+                step_salt: step_salt.clone(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        answered = turns.turns.iter().any(|t| t.branch == "answer");
+        let rounds = c
+            .list_re_rank_turns(proto::ListReRankTurnsRequest {
+                limit: None,
+                instance_id: Some(resp.instance_id.clone()),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if rounds.turns.iter().any(|t| t.outcome == "reranked") {
+            reranked = true;
+        }
+        if answered {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    running.shutdown().await.unwrap();
+    assert!(answered, "the react-rag chain settled a terminal Answer");
+    if reranked {
+        eprintln!("✓ react-rag: the retrieved passages were durably reranked");
+    } else {
+        eprintln!("· note: no rerank fired (the model may not have called retrieve this run)");
+    }
+}

--- a/crates/kx-model-harness/src/rag.rs
+++ b/crates/kx-model-harness/src/rag.rs
@@ -16,9 +16,8 @@
 //! enter the committed fact, a `MoteId`, or memoization. Downstream steps consume
 //! the retrieved content by EXACT hash.
 
-use std::fmt::Write as _;
-
 use kx_content::ContentRef;
+use kx_context_assembler::{render_rerank_prompt, rerank_output_cap};
 use kx_dataset::{
     mmr_rerank, rrf_fuse, ContentSchema, DataError, DataStore, Dataset, Hit, LexicalIndex,
     RetrievalIndex, MMR_LAMBDA_BP, RRF_C,
@@ -239,35 +238,6 @@ pub fn query_corpus_hybrid(
     Ok((fact_ref, ranked))
 }
 
-/// Bound the rerank turn's output: the permutation array (`n` indices ≈ 6 tokens
-/// each) PLUS generous headroom for a model that reasons before answering (e.g.
-/// Gemma's `<|channel>…<channel|>` preamble) — too tight a cap truncates the decode
-/// before the array and the parse fail-closes to the input order. Still bounded so a
-/// runaway decode can't burn the budget.
-fn rerank_output_cap(n: usize) -> u32 {
-    const REASONING_HEADROOM: usize = 256;
-    u32::try_from(n.saturating_mul(6).saturating_add(REASONING_HEADROOM)).unwrap_or(u32::MAX)
-}
-
-/// Build the listwise-rerank prompt: the query + the `n` candidate passages (each
-/// truncated), instructing the model to emit ONLY a permutation array of indices.
-fn rerank_prompt(query: &str, texts: &[String]) -> String {
-    const SNIPPET_MAX: usize = 400;
-    let n = texts.len();
-    let mut p = String::with_capacity(128 + n * SNIPPET_MAX);
-    let _ = write!(
-        p,
-        "Rank the passages by how well each answers the query. Respond with ONLY a JSON \
-         array of the passage indices, most relevant first — a permutation of 0..{n} with no \
-         duplicates (example: [2,0,1]).\n\nQuery: {query}\n\nPassages:\n"
-    );
-    for (i, t) in texts.iter().enumerate() {
-        let snippet: String = t.chars().take(SNIPPET_MAX).collect();
-        let _ = writeln!(p, "[{i}] {snippet}");
-    }
-    p
-}
-
 /// LLM listwise rerank (RC4c): ask `backend` to reorder `hits` (whose resolved
 /// `texts[i]` corresponds to `hits[i]`) by relevance to `query`, constrained to a
 /// permutation of `[0, n)` via the off-digest grammar carrier
@@ -313,7 +283,7 @@ pub fn rerank_hits(
         max_output_tokens: rerank_output_cap(n),
         ..InferenceParams::default()
     };
-    let input = InferenceInput::text(rerank_prompt(query, texts));
+    let input = InferenceInput::text(render_rerank_prompt(query, texts));
     // A dispatch failure ⇒ keep the upstream (RRF/MMR) order (fail-closed).
     let Ok(out) = backend.dispatch(model_id, &input, &params, warrant) else {
         return hits.to_vec();

--- a/crates/kx-mote/src/context_items.rs
+++ b/crates/kx-mote/src/context_items.rs
@@ -49,6 +49,25 @@ pub fn encode_context_items(items: &[ContextItemRef]) -> Vec<u8> {
     out
 }
 
+/// Encode context items PRESERVING their input order (RC4c-2b) — the SAME wire format
+/// as [`encode_context_items`] (`u32-le(name.len()) ‖ name ‖ content_ref[32]` per item)
+/// but WITHOUT the canonical sort/dedup, so a RERANKED order survives round-trip
+/// ([`decode_context_items`] returns items in encoded order, and the serve assembler
+/// renders in that order). Used ONLY for the off-digest, OUT-OF-BAND reranked-delivery
+/// bundle (the RC4c-2b chat-rag suppression gate) — NEVER for an identity-bearing entry
+/// config, which must stay canonical (a different order must not change a `MoteId`).
+#[must_use]
+pub fn encode_context_items_ordered(items: &[ContextItemRef]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for it in items {
+        let name = it.name.as_bytes();
+        out.extend_from_slice(&u32::try_from(name.len()).unwrap_or(u32::MAX).to_le_bytes());
+        out.extend_from_slice(name);
+        out.extend_from_slice(&it.content_ref);
+    }
+    out
+}
+
 /// Decode the canonical value back into items, in canonical (encoded) order. A
 /// malformed / truncated buffer decodes the items it can and stops (total +
 /// panic-free); the assembler treats the result as advisory context (the

--- a/crates/kx-mote/src/lib.rs
+++ b/crates/kx-mote/src/lib.rs
@@ -81,7 +81,9 @@ mod topology;
 pub use attempt::{
     is_legal_transition, transition, AttemptState, IllegalTransition, ALL_ATTEMPT_STATES,
 };
-pub use context_items::{decode_context_items, encode_context_items, ContextItemRef};
+pub use context_items::{
+    decode_context_items, encode_context_items, encode_context_items_ordered, ContextItemRef,
+};
 pub use def::{canonical_config, derive_mote_id, MoteDef, MOTE_DEF_SCHEMA_VERSION};
 pub use edge::{EdgeKind, EdgeMeta, ParentRef};
 pub use effect::EffectPattern;
@@ -94,7 +96,7 @@ pub use strings::{
     ConfigKey, ConfigVal, GraphPosition, ModelId, ToolName, ToolVersion, CONTEXT_ITEMS_KEY,
     IMAGE_REF_KEY, JUDGE_RUBRIC_KEY, PROMPT_KEY, REACT_INSTRUCTION_KEY, REACT_MAX_TOOL_CALLS_KEY,
     REACT_MAX_TURNS_KEY, REACT_REQUIRE_APPROVAL_KEY, REACT_TURN_KEY, REACT_UNCONSTRAINED_KEY,
-    RETRIEVAL_MODE_KEY, TOOL_ARGS_KEY,
+    RERANK_CANDIDATES_KEY, RERANK_QUERY_KEY, RERANK_TURN_KEY, RETRIEVAL_MODE_KEY, TOOL_ARGS_KEY,
 };
 pub use topology::{ChildDescriptor, RoleId, TopologyDecision};
 

--- a/crates/kx-mote/src/strings.rs
+++ b/crates/kx-mote/src/strings.rs
@@ -188,6 +188,39 @@ pub const IMAGE_REF_KEY: &str = "image_ref";
 /// no prior Mote carries this key, so adding the constant moves no existing digest.
 pub const RETRIEVAL_MODE_KEY: &str = "kx.retrieval.mode";
 
+/// RC4c-2b: the single canonical [`ConfigKey`] *name* marking a Mote as a live LLM
+/// listwise RERANK TURN — the coordinator-materialized, off-DAG Mote that reorders a
+/// RAG retrieval's candidate passages by relevance (permutation output). The value is
+/// the run-salt (`instance_id`), mirroring [`REACT_TURN_KEY`]; the gateway routes on
+/// key PRESENCE to the rerank decode arm (checked BEFORE the react arm, so a rerank
+/// turn is never mistaken for a react turn — off-budget by construction).
+///
+/// Inserted ONLY by `react_shape::build_rerank_turn`; no prior Mote carries this key,
+/// so adding the constant moves no existing digest. Like every routing marker it lives
+/// in `config_subset` ⇒ folds into [`crate::MoteDef::hash`] → `MoteId` (D53), so it
+/// cannot be dropped in transit without changing the identity the coordinator
+/// re-derives (structurally fail-closed). SN-8: the marker alone fires nothing — the
+/// coordinator's `settle_rerank_rounds` keys only off its own `ReRankRound` facts and
+/// re-decodes the permutation on the sole writer.
+pub const RERANK_TURN_KEY: &str = "kx.rerank.turn";
+
+/// RC4c-2b: the [`ConfigKey`] *name* under which a live rerank turn carries the
+/// content-store ref (a 32-byte [`crate::MoteId`]-style [`ContentRef`]) of the QUERY
+/// its candidates are scored against. Identity-bearing (a different query ⇒ a distinct
+/// rerank `MoteId`) and recovery-stable: the worker resolves the query text from this
+/// ref at dispatch, and the value equals the `ReRankRound` anchor's `query_ref` so a
+/// recovered turn re-derives byte-identically. Present ONLY on a rerank turn.
+pub const RERANK_QUERY_KEY: &str = "kx.rerank.query";
+
+/// RC4c-2b: the [`ConfigKey`] *name* under which a live rerank turn carries the
+/// content-store ref (32 bytes) of the BASE retrieval results whose passages are
+/// reranked (the committed `retrieve@1` observation for react-rag, or the grounded
+/// context bundle for chat-rag). Identity-bearing + recovery-stable (equals the
+/// `ReRankRound` anchor's `base_results_ref`); the worker resolves the candidate
+/// passages from it to render the rerank prompt. Present ONLY on a rerank turn, so
+/// adding the constant moves no existing digest.
+pub const RERANK_CANDIDATES_KEY: &str = "kx.rerank.candidates";
+
 /// The stable position of a Mote in its DAG.
 ///
 /// Assigned at DAG-compile time (workflow SDK) or derived from a topology

--- a/crates/kx-mote/src/strings.rs
+++ b/crates/kx-mote/src/strings.rs
@@ -205,7 +205,7 @@ pub const RETRIEVAL_MODE_KEY: &str = "kx.retrieval.mode";
 pub const RERANK_TURN_KEY: &str = "kx.rerank.turn";
 
 /// RC4c-2b: the [`ConfigKey`] *name* under which a live rerank turn carries the
-/// content-store ref (a 32-byte [`crate::MoteId`]-style [`ContentRef`]) of the QUERY
+/// content-store ref (a 32-byte content-addressed `ContentRef`) of the QUERY
 /// its candidates are scored against. Identity-bearing (a different query ⇒ a distinct
 /// rerank `MoteId`) and recovery-stable: the worker resolves the query text from this
 /// ref at dispatch, and the value equals the `ReRankRound` anchor's `query_ref` so a

--- a/crates/kx-projection/src/lib.rs
+++ b/crates/kx-projection/src/lib.rs
@@ -148,7 +148,7 @@ pub use promotion::{ContentStoreVerdicts, VerdictLookup};
 pub use register::RegisterMote;
 pub use run_metadata::{fold_run_metadata, RunMetadata, RunMetadataFold, RunRecord};
 pub use snapshot::Snapshot;
-pub use state::{ReactRoundRecord, ReplanRoundRecord, RunResolvedVersions};
+pub use state::{ReRankRoundRecord, ReactRoundRecord, ReplanRoundRecord, RunResolvedVersions};
 
 #[cfg(test)]
 mod tests;

--- a/crates/kx-projection/src/projection.rs
+++ b/crates/kx-projection/src/projection.rs
@@ -1192,6 +1192,25 @@ impl Projection {
             .max_by(|a, b| a.seq.cmp(&b.seq))
     }
 
+    /// The latest (highest-`seq`) `ReRankRound` for one run keyed by its
+    /// `base_results_ref` (= the retrieve observation's committed result_ref), or
+    /// `None`. The read-path (`resolve_parent_context`) delivery lookup: it has the
+    /// observation ref but NOT the rerank `MoteId` (the query is off the read path),
+    /// so it finds the frozen outcome by base ref. Bounded scan (a run writes at most
+    /// a few reranks; gated cheaply by `rerank_rounds_of(..).next().is_none()`).
+    #[must_use]
+    pub fn latest_rerank_round_by_base(
+        &self,
+        instance_id: &[u8; kx_journal::INSTANCE_ID_LEN],
+        base_results_ref: &ContentRef,
+    ) -> Option<&crate::state::ReRankRoundRecord> {
+        self.state
+            .rerank_rounds
+            .iter()
+            .filter(|r| &r.instance_id == instance_id && &r.base_results_ref == base_results_ref)
+            .max_by(|a, b| a.seq.cmp(&b.seq))
+    }
+
     /// The ReAct-turn metadata (PR-2d-1) folded so far — one record per
     /// `ReactRound` entry, in journal (seq) order.
     ///

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use kx_capability::{CapabilityBroker, INSTANCE_ID_LEN};
 use kx_content::{ContentRef, ContentStore, LocalFsContentStore};
 use kx_executor::{LocalResourceManager, MoteExecutor};
-use kx_mote::{ConfigKey, Mote, MoteId, NdClass, REACT_TURN_KEY};
+use kx_mote::{ConfigKey, Mote, MoteId, NdClass, REACT_TURN_KEY, RERANK_TURN_KEY};
 use kx_proto::proto;
 use kx_warrant::{ExecutorClass, WarrantSpec};
 use tokio::task::JoinHandle;
@@ -214,7 +214,10 @@ impl Worker {
             // next item. Transport/RPC errors on the lease/commit calls stay batch-level.
             let exec = if mote.nd_class() == NdClass::Pure {
                 run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)
-            } else if is_react_turn(&mote) || mote.def.critic_check.is_some() {
+            } else if is_react_turn(&mote)
+                || is_rerank_turn(&mote)
+                || mote.def.critic_check.is_some()
+            {
                 // PR-2d-2: a coordinator-materialized ReAct TURN (the identity-
                 // bearing marker, NO tool_contract) is a prompt-carrying ROND
                 // model Mote — it dispatches through the hosted EXECUTOR (whose
@@ -454,6 +457,21 @@ fn is_react_turn(mote: &Mote) -> bool {
             .def
             .config_subset
             .contains_key(&ConfigKey(REACT_TURN_KEY.to_string()))
+}
+
+/// RC4c-2b: `true` iff `mote` is a coordinator-materialized live LLM RERANK TURN — the
+/// identity-bearing [`RERANK_TURN_KEY`] marker with NO `tool_contract`. Like a ReAct
+/// turn it is a ROND model Mote that dispatches DIRECTLY through the hosted executor
+/// (whose `run_rerank_turn` arm renders the rerank prompt + commits the raw
+/// permutation), never the capability-broker WM path (a rerank PROPOSES an order; it
+/// fires no effect). Without this the worker would route it to `run_wm` and dead-letter
+/// it (no tool_contract to resolve).
+fn is_rerank_turn(mote: &Mote) -> bool {
+    mote.def.tool_contract.is_empty()
+        && mote
+            .def
+            .config_subset
+            .contains_key(&ConfigKey(RERANK_TURN_KEY.to_string()))
 }
 
 /// Wall-clock milliseconds since the Unix epoch (liveness only; never hashed).

--- a/docs/site/docs/agentic-rag.md
+++ b/docs/site/docs/agentic-rag.md
@@ -133,15 +133,17 @@ Two reranking layers improve precision after the BM25 + dense fusion:
   while preserving the fused relevance order. It runs on every live retrieval path (the Data Lab
   query, `chat-rag`, and the agentic `retrieve` tool) and is controllable per query
   (`--rerank on|off`; see [Data Lab → Hybrid retrieval](./datasets.md#hybrid-retrieval--chunking)).
-- **LLM listwise rerank (model-graded, authored RAG pipelines).** A model reorders the retrieved
+- **LLM listwise rerank (model-graded, LIVE in `kx serve`).** A model reorders the retrieved
   candidates by emitting a **permutation** of their indices (Ollama applies a strict whole-response
   JSON `format`; llama.cpp relies on the model + parser — see
   [engine notes](./local-inference-engines.md)). It is **fail-closed**: any non-permutation output
   keeps the deterministic order, so a rerank can never reorder into garbage (the model proposes, the
-  runtime enforces — SN-8). It completes the authored
-  RAG quartet **rewrite → retrieve (hybrid) → rerank → assemble**. Reaching the LLM rerank from the
-  live `kx serve` chat / agentic loop (a durable, replayable coordinator rerank-turn) is the next
-  step on the roadmap; the live paths use the deterministic MMR rerank today.
+  runtime enforces — SN-8). It completes the RAG quartet **rewrite → retrieve (hybrid) → rerank →
+  assemble**. As of RC4c-2b it runs **live in `kx serve`** as a **durable, replayable coordinator
+  rerank-turn** — enabled with `KX_SERVE_RAG_LLM_RERANK=1`, applied to both the agentic `retrieve`
+  loop (react-rag) and the grounded `chat-rag`/`vision-rag` answer, and recorded as an auditable
+  `ReRankRound` fact. See **[LLM rerank](./llm-rerank.md)** for the full contract + the
+  CLI/SDK/UI chaining. The deterministic MMR rerank remains the always-on default.
 
 See also: [Data Lab](./datasets.md) · [Agents & reasoning](./agent-runner.md) ·
 [Tools](./tools.md) · [Local inference engines](./local-inference-engines.md).

--- a/docs/site/docs/llm-rerank.md
+++ b/docs/site/docs/llm-rerank.md
@@ -1,0 +1,92 @@
+# LLM rerank (durable, replayable)
+
+The **LLM listwise rerank** reorders a RAG retrieval's candidate passages by relevance
+using the served model, so the most useful passage is read first. Unlike the always-on
+[deterministic MMR rerank](./datasets.md#hybrid-retrieval--chunking), the LLM rerank is a
+**durable, replayable coordinator turn**: the model proposes a permutation, the runtime
+enforces it fail-closed, and the reorder is committed as an auditable `ReRankRound` fact
+that survives a crash and re-serves from commit on replay (it is never re-sampled).
+
+## Enable it
+
+The LLM rerank is **off by default**. Turn it on for a `kx serve` process with:
+
+```sh
+KX_SERVE_RAG_LLM_RERANK=1 kx serve --features inference,hnsw
+```
+
+It then applies automatically on both live RAG paths:
+
+- **Agentic `retrieve` loop (`react-rag`)** — after the agent's `retrieve@1` observation
+  commits, its passages are reranked before the next reasoning turn reads them.
+- **Grounded answer (`chat-rag` / `vision-rag`)** — the grounded passages are reranked
+  before the single answer step dispatches (the answer is held until the rerank settles).
+
+There is no client-chosen knob: the rerank runs model-side under the run's own warrant
+(the model proposes an order; the runtime enforces exact validity — SN-8). The
+deterministic MMR rerank remains the always-on default and is unaffected.
+
+## Contract
+
+- **Fail-closed.** Any non-permutation output, a dispatch error, or a shape mismatch keeps
+  the upstream (RRF/MMR) order — a rerank can never reorder into garbage and never wedges
+  an answerable RAG turn.
+- **Off-budget.** The rerank does not consume the agent's ReAct `max_turns` /
+  `max_tool_calls`; it is a separate `ReRankRound` fact.
+- **Durable + replayable.** The reorder is a committed fact; recovery re-derives it from
+  committed state, and replay serves the same order (recovery/audit/time-travel — not a
+  re-run).
+- **Dual-engine.** Ollama applies a strict whole-response JSON `format`; llama.cpp relies
+  on the model plus the fail-closed parser (see [engine notes](./local-inference-engines.md)).
+
+## Observe it — one entry point, chained everywhere
+
+Every rerank is recorded as a `ReRankRound` fact you can list from the single `kx` / SDK
+entry point:
+
+```sh
+# CLI
+kx rerank list                       # recent rerank rounds (round · outcome · model · n · permutation)
+kx rerank list --instance <hex>      # scoped to one run
+kx rerank list --limit 20 --json     # machine-readable
+```
+
+```python
+# Python SDK — the same client that submits runs lists reranks
+from kortecx import KxClient
+kx = KxClient("http://127.0.0.1:50051")
+page = kx.list_rerank_turns(limit=20)          # sync
+for t in page.turns:
+    print(t.round, t.outcome, t.model_id, t.candidate_count, t.permutation)
+# async: await kx.list_rerank_turns(limit=20)
+```
+
+```typescript
+// TypeScript SDK
+import { KxClient } from "@kortecx/sdk";
+const kx = new KxClient("http://127.0.0.1:50051");
+const { turns } = await kx.listRerankTurns({ limit: 20 });
+turns.forEach((t) => console.log(t.round, t.outcome, t.modelId, t.candidateCount, t.permutation));
+```
+
+In the **console**, the **Monitoring → ReRank rounds** panel shows each round's outcome
+(`reranked` / `failed_closed` / `pending`), model, candidate count, and permutation.
+
+## Chaining example — grounded chat with rerank
+
+```sh
+# 1. Ingest a dataset
+kx datasets ingest kb ./docs/*.md
+
+# 2. Serve with the LLM rerank on
+KX_SERVE_RAG_LLM_RERANK=1 kx serve --features inference,hnsw &
+
+# 3. Ask a grounded question (chat-rag) — the answer reads the reranked passages
+kx apps run kx/recipes/chat-rag --dataset kb --prompt "how does recovery work?"
+
+# 4. Audit the rerank that fired
+kx rerank list --limit 1
+```
+
+See also: [Agentic RAG](./agentic-rag.md) · [Data Lab](./datasets.md) ·
+[Agents & reasoning](./agent-runner.md) · [Local inference engines](./local-inference-engines.md).

--- a/ui/src/components/sections/MonitoringSection.tsx
+++ b/ui/src/components/sections/MonitoringSection.tsx
@@ -1,8 +1,9 @@
 /**
  * Monitoring — the gateway-WIDE telemetry dashboard. Distinct from Activity (which is
  * run-scoped): this folds cross-run signals the gateway already exposes — run counts,
- * the self-correction trails (`ListReplanRounds` / `ListReactTurns`), the Morphic
- * action-capture stream (`ListCaptureRecords`), and liveness. Pure renderer: every
+ * the self-correction trails (`ListReplanRounds` / `ListReactTurns`), the listwise
+ * LLM re-rank trail (`ListReRankTurns`), the Morphic action-capture stream
+ * (`ListCaptureRecords`), and liveness. Pure renderer: every
  * number comes from `lib/monitoring.ts` over the hooks; each panel degrades to an
  * honest "not wired here" note when its RPC is unimplemented (never a hollow placeholder).
  *
@@ -22,6 +23,7 @@ import { type RunScopedRef, useResultMapMulti } from "../../kx/use-content-batch
 import { useEvalScore } from "../../kx/use-eval-score";
 import { useReactTurns } from "../../kx/use-react-turns";
 import { useReplanRounds } from "../../kx/use-replan-rounds";
+import { useRerankTurns } from "../../kx/use-rerank-turns";
 import { useRuns } from "../../kx/use-runs";
 import { useTelemetry } from "../../kx/use-telemetry";
 import { useTelemetrySummary } from "../../kx/use-telemetry-summary";
@@ -29,10 +31,12 @@ import { failureReasonLabel } from "../../lib/event-format";
 import { shortHex } from "../../lib/format";
 import {
   type Tally,
+  rerankPermutationLabel,
   summarizeAlerts,
   summarizeCaptures,
   summarizeReact,
   summarizeReplan,
+  summarizeRerank,
   summarizeRuns,
   summarizeTelemetryByModel,
   tallyRows,
@@ -602,12 +606,14 @@ function OverviewView() {
   const runs = useRuns();
   const replan = useReplanRounds();
   const react = useReactTurns();
+  const rerank = useRerankTurns();
   const capture = useCaptureRecords();
   const telemetry = useTelemetry({ pageSize: 1 });
 
   const runRollup = summarizeRuns(runs.runs);
   const replanSummary = summarizeReplan(replan.rounds);
   const reactSummary = summarizeReact(react.turns);
+  const rerankSummary = summarizeRerank(rerank.turns);
   const captureSummary = summarizeCaptures(capture.records);
   // Resolve the (bounded, 10-row) capture table's results to TEXT, grouped by
   // run (the records span runs; GetContentBatch is run-scoped). Telemetry stays
@@ -627,6 +633,7 @@ function OverviewView() {
     runs.refresh();
     void replan.refetch();
     void react.refetch();
+    void rerank.refetch();
     void capture.refetch();
     telemetry.refetch();
   }
@@ -644,6 +651,7 @@ function OverviewView() {
         <MetricCard label="Re-plan rounds" value={replanSummary.total} tone="scheduled" />
         <MetricCard label="ReAct turns" value={reactSummary.total} />
         <MetricCard label="Tool calls" value={reactSummary.toolCalls} />
+        <MetricCard label="ReRank rounds" value={rerankSummary.total} tone="info" />
         <MetricCard label="Captured actions" value={captureSummary.total} />
         <MetricCard
           label="Last mote wall ms"
@@ -711,6 +719,38 @@ function OverviewView() {
                     <td className="mono">{t.turn}</td>
                     <td>{t.branch || "—"}</td>
                     <td className="mono">{t.toolId ? `${t.toolId}@${t.toolVersion}` : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </Panel>
+
+        <Panel
+          title="ReRank rounds"
+          hint={`${rerankSummary.total} turns · ${rerankSummary.reranked} reranked`}
+          notWired={rerank.notWired}
+        >
+          <TallyList tally={rerankSummary.byOutcome} empty="No re-rank turns yet." />
+          {rerank.turns.length > 0 ? (
+            <table className="trail-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Outcome</th>
+                  <th>Model</th>
+                  <th>Candidates</th>
+                  <th>Permutation</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rerank.turns.slice(0, 8).map((t) => (
+                  <tr key={`${t.seq}-${t.round}`}>
+                    <td className="mono">{t.round}</td>
+                    <td className="mono">{t.outcome || "—"}</td>
+                    <td className="mono">{t.modelId || "—"}</td>
+                    <td className="mono">{t.candidateCount}</td>
+                    <td className="mono">{rerankPermutationLabel(t.permutation)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/ui/src/kx/query-keys.ts
+++ b/ui/src/kx/query-keys.ts
@@ -89,6 +89,9 @@ export const queryKeys = {
   /** The re-plan-round trail (`ListReplanRounds`), scoped by page size. */
   replanRounds: (endpoint: string, limit: number) =>
     ["kx", endpoint, "replan-rounds", limit] as const,
+  /** The re-rank-turn trail (`ListReRankTurns`, RC4c-2), scoped by page size. */
+  rerankTurns: (endpoint: string, limit: number) =>
+    ["kx", endpoint, "rerank-turns", limit] as const,
   /** The ReAct-turn trail (`ListReactTurns`); `instanceId` scopes to one run,
    *  `chainSalt` (PR-R1) to one chain within it (serve's shared journal). */
   reactTurns: (

--- a/ui/src/kx/use-rerank-turns.ts
+++ b/ui/src/kx/use-rerank-turns.ts
@@ -1,0 +1,32 @@
+/**
+ * The re-rank-turn history hook (`ListReRankTurns`) — the durable trail of a
+ * gateway's live listwise LLM re-rank loops (RC4c-2). Read-only, newest-first.
+ * Degrades to an empty list with `notWired` when the gateway does not wire the RPC
+ * (older binary).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnection } from "./connection-context";
+import { toUiError } from "./errors";
+import { queryKeys } from "./query-keys";
+
+export function useRerankTurns(limit = 100) {
+  const { client, endpoint, status } = useConnection();
+  const q = useQuery({
+    queryKey: queryKeys.rerankTurns(endpoint, limit),
+    enabled: status === "connected" && client !== null,
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("not connected");
+      }
+      return client.listRerankTurns({ limit });
+    },
+  });
+  return {
+    turns: q.data?.turns ?? [],
+    hasMore: q.data?.hasMore ?? false,
+    notWired: q.isError && toUiError(q.error).kind === "not-wired",
+    isLoading: q.isLoading,
+    refetch: q.refetch,
+  };
+}

--- a/ui/src/lib/monitoring.ts
+++ b/ui/src/lib/monitoring.ts
@@ -10,6 +10,7 @@ import type {
   AlertSummary,
   CaptureRecord,
   MoteTelemetryRow,
+  ReRankTurn,
   ReactTurn,
   ReplanRound,
 } from "@kortecx/sdk/web";
@@ -78,6 +79,44 @@ export function summarizeReact(turns: readonly ReactTurn[]): ReactSummary {
     }
   }
   return { total: turns.length, byBranch, byModel, toolCalls };
+}
+
+export interface RerankSummary {
+  readonly total: number;
+  /** Turns that produced an enforced reordering (`outcome === "reranked"`). */
+  readonly reranked: number;
+  /** Turns per settled outcome (pending | reranked | failed_closed). */
+  readonly byOutcome: Tally;
+  readonly byModel: Tally;
+}
+
+export function summarizeRerank(turns: readonly ReRankTurn[]): RerankSummary {
+  const byOutcome: Record<string, number> = {};
+  const byModel: Record<string, number> = {};
+  let reranked = 0;
+  for (const t of turns) {
+    bump(byOutcome, t.outcome || "—");
+    bump(byModel, t.modelId || "—");
+    if (t.outcome === "reranked") {
+      reranked += 1;
+    }
+  }
+  return { total: turns.length, reranked, byOutcome, byModel };
+}
+
+/** A compact, audit-honest rendering of an enforced re-rank permutation (the
+ *  reordered SOURCE indices; SN-8: an exact reordering, never a score). Empty (a
+ *  non-`reranked` outcome) → "—"; a long permutation is elided with its length so
+ *  the trail row stays single-line. Pure — a deterministic function of the input. */
+export function rerankPermutationLabel(permutation: readonly number[]): string {
+  if (permutation.length === 0) {
+    return "—";
+  }
+  const MAX = 8;
+  if (permutation.length <= MAX) {
+    return permutation.join(" ");
+  }
+  return `${permutation.slice(0, MAX).join(" ")} … (${permutation.length})`;
 }
 
 export interface CaptureSummary {

--- a/ui/test/component/MonitoringSection.test.tsx
+++ b/ui/test/component/MonitoringSection.test.tsx
@@ -1,4 +1,4 @@
-import { MoteTelemetryRow, ReplanRound } from "@kortecx/sdk/web";
+import { MoteTelemetryRow, ReRankTurn, ReplanRound } from "@kortecx/sdk/web";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MonitoringSection } from "../../src/components/sections/MonitoringSection";
@@ -27,6 +27,26 @@ describe("MonitoringSection", () => {
     // The replan model rolls up into a real tally row + a trail-table row (not a
     // placeholder) — both surface the resolved model id.
     await waitFor(() => expect(screen.getAllByText("qwen3").length).toBeGreaterThan(0));
+  });
+
+  it("folds the live re-rank trail into a real ReRank rounds panel", async () => {
+    const mock = makeMockClient({
+      listRerankTurns: async () => ({
+        turns: [new ReRankTurn(0, "aabb", "i1", "gemma3", "reranked", 3, [2, 0, 1], 41)],
+        hasMore: false,
+      }),
+    });
+    render(<MonitoringSection />, { wrapper: connectedWrapper(mock.client) });
+    // The re-rank turn rolls up into the outcome tally AND a trail-table row (not a
+    // placeholder) — both surface the resolved model + settled outcome. ("ReRank
+    // rounds" is BOTH the metric-card label and the panel heading, so target the h2.)
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "ReRank rounds" })).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(screen.getAllByText("gemma3").length).toBeGreaterThan(0));
+    expect(screen.getAllByText("reranked").length).toBeGreaterThan(0);
+    // The enforced permutation is rendered honestly (the reordered source indices).
+    expect(screen.getByText("2 0 1")).toBeInTheDocument();
   });
 
   it("exposes the Runs tab (POC-5c: run history moved here from Workflows)", async () => {

--- a/ui/test/mocks/kx-client.ts
+++ b/ui/test/mocks/kx-client.ts
@@ -22,6 +22,7 @@ export interface MockClientImpl {
   listAssetGrants?: (...args: unknown[]) => Promise<unknown>;
   listReplanRounds?: (...args: unknown[]) => Promise<unknown>;
   listReactTurns?: (...args: unknown[]) => Promise<unknown>;
+  listRerankTurns?: (...args: unknown[]) => Promise<unknown>;
   listCaptureRecords?: (...args: unknown[]) => Promise<unknown>;
   getMoteDetail?: (...args: unknown[]) => Promise<unknown>;
   getContentBatch?: (...args: unknown[]) => Promise<unknown>;
@@ -89,6 +90,9 @@ export function makeMockClient(impl: MockClientImpl = {}) {
   );
   const listReactTurns = vi.fn(
     impl.listReactTurns ?? (async () => ({ turns: [], hasMore: false })),
+  );
+  const listRerankTurns = vi.fn(
+    impl.listRerankTurns ?? (async () => ({ turns: [], hasMore: false })),
   );
   const listCaptureRecords = vi.fn(
     impl.listCaptureRecords ?? (async () => ({ records: [], hasMore: false })),
@@ -174,6 +178,7 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listAssetGrants,
     listReplanRounds,
     listReactTurns,
+    listRerankTurns,
     listCaptureRecords,
     getMoteDetail,
     getContentBatch,
@@ -220,6 +225,7 @@ export function makeMockClient(impl: MockClientImpl = {}) {
     listAssetGrants,
     listReplanRounds,
     listReactTurns,
+    listRerankTurns,
     listCaptureRecords,
     getMoteDetail,
     getContentBatch,

--- a/ui/test/unit/monitoring.test.ts
+++ b/ui/test/unit/monitoring.test.ts
@@ -2,15 +2,18 @@ import {
   AlertSummary,
   CaptureRecord,
   MoteTelemetryRow,
+  ReRankTurn,
   ReactTurn,
   ReplanRound,
 } from "@kortecx/sdk/web";
 import { describe, expect, it } from "vitest";
 import {
+  rerankPermutationLabel,
   summarizeAlerts,
   summarizeCaptures,
   summarizeReact,
   summarizeReplan,
+  summarizeRerank,
   summarizeRuns,
   summarizeTelemetryByModel,
   tallyRows,
@@ -79,6 +82,43 @@ describe("summarizeReact", () => {
     expect(s.byBranch.tool).toBe(2);
     expect(s.byBranch.answer).toBe(1);
     expect(s.byModel.qwen3).toBe(3);
+  });
+});
+
+describe("summarizeRerank", () => {
+  it("counts outcomes, models, and enforced reorderings", () => {
+    const turns = [
+      new ReRankTurn(0, "aa", "i0", "qwen3", "reranked", 3, [2, 0, 1], 30),
+      new ReRankTurn(0, "bb", "i0", "qwen3", "pending", 3, [], 28),
+      new ReRankTurn(0, "cc", "i1", "gemma3", "failed_closed", 4, [], 26),
+    ];
+    const s = summarizeRerank(turns);
+    expect(s.total).toBe(3);
+    expect(s.reranked).toBe(1);
+    expect(s.byOutcome.reranked).toBe(1);
+    expect(s.byOutcome.pending).toBe(1);
+    expect(s.byOutcome.failed_closed).toBe(1);
+    expect(s.byModel.qwen3).toBe(2);
+    expect(s.byModel.gemma3).toBe(1);
+  });
+
+  it("empty → zeroed rollup", () => {
+    const s = summarizeRerank([]);
+    expect(s.total).toBe(0);
+    expect(s.reranked).toBe(0);
+    expect(tallyRows(s.byOutcome)).toEqual([]);
+  });
+});
+
+describe("rerankPermutationLabel", () => {
+  it("an empty permutation (non-reranked outcome) → '—'", () => {
+    expect(rerankPermutationLabel([])).toBe("—");
+  });
+  it("a short permutation renders space-joined", () => {
+    expect(rerankPermutationLabel([2, 0, 1])).toBe("2 0 1");
+  });
+  it("a long permutation is elided with its length", () => {
+    expect(rerankPermutationLabel([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).toBe("0 1 2 3 4 5 6 7 … (10)");
   });
 });
 


### PR DESCRIPTION
## RC4c-2b — live LLM rerank-turn in `kx serve` (D172)

Wires the **live, durable, replayable LLM listwise rerank** into `kx serve`, building on
RC4c-2a's `ReRankRound` substrate (journal v16 + `ListReRankTurns`, already merged). Enabled
via `KX_SERVE_RAG_LLM_RERANK=1` (**default off**). The model proposes a permutation of the
retrieved passages; the runtime enforces it fail-closed; the reorder is a committed, crash-
recoverable, audited `ReRankRound` fact that re-serves from commit on replay.

### Both live paths
- **react-rag** — a gate in `progress_tool_batch` reranks the `retrieve@1` observation before
  the next reasoning turn reads it (off-budget; fail-open to base order; never wedges).
- **chat-rag / vision-rag** — a coordinator **suppression gate** HOLDS the grounded answer
  (lease-skip, mirroring the agentic-launch park) until a durable rerank of its context bundle
  settles, then delivers the reranked order **out-of-band** (`WorkItem.context_items`; the
  inline↔out-of-band double-prepend is fixed).

### Mechanism (mirrors the ReAct sole-writer lifecycle)
- `kx-mote`: `RERANK_TURN/QUERY/CANDIDATES` keys; `encode_context_items_ordered`.
- `kx-context-assembler`: shared `render_rerank_prompt` + `rerank_output_cap` (harness + serve, no drift).
- `kx-coordinator`: `build_rerank_turn` + `write_rerank_anchor`/`settle_rerank_rounds`/
  `recover_rerank_chain` (sole-writer `parse_permutation` freeze; any terminal failure →
  `FailedClosed`, **never** dead-letters the chain) wired into `run_settle_passes` + `recover`;
  reranked-order delivery via `resolve_parent_context`.
- `kx-gateway` `model_exec`: `is_rerank_turn` + `run_rerank_turn` (`Grammar::Permutation(n)`,
  temp 0, commit RAW → the coordinator settle owns the decode).
- `kx-projection`: `ReRankRoundRecord` re-export + `latest_rerank_round_by_base`.

### Cross-surface (single `kx` / `KxClient` entry point)
`kx rerank list` (CLI) · `list_rerank_turns` (Py + TS SDK, sync+async) · Monitoring
**ReRank rounds** panel (UI) · `agentic-rag.md` + new `llm-rerank.md` (docs, chaining pattern).

### Invariants + gates (all green locally)
- **Canonical digest `7d22d4bd` invariant** — `a0_guard::seam_preserves_canonical_demo_digest` +
  `schema_evolution` pass (off-DAG, default-off, no `MoteId` changes).
- **Frozen-trio** (`kx-scheduler`/`kx-executor`/`kx-inference`) diff-EMPTY.
- **No journal/checkpoint/proto bump** (`ReRankRound` + `ListReRankTurns` shipped in RC4c-2a).
- **No new external dep**; `fmt` + workspace `clippy --features inference,embedded-worker,hnsw --all-targets` clean.
- **`just eval` PASS** (all 5 gates ≥ baseline; `suite_digest` unchanged — corpus untouched).
- Coordinator/projection/journal/gateway/mote/context-assembler unit + integration tests pass;
  new unit tests guard the permutation delivery + fail-closed (incl. the bug below).

### Bug found + fixed (GR16, caught by a new unit test)
The chat-rag reranked bundle was being **canonicalized away** by `encode_context_items` (which
sorts by `content_ref`) — so the reorder was lost. Fixed with an order-preserving
`encode_context_items_ordered` used **only** for the off-digest, out-of-band delivery bundle.

### Deliberately deferred (own focused follow-ups)
- `T-OLLAMA-GRAMMAR-FORMAT` general answer-eligible tool-turn strict/`format` mode — orthogonal +
  risks the Ollama free-form answer path; the rerank turn's format handling was already closed by RC4c.
- kx-eval RAG-quality **rerank scorer** + golden-corpus extension (`suite_digest` re-baseline) + kx-profile **M7c** spike.
- **Live dual-engine Gemma e2e** (react-rag + chat-rag rerank on a running serve, incl. recover-mid-rerank) — needs a real model; run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
