### PR TITLE
feat(rc-sw2): swarm authoring + personas + single-entry-point chaining + integration-in-app

### DIFF
--- a/bindings/python/src/kortecx/__init__.py
+++ b/bindings/python/src/kortecx/__init__.py
@@ -77,7 +77,7 @@ from .errors import (
 )
 from .eval import RunScore
 from .feedback import FeedbackPage, FeedbackRow, rating_from_proto, rating_to_proto
-from .flow import Flow, flow
+from .flow import Flow, fan_out_gather, flow, map_reduce, swarm, team
 from .grants import AssetGrants, GrantView
 from .memory import (
     DecayCandidate,
@@ -90,6 +90,7 @@ from .memory import (
 )
 from .models import ModelLifecycleResult, ModelSummary, PullStatus
 from .motes import MoteConfigItem, MoteDetail, effect_pattern_name, nd_class_name
+from .personas import PERSONAS, persona, persona_names
 from .react import ReactTurn, ReactTurnPage
 from .recipes import (
     BlueprintForm,
@@ -229,6 +230,15 @@ __all__ = [
     "Flow",
     "flow",
     "Agent",
+    # RC-SW2 — multi-agent swarm authoring + a curated persona library (pure client
+    # composition: N parallel agentic leaves → gather; personas fold into PROMPT_KEY).
+    "swarm",
+    "team",
+    "fan_out_gather",
+    "map_reduce",
+    "persona",
+    "persona_names",
+    "PERSONAS",
     # PR-9c-1 — the embeddable agent-runner (goal → answer + audited actions).
     "run_agent",
     "run_agent_async",

--- a/bindings/python/src/kortecx/agent.py
+++ b/bindings/python/src/kortecx/agent.py
@@ -51,6 +51,7 @@ class Agent:
         self,
         instructions: str = "",
         *,
+        persona: Optional[str] = None,
         tools: "Optional[Union[Sequence[object], Mapping[str, str]]]" = None,
         model: str = "",
         max_turns: Optional[int] = None,
@@ -58,6 +59,17 @@ class Agent:
         reasoning: Optional[str] = None,
         dynamic: bool = False,
     ) -> None:
+        if persona is not None:
+            from .personas import PERSONAS
+
+            if persona not in PERSONAS:
+                raise KeyError(f"unknown persona {persona!r} — known: {sorted(PERSONAS)}")
+            # A curated role; explicit `instructions` (if any) layer on top of it.
+            instructions = (
+                f"{PERSONAS[persona]}\n\n{instructions}".strip()
+                if instructions
+                else PERSONAS[persona]
+            )
         self.instructions = instructions
         self.tools = tools
         self.model = model
@@ -81,6 +93,12 @@ class Agent:
             max_tool_calls=self.max_tool_calls,
             reasoning=self.reasoning,
         )
+
+    def on(self, task: str) -> "Flow":
+        """Bind this agent to ``task`` → a :class:`~kortecx.flow.Flow` (a thin alias of
+        :meth:`as_flow`; reads as ``researcher.on("topic A")``). Compose bound agents in
+        a swarm: ``kx.flow().parallel(a.on("A"), a.on("B")).then("Merge").run()``."""
+        return self.as_flow(task)
 
     def run(
         self,
@@ -122,12 +140,13 @@ class Agent:
             return kx.invoke(handle, args, wait=wait, timeout=timeout)
         if self.dynamic:
             # The react / react-auto recipes REQUIRE the bounded-loop budget (the
-            # `react_contract` slots; the UI's planReactArgs mirrors this) — default
-            # to the recipe's anchored 8 / 6 when the agent didn't set them.
+            # `react_contract` slots; the UI's planReactArgs mirrors this) — default to
+            # the recipe's anchored 8 / 20 when the agent didn't set them (decoupled:
+            # a turn may fire N tools; REACT_DEFAULT_MAX_TOOL_CALLS=20 — matches the TS SDK).
             args = {
                 "instruction": self._prompt(task),
                 "max_turns": self.max_turns if self.max_turns is not None else 8,
-                "max_tool_calls": self.max_tool_calls if self.max_tool_calls is not None else 6,
+                "max_tool_calls": self.max_tool_calls if self.max_tool_calls is not None else 20,
             }
             if not has_tools:
                 return kx.invoke(REACT_RECIPE_HANDLE, args, wait=wait, timeout=timeout)

--- a/bindings/python/src/kortecx/app.py
+++ b/bindings/python/src/kortecx/app.py
@@ -42,6 +42,12 @@ def _is_hex_ref(s: str) -> bool:
 GMAIL_CONNECTOR_COMMAND = "kx-connector-gmail"
 GMAIL_CREDENTIAL_REF = "KX_GMAIL_CREDENTIAL"
 
+#: RC-SW2: the curated Discord provider defaults (the bundled ``kx-connector-discord``
+#: sidecar, #277). Mirrors ``with_gmail`` — register with
+#: ``kx connections add --command kx-connector-discord --credential-ref KX_DISCORD_CREDENTIAL``.
+DISCORD_CONNECTOR_COMMAND = "kx-connector-discord"
+DISCORD_CREDENTIAL_REF = "KX_DISCORD_CREDENTIAL"
+
 
 class App:
     """A fluent App builder. Each method returns ``self``; terminate with
@@ -79,6 +85,12 @@ class App:
         self._secret_scope: List[str] = []
         self._branch_handle = ""
         self._replay: Dict[str, str] = {}
+        # RC-SW2: imperative pre-run registrations carried from a Flow via
+        # :meth:`Flow.as_app` (with_mcp connectors / with_memory facts). Run() executes
+        # them before RunApp so a `flow().with_mcp(...).as_app(...).run()` chain still
+        # registers its connector. Never part of the envelope (off the golden digest).
+        self._flow_mcp: List[Dict[str, Any]] = []
+        self._flow_memory: List[Dict[str, Any]] = []
 
     # -- composition --
 
@@ -167,6 +179,35 @@ class App:
         equivalent to ``with_connection("kx-connector-gmail", "KX_GMAIL_CREDENTIAL")``.
         Register it on the runtime with ``kx connections add --provider gmail``."""
         return self.with_connection(GMAIL_CONNECTOR_COMMAND, GMAIL_CREDENTIAL_REF)
+
+    def with_discord(self) -> "App":
+        """RC-SW2: declare the bundled Discord connector (the curated provider default) —
+        equivalent to ``with_connection("kx-connector-discord", "KX_DISCORD_CREDENTIAL")``.
+        Register it on the runtime with ``kx connections add --command kx-connector-discord
+        --credential-ref KX_DISCORD_CREDENTIAL`` (the sidecar reads a bot token by name)."""
+        return self.with_connection(DISCORD_CONNECTOR_COMMAND, DISCORD_CREDENTIAL_REF)
+
+    def secrets(self, names: "Union[str, List[str]]") -> "App":
+        """Add secret NAMES to ``guards.secret_scope`` — the run warrant's
+        ``SecretScope::AllowList`` narrows to these so a granted connector may be dialed
+        inside the agentic loop (G2/#285). The VALUE never travels (D81). A scope name is
+        **bounded server-side by the referenced connections** — pair it with the matching
+        :meth:`with_connection` / :meth:`with_gmail` / :meth:`with_discord`, or the entry
+        is inert (fails closed). Usually implicit via ``with_connection(scope_secret=True)``;
+        use this to declare scope explicitly."""
+        for name in [names] if isinstance(names, str) else names:
+            if name and name not in self._secret_scope:
+                self._secret_scope.append(name)
+        return self
+
+    def _carry_flow_side_channels(
+        self, mcp: "List[Dict[str, Any]]", memory: "List[Dict[str, Any]]"
+    ) -> None:
+        """Carry a promoting Flow's imperative side-channels (``with_mcp`` connectors +
+        ``with_memory`` facts) so :meth:`run` registers them before ``RunApp``. Set by
+        :meth:`Flow.as_app`; never part of the envelope."""
+        self._flow_mcp = list(mcp)
+        self._flow_memory = list(memory)
 
     # -- steering (4 axes; the server RE-RESOLVES each at bind) --
 
@@ -306,15 +347,29 @@ class App:
         timeout: float = 120.0,
         client=None,
     ) -> "Union[Run, Result]":
-        """Compile this App's blueprint and run it (exactly-once). ``args`` overrides
-        the entry step's free-params (reserved; ignored when empty). The server
-        re-resolves every warrant from the caller's grants (SN-8)."""
+        """Save this App and run it via ``RunApp`` (exactly-once). ``args`` (the App's
+        input schema) fold server-side into the entry step's prompt.
+
+        RC-SW2 fix: this now routes through ``SaveApp`` + ``RunApp`` instead of a local
+        ``submit_workflow`` recompile — so the App's ``references.connections`` +
+        ``guards.secret_scope`` reach the server and a credentialed connector (Gmail /
+        Discord) actually fires inside the agentic loop (the G2/#285 path). Saving is
+        expected: an ``App`` is an explicitly-named durable object (``kx.app(name)`` /
+        ``flow().as_app(name)``); the save is idempotent (content-addressed envelope +
+        handle upsert). The server re-resolves every warrant from the caller's grants
+        (SN-8)."""
         from .defaults import default_client
 
         kx = client if client is not None else default_client()
         self._resolve_pending(kx)
-        request = Chain.from_blueprint(self.to_envelope()["blueprint"])
-        return kx.submit_workflow(request, wait=wait, timeout=timeout)
+        # Imperative side-channels carried from a promoting Flow (Flow.as_app).
+        for spec in self._flow_mcp:
+            kx.register_mcp_server(**spec)
+        for fact in self._flow_memory:
+            kx.store_memory(**fact)
+        saved = kx.save_app(self.to_envelope())
+        str_args = {str(k): str(v) for k, v in dict(args).items()} if args else None
+        return kx.run_app(saved.handle, args=str_args, wait=wait, timeout=timeout)
 
 
 def app(name: str, *, version: str = "1", seed: int = 0) -> App:

--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -14,7 +14,7 @@ A thin, discoverable veneer over the operator AST in :mod:`kortecx.chains`: ever
 method appends to the SAME ``_Seq`` / ``_Par`` node graph the ``>>`` / ``&`` / ``|``
 operators build, so a :class:`Flow` lowers **byte-identically** to the equivalent
 chain (the golden-corpus tri-surface contract holds by construction — a Flow is sugar,
-never a new wire shape). Defaults are filled in (served model, budget 8/6, wait) so the
+never a new wire shape). Defaults are filled in (served model, budget 8/20, wait) so the
 common case is one line; every knob stays optional. SN-8: a Flow describes TOPOLOGY
 only — the server compiles + warrants every step.
 """
@@ -56,6 +56,72 @@ def _to_node(item: "FlowItem") -> "_Node":
     if isinstance(item, str):
         return _model(prompt=item)
     return _as_node(item)
+
+
+#: The default synthesizer prompt for :meth:`Flow.swarm` / :meth:`Flow.team` — a MODEL
+#: gather step reads every parallel participant's committed output (injected as its
+#: Data-edge parents, F-7) and merges them.
+_DEFAULT_SWARM_GATHER = (
+    "You are the lead. Synthesize the parallel agents' results above into one "
+    "coherent, complete answer. Reconcile disagreements, keep what is well-supported, "
+    "and drop redundancy."
+)
+_DEFAULT_FAN_GATHER = "Combine the parallel results above into one coherent answer."
+_DEFAULT_REDUCE = "Reduce the mapper results above into one consolidated result."
+
+
+def _join_goal(text: str, goal: str) -> str:
+    """Compose a participant prompt = its role/prompt + the shared ``goal`` (if any)."""
+    return f"{text}\n\n{goal}".strip() if goal else text
+
+
+def _participant_to_node(item: "object", goal: str) -> "_Node":
+    """Resolve ONE swarm/team participant to an agentic-leaf AST node.
+
+    Accepts a prompt ``str``, a ``(prompt, tools)`` tuple, a :class:`Flow` /
+    :class:`~kortecx.chains.Task` (already task-bound — ``goal`` ignored), or an
+    :class:`~kortecx.agent.Agent` / :func:`~kortecx.personas.persona` (duck-typed on
+    ``_prompt`` to avoid the ``agent → flow`` import cycle). A persona/Agent with a
+    tool set lowers to a bounded reason→tool→observe leaf."""
+    if isinstance(item, Flow):
+        return item._require_node()
+    if isinstance(item, (Task, _Seq, _Par)):
+        return item
+    if isinstance(item, tuple):
+        prompt = str(item[0])
+        tools = item[1] if len(item) > 1 else None
+        return _model(prompt=_join_goal(prompt, goal), tools=tools)
+    if isinstance(item, str):
+        return _model(prompt=_join_goal(item, goal))
+    prompt_fn = getattr(item, "_prompt", None)
+    if callable(prompt_fn):  # duck-typed Agent / persona
+        return _model(
+            prompt_fn(goal),
+            tools=getattr(item, "tools", None),
+            model=getattr(item, "model", "") or "",
+            max_turns=getattr(item, "max_turns", None),
+            max_tool_calls=getattr(item, "max_tool_calls", None),
+            reasoning=getattr(item, "reasoning", None),
+        )
+    raise ChainError(
+        f"not a swarm participant: {item!r} — pass a prompt, (prompt, tools), an "
+        "Agent/persona, or a Flow"
+    )
+
+
+def _sink_node(
+    gather: "Optional[Union[str, FlowItem]]", synthesize: bool, default_prompt: str
+) -> "_Node":
+    """Build the fan-in sink: a MODEL synthesizer (``gather`` is a prompt string, or the
+    ``default_prompt`` when ``synthesize`` and no explicit sink), an explicit sink node
+    (a Task/Flow ``gather``), or a PURE deterministic fold (``synthesize=False``)."""
+    if isinstance(gather, str):
+        return _model(prompt=gather)
+    if gather is not None:
+        return _to_node(gather)
+    if synthesize:
+        return _model(prompt=default_prompt)
+    return _as_node(_pure())
 
 
 class Flow:
@@ -247,6 +313,105 @@ class Flow:
         for spec in self._memory:
             kx.store_memory(**spec)
 
+    # -- orchestration (RC-SW2: parallel agentic patterns; pure client composition) --
+
+    def swarm(
+        self,
+        *agents: "object",
+        goal: str = "",
+        gather: "Optional[Union[str, FlowItem]]" = None,
+        synthesize: bool = True,
+    ) -> "Flow":
+        """Fan out to N parallel agents, then gather (a **swarm**). Each ``agent`` is a
+        prompt, a ``(prompt, tools)`` tuple, an :class:`~kortecx.agent.Agent` /
+        :func:`~kortecx.personas.persona`, or a :class:`Flow`; they run **concurrently**
+        as independent deterministic-agentic steps (each its own crash-safe, replayable
+        salt-2 chain), then a gather step merges their committed outputs::
+
+            (kx.flow()
+               .swarm(kx.persona("researcher"), kx.persona("critic"), kx.persona("writer"),
+                      goal="Write a briefing on durable execution")
+               .run())
+
+        ``goal`` is the shared task each participant works on (appended to its
+        role/instructions). By default (``synthesize=True``) the gather is a MODEL step
+        that reads every participant's output (injected as its Data-edge parents) and
+        writes one coherent answer; pass ``gather="<prompt>"`` to steer that synthesis,
+        a Task/Flow for a custom sink, or ``synthesize=False`` for a PURE deterministic
+        fold. Pure client-side composition (parallel MODEL leaves → one sink) — no new
+        step kind, byte-identical to the equivalent ``[a & b] > g`` chain; the SERVER
+        drives + warrants each agent (SN-8)."""
+        if not agents:
+            raise ChainError("swarm() needs at least one agent")
+        leaves = [_participant_to_node(a, goal) for a in agents]
+        self.parallel(*leaves)
+        return self.then(_sink_node(gather, synthesize, _DEFAULT_SWARM_GATHER))
+
+    def team(
+        self,
+        *agents: "object",
+        goal: str = "",
+        gather: "Optional[Union[str, FlowItem]]" = None,
+    ) -> "Flow":
+        """A **team**: the same topology as :meth:`swarm` with a lead that synthesizes
+        (``synthesize=True``). Reads naturally for role-based personas working a shared
+        ``goal``. ``team(*a, goal=g)`` ≡ ``swarm(*a, goal=g, synthesize=True)``."""
+        return self.swarm(*agents, goal=goal, gather=gather, synthesize=True)
+
+    def fan_out_gather(
+        self,
+        *branches: "FlowItem",
+        gather: "Optional[Union[str, FlowItem]]" = None,
+        synthesize: bool = True,
+    ) -> "Flow":
+        """Fan out to N parallel ``branches`` (each a prompt / Task / Flow), then gather
+        their outputs — sample-N-ways-and-combine. Default gather = a MODEL combine
+        step; ``gather="<prompt>"`` steers it, a Task/Flow gives a custom sink, and
+        ``synthesize=False`` folds deterministically (PURE). Surfaces the recipe
+        builder's ``fan_out_gather`` topology as first-class client composition."""
+        if not branches:
+            raise ChainError("fan_out_gather() needs at least one branch")
+        leaves = [_to_node(b) for b in branches]
+        self.parallel(*leaves)
+        return self.then(_sink_node(gather, synthesize, _DEFAULT_FAN_GATHER))
+
+    def map_reduce(
+        self,
+        *mappers: "FlowItem",
+        reduce: "Optional[Union[str, FlowItem]]" = None,
+        synthesize: bool = True,
+    ) -> "Flow":
+        """Map N ``mappers`` in parallel, then reduce their outputs. Default reduce = a
+        MODEL consolidation step; ``reduce="<prompt>"`` steers it, a Task/Flow gives a
+        custom reducer, and ``synthesize=False`` reduces deterministically (PURE).
+        Surfaces the recipe builder's ``map_reduce`` topology as client composition."""
+        if not mappers:
+            raise ChainError("map_reduce() needs at least one mapper")
+        leaves = [_to_node(m) for m in mappers]
+        self.parallel(*leaves)
+        return self.then(_sink_node(reduce, synthesize, _DEFAULT_REDUCE))
+
+    def as_app(self, name: str, *, version: str = "1"):
+        """Promote this Flow to a durable, named :class:`~kortecx.app.App` — the
+        EXPLICIT boundary (D177) from ad-hoc authoring to a shareable App that runs via
+        ``RunApp`` (server-resolved connections + ``secret_scope`` + skills). Chain the
+        App rails on the result::
+
+            (kx.flow().agent("Draft and send a reply", tools=["kx-connector-gmail/send"])
+               .as_app("mailer").with_gmail().secrets(["KX_GMAIL_CREDENTIAL"])
+               .run(args={"to": "x@y.com"}))
+
+        Naming the App is deliberate: connections / skills / secret scope ride the App
+        envelope (not the lowered graph, which stays byte-identical), so a bare
+        ``Flow.run()`` — which submits a plain workflow — has no place for them. Any
+        :meth:`with_mcp` / :meth:`with_memory` side-channels carry over as pre-run
+        registrations."""
+        from .app import app as _app
+
+        built = _app(name, version=version, seed=self._seed).blueprint(self)
+        built._carry_flow_side_channels(list(self._mcp), list(self._memory))
+        return built
+
     # -- terminals --
 
     def _require_node(self) -> "_Node":
