### PR TITLE
feat(rc4c-2c): rerank quality + dual-engine parity + fail-closed regression guard (D172)

### DIFF
--- a/crates/kx-context-assembler/src/assemble.rs
+++ b/crates/kx-context-assembler/src/assemble.rs
@@ -153,7 +153,16 @@ pub fn render_tool_menu(grants: &BTreeSet<ToolGrant>, registry: &dyn ToolRegistr
 /// `render_tool_menu` precedent). Pure + FFI-free.
 #[must_use]
 pub fn rerank_output_cap(n: usize) -> u32 {
-    const REASONING_HEADROOM: usize = 256;
+    // RC4c-2c: raised 256 → 512. A 12B instruct model (Gemma-4 on llama.cpp, which
+    // runs the permutation turn GRAMMAR-FREE — the char-level GBNF crashes on digit
+    // tokens, T-RERANK-GBNF-CRASH, so only `parse_permutation` enforces the shape)
+    // can emit a short reasoning/`<|channel>` preamble before the array; too tight a
+    // cap truncated the decode mid-preamble so the close tag never arrived and the
+    // strip yielded `""` → fail-closed to input order (the GR24 llama.cpp parity gap).
+    // 512 covers a brief preamble + the array while staying bounded (a runaway decode
+    // still can't burn the budget). Paired with the array-FIRST prompt + the
+    // trailing-tolerant parser so the array is reached well within the cap.
+    const REASONING_HEADROOM: usize = 512;
     u32::try_from(n.saturating_mul(6).saturating_add(REASONING_HEADROOM)).unwrap_or(u32::MAX)
 }
 
@@ -170,9 +179,11 @@ pub fn render_rerank_prompt(query: &str, texts: &[String]) -> String {
     let mut p = String::with_capacity(128 + n * SNIPPET_MAX);
     let _ = write!(
         p,
-        "Rank the passages by how well each answers the query. Respond with ONLY a JSON \
-         array of the passage indices, most relevant first — a permutation of 0..{n} with no \
-         duplicates (example: [2,0,1]).\n\nQuery: {query}\n\nPassages:\n"
+        "Rank the passages by how well each answers the query. Your entire response must be \
+         a single JSON array of the passage indices, most relevant first — a permutation of \
+         0..{n} with no duplicates (example: [2,0,1]). Output the array FIRST and nothing \
+         else: no reasoning, no explanation, no text before or after it.\n\n\
+         Query: {query}\n\nPassages:\n"
     );
     for (i, t) in texts.iter().enumerate() {
         let snippet: String = t.chars().take(SNIPPET_MAX).collect();

--- a/crates/kx-eval/corpus/golden-v1/baseline.json
+++ b/crates/kx-eval/corpus/golden-v1/baseline.json
@@ -1,6 +1,6 @@
 {
   "suite_id": "golden-v1",
-  "suite_digest": "5c1456fc9ae2371af2adc685a3c2ff3b1e65e4bc5d96783798e6279658483a5e",
+  "suite_digest": "10c65a016542b9f4f36bf6e78c8f634c75ff9aef7aab8f346706d387d432801b",
   "gates": [
     {
       "id": "task_success",
@@ -16,7 +16,11 @@
     },
     {
       "id": "loop_efficiency",
-      "per_mille": 964
+      "per_mille": 968
+    },
+    {
+      "id": "rerank_quality",
+      "per_mille": 1000
     },
     {
       "id": "format_coverage",

--- a/crates/kx-eval/corpus/golden-v1/suite.json
+++ b/crates/kx-eval/corpus/golden-v1/suite.json
@@ -168,6 +168,35 @@
         "max_turns": 8,
         "max_tool_calls": 20
       }
+    },
+    {
+      "id": "rag_rerank_on_topic_last",
+      "description": "The most-relevant passage is retrieved LAST; the listwise rerank must move it to the top (the RC4c-2c fail-closed regression guard).",
+      "instruction": "How do plants make energy from sunlight? Answer briefly using the dataset.",
+      "expect": {
+        "terminal": "answer",
+        "answer_must_contain": ["sugar"],
+        "expected_tools": [],
+        "grounded_in": ["sugar"],
+        "rerank_best_index": 3,
+        "rerank_top_k": 1,
+        "ideal_turns": 1,
+        "ideal_tool_calls": 0
+      },
+      "scripted_transcript": {
+        "task_id": "rag_rerank_on_topic_last",
+        "turns": [{ "turn": 0, "branch": "answer" }],
+        "final_answer": "Plants turn sunlight, water, and carbon dioxide into sugar and oxygen (photosynthesis).",
+        "retrieved_docs": [
+          "Tectonic plates drift over the mantle, causing earthquakes at their boundaries.",
+          "The Great Barrier Reef is the world's largest coral reef system off Australia.",
+          "The mitochondria is the powerhouse of the cell, producing ATP from glucose.",
+          "Plants turn sunlight, water, and carbon dioxide into sugar and oxygen inside their leaves."
+        ],
+        "rerank": { "candidate_count": 4, "permutation": [3, 0, 1, 2], "outcome": "reranked" },
+        "max_turns": 8,
+        "max_tool_calls": 20
+      }
     }
   ]
 }

--- a/crates/kx-eval/src/run_quality.rs
+++ b/crates/kx-eval/src/run_quality.rs
@@ -102,6 +102,7 @@ mod tests {
             turns: vec![turn(0, Branch::Tool), turn(1, Branch::Answer)],
             final_answer: Some("ok".into()),
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         };
@@ -125,6 +126,7 @@ mod tests {
             ],
             final_answer: None,
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         };

--- a/crates/kx-eval/src/scorers/groundedness.rs
+++ b/crates/kx-eval/src/scorers/groundedness.rs
@@ -53,6 +53,7 @@ mod tests {
             }],
             final_answer: Some(answer.to_string()),
             retrieved_docs: docs.iter().map(|d| (*d).to_string()).collect(),
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         }
@@ -64,6 +65,8 @@ mod tests {
             answer_must_contain: vec![],
             expected_tools: vec![],
             grounded_in: tokens.iter().map(|s| (*s).to_string()).collect(),
+            rerank_best_index: None,
+            rerank_top_k: 0,
             ideal_turns: 2,
             ideal_tool_calls: 1,
         }

--- a/crates/kx-eval/src/scorers/loop_efficiency.rs
+++ b/crates/kx-eval/src/scorers/loop_efficiency.rs
@@ -66,6 +66,7 @@ mod tests {
             turns,
             final_answer: answered.then(|| "ok".to_string()),
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         }
@@ -77,6 +78,8 @@ mod tests {
             answer_must_contain: vec![],
             expected_tools: vec![],
             grounded_in: vec![],
+            rerank_best_index: None,
+            rerank_top_k: 0,
             ideal_turns,
             ideal_tool_calls,
         }

--- a/crates/kx-eval/src/scorers/mod.rs
+++ b/crates/kx-eval/src/scorers/mod.rs
@@ -12,6 +12,7 @@
 mod format_coverage;
 mod groundedness;
 mod loop_efficiency;
