### PR TITLE
fix(rc-sw2): persona/Agent swarm participant mislowered prompt→model_id (Py↔TS parity)

### DIFF
--- a/bindings/python/src/kortecx/flow.py
+++ b/bindings/python/src/kortecx/flow.py
@@ -95,10 +95,14 @@ def _participant_to_node(item: "object", goal: str) -> "_Node":
         return _model(prompt=_join_goal(item, goal))
     prompt_fn = getattr(item, "_prompt", None)
     if callable(prompt_fn):  # duck-typed Agent / persona
+        # model_id is the FIRST positional arg of chains.model, prompt the SECOND — pass
+        # them positionally (as Flow.agent does); a keyword `model=` would leak into
+        # **params (chains.model has no `model` kwarg). The persona/Agent instructions +
+        # goal are the PROMPT, never the model_id.
         return _model(
+            getattr(item, "model", "") or "",
             prompt_fn(goal),
             tools=getattr(item, "tools", None),
-            model=getattr(item, "model", "") or "",
             max_turns=getattr(item, "max_turns", None),
             max_tool_calls=getattr(item, "max_tool_calls", None),
             reasoning=getattr(item, "reasoning", None),

--- a/bindings/python/tests/test_swarm_personas.py
+++ b/bindings/python/tests/test_swarm_personas.py
@@ -86,6 +86,22 @@ def test_swarm_accepts_agents_flows_and_personas() -> None:
     assert low["steps"][0]["tool_contract"] == {"mcp-echo/echo": "1"}
 
 
+def test_persona_and_agent_leaves_lower_prompt_not_model_id() -> None:
+    # Regression for F1: a persona/Agent participant's instructions are the PROMPT, never
+    # the model_id, and `model` must not leak into params.
+    leaf = kx.flow().swarm(kx.persona("researcher"), goal="the topic").lowering()["steps"][0]
+    assert leaf["model_id"] == "", "instructions must NOT land in model_id"
+    assert leaf["prompt"] == f"{kx.PERSONAS['researcher']}\n\nthe topic"
+    assert leaf["params"] == {}, "no leaked `model` param"
+    # An Agent with a pinned model forwards it as model_id (Py↔TS parity).
+    a = kx.Agent("You are an analyst.", model="gemma-4", tools=["mcp-echo/echo"])
+    aleaf = kx.flow().swarm(a, goal="X").lowering()["steps"][0]
+    assert aleaf["model_id"] == "gemma-4"
+    assert aleaf["prompt"] == "You are an analyst.\n\nX"
+    assert aleaf["tool_contract"] == {"mcp-echo/echo": "1"}
+    assert aleaf["params"] == {}
+
+
 def test_empty_swarm_is_an_error() -> None:
     with pytest.raises(ChainError):
         kx.swarm()

--- a/bindings/typescript/src/flow.ts
+++ b/bindings/typescript/src/flow.ts
@@ -355,8 +355,10 @@ export class Flow {
     }
     if (isAgentLike(item)) {
       const base = item.instructions;
+      // Forward the Agent's pinned model as model_id (Py↔TS parity); instructions+goal
+      // are the PROMPT.
       return task.model(
-        "",
+        item.opts.model ?? "",
         base ? joinGoal(base, goal) : goal,
         {},
         {

--- a/bindings/typescript/test/swarm-personas.test.ts
+++ b/bindings/typescript/test/swarm-personas.test.ts
@@ -92,6 +92,22 @@ describe("swarm / team / fanOutGather / mapReduce lowering", () => {
     expect(low.steps[0]?.tool_contract).toEqual({ "mcp-echo/echo": "1" });
   });
 
+  it("persona/Agent leaves lower prompt (not model_id); an Agent's model forwards", () => {
+    // Regression for F1/F2 (Py↔TS parity): instructions are the PROMPT, model_id="".
+    const leaf = flow()
+      .swarm([persona("researcher")], { goal: "the topic" })
+      .lower().steps[0];
+    expect(leaf?.model_id).toBe("");
+    expect(leaf?.prompt).toBe(`${PERSONAS.researcher}\n\nthe topic`);
+    expect(leaf?.params).toEqual({});
+    const a = new Agent("You are an analyst.", { model: "gemma-4", tools: ["mcp-echo/echo"] });
+    const aleaf = flow().swarm([a], { goal: "X" }).lower().steps[0];
+    expect(aleaf?.model_id).toBe("gemma-4");
+    expect(aleaf?.prompt).toBe("You are an analyst.\n\nX");
+    expect(aleaf?.tool_contract).toEqual({ "mcp-echo/echo": "1" });
+    expect(aleaf?.params).toEqual({});
+  });
+
   it("an empty swarm is an error", () => {
     expect(() => swarm([])).toThrow();
     expect(() => flow().fanOutGather([])).toThrow();

--- a/ui/src/components/builder/StepConfigDrawer.tsx
+++ b/ui/src/components/builder/StepConfigDrawer.tsx
@@ -142,7 +142,20 @@ export function StepConfigDrawer({
                     data-testid={`step-config-persona-${name}`}
                     onClick={() => {
                       const role = PERSONAS[name] ?? "";
-                      const body = step.prompt.trim();
+                      // Strip a leading persona (any known role) first, so re-picking a
+                      // persona SWAPS the role rather than stacking it.
+                      let body = step.prompt;
+                      for (const known of Object.values(PERSONAS)) {
+                        if (body === known) {
+                          body = "";
+                          break;
+                        }
+                        if (body.startsWith(`${known}\n\n`)) {
+                          body = body.slice(known.length + 2);
+                          break;
+                        }
+                      }
+                      body = body.trim();
                       onChange({ ...step, prompt: body ? `${role}\n\n${body}` : role });
                     }}
                   >


### PR DESCRIPTION
An adversarial post-merge review of #286 (RC-SW2) found a **critical correctness + parity bug** CI didn't catch.

**F1 (critical):** In Python `flow.py`, a persona/Agent swarm participant passed the prompt *positionally* to `chains.model(model_id, prompt, ...)`, so the instructions landed in `model_id` (not `prompt`) and `model=` leaked into `params`. `kx.swarm(kx.persona("researcher"), goal=…)` — the headline example — lowered leaves with an **empty task prompt** + a `model_id` set to the full instruction text, and diverged from TS (D177 tri-surface parity contract).

**F2:** TS `resolveParticipant` dropped an Agent's pinned `model`. Fixed both sides to forward it as `model_id`, so a persona/Agent leaf lowers **byte-identically** in Py and TS.

**F3 (minor UX):** the UI persona chip now **swaps** the leading role instead of stacking it on repeat click.

**Why #286 CI missed it:** the swarm-participant tests asserted only `tool_contract` + step count on persona/Agent leaves (tools *were* passed correctly). New Py + TS regression tests now assert the leaf's `prompt`/`model_id`/`params`.

Verified: Py 14/14, TS 13/13, UI 10/10; ruff/mypy/tsc/biome clean; persona leaf Py == TS. Pure client SDK/UI fix — digest `7d22d4bd` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)