@@ -303,3 +468,49 @@ def flow(*, seed: int = 0) -> Flow:
     """Start a fluent chain: ``kx.flow().agent(...).then(...).run()``. The headline
     authoring surface — reads top-to-bottom, IDE-discoverable, defaults filled in."""
     return Flow(seed=seed)
+
+
+# -- top-level orchestration factories (a swarm is usually the whole flow) --
+
+
+def swarm(
+    *agents: "object",
+    goal: str = "",
+    gather: "Optional[Union[str, FlowItem]]" = None,
+    synthesize: bool = True,
+    seed: int = 0,
+) -> Flow:
+    """``kx.swarm(...)`` — N parallel agents → gather, as a whole flow (RC-SW2). Sugar
+    for ``kx.flow(seed=seed).swarm(...)``; see :meth:`Flow.swarm`."""
+    return flow(seed=seed).swarm(*agents, goal=goal, gather=gather, synthesize=synthesize)
+
+
+def team(
+    *agents: "object",
+    goal: str = "",
+    gather: "Optional[Union[str, FlowItem]]" = None,
+    seed: int = 0,
+) -> Flow:
+    """``kx.team(...)`` — a swarm with a lead that synthesizes; see :meth:`Flow.team`."""
+    return flow(seed=seed).team(*agents, goal=goal, gather=gather)
+
+
+def fan_out_gather(
+    *branches: "FlowItem",
+    gather: "Optional[Union[str, FlowItem]]" = None,
+    synthesize: bool = True,
+    seed: int = 0,
+) -> Flow:
+    """``kx.fan_out_gather(...)`` — sample N ways, combine; see :meth:`Flow.fan_out_gather`."""
+    return flow(seed=seed).fan_out_gather(*branches, gather=gather, synthesize=synthesize)
+
+
+def map_reduce(
+    *mappers: "FlowItem",
+    reduce: "Optional[Union[str, FlowItem]]" = None,
+    synthesize: bool = True,
+    seed: int = 0,
+) -> Flow:
+    """``kx.map_reduce(...)`` — map N mappers in parallel, then reduce; see
+    :meth:`Flow.map_reduce`."""
+    return flow(seed=seed).map_reduce(*mappers, reduce=reduce, synthesize=synthesize)