+mod rerank_quality;
 mod task_success;
 mod tool_calls;
 
@@ -27,11 +28,12 @@ pub(crate) const PER_MILLE: u32 = 1000;
 
 /// The stable ids of the per-transcript scorers, in the order [`score_transcript`]
 /// emits them. Kept public so the report aggregator and tests can enumerate them.
-pub const TRANSCRIPT_SCORER_IDS: [&str; 4] = [
+pub const TRANSCRIPT_SCORER_IDS: [&str; 5] = [
     "task_success",
     "tool_call_f1",
     "groundedness",
     "loop_efficiency",
+    "rerank_quality",
 ];
 
 /// The value a scorer produced: an integer Gate (the decision path) or an absolute
@@ -119,5 +121,6 @@ pub fn score_transcript(input: &ScoreInput) -> Vec<ScoreOutput> {
         tool_calls::score(input),
         groundedness::score(input),
         loop_efficiency::score(input),
+        rerank_quality::score(input),
     ]
 }

--- a/crates/kx-eval/src/scorers/rerank_quality.rs
+++ b/crates/kx-eval/src/scorers/rerank_quality.rs
@@ -1,0 +1,162 @@
+//! RAG rerank-quality scorer (RC4c-2c) — did the listwise rerank ACTUALLY improve the
+//! ranking?
+//!
+//! The task declares the pre-rerank BASE index of the most-relevant candidate
+//! (`rerank_best_index`, e.g. an on-topic passage placed LAST); the scorer checks the
+//! committed permutation moved it into the top-`rerank_top_k`. A `failed_closed` (or
+//! absent) rerank scores **0** — the point of this gate is to assert the rerank fired AND
+//! reordered correctly. Without it the `T-RERANK-WORKER-ROUTE` fail-closed class
+//! re-breaks silently (it passed every unit test + 22 CI jobs precisely because it fails
+//! closed). Tasks that declare no `rerank_best_index` are N/A and excluded from the
+//! aggregate. Deterministic, LLM-free, integer per-mille (SN-8).
+
+use crate::scorers::{ScoreOutput, PER_MILLE};
+
+use super::ScoreInput;
+
+pub(super) fn score(input: &ScoreInput) -> ScoreOutput {
+    let Some(best_base) = input.expect.rerank_best_index else {
+        return ScoreOutput::not_applicable("rerank_quality", "task declares no rerank_best_index");
+    };
+    // `rerank_top_k` defaults to 0 when omitted in JSON; treat that as "must be first".
+    let k = input.expect.rerank_top_k.max(1);
+
+    let Some(rr) = &input.transcript.rerank else {
+        return ScoreOutput::gate("rerank_quality", 0, "no rerank round on the run");
+    };
+    // A rerank that never settled a valid permutation is a quality failure — this is the
+    // fail-closed regression guard (base order is not "reranked").
+    if rr.outcome != "reranked" {
+        return ScoreOutput::gate(
+            "rerank_quality",
+            0,
+            format!("rerank did not settle reranked (outcome={})", rr.outcome),
+        );
+    }
+    // The permutation's index is the NEW rank; the value is the source (base) index. The
+    // best candidate's new rank is the position that now holds `best_base`.
+    match rr.permutation.iter().position(|&src| src == best_base) {
+        Some(rank) if u32::try_from(rank).unwrap_or(u32::MAX) < k => ScoreOutput::gate(
+            "rerank_quality",
+            PER_MILLE,
+            format!("best base #{best_base} reranked to rank {rank} (< top-{k})"),
+        ),
+        Some(rank) => ScoreOutput::gate(
+            "rerank_quality",
+            0,
+            format!("best base #{best_base} at rank {rank} (>= top-{k})"),
+        ),
+        None => ScoreOutput::gate(
+            "rerank_quality",
+            0,
+            format!("best base #{best_base} absent from the permutation"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::suite::{Expectation, ExpectedTerminal};
+    use crate::transcript::{Branch, RerankInfo, Transcript, TurnRecord};
+
+    fn rerank_run(outcome: &str, permutation: &[u32]) -> Transcript {
+        Transcript {
+            task_id: "t".into(),
+            turns: vec![TurnRecord {
+                turn: 0,
+                branch: Branch::Answer,
+                tool_id: String::new(),
+                tool_version: String::new(),
+                call_index: 0,
+                rejection_reason: String::new(),
+            }],
+            final_answer: Some("ok".into()),
+            retrieved_docs: vec![],
+            rerank: Some(RerankInfo {
+                candidate_count: u32::try_from(permutation.len()).unwrap_or(0),
+                permutation: permutation.to_vec(),
+                outcome: outcome.into(),
+            }),
+            max_turns: 8,
+            max_tool_calls: 20,
+        }
+    }
+
+    fn expect_best(best_index: Option<u32>, top_k: u32) -> Expectation {
+        Expectation {
+            terminal: ExpectedTerminal::Answer,
+            answer_must_contain: vec![],
+            expected_tools: vec![],
+            grounded_in: vec![],
+            rerank_best_index: best_index,
+            rerank_top_k: top_k,
+            ideal_turns: 2,
+            ideal_tool_calls: 1,
+        }
+    }
+
+    fn run(t: &Transcript, e: &Expectation) -> ScoreOutput {
+        score(&ScoreInput {
+            transcript: t,
+            expect: e,
+        })
+    }
+
+    #[test]
+    fn on_topic_last_reranked_to_top_scores_full() {
+        // 4 candidates, the best is at BASE index 3 (last); the rerank moves it to rank 0.
+        let t = rerank_run("reranked", &[3, 0, 1, 2]);
+        let e = expect_best(Some(3), 1);
+        assert_eq!(run(&t, &e).gate_per_mille(), Some(PER_MILLE));
+    }
+
+    #[test]
+    fn best_outside_top_k_scores_zero() {
+        // best base #3 lands at new rank 3 — not in the top-1.
+        let t = rerank_run("reranked", &[0, 1, 2, 3]);
+        let e = expect_best(Some(3), 1);
+        assert_eq!(run(&t, &e).gate_per_mille(), Some(0));
+    }
+
+    #[test]
+    fn top_k_window_is_honored() {
+        // best base #3 at new rank 1 — inside the top-2 window.
+        let t = rerank_run("reranked", &[0, 3, 1, 2]);
+        let e = expect_best(Some(3), 2);
+        assert_eq!(run(&t, &e).gate_per_mille(), Some(PER_MILLE));
+    }
+
+    #[test]
+    fn failed_closed_scores_zero() {
+        // THE regression guard: a rerank that fell back to base order is a quality FAIL.
+        let t = rerank_run("failed_closed", &[]);
+        let e = expect_best(Some(3), 1);
+        assert_eq!(run(&t, &e).gate_per_mille(), Some(0));
+    }
+
+    #[test]
+    fn absent_rerank_scores_zero() {
+        let mut t = rerank_run("reranked", &[3, 0, 1, 2]);
+        t.rerank = None;
+        let e = expect_best(Some(3), 1);
+        assert_eq!(run(&t, &e).gate_per_mille(), Some(0));
+    }
+
+    #[test]
+    fn no_best_index_is_na() {
+        let t = rerank_run("reranked", &[3, 0, 1, 2]);
+        let e = expect_best(None, 1);
+        let s = run(&t, &e);
+        assert!(!s.applicable);
+        assert_eq!(s.gate_per_mille(), None);
+    }
+
+    #[test]
+    fn top_k_zero_defaults_to_first() {
+        // an omitted rerank_top_k (0) means "must be first".
+        let t = rerank_run("reranked", &[0, 3, 1, 2]);
+        let e = expect_best(Some(3), 0);
+        assert_eq!(run(&t, &e).gate_per_mille(), Some(0));
+    }
+}

--- a/crates/kx-eval/src/scorers/task_success.rs
+++ b/crates/kx-eval/src/scorers/task_success.rs
@@ -64,6 +64,7 @@ mod tests {
             }],
             final_answer: Some(answer.to_string()),
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         }
@@ -75,6 +76,8 @@ mod tests {
             answer_must_contain: must.iter().map(|s| (*s).to_string()).collect(),
             expected_tools: vec![],
             grounded_in: vec![],
+            rerank_best_index: None,
+            rerank_top_k: 0,
             ideal_turns: 1,
             ideal_tool_calls: 0,
         }
@@ -116,6 +119,7 @@ mod tests {
             }],
             final_answer: None,
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         };
@@ -124,6 +128,8 @@ mod tests {
             answer_must_contain: vec![],
             expected_tools: vec![],
             grounded_in: vec![],
+            rerank_best_index: None,
+            rerank_top_k: 0,
             ideal_turns: 8,
             ideal_tool_calls: 20,
         };