--- a/bindings/python/src/kortecx/personas.py
+++ b/bindings/python/src/kortecx/personas.py
@@ -1,0 +1,131 @@
+"""Curated **personas** — reusable, named agent instruction sets (RC-SW2).
+
+```python
+import kortecx as kx
+
+# a persona is just an Agent preset (its curated instructions become the step prompt)
+kx.swarm(kx.persona("researcher"), kx.persona("critic"), kx.persona("writer"),
+         goal="Write a briefing on durable execution").run()
+```
+
+A persona is a curated **instruction string** with a stable name. :func:`persona`
+returns an :class:`~kortecx.agent.Agent` whose ``instructions`` are that string, so a
+persona composes anywhere an Agent does — a swarm participant, a reusable
+``persona("researcher").on("topic A")`` flow, or a standalone ``.run(task)``.
+
+Personas are **identity-bearing, not presentation-only**: the instruction text folds
+into the agent step's ``config_subset[PROMPT_KEY]`` (like any prompt), so two agents
+that differ only by persona are genuinely distinct, replayable Motes — the same
+persona + task always re-derives the same ``MoteId``. This is purely client-side
+authoring sugar (a curated ``{name: instructions}`` table); the SERVER still compiles
++ warrants every step (SN-8), and the canonical projection digest is unaffected (the
+demo uses no persona — a persona only ever changes NEW motes).
+
+The library is intentionally small + provider-neutral; pass your own string to
+``Agent(instructions=...)`` for anything bespoke. ``persona(name, tools=[...])`` layers
+a tool set onto the role (making the step a bounded reason→tool→observe agent).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Union
+
+if TYPE_CHECKING:
+    from .agent import Agent
+
+#: The curated persona library: a stable ``name → instructions`` map. The strings are
+#: role framings (not tasks) — a swarm/`.on()` supplies the concrete task. Kept concise
+#: so they steer without dominating a small local model's context window.
+PERSONAS: "dict[str, str]" = {
+    "researcher": (
+        "You are a meticulous researcher. Gather the relevant facts, cite concrete "
+        "evidence, separate what is known from what is inferred, and flag gaps or "
+        "uncertainty explicitly. Prefer primary detail over generalities."
+    ),
+    "analyst": (
+        "You are a rigorous analyst. Break the problem into parts, reason step by step, "
+        "quantify where you can, and state the assumptions behind each conclusion. Call "
+        "out the strongest and weakest points of your own analysis."
+    ),
+    "critic": (
+        "You are a sharp, fair critic. Find the flaws, unstated assumptions, edge cases, "
+        "and failure modes in the material under review. Be specific and constructive: "
+        "for each problem, say why it matters and what would fix it."
+    ),
+    "skeptic": (
+        "You are a disciplined skeptic. Challenge every claim: ask what evidence supports "
+        "it, what would falsify it, and where it could be wrong. Do not accept a "
+        "conclusion until it survives scrutiny; say plainly when it does not."
+    ),
+    "planner": (
+        "You are a decisive planner. Turn the goal into an ordered, concrete plan: the "
+        "steps, their dependencies, the owner or tool for each, and the risks. Prefer the "
+        "simplest plan that achieves the goal; make the sequencing explicit."
+    ),
+    "strategist": (
+        "You are a strategist. Consider the options, their trade-offs, and second-order "
+        "effects, then recommend one course of action with the reasoning behind it. Be "
+        "explicit about what you are optimizing for and what you are trading away."
+    ),
+    "engineer": (
+        "You are a pragmatic engineer. Produce correct, minimal, maintainable solutions; "
+        "handle edge cases and failure paths; and explain the key design decisions. "
+        "Prefer clarity over cleverness and state the assumptions you relied on."
+    ),
+    "writer": (
+        "You are a clear, precise writer. Turn the material into well-structured prose "
+        "with a strong through-line: lead with the point, support it concisely, and cut "
+        "filler. Match the tone to the audience; never invent facts."
+    ),
+    "editor": (
+        "You are a careful editor. Tighten the writing for clarity, accuracy, and flow "
+        "without changing the meaning. Fix structure, remove redundancy, and flag any "
+        "claim that is unsupported or ambiguous."
+    ),
+    "summarizer": (
+        "You are a faithful summarizer. Distill the material to its essential points in "
+        "the fewest words that preserve meaning. Keep the load-bearing details, drop the "
+        "rest, and never introduce information that was not present."
+    ),
+}
+
+
+def persona_names() -> "List[str]":
+    """The sorted names in the curated persona library."""
+    return sorted(PERSONAS)
+
+
+def persona(
+    name: str,
+    *,
+    tools: "Optional[Union[Sequence[object], Mapping[str, str]]]" = None,
+    model: str = "",
+    max_turns: "Optional[int]" = None,
+    max_tool_calls: "Optional[int]" = None,
+    reasoning: "Optional[str]" = None,
+    dynamic: bool = False,
+) -> "Agent":
+    """Return an :class:`~kortecx.agent.Agent` preset with the curated ``name`` role.
+
+    Layer a tool set with ``tools=[...]`` to make the persona a bounded
+    reason→tool→observe agent. Compose it directly (``kx.swarm(persona("critic"),
+    ...)``), bind a task (``persona("researcher").on("topic")``), or run it standalone
+    (``persona("writer").run("draft the intro")``). Raises :class:`KeyError` for an
+    unknown name — pass ``Agent(instructions=...)`` with your own string for a bespoke
+    role."""
+    from .agent import Agent
+
+    if name not in PERSONAS:
+        raise KeyError(
+            f"unknown persona {name!r} — known: {persona_names()} "
+            "(or use Agent(instructions=...) with your own role)"
+        )
+    return Agent(
+        PERSONAS[name],
+        tools=tools,
+        model=model,
+        max_turns=max_turns,
+        max_tool_calls=max_tool_calls,
+        reasoning=reasoning,
+        dynamic=dynamic,
+    )

--- a/bindings/python/tests/test_swarm_personas.py
+++ b/bindings/python/tests/test_swarm_personas.py
@@ -1,0 +1,216 @@
+"""RC-SW2 — swarm/team authoring, the persona library, and the App.run→RunApp fix.
+
+All client-side (no server): the swarm/fan-out/map-reduce methods lower to the same
+``[a & b] > g`` topology the golden corpus pins, personas fold into an agent's prompt,
+and ``App.run`` routes through ``SaveApp`` + ``RunApp`` (never a local ``submit_workflow``
+recompile — the regression that dropped ``references.connections`` + ``secret_scope``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import kortecx as kx
+from kortecx.chains import ChainError
+
+# ---- swarm / team / fan_out_gather / map_reduce lowering (client-side) ----
+
+
+def test_swarm_lowers_to_parallel_agentic_leaves_then_synthesizer() -> None:
+    f = kx.swarm(
+        ("Analyze the market", ["mcp-echo/echo"]),
+        ("Critique the analysis", ["mcp-echo/echo"]),
+        goal="the Q3 plan",
+    )
+    low = f.lowering()
+    assert len(low["steps"]) == 3, "2 agentic leaves + 1 synthesizer"
+    # the two leaves are agentic MODEL steps (tool_contract set), goal appended.
+    for i in (0, 1):
+        assert low["steps"][i]["kind"] == "model"
+        assert low["steps"][i]["tool_contract"] == {"mcp-echo/echo": "1"}
+        assert low["steps"][i]["prompt"].endswith("the Q3 plan")
+    # the gather is a plain MODEL synthesizer (no tools) that fans in both leaves.
+    assert low["steps"][2]["kind"] == "model"
+    assert low["steps"][2]["tool_contract"] == {}
+    assert low["edges"] == [
+        {"parent": 0, "child": 2, "edge": "data"},
+        {"parent": 1, "child": 2, "edge": "data"},
+    ]
+
+
+def test_swarm_is_byte_identical_to_the_equivalent_chain() -> None:
+    # A swarm is pure composition — it lowers to exactly the `[a@echo & b@echo] > g`
+    # topology the string DSL authors (the tri-surface golden contract).
+    sw = kx.swarm(("A", ["echo"]), ("B", ["echo"]), gather="Merge")
+    dsl = kx.chain(
+        "[a & b] > g",
+        {
+            "a": kx.model(prompt="A", tools=["echo"]),
+            "b": kx.model(prompt="B", tools=["echo"]),
+            "g": kx.model(prompt="Merge"),
+        },
+    )
+    assert sw.lowering() == dsl.lowering()
+
+
+def test_team_defaults_to_a_model_synthesizer() -> None:
+    t = kx.team(kx.persona("researcher"), kx.persona("critic"), goal="write a brief")
+    low = t.lowering()
+    assert len(low["steps"]) == 3
+    assert low["steps"][2]["kind"] == "model" and low["steps"][2]["prompt"]
+
+
+def test_swarm_synthesize_false_uses_a_pure_gather() -> None:
+    low = kx.swarm("sample A", "sample B", synthesize=False).lowering()
+    assert low["steps"][2]["kind"] == "pure"
+
+
+def test_fan_out_gather_and_map_reduce_lower_to_fan_in() -> None:
+    fog = kx.fan_out_gather("angle 1", "angle 2", "angle 3", gather="combine").lowering()
+    assert len(fog["steps"]) == 4 and len(fog["edges"]) == 3
+    mr = kx.map_reduce("map A", "map B", reduce="reduce").lowering()
+    assert len(mr["steps"]) == 3 and len(mr["edges"]) == 2
+
+
+def test_swarm_accepts_agents_flows_and_personas() -> None:
+    a = kx.Agent("You are an analyst.", tools=["mcp-echo/echo"])
+    f = kx.flow().swarm(
+        a,  # an Agent
+        kx.persona("writer"),  # a persona → Agent
+        "just a prompt",  # a bare string
+        kx.flow().agent("a sub-flow branch"),  # a Flow
+        goal="the topic",
+    )
+    low = f.lowering()
+    assert len(low["steps"]) == 5  # 4 leaves + synthesizer
+    assert low["steps"][0]["tool_contract"] == {"mcp-echo/echo": "1"}
+
+
+def test_empty_swarm_is_an_error() -> None:
+    with pytest.raises(ChainError):
+        kx.swarm()
+    with pytest.raises(ChainError):
+        kx.flow().fan_out_gather()
+
+
+# ---- personas ----
+
+
+def test_persona_library_and_factory() -> None:
+    assert "researcher" in kx.persona_names()
+    r = kx.persona("researcher", tools=["retrieve"])
+    assert isinstance(r, kx.Agent)
+    assert r.instructions == kx.PERSONAS["researcher"]
+    assert r.tools == ["retrieve"]
+
+
+def test_agent_persona_kwarg_and_on_alias() -> None:
+    a = kx.Agent(persona="critic")
+    assert a.instructions == kx.PERSONAS["critic"]
+    # explicit instructions layer on top of the curated role.
+    a2 = kx.Agent("Focus on security.", persona="critic")
+    assert a2.instructions.startswith(kx.PERSONAS["critic"])
+    assert a2.instructions.endswith("Focus on security.")
+    # .on(task) is an alias of .as_flow(task).
+    assert a.on("review X").lowering() == a.as_flow("review X").lowering()
+
+
+def test_unknown_persona_raises() -> None:
+    with pytest.raises(KeyError):
+        kx.persona("nonexistent")
+    with pytest.raises(KeyError):
+        kx.Agent(persona="nonexistent")
+
+
+# ---- App.run → SaveApp + RunApp (the integration-in-app fix) ----
+
+
+class _FakeClient:
+    """Records the terminal calls App.run makes, so we can assert it routes through
+    SaveApp + RunApp and NEVER the references-dropping local submit_workflow."""
+
+    def __init__(self) -> None:
+        self.saved: list = []
+        self.ran: list = []
+        self.submitted: list = []
+        self.registered: list = []
+        self.memories: list = []
+
+    def put_content(self, data, media_type=""):  # for _resolve_pending
+        class _R:
+            content_ref = "a" * 64
+
+        return _R()
+
+    def save_app(self, envelope, handle=None):
+        self.saved.append((envelope, handle))
+
+        class _S:
+            pass
+
+        s = _S()
+        s.handle = "apps/local/mailer"
+        return s
+
+    def run_app(self, handle, *, args=None, wait=True, timeout=120.0):
+        self.ran.append((handle, args, wait))
+        return {"ran": handle}
+
+    def submit_workflow(self, request, *, wait=True, timeout=120.0):
+        self.submitted.append(request)  # must stay empty
+        return {"submitted": True}
+
+    def register_mcp_server(self, **spec):
+        self.registered.append(spec)
+
+    def store_memory(self, **spec):
+        self.memories.append(spec)
+
+
+def test_app_run_routes_through_save_and_run_app_not_submit_workflow() -> None:
+    fake = _FakeClient()
+    out = (
+        kx.app("mailer")
+        .blueprint(kx.flow().agent("Draft and send", tools=["kx-connector-gmail/send"]))
+        .with_gmail()
+        .run(args={"to": "x@y.com"}, client=fake)
+    )
+    assert out == {"ran": "apps/local/mailer"}
+    assert len(fake.saved) == 1, "App.run saves the envelope (an explicitly-named App)"
+    assert fake.ran == [("apps/local/mailer", {"to": "x@y.com"}, True)]
+    assert fake.submitted == [], "must NOT drop to submit_workflow (that loses references)"
+    # the saved envelope carried the connection + secret_scope RunApp needs.
+    env = fake.saved[0][0]
+    assert env["references"]["connections"][0]["descriptor"] == "kx-connector-gmail"
+    assert env["steering_config"]["guards"]["secret_scope"] == ["KX_GMAIL_CREDENTIAL"]
+
+
+def test_with_discord_and_secrets() -> None:
+    env = (
+        kx.app("notifier")
+        .blueprint(kx.flow().agent("post an update", tools=["kx-connector-discord/send_message"]))
+        .with_discord()
+        .secrets("KX_EXTRA_CRED")
+        .to_envelope()
+    )
+    conns = env["references"]["connections"]
+    assert conns[0]["descriptor"] == "kx-connector-discord"
+    assert conns[0]["credential_ref"] == "KX_DISCORD_CREDENTIAL"
+    scope = env["steering_config"]["guards"]["secret_scope"]
+    assert "KX_DISCORD_CREDENTIAL" in scope and "KX_EXTRA_CRED" in scope
+
+
+def test_flow_as_app_promotes_topology_and_carries_side_channels() -> None:
+    fake = _FakeClient()
+    (
+        kx.flow()
+        .with_mcp("fs", endpoint="npx", args=["-y", "server-filesystem", "/data"])
+        .agent("list /data", tools=["fs/list_directory"])
+        .as_app("lister")
+        .with_gmail()
+        .run(client=fake)
+    )
+    # the blueprint topology carried; the with_mcp side-channel registered pre-run.
+    assert len(fake.saved) == 1
+    assert fake.registered and fake.registered[0]["name"] == "fs"
+    assert fake.ran and fake.ran[0][0] == "apps/local/mailer"

--- a/bindings/typescript/src/agent.ts
+++ b/bindings/typescript/src/agent.ts
@@ -20,6 +20,7 @@ import type { ImageInput } from "./client.js";
 import { getDefaultClient } from "./default-client.js";
 import { KxNotFound, KxUsage } from "./errors.js";
 import { type FlowClient, flow } from "./flow.js";
+import { PERSONAS } from "./personas.js";
 import type { Result, Run } from "./run.js";
 import { KxToolError, type LocalToolDef, registerLocalTools } from "./tools.js";
 
@@ -39,6 +40,10 @@ export interface AgentOptions {
   reasoning?: ReasoningMode;
   /** `false` (default) = the deterministic/frozen lane; `true` = the steered react recipe. */
   dynamic?: boolean;
+  /** RC-SW2: a curated persona name (from {@link import("./personas.js").PERSONAS}) whose
+   * role instructions become this agent's base instructions. Any explicit `instructions`
+   * layer on top. Throws for an unknown name. */
+  persona?: string;
 }
 
 /** The client surface {@link Agent.run} needs: `runChain` (frozen) + `invoke` (dynamic)
@@ -87,10 +92,23 @@ function hasTools(tools: AgentOptions["tools"]): boolean {
 
 /** A reusable agent: instructions + an optional tool set + model/loop config. */
 export class Agent {
+  readonly instructions: string;
+
   constructor(
-    readonly instructions = "",
+    instructions = "",
     readonly opts: AgentOptions = {},
-  ) {}
+  ) {
+    let resolved = instructions;
+    if (opts.persona !== undefined) {
+      const base = PERSONAS[opts.persona];
+      if (base === undefined) {
+        throw new KxUsage(`unknown persona ${JSON.stringify(opts.persona)}`);
+      }
+      // A curated role; explicit `instructions` (if any) layer on top of it.
+      resolved = instructions ? `${base}\n\n${instructions}`.trim() : base;
+    }
+    this.instructions = resolved;
+  }
 
   private prompt(task: string): string {
     return this.instructions ? `${this.instructions}\n\n${task}`.trim() : task;
@@ -105,6 +123,12 @@ export class Agent {
       maxToolCalls: this.opts.maxToolCalls,
       reasoning: this.opts.reasoning,
     });
+  }
+
+  /** Bind this agent to `task` → a {@link import("./flow.js").Flow} (a thin alias of
+   * {@link Agent.asFlow}; reads as `researcher.on("topic A")`). */
+  on(task: string) {
+    return this.asFlow(task);
   }
 
   /**

--- a/bindings/typescript/src/app.ts
+++ b/bindings/typescript/src/app.ts
@@ -24,10 +24,10 @@
 
 import { APP_SCHEMA, type SaveAppResult, type Skill, prettyJson } from "./apps.js";
 import type { DagSpecJson } from "./chains.js";
-import { Chain } from "./chains.js";
 import { getDefaultClient } from "./default-client.js";
 import { KxUsage } from "./errors.js";
 import { flow } from "./flow.js";
+import type { RegisterMcpServerInput } from "./toolscout.js";
 
 /** Anything that can produce a portable blueprint (a Flow or a Chain). */
 export interface BlueprintSource {
@@ -38,7 +38,16 @@ export interface BlueprintSource {
 export interface AppClient {
   putContent(payload: Uint8Array, opts?: { mediaType?: string }): Promise<{ contentRef: string }>;
   saveApp(envelope: unknown, opts?: { handle?: string }): Promise<SaveAppResult>;
-  submitWorkflow(request: unknown, opts?: { wait?: boolean; timeoutMs?: number }): Promise<unknown>;
+  /** RC-SW2: the App run path — SaveApp + RunApp so `references.connections` +
+   * `guards.secret_scope` reach the server (a credentialed connector can be dialed). */
+  runApp(
+    handle: string,
+    opts?: { wait?: boolean; timeoutMs?: number; args?: Record<string, string> },
+  ): Promise<unknown>;
+  /** OPTIONAL — used only when a promoting Flow (`asApp`) carried `withMcp` connectors. */
+  registerMcpServer?(input: RegisterMcpServerInput): Promise<unknown>;
+  /** OPTIONAL — used only when a promoting Flow (`asApp`) carried `withMemory` facts. */
+  storeMemory?(content: string | Uint8Array, opts?: { kind?: number }): Promise<unknown>;
 }
 
 function resolveClient(explicit?: AppClient): AppClient {
@@ -67,6 +76,10 @@ type ConnectionEntry = { descriptor: string; credential_ref: string };
  * Mirrors the CLI `kx connections add --provider gmail` + the Python SDK. */
 const GMAIL_CONNECTOR_COMMAND = "kx-connector-gmail";
 const GMAIL_CREDENTIAL_REF = "KX_GMAIL_CREDENTIAL";
+/** RC-SW2: the curated Discord provider defaults (the bundled `kx-connector-discord`
+ * sidecar, #277). Mirrors `withGmail` + the Python SDK. */
+const DISCORD_CONNECTOR_COMMAND = "kx-connector-discord";
+const DISCORD_CREDENTIAL_REF = "KX_DISCORD_CREDENTIAL";
 type Pending = { rail: string; name: string; body: string; skill?: Skill };
 
 /** A fluent App builder. Each method returns `this`; terminate with
@@ -91,6 +104,11 @@ export class AppBuilder {
   private _maxTurns?: number;
   private _maxToolCalls?: number;
   private _branchHandle = "";
+  /** RC-SW2: imperative pre-run registrations carried from a Flow via {@link Flow.asApp}
+   * (with_mcp connectors / with_memory facts). {@link run} executes them before RunApp.
+   * Never part of the envelope (off the golden digest). */
+  private _flowMcp: RegisterMcpServerInput[] = [];
+  private _flowMemory: string[] = [];
 
   constructor(
     private readonly _name: string,
@@ -191,6 +209,35 @@ export class AppBuilder {
    * runtime with `kx connections add --provider gmail`. */
   withGmail(): this {
     return this.withConnection(GMAIL_CONNECTOR_COMMAND, GMAIL_CREDENTIAL_REF);
+  }
+
+  /** RC-SW2: declare the bundled Discord connector (the curated provider default) —
+   * equivalent to `withConnection("kx-connector-discord", "KX_DISCORD_CREDENTIAL")`.
+   * Register with `kx connections add --command kx-connector-discord --credential-ref
+   * KX_DISCORD_CREDENTIAL`. */
+  withDiscord(): this {
+    return this.withConnection(DISCORD_CONNECTOR_COMMAND, DISCORD_CREDENTIAL_REF);
+  }
+
+  /** Add secret NAMES to `guards.secret_scope` — the run warrant's
+   * `SecretScope::AllowList` narrows to these so a granted connector may be dialed inside
+   * the agentic loop (G2/#285). The VALUE never travels (D81). A scope name is bounded
+   * server-side by the referenced connections — pair it with the matching
+   * {@link withConnection} / {@link withGmail} / {@link withDiscord}, or the entry is
+   * inert (fails closed). Usually implicit via `withConnection(..., { scopeSecret: true })`. */
+  secrets(names: string | string[]): this {
+    for (const name of typeof names === "string" ? [names] : names) {
+      if (name && !this._secretScope.includes(name)) this._secretScope.push(name);
+    }
+    return this;
+  }
+
+  /** Carry a promoting Flow's imperative side-channels (with_mcp connectors + with_memory
+   * facts) so {@link run} registers them before RunApp. Set by {@link Flow.asApp}; never
+   * part of the envelope. */
+  carryFlowSideChannels(mcp: readonly RegisterMcpServerInput[], memory: readonly string[]): void {
+    this._flowMcp = [...mcp];
+    this._flowMemory = [...memory];
   }
 
   /** Set steering knobs (a WISH the server re-resolves at bind — never authority). */
@@ -318,17 +365,37 @@ export class AppBuilder {
     return client.saveApp(this.toEnvelope(), { handle: opts.handle });
   }
 
-  /** Compile this App's blueprint and run it (exactly-once). The server re-resolves
-   * every warrant from the caller's grants (SN-8). */
+  /** Save this App and run it via `RunApp` (exactly-once). `args` (the App's input schema)
+   * fold server-side into the entry step's prompt.
+   *
+   * RC-SW2 fix: routes through `SaveApp` + `RunApp` instead of a local `submitWorkflow`
+   * recompile — so the App's `references.connections` + `guards.secret_scope` reach the
+   * server and a credentialed connector (Gmail / Discord) actually fires inside the
+   * agentic loop (the G2/#285 path). Saving is expected: an App is an explicitly-named
+   * durable object; the save is idempotent (content-addressed envelope + handle upsert).
+   * The server re-resolves every warrant from the caller's grants (SN-8). */
   async run(
-    _args: Readonly<Record<string, unknown>> = {},
+    args: Readonly<Record<string, unknown>> = {},
     opts: { wait?: boolean; timeoutMs?: number; client?: AppClient } = {},
   ): Promise<unknown> {
     const client = resolveClient(opts.client);
     await this.resolvePending(client);
-    const blueprint = this.toEnvelope().blueprint as DagSpecJson;
-    const request = Chain.fromBlueprint(blueprint);
-    return client.submitWorkflow(request, { wait: opts.wait ?? true, timeoutMs: opts.timeoutMs });
+    // Imperative side-channels carried from a promoting Flow (Flow.asApp).
+    if (this._flowMcp.length > 0 && typeof client.registerMcpServer === "function") {
+      for (const spec of this._flowMcp) await client.registerMcpServer(spec);
+    }
+    if (this._flowMemory.length > 0 && typeof client.storeMemory === "function") {
+      for (const fact of this._flowMemory) await client.storeMemory(fact);
+    }
+    const saved = await client.saveApp(this.toEnvelope());
+    const entries = Object.entries(args);
+    const strArgs =
+      entries.length > 0 ? Object.fromEntries(entries.map(([k, v]) => [k, String(v)])) : undefined;
+    return client.runApp(saved.handle, {
+      args: strArgs,
+      wait: opts.wait ?? true,
+      timeoutMs: opts.timeoutMs,
+    });
   }
 }
 

--- a/bindings/typescript/src/chains.ts
+++ b/bindings/typescript/src/chains.ts
@@ -239,7 +239,7 @@ export const task = {
    * `{ name: version }` map) to make it a **deterministic-agentic step** — the model
    * runs a bounded reason→tool→observe loop over the granted tool SET (the same step
    * the string DSL authors as `handle@tool@tool`). `opts.maxTurns` / `maxToolCalls`
-   * bound the loop (default 8 / 6; ignored with no tools).
+   * bound the loop (default 8 / 20 — decoupled, a turn may fire N tools; ignored with no tools).
    */
   model(
     modelId = "",

--- a/bindings/typescript/src/common.ts
+++ b/bindings/typescript/src/common.ts
@@ -127,6 +127,17 @@ export type {
 // Batch V2 — the fluent builder + first-class Agent (the headline authoring surface).
 export { Flow, flow } from "./flow.js";
 export type { FlowItem, AgentStepOptions, FlowClient } from "./flow.js";
+// RC-SW2 — multi-agent swarm authoring + a curated persona library (pure client
+// composition: N parallel agentic leaves → gather; personas fold into the step prompt).
+export { swarm, team, fanOutGather, mapReduce } from "./flow.js";
+export type {
+  SwarmParticipant,
+  SwarmOptions,
+  TeamOptions,
+  FanOptions,
+  ReduceOptions,
+} from "./flow.js";
+export { PERSONAS, persona, personaNames } from "./personas.js";
 // POC-4 — the App builder + envelope (kortecx.app/v1) + catalog views.
 export { app, AppBuilder, minimalAppEnvelope } from "./app.js";
 export type { BlueprintSource, AppClient } from "./app.js";
@@ -245,7 +256,14 @@ export type {
 export { WaitState } from "./wait.js";
 export type { WaitOutcome, WaitMode } from "./wait.js";
 
-export { KxClientBase, VISION_RECIPE_HANDLE } from "./client.js";
+export {
+  KxClientBase,
+  VISION_RECIPE_HANDLE,
+  // RC4b: the agentic-RAG / vision recipe handles (parity with the Python SDK barrel).
+  REACT_RAG_RECIPE_HANDLE,
+  VISION_RAG_RECIPE_HANDLE,
+  REACT_VISION_RECIPE_HANDLE,
+} from "./client.js";
 export type { KxClientOptions, InvokeOptions, Id, ImageInput } from "./client.js";
 
 export { DEFAULT_ENDPOINT, isNonloopbackPlaintext } from "./transport.js";

--- a/bindings/typescript/src/defaults.ts
+++ b/bindings/typescript/src/defaults.ts
@@ -155,3 +155,13 @@ export function run(
 export function invoke(handle: string, args: Args, opts?: InvokeOptions): Promise<Run | Result> {
   return defaultClient().invoke(handle, args, opts);
 }
+
+/** Module-level convenience — a grounded chat via the default client (the TS mirror of
+ * Python's `kx.chat`). Pass `dataset` (+ optional `k`) to auto-RAG the answer over a
+ * dataset's retrieved text; returns the answer text. */
+export function chat(
+  prompt: string,
+  opts: { dataset?: string; k?: number; timeoutMs?: number } = {},
+): Promise<string> {
+  return defaultClient().chat(prompt, opts);
+}

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -67,11 +67,12 @@ const DEFAULT_FAN_GATHER = "Combine the parallel results above into one coherent
 const DEFAULT_REDUCE = "Reduce the mapper results above into one consolidated result.";
 
 /** A swarm/team participant (RC-SW2): a prompt, a `[prompt, tools]` tuple, an Agent /
- * persona (duck-typed), or a Frag. */
+ * persona (duck-typed), a {@link Flow} (already task-bound), or a Frag. */
 export type SwarmParticipant =
   | string
   | readonly [string, AgentStepOptions["tools"]?]
   | Frag
+  | Flow
   | AgentLike;
 
 /** The minimal Agent shape a participant can be (duck-typed to avoid the flow↔agent

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -18,6 +18,7 @@
  */
 
 import type { MessageInitShape } from "@bufbuild/protobuf";
+import { type AppBuilder, app } from "./app.js";
 import {
   type Chain,
   ChainParseError,
@@ -55,6 +56,78 @@ const IMAGE_REF_KEY = "image_ref";
 function toFrag(item: FlowItem): Frag {
   // A bare string is an agent (MODEL) step with all-default config (the common case).
   return typeof item === "string" ? task.model("", item) : item;
+}
+
+/** The default synthesizer prompt for {@link Flow.swarm} / {@link Flow.team} — a MODEL
+ * gather reads every participant's committed output (its Data-edge parents, F-7). */
+const DEFAULT_SWARM_GATHER =
+  "You are the lead. Synthesize the parallel agents' results above into one coherent, " +
+  "complete answer. Reconcile disagreements, keep what is well-supported, and drop redundancy.";
+const DEFAULT_FAN_GATHER = "Combine the parallel results above into one coherent answer.";
+const DEFAULT_REDUCE = "Reduce the mapper results above into one consolidated result.";
+
+/** A swarm/team participant (RC-SW2): a prompt, a `[prompt, tools]` tuple, an Agent /
+ * persona (duck-typed), or a Frag. */
+export type SwarmParticipant =
+  | string
+  | readonly [string, AgentStepOptions["tools"]?]
+  | Frag
+  | AgentLike;
+
+/** The minimal Agent shape a participant can be (duck-typed to avoid the flow↔agent
+ * import cycle): public `instructions` + an `opts` config bag. */
+interface AgentLike {
+  instructions: string;
+  opts: AgentStepOptions & { dynamic?: boolean; persona?: string };
+}
+
+function isAgentLike(x: unknown): x is AgentLike {
+  return (
+    typeof x === "object" &&
+    x !== null &&
+    typeof (x as AgentLike).instructions === "string" &&
+    typeof (x as AgentLike).opts === "object"
+  );
+}
+
+/** Options for {@link Flow.swarm} / the top-level {@link swarm}. */
+export interface SwarmOptions {
+  /** The shared task each participant works on (appended to its role/prompt). */
+  goal?: string;
+  /** The gather sink: a synthesis prompt (a MODEL step) or an explicit Frag. Default = a
+   * MODEL synthesizer with a sensible prompt. */
+  gather?: string | Frag;
+  /** `true` (default) = a MODEL synthesizer gather; `false` = a PURE deterministic fold. */
+  synthesize?: boolean;
+}
+/** Options for {@link Flow.team} (a swarm that always synthesizes). */
+export type TeamOptions = Omit<SwarmOptions, "synthesize">;
+/** Options for {@link Flow.fanOutGather}. */
+export interface FanOptions {
+  gather?: string | Frag;
+  synthesize?: boolean;
+}
+/** Options for {@link Flow.mapReduce}. */
+export interface ReduceOptions {
+  reduce?: string | Frag;
+  synthesize?: boolean;
+}
+
+function joinGoal(text: string, goal: string): string {
+  return goal ? `${text}\n\n${goal}`.trim() : text;
+}
+
+/** Build the fan-in sink: a MODEL synthesizer (`gather` a prompt string, or the
+ * `defaultPrompt` when `synthesize`), an explicit sink Frag, or a PURE fold. */
+function sinkFrag(
+  gather: string | Frag | undefined,
+  synthesize: boolean,
+  defaultPrompt: string,
+): Frag {
+  if (typeof gather === "string") return task.model("", gather);
+  if (gather !== undefined) return gather;
+  if (synthesize) return task.model("", defaultPrompt);
+  return task.pure({});
 }
 
 /** A minimal client surface the Flow terminals need (avoids a node/web import cycle).
@@ -265,6 +338,106 @@ export class Flow {
     for (const fact of this.memoryFacts) await client.storeMemory(fact);
   }
 
+  // -- orchestration (RC-SW2: parallel agentic patterns; pure client composition) --
+
+  /** Resolve ONE swarm participant to an agentic-leaf Frag (mirrors Python
+   * `_participant_to_node`; Agents duck-typed to avoid the flow↔agent cycle). */
+  private resolveParticipant(item: SwarmParticipant, goal: string): Frag {
+    if (typeof item === "string") return task.model("", joinGoal(item, goal));
+    if (Array.isArray(item)) {
+      const [prompt, tools] = item as readonly [string, AgentStepOptions["tools"]?];
+      return task.model("", joinGoal(String(prompt), goal), {}, { tools });
+    }
+    if (item instanceof Flow) {
+      if (item.node === undefined) throw new ChainParseError("empty flow participant");
+      return item.node;
+    }
+    if (isAgentLike(item)) {
+      const base = item.instructions;
+      return task.model(
+        "",
+        base ? joinGoal(base, goal) : goal,
+        {},
+        {
+          tools: item.opts.tools,
+          maxTurns: item.opts.maxTurns,
+          maxToolCalls: item.opts.maxToolCalls,
+          reasoning: item.opts.reasoning,
+        },
+      );
+    }
+    return item as Frag;
+  }
+
+  /** Fan out to N parallel agents, then gather (a **swarm**). Each participant is a
+   * prompt, a `[prompt, tools]` tuple, an Agent / persona, or a Flow; they run
+   * CONCURRENTLY as independent deterministic-agentic steps (each its own crash-safe
+   * salt-2 chain), then a gather step merges their committed outputs:
+   *
+   * ```ts
+   * await kx.flow()
+   *   .swarm([kx.persona("researcher"), kx.persona("critic"), kx.persona("writer")],
+   *          { goal: "Write a briefing on durable execution" })
+   *   .run();
+   * ```
+   *
+   * `opts.goal` is the shared task each participant works on. By default
+   * (`synthesize: true`) the gather is a MODEL step that reads every participant's output
+   * (its Data-edge parents, F-7) and writes one answer; `opts.gather: "<prompt>"` steers
+   * it, a Frag gives a custom sink, and `synthesize: false` folds deterministically
+   * (PURE). Pure client composition — byte-identical to the equivalent `[a & b] > g`
+   * chain; no new step kind. */
+  swarm(participants: SwarmParticipant[], opts: SwarmOptions = {}): this {
+    if (participants.length === 0) throw new ChainParseError("swarm() needs at least one agent");
+    const goal = opts.goal ?? "";
+    this.parallel(...participants.map((a) => this.resolveParticipant(a, goal)));
+    return this.then(sinkFrag(opts.gather, opts.synthesize ?? true, DEFAULT_SWARM_GATHER));
+  }
+
+  /** A **team**: the same topology as {@link Flow.swarm} with a lead that synthesizes.
+   * `team(a, { goal })` ≡ `swarm(a, { goal, synthesize: true })`. */
+  team(participants: SwarmParticipant[], opts: TeamOptions = {}): this {
+    return this.swarm(participants, { ...opts, synthesize: true });
+  }
+
+  /** Fan out to N parallel `branches` (each a prompt / Frag), then gather —
+   * sample-N-ways-and-combine. `opts.gather` steers the sink; `synthesize: false` folds
+   * deterministically (PURE). */
+  fanOutGather(branches: FlowItem[], opts: FanOptions = {}): this {
+    if (branches.length === 0)
+      throw new ChainParseError("fanOutGather() needs at least one branch");
+    this.parallel(...branches);
+    return this.then(sinkFrag(opts.gather, opts.synthesize ?? true, DEFAULT_FAN_GATHER));
+  }
+
+  /** Map N `mappers` in parallel, then reduce. `opts.reduce` steers the reducer;
+   * `synthesize: false` reduces deterministically (PURE). */
+  mapReduce(mappers: FlowItem[], opts: ReduceOptions = {}): this {
+    if (mappers.length === 0) throw new ChainParseError("mapReduce() needs at least one mapper");
+    this.parallel(...mappers);
+    return this.then(sinkFrag(opts.reduce, opts.synthesize ?? true, DEFAULT_REDUCE));
+  }
+
+  /** Promote this Flow to a durable, named {@link import("./app.js").AppBuilder} — the
+   * EXPLICIT boundary (D177) from ad-hoc authoring to a shareable App that runs via
+   * `RunApp` (server-resolved connections + secret_scope + skills). Chain the App rails
+   * on the result:
+   *
+   * ```ts
+   * await kx.flow().agent("Draft and send a reply", { tools: ["kx-connector-gmail/send"] })
+   *   .asApp("mailer").withGmail().secrets(["KX_GMAIL_CREDENTIAL"])
+   *   .run({ to: "x@y.com" });
+   * ```
+   *
+   * Naming is deliberate: connections / skills / secret scope ride the App envelope
+   * (not the byte-identical lowered graph), so a bare `Flow.run()` has no place for them.
+   * Any `withMcp` / `withMemory` side-channels carry over as pre-run registrations. */
+  asApp(name: string, opts: { version?: string } = {}): AppBuilder {
+    const built = app(name, opts).blueprint(this);
+    built.carryFlowSideChannels(this.mcp, this.memoryFacts);
+    return built;
+  }
+
   /** Lower this flow to a {@link Chain}. */
   toChain(): Chain {
     if (this.node === undefined) {
@@ -318,4 +491,37 @@ export class Flow {
  * authoring surface — reads top-to-bottom, IDE-discoverable, defaults filled in. */
 export function flow(opts: { seed?: number } = {}): Flow {
   return new Flow(opts);
+}
+
+// -- top-level orchestration factories (a swarm is usually the whole flow) --
+
+/** `swarm(participants, opts)` — N parallel agents → gather, as a whole flow (RC-SW2).
+ * Sugar for `flow(seed).swarm(...)`; see {@link Flow.swarm}. */
+export function swarm(
+  participants: SwarmParticipant[],
+  opts: SwarmOptions & { seed?: number } = {},
+): Flow {
+  return flow({ seed: opts.seed }).swarm(participants, opts);
+}
+
+/** `team(participants, opts)` — a swarm with a lead that synthesizes; see {@link Flow.team}. */
+export function team(
+  participants: SwarmParticipant[],
+  opts: TeamOptions & { seed?: number } = {},
+): Flow {
+  return flow({ seed: opts.seed }).team(participants, opts);
+}
+
+/** `fanOutGather(branches, opts)` — sample N ways, combine; see {@link Flow.fanOutGather}. */
+export function fanOutGather(
+  branches: FlowItem[],
+  opts: FanOptions & { seed?: number } = {},
+): Flow {
+  return flow({ seed: opts.seed }).fanOutGather(branches, opts);
+}
+
+/** `mapReduce(mappers, opts)` — map N mappers in parallel, then reduce; see
+ * {@link Flow.mapReduce}. */
+export function mapReduce(mappers: FlowItem[], opts: ReduceOptions & { seed?: number } = {}): Flow {
+  return flow({ seed: opts.seed }).mapReduce(mappers, opts);
 }

--- a/bindings/typescript/src/personas.ts
+++ b/bindings/typescript/src/personas.ts
@@ -1,0 +1,83 @@
+/**
+ * Curated **personas** — reusable, named agent instruction sets (RC-SW2), the TS
+ * mirror of `kortecx.personas`.
+ *
+ * ```ts
+ * import * as kx from "@kortecx/sdk";
+ *
+ * await kx.swarm(kx.persona("researcher"), kx.persona("critic"), kx.persona("writer"),
+ *                { goal: "Write a briefing on durable execution" }).run();
+ * ```
+ *
+ * A persona is a curated instruction string with a stable name. {@link persona}
+ * returns an {@link Agent} whose `instructions` are that string, so a persona composes
+ * anywhere an Agent does. Personas are identity-bearing (the text folds into the
+ * agent step's prompt), not presentation-only — the same persona + task always
+ * re-derives the same MoteId. Pure client-side sugar; the SERVER compiles + warrants
+ * every step (SN-8). The strings are byte-identical to the Python SDK.
+ */
+
+import { Agent, type AgentOptions } from "./agent.js";
+
+/** The curated persona library: a stable `name → instructions` map. Role framings, not
+ *  tasks — a swarm / `.on()` supplies the concrete task. Byte-identical to Python. */
+export const PERSONAS: Readonly<Record<string, string>> = {
+  researcher:
+    "You are a meticulous researcher. Gather the relevant facts, cite concrete " +
+    "evidence, separate what is known from what is inferred, and flag gaps or " +
+    "uncertainty explicitly. Prefer primary detail over generalities.",
+  analyst:
+    "You are a rigorous analyst. Break the problem into parts, reason step by step, " +
+    "quantify where you can, and state the assumptions behind each conclusion. Call " +
+    "out the strongest and weakest points of your own analysis.",
+  critic:
+    "You are a sharp, fair critic. Find the flaws, unstated assumptions, edge cases, " +
+    "and failure modes in the material under review. Be specific and constructive: " +
+    "for each problem, say why it matters and what would fix it.",
+  skeptic:
+    "You are a disciplined skeptic. Challenge every claim: ask what evidence supports " +
+    "it, what would falsify it, and where it could be wrong. Do not accept a " +
+    "conclusion until it survives scrutiny; say plainly when it does not.",
+  planner:
+    "You are a decisive planner. Turn the goal into an ordered, concrete plan: the " +
+    "steps, their dependencies, the owner or tool for each, and the risks. Prefer the " +
+    "simplest plan that achieves the goal; make the sequencing explicit.",
+  strategist:
+    "You are a strategist. Consider the options, their trade-offs, and second-order " +
+    "effects, then recommend one course of action with the reasoning behind it. Be " +
+    "explicit about what you are optimizing for and what you are trading away.",
+  engineer:
+    "You are a pragmatic engineer. Produce correct, minimal, maintainable solutions; " +
+    "handle edge cases and failure paths; and explain the key design decisions. " +
+    "Prefer clarity over cleverness and state the assumptions you relied on.",
+  writer:
+    "You are a clear, precise writer. Turn the material into well-structured prose " +
+    "with a strong through-line: lead with the point, support it concisely, and cut " +
+    "filler. Match the tone to the audience; never invent facts.",
+  editor:
+    "You are a careful editor. Tighten the writing for clarity, accuracy, and flow " +
+    "without changing the meaning. Fix structure, remove redundancy, and flag any " +
+    "claim that is unsupported or ambiguous.",
+  summarizer:
+    "You are a faithful summarizer. Distill the material to its essential points in " +
+    "the fewest words that preserve meaning. Keep the load-bearing details, drop the " +
+    "rest, and never introduce information that was not present.",
+};
+
+/** The sorted names in the curated persona library. */
+export function personaNames(): string[] {
+  return Object.keys(PERSONAS).sort();
+}
+
+/** Return an {@link Agent} preset with the curated `name` role. Layer `tools` to make
+ *  it a bounded reason→tool→observe agent. Throws for an unknown name — pass
+ *  `new Agent(instructions, ...)` with your own string for a bespoke role. */
+export function persona(name: string, opts: AgentOptions = {}): Agent {
+  const base = PERSONAS[name];
+  if (base === undefined) {
+    throw new Error(
+      `unknown persona ${JSON.stringify(name)} — known: ${personaNames().join(", ")}`,
+    );
+  }
+  return new Agent(base, opts);
+}

--- a/bindings/typescript/test/swarm-personas.test.ts
+++ b/bindings/typescript/test/swarm-personas.test.ts
@@ -34,12 +34,12 @@ describe("swarm / team / fanOutGather / mapReduce lowering", () => {
     ).lower();
     expect(low.steps).toHaveLength(3); // 2 agentic leaves + 1 synthesizer
     for (const i of [0, 1]) {
-      expect(low.steps[i].kind).toBe("model");
-      expect(low.steps[i].tool_contract).toEqual({ "mcp-echo/echo": "1" });
-      expect(low.steps[i].prompt.endsWith("the Q3 plan")).toBe(true);
+      expect(low.steps[i]?.kind).toBe("model");
+      expect(low.steps[i]?.tool_contract).toEqual({ "mcp-echo/echo": "1" });
+      expect(low.steps[i]?.prompt?.endsWith("the Q3 plan")).toBe(true);
     }
-    expect(low.steps[2].kind).toBe("model");
-    expect(low.steps[2].tool_contract).toEqual({});
+    expect(low.steps[2]?.kind).toBe("model");
+    expect(low.steps[2]?.tool_contract).toEqual({});
     expect(low.edges).toEqual([
       { parent: 0, child: 2, edge: "data" },
       { parent: 1, child: 2, edge: "data" },
@@ -67,9 +67,9 @@ describe("swarm / team / fanOutGather / mapReduce lowering", () => {
   it("team defaults to a model synthesizer; synthesize:false uses a pure gather", () => {
     const t = team([persona("researcher"), persona("critic")], { goal: "write a brief" }).lower();
     expect(t.steps).toHaveLength(3);
-    expect(t.steps[2].kind).toBe("model");
+    expect(t.steps[2]?.kind).toBe("model");
     const pure = swarm(["sample A", "sample B"], { synthesize: false }).lower();
-    expect(pure.steps[2].kind).toBe("pure");
+    expect(pure.steps[2]?.kind).toBe("pure");
   });
 
   it("fanOutGather and mapReduce lower to fan-in", () => {
@@ -89,7 +89,7 @@ describe("swarm / team / fanOutGather / mapReduce lowering", () => {
       })
       .lower();
     expect(low.steps).toHaveLength(5); // 4 leaves + synthesizer
-    expect(low.steps[0].tool_contract).toEqual({ "mcp-echo/echo": "1" });
+    expect(low.steps[0]?.tool_contract).toEqual({ "mcp-echo/echo": "1" });
   });
 
   it("an empty swarm is an error", () => {
@@ -108,7 +108,7 @@ describe("personas", () => {
     const a = new Agent("", { persona: "critic" });
     expect(a.instructions).toBe(PERSONAS.critic);
     const a2 = new Agent("Focus on security.", { persona: "critic" });
-    expect(a2.instructions.startsWith(PERSONAS.critic)).toBe(true);
+    expect(a2.instructions.startsWith(PERSONAS.critic ?? "")).toBe(true);
     expect(a2.instructions.endsWith("Focus on security.")).toBe(true);
     // .on(task) is an alias of .asFlow(task).
     expect(a.on("review X").lower()).toEqual(a.asFlow("review X").lower());
@@ -209,6 +209,6 @@ describe("App.run → SaveApp + RunApp (the integration-in-app fix)", () => {
     expect(calls.saved).toHaveLength(1);
     expect(calls.registered).toHaveLength(1);
     expect((calls.registered[0] as { name: string }).name).toBe("fs");
-    expect(calls.ran[0][0]).toBe("apps/local/mailer");
+    expect(calls.ran[0]?.[0]).toBe("apps/local/mailer");
   });
 });

--- a/bindings/typescript/test/swarm-personas.test.ts
+++ b/bindings/typescript/test/swarm-personas.test.ts
@@ -1,0 +1,214 @@
+/**
+ * RC-SW2 — swarm/team authoring, the persona library, and the App.run→RunApp fix (TS).
+ *
+ * The TS mirror of `bindings/python/tests/test_swarm_personas.py`: swarm/fan-out/map-
+ * reduce lower to the same `[a & b] > g` topology the golden corpus pins, personas fold
+ * into an agent's prompt, and `App.run` routes through SaveApp + RunApp (never a local
+ * submitWorkflow recompile — the regression that dropped connections + secret_scope).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  Agent,
+  PERSONAS,
+  app,
+  chain,
+  fanOutGather,
+  flow,
+  mapReduce,
+  persona,
+  personaNames,
+  swarm,
+  task,
+  team,
+} from "../src/node.js";
+
+describe("swarm / team / fanOutGather / mapReduce lowering", () => {
+  it("swarm lowers to parallel agentic leaves then a synthesizer", () => {
+    const low = swarm(
+      [
+        ["Analyze the market", ["mcp-echo/echo"]],
+        ["Critique the analysis", ["mcp-echo/echo"]],
+      ],
+      { goal: "the Q3 plan" },
+    ).lower();
+    expect(low.steps).toHaveLength(3); // 2 agentic leaves + 1 synthesizer
+    for (const i of [0, 1]) {
+      expect(low.steps[i].kind).toBe("model");
+      expect(low.steps[i].tool_contract).toEqual({ "mcp-echo/echo": "1" });
+      expect(low.steps[i].prompt.endsWith("the Q3 plan")).toBe(true);
+    }
+    expect(low.steps[2].kind).toBe("model");
+    expect(low.steps[2].tool_contract).toEqual({});
+    expect(low.edges).toEqual([
+      { parent: 0, child: 2, edge: "data" },
+      { parent: 1, child: 2, edge: "data" },
+    ]);
+  });
+
+  it("swarm is byte-identical to the equivalent chain", () => {
+    const sw = swarm(
+      [
+        ["A", ["echo"]],
+        ["B", ["echo"]],
+      ],
+      { gather: "Merge" },
+    );
+    const dsl = chain("[a & b] > g", {
+      tasks: {
+        a: task.model("", "A", {}, { tools: ["echo"] }),
+        b: task.model("", "B", {}, { tools: ["echo"] }),
+        g: task.model("", "Merge"),
+      },
+    });
+    expect(sw.lower()).toEqual(dsl.lower());
+  });
+
+  it("team defaults to a model synthesizer; synthesize:false uses a pure gather", () => {
+    const t = team([persona("researcher"), persona("critic")], { goal: "write a brief" }).lower();
+    expect(t.steps).toHaveLength(3);
+    expect(t.steps[2].kind).toBe("model");
+    const pure = swarm(["sample A", "sample B"], { synthesize: false }).lower();
+    expect(pure.steps[2].kind).toBe("pure");
+  });
+
+  it("fanOutGather and mapReduce lower to fan-in", () => {
+    const fog = fanOutGather(["angle 1", "angle 2", "angle 3"], { gather: "combine" }).lower();
+    expect(fog.steps).toHaveLength(4);
+    expect(fog.edges).toHaveLength(3);
+    const mr = mapReduce(["map A", "map B"], { reduce: "reduce" }).lower();
+    expect(mr.steps).toHaveLength(3);
+    expect(mr.edges).toHaveLength(2);
+  });
+
+  it("swarm accepts agents, personas, prompts, and flows", () => {
+    const a = new Agent("You are an analyst.", { tools: ["mcp-echo/echo"] });
+    const low = flow()
+      .swarm([a, persona("writer"), "just a prompt", flow().agent("a sub-flow branch")], {
+        goal: "the topic",
+      })
+      .lower();
+    expect(low.steps).toHaveLength(5); // 4 leaves + synthesizer
+    expect(low.steps[0].tool_contract).toEqual({ "mcp-echo/echo": "1" });
+  });
+
+  it("an empty swarm is an error", () => {
+    expect(() => swarm([])).toThrow();
+    expect(() => flow().fanOutGather([])).toThrow();
+  });
+});
+
+describe("personas", () => {
+  it("the library, the factory, and Agent(persona) + .on()", () => {
+    expect(personaNames()).toContain("researcher");
+    const r = persona("researcher", { tools: ["retrieve"] });
+    expect(r).toBeInstanceOf(Agent);
+    expect(r.instructions).toBe(PERSONAS.researcher);
+
+    const a = new Agent("", { persona: "critic" });
+    expect(a.instructions).toBe(PERSONAS.critic);
+    const a2 = new Agent("Focus on security.", { persona: "critic" });
+    expect(a2.instructions.startsWith(PERSONAS.critic)).toBe(true);
+    expect(a2.instructions.endsWith("Focus on security.")).toBe(true);
+    // .on(task) is an alias of .asFlow(task).
+    expect(a.on("review X").lower()).toEqual(a.asFlow("review X").lower());
+  });
+
+  it("an unknown persona throws", () => {
+    expect(() => persona("nonexistent")).toThrow();
+    expect(() => new Agent("", { persona: "nonexistent" })).toThrow();
+  });
+
+  it("the persona strings are byte-identical to the Python SDK", () => {
+    // A guard: keep the curated set (names + count) stable across surfaces. The string
+    // bodies are copied verbatim from personas.py; personaNames pins the roster.
+    expect(personaNames()).toEqual([
+      "analyst",
+      "critic",
+      "editor",
+      "engineer",
+      "planner",
+      "researcher",
+      "skeptic",
+      "strategist",
+      "summarizer",
+      "writer",
+    ]);
+  });
+});
+
+interface FakeCalls {
+  saved: unknown[];
+  ran: Array<[string, unknown, boolean | undefined]>;
+  submitted: unknown[];
+  registered: unknown[];
+}
+
+function fakeClient(): { client: Record<string, unknown>; calls: FakeCalls } {
+  const calls: FakeCalls = { saved: [], ran: [], submitted: [], registered: [] };
+  const client = {
+    async putContent() {
+      return { contentRef: "a".repeat(64) };
+    },
+    async saveApp(envelope: unknown) {
+      calls.saved.push(envelope);
+      return { handle: "apps/local/mailer" };
+    },
+    async runApp(handle: string, opts?: { args?: unknown; wait?: boolean }) {
+      calls.ran.push([handle, opts?.args, opts?.wait]);
+      return { ran: handle };
+    },
+    async submitWorkflow(request: unknown) {
+      calls.submitted.push(request); // must stay empty
+      return { submitted: true };
+    },
+    async registerMcpServer(input: unknown) {
+      calls.registered.push(input);
+    },
+  };
+  return { client, calls };
+}
+
+describe("App.run → SaveApp + RunApp (the integration-in-app fix)", () => {
+  it("routes through save + runApp, never submitWorkflow", async () => {
+    const { client, calls } = fakeClient();
+    const out = await app("mailer")
+      .blueprint(flow().agent("Draft and send", { tools: ["kx-connector-gmail/send"] }))
+      .withGmail()
+      .run({ to: "x@y.com" }, { client: client as any });
+    expect(out).toEqual({ ran: "apps/local/mailer" });
+    expect(calls.saved).toHaveLength(1);
+    expect(calls.ran).toEqual([["apps/local/mailer", { to: "x@y.com" }, true]]);
+    expect(calls.submitted).toEqual([]); // must NOT drop to submitWorkflow
+    const env = calls.saved[0] as Record<string, any>;
+    expect(env.references.connections[0].descriptor).toBe("kx-connector-gmail");
+    expect(env.steering_config.guards.secret_scope).toEqual(["KX_GMAIL_CREDENTIAL"]);
+  });
+
+  it("withDiscord + secrets", () => {
+    const env = app("notifier")
+      .blueprint(flow().agent("post an update", { tools: ["kx-connector-discord/send_message"] }))
+      .withDiscord()
+      .secrets("KX_EXTRA_CRED")
+      .toEnvelope() as Record<string, any>;
+    expect(env.references.connections[0].descriptor).toBe("kx-connector-discord");
+    expect(env.references.connections[0].credential_ref).toBe("KX_DISCORD_CREDENTIAL");
+    const scope = env.steering_config.guards.secret_scope as string[];
+    expect(scope).toContain("KX_DISCORD_CREDENTIAL");
+    expect(scope).toContain("KX_EXTRA_CRED");
+  });
+
+  it("Flow.asApp promotes topology and carries side-channels", async () => {
+    const { client, calls } = fakeClient();
+    await flow()
+      .withMcp({ name: "fs", endpoint: "npx", args: ["-y", "server-filesystem", "/data"] })
+      .agent("list /data", { tools: ["fs/list_directory"] })
+      .asApp("lister")
+      .withGmail()
+      .run({}, { client: client as any });
+    expect(calls.saved).toHaveLength(1);
+    expect(calls.registered).toHaveLength(1);
+    expect((calls.registered[0] as { name: string }).name).toBe("fs");
+    expect(calls.ran[0][0]).toBe("apps/local/mailer");
+  });
+});

--- a/crates/kx-cli/src/cli.rs
+++ b/crates/kx-cli/src/cli.rs
@@ -73,7 +73,7 @@ usage: kx <command> [args]
     kx tools list | score --intent <text> --tool <id>@<ver>... | discover | register | deregister
     kx connections add --name <n> (--command <path> | --url <url>) | list | test | remove | discover   (external MCP gateways)
     kx skills add (--dir <pack> | --manifest <file> [--instructions <md>]) | list | show --name <n> | remove --name <n>   (kortecx.skill/v1 catalog)
-    kx new skill <name> [--dir <parent>]   (scaffold a skill pack, offline)
+    kx new (skill | connector) <name> [--dir <parent>]   (scaffold a skill pack / MCP connector crate, offline)
     kx secrets set --name <N> --value <V> | list | rm --name <N>   (MM-3/D110 local keychain; values write-only)
     kx triggers add --name <N> --kind <webhook|cron|grpc> --recipe <h> [--auth <a>] [--secret-ref <N>] [--schedule <secs>] [--enabled] | list | test | fire | rm   (D113 event ingress)
     kx context add <handle> (--item <name>=<hex32> | --file <name>=<path>)... [--description <s>] | list | get <handle> | remove <handle>   (context bundles)
@@ -767,7 +767,14 @@ kx new skill <name> [--dir <parent>]
   Scaffold a kortecx.skill/v1 pack (OFFLINE — no gateway): <dir>/<name>/ gains
   skill.json (fill in the tool wishes) + instructions.md (the skill's know-how)
   + README.md (a next-steps checklist: `just test-skill`, `kx skills add`,
-  attach with `kx app new --skill`). Refuses a non-empty target directory."
+  attach with `kx app new --skill`). Refuses a non-empty target directory.
+kx new connector <name> [--dir <parent>]   (default --dir integrations)
+  Scaffold a bundled MCP connector sidecar crate (OFFLINE) at
+  <dir>/kx-connector-<name>/: Cargo.toml + src/{main,lib}.rs (a stdio JSON-RPC 2.0
+  server with a `ping` starter tool + credential-by-ref D81 + a FAKE mode) +
+  tests/conformance.rs + README.md. No kx-* runtime dep (cannot move the digest).
+  Next: implement your tools, `cargo test -p kx-connector-<name>`, add it to the
+  workspace members, then `kx connections add --command kx-connector-<name>`."
             .into(),
         "recipe" => "\
 kx recipe list [client flags]

--- a/crates/kx-cli/src/verbs/new.rs
+++ b/crates/kx-cli/src/verbs/new.rs
@@ -1,19 +1,27 @@
-//! `kx new skill <name> [--dir <parent>]` — scaffold a `kortecx.skill/v1` pack
-//! (RC-SW1, the D175 test-infra scaffolder). Fully OFFLINE (no gateway): emits
-//! the three pack files with a template the author fills in, then points at the
-//! conformance + add + registry steps.
+//! `kx new <kind> <name> [--dir <parent>]` — offline scaffolders (no gateway):
 //!
-//! What it deliberately does NOT do: contact a gateway, derive refs/hashes, run
-//! conformance, or edit `registry/index.json` / `feature-ledger.toml` — a skill
-//! is declarative by construction; the emitted README carries the next-steps
-//! checklist instead.
+//! - `kx new skill <name>` — a `kortecx.skill/v1` pack (RC-SW1, D175): the three
+//!   pack files with a template the author fills in, then the conformance + add +
+//!   registry checklist.
+//! - `kx new connector <name>` — a bundled MCP connector *sidecar* crate (RC-SW2,
+//!   the D175 test-infra scaffolder): a self-contained stdio JSON-RPC 2.0 server
+//!   (`initialize` → `tools/list` → `tools/call`) with ONE starter tool, the
+//!   credential-by-reference (D81) discipline, an offline FAKE mode, and a
+//!   conformance test — modelled on `integrations/kx-connector-discord` so a
+//!   parallel session can stand a new integration up in minutes. It has **no
+//!   `kx-*` runtime dependency** (an external process the runtime dials), so it
+//!   cannot move the projection digest or perturb the frozen trio.
+//!
+//! What both deliberately do NOT do: contact a gateway, derive refs/hashes, run
+//! conformance, edit `Cargo.toml` members / `registry/index.json` /
+//! `feature-ledger.toml` — the emitted README carries the next-steps checklist.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::client::next_value;
 use crate::error::CliError;
 
-/// The `new` subcommand (`skill` today; `connector` is a later enabler).
+/// The `new` subcommand: `skill` (RC-SW1) or `connector` (RC-SW2).
 #[derive(Debug)]
 pub enum NewSub {
     /// Scaffold a skill pack directory.
@@ -21,6 +29,15 @@ pub enum NewSub {
         /// The skill (and directory) name — `[a-z0-9._-]{1,64}`.
         name: String,
         /// Parent directory (default `.`); the pack lands at `<dir>/<name>/`.
+        dir: PathBuf,
+    },
+    /// Scaffold a bundled MCP connector sidecar crate.
+    Connector {
+        /// The connector (provider) name — `[a-z0-9-]{1,48}`; the crate lands at
+        /// `<dir>/kx-connector-<name>/`.
+        name: String,
+        /// Parent directory (default `integrations`, so the crate's dev-dep path
+        /// to `kx-extension-sdk` resolves inside the workspace tree).
         dir: PathBuf,
     },
 }
@@ -83,18 +100,361 @@ Fill in `skill.json` `tools` with the `(tool_id → version)` wishes, e.g.
    `feature-ledger.toml` row (`just registry-check` verifies).
 ";
 
+// ---------------------------------------------------------------------------
+// connector scaffold templates. `__NAME__` = the kebab provider name;
+// `__ENV__`  = its env-var form (uppercased, `-`→`_`), for the credential var.
+// ---------------------------------------------------------------------------
+
+const CONNECTOR_CARGO_TEMPLATE: &str = r#"# SPDX-License-Identifier: Apache-2.0
+[package]
+name         = "kx-connector-__NAME__"
+version      = "0.1.0"
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+authors      = { workspace = true }
+repository   = { workspace = true }
+description  = "kortecx bundled __NAME__ MCP connector — a standalone MCP stdio server (initialize -> tools/list -> tools/call). Authenticates by-reference (D81): a credential is injected out-of-band BY NAME (KX___ENV___CREDENTIAL) and used INSIDE this process; the secret value never appears in a reply, a log, or the runtime. An external process the runtime DIALS via `kx connections add` — never linked into the gateway or the frozen trio (no kx-* dependency)."
+
+[lib]
+path = "src/lib.rs"
+
+# The __NAME__ MCP connector binary — dialed via
+# `kx connections add --command kx-connector-__NAME__ --credential-ref KX___ENV___CREDENTIAL`.
+[[bin]]
+name = "kx-connector-__NAME__"
+path = "src/main.rs"
+
+[dependencies]
+serde      = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
+ureq       = { workspace = true }
+thiserror  = { workspace = true }
+
+[dev-dependencies]
+# The conformance harness (dials THIS bin through the real register_server path).
+kx-extension-sdk = { path = "../../crates/kx-extension-sdk", version = "0.1.0" }
+
+[lints]
+workspace = true
+"#;
+
+const CONNECTOR_MAIN_TEMPLATE: &str = r#"// SPDX-License-Identifier: Apache-2.0
+//! The `kx-connector-__NAME__` binary: a newline-delimited JSON-RPC 2.0 MCP server
+//! over stdio. It builds its client from the environment (the injected credential,
+//! D81) once at start, then answers one request per input line. The credential
+//! value is never written to stdout, stderr, or a log.
+
+use std::io::{BufRead, Write};
+
+use kx_connector___NAMEID__::{handle_line, Client};
+
+fn main() {
+    let client = Client::from_env();
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let reply = handle_line(&line, &client);
+        if writeln!(out, "{reply}").is_err() || out.flush().is_err() {
+            break;
+        }
+    }
+}
+"#;
+
+const CONNECTOR_LIB_TEMPLATE: &str = r##"// SPDX-License-Identifier: Apache-2.0
+//! `kx-connector-__NAME__` — a bundled __NAME__ MCP connector (scaffold).
+//!
+//! A standalone Model Context Protocol server: newline-delimited JSON-RPC 2.0 over
+//! stdio, speaking `initialize` -> `tools/list` -> `tools/call`. It ships ONE
+//! starter tool (`ping`); replace it with your provider's real tools.
+//!
+//! ## Credential discipline (D81 — secret-by-reference)
+//! The runtime resolves the connection's `credential_ref` NAME against the caller's
+//! own secret store and injects the VALUE into this process's environment
+//! ([`CREDENTIAL_ENV`]). Read it, authenticate to your provider INSIDE this process,
+//! and NEVER place the value in a reply, a log line, or an error — so it never
+//! reaches the runtime's journal, a `MoteId`, or a staged effect.
+//!
+//! ## Offline mode (tests / CI / conformance)
+//! With [`FAKE_ENV`] set the connector runs fully offline with deterministic canned
+//! responses (no network, no credential), so the MCP protocol + the
+//! secret-never-echoed contract are gated without a live credential.
+//!
+//! This crate is an **external process** the runtime dials — no dependency on the
+//! gateway, the journal, or the frozen trio, so building or running it cannot move
+//! the projection digest or perturb the core. As it grows, split `Client` / the MCP
+//! protocol / the tool catalog into modules (see `integrations/kx-connector-discord`
+//! for the pattern).
+
+#![allow(clippy::module_name_repetitions)]
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)
+)]
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+/// The env var NAME (D81) under which the runtime injects this connector's
+/// credential VALUE out-of-band. The value never appears in a reply/log/error.
+pub const CREDENTIAL_ENV: &str = "KX___ENV___CREDENTIAL";
+/// Offline switch: canned deterministic responses (no network, no credential).
+pub const FAKE_ENV: &str = "KX___ENV___FAKE";
+/// The MCP protocol version advertised at `initialize`.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// The __NAME__ client — holds the injected credential (never logged) + a fake flag.
+pub struct Client {
+    #[allow(dead_code)]
+    credential: Option<String>,
+    fake: bool,
+}
+
+impl Client {
+    /// Build from the environment: the injected credential (by NAME, D81) + fake mode.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            credential: std::env::var(CREDENTIAL_ENV).ok(),
+            fake: std::env::var(FAKE_ENV).is_ok(),
+        }
+    }
+
+    /// A credential-free offline client for tests.
+    #[must_use]
+    pub fn fake() -> Self {
+        Self {
+            credential: None,
+            fake: true,
+        }
+    }
+
+    /// The starter `ping` tool: echoes a note back. Replace with your real provider
+    /// calls. NEVER return the credential in any branch.
+    fn ping(&self, note: &str) -> Result<String, String> {
+        if self.fake {
+            return Ok(format!(
+                r#"{{"status":"ok","echo":{},"mode":"fake"}}"#,
+                json_str(note)
+            ));
+        }
+        // TODO(author): call your provider's REST API here (blocking `ureq`), using
+        // `self.credential` for auth INSIDE this process. Return a JSON string; map
+        // failures to `Err(reason)` (the reason must NEVER include the credential).
+        Ok(format!(
+            r#"{{"status":"ok","echo":{},"mode":"live"}}"#,
+            json_str(note)
+        ))
+    }
+}
+
+/// Parse one newline-delimited JSON-RPC request and produce its reply line.
+/// Fail-closed: an unparseable line yields a parse error (`-32700`).
+#[must_use]
+pub fn handle_line(line: &str, client: &Client) -> String {
+    match serde_json::from_str::<Req>(line) {
+        Ok(req) => handle(&req, client),
+        Err(_) => error(0, -32700, "parse error"),
+    }
+}
+
+#[derive(Deserialize)]
+struct Req {
+    #[serde(default)]
+    id: u64,
+    method: String,
+    #[serde(default)]
+    params: Option<Params>,
+}
+
+#[derive(Deserialize)]
+struct Params {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<Box<RawValue>>,
+}
+
+fn handle(req: &Req, client: &Client) -> String {
+    let id = req.id;
+    match req.method.as_str() {
+        "initialize" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"protocolVersion":"{PROTOCOL_VERSION}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"kx-connector-__NAME__","version":"1"}}}}}}"#
+        ),
+        "tools/list" => format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"tools":{CATALOG}}}}}"#
+        ),
+        "tools/call" => call(req, client),
+        other => error(id, -32601, &format!("no such method: {other}")),
+    }
+}
+
+/// The `tools/list` catalog. Add one object per tool your connector exposes.
+const CATALOG: &str = r#"[{"name":"ping","description":"A starter tool: echoes a note back. Replace with your real tools.","inputSchema":{"type":"object","properties":{"note":{"type":"string"}},"required":[]}}]"#;
+
+#[derive(Deserialize)]
+struct PingArgs {
+    #[serde(default)]
+    note: Option<String>,
+}
+
+fn call(req: &Req, client: &Client) -> String {
+    let id = req.id;
+    let params = req.params.as_ref();
+    let name = params.and_then(|p| p.name.as_deref()).unwrap_or_default();
+    let args_raw = params
+        .and_then(|p| p.arguments.as_ref())
+        .map_or_else(|| "{}".to_string(), |a| a.get().to_string());
+    match name {
+        "ping" => match serde_json::from_str::<PingArgs>(&args_raw) {
+            Ok(a) => match client.ping(a.note.as_deref().unwrap_or("ping")) {
+                Ok(json) => result(id, &json),
+                Err(e) => error(id, -32000, &e),
+            },
+            Err(e) => error(id, -32602, &e.to_string()),
+        },
+        other => error(id, -32602, &format!("no such tool: {other}")),
+    }
+}
+
+fn json_str(s: &str) -> String {
+    serde_json::to_string(s).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+/// A fail-closed JSON-RPC error reply. Never carries a credential value.
+#[must_use]
+pub fn error(id: u64, code: i64, message: &str) -> String {
+    let msg = serde_json::to_string(message).unwrap_or_else(|_| "\"error\"".to_string());
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":{code},"message":{msg}}}}}"#)
+}
+
+/// A JSON-RPC success reply wrapping a `result` object given as raw JSON text.
+#[must_use]
+pub fn result(id: u64, result_json: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{result_json}}}"#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{handle_line, Client, PROTOCOL_VERSION};
+
+    #[test]
+    fn initialize_lists_ping_and_calls_it() {
+        let c = Client::fake();
+        assert!(handle_line(r#"{"id":1,"method":"initialize"}"#, &c).contains(PROTOCOL_VERSION));
+        assert!(handle_line(r#"{"id":2,"method":"tools/list"}"#, &c).contains("ping"));
+        let reply = handle_line(
+            r#"{"id":3,"method":"tools/call","params":{"name":"ping","arguments":{"note":"hi"}}}"#,
+            &c,
+        );
+        assert!(reply.contains(r#""result""#) && reply.contains("hi"));
+    }
+
+    #[test]
+    fn parse_error_unknown_method_and_unknown_tool_fail_closed() {
+        let c = Client::fake();
+        assert!(handle_line("not json", &c).contains("-32700"));
+        assert!(handle_line(r#"{"id":1,"method":"frob"}"#, &c).contains("-32601"));
+        assert!(
+            handle_line(r#"{"id":1,"method":"tools/call","params":{"name":"nope"}}"#, &c)
+                .contains("-32602")
+        );
+    }
+}
+"##;
+
+const CONNECTOR_CONFORMANCE_TEMPLATE: &str = r#"// SPDX-License-Identifier: Apache-2.0
+//! Conformance: the scaffolded connector passes the Extension Acceptance Gate
+//! subset (out-of-process · warrant/SN-8 · secret-by-ref · on/off), driven OFFLINE
+//! (`KX___ENV___FAKE`) so it needs no credentials and no network.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::pedantic)]
+
+use kx_extension_sdk::conformance::{run_conformance, ConnectorUnderTest};
+use kx_extension_sdk::prelude::{SessionMode, TransportSpec};
+
+#[test]
+fn connector_passes_conformance_offline() {
+    const SECRET: &str = "SEKRET-__ENV__-DEADBEEF-do-not-leak-0123456789";
+    const CRED_VAR: &str = "KX___ENV___CREDENTIAL";
+
+    std::env::set_var("KX___ENV___FAKE", "1");
+    std::env::set_var(CRED_VAR, SECRET);
+
+    let cut = ConnectorUnderTest {
+        name: "__NAME__".into(),
+        transport: TransportSpec::Stdio {
+            command: env!("CARGO_BIN_EXE_kx-connector-__NAME__").to_string(),
+            args: vec![],
+        },
+        credential_ref: Some(CRED_VAR.to_string()),
+        session_mode: SessionMode::Stateless,
+    };
+    let report = run_conformance(&cut);
+
+    std::env::remove_var(CRED_VAR);
+    std::env::remove_var("KX___ENV___FAKE");
+
+    assert!(report.reachable, "connector should be reachable: {report:#?}");
+    assert!(report.discovered >= 1, "expected the ping tool: {report:#?}");
+    assert!(report.passed(), "connector failed conformance: {report:#?}");
+    for item in [3u8, 5, 7, 10] {
+        assert!(
+            report.checks.iter().any(|c| c.gate_item == item && c.passed),
+            "gate item {item} missing or failed: {report:#?}"
+        );
+    }
+}
+"#;
+
+const CONNECTOR_README_TEMPLATE: &str = "# kx-connector-__NAME__
+
+A bundled __NAME__ MCP connector *sidecar*: a standalone stdio JSON-RPC 2.0 server
+(`initialize` → `tools/list` → `tools/call`) with one starter tool. It has **no
+`kx-*` runtime dependency** — an external process the runtime DIALS, so building or
+running it cannot move the projection digest (`7d22d4bd…`) or touch the frozen trio.
+
+Credentials are **by reference** (D81): the runtime injects your credential VALUE
+into `KX___ENV___CREDENTIAL` out-of-band; this process reads it and authenticates
+INSIDE itself. The value NEVER appears in a reply, a log, or an error.
+
+## Next steps
+
+1. Implement your tools in `src/lib.rs` (replace the `ping` starter): add a row to
+   `CATALOG`, a decode struct, and a `Client` method; keep FAKE mode deterministic.
+2. `cargo test -p kx-connector-__NAME__` — the unit + conformance tests
+   (offline, `KX___ENV___FAKE`).
+3. Wire it into the workspace: add `\"integrations/kx-connector-__NAME__\"` to the
+   root `Cargo.toml` `members`, and (to upstream) a `registry/index.json` entry +
+   a `feature-ledger.toml` row (`just registry-check` verifies).
+4. Use it: `kx connections add --command kx-connector-__NAME__ --credential-ref \\
+   KX___ENV___CREDENTIAL` then `kx connections fire __NAME__/ping --arg note=hi`,
+   or attach it to an App and run via `RunApp` (`.with_connection(...)`).
+";
+
 /// Parse `new` args (the verb already consumed).
 pub fn parse(mut args: impl Iterator<Item = String>) -> Result<NewArgs, CliError> {
     let kind = args
         .next()
-        .ok_or_else(|| CliError::Usage("new requires a kind: skill".into()))?;
-    if kind != "skill" {
+        .ok_or_else(|| CliError::Usage("new requires a kind: skill | connector".into()))?;
+    if kind != "skill" && kind != "connector" {
         return Err(CliError::Usage(format!(
-            "unknown new kind {kind:?} (expected skill)"
+            "unknown new kind {kind:?} (expected skill | connector)"
         )));
     }
+    let default_dir = if kind == "connector" {
+        "integrations"
+    } else {
+        "."
+    };
     let mut name: Option<String> = None;
-    let mut dir = PathBuf::from(".");
+    let mut dir = PathBuf::from(default_dir);
     while let Some(flag) = args.next() {
         match flag.as_str() {
             "--dir" => dir = PathBuf::from(next_value(&mut args, "--dir")?),
@@ -105,15 +465,24 @@ pub fn parse(mut args: impl Iterator<Item = String>) -> Result<NewArgs, CliError
             extra => return Err(CliError::Usage(format!("unexpected argument {extra:?}"))),
         }
     }
-    let name = name.ok_or_else(|| CliError::Usage("new skill requires <name>".into()))?;
-    Ok(NewArgs {
-        sub: NewSub::Skill { name, dir },
-    })
+    let name = name.ok_or_else(|| CliError::Usage(format!("new {kind} requires <name>")))?;
+    let sub = if kind == "connector" {
+        NewSub::Connector { name, dir }
+    } else {
+        NewSub::Skill { name, dir }
+    };
+    Ok(NewArgs { sub })
 }
 
 /// Execute `new` (offline).
 pub fn execute(args: NewArgs) -> Result<(), CliError> {
-    let NewSub::Skill { name, dir } = args.sub;
+    match args.sub {
+        NewSub::Skill { name, dir } => execute_skill(&name, &dir),
+        NewSub::Connector { name, dir } => execute_connector(&name, &dir),
+    }
+}
+
+fn execute_skill(name: &str, dir: &Path) -> Result<(), CliError> {
     // The same grammar kx-skill enforces — fail here with the author-friendly
     // message instead of at add time.
     if name.is_empty()
@@ -126,28 +495,14 @@ pub fn execute(args: NewArgs) -> Result<(), CliError> {
             "skill name must be 1-64 chars of [a-z0-9._-], got {name:?}"
         )));
     }
-    let pack = dir.join(&name);
-    // Fail-closed: never clobber an existing non-empty directory.
-    if pack.exists()
-        && pack
-            .read_dir()
-            .map(|mut d| d.next().is_some())
-            .unwrap_or(true)
-    {
-        return Err(CliError::Usage(format!(
-            "{} already exists and is not empty",
-            pack.display()
-        )));
-    }
-    std::fs::create_dir_all(&pack)
-        .map_err(|e| CliError::Usage(format!("{}: {e}", pack.display())))?;
+    let pack = dir.join(name);
+    ensure_empty_dir(&pack)?;
     for (file, template) in [
         ("skill.json", SKILL_JSON_TEMPLATE),
         ("instructions.md", INSTRUCTIONS_TEMPLATE),
         ("README.md", README_TEMPLATE),
     ] {
-        std::fs::write(pack.join(file), template.replace("__NAME__", &name))
-            .map_err(|e| CliError::Usage(format!("{}/{file}: {e}", pack.display())))?;
+        write_file(&pack.join(file), &template.replace("__NAME__", name))?;
     }
     println!(
         "scaffolded skill pack {}\n  next: edit skill.json (the tool wishes) + instructions.md, \
@@ -157,6 +512,88 @@ pub fn execute(args: NewArgs) -> Result<(), CliError> {
         pack.display()
     );
     Ok(())
+}
+
+fn execute_connector(name: &str, dir: &Path) -> Result<(), CliError> {
+    // A connector crate name is `kx-connector-<name>`; the provider name is a strict
+    // kebab identifier so it is a valid crate-name suffix + a URL-path-safe tool
+    // namespace.
+    if name.is_empty()
+        || name.len() > 48
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        || name.starts_with('-')
+        || name.ends_with('-')
+    {
+        return Err(CliError::Usage(format!(
+            "connector name must be 1-48 chars of [a-z0-9-] (no leading/trailing '-'), got {name:?}"
+        )));
+    }
+    let env = name.to_ascii_uppercase().replace('-', "_");
+    let name_id = name.replace('-', "_");
+    let subst = |t: &str| {
+        t.replace("__NAMEID__", &name_id)
+            .replace("__NAME__", name)
+            .replace("__ENV__", &env)
+    };
+    let crate_dir = dir.join(format!("kx-connector-{name}"));
+    ensure_empty_dir(&crate_dir)?;
+    write_file(
+        &crate_dir.join("Cargo.toml"),
+        &subst(CONNECTOR_CARGO_TEMPLATE),
+    )?;
+    write_file(
+        &crate_dir.join("src/main.rs"),
+        &subst(CONNECTOR_MAIN_TEMPLATE),
+    )?;
+    write_file(
+        &crate_dir.join("src/lib.rs"),
+        &subst(CONNECTOR_LIB_TEMPLATE),
+    )?;
+    write_file(
+        &crate_dir.join("tests/conformance.rs"),
+        &subst(CONNECTOR_CONFORMANCE_TEMPLATE),
+    )?;
+    write_file(
+        &crate_dir.join("README.md"),
+        &subst(CONNECTOR_README_TEMPLATE),
+    )?;
+    println!(
+        "scaffolded connector crate {}\n  next: implement your tools in src/lib.rs, run \
+         `cargo test -p kx-connector-{}`, add it to the workspace `members`, then \
+         `kx connections add --command kx-connector-{} --credential-ref KX_{}_CREDENTIAL`",
+        crate_dir.display(),
+        name,
+        name,
+        env
+    );
+    Ok(())
+}
+
+/// Fail-closed: never clobber an existing non-empty directory; create it otherwise.
+fn ensure_empty_dir(path: &Path) -> Result<(), CliError> {
+    if path.exists()
+        && path
+            .read_dir()
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(true)
+    {
+        return Err(CliError::Usage(format!(
+            "{} already exists and is not empty",
+            path.display()
+        )));
+    }
+    std::fs::create_dir_all(path).map_err(|e| CliError::Usage(format!("{}: {e}", path.display())))
+}
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write_file(path: &std::path::Path, contents: &str) -> Result<(), CliError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| CliError::Usage(format!("{}: {e}", parent.display())))?;
+    }
+    std::fs::write(path, contents).map_err(|e| CliError::Usage(format!("{}: {e}", path.display())))
 }
 
 #[cfg(test)]
@@ -171,27 +608,36 @@ mod tests {
                 .map(|s| (*s).to_string()),
         )
         .unwrap();
-        let NewSub::Skill { name, dir } = a.sub;
+        let NewSub::Skill { name, dir } = a.sub else {
+            panic!("expected skill");
+        };
         assert_eq!(name, "triage");
         assert_eq!(dir, PathBuf::from("/tmp/x"));
+    }
+
+    #[test]
+    fn parses_new_connector_defaulting_dir_to_integrations() {
+        let a = parse(["connector", "slack"].iter().map(|s| (*s).to_string())).unwrap();
+        let NewSub::Connector { name, dir } = a.sub else {
+            panic!("expected connector");
+        };
+        assert_eq!(name, "slack");
+        assert_eq!(dir, PathBuf::from("integrations"));
     }
 
     #[test]
     fn rejects_missing_name_bad_kind_and_unknown_flags() {
         let p = |parts: &[&str]| parse(parts.iter().map(|s| (*s).to_string()));
         assert!(p(&[]).is_err());
-        assert!(
-            p(&["connector", "x"]).is_err(),
-            "connector is a later enabler"
-        );
+        assert!(p(&["gadget", "x"]).is_err(), "unknown kind");
         assert!(p(&["skill"]).is_err(), "needs a name");
+        assert!(p(&["connector"]).is_err(), "needs a name");
         assert!(p(&["skill", "x", "--frob", "y"]).is_err());
     }
 
     #[test]
-    fn the_emitted_template_passes_pack_validation_after_a_wish_is_added() {
-        // Template-drift pin: what `kx new skill` emits must load as a valid
-        // pack (kx-skill is the SAME validator the server runs).
+    fn the_emitted_skill_template_passes_pack_validation() {
+        // Template-drift pin: what `kx new skill` emits must load as a valid pack.
         let tmp = tempfile::tempdir().unwrap();
         execute(
             parse(
@@ -209,18 +655,49 @@ mod tests {
     }
 
     #[test]
-    fn refuses_a_non_empty_target_and_a_bad_name() {
+    fn the_emitted_connector_crate_has_the_expected_files_and_substitutions() {
         let tmp = tempfile::tempdir().unwrap();
-        let run = |name: &str| {
-            execute(NewArgs {
-                sub: NewSub::Skill {
-                    name: name.to_string(),
-                    dir: tmp.path().to_path_buf(),
-                },
-            })
-        };
-        assert!(run("UPPER").is_err(), "grammar enforced offline");
-        run("taken").unwrap();
-        assert!(run("taken").is_err(), "never clobbers a non-empty pack");
+        execute_connector("my-thing", tmp.path()).unwrap();
+        let crate_dir = tmp.path().join("kx-connector-my-thing");
+        for f in [
+            "Cargo.toml",
+            "src/main.rs",
+            "src/lib.rs",
+            "tests/conformance.rs",
+            "README.md",
+        ] {
+            assert!(crate_dir.join(f).exists(), "missing {f}");
+        }
+        let cargo = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+        assert!(cargo.contains("name         = \"kx-connector-my-thing\""));
+        assert!(
+            cargo.contains("KX_MY_THING_CREDENTIAL"),
+            "env var substituted"
+        );
+        assert!(
+            !cargo.contains("__NAME__") && !cargo.contains("__ENV__"),
+            "no placeholders left"
+        );
+        let lib = std::fs::read_to_string(crate_dir.join("src/lib.rs")).unwrap();
+        assert!(lib.contains("KX_MY_THING_CREDENTIAL") && lib.contains("KX_MY_THING_FAKE"));
+        assert!(!lib.contains("__NAME__") && !lib.contains("__NAMEID__"));
+        let main = std::fs::read_to_string(crate_dir.join("src/main.rs")).unwrap();
+        assert!(
+            main.contains("kx_connector_my_thing::"),
+            "crate ident substituted"
+        );
+    }
+
+    #[test]
+    fn refuses_a_non_empty_target_and_bad_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(execute_skill("UPPER", tmp.path()).is_err());
+        assert!(execute_connector("Bad_Name", tmp.path()).is_err());
+        assert!(execute_connector("-lead", tmp.path()).is_err());
+        execute_skill("taken", tmp.path()).unwrap();
+        assert!(
+            execute_skill("taken", tmp.path()).is_err(),
+            "never clobbers a non-empty pack"
+        );
     }
 }

--- a/crates/kx-gateway/tests/app_live_serve.rs
+++ b/crates/kx-gateway/tests/app_live_serve.rs
@@ -239,11 +239,11 @@ async fn app_catalog_round_trips_and_runs_on_a_live_model() {
     std::env::remove_var("KX_SERVE_AUTOGRANT");
 }
 
-/// Resolve the bundled `kx-connector-gmail` sidecar binary (release preferred), if built.
-fn gmail_connector_bin() -> Option<PathBuf> {
+/// Resolve a bundled connector sidecar binary by crate name (release preferred), if built.
+fn connector_bin(bin_name: &str) -> Option<PathBuf> {
     for profile in ["release", "debug"] {
         let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join(format!("../../target/{profile}/kx-connector-gmail"));
+            .join(format!("../../target/{profile}/{bin_name}"));
         if p.is_file() {
             return Some(p);
         }
@@ -251,87 +251,95 @@ fn gmail_connector_bin() -> Option<PathBuf> {
     None
 }
 
-/// The `kortecx.app/v1` envelope for a Gmail-integration App: an agentic MODEL step
-/// granting the registered `gmail/search` tool, a by-reference connection pointer, and
-/// (when `scope_secret`) the connection's credential in `guards.secret_scope`. G2's
-/// load-bearing bit: with the secret in scope the run warrant permits dialing the
-/// credentialed connector; without it the dial fails closed at the broker.
-fn gmail_app_envelope(connector_path: &str, scope_secret: bool) -> Vec<u8> {
+/// Resolve the serve engine (GR24): the Ollama opt-in FIRST (a served GGUF standin would
+/// otherwise register as PRIMARY and mask `KX_SERVE_OLLAMA`), else a GGUF drives llama.cpp
+/// (Gemma-4 locally / Qwen3 in CI). Sets `KX_SERVE_MODEL_GGUF` for the llama.cpp arm.
+fn resolve_engine() -> Option<&'static str> {
+    if ollama_opted_in() {
+        Some("ollama")
+    } else if let Some(gguf) = serve_model() {
+        std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
+        Some("llama.cpp")
+    } else {
+        None
+    }
+}
+
+/// A `kortecx.app/v1` envelope for a connector-integration App: one agentic MODEL step
+/// granting the registered `<server>/<tool>`, a by-reference connection pointer, and (when
+/// `scope_secret`) the connection's credential in `guards.secret_scope` — the load-bearing
+/// bit that lets the run warrant dial the credentialed connector (G2/#285).
+fn connector_app_envelope(
+    connector_path: &str,
+    granted_tool: &str,
+    credential_ref: &str,
+    prompt: &str,
+    scope_secret: bool,
+) -> Vec<u8> {
     let blueprint = serde_json::json!({
         "seed": 0,
         "steps": [{
             "kind": "model",
-            "prompt": "Search my Gmail for unread messages using the gmail/search tool, \
-                       then briefly answer with what you found.",
-            "tool_contract": { "gmail/search": "1" },
-            // A GENEROUS budget so the model has room to dial the credentialed connector AND
-            // then answer over the tool result — on Gemma-4 the log then shows the full
-            // vertical (fires gmail/search → observation commits → answers). The live test
-            // OBSERVES; it does not gate on whether an answer lands (the deterministic proofs
-            // do), so the budget only affects how far the logged trajectory gets.
+            "prompt": prompt,
+            "tool_contract": { granted_tool: "1" },
             "params": { "max_turns": "8", "max_tool_calls": "2" }
         }]
     });
-    let mut env = kx_app::AppEnvelope::new("Gmail Agent", blueprint);
-    env.description = "an agentic App that dials the bundled Gmail connector".to_string();
+    let mut env = kx_app::AppEnvelope::new("Connector Agent", blueprint);
+    env.description = format!("an agentic App that dials the {granted_tool} connector");
     env.references.connections.push(kx_app::ConnectionRef {
         descriptor: connector_path.to_string(),
-        credential_ref: "KX_GMAIL_CREDENTIAL".to_string(),
+        credential_ref: credential_ref.to_string(),
     });
     if scope_secret {
-        env.steering_config.guards.secret_scope = vec!["KX_GMAIL_CREDENTIAL".to_string()];
+        env.steering_config.guards.secret_scope = vec![credential_ref.to_string()];
     }
     env.to_canonical_json().unwrap()
 }
 
-/// G2 LIVE witness (GR15/GR24) + `T-RUNAPP-SECRET-SCOPE-OBSERVATION` regression:
-/// an App that references the bundled Gmail connector + declares its credential in
-/// `secret_scope`, RUN via the new server-side `RunApp`, on a live model. Proves the
-/// whole vertical: RunApp reads the stored envelope, resolves the connection against the
-/// caller's own registry, grants the declared secret scope to the agentic warrant, and
-/// the agent can dial the credentialed connector (FAKE mode — a real MCP subprocess +
-/// real JSON-RPC round-trip, canned upstream).
-///
-/// A GR16 OBSERVE-witness (mirroring `react_serve_connector.rs`): it asserts only ROBUST
-/// invariants — the chain SETTLES to a terminal, and if a tool fired it was the granted
-/// `gmail/search` (SN-8) — and LOGS the trajectory (which engine, whether it dialed vs
-/// answered directly is model-nondeterministic). It deliberately does NOT gate on the fix:
-/// a committed observation that then hits the tool-call budget dead-letters AT the tool
-/// turn, indistinguishable at the ListReactTurns level from a SecretScope dead-letter
-/// (whose reason is synthesized and never names the axis). The fix's REGRESSION PROOF is
-/// deterministic + always in CI: `kx-proto::secret_scope_allowlist_survives_the_coordinator_wire`
-/// (the wire round-trip) + `kx-coordinator::observation_dispatch_preserves_the_chain_secret_scope`
-/// (the leased observation warrant carries the AllowList). Drive on Gemma-4 locally (the
-/// log then shows the full vertical: fires gmail/search → observation commits → answers).
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "real in-process LLM inference + the built kx-connector-gmail; opt in with --ignored"]
-async fn runapp_gmail_connection_and_secret_scope_live() {
-    // GR24 dual-engine: the Ollama opt-in (`KX_SERVE_OLLAMA=on
-    // KX_SERVE_OLLAMA_MODELS=gemma3:12b`) drives Ollama; otherwise a GGUF drives llama.cpp
-    // (Gemma-4 locally / Qwen3 in CI). Check the Ollama opt-in FIRST — else the GGUF standin
-    // (present in CI) would always win and silently ignore `KX_SERVE_OLLAMA` (a served GGUF
-    // registers as the PRIMARY chat route, model_exec.rs), making the Ollama arm unreachable.
-    let engine = if ollama_opted_in() {
-        // Leave KX_SERVE_MODEL_GGUF unset so serve routes to the Ollama backend.
-        "ollama"
-    } else if let Some(gguf) = serve_model() {
-        std::env::set_var("KX_SERVE_MODEL_GGUF", &gguf);
-        "llama.cpp"
-    } else {
+/// One connector under a live RunApp witness (parametrized over any bundled sidecar).
+struct ConnectorCase {
+    /// The MCP server name (namespaces the tools as `<server>/<tool>`).
+    server_name: &'static str,
+    /// The bundled sidecar binary crate name (`kx-connector-gmail` / `-discord` / …).
+    bin_name: &'static str,
+    /// The credential-ref NAME (D81) the sidecar reads out-of-band.
+    credential_ref: &'static str,
+    /// A canned credential value (FAKE mode ignores it; the scope must still resolve).
+    credential_value: &'static str,
+    /// The FAKE env switch (offline canned responses).
+    fake_env: &'static str,
+    /// The single granted tool the agent may fire (SN-8).
+    granted_tool: &'static str,
+    /// The task prompt.
+    prompt: &'static str,
+}
+
+/// GR15/GR24 LIVE witness + the `T-RUNAPP-SECRET-SCOPE-OBSERVATION` regression, generalized
+/// over ANY bundled connector (the parallel-session enabler): register the connection, scope
+/// its credential, save the App, RUN via `RunApp`, and OBSERVE the agentic loop on a live
+/// model. A GR16 OBSERVE-witness (mirroring `react_serve_connector.rs`) — asserts only ROBUST
+/// invariants (settles to a terminal; a fired tool is the granted one, SN-8) and LOGS the
+/// trajectory. The fix's deterministic REGRESSION PROOFS live in CI:
+/// `kx-proto::secret_scope_allowlist_survives_the_coordinator_wire` +
+/// `kx-coordinator::observation_dispatch_preserves_the_chain_secret_scope`.
+async fn runapp_connection_live(case: &ConnectorCase) {
+    let Some(engine) = resolve_engine() else {
         eprintln!(
             "skipping: no serve model — set KX_SERVE_MODEL_GGUF (Gemma-4/Qwen3) or \
              KX_SERVE_OLLAMA=on KX_SERVE_OLLAMA_MODELS=gemma3:12b"
         );
         return;
     };
-    let Some(connector) = gmail_connector_bin() else {
-        eprintln!("skipping: kx-connector-gmail not built — `cargo build -p kx-connector-gmail`");
+    let Some(connector) = connector_bin(case.bin_name) else {
+        eprintln!(
+            "skipping: {} not built — `cargo build -p {}`",
+            case.bin_name, case.bin_name
+        );
         return;
     };
     std::env::set_var("KX_SERVE_AUTOGRANT", "1");
-    // FAKE mode: the connector answers with canned data (no network, no real creds) —
-    // inherited by the sidecar the gateway spawns.
-    std::env::set_var("KX_GMAIL_FAKE", "1");
+    std::env::set_var(case.fake_env, "1");
 
     let dir = tempfile::TempDir::new().unwrap();
     let running = start(common::gateway_config(&dir, true, HashMap::new()))
@@ -339,37 +347,40 @@ async fn runapp_gmail_connection_and_secret_scope_live() {
         .unwrap();
     let mut c = client(running.local_addr()).await;
 
-    // Register the Gmail connection (the connector namespaces its tools under `gmail/*`).
     let reg = c
         .register_mcp_server(proto::RegisterMcpServerRequest {
-            server_name: "gmail".to_string(),
+            server_name: case.server_name.to_string(),
             transport: "stdio".to_string(),
             endpoint: connector.to_string_lossy().into_owned(),
             args: vec![],
             tls_required: false,
-            credential_ref: "KX_GMAIL_CREDENTIAL".to_string(),
+            credential_ref: case.credential_ref.to_string(),
             session_mode: String::new(),
         })
         .await
         .expect("RegisterMcpServer")
         .into_inner();
     eprintln!(
-        "gmail connection: health={} discovered={}",
-        reg.health, reg.discovered
+        "{} connection: health={} discovered={}",
+        case.server_name, reg.health, reg.discovered
     );
-    // Set the credential secret (FAKE mode ignores its value; the scope must resolve).
     let _ = c
         .put_secret(proto::PutSecretRequest {
-            name: "KX_GMAIL_CREDENTIAL".to_string(),
-            value: r#"{"client_id":"x","client_secret":"y","refresh_token":"z"}"#.to_string(),
+            name: case.credential_ref.to_string(),
+            value: case.credential_value.to_string(),
         })
         .await;
 
-    // Save the App (references the connection + scopes its credential) and RUN it via
-    // the NEW RunApp (which honors references.connections + guards.secret_scope).
-    let envelope = gmail_app_envelope(&connector.to_string_lossy(), true);
+    let handle_str = format!("apps/local/{}-agent", case.server_name);
+    let envelope = connector_app_envelope(
+        &connector.to_string_lossy(),
+        case.granted_tool,
+        case.credential_ref,
+        case.prompt,
+        true,
+    );
     c.save_app(proto::SaveAppRequest {
-        handle: "apps/local/gmail-agent".to_string(),
+        handle: handle_str.clone(),
         envelope_json: envelope,
     })
     .await
@@ -388,40 +399,25 @@ async fn runapp_gmail_connection_and_secret_scope_live() {
         eprintln!("skipping the run leg: kx/recipes/react not provisioned");
         running.shutdown().await.unwrap();
         std::env::remove_var("KX_SERVE_AUTOGRANT");
-        std::env::remove_var("KX_GMAIL_FAKE");
+        std::env::remove_var(case.fake_env);
         return;
     }
 
     let handle = c
         .run_app(proto::RunAppRequest {
-            handle: "apps/local/gmail-agent".to_string(),
+            handle: handle_str,
             args: Vec::new(),
         })
         .await
-        .expect("RunApp of the Gmail App")
+        .expect("RunApp of the connector App")
         .into_inner();
     assert_eq!(handle.instance_id.len(), 16, "RunApp returns a run handle");
 
-    // Poll the chain to a terminal and capture its STRUCTURE for the log. This live test is
-    // a GR16 OBSERVE-witness (like `react_serve_connector.rs`): whether a model dials vs
-    // answers directly is model+engine behavior, so it asserts only ROBUST invariants
-    // (settlement + the fired tool is the granted one) and LOGS the rest for inspection.
-    //
-    // The fix's REGRESSION PROOF is deterministic + always in CI, NOT here:
-    // kx-proto `secret_scope_allowlist_survives_the_coordinator_wire` (the wire round-trip)
-    // + kx-coordinator `observation_dispatch_preserves_the_chain_secret_scope` (the leased
-    // observation warrant carries the AllowList). A live oracle CANNOT prove the fix on its
-    // own: a committed observation that then hits the tool-call budget dead-letters AT the
-    // tool turn (cumulative `tool_calls`, coordinator `advance_react_chain`) —
-    // indistinguishable at the ListReactTurns level from the SecretScope dead-letter, whose
-    // reason is synthesized and never names the axis. So we OBSERVE + log; on Gemma-4 the log
-    // shows the full vertical (fires gmail/search → observation commits → answers).
     let mut tool_fired = false;
     let mut fired_tool_ids: Vec<String> = Vec::new();
     let mut answered = false;
     let mut dead_lettered = false;
-    let mut dead_letter_reasons: Vec<String> = Vec::new();
-    let mut final_turns: Vec<(u32, String)> = Vec::new();
+    let mut dl_reasons: Vec<String> = Vec::new();
     for _ in 0..3000 {
         let turns = c
             .list_react_turns(proto::ListReactTurnsRequest {
@@ -443,7 +439,7 @@ async fn runapp_gmail_connection_and_secret_scope_live() {
         answered = turns.turns.iter().any(|t| t.branch == "answer");
         dead_lettered = turns.turns.iter().any(|t| t.branch == "dead_lettered");
         if dead_lettered {
-            dead_letter_reasons = turns
+            dl_reasons = turns
                 .turns
                 .iter()
                 .filter(|t| t.branch == "dead_lettered" && !t.rejection_reason.is_empty())
@@ -451,47 +447,195 @@ async fn runapp_gmail_connection_and_secret_scope_live() {
                 .collect();
         }
         if answered || dead_lettered {
-            final_turns = turns
-                .turns
-                .iter()
-                .map(|t| (t.turn, t.branch.clone()))
-                .collect();
             break;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    final_turns.sort();
     eprintln!(
-        "LIVE RunApp Gmail [{engine}]: tool_fired={tool_fired} fired_tools={fired_tool_ids:?} \
-         answered={answered} dead_lettered={dead_lettered} dl_reasons={dead_letter_reasons:?} \
-         turns={final_turns:?}"
+        "LIVE RunApp {} [{engine}]: tool_fired={tool_fired} fired_tools={fired_tool_ids:?} \
+         answered={answered} dead_lettered={dead_lettered} dl_reasons={dl_reasons:?}",
+        case.server_name
     );
-    // Robust invariant: the chain SETTLED to a terminal (a bounded chain never wedges
-    // silently) — the RunApp vertical (envelope → connection resolve → agentic loop) ran.
     assert!(
         answered || dead_lettered,
-        "the Gmail App settled to a terminal via RunApp on the live model [{engine}]"
+        "the {} App settled to a terminal via RunApp on the live model [{engine}]",
+        case.server_name
     );
-    // SN-8: if a tool fired it was the granted `gmail/search` — never a hallucinated id.
     if tool_fired {
         assert!(
             fired_tool_ids
                 .iter()
-                .all(|id| id.is_empty() || id == "gmail/search"),
-            "if a tool fired it was the granted gmail/search. fired_tools={fired_tool_ids:?}"
-        );
-    }
-    // SN-8: if a tool fired it was the granted `gmail/search` — never a hallucinated id.
-    if tool_fired {
-        assert!(
-            fired_tool_ids
-                .iter()
-                .all(|id| id.is_empty() || id == "gmail/search"),
-            "if a tool fired it was the granted gmail/search. fired_tools={fired_tool_ids:?}"
+                .all(|id| id.is_empty() || id == case.granted_tool),
+            "if a tool fired it was the granted {}. fired_tools={fired_tool_ids:?}",
+            case.granted_tool
         );
     }
 
     running.shutdown().await.unwrap();
     std::env::remove_var("KX_SERVE_AUTOGRANT");
-    std::env::remove_var("KX_GMAIL_FAKE");
+    std::env::remove_var(case.fake_env);
+}
+
+/// G2/#285 Gmail witness — the thin caller over the generic connector harness.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real in-process LLM inference + the built kx-connector-gmail; opt in with --ignored"]
+async fn runapp_gmail_connection_and_secret_scope_live() {
+    runapp_connection_live(&ConnectorCase {
+        server_name: "gmail",
+        bin_name: "kx-connector-gmail",
+        credential_ref: "KX_GMAIL_CREDENTIAL",
+        credential_value: r#"{"client_id":"x","client_secret":"y","refresh_token":"z"}"#,
+        fake_env: "KX_GMAIL_FAKE",
+        granted_tool: "gmail/search",
+        prompt: "Search my Gmail for unread messages using the gmail/search tool, then \
+                 briefly answer with what you found.",
+    })
+    .await;
+}
+
+/// RC-SW2 Discord witness — the same generic harness pointed at the bundled Discord sidecar
+/// (#277), so a parallel session can test ANY connector-in-App path without new harness code.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real in-process LLM inference + the built kx-connector-discord; opt in with --ignored"]
+async fn runapp_discord_connection_and_secret_scope_live() {
+    runapp_connection_live(&ConnectorCase {
+        server_name: "discord",
+        bin_name: "kx-connector-discord",
+        credential_ref: "KX_DISCORD_CREDENTIAL",
+        credential_value: r#"{"bot_token":"x"}"#,
+        fake_env: "KX_DISCORD_FAKE",
+        granted_tool: "discord/read_channel",
+        prompt: "Read the most recent messages from channel 123 using the \
+                 discord/read_channel tool, then briefly summarize them.",
+    })
+    .await;
+}
+
+/// The RC-SW2 swarm request `kx.swarm(...)` / `flow().swarm(...)` lowers to: N parallel MODEL
+/// leaves (no inter-edges) fanned into one MODEL gather that reads every leaf's committed
+/// output (its Data-edge parents, F-7). Built here as the raw proto the SDK produces.
+fn swarm_request() -> proto::SubmitWorkflowRequest {
+    let model = |prompt: &str| proto::WorkflowStep {
+        kind: proto::WorkflowStepKind::Model as i32,
+        model_id: String::new(),
+        prompt: prompt.to_string(),
+        body_signature_id: Vec::new(),
+        tool_contract: Default::default(),
+        params: Default::default(),
+    };
+    proto::SubmitWorkflowRequest {
+        seed: 0,
+        steps: vec![
+            model("In one sentence, give a concrete BENEFIT of durable agentic execution."),
+            model(
+                "In one sentence, give a concrete RISK or limitation of durable agentic execution.",
+            ),
+            model("Combine the two points above into a two-sentence summary."),
+        ],
+        edges: vec![
+            proto::WorkflowEdge {
+                parent: 0,
+                child: 2,
+                edge_kind: proto::EdgeKind::Data as i32,
+                non_cascade: false,
+            },
+            proto::WorkflowEdge {
+                parent: 1,
+                child: 2,
+                edge_kind: proto::EdgeKind::Data as i32,
+                non_cascade: false,
+            },
+        ],
+        execution_mode: proto::WorkflowExecutionMode::Frozen as i32,
+        context_bundles: vec![],
+    }
+}
+
+/// RC-SW2 LIVE swarm witness (GR15/GR24): a 2-agent swarm → gather runs end-to-end on a live
+/// model, both engines. Proves the multi-agent vertical: two INDEPENDENT parallel model
+/// chains commit, then the gather synthesizes over BOTH committed outputs (F-7). A GR16
+/// OBSERVE-witness — asserts the swarm settled with all three motes committed and the gather
+/// produced REAL non-empty output (GR15), and LOGS the synthesis. Pure composition of
+/// existing step kinds (no new wire shape); the deterministic shape is pinned by the golden
+/// `swarm_agentic_gather` corpus row + the SDK unit tests.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "real in-process LLM inference; needs a GGUF (Gemma-4 locally); opt in with --ignored"]
+async fn swarm_runs_parallel_agents_and_gathers_live() {
+    let Some(engine) = resolve_engine() else {
+        eprintln!("skipping: no serve model — set KX_SERVE_MODEL_GGUF or KX_SERVE_OLLAMA=on");
+        return;
+    };
+    let dir = tempfile::TempDir::new().unwrap();
+    let running = start(common::gateway_config(&dir, true, HashMap::new()))
+        .await
+        .unwrap();
+    let mut c = client(running.local_addr()).await;
+
+    let handle = c
+        .submit_workflow(swarm_request())
+        .await
+        .expect("SubmitWorkflow of the swarm")
+        .into_inner();
+    assert_eq!(handle.instance_id.len(), 16);
+
+    // Poll the projection: the swarm settles when all 3 motes (2 leaves + gather) commit.
+    let mut committed: Vec<[u8; 32]> = Vec::new();
+    let mut terminal_ref: Option<[u8; 32]> = None;
+    for _ in 0..2400 {
+        let view = c
+            .get_projection(proto::GetProjectionRequest {
+                instance_id: handle.instance_id.clone(),
+                at_seq: None,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        committed = view
+            .motes
+            .iter()
+            .filter(|m| m.state == proto::MoteSnapshotState::Committed as i32)
+            .filter_map(|m| m.result_ref.clone().and_then(|r| r.try_into().ok()))
+            .collect();
+        // The gather is the child of both leaves — the mote with two parents.
+        if let Some(g) = view
+            .motes
+            .iter()
+            .find(|m| m.parents.len() == 2 && m.state == proto::MoteSnapshotState::Committed as i32)
+        {
+            terminal_ref = g.result_ref.clone().and_then(|r| r.try_into().ok());
+        }
+        if committed.len() >= 3 && terminal_ref.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    eprintln!(
+        "LIVE swarm [{engine}]: committed={} terminal_committed={}",
+        committed.len(),
+        terminal_ref.is_some()
+    );
+    assert!(
+        committed.len() >= 3,
+        "the 2-agent swarm + gather all committed on the live model [{engine}] (got {})",
+        committed.len()
+    );
+    let gather_ref = terminal_ref.expect("the gather (fan-in sink) committed");
+    let content = c
+        .get_content(proto::GetContentRequest {
+            content_ref: gather_ref.to_vec(),
+            instance_id: handle.instance_id.clone(),
+        })
+        .await
+        .expect("GetContent of the gather output")
+        .into_inner();
+    let text = String::from_utf8_lossy(&content.payload);
+    eprintln!("LIVE swarm [{engine}] synthesis: {}", text.trim());
+    // GR15: the gather produced REAL model output over the two agents' committed results.
+    assert!(
+        !text.trim().is_empty(),
+        "the swarm gather produced a non-empty synthesis on the live model [{engine}]"
+    );
+
+    running.shutdown().await.unwrap();
 }

--- a/docs/site/docs/authoring-a-connector.md
+++ b/docs/site/docs/authoring-a-connector.md
@@ -115,6 +115,18 @@ The SDK ships a minimal, complete **reference connector** to copy from —
 `kx-connector-example` (`crates/kx-extension-sdk/src/bin/reference_connector.rs`): two
 pure tools (`echo`, `reverse`), full handshake, no environment echo.
 
+**Scaffold your own with `kx new connector`.** It emits a self-contained, buildable
+sidecar crate (a `ping` starter tool + the credential-by-reference discipline + an offline
+`FAKE` mode + a passing conformance test) modelled on the bundled connectors — no `kx-*`
+dependency, so it cannot move the projection digest:
+
+```bash
+kx new connector slack           # → integrations/kx-connector-slack/ (default --dir integrations)
+cargo test -p kx-connector-slack # the emitted unit + conformance tests pass out of the box
+# implement your tools in src/lib.rs, add the crate to the workspace members, then:
+kx connections add --command kx-connector-slack --credential-ref KX_SLACK_CREDENTIAL
+```
+
 :::tip Security contract
 - **Never echo your environment.** An injected credential (see below) must reach no
   reply, so it never lands in a journal/content/telemetry sink (D81).

--- a/docs/site/docs/swarms.md
+++ b/docs/site/docs/swarms.md
@@ -1,0 +1,129 @@
+---
+id: swarms
+title: Swarms & personas
+sidebar_label: Swarms & personas
+description: Author multi-agent swarms — N agents running concurrently, each a crash-safe replayable chain, fanned into one gather — with a curated persona library, over one fluent spine (Python · TypeScript · CLI).
+---
+
+# Swarms & personas
+
+A **swarm** runs N agents *concurrently*, each as its own crash-safe, deterministically
+replayable chain, then merges their committed outputs with a **gather** step. It is pure
+composition over the same spine as everything else — `swarm(...)` lowers **byte-identically**
+to the equivalent `[a & b] > gather` chain, so no new wire shape, no new step kind, and the
+durable guarantees (exactly-once, crash-recovery, warrant-governance) hold for every agent
+in the swarm.
+
+A **persona** is a curated, named instruction set (`researcher`, `critic`, `writer`, …) you
+attach to an agent. Personas fold into the agent's prompt, so two agents that differ only by
+persona are genuinely distinct, replayable steps.
+
+> **One spine.** `swarm` / `team` / `fan_out_gather` / `map_reduce` are methods on the same
+> `flow()` builder and top-level `kx.*` factories. Attach an integration and it becomes an
+> [App](./apps.md); everything lowers through the one `SubmitWorkflow` / `RunApp` path.
+
+## A swarm of personas
+
+<!-- prettier-ignore -->
+```python
+import kortecx as kx
+
+# Three roles work the shared goal in parallel; a lead synthesizes their outputs.
+result = kx.swarm(
+    kx.persona("researcher"),
+    kx.persona("critic"),
+    kx.persona("writer"),
+    goal="Write a briefing on durable execution",
+).run()
+print(result.text)
+```
+
+```typescript
+import * as kx from "@kortecx/sdk";
+
+const result = await kx
+  .swarm([kx.persona("researcher"), kx.persona("critic"), kx.persona("writer")],
+         { goal: "Write a briefing on durable execution" })
+  .run();
+```
+
+```bash
+# The string DSL authors the same topology: two agentic leaves → a gather.
+kx chain "[a@web-search & b@web-search] > g" \
+  --task 'a={"kind":"model","prompt":"Research angle A"}' \
+  --task 'b={"kind":"model","prompt":"Research angle B"}' \
+  --task 'g={"kind":"model","prompt":"Synthesize the findings"}' \
+  --wait
+```
+
+Each participant may be a prompt, a `(prompt, tools)` pair, an `Agent` / `persona`, or a
+`Flow`. Give a participant tools and it becomes a bounded reason→tool→observe agent:
+
+```python
+analyst = kx.persona("analyst", tools=["web-search@1"])
+kx.swarm(analyst, kx.persona("skeptic"), goal="Is the Q3 forecast credible?").run()
+```
+
+## The gather
+
+By default the gather is a **model synthesizer** that reads every participant's committed
+output (injected as its data-edge parents) and writes one coherent answer. Steer it, or fold
+deterministically instead:
+
+```python
+kx.swarm(a, b, c, gather="Merge into a single ranked list")   # a custom synthesis prompt
+kx.swarm(a, b, c, synthesize=False)                            # a PURE deterministic fold
+kx.team(a, b, c, goal="…")                                     # a swarm with a lead (always synthesizes)
+```
+
+`fan_out_gather(*samplers)` (sample N ways, combine) and `map_reduce(*mappers, reduce=…)`
+are the same fan-in family with plain (non-persona) branches.
+
+## Reusable agents
+
+An `Agent` is a reusable named step; bind it to a task with `.on(...)` (an alias of
+`.as_flow(...)`):
+
+```python
+researcher = kx.agent("You are a meticulous researcher.", tools=["web-search@1"])
+kx.flow().parallel(researcher.on("topic A"),
+                   researcher.on("topic B")).then("Synthesize").run()
+```
+
+## A swarm that acts — integrations in an App
+
+When a swarm needs a **credentialed connector** (Gmail, Discord, …), name it an **App** with
+`.as_app(name)` — that is the explicit boundary where connections and secret scope attach.
+Running an App routes through `RunApp`, so the server resolves your registered connection and
+narrows the run warrant's secret scope (the value never travels, D81):
+
+```python
+# kx connections add --provider gmail   (register the connector once)
+(kx.flow()
+   .agent("Draft and send a summary reply", tools=["kx-connector-gmail/send"])
+   .as_app("mailer").with_gmail().secrets(["KX_GMAIL_CREDENTIAL"])
+   .run(args={"to": "team@example.com"}))
+```
+
+```typescript
+await kx.flow()
+  .agent("Draft and send a summary reply", { tools: ["kx-connector-gmail/send"] })
+  .asApp("mailer").withGmail().secrets(["KX_GMAIL_CREDENTIAL"])
+  .run({ to: "team@example.com" });
+```
+
+`with_discord()` is the Discord equivalent. See [Apps](./apps.md) for the full envelope and
+[Authoring a connector](./authoring-a-connector.md) for `kx new connector` (scaffold your own
+sidecar).
+
+## What holds
+
+- **Concurrent, not sequential** — each agent is an independent chain that commits on its own;
+  the gather fires once all have committed.
+- **Crash-safe + replayable** — kill a swarm mid-run and recovery re-derives byte-identical
+  agent identities; the projection digest is unchanged.
+- **Governed** — the server compiles and warrants every agent (SN-8); the client only proposes
+  topology. Personas and swarm sugar change *what is proposed*, never authority.
+- **One lowering** — `swarm(...).to_chain()` / `.to_blueprint()` round-trips through the same
+  `DagSpec` the string DSL and the visual builder produce; the Python, TypeScript, and CLI
+  surfaces lower it byte-identically (the golden tri-surface contract).

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
         "workflows",
         "blueprint-builder",
         "agent-runner",
+        "swarms",
         "security",
         "tools",
         "agentic-prompts",

--- a/feature-ledger.toml
+++ b/feature-ledger.toml
@@ -286,7 +286,8 @@ notes    = "MEDIUM blast radius + a real security surface (security review requi
 [[feature]]
 id       = "rc-sw1-skills"
 lane     = "oss"
-state    = "in-progress"
+state    = "merged"
+pr       = "284"
 branch   = "feat/rc-sw1-skills"
 covers   = [
   "kortecx.skill/v1 declarative skill bundles (instructions + tool grant-WISHES + context; NO code — the executable leg is always an out-of-process MCP connector/broker capability, D159/D174.4): a NEW FFI-free kx-skill format crate (manifest type + validate() with authority deny-keys + pack loader; the apps.db/kx-blueprint leaf posture)",
@@ -295,4 +296,20 @@ covers   = [
   "run_skill_conformance harness (kx-extension-sdk sibling of run_conformance: declarative/no-authority/wish-resolvable/binds-empty-grants-to-zero) + just test-skill + 2-3 reference skill packs (skills/**) + a skill_quality kx-eval scorer + registry/index.json v1 (family/name/version/source/conformance)",
 ]
 inherits = ["rc5b-consolidation-decay-memory-ui", "app-pointer-run-resolution", "gmail-integration", "connector-extension-sdk"]
-notes    = "The NEXT shared-lane PR (D174.3 sequencing; D175 program). B-spec: private docs/plans/2026-07-02-capability-families-skills-tools-integrations-program.md SECTION 4 (start there — D143). CORRECTED naming per D175.2: dedicated kx-skill crate + skills.db, NOT kx-bundle/bundles.db (those are TaskBundle + the PR-7 context-bundle store). Auto-mode (skill menu + KX_SERVE_AUTOSKILL) DEFERRED to its own PR or RC-SW4. Honest digest note: skill-BEARING runs legitimately produce different bytes (warrant_ref content-addressed + identity-bearing context); canonical 7d22d4bd invariance holds via the default-empty no-op (a0_guard + frozen-trio-EMPTY prove in-PR). Unblocks RC-SW2 personas."
+notes    = "The NEXT shared-lane PR (D174.3 sequencing; D175 program). B-spec: private docs/plans/2026-07-02-capability-families-skills-tools-integrations-program.md SECTION 4 (start there — D143). CORRECTED naming per D175.2: dedicated kx-skill crate + skills.db, NOT kx-bundle/bundles.db (those are TaskBundle + the PR-7 context-bundle store). Auto-mode (skill menu + KX_SERVE_AUTOSKILL) DEFERRED to its own PR or RC-SW4. Honest digest note: skill-BEARING runs legitimately produce different bytes (warrant_ref content-addressed + identity-bearing context); canonical 7d22d4bd invariance holds via the default-empty no-op (a0_guard + frozen-trio-EMPTY prove in-PR). Unblocks RC-SW2 personas. Merged OSS #284 42ff3853 (2026-07-02); ledger flipped in-progress->merged during rc-sw2."
+
+[[feature]]
+id       = "rc-sw2-swarm-personas"
+lane     = "oss"
+state    = "in-progress"
+branch   = "feat/rc-sw2-swarm-authoring-personas"
+covers   = [
+  "swarm()/team() authoring — first-class Py/TS SDK factories (kx.swarm/kx.team) that lower PURE CLIENT-SIDE to N parallel deterministic-agentic MODEL leaves (each a model step with a tool_contract + prompt = the is_agentic_launch shape the coordinator already drives as an isolated salt-2 chain, state.rs) fanned into one gather sink (PURE fold by default; a MODEL synthesizer when synthesize=True / team()). No new WorkflowStepKind, no coordinator/compile/proto change — the same (steps, edges) the string DSL '[a@t & b@t] > g' already lowers (agentic_multi_tool + fanin_group corpus rows); byte-identical across Py/TS/CLI via tests/golden/chains/corpus.json",
+  "persona library — a curated {name: instructions} map (personas.py/personas.ts: researcher/critic/planner/writer/...) folded into an agent's PROMPT_KEY (identity-bearing, opt-in, new-motes-only => digest-invariant; presentation-only rejected as a dedup/replay hazard); consumed via kx.persona(name)->Agent, Agent(persona=name), and the .on(task) alias of Agent.as_flow/run",
+  "fan_out_gather()/map_reduce() surfaced as client-side Flow compositions (the same fan-in family as swarm, plain generator/transform leaves)",
+  "App.run() -> SaveApp + RunApp delegation fix (Py app.py + TS app.ts both locally recompiled via submit_workflow, DROPPING references.connections + guards.secret_scope and ignoring args) + an explicit Flow.as_app(name) persist boundary (no hidden catalog write; a bare .run() on an integration-bearing unsaved envelope is a clear error) => credentialed connectors now actually fire from the SDK path",
+  "integration reach for parallel-session testing: App.with_discord() curated shortcut (kx-connector-discord exists, #277) + .secrets() sugar; a GENERIC connector RunApp live-harness (parametrize app_live_serve.rs runapp_gmail_... into runapp_connection_live(cmd,cred,probe) so any sidecar is testable); a `kx new connector` scaffold (verbs/new.rs, mirrors kx-connector-gmail; only `kx new skill` existed)",
+  "Py<->TS parity fixes: Python Agent dynamic-lane max_tool_calls 6->20 (match TS + server default REACT_DEFAULT_MAX_TOOL_CALLS=20); TS module-level chat(); TS barrel export of REACT_RAG/VISION_RAG/react-vision recipe handles; stale chains.py docstring fix",
+]
+inherits = ["rc-sw1-skills", "app-pointer-run-resolution", "gmail-integration", "discord-connector", "first-class-integrations"]
+notes    = "RC-SW2 (D174.3/D176/D177). PURELY ADDITIVE client-side composition + ONE runtime-behavior fix (App.run delegation). Digest 7d22d4bd INVARIANT BY CONSTRUCTION (swarm/personas touch only NEW motes; connections/skills/secrets ride OFF the lowered graph) + frozen-trio EMPTY + no proto/journal/WorkflowStepKind change; proven in-PR by a0_guard (8/8) + tri-surface golden parity. DEFERRED (own follow-ups, recorded so not re-litigated): .retry_until() critic-gated best-of-N -> RC-SW4 (needs a server kx/recipes/retry-until binder + free-param slots; critic kind is not in the client palette; natural home = supervisor/consensus); branch() -> RC-SW3 (dynamic topology-shaper + EdgeKind::Control cascade, NOT pure composition); effect=/idempotency= override hatch -> own D-number (effect_pattern is a MoteDef identity + executor double-effect/refusal gate; a client override is an SN-8 + un-deduped-double-effect risk); full Flow-level .connect()/.skill()/.secrets()/.use()/.context() sugar -> own D177 ergonomics PR; supervisor()/consensus()/handoff() -> RC-SW4; .with_slack() -> when kx-connector-slack lands (GR25 extension lane); T-SWARM-CHILD-SECRET-SCOPE-NARROW (narrow.rs, dynamic child secret_scope) -> RC-SW4."

--- a/tests/golden/chains/corpus.json
+++ b/tests/golden/chains/corpus.json
@@ -611,5 +611,26 @@
       ],
       "edges": [{ "parent": 0, "child": 1, "edge": "data" }]
     }
+  },
+  {
+    "name": "swarm_agentic_gather",
+    "dsl": "[a@echo & b@echo] > g",
+    "seed": 0,
+    "tasks": {
+      "a": { "kind": "model", "prompt": "Research angle A." },
+      "b": { "kind": "model", "prompt": "Research angle B." },
+      "g": { "kind": "model", "prompt": "Synthesize the findings." }
+    },
+    "expect": {
+      "steps": [
+        { "kind": "model", "model_id": "", "prompt": "Research angle A.", "body_signature_id": null, "tool_contract": { "echo": "1" }, "params": {} },
+        { "kind": "model", "model_id": "", "prompt": "Research angle B.", "body_signature_id": null, "tool_contract": { "echo": "1" }, "params": {} },
+        { "kind": "model", "model_id": "", "prompt": "Synthesize the findings.", "body_signature_id": null, "tool_contract": {}, "params": {} }
+      ],
+      "edges": [
+        { "parent": 0, "child": 2, "edge": "data" },
+        { "parent": 1, "child": 2, "edge": "data" }
+      ]
+    }
   }
 ]

--- a/ui/src/components/builder/StepConfigDrawer.tsx
+++ b/ui/src/components/builder/StepConfigDrawer.tsx
@@ -7,7 +7,7 @@
  * appears only where the wire enforces it (don't-fake-gaps, D142).
  */
 
-import type { ModelSummary } from "@kortecx/sdk/web";
+import { type ModelSummary, PERSONAS, personaNames } from "@kortecx/sdk/web";
 import { m } from "framer-motion";
 import { useEffect } from "react";
 import { useDiscoverTools } from "../../kx/use-tool-registry";
@@ -129,6 +129,31 @@ export function StepConfigDrawer({
                   ))}
                 </div>
               )}
+            </div>
+
+            <div className="builder-field">
+              <span className="builder-field__label">Persona</span>
+              <div className="builder-chips" data-testid="step-config-persona">
+                {personaNames().map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    className="chip"
+                    data-testid={`step-config-persona-${name}`}
+                    onClick={() => {
+                      const role = PERSONAS[name] ?? "";
+                      const body = step.prompt.trim();
+                      onChange({ ...step, prompt: body ? `${role}\n\n${body}` : role });
+                    }}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
+              <span className="builder-field__hint">
+                RC-SW2: a curated role. Clicking prepends its instructions to the prompt (an
+                editable template); the same as the SDK <code>kx.persona("…")</code>.
+              </span>
             </div>
 
             <div className="builder-field">

--- a/ui/src/components/tools/ConnectionsPanel.tsx
+++ b/ui/src/components/tools/ConnectionsPanel.tsx
@@ -139,6 +139,12 @@ const PROVIDERS = [
     command: "kx-connector-gmail",
     credentialRef: "KX_GMAIL_CREDENTIAL",
   },
+  {
+    id: "discord",
+    label: "Discord",
+    command: "kx-connector-discord",
+    credentialRef: "KX_DISCORD_CREDENTIAL",
+  },
 ] as const;
 
 export function ConnectionsPanel() {

--- a/ui/test/component/ConnectionsPanel.test.tsx
+++ b/ui/test/component/ConnectionsPanel.test.tsx
@@ -154,6 +154,19 @@ describe("ConnectionsPanel", () => {
     });
   });
 
+  it("RC-SW2: 'Connect Discord' prefills the bundled discord connector defaults", () => {
+    render(<ConnectionsPanel />);
+    fireEvent.click(screen.getByTestId("connection-provider-discord"));
+    fireEvent.submit(screen.getByTestId("connections-add-form"));
+    expect(registerM.mutate).toHaveBeenCalledTimes(1);
+    expect(registerM.mutate.mock.calls[0]?.[0]).toMatchObject({
+      name: "discord",
+      transport: "stdio",
+      endpoint: "kx-connector-discord",
+      credentialRef: "KX_DISCORD_CREDENTIAL",
+    });
+  });
+
   it("switches to http transport and shows the TLS toggle", () => {
     render(<ConnectionsPanel />);
     fireEvent.click(screen.getByTestId("connection-transport-http"));


### PR DESCRIPTION
## RC-SW2 — swarm authoring + personas + single-entry-point chaining + integration-in-app

The next OSS-RC PR (D174/D176/D177). **Pure additive client composition + one runtime-behavior fix (App.run→RunApp)** — digest `7d22d4bd…` invariant by construction, frozen-trio EMPTY, no proto/journal/`WorkflowStepKind`/coordinator change. 25 files, +2.3k/−200; no core-Rust/projection touch (only `kx-cli` + a test file).

### What ships
- **Swarm authoring** — `swarm()`/`team()`/`fan_out_gather()`/`map_reduce()` (Flow methods + `kx.*` factories, Py+TS): N parallel deterministic-agentic leaves → a gather sink (MODEL synthesizer default; PURE fold via `synthesize=False`). Byte-identical to the equivalent `[a & b] > g` chain — **no new step kind**.
- **Persona library** — a curated `{name: instructions}` set (`researcher`/`critic`/`writer`/…) folded into an agent's prompt (identity-bearing, opt-in), via `kx.persona(name)→Agent`, `Agent(persona=…)`, and the `.on(task)` alias. TS imports the same `PERSONAS` so the roster stays in sync (Py/TS byte-identical strings).
- **App.run()→SaveApp+RunApp fix** (Py `app.py` + TS `app.ts`) — was a local `submit_workflow` recompile that **dropped `references.connections` + `guards.secret_scope`**, so a credentialed connector could not fire. + `Flow.as_app(name)` explicit boundary (carries `with_mcp`/`with_memory`), `App.with_discord()`, `App.secrets()`.
- **Integration reach** — a curated **Discord** connect chip (UI + SDK `.with_discord()`), a **`kx new connector`** scaffold (a buildable, conformance-passing sidecar starter), and a **generic connector live-harness** (`runapp_connection_live`) so any sidecar is testable in a parallel session.
- **Py↔TS parity** — Python Agent dynamic-lane `max_tool_calls` 6→20 (matches TS + server default); TS module-level `chat()`; TS barrel exports `REACT_RAG`/`VISION_RAG`/`REACT_VISION` handles; stale `8/6` docstrings → `8/20`.
- **UI** — persona picker in the builder's step config + the Discord chip in Connections.
- **Docs** — a `swarms.md` chaining page (Py/TS/CLI) + a `kx new connector` section (D143 docs-ride-the-feature).

### Live validation (this session; models restarted per run, GR15/GR24)
- **Swarm on llama.cpp Gemma-4-12B**: `committed=3`, real synthesis combining both agents (benefit + risk).
- **Swarm on Ollama gemma3:12b**: `committed=3`, real synthesis (dual-engine).
- **Discord connector-in-app on Ollama**: sidecar dialed (`health=connected discovered=3`), App resolved connection + secret_scope via RunApp, agent answered.
- `kx new connector` scaffold: a generated crate **builds + passes the conformance gate** (out-of-process / warrant / secret-by-ref / on-off).

### Always-in-CI coverage
- Golden `swarm_agentic_gather` row (Rust + Py + TS, tri-surface byte-identity).
- SDK unit tests: swarm==chain byte-identity, `App.run`→save+runApp (never `submit_workflow`), personas, `.as_app`.
- `kx new connector` scaffold tests; ConnectionsPanel Discord chip; full UI suite (746).

### Deferred (recorded so it isn't re-litigated)
`branch()`→RC-SW3 · `effect=/idempotency=` override hatch → its own D-number + threat model · full Flow-level `.connect/.skill/.secrets` sugar → own D177 ergonomics PR · `supervisor/consensus/handoff` + `.retry_until()` critic-loop → RC-SW4 · `.with_slack()` → when the connector crate lands. `kx-eval`/`kx-profile` are no-op here (pure composition: no new scorer, no new hot path — RC-SW3 owns parallel exec).

### Invariants proven
digest `7d22d4bd` (a0_guard 8/8) · frozen-trio src diff EMPTY · additive-only (no proto/codegen drift) · Py↔TS golden parity green · SN-8 (server builds every warrant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)