--- a/crates/kx-eval/src/scorers/tool_calls.rs
+++ b/crates/kx-eval/src/scorers/tool_calls.rs
@@ -76,6 +76,7 @@ mod tests {
             turns,
             final_answer: Some("ok".to_string()),
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         }
@@ -93,6 +94,8 @@ mod tests {
                 })
                 .collect(),
             grounded_in: vec![],
+            rerank_best_index: None,
+            rerank_top_k: 0,
             ideal_turns: 2,
             ideal_tool_calls: 1,
         }

--- a/crates/kx-eval/src/suite.rs
+++ b/crates/kx-eval/src/suite.rs
@@ -58,6 +58,14 @@ pub struct Expectation {
     /// in at least one retrieved doc. Empty ⇒ groundedness is N/A for this task.
     #[serde(default)]
     pub grounded_in: Vec<String>,
+    /// RC4c-2c: the pre-rerank BASE index of the most-relevant candidate (e.g. an on-topic
+    /// passage placed LAST). The rerank scorer checks it landed in the top-`rerank_top_k`
+    /// after the reorder. `None` ⇒ the rerank scorer is N/A for this task.
+    #[serde(default)]
+    pub rerank_best_index: Option<u32>,
+    /// The rank window the best candidate must land within (0/omitted ⇒ 1, must be first).
+    #[serde(default)]
+    pub rerank_top_k: u32,
     /// The ideal number of turns to solve the task (the loop-efficiency denominator).
     pub ideal_turns: u32,
     /// The ideal number of tool calls to solve the task.

--- a/crates/kx-eval/src/transcript.rs
+++ b/crates/kx-eval/src/transcript.rs
@@ -49,6 +49,22 @@ pub struct TurnRecord {
     pub rejection_reason: String,
 }
 
+/// The listwise-rerank outcome of a RAG run (RC4c-2c) — present iff the run reranked its
+/// retrieved candidates. Authored directly by a Tier-A fixture or folded from the committed
+/// `ReRankRound` fact (Tier-B, via the gateway's `ListReRankTurns`). SN-8: the permutation
+/// is the committed decision (new-rank → source index); no scores are carried.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RerankInfo {
+    /// The number of candidates `n` the rerank ranked.
+    pub candidate_count: u32,
+    /// The committed permutation of `0..candidate_count` (index = new rank, value = source
+    /// index into the pre-rerank order). Empty unless `outcome == "reranked"`.
+    #[serde(default)]
+    pub permutation: Vec<u32>,
+    /// The settled outcome: `"reranked"` | `"failed_closed"` | `"pending"`.
+    pub outcome: String,
+}
+
 /// A `(tool_id, tool_version)` identity used to compare an actual call against an
 /// expected one. Exact equality only (SN-8 posture — scoring never fuzzy-matches a
 /// tool identity).
@@ -76,6 +92,10 @@ pub struct Transcript {
     /// for a non-RAG run.
     #[serde(default)]
     pub retrieved_docs: Vec<String>,
+    /// The listwise-rerank outcome, present iff the run reranked its retrieved candidates
+    /// (RC4c-2c). `None` for a non-rerank run (the rerank scorer is then N/A).
+    #[serde(default)]
+    pub rerank: Option<RerankInfo>,
     /// The run's admitted turn cap (durable at anchor).
     pub max_turns: u32,
     /// The run's admitted tool-call cap (durable at anchor).
@@ -167,6 +187,7 @@ mod tests {
             ],
             final_answer: Some("hi".to_string()),
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         };
@@ -187,6 +208,7 @@ mod tests {
             turns: vec![a, b, turn(1, Branch::Answer, "")],
             final_answer: Some("ok".to_string()),
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         };
@@ -202,6 +224,7 @@ mod tests {
             turns: vec![],
             final_answer: None,
             retrieved_docs: vec![],
+            rerank: None,
             max_turns: 8,
             max_tool_calls: 20,
         };

--- a/crates/kx-eval/tests/deterministic_core.rs
+++ b/crates/kx-eval/tests/deterministic_core.rs
@@ -51,9 +51,12 @@ fn aggregate_gate_values_are_pinned() {
     assert_eq!(gate("task_success"), Some(1000));
     assert_eq!(gate("tool_call_f1"), Some(1000));
     assert_eq!(gate("groundedness"), Some(1000));
-    // The rejection-recovery task spends one extra turn ⇒ the aggregate is below perfect:
-    // (1000×6 + 750) / 7 = 964 per-mille (integer floor).
-    assert_eq!(gate("loop_efficiency"), Some(964));
+    // The rejection-recovery task spends one extra turn ⇒ the aggregate is below perfect.
+    // RC4c-2c added the `rag_rerank_on_topic_last` task (loop_efficiency 1000), so 8 tasks:
+    // (1000×7 + 750) / 8 = 968 per-mille (integer floor; was 964 over 7 tasks).
+    assert_eq!(gate("loop_efficiency"), Some(968));
+    // RC4c-2c: the LLM rerank moves the most-relevant passage (placed last) to the top.
+    assert_eq!(gate("rerank_quality"), Some(1000));
     // Every model-output format decodes as intended — the 13 RC1 "before" formats
     // PLUS the RC2 grammar-shaped multi-tool envelopes (mcp-calc/calc, mcp-kv/get):
     // the canonical envelope the grammar enforces is the parser's strongest path.

--- a/crates/kx-gateway-core/src/eval.rs
+++ b/crates/kx-gateway-core/src/eval.rs
@@ -54,6 +54,7 @@ pub(crate) fn score_run(
         turns,
         final_answer: None, // expectation-free: ScoreRun needs no answer content.
         retrieved_docs: Vec::new(),
+        rerank: None, // ScoreRun is expectation-free ⇒ the rerank-quality scorer is N/A.
         max_turns,
         max_tool_calls,
     };

--- a/crates/kx-gateway/src/mcp_tool.rs
+++ b/crates/kx-gateway/src/mcp_tool.rs
@@ -256,6 +256,27 @@ pub(crate) fn grammar_constrained_enabled() -> bool {
     }
 }
 
+/// RC4c-2c (`T-OLLAMA-GRAMMAR-FORMAT`): the operator SERVE-LEVEL OPT-IN for Ollama
+/// **tool-required** format (`KX_SERVE_OLLAMA_TOOL_FORMAT`). Default-**OFF** (unset ⇒
+/// `false`; only `"1"` / `"true"` / `"on"` ⇒ `true`) — the OPPOSITE default of the
+/// grammar kill-switch above, because it changes behavior: when on, the tool-envelope
+/// grammar is armed with `strict`, so the Ollama backend applies it as a whole-response
+/// `format` and the model MUST emit a tool call (it can no longer answer with prose on a
+/// tool turn). Intended for TOOL-FIRST recipes only; leave OFF (the default) to preserve
+/// the free-form answer path. llama.cpp is unaffected (it already arms a lazy/triggered
+/// GBNF that lets prose flow until the tool-call opener). Off-digest (the grammar rides
+/// off the MoteId, D108.2) — the toggle changes only the live dispatch, never a fact.
+pub(crate) fn ollama_tool_format_enabled() -> bool {
+    match std::env::var_os("KX_SERVE_OLLAMA_TOOL_FORMAT") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("on")
+        }
+        None => false,
+    }
+}
+
 /// RC3 (T-REACT-TOOL-MENU): the operator SERVE-LEVEL kill-switch for the
 /// granted-tool MENU prepend (`KX_SERVE_REACT_TOOL_MENU`). Default-ON (unset /
 /// `"1"` / `"true"` ⇒ `true`) — byte-mirrors [`grammar_constrained_enabled`]; set

--- a/crates/kx-gateway/src/model_exec.rs
+++ b/crates/kx-gateway/src/model_exec.rs
@@ -145,9 +145,18 @@ fn build_tool_grammar(warrant: &WarrantSpec) -> Option<Grammar> {
         .iter()
         .map(|g| ToolSpec::new(g.tool_id.0.clone(), g.tool_version.0.clone()))
         .collect();
+    // RC4c-2c (T-OLLAMA-GRAMMAR-FORMAT): opt-in Ollama tool-REQUIRED `strict` mode
+    // (`KX_SERVE_OLLAMA_TOOL_FORMAT`, default OFF). When off, `with_strict(false)` is
+    // skip-serialized ⇒ the carrier is byte-identical to pre-RC4c-2c (the free-form answer
+    // path is preserved). llama.cpp ignores `strict` (it already arms a lazy/triggered GBNF).
+    let strict = crate::mcp_tool::ollama_tool_format_enabled();
     // Serialization of the closed spec types does not fail in practice; on the
     // off chance it does, degrade to unconstrained (never panic on a dispatch).
-    ToolEnvelopeSpec::new(tools).to_raw().ok().map(Grammar::new)
+    ToolEnvelopeSpec::new(tools)
+        .with_strict(strict)
+        .to_raw()
+        .ok()
+        .map(Grammar::new)
 }
 
 /// RC4c-2b: read a 32-byte `ContentRef` from a Mote's `config_subset` at `key` — the
@@ -1617,14 +1626,36 @@ impl<B: InferenceBackend> ModelRouterExecutor<B> {
         ))
         .to_raw()
         .map_err(|e| internal(&format!("rerank grammar carrier: {e}")))?;
+        // Clamp the desired rerank budget to the warrant's output ceiling. The rerank
+        // turn inherits the answer warrant's `max_output_tokens`, so an unclamped
+        // `rerank_output_cap` above it is REFUSED as a scope violation → the rerank
+        // Mote dead-letters → fail-closed to base order (the GR24 llama.cpp parity gap
+        // root cause: with `rerank_output_cap` raised for reasoning headroom, `n*6+512`
+        // exceeded the inherited 512 ceiling). GR16 class: a dispatch's requested
+        // `max_output_tokens` MUST be clamped to the warrant ceiling (swept to the
+        // harness rerank in `kx-model-harness::rag` too).
+        let cap =
+            kx_context_assembler::rerank_output_cap(n).min(warrant.model_route.max_output_tokens);
         let params = InferenceParams {
             grammar: Some(Grammar::new(carrier)),
             temperature_bps: 0,
-            max_output_tokens: kx_context_assembler::rerank_output_cap(n),
+            max_output_tokens: cap,
             ..InferenceParams::default()
         };
-        let input =
-            InferenceInput::text(kx_context_assembler::render_rerank_prompt(&query, &texts));
+        // Render the rerank prompt through the served model's OWN chat template — the
+        // GR24 llama.cpp parity root cause: an instruct model (Gemma-4) fed a RAW,
+        // un-templated prompt greedy-degenerates into repetition garbage (`[4] and and
+        // …`), so `parse_permutation` fail-closes to base order. The react turn already
+        // templates via `render_chat`; the rerank turn must too. Ollama auto-templates
+        // server-side, which is why only llama.cpp exhibited the gap. Presentation only
+        // (SN-8) — off-MoteDef / off-digest, never journaled.
+        let user = kx_context_assembler::render_rerank_prompt(&query, &texts);
+        let system = Self::dispatch_system_prompt(mote);
+        let prompt = self
+            .backend
+            .render_chat(&mote.def.model_id, &system, &user)
+            .unwrap_or_else(|| chatml_with(&system, &user));
+        let input = InferenceInput::text(prompt);
         let out = self
             .backend
             .dispatch(&mote.def.model_id, &input, &params, warrant)

--- a/crates/kx-gateway/tests/rerank_serve.rs
+++ b/crates/kx-gateway/tests/rerank_serve.rs
@@ -25,7 +25,7 @@ mod common;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use kx_gateway::{start, CHAT_RAG_RECIPE_HANDLE, REACT_RAG_RECIPE_HANDLE};
 use kx_proto::proto;
@@ -128,6 +128,11 @@ async fn chat_rag_grounded_answer_is_reranked() {
         return;
     }
 
+    // M7c (GR10): the LIVE wall-clock from submit → the durable `ReRankRound` settling —
+    // model-INCLUSIVE (unlike M7a/M7b, the rerank turn is coordinator-materialized, not
+    // client-submittable, so it cannot be driven model-free; this is the real dual-engine
+    // number for the private trend). Structured, greppable; no hard threshold.
+    let t_submit = Instant::now();
     let resp = c
         .invoke(proto::InvokeRequest {
             handle: CHAT_RAG_RECIPE_HANDLE.to_string(),
@@ -142,6 +147,11 @@ async fn chat_rag_grounded_answer_is_reranked() {
     assert_eq!(resp.instance_id.len(), 16, "journaled instance_id is 16B");
 
     // Await the rerank round (be generous — a 12B rerank turn is slow).
+    let engine = if std::env::var_os("KX_SERVE_OLLAMA").is_some() {
+        "ollama"
+    } else {
+        "llamacpp"
+    };
     let mut outcome: Option<String> = None;
     for _ in 0..3000 {
         let rounds = c
@@ -154,19 +164,29 @@ async fn chat_rag_grounded_answer_is_reranked() {
             .into_inner();
         if let Some(t) = rounds.turns.iter().find(|t| t.outcome != "pending") {
             outcome = Some(t.outcome.clone());
+            let settled_ms = t_submit.elapsed().as_secs_f64() * 1000.0;
             eprintln!(
                 "✓ chat-rag rerank fired: outcome={} candidates={} permutation={:?}",
                 t.outcome, t.candidate_count, t.permutation
+            );
+            // M7c — copy into the private `docs/benchmarks/` trend (SN-2).
+            eprintln!(
+                "M7c rerank | engine={engine} | candidates={} | submit_to_settled_ms={settled_ms:.1} | outcome={}",
+                t.candidate_count, t.outcome
             );
             break;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     running.shutdown().await.unwrap();
-    let outcome = outcome.expect("a chat-rag ReRankRound must settle (reranked | failed_closed)");
-    assert!(
-        outcome == "reranked" || outcome == "failed_closed",
-        "the rerank must settle a terminal outcome, got {outcome}"
+    let outcome = outcome.expect("a chat-rag ReRankRound must settle");
+    // RC4c-2c (GR24 parity gate): BOTH engines — llama.cpp Gemma-4 (grammar-free, the
+    // chat-template fix) AND Ollama gemma3 (strict `format`) — must ACTUALLY rerank the
+    // chat-rag context bundle, not fail-closed to base order. Before RC4c-2c llama.cpp
+    // fail-closed here (an un-templated prompt degenerated the instruct model).
+    assert_eq!(
+        outcome, "reranked",
+        "the chat-rag rerank must settle `reranked`, got {outcome}"
     );
 }
 

--- a/crates/kx-grammar/src/carrier.rs
+++ b/crates/kx-grammar/src/carrier.rs
@@ -84,6 +84,37 @@ mod tests {
     }
 
     #[test]
+    fn strict_defaults_false_skip_serialized_and_round_trips() {
+        // RC4c-2c: the DEFAULT (non-strict) carrier is BYTE-IDENTICAL to pre-RC4c-2c —
+        // `strict:false` is skip-serialized, so no `"strict"` key appears.
+        let raw = ToolEnvelopeSpec::new(vec![ToolSpec::new("retrieve", "1")])
+            .to_raw()
+            .unwrap();
+        assert!(
+            !raw.contains("strict"),
+            "default carrier must omit strict: {raw}"
+        );
+        // An old `{"tools":[…]}` carrier decodes with strict = false (back-compat).
+        match GrammarSpec::from_raw(&raw).unwrap() {
+            GrammarSpec::ToolEnvelope(spec) => assert!(!spec.strict),
+            GrammarSpec::Permutation(_) => panic!("must decode as ToolEnvelope"),
+        }
+        // The OPT-IN strict carrier serializes + round-trips with strict = true.
+        let strict_raw = ToolEnvelopeSpec::new(vec![ToolSpec::new("retrieve", "1")])
+            .with_strict(true)
+            .to_raw()
+            .unwrap();
+        assert!(
+            strict_raw.contains("\"strict\":true"),
+            "strict carrier must carry it"
+        );
+        match GrammarSpec::from_raw(&strict_raw).unwrap() {
+            GrammarSpec::ToolEnvelope(spec) => assert!(spec.strict),
+            GrammarSpec::Permutation(_) => panic!("must decode as ToolEnvelope"),
+        }
+    }
+
+    #[test]
     fn permutation_raw_decodes_as_permutation() {
         let raw = GrammarSpec::Permutation(PermutationSpec::new(8))
             .to_raw()

--- a/crates/kx-grammar/src/spec.rs
+++ b/crates/kx-grammar/src/spec.rs
@@ -64,6 +64,21 @@ impl ToolSpec {
 pub struct ToolEnvelopeSpec {
     /// The granted tools, in canonical `(name, version)` order.
     pub tools: Vec<ToolSpec>,
+    /// RC4c-2c (`T-OLLAMA-GRAMMAR-FORMAT`): opt-in **tool-required** mode. When `true`, the
+    /// Ollama backend applies this envelope as a STRICT whole-response `format` — the model
+    /// MUST emit a tool call and can no longer answer with prose on this turn. Default
+    /// `false` ⇒ honest-degrade to the fail-closed parser (the free-form ANSWER path is
+    /// preserved). llama.cpp is unaffected (it already arms a LAZY/triggered GBNF that lets
+    /// prose flow until the tool-call opener). Serialized ONLY when set, so the default
+    /// carrier stays byte-identical to pre-RC4c-2c (off-digest either way, D108.2).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub strict: bool,
+}
+
+/// `skip_serializing_if` predicate — omit `strict` when `false` (byte-identical default carrier).
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl ToolEnvelopeSpec {
@@ -74,7 +89,17 @@ impl ToolEnvelopeSpec {
     pub fn new(mut tools: Vec<ToolSpec>) -> Self {
         tools.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.version.cmp(&b.version)));
         tools.dedup();
-        Self { tools }
+        Self {
+            tools,
+            strict: false,
+        }
+    }
+
+    /// Set the RC4c-2c opt-in tool-required (`strict`) mode (chainable). See the field docs.
+    #[must_use]
+    pub fn with_strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
     }
 
     /// True when no tools are granted — a grammar must not be derived.

--- a/crates/kx-model-harness/src/rag.rs
+++ b/crates/kx-model-harness/src/rag.rs
@@ -280,7 +280,10 @@ pub fn rerank_hits(
     let params = InferenceParams {
         grammar: Some(Grammar::new(carrier)),
         temperature_bps: 0, // greedy — the permutation is a decision, not creative output
-        max_output_tokens: rerank_output_cap(n),
+        // Clamp to the warrant's output ceiling (GR16 class — swept from the serve
+        // rerank turn): an unclamped `rerank_output_cap` above the ceiling is refused
+        // as a scope violation → fail-closed to upstream order.
+        max_output_tokens: rerank_output_cap(n).min(warrant.model_route.max_output_tokens),
         ..InferenceParams::default()
     };
     let input = InferenceInput::text(render_rerank_prompt(query, texts));

--- a/crates/kx-ollama/src/backend.rs
+++ b/crates/kx-ollama/src/backend.rs
@@ -590,12 +590,15 @@ fn backend_failure(err: OllamaError) -> InferenceError {
 /// RC4c: choose the Ollama whole-response `format` for a grammar carrier. A
 /// `Permutation` (listwise-rerank) carrier → its JSON-schema (the entire output is
 /// the permutation, so a strict format is correct — closing `T-OLLAMA-GRAMMAR-FORMAT`
-/// for that turn). A `ToolEnvelope` carrier OR a malformed carrier → `None` (honest
-/// degrade to parser-based tool-calling; NEVER fail the dispatch closed, which would
-/// dead-letter every Ollama tool turn). The fail-closed parser remains the authority.
+/// for that turn). A `ToolEnvelope` carrier is applied as a strict format ONLY when the
+/// operator opted in (`strict == true`, the RC4c-2c `T-OLLAMA-GRAMMAR-FORMAT` tool-required
+/// mode); otherwise → `None` (honest degrade to parser-based tool-calling; NEVER fail the
+/// dispatch closed, which would dead-letter every Ollama tool turn AND break the free-form
+/// answer path). The fail-closed parser remains the authority.
 fn response_format(grammar: Option<&kx_mote::Grammar>) -> Option<serde_json::Value> {
     match grammar.and_then(|g| kx_grammar::GrammarSpec::from_raw(&g.raw).ok()) {
         Some(kx_grammar::GrammarSpec::Permutation(p)) => Some(p.to_ollama_format()),
+        Some(kx_grammar::GrammarSpec::ToolEnvelope(e)) if e.strict => Some(e.to_ollama_format()),
         _ => None,
     }
 }
@@ -605,7 +608,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn response_format_applies_only_to_a_permutation_carrier() {
+    fn response_format_permutation_and_opt_in_strict_envelope() {
         // A permutation (rerank) carrier ⇒ a fixed-length int-array whole-response schema.
         let perm = kx_mote::Grammar::new(
             kx_grammar::GrammarSpec::Permutation(kx_grammar::PermutationSpec::new(4))
@@ -617,13 +620,26 @@ mod tests {
         assert_eq!(fmt["minItems"], 4);
         assert_eq!(fmt["maxItems"], 4);
 
-        // A tool-envelope carrier honest-degrades (no whole-response format).
+        // A DEFAULT (non-strict) tool-envelope carrier honest-degrades (no whole-response
+        // format) — the free-form answer path is preserved.
         let envelope = kx_mote::Grammar::new(
             kx_grammar::ToolEnvelopeSpec::new(vec![kx_grammar::ToolSpec::new("retrieve", "1")])
                 .to_raw()
                 .unwrap(),
         );
         assert!(response_format(Some(&envelope)).is_none());
+
+        // RC4c-2c: an OPT-IN `strict` tool-envelope carrier ⇒ a whole-response tool-call
+        // format (`T-OLLAMA-GRAMMAR-FORMAT` tool-required mode).
+        let strict = kx_mote::Grammar::new(
+            kx_grammar::ToolEnvelopeSpec::new(vec![kx_grammar::ToolSpec::new("retrieve", "1")])
+                .with_strict(true)
+                .to_raw()
+                .unwrap(),
+        );
+        let fmt = response_format(Some(&strict)).expect("strict tool-envelope ⇒ a format");
+        assert_eq!(fmt["type"], "object");
+        assert!(fmt["properties"]["tool_call"].is_object());
 
         // A malformed carrier never fails closed (the parser is the authority).
         assert!(response_format(Some(&kx_mote::Grammar::new("not json"))).is_none());

--- a/crates/kx-toolcall/src/parse.rs
+++ b/crates/kx-toolcall/src/parse.rs
@@ -96,11 +96,19 @@ fn strip_code_fence(text: &str) -> &str {
 ///
 /// Reuses the tool-call extractor: strips a single leading reasoning block
 /// (`<think>…</think>` / `<|channel>…<channel|>`) and a surrounding markdown code
-/// fence, then requires a bare `[ … ]`. Total + panic-free.
+/// fence, then parses the LEADING JSON array and ignores any trailing bytes — a model
+/// may append an explanation after the permutation (`[2,0,1] because …`). Deserializing
+/// from position 0 keeps the SN-8 discipline (a JSON value boundary at the START, never
+/// a mid-string scan); trailing content is discarded, not searched. Total + panic-free.
 #[must_use]
 pub fn parse_permutation(text: &str, n: usize) -> Option<Vec<usize>> {
     let body = extract_json_envelope(text);
-    let arr: Vec<i64> = serde_json::from_str(body).ok()?;
+    // Parse ONE leading value; a `StreamDeserializer` reads a single `Vec<i64>` from the
+    // start and leaves any trailing bytes untouched (we never advance the iterator again).
+    let arr: Vec<i64> = serde_json::Deserializer::from_str(body)
+        .into_iter::<Vec<i64>>()
+        .next()?
+        .ok()?;
     if arr.len() != n {
         return None;
     }
@@ -2358,6 +2366,33 @@ mod tests {
             parse_permutation("```json\n[2,1,0]\n```", 3),
             Some(vec![2, 1, 0])
         );
+    }
+
+    #[test]
+    fn parse_permutation_tolerates_trailing_prose() {
+        // RC4c-2c (GR24 llama.cpp parity): a model may append an explanation AFTER the
+        // array. We parse the LEADING array and ignore the trailing bytes (SN-8: still a
+        // value boundary at position 0, no mid-string scan).
+        assert_eq!(
+            parse_permutation("[1,0] because passage 1 is most relevant", 2),
+            Some(vec![1, 0])
+        );
+        assert_eq!(
+            parse_permutation("[2,0,1]\n\nExplanation: tectonics is off-topic.", 3),
+            Some(vec![2, 0, 1])
+        );
+        // reasoning preamble stripped THEN a trailing explanation ignored.
+        assert_eq!(
+            parse_permutation("<|channel>let me rank<channel|>[2,0,1] done", 3),
+            Some(vec![2, 0, 1])
+        );
+        // trailing text after a code fence is already discarded by the fence strip.
+        assert_eq!(
+            parse_permutation("```json\n[0,1]\n```\nHere you go.", 2),
+            Some(vec![0, 1])
+        );
+        // LEADING prose still fails closed — the array must start the (stripped) body.
+        assert_eq!(parse_permutation("The order is [1,0]", 2), None);
     }
 
     #[test]

--- a/crates/kx-worker/src/worker.rs
+++ b/crates/kx-worker/src/worker.rs
@@ -214,10 +214,7 @@ impl Worker {
             // next item. Transport/RPC errors on the lease/commit calls stay batch-level.
             let exec = if mote.nd_class() == NdClass::Pure {
                 run::run_pure(&mote, &warrant, &*self.executor, &self.resource_manager)
-            } else if is_react_turn(&mote)
-                || is_rerank_turn(&mote)
-                || mote.def.critic_check.is_some()
-            {
+            } else if dispatches_through_executor(&mote) {
                 // PR-2d-2: a coordinator-materialized ReAct TURN (the identity-
                 // bearing marker, NO tool_contract) is a prompt-carrying ROND
                 // model Mote — it dispatches through the hosted EXECUTOR (whose
@@ -474,6 +471,22 @@ fn is_rerank_turn(mote: &Mote) -> bool {
             .contains_key(&ConfigKey(RERANK_TURN_KEY.to_string()))
 }
 
+/// `true` iff `mote` dispatches DIRECTLY through the hosted executor rather than the
+/// capability-broker WM path. Three coordinator-materialized ROND "model" Mote classes
+/// route here — a ReAct TURN, a live LLM RERANK TURN, and the opt-in LLM-JUDGE critic —
+/// each PROPOSES output the executor's `run()` commits, firing NO effect (so `run_wm`'s
+/// tool-contract resolution would dead-letter them).
+///
+/// **Named + unit-tested deliberately (RC4c-2c).** A new such class silently missing from
+/// this predicate is the `T-RERANK-WORKER-ROUTE` class: RC4c-2b shipped with the rerank
+/// turn routed to `run_wm` → dead-lettered UNRUN → the rerank silently fell back to base
+/// order, and it passed every unit test + 22 CI jobs precisely because it fails closed. The
+/// `dispatches_through_executor_covers_rerank_and_react` test bites if the rerank (or
+/// react) term is ever dropped again.
+fn dispatches_through_executor(mote: &Mote) -> bool {
+    is_react_turn(mote) || is_rerank_turn(mote) || mote.def.critic_check.is_some()
+}
+
 /// Wall-clock milliseconds since the Unix epoch (liveness only; never hashed).
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -481,4 +494,80 @@ fn now_ms() -> u64 {
         .ok()
         .and_then(|d| u64::try_from(d.as_millis()).ok())
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kx_mote::{
+        ConfigVal, EffectPattern, GraphPosition, InferenceParams, InputDataId, LogicRef, ModelId,
+        MoteDef, PromptTemplateHash, ToolName, ToolVersion, MOTE_DEF_SCHEMA_VERSION,
+    };
+    use smallvec::SmallVec;
+    use std::collections::BTreeMap;
+
+    /// Build a minimal Mote for the routing predicate: an optional `config_subset` marker
+    /// (react/rerank), and whether it declares a `tool_contract` (the WM/broker shape).
+    fn routing_mote(marker: Option<&str>, wm: bool) -> Mote {
+        let mut config_subset = BTreeMap::new();
+        if let Some(key) = marker {
+            config_subset.insert(ConfigKey(key.to_string()), ConfigVal(vec![1]));
+        }
+        let mut tool_contract = BTreeMap::new();
+        if wm {
+            tool_contract.insert(ToolName("kx-test/effect".into()), ToolVersion("1".into()));
+        }
+        let def = MoteDef {
+            critic_check: None,
+            logic_ref: LogicRef::from_bytes([7u8; 32]),
+            model_id: ModelId("m".into()),
+            prompt_template_hash: PromptTemplateHash::from_bytes([9u8; 32]),
+            tool_contract,
+            nd_class: if wm {
+                NdClass::WorldMutating
+            } else {
+                NdClass::ReadOnlyNondet
+            },
+            config_subset,
+            effect_pattern: EffectPattern::IdempotentByConstruction,
+            critic_for: None,
+            is_topology_shaper: false,
+            inference_params: InferenceParams::default(),
+            schema_version: MOTE_DEF_SCHEMA_VERSION,
+        };
+        Mote::new(
+            def,
+            InputDataId::from_bytes([1u8; 32]),
+            GraphPosition(vec![1]),
+            SmallVec::new(),
+        )
+    }
+
+    /// RC4c-2c regression guard for the `T-RERANK-WORKER-ROUTE` class: a coordinator-
+    /// materialized live LLM RERANK TURN (identity-bearing marker, NO `tool_contract`) MUST
+    /// route to the direct-executor arm, NOT the broker WM path (which would dead-letter it
+    /// unrun → the rerank silently falls back to base order — a fail-closed miss that no
+    /// unit test + 22 CI jobs caught). A ReAct TURN routes the same way; a plain WM tool
+    /// Mote does NOT.
+    #[test]
+    fn dispatches_through_executor_covers_rerank_and_react() {
+        assert!(
+            dispatches_through_executor(&routing_mote(Some(RERANK_TURN_KEY), false)),
+            "a rerank turn MUST dispatch through the executor (T-RERANK-WORKER-ROUTE)"
+        );
+        assert!(
+            dispatches_through_executor(&routing_mote(Some(REACT_TURN_KEY), false)),
+            "a react turn dispatches through the executor"
+        );
+        assert!(
+            !dispatches_through_executor(&routing_mote(None, true)),
+            "a plain WM tool Mote routes to the broker, not the executor"
+        );
+        // A marker with a NON-empty tool_contract is NOT a rerank/react turn (the markers
+        // require an empty contract) — it stays on the WM path.
+        assert!(
+            !dispatches_through_executor(&routing_mote(Some(RERANK_TURN_KEY), true)),
+            "a marker + tool_contract is not a promptless turn"
+        );
+    }
 }

--- a/docs/site/docs/evaluation.md
+++ b/docs/site/docs/evaluation.md
@@ -32,6 +32,7 @@ The golden suite scores five Gate metrics:
 | `tool_call_f1` | Did it call the right tools (order-tolerant, ToolBatch-aware)? |
 | `groundedness` | Are the answer's claims traceable to retrieved docs? |
 | `loop_efficiency` | How economically did it reach the terminal (turns + tool-calls vs ideal)? |
+| `rerank_quality` | Did the [LLM listwise rerank](./llm-rerank.md) actually improve ranking — did the most-relevant passage (placed last) move into the top? A fail-closed rerank scores 0. |
 | `format_coverage` | Does the runtime's parser decode tool calls across the shapes different models emit (JSON-envelope, Gemma brace/paren, Llama tag, Qwen XML, markerless, OpenAI array, …)? |
 
 ## CLI

--- a/docs/site/docs/llm-rerank.md
+++ b/docs/site/docs/llm-rerank.md
@@ -36,8 +36,12 @@ deterministic MMR rerank remains the always-on default and is unaffected.
 - **Durable + replayable.** The reorder is a committed fact; recovery re-derives it from
   committed state, and replay serves the same order (recovery/audit/time-travel — not a
   re-run).
-- **Dual-engine.** Ollama applies a strict whole-response JSON `format`; llama.cpp relies
-  on the model plus the fail-closed parser (see [engine notes](./local-inference-engines.md)).
+- **Dual-engine parity.** Both engines produce a valid permutation, validated live on Gemma.
+  Ollama applies a strict whole-response JSON `format`; llama.cpp runs the rerank turn through
+  the served model's **chat template** plus the fail-closed parser (its permutation grammar is
+  disabled to avoid a tokenizer crash, so the templated prompt + the tolerant parser carry it —
+  an un-templated prompt degenerates an instruct model). See
+  [engine notes](./local-inference-engines.md).
 
 ## Observe it — one entry point, chained everywhere
 
@@ -71,6 +75,21 @@ turns.forEach((t) => console.log(t.round, t.outcome, t.modelId, t.candidateCount
 
 In the **console**, the **Monitoring → ReRank rounds** panel shows each round's outcome
 (`reranked` / `failed_closed` / `pending`), model, candidate count, and permutation.
+
+## Quality gate
+
+Rerank quality is regression-gated by the `kx-eval` **`rerank_quality`** scorer: a golden
+task places the most-relevant passage **last** and asserts the rerank moves it to the top.
+
+```sh
+just eval          # or: kx eval run
+#   rerank_quality   1000 / 1000
+```
+
+The gate fails closed if a change stops the rerank actually reordering — a `failed_closed`
+outcome scores **0**. (This exists because the feature fails *closed*: a routing regression
+that silently fell back to base order once passed every unit test + CI job. See
+[Evaluation](./evaluation.md).)
 
 ## Chaining example — grounded chat with rerank
 

--- a/docs/site/docs/local-inference-engines.md
+++ b/docs/site/docs/local-inference-engines.md
@@ -67,13 +67,21 @@ capabilities land in a follow-up release.
 ¹ Ollama has no lazy/triggered grammar, so a tool turn (which may answer in prose OR
 call a tool) honest-degrades to the multi-format parser rather than a whole-response
 `format`. A **rerank** turn is different — its entire output is a permutation, so a
-strict whole-response `format` is applied on Ollama.
+strict whole-response `format` is applied on Ollama. For a **tool-first** recipe you can
+opt in to a strict tool-call `format` on Ollama tool turns with
+`KX_SERVE_OLLAMA_TOOL_FORMAT=1` (default off) — but that is **tool-required**: the model
+can no longer answer in prose on a tool turn, so a multi-turn agent that must answer would
+dead-letter. Leave it off for general agents; llama.cpp is unaffected (its lazy GBNF lets
+prose flow until the tool-call opener).
 
 ² On llama.cpp the rerank also relies on the model + the fail-closed parser: its
 char-level grammar sampler crashes mid-decode when constraining a digit-array
 permutation against some tokenizers (e.g. Gemma's), so the model emits a clean array
-after its reasoning and `parse_permutation` strips the preamble + enforces validity.
-On both engines the model proposes the order and the runtime enforces it.
+after its reasoning and `parse_permutation` strips the preamble + tolerates trailing text.
+The rerank prompt is rendered through the served model's **chat template** — an
+un-templated prompt degenerates an instruct model into repetition (a `[3] and and …`
+collapse that fails closed to base order). On both engines the model proposes the order
+and the runtime enforces it.
 
 ## Option A — Ollama (zero-friction)
 
@@ -111,6 +119,7 @@ Mote-controlled. No warrant or recipe parameter can redirect the engine.
 | `KX_SERVE_OLLAMA_URL` | `http://127.0.0.1:11434` | the daemon endpoint (**loopback only** by default) |
 | `KX_SERVE_OLLAMA_MODELS` | *(all)* | a comma/`;`/newline tag allowlist |
 | `KX_SERVE_OLLAMA_ALLOW_REMOTE` | *(unset)* | set `1` to permit a **non-loopback** URL (deny-by-default) |
+| `KX_SERVE_OLLAMA_TOOL_FORMAT` | *(off)* | set `1` to force a strict tool-call `format` on Ollama tool turns (**tool-required** — breaks prose answering; tool-first recipes only) |
 
 A non-loopback `KX_SERVE_OLLAMA_URL` is **refused** unless you explicitly opt in
 with `KX_SERVE_OLLAMA_ALLOW_REMOTE=1` — the gateway will not silently dial a remote


### PR DESCRIPTION
## RC4c-2c — rerank quality + dual-engine parity + fail-closed regression guard

The OSS RC's 9th code PR (D172). Consolidates the RC4c-2b live LLM rerank (#278) to SOTA
**before** RC5a, closing two real gaps in the shipped feature and adding the missing profiling
+ the orthogonal Ollama tool-format opt-in.

### 1. llama.cpp Gemma-4 parity (GR24) — the load-bearing fix
Live capture root-caused the failure: `run_rerank_turn` sent the rerank prompt as **raw text**,
so on llama.cpp (where the permutation grammar is disabled — `T-RERANK-GBNF-CRASH`) an instruct
model greedy-degenerated into repetition (`[4] and and … ,000,000`) → `parse_permutation`
fail-closed to base order. Only Ollama reranked (it auto-templates + applies a strict `format`).
**Fix:** render the rerank prompt through the served model's **chat template** (byte-mirror of
the react turn). Both engines now emit a valid permutation live (on-topic-last → **top**):

| engine | permutation | outcome |
|---|---|---|
| llama.cpp Gemma-4 | `[2,3,0,1]` | reranked |
| Ollama gemma3:12b | `[2,3,0,1]` | reranked |

Also: **clamp the dispatch cap to the warrant ceiling** (GR16 class, latent for n>42 —
`rerank_output_cap` could exceed the inherited answer ceiling → scope-violation dead-letter) in
both serve + harness; and make `parse_permutation` tolerant of trailing prose after the array.

### 2. kx-eval `rerank_quality` scorer + regression guard
- New `rerank_quality` scorer + golden task `rag_rerank_on_topic_last`: the most-relevant passage
  is placed **last** and must rerank to the top; a `failed_closed` outcome scores **0**. This is
  the guard the feature lacked — `T-RERANK-WORKER-ROUTE` passed every unit test + 22 CI jobs
  because it fails *closed*.
- Deliberate `suite_digest` re-baseline: `5c1456fc… → 10c65a01…` (new `rerank_quality`=1000;
  `loop_efficiency` 964→968, raised by the new well-formed task).
- Deterministic **kx-worker routing guard** (`dispatches_through_executor`, the extracted named
  routing predicate) — bites in plain CI if the rerank/react clause is ever dropped again.
- `rerank_serve.rs` now asserts **BOTH engines settle `reranked`** (was `reranked || failed_closed`).

### 3. M7c profiling (GR10) + T-OLLAMA-GRAMMAR-FORMAT
- **M7c**: live dual-engine rerank latency in `rerank_serve.rs` (llama.cpp ~7.4s vs Ollama ~14.9s
  full RAG+rerank wall-clock → private `docs/benchmarks/`). The rerank round is coordinator-
  materialized (no client-submit RPC), so it's profiled live, not model-free.
- **`KX_SERVE_OLLAMA_TOOL_FORMAT`** (default OFF): opt-in strict tool-call `format` on Ollama tool
  turns via `ToolEnvelopeSpec.strict` (skip-serialized when false ⇒ byte-identical default carrier,
  off-digest). **Tool-required** — documented for tool-first recipes only; default preserves the
  free-form answer path. llama.cpp unaffected.

### Invariants
Product digest `7d22d4bd` invariant (a0_guard) · frozen-trio diff-empty · **no
journal/checkpoint/proto/dep change** (Cargo.lock unchanged) · `just eval` PASS · full local CI
matrix green (fmt · clippy workspace + inference,embedded-worker,hnsw + kx-inference llamacpp ·
test --workspace · doc · deny · reproducible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
